### PR TITLE
Add /exit command to gracefully shut down ori-agent server

### DIFF
--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -78,6 +78,11 @@ func (h *Handler) SetWorkspaceStore(ws agentstudio.Store) {
 	h.commandHandler.SetWorkspaceStore(ws)
 }
 
+// SetShutdownFunc sets the shutdown function for the /exit command
+func (h *Handler) SetShutdownFunc(fn func()) {
+	h.commandHandler.SetShutdownFunc(fn)
+}
+
 // findTool searches for a tool by name in both plugins and MCP servers
 func (h *Handler) findTool(ag *agent.Agent, toolName string) (pluginapi.Tool, bool) {
 	// First check native plugins
@@ -679,6 +684,10 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if q == "/tools" {
 		h.commandHandler.HandleToolsList(w, r)
+		return
+	}
+	if q == "/exit" {
+		h.commandHandler.HandleExit(w, r)
 		return
 	}
 	if strings.HasPrefix(q, "/switch") {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -406,6 +406,13 @@ func New() (*Server, error) {
 	s.chatHandler.SetCostTracker(s.costTracker)       // Inject cost tracker
 	s.chatHandler.SetMCPRegistry(s.mcpRegistry)       // Inject MCP registry
 	s.chatHandler.SetWorkspaceStore(s.workspaceStore) // Inject workspace store for /workspace commands
+	s.chatHandler.SetShutdownFunc(func() {
+		// Gracefully shut down server and exit
+		log.Println("🛑 Shutting down ori-agent server...")
+		s.Shutdown()
+		log.Println("✅ Server shut down complete. Exiting...")
+		os.Exit(0)
+	})
 	s.pluginRegistryHandler = pluginhttp.NewRegistryHandler(s.st, s.registryManager, s.pluginDownloader, s.agentStorePath)
 
 	// Create plugin main handler first so we can pass it to init handler


### PR DESCRIPTION
Implemented a new /exit command that allows users to gracefully shut down the ori-agent server from within the chat interface.

Changes:
- Added shutdownFunc field to CommandHandler for handling server shutdown
- Implemented HandleExit method that sends a goodbye message and triggers shutdown
- Updated /help command to include the new /exit command
- Registered /exit command in ChatHandler's command routing
- Set shutdown function in server initialization to call s.Shutdown() and os.Exit(0)

The shutdown process:
1. User sends /exit command
2. Server responds with a goodbye message
3. After a 100ms delay (to ensure response is sent), server initiates shutdown
4. Server gracefully shuts down all background services and plugins
5. Process exits with status code 0

Location: internal/chathttp/commands.go (HandleExit method)