### PR TITLE
Add agent management functionality to studios dashboard

### DIFF
--- a/internal/web/templates/pages/studios.tmpl
+++ b/internal/web/templates/pages/studios.tmpl
@@ -55,6 +55,12 @@
               <p class="mb-0" style="color: var(--text-secondary);">Collaborative multi-agent workspaces with visual canvas</p>
             </div>
             <div class="d-flex gap-2">
+              <button class="modern-btn modern-btn-secondary" onclick="openManageAgentsModal()">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                  <path d="M12,5.5A3.5,3.5 0 0,1 15.5,9A3.5,3.5 0 0,1 12,12.5A3.5,3.5 0 0,1 8.5,9A3.5,3.5 0 0,1 12,5.5M5,8C5.56,8 6.08,8.15 6.53,8.42C6.38,9.85 6.8,11.27 7.66,12.38C7.16,13.34 6.16,14 5,14A3,3 0 0,1 2,11A3,3 0 0,1 5,8M19,8A3,3 0 0,1 22,11A3,3 0 0,1 19,14C17.84,14 16.84,13.34 16.34,12.38C17.2,11.27 17.62,9.85 17.47,8.42C17.92,8.15 18.44,8 19,8M5.5,18.25C5.5,16.18 8.41,14.5 12,14.5C15.59,14.5 18.5,16.18 18.5,18.25V20H5.5V18.25M0,20V18.5C0,17.11 1.89,15.94 4.45,15.6C3.86,16.28 3.5,17.22 3.5,18.25V20H0M24,20H20.5V18.25C20.5,17.22 20.14,16.28 19.55,15.6C22.11,15.94 24,17.11 24,18.5V20Z"/>
+                </svg>
+                Manage Agents
+              </button>
               <button class="modern-btn modern-btn-primary" onclick="openCreateWorkspaceModal()">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
                   <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/>
@@ -393,6 +399,80 @@
         </div>
         <div class="modal-body" id="workspace-details-content" style="max-height: 70vh; overflow-y: auto;">
           <!-- Content will be populated dynamically -->
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Manage Agents Modal -->
+  <div class="modal fade" id="manageAgentsModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" style="color: var(--text-primary);">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="me-2">
+              <path d="M12,5.5A3.5,3.5 0 0,1 15.5,9A3.5,3.5 0 0,1 12,12.5A3.5,3.5 0 0,1 8.5,9A3.5,3.5 0 0,1 12,5.5M5,8C5.56,8 6.08,8.15 6.53,8.42C6.38,9.85 6.8,11.27 7.66,12.38C7.16,13.34 6.16,14 5,14A3,3 0 0,1 2,11A3,3 0 0,1 5,8M19,8A3,3 0 0,1 22,11A3,3 0 0,1 19,14C17.84,14 16.84,13.34 16.34,12.38C17.2,11.27 17.62,9.85 17.47,8.42C17.92,8.15 18.44,8 19,8Z"/>
+            </svg>
+            Manage Agents
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" style="max-height: 70vh; overflow-y: auto;">
+          <!-- Create Agent Section -->
+          <div class="mb-4">
+            <h6 style="color: var(--text-primary);">Create New Agent</h6>
+            <form id="createAgentForm" class="modern-card p-3">
+              <div class="row">
+                <div class="col-md-6 mb-3">
+                  <label class="form-label" style="color: var(--text-primary);">Agent Name</label>
+                  <input type="text" id="new-agent-name" class="form-control" placeholder="my-agent" required>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <label class="form-label" style="color: var(--text-primary);">Type</label>
+                  <select id="new-agent-type" class="form-control">
+                    <option value="tool-calling">Tool-Calling Agent</option>
+                    <option value="chat">Chat Agent</option>
+                  </select>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-8 mb-3">
+                  <label class="form-label" style="color: var(--text-primary);">Model</label>
+                  <input type="text" id="new-agent-model" class="form-control" placeholder="gpt-4o (optional)">
+                </div>
+                <div class="col-md-4 mb-3">
+                  <label class="form-label" style="color: var(--text-primary);">Temperature</label>
+                  <input type="number" id="new-agent-temperature" class="form-control" placeholder="1.0" step="0.1" min="0" max="2">
+                </div>
+              </div>
+              <div class="mb-3">
+                <label class="form-label" style="color: var(--text-primary);">System Prompt (optional)</label>
+                <textarea id="new-agent-prompt" class="form-control" rows="2" placeholder="You are a helpful assistant..."></textarea>
+              </div>
+              <button type="submit" class="modern-btn modern-btn-primary">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                  <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/>
+                </svg>
+                Create Agent
+              </button>
+            </form>
+          </div>
+
+          <!-- Existing Agents Section -->
+          <div>
+            <h6 style="color: var(--text-primary);">Existing Agents</h6>
+            <div id="agents-list" class="modern-card p-3">
+              <div class="text-center py-3">
+                <div class="spinner-border text-primary" role="status">
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+                <p class="mt-2" style="color: var(--text-muted);">Loading agents...</p>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -1605,6 +1685,142 @@
       if (window.agentCanvas) {
         window.agentCanvas.backgroundColor = color;
         window.agentCanvas.draw();
+      }
+    }
+
+    // ========== AGENT MANAGEMENT FUNCTIONS ==========
+
+    let systemAgents = [];
+
+    async function openManageAgentsModal() {
+      const modal = new bootstrap.Modal(document.getElementById('manageAgentsModal'));
+      modal.show();
+
+      // Load agents when modal opens
+      await loadSystemAgents();
+    }
+
+    async function loadSystemAgents() {
+      try {
+        const response = await fetch('/api/agents');
+        const data = await response.json();
+
+        systemAgents = data.agents || [];
+        renderAgentsList();
+      } catch (error) {
+        console.error('Error loading agents:', error);
+        document.getElementById('agents-list').innerHTML = `
+          <div class="alert alert-danger">Failed to load agents: ${escapeHtml(error.message)}</div>
+        `;
+      }
+    }
+
+    function renderAgentsList() {
+      const container = document.getElementById('agents-list');
+
+      if (systemAgents.length === 0) {
+        container.innerHTML = `
+          <div class="text-center py-3">
+            <p style="color: var(--text-muted);">No agents found</p>
+          </div>
+        `;
+        return;
+      }
+
+      container.innerHTML = systemAgents.map(agent => `
+        <div class="d-flex align-items-center justify-content-between p-2 mb-2" style="border-left: 3px solid var(--primary-color); background: var(--surface-color); border-radius: var(--radius-sm);">
+          <div class="d-flex align-items-center gap-3">
+            <div class="status-indicator status-online"></div>
+            <div>
+              <div style="color: var(--text-primary); font-weight: 500;">${escapeHtml(agent.name)}</div>
+              <div class="text-muted small">${escapeHtml(agent.type || 'tool-calling')}</div>
+            </div>
+          </div>
+          <button class="btn btn-sm btn-outline-danger" onclick="deleteSystemAgent('${escapeHtml(agent.name)}')" title="Delete agent">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+            </svg>
+          </button>
+        </div>
+      `).join('');
+    }
+
+    document.getElementById('createAgentForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+
+      const name = document.getElementById('new-agent-name').value.trim();
+      const type = document.getElementById('new-agent-type').value;
+      const model = document.getElementById('new-agent-model').value.trim();
+      const temperature = document.getElementById('new-agent-temperature').value;
+      const systemPrompt = document.getElementById('new-agent-prompt').value.trim();
+
+      if (!name) {
+        alert('Please enter an agent name');
+        return;
+      }
+
+      // Check if agent already exists
+      if (systemAgents.some(a => a.name === name)) {
+        alert('An agent with this name already exists');
+        return;
+      }
+
+      try {
+        const requestBody = { name, type };
+
+        if (model) requestBody.model = model;
+        if (temperature) requestBody.temperature = parseFloat(temperature);
+        if (systemPrompt) requestBody.system_prompt = systemPrompt;
+
+        const response = await fetch('/api/agents', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(error || 'Failed to create agent');
+        }
+
+        const result = await response.json();
+
+        // Clear form
+        document.getElementById('createAgentForm').reset();
+
+        // Reload agents list
+        await loadSystemAgents();
+
+        // Show success message
+        alert('Agent created successfully: ' + name);
+      } catch (error) {
+        console.error('Error creating agent:', error);
+        alert('Failed to create agent: ' + error.message);
+      }
+    });
+
+    async function deleteSystemAgent(agentName) {
+      if (!confirm(`Are you sure you want to delete agent "${agentName}"? This action cannot be undone.`)) {
+        return;
+      }
+
+      try {
+        const response = await fetch(`/api/agents?name=${encodeURIComponent(agentName)}`, {
+          method: 'DELETE'
+        });
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(error || 'Failed to delete agent');
+        }
+
+        // Reload agents list
+        await loadSystemAgents();
+
+        alert('Agent deleted successfully: ' + agentName);
+      } catch (error) {
+        console.error('Error deleting agent:', error);
+        alert('Failed to delete agent: ' + error.message);
       }
     }
   </script>


### PR DESCRIPTION
- Add "Manage Agents" button in studios dashboard header
- Create modal for managing system agents with:
  - Form to create new agents (name, type, model, temperature, system prompt)
  - List of existing agents with delete functionality
- Implement JavaScript functions for:
  - Opening manage agents modal
  - Loading and displaying all system agents
  - Creating new agents via POST /api/agents
  - Deleting agents via DELETE /api/agents?name=X
- Users can now create and delete agents directly from the studios page
- Backend API already exists in internal/agenthttp/agents.go

This allows users to manage agents without navigating away from the studios dashboard, providing a more streamlined workflow for multi-agent collaboration.