### PR TITLE
fix(workspace): restore tool support via LLMTaskHandler delegation

### DIFF
--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -108,6 +108,7 @@ type ServerBuilder struct {
 	updateMgr             *updatemanager.Manager
 	workspaceStore        workspace.Store
 	workspaceFileStore    *workspace.FileStore
+	taskHandler           *workspace.LLMTaskHandler
 	taskExecutor          *workspace.TaskExecutor
 	stepExecutor          *workspace.StepExecutor
 	taskScheduler         *workspace.TaskScheduler

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -158,29 +158,29 @@ func (b *ServerBuilder) initializeEventSystem() error {
 
 // initializeTaskExecution creates task handler, executor, step executor, and scheduler.
 func (b *ServerBuilder) initializeTaskExecution() error {
-	taskHandler := workspace.NewLLMTaskHandler(b.st, b.llmFactory, b.workspaceStore)
-	taskHandler.SetEventBus(b.eventBus)
-	taskHandler.SetMCPRegistry(b.mcpRegistry)
+	b.taskHandler = workspace.NewLLMTaskHandler(b.st, b.llmFactory, b.workspaceStore)
+	b.taskHandler.SetEventBus(b.eventBus)
+	b.taskHandler.SetMCPRegistry(b.mcpRegistry)
 	runtimeResolver := workspace.NewAgentRuntimeResolver(b.st, b.workspaceStore, b.mcpRegistry, b.mcpConfigManager)
 	if b.skillsManager != nil {
 		runtimeResolver.SetSkillResolver(newSkillResolverAdapter(b.skillsManager))
 	}
-	taskHandler.SetRuntimeResolver(runtimeResolver)
+	b.taskHandler.SetRuntimeResolver(runtimeResolver)
 	b.chatHandler.SetRuntimeResolver(runtimeResolver)
 	if b.sessionStore != nil {
-		taskHandler.SetContextStore(session.NewWorkspaceTaskContextAdapter(b.sessionStore))
+		b.taskHandler.SetContextStore(session.NewWorkspaceTaskContextAdapter(b.sessionStore))
 	}
 	if fn := b.buildWorkspaceToolFactory(); fn != nil {
-		taskHandler.SetWorkspaceToolFactory(fn)
+		b.taskHandler.SetWorkspaceToolFactory(fn)
 	}
 
-	b.taskExecutor = workspace.NewTaskExecutor(b.workspaceStore, taskHandler, workspace.ExecutorConfig{
+	b.taskExecutor = workspace.NewTaskExecutor(b.workspaceStore, b.taskHandler, workspace.ExecutorConfig{
 		PollInterval:  10 * time.Second,
 		MaxConcurrent: 5,
 	})
 	b.taskExecutor.SetEventBus(b.eventBus)
 
-	b.stepExecutor = workspace.NewStepExecutor(b.workspaceStore, taskHandler, workspace.StepExecutorConfig{
+	b.stepExecutor = workspace.NewStepExecutor(b.workspaceStore, b.taskHandler, workspace.StepExecutorConfig{
 		PollInterval: 5 * time.Second,
 	})
 
@@ -259,6 +259,9 @@ func (b *ServerBuilder) initializeWorkspaceOrchestrator() error {
 
 	llmAdapter := workspace.NewLLMFactoryAdapter(b.llmFactory, "openai")
 	b.workspaceOrchestrator = workspace.NewOrchestrator(b.workspaceStore, b.st, llmAdapter, b.eventBus)
+	if b.taskHandler != nil {
+		b.workspaceOrchestrator.SetTaskHandler(b.taskHandler)
+	}
 	if verbose {
 		logger.Info("Workspace orchestrator initialized", logger.Fields{})
 	}

--- a/internal/workspace/orchestrator.go
+++ b/internal/workspace/orchestrator.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/store"
@@ -18,9 +17,10 @@ import (
 // Orchestrator manages autonomous task delegation and agent coordination
 type Orchestrator struct {
 	workspaceStore Store
-	agentStore     store.Store // For loading agents and their tools
-	llmProvider    LLMProvider // For intelligent task breakdown
-	eventBus       *EventBus   // For real-time updates
+	agentStore     store.Store  // For loading agents and their tools
+	llmProvider    LLMProvider  // For intelligent task breakdown
+	eventBus       *EventBus    // For real-time updates
+	taskHandler    taskExecutor // For single-task LLM execution (delegated)
 }
 
 // LLMProvider interface for calling AI models
@@ -32,6 +32,14 @@ type LLMProvider interface {
 	ChatWithMessages(ctx context.Context, messages []llm.Message, tools []llm.Tool) (*llm.ChatResponse, error)
 }
 
+// taskExecutor describes the single-task LLM execution surface the orchestrator
+// delegates to. LLMTaskHandler.ExecuteTask satisfies this interface; it owns
+// MCP/workspace tool loading and the multi-turn tool-call loop, so the
+// orchestrator does not duplicate that work.
+type taskExecutor interface {
+	ExecuteTask(ctx context.Context, agentName string, task Task) (string, error)
+}
+
 // NewOrchestrator creates a new orchestrator
 func NewOrchestrator(workspaceStore Store, agentStore store.Store, llmProvider LLMProvider, eventBus *EventBus) *Orchestrator {
 	return &Orchestrator{
@@ -40,6 +48,12 @@ func NewOrchestrator(workspaceStore Store, agentStore store.Store, llmProvider L
 		llmProvider:    llmProvider,
 		eventBus:       eventBus,
 	}
+}
+
+// SetTaskHandler wires the task executor used for single-task LLM execution.
+// Must be called before ExecuteTask, otherwise ExecuteTask returns an error.
+func (o *Orchestrator) SetTaskHandler(h taskExecutor) {
+	o.taskHandler = h
 }
 
 // ExecuteMission starts autonomous execution of a mission
@@ -206,7 +220,10 @@ func (o *Orchestrator) ExecuteTasksSequentially(ctx context.Context, workspaceID
 	})
 }
 
-// ExecuteTask executes a single task by delegating to an agent
+// ExecuteTask executes a single task by delegating to an agent.
+// LLM execution (tool loading, model/provider selection, tool-call loop) is
+// delegated to the LLMTaskHandler wired via SetTaskHandler; the orchestrator
+// owns workspace state, message events, and task lifecycle bookkeeping.
 func (o *Orchestrator) ExecuteTask(ctx context.Context, workspaceID string, task Task) error {
 	logger.Debug("[Orchestrator] Executing task : (assigned to: )", logger.Fields{"task_id": task.ID, "description": task.Description, "to": task.To})
 
@@ -278,8 +295,17 @@ func (o *Orchestrator) ExecuteTask(ctx context.Context, workspaceID string, task
 		"content": message.Content,
 	})
 
-	// Execute task using LLM provider
-	result, err := o.executeTaskWithLLM(ctx, task)
+	// Execute task using the wired task handler. Tool loading (MCP + workspace),
+	// the multi-turn tool-call loop, and provider/model selection all live in
+	// LLMTaskHandler — the orchestrator does not duplicate that work.
+	// A missing handler is treated as a task failure (rather than an early
+	// return) so the workspace state and lifecycle events stay consistent.
+	var result string
+	if o.taskHandler == nil {
+		err = fmt.Errorf("orchestrator: task handler not configured (call SetTaskHandler before ExecuteTask)")
+	} else {
+		result, err = o.taskHandler.ExecuteTask(ctx, task.To, task)
+	}
 
 	completed := time.Now()
 	if err != nil {
@@ -325,147 +351,6 @@ func (o *Orchestrator) ExecuteTask(ctx context.Context, workspaceID string, task
 	})
 
 	return nil
-}
-
-// executeTaskWithLLM executes a task using the LLM provider.
-//
-// TODO: Tool support was lost in commit 672e8a3b ("Remove plugin system entirely
-// in favor of MCP and skills") — the loop that populated `tools` from plugin
-// definitions was removed but never re-implemented for MCP/skills. Tasks routed
-// through this path currently run without their agent's tools. Re-wire tool
-// loading via MCP/skills (see internal/mcp and internal/skills) before relying
-// on this path for tool-using tasks.
-func (o *Orchestrator) executeTaskWithLLM(ctx context.Context, task Task) (string, error) {
-	if o.llmProvider == nil {
-		return "", fmt.Errorf("LLM provider not configured")
-	}
-
-	logger.Debug("[Orchestrator] Executing task with LLM", logger.Fields{"task_id": task.ID, "description": task.Description, "assigned_to": task.To})
-
-	// Resolve the agent. Tools are not loaded here — see the TODO on this
-	// function's doc comment.
-	var tools []llm.Tool
-	var ag *agent.Agent
-	if o.agentStore != nil && task.To != "" {
-		var ok bool
-		ag, ok = o.agentStore.GetAgent(task.To)
-		if ok && ag != nil {
-			logger.Debug("[Orchestrator] Loaded agent", logger.Fields{"agent": task.To})
-		} else {
-			logger.Warn("[Orchestrator] Agent not found, executing without tools", logger.Fields{"agent": task.To})
-		}
-	}
-
-	// Create system prompt with agent role.
-	systemPrompt := fmt.Sprintf(
-		"You are %s, an AI agent in a multi-agent workspace. You have been assigned a task. "+
-			"Please complete the task to the best of your ability and provide a clear result.",
-		task.To,
-	)
-
-	// Build user message with task description and formatted context
-	taskPrompt := fmt.Sprintf("# Task Assignment\n\n%s\n\n", task.Description)
-
-	// Format input task results if available
-	if inputResults, ok := task.Context["input_task_results"]; ok {
-		if resultsMap, ok := inputResults.(map[string]string); ok && len(resultsMap) > 0 {
-			taskPrompt += "## Input from Previous Tasks\n\n"
-			for taskID, result := range resultsMap {
-				taskPrompt += fmt.Sprintf("**Task %s Result:**\n```\n%s\n```\n\n", taskID, result)
-			}
-		}
-	}
-
-	// Include other context fields
-	hasOtherContext := false
-	for key := range task.Context {
-		if key != "input_task_results" {
-			hasOtherContext = true
-			break
-		}
-	}
-
-	if hasOtherContext {
-		taskPrompt += "## Additional Context\n\n"
-		for key, value := range task.Context {
-			if key != "input_task_results" {
-				taskPrompt += fmt.Sprintf("- **%s**: %v\n", key, value)
-			}
-		}
-		taskPrompt += "\n"
-	}
-
-	taskPrompt += "Please complete this task. If you have tools available, use them to accomplish the task rather than providing general information."
-
-	// Call LLM with timeout and tools
-	llmCtx, cancel := context.WithTimeout(ctx, 60*time.Second) // Longer timeout for tool execution
-	defer cancel()
-
-	resp, err := o.llmProvider.ChatWithTools(llmCtx, systemPrompt, taskPrompt, tools)
-	if err != nil {
-		if friendlyMsg := classifyContextError(err); friendlyMsg != "" {
-			return "", fmt.Errorf("%s", friendlyMsg)
-		}
-		return "", fmt.Errorf("LLM call failed: %w", err)
-	}
-
-	// Check if LLM wants to call tools
-	if len(resp.ToolCalls) > 0 && ag != nil {
-		logger.Debug("[Orchestrator] LLM requested tool calls", logger.Fields{"count": len(resp.ToolCalls)})
-		return o.executeToolCallsAndContinue(llmCtx, ag, systemPrompt, taskPrompt, tools, resp)
-	}
-
-	result := resp.Content
-	logger.Info("[Orchestrator] Task completed with result", logger.Fields{"result_length": len(result)})
-
-	return result, nil
-}
-
-// executeToolCallsAndContinue executes tool calls and continues the conversation
-func (o *Orchestrator) executeToolCallsAndContinue(ctx context.Context, ag *agent.Agent, systemPrompt, taskPrompt string, tools []llm.Tool, resp *llm.ChatResponse) (string, error) {
-	maxIterations := 5 // Prevent infinite loops
-	messages := []llm.Message{
-		{Role: "system", Content: systemPrompt},
-		{Role: "user", Content: taskPrompt},
-		{Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls},
-	}
-
-	for iteration := 0; iteration < maxIterations && len(resp.ToolCalls) > 0; iteration++ {
-		logger.Debug("[Orchestrator] Executing tool calls", logger.Fields{"iteration": iteration, "tool_count": len(resp.ToolCalls)})
-
-		// Execute each tool call
-		for _, toolCall := range resp.ToolCalls {
-			toolResult := o.executeToolCall(ctx, ag, toolCall)
-			messages = append(messages, llm.Message{
-				Role:       "tool",
-				Content:    toolResult,
-				ToolCallID: toolCall.ID,
-			})
-			logger.Debug("[Orchestrator] Tool call executed", logger.Fields{"tool": toolCall.Name, "result_length": len(toolResult)})
-		}
-
-		// Continue conversation with tool results using full message history
-		var err error
-		resp, err = o.llmProvider.ChatWithMessages(ctx, messages, tools)
-		if err != nil {
-			return "", fmt.Errorf("LLM continuation failed: %w", err)
-		}
-
-		// Add assistant response to messages
-		messages = append(messages, llm.Message{
-			Role:      "assistant",
-			Content:   resp.Content,
-			ToolCalls: resp.ToolCalls,
-		})
-	}
-
-	return resp.Content, nil
-}
-
-// executeToolCall executes a single tool call and returns the result.
-// Tool execution is handled via MCP; this is a fallback that reports the tool as not found.
-func (o *Orchestrator) executeToolCall(ctx context.Context, ag *agent.Agent, toolCall llm.ToolCall) string {
-	return fmt.Sprintf("Error: Tool '%s' not found (plugins deprecated, use MCP)", toolCall.Name)
 }
 
 // formatAgentCapabilities formats agent list with capabilities.

--- a/internal/workspace/orchestrator_test.go
+++ b/internal/workspace/orchestrator_test.go
@@ -1,0 +1,191 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// orchestratorTestSetup seeds a workspace store with a single workspace that
+// contains the orchestrator + a single test agent and one pending task.
+// Returns the store, the workspace ID, and the seeded task ID.
+func orchestratorTestSetup(t *testing.T) (Store, string, string) {
+	t.Helper()
+	store := newExecutorTestStore(t)
+	ws := NewWorkspace(CreateWorkspaceParams{
+		Name:   "orchestrator-test",
+		Agents: []string{"orchestrator", "agent-a"},
+	})
+	task := Task{
+		ID:          "task-1",
+		To:          "agent-a",
+		Description: "do the thing",
+		Status:      TaskStatusPending,
+	}
+	if err := ws.AddTask(task); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+	return store, ws.ID, task.ID
+}
+
+func TestOrchestrator_ExecuteTask_DelegatesToHandler(t *testing.T) {
+	store, wsID, taskID := orchestratorTestSetup(t)
+	handler := &fakeTaskHandler{}
+
+	o := NewOrchestrator(store, nil, nil, nil)
+	o.SetTaskHandler(handler)
+
+	task := Task{ID: taskID, To: "agent-a", Description: "do the thing"}
+	if err := o.ExecuteTask(context.Background(), wsID, task); err != nil {
+		t.Fatalf("ExecuteTask: %v", err)
+	}
+	if got := handler.calls; got != 1 {
+		t.Fatalf("expected 1 delegation call, got %d", got)
+	}
+	if seen := handler.seenIDs[taskID]; seen != 1 {
+		t.Fatalf("expected handler to see task %q once, saw %d", taskID, seen)
+	}
+
+	// Reload from store and assert the task was marked completed with the result
+	// from the stub.
+	got, err := store.Get(wsID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	final := getTaskOrNil(t, got, taskID)
+	if final == nil {
+		t.Fatalf("task %q missing after ExecuteTask", taskID)
+	}
+	if final.Status != TaskStatusCompleted {
+		t.Fatalf("expected status %q, got %q", TaskStatusCompleted, final.Status)
+	}
+	if final.Result != "ok" {
+		t.Fatalf("expected result %q (from fakeTaskHandler), got %q", "ok", final.Result)
+	}
+}
+
+// erroringTaskHandler returns a fixed error from ExecuteTask.
+type erroringTaskHandler struct{ err error }
+
+func (h *erroringTaskHandler) ExecuteTask(_ context.Context, _ string, _ Task) (string, error) {
+	return "", h.err
+}
+
+func TestOrchestrator_ExecuteTask_PropagatesError(t *testing.T) {
+	store, wsID, taskID := orchestratorTestSetup(t)
+	wantErr := errors.New("boom")
+	handler := &erroringTaskHandler{err: wantErr}
+
+	o := NewOrchestrator(store, nil, nil, nil)
+	o.SetTaskHandler(handler)
+
+	task := Task{ID: taskID, To: "agent-a", Description: "do the thing"}
+	err := o.ExecuteTask(context.Background(), wsID, task)
+	if !errors.Is(err, wantErr) && err != wantErr {
+		// ExecuteTask returns the handler error directly today.
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+
+	got, err := store.Get(wsID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	final := getTaskOrNil(t, got, taskID)
+	if final == nil {
+		t.Fatalf("task %q missing after ExecuteTask", taskID)
+	}
+	if final.Status != TaskStatusFailed {
+		t.Fatalf("expected status %q, got %q", TaskStatusFailed, final.Status)
+	}
+	if !strings.Contains(final.Error, "boom") {
+		t.Fatalf("expected task error to contain 'boom', got %q", final.Error)
+	}
+}
+
+func TestOrchestrator_ExecuteTask_PublishesLifecycleEvents(t *testing.T) {
+	store, wsID, taskID := orchestratorTestSetup(t)
+	bus := NewEventBus(16, 64)
+	handler := &fakeTaskHandler{}
+
+	o := NewOrchestrator(store, nil, nil, bus)
+	o.SetTaskHandler(handler)
+
+	task := Task{ID: taskID, To: "agent-a", Description: "do the thing"}
+	if err := o.ExecuteTask(context.Background(), wsID, task); err != nil {
+		t.Fatalf("ExecuteTask: %v", err)
+	}
+
+	// Pull from event history. EventBus.GetHistory returns events in reverse
+	// chronological order, so we expect the lifecycle in reverse below.
+	hist := bus.GetHistory(nil, 100)
+	wantReversed := []EventType{"task_completed", "message_sent", "task_started"}
+	got := []EventType{}
+	for _, ev := range hist {
+		if slices.Contains(wantReversed, ev.Type) {
+			got = append(got, ev.Type)
+		}
+	}
+	if len(got) != len(wantReversed) {
+		t.Fatalf("expected events %v in reverse-chronological history, got %v (full history: %v)", wantReversed, got, eventTypes(hist))
+	}
+	for i, w := range wantReversed {
+		if got[i] != w {
+			t.Fatalf("event %d: expected %q, got %q (sequence: %v)", i, w, got[i], got)
+		}
+	}
+}
+
+func TestOrchestrator_ExecuteTask_HandlerNil(t *testing.T) {
+	store, wsID, taskID := orchestratorTestSetup(t)
+
+	o := NewOrchestrator(store, nil, nil, nil) // SetTaskHandler intentionally not called
+
+	task := Task{ID: taskID, To: "agent-a", Description: "do the thing"}
+	err := o.ExecuteTask(context.Background(), wsID, task)
+	if err == nil {
+		t.Fatal("expected error when task handler is not configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "task handler not configured") {
+		t.Fatalf("expected error to mention 'task handler not configured', got %q", err.Error())
+	}
+
+	// Task should be marked failed in the store and the failure event should mention the same.
+	got, err := store.Get(wsID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	final := getTaskOrNil(t, got, taskID)
+	if final == nil {
+		t.Fatalf("task %q missing after ExecuteTask", taskID)
+	}
+	if final.Status != TaskStatusFailed {
+		t.Fatalf("expected status %q, got %q", TaskStatusFailed, final.Status)
+	}
+}
+
+func eventTypes(events []Event) []EventType {
+	out := make([]EventType, 0, len(events))
+	for _, ev := range events {
+		out = append(out, ev.Type)
+	}
+	return out
+}
+
+func getTaskOrNil(t *testing.T, ws *Workspace, taskID string) *Task {
+	t.Helper()
+	task, err := ws.GetTask(taskID)
+	if err != nil {
+		return nil
+	}
+	return task
+}
+
+// Compile-time assertion: LLMTaskHandler satisfies the orchestrator's
+// taskExecutor interface. If the signature drifts, this fails to build —
+// catching the regression at compile time rather than runtime.
+var _ taskExecutor = (*LLMTaskHandler)(nil)


### PR DESCRIPTION
## Summary

- Tool support in `Orchestrator.executeTaskWithLLM` was lost in commit 672e8a3b ("Remove plugin system entirely in favor of MCP and skills"). Tasks routed through `Orchestrator.ExecuteTask` have been silently running without their agent's tools since.
- Rather than rebuild tool wiring, this PR delegates single-task LLM execution to the existing `LLMTaskHandler.ExecuteTask`, which already loads MCP + workspace tools and runs the multi-turn tool-call loop.
- Adds a `taskExecutor` interface, `SetTaskHandler` setter, nil-handler guard, and focused tests for delegation, error propagation, lifecycle events, and missing handler configuration.

Driven by [`tasks/prd-orchestrator-tool-support.md`](../blob/fix/orchestrator-tool-support/tasks/prd-orchestrator-tool-support.md).

## Out of scope

`Orchestrator.ExecuteMission` and the `executeResearchPipeline` / `executeResearchWorkflow` / `executeParallelWorkflow` helpers have the same latent regression and are explicitly not touched here. See PRD section 5 for the rationale; a follow-up should extract the delegation pattern from this PR and apply it once those flows are confirmed active.

## Test plan

- [x] `go test ./internal/workspace`
- [x] `go test ./internal/server`
- [x] CI checks passing before branch cleanup; rerun expected after force-push
- [ ] Smoke-test in a running server: assign a workspace task to an agent with at least one MCP server bound, confirm the LLM receives the tools and successfully calls one.
