### PR TITLE
Simplify the task page + migrate result storage to JSONL

### DIFF
--- a/cmd/test-cli/main.go
+++ b/cmd/test-cli/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -58,24 +61,18 @@ func (r *TestRunner) run() {
 		case "2":
 			r.buildServer()
 		case "3":
-			r.buildPlugins()
-		case "4":
 			r.startServer()
-		case "5":
+		case "4":
 			r.stopServer()
-		case "6":
+		case "5":
 			r.runQuickTest()
-		case "7":
-			r.testPlugin()
-		case "8":
-			r.testWorkflow()
-		case "9":
+		case "6":
 			r.runAllTests()
-		case "10":
+		case "7":
 			r.interactiveChat()
-		case "11":
+		case "8":
 			r.viewLogs()
-		case "12":
+		case "9":
 			r.cleanupTestData()
 		case "h", "help":
 			r.printHelp()
@@ -96,20 +93,17 @@ func (r *TestRunner) printMenu() {
 	fmt.Println(colorWhite + "Setup & Environment" + colorReset)
 	fmt.Println("  1. Check environment")
 	fmt.Println("  2. Build server")
-	fmt.Println("  3. Build plugins")
-	fmt.Println("  4. Start server")
-	fmt.Println("  5. Stop server")
+	fmt.Println("  3. Start server")
+	fmt.Println("  4. Stop server")
 	fmt.Println()
 	fmt.Println(colorWhite + "Testing" + colorReset)
-	fmt.Println("  6. Quick test (health check)")
-	fmt.Println("  7. Test specific plugin")
-	fmt.Println("  8. Test workflow")
-	fmt.Println("  9. Run all automated tests")
-	fmt.Println("  10. Interactive chat test")
+	fmt.Println("  5. Quick test (health check)")
+	fmt.Println("  6. Run all automated tests")
+	fmt.Println("  7. Interactive chat test")
 	fmt.Println()
 	fmt.Println(colorWhite + "Utilities" + colorReset)
-	fmt.Println("  11. View logs")
-	fmt.Println("  12. Cleanup test data")
+	fmt.Println("  8. View logs")
+	fmt.Println("  9. Cleanup test data")
 	fmt.Println()
 	fmt.Println("  h. Help    q. Quit")
 	fmt.Println(colorBlue + "═══════════════════════════════════════" + colorReset)
@@ -124,7 +118,6 @@ func (r *TestRunner) checkEnvironment() {
 	}{
 		{"Go installed", r.checkGo},
 		{"Server binary", r.checkServerBinary},
-		{"Plugins built", r.checkPlugins},
 		{"API key set", r.checkAPIKey},
 		{"Port available", r.checkPort},
 	}
@@ -168,21 +161,6 @@ func (r *TestRunner) buildServer() {
 	fmt.Println(colorGreen + "✓ Server built successfully!" + colorReset)
 }
 
-func (r *TestRunner) buildPlugins() {
-	fmt.Println(colorCyan + "\n🔨 Building plugins..." + colorReset)
-
-	cmd := exec.Command("bash", "./scripts/build-plugins.sh")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		fmt.Printf("%s✗ Plugin build failed: %v%s\n", colorRed, err, colorReset)
-		return
-	}
-
-	fmt.Println(colorGreen + "✓ Plugins built successfully!" + colorReset)
-}
-
 func (r *TestRunner) startServer() {
 	if r.serverRunning {
 		fmt.Println(colorYellow + "⚠ Server already running" + colorReset)
@@ -216,17 +194,35 @@ func (r *TestRunner) startServer() {
 		return
 	}
 
-	// Wait for server to be ready
+	// Poll /health until the server is ready (or we give up).
 	fmt.Print("Waiting for server to start")
-	for i := 0; i < 20; i++ {
-		time.Sleep(500 * time.Millisecond)
+	healthURL := fmt.Sprintf("%s/health", r.serverURL)
+	client := &http.Client{Timeout: 1 * time.Second}
+	const maxAttempts = 40 // 40 * 250ms = 10s
+	ready := false
+	for range maxAttempts {
+		time.Sleep(250 * time.Millisecond)
 		fmt.Print(".")
-		// TODO: Check if server is actually ready via health check
+		resp, err := client.Get(healthURL)
+		if err != nil {
+			continue
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			ready = true
+			break
+		}
 	}
 	fmt.Println()
 
+	if !ready {
+		fmt.Printf("%s✗ Server did not become ready within 10s. See test-server.log%s\n", colorRed, colorReset)
+		_ = cmd.Process.Kill()
+		return
+	}
+
 	r.serverRunning = true
-	fmt.Printf("%s✓ Server started on http://localhost:%s%s\n", colorGreen, port, colorReset)
+	fmt.Printf("%s✓ Server started on %s%s\n", colorGreen, r.serverURL, colorReset)
 	fmt.Println("  Logs: test-server.log")
 }
 
@@ -255,7 +251,7 @@ func (r *TestRunner) runQuickTest() {
 	fmt.Println(colorCyan + "\n⚡ Running quick test..." + colorReset)
 
 	if !r.serverRunning {
-		fmt.Println(colorYellow + "⚠ Server not running. Start it first (option 4)" + colorReset)
+		fmt.Println(colorYellow + "⚠ Server not running. Start it first (option 3)" + colorReset)
 		return
 	}
 
@@ -276,41 +272,6 @@ func (r *TestRunner) runQuickTest() {
 	} else {
 		fmt.Printf(colorRed+"✗ Health check failed: HTTP %d\n"+colorReset, resp.StatusCode)
 	}
-}
-
-func (r *TestRunner) testPlugin() {
-	fmt.Println(colorCyan + "\n🔌 Plugin Test" + colorReset)
-
-	if !r.serverRunning {
-		fmt.Println(colorYellow + "⚠ Server not running. Start it first (option 4)" + colorReset)
-		return
-	}
-
-	// List available plugins
-	fmt.Println("\nAvailable plugins:")
-	plugins := []string{"math", "weather", "result-handler"}
-	for i, p := range plugins {
-		fmt.Printf("  %d. %s\n", i+1, p)
-	}
-
-	_ = r.prompt("\nSelect plugin number")
-	// TODO: Implement plugin testing
-
-	fmt.Println(colorGreen + "✓ Plugin test completed" + colorReset)
-}
-
-func (r *TestRunner) testWorkflow() {
-	fmt.Println(colorCyan + "\n🔄 Workflow Test" + colorReset)
-
-	fmt.Println("\nAvailable workflows:")
-	fmt.Println("  1. Create agent → Enable plugin → Chat")
-	fmt.Println("  2. Multi-agent collaboration")
-	fmt.Println("  3. Error recovery")
-
-	_ = r.prompt("\nSelect workflow number")
-	// TODO: Implement workflow testing
-
-	fmt.Println(colorGreen + "✓ Workflow test completed" + colorReset)
 }
 
 func (r *TestRunner) runAllTests() {
@@ -340,18 +301,27 @@ func (r *TestRunner) interactiveChat() {
 	fmt.Println(colorCyan + "\n💬 Interactive Chat Test" + colorReset)
 
 	if !r.serverRunning {
-		fmt.Println(colorYellow + "⚠ Server not running. Start it first (option 4)" + colorReset)
+		fmt.Println(colorYellow + "⚠ Server not running. Start it first (option 3)" + colorReset)
 		return
 	}
 
 	agentName := r.prompt("Agent name")
-	_ = r.prompt("Model (default: gpt-4o)") // Model selection not yet implemented
+	if agentName == "" {
+		fmt.Println(colorRed + "✗ Agent name required" + colorReset)
+		return
+	}
+	model := r.prompt("Model (default: gpt-4o)")
+	if model == "" {
+		model = "gpt-4o"
+	}
 
 	fmt.Printf("\n%sCreating agent '%s'...%s\n", colorCyan, agentName, colorReset)
-	// TODO: Create agent via API
+	if err := r.apiCreateAgent(agentName, model); err != nil {
+		fmt.Printf("%s✗ Failed to create agent: %v%s\n", colorRed, err, colorReset)
+		return
+	}
 
 	r.agents = append(r.agents, agentName)
-
 	fmt.Println(colorGreen + "✓ Agent created!" + colorReset)
 	fmt.Println("\nType messages (or 'exit' to return to menu):")
 
@@ -360,10 +330,99 @@ func (r *TestRunner) interactiveChat() {
 		if msg == "exit" {
 			break
 		}
+		if msg == "" {
+			continue
+		}
 
-		// TODO: Send message to agent
-		fmt.Printf("%s%s:%s Mock response to: %s\n", colorCyan, agentName, colorReset, msg)
+		reply, err := r.apiSendChat(agentName, msg)
+		if err != nil {
+			fmt.Printf("%s✗ Chat failed: %v%s\n", colorRed, err, colorReset)
+			continue
+		}
+		fmt.Printf("%s%s:%s %s\n", colorCyan, agentName, colorReset, reply)
 	}
+}
+
+// apiCreateAgent creates an agent via POST /api/agents.
+// The server defaults missing fields (provider, system prompt, etc.) based on
+// global settings, so we only send the minimum needed to drive a chat round.
+func (r *TestRunner) apiCreateAgent(name, model string) error {
+	body, err := json.Marshal(map[string]any{
+		"name":        name,
+		"type":        "tool-calling",
+		"model":       model,
+		"description": "Created by test-cli",
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, r.serverURL+"/api/agents", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+	}
+	return nil
+}
+
+// apiSendChat posts a chat turn to /api/chat and returns the reply text.
+// We only surface the "response" field; the chat API returns extra metadata
+// (route info, action plans, etc.) that the CLI doesn't need to render.
+func (r *TestRunner) apiSendChat(agentName, message string) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"question":   message,
+		"agent_name": agentName,
+	})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest(http.MethodPost, r.serverURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+	}
+
+	var payload struct {
+		Response string `json:"response"`
+		Error    string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if payload.Error != "" {
+		return "", fmt.Errorf("%s", payload.Error)
+	}
+	return payload.Response, nil
+}
+
+func readErrorBody(body io.Reader) string {
+	const maxBytes = 512
+	buf, err := io.ReadAll(io.LimitReader(body, maxBytes))
+	if err != nil {
+		return "(failed to read body)"
+	}
+	return strings.TrimSpace(string(buf))
 }
 
 func (r *TestRunner) viewLogs() {
@@ -389,16 +448,46 @@ func (r *TestRunner) cleanupTestData() {
 		return
 	}
 
-	// Delete test agents
+	// Delete test agents via API. Skip silently when the server is offline,
+	// since cleanup is also useful as a "remove the log file" command.
+	remaining := make([]string, 0, len(r.agents))
 	for _, agent := range r.agents {
 		fmt.Printf("  Deleting agent: %s\n", agent)
-		// TODO: Delete via API
+		if !r.serverRunning {
+			fmt.Printf("    %s⚠ Server not running; agent record left in place%s\n", colorYellow, colorReset)
+			remaining = append(remaining, agent)
+			continue
+		}
+		if err := r.apiDeleteAgent(agent); err != nil {
+			fmt.Printf("    %s✗ %v%s\n", colorRed, err, colorReset)
+			remaining = append(remaining, agent)
+		}
 	}
+	r.agents = remaining
 
 	// Delete logs
 	_ = os.Remove("test-server.log")
 
 	fmt.Println(colorGreen + "✓ Cleanup complete" + colorReset)
+}
+
+// apiDeleteAgent removes an agent via DELETE /api/agents?name=...
+func (r *TestRunner) apiDeleteAgent(name string) error {
+	target := fmt.Sprintf("%s/api/agents?name=%s", r.serverURL, url.QueryEscape(name))
+	req, err := http.NewRequest(http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+	}
+	return nil
 }
 
 func (r *TestRunner) printHelp() {
@@ -407,22 +496,20 @@ func (r *TestRunner) printHelp() {
 
 Typical workflow:
   1. Check environment (option 1)
-  2. Build server & plugins (options 2-3)
-  3. Start server (option 4)
-  4. Run tests (options 6-10)
-  5. Stop server (option 5)
+  2. Build server (option 2)
+  3. Start server (option 3)
+  4. Run tests (options 5-7)
+  5. Stop server (option 4)
 
 Test Types:
   - Quick Test: Simple health check
-  - Plugin Test: Test specific plugin functionality
-  - Workflow Test: End-to-end user scenarios
-  - All Tests: Run full automated test suite
-  - Interactive Chat: Manual testing via CLI
+  - All Tests: Run full automated test suite (tests/user/...)
+  - Interactive Chat: Create an agent and chat with it via the HTTP API
 
 Tips:
   - Set OPENAI_API_KEY or ANTHROPIC_API_KEY before testing
-  - View logs (option 11) if tests fail
-  - Clean up (option 12) between test runs`)
+  - View logs (option 8) if tests fail
+  - Clean up (option 9) between test runs to remove test agents`)
 }
 
 // Helper functions
@@ -442,58 +529,6 @@ func (r *TestRunner) checkServerBinary() (bool, string) {
 		return false, "Run 'make build' or option 2"
 	}
 	return true, path
-}
-
-func (r *TestRunner) checkPlugins() (bool, string) {
-	// Check built-in plugins
-	builtInPlugins := []string{"math", "weather"}
-	builtInFound := 0
-
-	for _, p := range builtInPlugins {
-		path := filepath.Join("plugins", p, p)
-		if _, err := os.Stat(path); err == nil {
-			builtInFound++
-		}
-	}
-
-	// Check shared plugins (../plugins)
-	sharedPlugins := []string{
-		"ori-music-project-manager",
-		"ori-reaper",
-		"ori-mac-os-tools",
-		"ori-meta-threads-manager",
-		"ori-agent-doc-builder",
-	}
-	sharedFound := 0
-
-	for _, p := range sharedPlugins {
-		// Check multiple possible locations
-		paths := []string{
-			filepath.Join("..", "plugins", p, p),
-			filepath.Join("uploaded_plugins", p),
-		}
-
-		for _, path := range paths {
-			if _, err := os.Stat(path); err == nil {
-				sharedFound++
-				break
-			}
-		}
-	}
-
-	totalPlugins := len(builtInPlugins) + len(sharedPlugins)
-	totalFound := builtInFound + sharedFound
-
-	if totalFound == 0 {
-		return false, "Run './scripts/build-plugins.sh' or './scripts/build-external-plugins.sh'"
-	}
-
-	status := fmt.Sprintf("%d/%d total (built-in: %d/%d, shared: %d/%d)",
-		totalFound, totalPlugins,
-		builtInFound, len(builtInPlugins),
-		sharedFound, len(sharedPlugins))
-
-	return totalFound > 0, status
 }
 
 func (r *TestRunner) checkAPIKey() (bool, string) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,7 @@ export default defineConfig([
       'internal/web/static/js/modules/dashboard-tasks.js',
       'internal/web/static/js/modules/dashboard-ui.js',
       'internal/web/static/js/modules/note-ai-assist.js',
+      'internal/web/static/js/modules/note-ai-assist.test.js',
       'internal/web/static/js/modules/note-backlinks.js',
       'internal/web/static/js/modules/note-backlinks.test.js',
       'internal/web/static/js/modules/note-editor.js',

--- a/internal/chathttp/agent_runtime.go
+++ b/internal/chathttp/agent_runtime.go
@@ -44,7 +44,7 @@ func (h *Handler) resolveEffectiveAgent(agentName string, routeCtx normalizedCha
 		}
 		baseAgent = cloneAgentForChat(baseAgent)
 		result := &resolvedChatAgent{Agent: baseAgent}
-		h.attachWorkspaceTools(result, routeCtx.WorkspaceID)
+		h.attachWorkspaceTools(result, routeCtx)
 		return result, nil
 	}
 
@@ -57,7 +57,7 @@ func (h *Handler) resolveEffectiveAgent(agentName string, routeCtx normalizedCha
 		if len(resolved.EffectiveSkills) > 0 {
 			result.EffectiveSkills = append([]workspace.ResolvedSkill{}, resolved.EffectiveSkills...)
 		}
-		h.attachWorkspaceTools(result, routeCtx.WorkspaceID)
+		h.attachWorkspaceTools(result, routeCtx)
 		return result, nil
 	}
 
@@ -75,15 +75,16 @@ func (h *Handler) resolveEffectiveAgent(agentName string, routeCtx normalizedCha
 	baseAgent = cloneAgentForChat(baseAgent)
 
 	result := &resolvedChatAgent{Agent: baseAgent}
-	h.attachWorkspaceTools(result, routeCtx.WorkspaceID)
+	h.attachWorkspaceTools(result, routeCtx)
 	return result, nil
 }
 
 // attachWorkspaceTools adds workspace-scoped tools to a resolved agent when
 // the necessary stores are available. This must be called on every code path
 // that returns a resolvedChatAgent for a workspace surface.
-func (h *Handler) attachWorkspaceTools(ag *resolvedChatAgent, workspaceID string) {
-	if h.sessionStore == nil || h.workspaceStore == nil || strings.TrimSpace(workspaceID) == "" {
+func (h *Handler) attachWorkspaceTools(ag *resolvedChatAgent, routeCtx normalizedChatRouteContext) {
+	workspaceID := strings.TrimSpace(routeCtx.WorkspaceID)
+	if h.sessionStore == nil || h.workspaceStore == nil || workspaceID == "" {
 		logger.Debug("attachWorkspaceTools: skipping", logger.Fields{
 			"workspace_id":    workspaceID,
 			"session_store":   h.sessionStore != nil,
@@ -94,6 +95,9 @@ func (h *Handler) attachWorkspaceTools(ag *resolvedChatAgent, workspaceID string
 	wtp := NewWorkspaceToolProvider(h.sessionStore, h.workspaceStore, workspaceID)
 	if h.fileStore != nil {
 		wtp.SetFileStore(h.fileStore)
+	}
+	if taskID := strings.TrimSpace(routeCtx.TaskID); taskID != "" {
+		wtp.SetTaskID(taskID)
 	}
 	if h.store != nil || h.mcpRegistry != nil || h.skillsManager != nil {
 		var mcpLister mcpServerLister
@@ -109,6 +113,7 @@ func (h *Handler) attachWorkspaceTools(ag *resolvedChatAgent, workspaceID string
 	ag.WorkspaceTools = wtp
 	logger.Info("attachWorkspaceTools: attached workspace tools", logger.Fields{
 		"workspace_id": workspaceID,
+		"task_id":      routeCtx.TaskID,
 		"tool_count":   len(wtp.Tools()),
 	})
 }

--- a/internal/chathttp/route_context_prompt.go
+++ b/internal/chathttp/route_context_prompt.go
@@ -9,6 +9,7 @@ type chatRouteContext struct {
 	Surface     string `json:"surface,omitempty"`
 	PagePath    string `json:"page_path,omitempty"`
 	WorkspaceID string `json:"workspace_id,omitempty"`
+	TaskID      string `json:"task_id,omitempty"`
 	Origin      string `json:"origin,omitempty"`
 }
 
@@ -16,12 +17,14 @@ type normalizedChatRouteContext struct {
 	Surface     string
 	PagePath    string
 	WorkspaceID string
+	TaskID      string
 	Origin      string
 }
 
 const (
 	maxRouteContextPagePathLen    = 256
 	maxRouteContextWorkspaceIDLen = 128
+	maxRouteContextTaskIDLen      = 128
 	maxRouteContextOriginLen      = 96
 	maxRouteContextSurfaceLen     = 32
 )
@@ -30,6 +33,7 @@ var allowedRouteSurfaces = map[string]struct{}{
 	"workspace_detail": {},
 	"workspace_canvas": {},
 	"workspace_chat":   {},
+	"workspace_task":   {},
 	"workspace_hub":    {},
 	"dashboard":        {},
 	"chat":             {},
@@ -44,6 +48,10 @@ func normalizeChatRouteContext(input *chatRouteContext) normalizedChatRouteConte
 	workspaceID := sanitizeRouteContextIdentifier(input.WorkspaceID, maxRouteContextWorkspaceIDLen)
 	if workspaceID == "" {
 		workspaceID = sanitizeRouteContextIdentifier(extractWorkspaceIDFromPagePath(pagePath), maxRouteContextWorkspaceIDLen)
+	}
+	taskID := sanitizeRouteContextIdentifier(input.TaskID, maxRouteContextTaskIDLen)
+	if taskID == "" {
+		taskID = sanitizeRouteContextIdentifier(extractTaskIDFromPagePath(pagePath), maxRouteContextTaskIDLen)
 	}
 	if pagePath == "" && workspaceID != "" {
 		pagePath = "/workspaces/" + workspaceID
@@ -63,6 +71,7 @@ func normalizeChatRouteContext(input *chatRouteContext) normalizedChatRouteConte
 		Surface:     surface,
 		PagePath:    pagePath,
 		WorkspaceID: workspaceID,
+		TaskID:      taskID,
 		Origin:      sanitizeRouteContextOrigin(input.Origin),
 	}
 }
@@ -78,6 +87,9 @@ func inferChatRouteSurface(pathname, workspaceID string) string {
 	if strings.HasPrefix(path, "/workspaces/") {
 		if strings.Contains(path, "/canvas") {
 			return "workspace_canvas"
+		}
+		if strings.Contains(path, "/task/") || strings.Contains(path, "/tasks/") {
+			return "workspace_task"
 		}
 		return "workspace_detail"
 	}
@@ -116,6 +128,36 @@ func extractWorkspaceIDFromPagePath(pathname string) string {
 	return strings.TrimSpace(rest)
 }
 
+// extractTaskIDFromPagePath extracts the task ID from a workspace task page
+// URL like /workspaces/{ws}/task/{taskId} or /workspaces/{ws}/tasks/{taskId}.
+func extractTaskIDFromPagePath(pathname string) string {
+	path := strings.TrimSpace(pathname)
+	if path == "" {
+		return ""
+	}
+	lower := strings.ToLower(path)
+	prefix := "/workspaces/"
+	if !strings.HasPrefix(lower, prefix) {
+		return ""
+	}
+	rest := path[len(prefix):]
+	idx := strings.Index(rest, "/")
+	if idx < 0 {
+		return ""
+	}
+	rest = rest[idx+1:]
+	for _, seg := range []string{"task/", "tasks/"} {
+		if strings.HasPrefix(strings.ToLower(rest), seg) {
+			rest = rest[len(seg):]
+			if endIdx := strings.Index(rest, "/"); endIdx >= 0 {
+				rest = rest[:endIdx]
+			}
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
+
 func buildRouteContextSystemPrompt(ctx normalizedChatRouteContext) string {
 	if strings.TrimSpace(ctx.Surface) == "" && strings.TrimSpace(ctx.WorkspaceID) == "" {
 		return ""
@@ -126,6 +168,12 @@ func buildRouteContextSystemPrompt(ctx normalizedChatRouteContext) string {
 	}
 
 	switch ctx.Surface {
+	case "workspace_task":
+		lines = append(lines,
+			"Primary mode: task-focused assistance.",
+			"Stay focused on the active task identified below. Use current_task and task_runs tools to inspect its details and run history before suggesting changes.",
+			"Only branch into broader workspace topics when explicitly asked.",
+		)
 	case "workspace_detail", "workspace_canvas", "workspace_chat":
 		lines = append(lines,
 			"Primary mode: workspace-focused assistance.",
@@ -157,6 +205,9 @@ func buildRouteContextSystemPrompt(ctx normalizedChatRouteContext) string {
 
 	if strings.TrimSpace(ctx.WorkspaceID) != "" {
 		lines = append(lines, fmt.Sprintf("Active workspace_id: %q", ctx.WorkspaceID))
+	}
+	if strings.TrimSpace(ctx.TaskID) != "" {
+		lines = append(lines, fmt.Sprintf("Active task_id: %q", ctx.TaskID))
 	}
 	if strings.TrimSpace(ctx.PagePath) != "" {
 		lines = append(lines, fmt.Sprintf("Page path: %q", ctx.PagePath))

--- a/internal/chathttp/workspace_context_prompt.go
+++ b/internal/chathttp/workspace_context_prompt.go
@@ -27,9 +27,11 @@ const (
 	workspaceSnapshotMaxFiles       = 5
 	workspaceSnapshotMaxDirectories = 5
 	workspaceSnapshotMaxSessions    = 5
+	workspaceSnapshotMaxTaskRuns    = 5
 	workspaceSnapshotTextLimit      = 120
 	workspaceSnapshotPreviewLimit   = 160
 	workspaceSnapshotPathLimit      = 180
+	workspaceSnapshotResultLimit    = 600
 )
 
 func (h *Handler) buildRuntimeSystemPrompt(ctx context.Context, routeCtx normalizedChatRouteContext) string {
@@ -58,13 +60,19 @@ func buildWorkspaceRuntimeSystemPromptForToolCapability(
 ) string {
 	routePrompt := buildRouteContextSystemPrompt(routeCtx)
 	workspacePrompt := buildWorkspaceSnapshotPromptForToolCapability(ctx, routeCtx, workspaceStore, sessionStore, toolCallable)
-	if workspacePrompt == "" {
-		return routePrompt
+	taskPrompt := buildTaskSnapshotPrompt(routeCtx, workspaceStore)
+
+	parts := []string{}
+	if strings.TrimSpace(routePrompt) != "" {
+		parts = append(parts, routePrompt)
 	}
-	if strings.TrimSpace(routePrompt) == "" {
-		return workspacePrompt
+	if strings.TrimSpace(workspacePrompt) != "" {
+		parts = append(parts, workspacePrompt)
 	}
-	return routePrompt + "\n\n---\n" + workspacePrompt
+	if strings.TrimSpace(taskPrompt) != "" {
+		parts = append(parts, taskPrompt)
+	}
+	return strings.Join(parts, "\n\n---\n")
 }
 
 func buildWorkspaceSnapshotPrompt(
@@ -269,11 +277,111 @@ func shouldAttachWorkspaceSnapshot(routeCtx normalizedChatRouteContext) bool {
 		return false
 	}
 	switch routeCtx.Surface {
-	case "workspace_detail", "workspace_canvas", "workspace_chat":
+	case "workspace_detail", "workspace_canvas", "workspace_chat", "workspace_task":
 		return true
 	default:
 		return false
 	}
+}
+
+func shouldAttachTaskSnapshot(routeCtx normalizedChatRouteContext) bool {
+	if routeCtx.Surface != "workspace_task" {
+		return false
+	}
+	return strings.TrimSpace(routeCtx.WorkspaceID) != "" && strings.TrimSpace(routeCtx.TaskID) != ""
+}
+
+// buildTaskSnapshotPrompt emits a "# Current Task" block describing the task
+// identified by routeCtx.TaskID, including recent run history. Returns "" if
+// the task can't be found or the route surface isn't workspace_task.
+func buildTaskSnapshotPrompt(
+	routeCtx normalizedChatRouteContext,
+	workspaceStore workspaceSnapshotWorkspaceStore,
+) string {
+	if !shouldAttachTaskSnapshot(routeCtx) || workspaceStore == nil {
+		return ""
+	}
+	ws, err := workspaceStore.Get(routeCtx.WorkspaceID)
+	if err != nil || ws == nil {
+		return ""
+	}
+	var task *workspace.Task
+	for i := range ws.Tasks {
+		if ws.Tasks[i].ID == routeCtx.TaskID {
+			task = &ws.Tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return ""
+	}
+
+	lines := []string{
+		"# Current Task",
+		"This chat is scoped to a single task. Use the active task as the default subject for any user request that doesn't name another target.",
+		"",
+		"Task:",
+		fmt.Sprintf("- ID: %q", sanitizeWorkspaceSnapshotText(task.ID, workspaceSnapshotTextLimit)),
+		fmt.Sprintf("- Description: %q", sanitizeWorkspaceSnapshotText(task.Description, workspaceSnapshotPreviewLimit)),
+		fmt.Sprintf("- Status: %q", sanitizeWorkspaceSnapshotText(string(task.Status), workspaceSnapshotTextLimit)),
+		fmt.Sprintf("- Assigned to: %q", sanitizeWorkspaceTaskAssignee(*task)),
+	}
+	if task.Priority != 0 {
+		lines = append(lines, fmt.Sprintf("- Priority: %d", task.Priority))
+	}
+	if details := sanitizeWorkspaceSnapshotText(task.Details, workspaceSnapshotPreviewLimit); details != "" {
+		lines = append(lines, fmt.Sprintf("- Details: %q", details))
+	}
+	if !task.CreatedAt.IsZero() {
+		lines = append(lines, fmt.Sprintf("- Created at: %q", formatWorkspaceSnapshotTime(task.CreatedAt)))
+	}
+	if task.StartedAt != nil && !task.StartedAt.IsZero() {
+		lines = append(lines, fmt.Sprintf("- Started at: %q", formatWorkspaceSnapshotTime(*task.StartedAt)))
+	}
+	if task.CompletedAt != nil && !task.CompletedAt.IsZero() {
+		lines = append(lines, fmt.Sprintf("- Completed at: %q", formatWorkspaceSnapshotTime(*task.CompletedAt)))
+	}
+	if result := sanitizeWorkspaceSnapshotText(task.Result, workspaceSnapshotResultLimit); result != "" {
+		lines = append(lines, fmt.Sprintf("- Latest result (truncated): %q", result))
+	}
+	if taskErr := sanitizeWorkspaceSnapshotText(task.Error, workspaceSnapshotResultLimit); taskErr != "" {
+		lines = append(lines, fmt.Sprintf("- Latest error (truncated): %q", taskErr))
+	}
+	if task.ScheduleEnabled && task.Schedule != nil {
+		lines = append(lines, fmt.Sprintf("- Schedule: enabled (executions=%d, failures=%d)", task.ExecutionCount, task.FailureCount))
+	}
+	if task.CurrentRunID != "" {
+		lines = append(lines, fmt.Sprintf("- Current run ID: %q", sanitizeWorkspaceSnapshotText(task.CurrentRunID, workspaceSnapshotTextLimit)))
+	}
+
+	runs := task.ExecutionHistory
+	if len(runs) > 0 {
+		lines = append(lines, "", fmt.Sprintf("Recent runs (showing up to %d of %d):", workspaceSnapshotMaxTaskRuns, len(runs)))
+		start := 0
+		if len(runs) > workspaceSnapshotMaxTaskRuns {
+			start = len(runs) - workspaceSnapshotMaxTaskRuns
+		}
+		for _, run := range runs[start:] {
+			summary := sanitizeWorkspaceSnapshotText(run.Summary, workspaceSnapshotPreviewLimit)
+			if summary == "" {
+				summary = sanitizeWorkspaceSnapshotText(run.Result, workspaceSnapshotPreviewLimit)
+			}
+			lines = append(lines, fmt.Sprintf(
+				"- Run: executed_at=%q status=%q duration_ms=%d summary=%q",
+				formatWorkspaceSnapshotTime(run.ExecutedAt),
+				sanitizeWorkspaceSnapshotText(run.Status, workspaceSnapshotTextLimit),
+				run.Duration,
+				summary,
+			))
+		}
+	}
+
+	lines = append(lines,
+		"",
+		"Use current_task and task_runs tools to fetch additional task detail or full result/error bodies before suggesting destructive changes.",
+	)
+
+	return strings.Join(lines, "\n")
 }
 
 type workspaceAgentSummary struct {

--- a/internal/chathttp/workspace_tools.go
+++ b/internal/chathttp/workspace_tools.go
@@ -27,6 +27,10 @@ type WorkspaceToolProvider struct {
 	fileStore      *workspace.FileStore // Optional: for syncing notes to disk
 	workspaceID    string
 
+	// taskID, when set, marks this chat as scoped to a single task and
+	// enables the current_task / task_runs tools.
+	taskID string
+
 	// Optional dependencies for management tools (Phase 2)
 	agentStore    store.Store
 	mcpRegistry   mcpServerLister
@@ -57,6 +61,12 @@ func (p *WorkspaceToolProvider) SetFileStore(fs *workspace.FileStore) {
 	p.fileStore = fs
 }
 
+// SetTaskID scopes the provider to a single task and enables the
+// current_task / task_runs tools.
+func (p *WorkspaceToolProvider) SetTaskID(taskID string) {
+	p.taskID = strings.TrimSpace(taskID)
+}
+
 // SetManagementDeps sets optional dependencies needed for management tools.
 func (p *WorkspaceToolProvider) SetManagementDeps(agentStore store.Store, mcpReg mcpServerLister, skillsMgr skillLister) {
 	p.agentStore = agentStore
@@ -77,6 +87,11 @@ func (p *WorkspaceToolProvider) Tools() []toolapi.Tool {
 		p.readDirectoriesTool(),
 	}
 
+	// Task-scoped tools (only when the chat is bound to a specific task)
+	if p.taskID != "" {
+		tools = append(tools, p.currentTaskTool(), p.taskRunsTool())
+	}
+
 	// Phase 2: Management tools (only when dependencies are available)
 	if p.agentStore != nil {
 		tools = append(tools, p.manageAgentsTool())
@@ -89,6 +104,179 @@ func (p *WorkspaceToolProvider) Tools() []toolapi.Tool {
 	}
 
 	return tools
+}
+
+// --- current_task (read) ---
+
+func (p *WorkspaceToolProvider) currentTaskTool() toolapi.Tool {
+	return &nativeUtilityTool{
+		definition: toolapi.ToolDefinition{
+			Name:        "current_task",
+			Description: "Read the full record of the task this chat is scoped to. Returns description, status, assignee, latest result, error, schedule, and identifiers.",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		call: func(ctx context.Context, args string) (string, error) {
+			ws, err := p.workspaceStore.Get(p.workspaceID)
+			if err != nil {
+				return "", fmt.Errorf("workspace not found: %w", err)
+			}
+			for _, t := range ws.Tasks {
+				if t.ID != p.taskID {
+					continue
+				}
+				out := map[string]any{
+					"id":             t.ID,
+					"workspace_id":   t.WorkspaceID,
+					"description":    t.Description,
+					"status":         string(t.Status),
+					"assigned_to":    t.To,
+					"priority":       t.Priority,
+					"created_at":     t.CreatedAt.Format(time.RFC3339),
+					"execution_mode": string(t.ExecutionMode),
+				}
+				if t.Details != "" {
+					out["details"] = t.Details
+				}
+				if t.Result != "" {
+					out["result"] = t.Result
+				}
+				if t.Error != "" {
+					out["error"] = t.Error
+				}
+				if t.StartedAt != nil {
+					out["started_at"] = t.StartedAt.Format(time.RFC3339)
+				}
+				if t.CompletedAt != nil {
+					out["completed_at"] = t.CompletedAt.Format(time.RFC3339)
+				}
+				if t.CurrentRunID != "" {
+					out["current_run_id"] = t.CurrentRunID
+				}
+				if t.ParentTaskID != "" {
+					out["parent_task_id"] = t.ParentTaskID
+				}
+				if t.AssignedNodeID != "" {
+					out["assigned_node_id"] = t.AssignedNodeID
+				}
+				if t.ScheduleEnabled {
+					out["schedule_enabled"] = true
+					out["execution_count"] = t.ExecutionCount
+					out["failure_count"] = t.FailureCount
+					if t.NextRun != nil {
+						out["next_run"] = t.NextRun.Format(time.RFC3339)
+					}
+					if t.LastRun != nil {
+						out["last_run"] = t.LastRun.Format(time.RFC3339)
+					}
+				}
+				if t.ResultStorage != nil {
+					out["result_storage"] = t.ResultStorage
+				}
+				return marshalToolResponse(out)
+			}
+			return marshalToolResponse(map[string]any{
+				"task_found": false,
+				"task_id":    p.taskID,
+				"message":    "Task not found in this workspace.",
+			})
+		},
+	}
+}
+
+// --- task_runs (read) ---
+
+func (p *WorkspaceToolProvider) taskRunsTool() toolapi.Tool {
+	return &nativeUtilityTool{
+		definition: toolapi.ToolDefinition{
+			Name:        "task_runs",
+			Description: "List recorded runs (execution history) for the active task. Returns each run's status, summary, full result/error, duration, and timestamp.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Optional. Cap the number of most-recent runs returned. Defaults to 20.",
+					},
+					"status": map[string]any{
+						"type":        "string",
+						"description": "Optional. Filter by run status: success, failed, blocked.",
+					},
+				},
+			},
+		},
+		call: func(ctx context.Context, args string) (string, error) {
+			var req struct {
+				Limit  int    `json:"limit"`
+				Status string `json:"status"`
+			}
+			if strings.TrimSpace(args) != "" {
+				if err := json.Unmarshal([]byte(args), &req); err != nil {
+					return "", fmt.Errorf("invalid arguments: %w", err)
+				}
+			}
+			if req.Limit <= 0 {
+				req.Limit = 20
+			}
+
+			ws, err := p.workspaceStore.Get(p.workspaceID)
+			if err != nil {
+				return "", fmt.Errorf("workspace not found: %w", err)
+			}
+			for _, t := range ws.Tasks {
+				if t.ID != p.taskID {
+					continue
+				}
+				runs := t.ExecutionHistory
+				if req.Status != "" {
+					filtered := make([]workspace.TaskExecution, 0, len(runs))
+					for _, run := range runs {
+						if strings.EqualFold(run.Status, req.Status) {
+							filtered = append(filtered, run)
+						}
+					}
+					runs = filtered
+				}
+				if len(runs) > req.Limit {
+					runs = runs[len(runs)-req.Limit:]
+				}
+				items := make([]map[string]any, 0, len(runs))
+				for _, run := range runs {
+					item := map[string]any{
+						"executed_at": run.ExecutedAt.Format(time.RFC3339),
+						"status":      run.Status,
+						"duration_ms": run.Duration,
+					}
+					if run.RunID != "" {
+						item["run_id"] = run.RunID
+					}
+					if run.Summary != "" {
+						item["summary"] = run.Summary
+					}
+					if run.Result != "" {
+						item["result"] = run.Result
+					}
+					if run.Error != "" {
+						item["error"] = run.Error
+					}
+					items = append(items, item)
+				}
+				return marshalToolResponse(map[string]any{
+					"task_id":    p.taskID,
+					"total_runs": len(t.ExecutionHistory),
+					"returned":   len(items),
+					"runs":       items,
+				})
+			}
+			return marshalToolResponse(map[string]any{
+				"task_found": false,
+				"task_id":    p.taskID,
+				"runs":       []any{},
+			})
+		},
+	}
 }
 
 // --- workspace_notes (read) ---

--- a/internal/orchestrationhttp/task_handler.go
+++ b/internal/orchestrationhttp/task_handler.go
@@ -2068,9 +2068,16 @@ func appendApprovedTaskCSV(store workspace.Store, ws *workspace.Workspace, task 
 		return fmt.Errorf("approved CSV is empty")
 	}
 
+	// The dataset is JSONL; convert the approved CSV to JSONL records and append
+	// those so the approve-held-run path writes the same .jsonl as the executor.
+	jsonlData, err := workspace.CSVToJSONL(csvData)
+	if err != nil {
+		return err
+	}
+
 	storeFilePath := storage.FilePath
 	if strings.TrimSpace(storeFilePath) == "" {
-		storeFilePath = workspace.AppendCSVFileName(task, storage)
+		storeFilePath = workspace.AppendJSONLFileName(task, storage)
 	}
 
 	if strings.TrimSpace(storage.StoreNodeID) != "" {
@@ -2086,14 +2093,10 @@ func appendApprovedTaskCSV(store workspace.Store, ws *workspace.Workspace, task 
 		}
 		storeNodeCopy := *storeNode
 		storeNodeCopy.WriteMode = "append"
-		storeNodeCopy.Format = "csv"
-		dataToStore := csvData
-		strictData, err := workspace.CSVWithoutHeaderForExistingStoreStrictInWorkspace(&storeNodeCopy, store, ws.ID, storeFilePath, dataToStore)
-		if err != nil {
-			return err
-		}
-		dataToStore = strictData
-		if err := workspace.WriteToStoreForWorkspace(&storeNodeCopy, store, ws.ID, storeFilePath, dataToStore); err != nil {
+		storeNodeCopy.Format = "jsonl"
+		// JSONL records are self-describing; append them directly (no CSV
+		// header reconciliation).
+		if err := workspace.WriteToStoreForWorkspace(&storeNodeCopy, store, ws.ID, storeFilePath, jsonlData); err != nil {
 			return err
 		}
 		storeNode.LastWriteTime = storeNodeCopy.LastWriteTime
@@ -2114,7 +2117,7 @@ func appendApprovedTaskCSV(store workspace.Store, ws *workspace.Workspace, task 
 		if relativeFilePath == "" {
 			relativeFilePath = storeFilePath
 		} else if strings.HasSuffix(relativeFilePath, "/") || !strings.Contains(filepath.Base(relativeFilePath), ".") {
-			relativeFilePath = filepath.Join(relativeFilePath, workspace.AppendCSVFileName(task, storage))
+			relativeFilePath = filepath.Join(relativeFilePath, workspace.AppendJSONLFileName(task, storage))
 		}
 		finalPath, err := workspace.BuildFinalPath(baseDir, relativeFilePath)
 		if err != nil {
@@ -2135,9 +2138,9 @@ func appendApprovedTaskCSV(store workspace.Store, ws *workspace.Workspace, task 
 		}
 		filePath = filepath.Join(baseOutputDir, storeFilePath)
 	} else if strings.HasSuffix(filePath, "/") || !strings.Contains(filepath.Base(filePath), ".") {
-		filePath = filepath.Join(filePath, workspace.AppendCSVFileName(task, storage))
+		filePath = filepath.Join(filePath, workspace.AppendJSONLFileName(task, storage))
 	}
-	return workspace.AppendCSVToFileStrict(filePath, csvData)
+	return workspace.AppendJSONLToFile(filePath, jsonlData)
 }
 
 // BulkDeleteTasksHandler handles DELETE /api/orchestration/tasks/bulk

--- a/internal/orchestrationhttp/task_handler_test.go
+++ b/internal/orchestrationhttp/task_handler_test.go
@@ -1073,12 +1073,9 @@ func TestHandleTaskOutputReview_ApproveAppend(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read approved csv: %v", err)
-	}
-	if string(data) != "date,location,pollen_count\n2026-05-20,NYC,8" {
-		t.Fatalf("unexpected csv data: %q", string(data))
+	records := readReviewJSONL(t, outputPath)
+	if len(records) != 1 || records[0]["date"] != "2026-05-20" || records[0]["location"] != "NYC" || records[0]["pollen_count"] != "8" {
+		t.Fatalf("unexpected appended records: %#v", records)
 	}
 	updatedWS, err := store.Get(ws.ID)
 	if err != nil {
@@ -1100,14 +1097,16 @@ func TestHandleTaskOutputReview_ApproveAppend(t *testing.T) {
 	}
 }
 
-func TestHandleTaskOutputReview_ApproveAppendBlocksCSVHeaderMismatch(t *testing.T) {
+func TestHandleTaskOutputReview_ApproveAppendWritesJSONL(t *testing.T) {
 	store := workspace.NewInMemoryStore()
 	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Reviews"})
 	ws.ID = "workspace-review-approve-header-mismatch"
 
-	outputPath := filepath.Join(t.TempDir(), "pollen.csv")
-	if err := os.WriteFile(outputPath, []byte("wrong,header\n1,2"), 0644); err != nil {
-		t.Fatalf("write existing csv: %v", err)
+	outputPath := filepath.Join(t.TempDir(), "pollen.jsonl")
+	// A pre-existing record must not block the approval append (JSONL has no
+	// header to reconcile, unlike the old CSV-append path).
+	if err := os.WriteFile(outputPath, []byte(`{"date":"2026-05-19","location":"Boston"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write existing jsonl: %v", err)
 	}
 	task := workspace.Task{
 		ID:          "task-review-approve-header-mismatch",
@@ -1162,12 +1161,13 @@ func TestHandleTaskOutputReview_ApproveAppendBlocksCSVHeaderMismatch(t *testing.
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read csv: %v", err)
+	records := readReviewJSONL(t, outputPath)
+	if len(records) != 2 {
+		t.Fatalf("expected existing + approved record, got %d", len(records))
 	}
-	if string(data) != "wrong,header\n1,2" {
-		t.Fatalf("csv should not append on header mismatch, got %q", string(data))
+	approved := records[len(records)-1]
+	if approved["date"] != "2026-05-20" || approved["location"] != "NYC" {
+		t.Fatalf("unexpected approved record: %#v", approved)
 	}
 	updatedWS, err := store.Get(ws.ID)
 	if err != nil {
@@ -1178,15 +1178,32 @@ func TestHandleTaskOutputReview_ApproveAppendBlocksCSVHeaderMismatch(t *testing.
 		t.Fatalf("reload task: %v", err)
 	}
 	validation := updatedTask.ExecutionHistory[0].Validation
-	if validation == nil || validation.ValidationStatus != workspace.TaskValidationNeedsReview || validation.StorageStatus != workspace.TaskStorageSkippedInvalid {
-		t.Fatalf("validation = %+v, want needs_review/skipped_invalid", validation)
+	if validation == nil || validation.ValidationStatus != workspace.TaskValidationManuallyApproved || validation.StorageStatus != workspace.TaskStorageManuallyAppended {
+		t.Fatalf("validation = %+v, want manually_approved/manually_appended", validation)
 	}
-	if len(validation.Errors) == 0 || validation.Errors[0].Code != "csv_header_mismatch" {
-		t.Fatalf("expected csv_header_mismatch, got %+v", validation.Errors)
+}
+
+// readReviewJSONL parses a .jsonl dataset file into records. The review/approve
+// append paths now write JSONL (converted from the CSV they validate).
+func readReviewJSONL(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read jsonl: %v", err)
 	}
-	if strings.Join(validation.Errors[0].Expected, ",") != "date,location" || strings.Join(validation.Errors[0].Actual, ",") != "wrong,header" {
-		t.Fatalf("unexpected headers: %+v", validation.Errors[0])
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("line %q is not JSON: %v", line, err)
+		}
+		records = append(records, record)
 	}
+	return records
 }
 
 func TestTaskOutputReviewApproval_UsesValidationSpecSnapshot(t *testing.T) {
@@ -1335,13 +1352,14 @@ func TestHandleTaskOutputReview_RetryNormalizationUsesRunSpecSnapshot(t *testing
 	if executor.normalizeCalls != 1 {
 		t.Fatalf("normalizeCalls=%d, want 1", executor.normalizeCalls)
 	}
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read normalized csv: %v", err)
+	records := readReviewJSONL(t, outputPath)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 normalized record, got %d", len(records))
 	}
-	wantCSV := "run_id,executed_at,status,duration_ms,forecast_date,pollen_count\nrun-review-normalize,2026-05-21T09:30:00Z,success,2500,2026-05-21,9.7"
-	if string(data) != wantCSV {
-		t.Fatalf("csv data = %q, want %q", string(data), wantCSV)
+	record := records[0]
+	if record["forecast_date"] != "2026-05-21" || record["pollen_count"] != "9.7" ||
+		record["run_id"] != "run-review-normalize" || record["status"] != "success" {
+		t.Fatalf("unexpected normalized record: %#v", record)
 	}
 	updatedWS, err := store.Get(ws.ID)
 	if err != nil {
@@ -1467,12 +1485,9 @@ func TestAppendCSVContractReviewSmoke_CreateInvalidApprove(t *testing.T) {
 	if approveRec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", approveRec.Code, approveRec.Body.String())
 	}
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read approved csv: %v", err)
-	}
-	if string(data) != "date,location,pollen_count\n2026-05-20,NYC,8" {
-		t.Fatalf("unexpected approved csv: %q", string(data))
+	records := readReviewJSONL(t, outputPath)
+	if len(records) != 1 || records[0]["date"] != "2026-05-20" || records[0]["location"] != "NYC" || records[0]["pollen_count"] != "8" {
+		t.Fatalf("unexpected approved records: %#v", records)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -755,6 +755,15 @@ func (s *Server) routeWorkspaceRuntimeRequest(w http.ResponseWriter, r *http.Req
 		return true
 	}
 
+	if strings.HasSuffix(path, "/output-dir/open") {
+		if r.Method == http.MethodPost {
+			s.Handlers.Workspace.OpenWorkspaceOutputDir(w, r)
+		} else {
+			orihttp.MethodNotAllowed(w)
+		}
+		return true
+	}
+
 	if strings.HasSuffix(path, "/agent-snapshots") {
 		s.Handlers.Workspace.ListAgentSnapshots(w, r)
 		return true

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -774,6 +774,8 @@ func (s *Server) routeWorkspaceRuntimeRequest(w http.ResponseWriter, r *http.Req
 			s.Handlers.Workspace.ExecuteTaskManually(w, r)
 		} else if strings.HasSuffix(path, "/results/append-csv") && r.Method == http.MethodPost {
 			s.Handlers.Workspace.AppendResultToCSV(w, r)
+		} else if strings.HasSuffix(path, "/results/export-csv") && r.Method == http.MethodGet {
+			s.Handlers.Workspace.ExportResultCSV(w, r)
 		} else if strings.HasSuffix(path, "/output-spec/draft") && (r.Method == http.MethodPost || r.Method == http.MethodPatch) {
 			s.Handlers.Workspace.SaveTaskOutputSpecDraft(w, r)
 		} else if strings.HasSuffix(path, "/output-spec/approve") && r.Method == http.MethodPost {

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -4124,3 +4124,299 @@ body.chat-panel-open .chat-panel-backdrop {
 .launcher-group-header.is-drag-over {
   background-color: rgba(31, 107, 78, 0.15);
 }
+
+/* ============================================================
+   Floating Support Chat Widget
+   ============================================================ */
+.hub-support-chat {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 1080;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.hub-support-chat-launcher,
+.hub-support-chat-panel {
+  pointer-events: auto;
+}
+
+.hub-support-chat-launcher {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-primary, #1F6B4E);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+  position: relative;
+}
+
+.hub-support-chat-launcher:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22), 0 3px 8px rgba(0, 0, 0, 0.14);
+}
+
+.hub-support-chat-launcher:focus-visible {
+  outline: 2px solid var(--accent-primary, #1F6B4E);
+  outline-offset: 3px;
+}
+
+.hub-support-chat-launcher-icon {
+  position: absolute;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.hub-support-chat-launcher-icon-close {
+  opacity: 0;
+  transform: rotate(-45deg);
+}
+
+.hub-support-chat[data-state="open"] .hub-support-chat-launcher-icon-bubble {
+  opacity: 0;
+  transform: rotate(45deg);
+}
+
+.hub-support-chat[data-state="open"] .hub-support-chat-launcher-icon-close {
+  opacity: 1;
+  transform: rotate(0);
+}
+
+.hub-support-chat-panel {
+  width: 360px;
+  max-width: calc(100vw - 48px);
+  height: 480px;
+  max-height: calc(100vh - 120px);
+  background: var(--bg-primary, #fff);
+  border: 1px solid var(--border-color, #e2e2e2);
+  border-radius: 14px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22), 0 4px 12px rgba(0, 0, 0, 0.10);
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+  transform-origin: bottom right;
+  animation: hub-support-chat-pop 0.18s ease-out;
+}
+
+.hub-support-chat[data-state="open"] .hub-support-chat-panel {
+  display: flex;
+}
+
+@keyframes hub-support-chat-pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.hub-support-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--accent-primary, #1F6B4E);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.hub-support-chat-header-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+  min-width: 0;
+}
+
+.hub-support-chat-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.hub-support-chat-subtitle {
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.hub-support-chat-close {
+  border: none;
+  background: transparent;
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0.9;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.hub-support-chat-close:hover {
+  background: rgba(255, 255, 255, 0.18);
+  opacity: 1;
+}
+
+.hub-support-chat-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--bg-secondary, #f7f7f7);
+}
+
+.hub-support-chat-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--text-secondary, #777);
+  padding: 16px 12px;
+}
+
+.hub-support-chat-empty-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #222);
+  margin-bottom: 4px;
+}
+
+.hub-support-chat-empty-sub {
+  font-size: 12px;
+}
+
+.hub-support-chat-msg {
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.hub-support-chat-msg-user {
+  align-self: flex-end;
+  background: var(--accent-primary, #1F6B4E);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.hub-support-chat-msg-bot {
+  align-self: flex-start;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #222);
+  border: 1px solid var(--border-color, #e2e2e2);
+  border-bottom-left-radius: 4px;
+}
+
+.hub-support-chat-msg-error {
+  align-self: flex-start;
+  background: #fdecea;
+  color: #b3261e;
+  border: 1px solid #f5c6c1;
+  border-bottom-left-radius: 4px;
+}
+
+.hub-support-chat-typing {
+  align-self: flex-start;
+  display: flex;
+  gap: 4px;
+  padding: 10px 14px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-secondary, #777);
+  border: 1px solid var(--border-color, #e2e2e2);
+  border-radius: 12px;
+  border-bottom-left-radius: 4px;
+}
+
+.hub-support-chat-typing span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.4;
+  animation: hub-support-chat-bounce 1.2s infinite;
+}
+
+.hub-support-chat-typing span:nth-child(2) { animation-delay: 0.15s; }
+.hub-support-chat-typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes hub-support-chat-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+  30%           { transform: translateY(-3px); opacity: 1; }
+}
+
+.hub-support-chat-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color, #e2e2e2);
+  background: var(--bg-primary, #fff);
+  flex-shrink: 0;
+}
+
+.hub-support-chat-input {
+  flex: 1;
+  resize: none;
+  max-height: 96px;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color, #e2e2e2);
+  border-radius: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #222);
+  line-height: 1.4;
+  outline: none;
+}
+
+.hub-support-chat-input:focus {
+  border-color: var(--accent-primary, #1F6B4E);
+  box-shadow: 0 0 0 2px rgba(31, 107, 78, 0.18);
+}
+
+.hub-support-chat-send {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-primary, #1F6B4E);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.hub-support-chat-send:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.hub-support-chat-send:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 480px) {
+  .hub-support-chat {
+    right: 12px;
+    bottom: 12px;
+  }
+  .hub-support-chat-panel {
+    width: calc(100vw - 24px);
+    height: 70vh;
+  }
+}

--- a/internal/web/static/js/modules/workspace-hub-support-chat.js
+++ b/internal/web/static/js/modules/workspace-hub-support-chat.js
@@ -101,9 +101,17 @@
 
   function detectSurface() {
     const path = (window.location.pathname || '').toLowerCase();
-    if (/^\/workspaces\/[^/]+\/tasks\/[^/]+/.test(path)) return 'workspace_task';
+    if (/^\/workspaces\/[^/]+\/(?:task|tasks)\/[^/]+/.test(path)) return 'workspace_task';
     if (/^\/workspaces\/[^/]+/.test(path)) return 'workspace_detail';
     return 'workspace_hub';
+  }
+
+  function resolveTaskId() {
+    if (window.workspaceTaskPage && window.workspaceTaskPage.taskId) {
+      return window.workspaceTaskPage.taskId;
+    }
+    const match = (window.location.pathname || '').match(/\/workspaces\/[^/]+\/(?:task|tasks)\/([^/]+)/i);
+    return match ? decodeURIComponent(match[1]) : '';
   }
 
   function resolveWorkspaceId() {
@@ -188,10 +196,14 @@
       const routeContext = {
         page_path: window.location.pathname || '',
         origin: 'support_widget',
-        surface: surface.key === 'workspace_hub' ? 'workspace_hub' : surface.key
+        surface: surface.key
       };
       const workspaceId = resolveWorkspaceId();
       if (workspaceId) routeContext.workspace_id = workspaceId;
+      if (surface.key === 'workspace_task') {
+        const taskId = resolveTaskId();
+        if (taskId) routeContext.task_id = taskId;
+      }
       body.route_context = routeContext;
 
       const response = await fetch('/api/chat', {

--- a/internal/web/static/js/modules/workspace-hub-support-chat.js
+++ b/internal/web/static/js/modules/workspace-hub-support-chat.js
@@ -1,10 +1,15 @@
 /**
  * Workspace Hub Support Chat
  *
- * Floating, Intercom-style chat widget pinned to the bottom-right of the
- * workspace-hub page. Sends messages directly to /api/chat using the agent
- * resolved from the currently-open workspace, and renders the conversation
- * inside its own panel (independent of the main chat UI).
+ * Floating, Intercom-style chat widget pinned to the bottom-right of
+ * workspace pages. The widget routes to a different agent and adopts a
+ * different persona depending on which surface it's loaded on:
+ *
+ *  - workspace_hub    -> "Ori" (system assistant); focused on workspace
+ *                        creation/lookup/navigation.
+ *  - workspace_detail -> workspace.shared_data.entry_agent_name (strict);
+ *                        focused on what's available inside the workspace.
+ *  - workspace_task   -> task.assigned_to (strict); focused on this task.
  *
  * @module workspace-hub-support-chat
  */
@@ -13,8 +18,56 @@
 
   const SESSION_HEADER = 'X-Session-ID';
   const WIDGET_SESSION_PREFIX = 'support-widget-';
+  const SYSTEM_AGENT_NAME = 'Ori';
+
+  const SURFACES = {
+    workspace_hub: {
+      title: 'Workspaces Assistant',
+      subtitle: 'Create, find, and navigate workspaces',
+      placeholder: 'Ask about workspaces...',
+      emptyTitle: 'Hi! How can I help with your workspaces?',
+      emptySub: 'I can help you create, find, or summarize workspaces.',
+      resolveAgent: () => SYSTEM_AGENT_NAME,
+      requireAgent: false
+    },
+    workspace_detail: {
+      title: 'Workspace Assistant',
+      subtitle: 'Ask about this workspace',
+      placeholder: 'Ask about tasks, notes, files, agents...',
+      emptyTitle: 'Hi! How can I help?',
+      emptySub: 'I have context on this workspace.',
+      resolveAgent: () => {
+        const ws = window.workspaceDetail && window.workspaceDetail.workspace;
+        if (!ws) return '';
+        const shared = ws.shared_data || ws.SharedData || {};
+        const entry = shared.entry_agent_name || ws.entry_agent_name || '';
+        return typeof entry === 'string' ? entry.trim() : '';
+      },
+      requireAgent: true,
+      missingAgentMessage:
+        'No entry agent is configured for this workspace yet. ' +
+        'Set one in workspace settings to enable the assistant.'
+    },
+    workspace_task: {
+      title: 'Task Assistant',
+      subtitle: 'Help with this task',
+      placeholder: 'Ask about this task...',
+      emptyTitle: 'Hi! How can I help with this task?',
+      emptySub: 'I have context on this task and workspace.',
+      resolveAgent: () => {
+        const task = window.workspaceTaskPage && window.workspaceTaskPage.task;
+        if (!task || typeof task !== 'object') return '';
+        return typeof task.assigned_to === 'string' ? task.assigned_to.trim() : '';
+      },
+      requireAgent: true,
+      missingAgentMessage:
+        'No agent is assigned to this task yet. ' +
+        'Assign an agent to enable the assistant.'
+    }
+  };
 
   let elements = null;
+  let surface = null;
   let widgetSessionId = '';
   let sending = false;
 
@@ -46,38 +99,11 @@
     return escapeHtml(text).replace(/\n/g, '<br>');
   }
 
-  function pickFirstAgentName(workspace) {
-    if (!workspace || typeof workspace !== 'object') return '';
-    const instances = Array.isArray(workspace.agent_instances) ? workspace.agent_instances : null;
-    if (instances && instances.length > 0) {
-      const first = instances[0];
-      if (first && typeof first === 'object' && first.name) return first.name;
-      if (typeof first === 'string') return first;
-    }
-    const names = Array.isArray(workspace.agents) ? workspace.agents : null;
-    if (names && names.length > 0) return names[0];
-    return '';
-  }
-
-  function resolveWorkspaceAgent() {
-    const detail = window.workspaceDetail;
-    if (detail) {
-      const fromDetail = pickFirstAgentName(detail.workspace);
-      if (fromDetail) return fromDetail;
-    }
-    const taskPage = window.workspaceTaskPage;
-    if (taskPage) {
-      const fromTask = pickFirstAgentName(taskPage.workspace) || pickFirstAgentName(taskPage.workspaceData);
-      if (fromTask) return fromTask;
-      if (taskPage.task && typeof taskPage.task === 'object' && taskPage.task.agent_name) {
-        return taskPage.task.agent_name;
-      }
-    }
-    const activeAgent = window.sessionManager
-      && typeof window.sessionManager.getActiveSession === 'function'
-      ? window.sessionManager.getActiveSession()?.agent_name
-      : '';
-    return activeAgent || '';
+  function detectSurface() {
+    const path = (window.location.pathname || '').toLowerCase();
+    if (/^\/workspaces\/[^/]+\/tasks\/[^/]+/.test(path)) return 'workspace_task';
+    if (/^\/workspaces\/[^/]+/.test(path)) return 'workspace_detail';
+    return 'workspace_hub';
   }
 
   function resolveWorkspaceId() {
@@ -137,6 +163,15 @@
     const trimmed = String(text || '').trim();
     if (!trimmed || sending) return;
 
+    const agentName = surface.resolveAgent();
+    if (surface.requireAgent && !agentName) {
+      appendMessage(trimmed, 'user');
+      elements.input.value = '';
+      autoResizeInput();
+      appendMessage(surface.missingAgentMessage, 'error');
+      return;
+    }
+
     appendMessage(trimmed, 'user');
     elements.input.value = '';
     autoResizeInput();
@@ -149,13 +184,13 @@
         [SESSION_HEADER]: ensureSessionId()
       };
       const body = { question: trimmed };
-      const agentName = resolveWorkspaceAgent();
       if (agentName) body.agent_name = agentName;
-      const workspaceId = resolveWorkspaceId();
       const routeContext = {
         page_path: window.location.pathname || '',
-        origin: 'support_widget'
+        origin: 'support_widget',
+        surface: surface.key === 'workspace_hub' ? 'workspace_hub' : surface.key
       };
+      const workspaceId = resolveWorkspaceId();
       if (workspaceId) routeContext.workspace_id = workspaceId;
       body.route_context = routeContext;
 
@@ -190,6 +225,18 @@
     const el = elements.input;
     el.style.height = 'auto';
     el.style.height = Math.min(el.scrollHeight, 96) + 'px';
+  }
+
+  function applySurfaceToUI() {
+    const titleEl = $('hubSupportChatTitle');
+    const subtitleEl = $('hubSupportChatSubtitle');
+    if (titleEl) titleEl.textContent = surface.title;
+    if (subtitleEl) subtitleEl.textContent = surface.subtitle;
+    if (elements.input) elements.input.placeholder = surface.placeholder;
+    const emptyTitle = elements.body.querySelector('.hub-support-chat-empty-title');
+    const emptySub = elements.body.querySelector('.hub-support-chat-empty-sub');
+    if (emptyTitle) emptyTitle.textContent = surface.emptyTitle;
+    if (emptySub) emptySub.textContent = surface.emptySub;
   }
 
   function openPanel() {
@@ -248,12 +295,18 @@
       sendBtn: $('hubSupportChatSendBtn')
     };
     if (!elements.launcher || !elements.panel || !elements.form) return;
+
+    const key = detectSurface();
+    surface = Object.assign({ key }, SURFACES[key] || SURFACES.workspace_hub);
+
+    applySurfaceToUI();
     bindHandlers();
     window.hubSupportChat = {
       open: openPanel,
       close: closePanel,
       toggle: togglePanel,
-      send: sendMessage
+      send: sendMessage,
+      surface: () => surface.key
     };
   }
 

--- a/internal/web/static/js/modules/workspace-hub-support-chat.js
+++ b/internal/web/static/js/modules/workspace-hub-support-chat.js
@@ -1,0 +1,265 @@
+/**
+ * Workspace Hub Support Chat
+ *
+ * Floating, Intercom-style chat widget pinned to the bottom-right of the
+ * workspace-hub page. Sends messages directly to /api/chat using the agent
+ * resolved from the currently-open workspace, and renders the conversation
+ * inside its own panel (independent of the main chat UI).
+ *
+ * @module workspace-hub-support-chat
+ */
+(function () {
+  'use strict';
+
+  const SESSION_HEADER = 'X-Session-ID';
+  const WIDGET_SESSION_PREFIX = 'support-widget-';
+
+  let elements = null;
+  let widgetSessionId = '';
+  let sending = false;
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderMarkdown(text) {
+    if (window.marked && typeof window.marked.parse === 'function') {
+      try {
+        const html = window.marked.parse(String(text || ''), { breaks: true });
+        if (window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+          return window.DOMPurify.sanitize(html);
+        }
+        return html;
+      } catch (_) {
+        // fall through to plain text
+      }
+    }
+    return escapeHtml(text).replace(/\n/g, '<br>');
+  }
+
+  function pickFirstAgentName(workspace) {
+    if (!workspace || typeof workspace !== 'object') return '';
+    const instances = Array.isArray(workspace.agent_instances) ? workspace.agent_instances : null;
+    if (instances && instances.length > 0) {
+      const first = instances[0];
+      if (first && typeof first === 'object' && first.name) return first.name;
+      if (typeof first === 'string') return first;
+    }
+    const names = Array.isArray(workspace.agents) ? workspace.agents : null;
+    if (names && names.length > 0) return names[0];
+    return '';
+  }
+
+  function resolveWorkspaceAgent() {
+    const detail = window.workspaceDetail;
+    if (detail) {
+      const fromDetail = pickFirstAgentName(detail.workspace);
+      if (fromDetail) return fromDetail;
+    }
+    const taskPage = window.workspaceTaskPage;
+    if (taskPage) {
+      const fromTask = pickFirstAgentName(taskPage.workspace) || pickFirstAgentName(taskPage.workspaceData);
+      if (fromTask) return fromTask;
+      if (taskPage.task && typeof taskPage.task === 'object' && taskPage.task.agent_name) {
+        return taskPage.task.agent_name;
+      }
+    }
+    const activeAgent = window.sessionManager
+      && typeof window.sessionManager.getActiveSession === 'function'
+      ? window.sessionManager.getActiveSession()?.agent_name
+      : '';
+    return activeAgent || '';
+  }
+
+  function resolveWorkspaceId() {
+    if (window.workspaceDetail && window.workspaceDetail.workspaceId) {
+      return window.workspaceDetail.workspaceId;
+    }
+    if (window.workspaceTaskPage && window.workspaceTaskPage.workspaceId) {
+      return window.workspaceTaskPage.workspaceId;
+    }
+    if (window.currentWorkspaceId) return window.currentWorkspaceId;
+    return '';
+  }
+
+  function ensureSessionId() {
+    if (widgetSessionId) return widgetSessionId;
+    const rand = Math.random().toString(36).slice(2, 10);
+    widgetSessionId = `${WIDGET_SESSION_PREFIX}${Date.now().toString(36)}-${rand}`;
+    return widgetSessionId;
+  }
+
+  function clearEmptyState() {
+    const empty = elements.body.querySelector('.hub-support-chat-empty');
+    if (empty) empty.remove();
+  }
+
+  function appendMessage(text, kind) {
+    clearEmptyState();
+    const node = document.createElement('div');
+    node.className = `hub-support-chat-msg hub-support-chat-msg-${kind}`;
+    if (kind === 'bot') {
+      node.innerHTML = renderMarkdown(text);
+    } else {
+      node.textContent = String(text || '');
+    }
+    elements.body.appendChild(node);
+    elements.body.scrollTop = elements.body.scrollHeight;
+    return node;
+  }
+
+  function showTyping() {
+    const node = document.createElement('div');
+    node.className = 'hub-support-chat-typing';
+    node.setAttribute('aria-label', 'Assistant is typing');
+    node.innerHTML = '<span></span><span></span><span></span>';
+    elements.body.appendChild(node);
+    elements.body.scrollTop = elements.body.scrollHeight;
+    return node;
+  }
+
+  function setSending(isSending) {
+    sending = isSending;
+    elements.sendBtn.disabled = isSending;
+    elements.input.disabled = isSending;
+  }
+
+  async function sendMessage(text) {
+    const trimmed = String(text || '').trim();
+    if (!trimmed || sending) return;
+
+    appendMessage(trimmed, 'user');
+    elements.input.value = '';
+    autoResizeInput();
+    setSending(true);
+    const typingNode = showTyping();
+
+    try {
+      const headers = {
+        'Content-Type': 'application/json',
+        [SESSION_HEADER]: ensureSessionId()
+      };
+      const body = { question: trimmed };
+      const agentName = resolveWorkspaceAgent();
+      if (agentName) body.agent_name = agentName;
+      const workspaceId = resolveWorkspaceId();
+      const routeContext = {
+        page_path: window.location.pathname || '',
+        origin: 'support_widget'
+      };
+      if (workspaceId) routeContext.workspace_id = workspaceId;
+      body.route_context = routeContext;
+
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
+
+      typingNode.remove();
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      const replyText = data && (data.response || data.message || data.text);
+      if (replyText) {
+        appendMessage(replyText, 'bot');
+      } else {
+        appendMessage('(no response)', 'bot');
+      }
+    } catch (err) {
+      typingNode.remove();
+      appendMessage(`Couldn't reach the assistant: ${err && err.message ? err.message : err}`, 'error');
+    } finally {
+      setSending(false);
+      elements.input.focus();
+    }
+  }
+
+  function autoResizeInput() {
+    const el = elements.input;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 96) + 'px';
+  }
+
+  function openPanel() {
+    elements.root.setAttribute('data-state', 'open');
+    elements.launcher.setAttribute('aria-expanded', 'true');
+    elements.panel.setAttribute('aria-hidden', 'false');
+    setTimeout(() => elements.input.focus(), 30);
+  }
+
+  function closePanel() {
+    elements.root.setAttribute('data-state', 'closed');
+    elements.launcher.setAttribute('aria-expanded', 'false');
+    elements.panel.setAttribute('aria-hidden', 'true');
+  }
+
+  function togglePanel() {
+    if (elements.root.getAttribute('data-state') === 'open') {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  }
+
+  function bindHandlers() {
+    elements.launcher.addEventListener('click', togglePanel);
+    elements.closeBtn.addEventListener('click', closePanel);
+    elements.form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      sendMessage(elements.input.value);
+    });
+    elements.input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage(elements.input.value);
+      }
+    });
+    elements.input.addEventListener('input', autoResizeInput);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && elements.root.getAttribute('data-state') === 'open') {
+        closePanel();
+      }
+    });
+  }
+
+  function init() {
+    const root = $('hubSupportChat');
+    if (!root) return;
+    elements = {
+      root,
+      launcher: $('hubSupportChatLauncher'),
+      panel: $('hubSupportChatPanel'),
+      closeBtn: $('hubSupportChatCloseBtn'),
+      body: $('hubSupportChatBody'),
+      form: $('hubSupportChatForm'),
+      input: $('hubSupportChatInput'),
+      sendBtn: $('hubSupportChatSendBtn')
+    };
+    if (!elements.launcher || !elements.panel || !elements.form) return;
+    bindHandlers();
+    window.hubSupportChat = {
+      open: openPanel,
+      close: closePanel,
+      toggle: togglePanel,
+      send: sendMessage
+    };
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -4726,7 +4726,7 @@ export class WorkspaceTaskPage {
     const existing = owner?.result_storage || {};
     const nextStorage = {
       enabled: Boolean(checked),
-      format: 'csv',
+      format: 'jsonl',
       write_mode: checked ? 'append' : String(existing.write_mode || 'append'),
       file_path: String(existing.file_path || ''),
       store_node_id: String(existing.store_node_id || ''),
@@ -5030,7 +5030,8 @@ export class WorkspaceTaskPage {
       String(existing.store_node_id || '') === nextStorage.store_node_id &&
       String(existing.storage_target || '') === nextStorage.storage_target &&
       String(existing.workspace_folder || '') === nextStorage.workspace_folder &&
-      String(existing.file_name || '') === nextStorage.file_name
+      String(existing.file_name || '') === nextStorage.file_name &&
+      String(existing.format || '') === nextStorage.format
     ) {
       this.notify('info', 'Destination is already set.');
       return;
@@ -5283,7 +5284,7 @@ export class WorkspaceTaskPage {
           schedule_name: owner?.schedule_name || this.task?.schedule_name || '',
           result_storage: {
             enabled: true,
-            format: 'csv',
+            format: 'jsonl',
             write_mode: 'append',
             file_path: String(storage.file_path || ''),
             store_node_id: String(storage.store_node_id || ''),
@@ -5376,7 +5377,7 @@ export class WorkspaceTaskPage {
     const existingStorage = owner?.result_storage || {};
     const nextStorage = {
       enabled: true,
-      format: 'csv',
+      format: 'jsonl',
       write_mode: 'append',
       file_path: String(existingStorage.file_path || ''),
       store_node_id: String(existingStorage.store_node_id || ''),

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -4369,7 +4369,7 @@ export class WorkspaceTaskPage {
     let locationHint = '';
     if (storeNodeId) {
       const storeLabel = this.getStoreNodeDisplayLabel(storeNodeId);
-      label = filePath || 'runs.csv';
+      label = filePath || this.defaultAppendCsvFilename();
       locationHint = `in ${storeLabel}`;
     } else if (filePath) {
       const segments = filePath.split('/');
@@ -4873,7 +4873,7 @@ export class WorkspaceTaskPage {
         <i class="bi bi-folder2-open" aria-hidden="true"></i>
         <span>${this.escapeHtml(openFolderLabel)}</span>
       </button>`;
-    const fileName = String(storage.file_name || '').trim() || this.defaultAppendCsvFilename(owner);
+    const fileName = this.normalizeDatasetFileName(storage.file_name) || this.defaultAppendCsvFilename(owner);
 
     container.innerHTML = `
       <div class="workspace-task-automation-storage-block" data-state="on">
@@ -4882,7 +4882,7 @@ export class WorkspaceTaskPage {
           <label class="workspace-task-automation-storage-option">
             <input type="radio" name="workspace-task-automation-storage-target" value="default"${target === 'default' ? ' checked' : ''} />
             <span>Default output folder${defaultPathHint}${openFolderBtn}</span>
-            <input type="text" data-role="automation-storage-filename" class="workspace-task-automation-storage-input" placeholder="file name (e.g. nyc_pollen.csv)" value="${this.escapeHtml(fileName)}" aria-label="CSV file name" />
+            <input type="text" data-role="automation-storage-filename" class="workspace-task-automation-storage-input" placeholder="file name (e.g. nyc_pollen.jsonl)" value="${this.escapeHtml(fileName)}" aria-label="Dataset file name" />
           </label>
           <label class="workspace-task-automation-storage-option${storeOptions ? '' : ' is-disabled'}">
             <input type="radio" name="workspace-task-automation-storage-target" value="store"${target === 'store' ? ' checked' : ''}${storeOptions ? '' : ' disabled'} />
@@ -5010,12 +5010,13 @@ export class WorkspaceTaskPage {
     // so the filename keeps tracking the task description. A full custom path
     // carries its own filename, so file_name doesn't apply there.
     const derivedFileName = this.defaultAppendCsvFilename(owner);
-    const customFileName = (target !== 'custom' && fileNameInput && fileNameInput !== derivedFileName)
-      ? fileNameInput
+    const normalizedFileName = this.normalizeDatasetFileName(fileNameInput);
+    const customFileName = (target !== 'custom' && normalizedFileName && normalizedFileName !== derivedFileName)
+      ? normalizedFileName
       : '';
     const nextStorage = {
       enabled: true,
-      format: 'csv',
+      format: 'jsonl',
       write_mode: 'append',
       file_path: target === 'custom' ? customPath : '',
       store_node_id: target === 'store' ? storeNodeId : '',
@@ -5093,10 +5094,9 @@ export class WorkspaceTaskPage {
     const storageTarget = String(storage.storage_target || '').trim();
     const workspaceFolder = String(storage.workspace_folder || '').trim();
     const filePathIsFile = filePath && !filePath.endsWith('/') && this.basename(filePath).includes('.');
-    const customFileName = String(storage.file_name || '').trim();
     const filename = filePathIsFile
       ? this.basename(filePath)
-      : (customFileName || this.defaultAppendCsvFilename(owner));
+      : (this.normalizeDatasetFileName(storage.file_name) || this.defaultAppendCsvFilename(owner));
     const joinFile = (dir) => `${String(dir || '').replace(/\/+$/, '')}/${filename}`;
 
     let dest;
@@ -5123,9 +5123,10 @@ export class WorkspaceTaskPage {
     return parts[parts.length - 1] || '';
   }
 
-  // defaultAppendCsvFilename mirrors the backend (defaultAppendCSVFilename):
-  // the task description, capped at 30 chars, with non [A-Za-z0-9_-] dropped
-  // and spaces turned into underscores, plus a .csv suffix.
+  // defaultAppendCsvFilename mirrors the backend (AppendJSONLFileName): the
+  // task description, capped at 30 chars, with non [A-Za-z0-9_-] dropped and
+  // spaces turned into underscores, plus a .jsonl suffix (the canonical append
+  // format). The name is kept for its many call sites.
   defaultAppendCsvFilename(task = this.task) {
     let name = String(task?.description || '');
     if (name.length > 30) name = name.slice(0, 30);
@@ -5135,7 +5136,23 @@ export class WorkspaceTaskPage {
       else if (ch === ' ') slug += '_';
     }
     if (!slug) slug = 'task';
-    return `${slug}.csv`;
+    return `${slug}.jsonl`;
+  }
+
+  // normalizeDatasetFileName strips whatever extension a user typed (.csv,
+  // .json, …) and forces .jsonl — the dataset is JSONL, so the destination
+  // filename should reflect that. Returns '' when there's nothing usable.
+  normalizeDatasetFileName(name) {
+    let trimmed = String(name || '').trim();
+    if (!trimmed) return '';
+    trimmed = trimmed.replace(/\.(jsonl|csv|json|txt|ndjson)$/i, '');
+    let slug = '';
+    for (const ch of trimmed) {
+      if (/[A-Za-z0-9_-]/.test(ch)) slug += ch;
+      else if (ch === ' ') slug += '_';
+    }
+    if (!slug) return '';
+    return `${slug}.jsonl`;
   }
 
   // Get a trimmed sample of the current task result, used to ground the

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -2949,17 +2949,18 @@ export class WorkspaceTaskPage {
         `;
       }
 
+      // Build the value HTML separately and inline it with no surrounding
+      // whitespace: the value uses white-space: pre-wrap (to preserve real line
+      // breaks in a multi-line Task Details brief), so any newlines/indentation
+      // between the <div> tags and ${...} would render as stray blank lines and
+      // a leading indent.
+      const valueHtml = item.href
+        ? `<a href="${this.escapeHtml(item.href)}" class="workspace-task-overview-link">${this.escapeHtml(item.value)}</a>`
+        : this.escapeHtml(item.value);
       return `
         <article class="workspace-task-overview-item${item.full ? ' full' : ''}">
-          <div class="workspace-task-overview-title">
-            ${this.escapeHtml(item.title)}
-            ${renderEditButton(item)}
-          </div>
-          <div class="workspace-task-overview-value">
-            ${item.href
-              ? `<a href="${this.escapeHtml(item.href)}" class="workspace-task-overview-link">${this.escapeHtml(item.value)}</a>`
-              : this.escapeHtml(item.value)}
-          </div>
+          <div class="workspace-task-overview-title">${this.escapeHtml(item.title)}${renderEditButton(item)}</div>
+          <div class="workspace-task-overview-value">${valueHtml}</div>
         </article>
       `;
     }).join('');

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -970,7 +970,7 @@ export class WorkspaceTaskPage {
       relationshipsCard: document.getElementById('workspace-task-relationships-card'),
       relationships: document.getElementById('workspace-task-relationships'),
       outputCard: document.getElementById('workspace-task-output-card'),
-      outputShapeCard: document.getElementById('workspace-task-output-shape-card'),
+      outputShapeWrap: document.getElementById('workspace-task-output-shape-wrap'),
       outputShape: document.getElementById('workspace-task-output-shape'),
       outputCopyBtn: document.getElementById('workspace-task-output-copy'),
       outputSaveNoteBtn: document.getElementById('workspace-task-output-save-note'),
@@ -2559,6 +2559,11 @@ export class WorkspaceTaskPage {
         Array.isArray(t.execution_history) ? t.execution_history.length : 0,
         t.execution_history?.[t.execution_history.length - 1]?.executed_at || '',
         sigAutomation,
+        // The Automation & output card's visibility now also depends on whether
+        // this task declares a structured output shape, so a spec change must
+        // re-run renderSchedule (sigAutomation tracks the storage owner's spec,
+        // which can differ from this.task's on a workflow parent).
+        t.output_spec || null, t.output_schema || null, t.output_contract || null,
       ]),
       context: JSON.stringify([t.id, t.context || {}]),
       blockedState: JSON.stringify([t.id, sigStatusInfo, sigBlocked]),
@@ -6339,8 +6344,22 @@ export class WorkspaceTaskPage {
   // task's declared schema fields, CSV contract columns, and the run-info
   // metadata flagged for CSV inclusion. Falls back to an empty-state when
   // no structured spec is configured (LLM returns free text).
+  // hasStructuredOutputShape reports whether the task declares a structured
+  // output — JSON schema fields or CSV contract columns. Drives both the
+  // "Expected output shape" subsection and whether the Automation & output
+  // card is shown at all when nothing else (schedule/storage) keeps it up.
+  hasStructuredOutputShape() {
+    const t = this.task || {};
+    const spec = t.output_spec || null;
+    const schemaSource = (spec && spec.schema) || t.output_schema || null;
+    const contractSource = (spec && spec.contract) || t.output_contract || null;
+    const schemaFields = Array.isArray(schemaSource?.fields) ? schemaSource.fields : [];
+    const contractColumns = Array.isArray(contractSource?.columns) ? contractSource.columns : [];
+    return schemaFields.length > 0 || contractColumns.length > 0;
+  }
+
   renderTaskOutputShape() {
-    if (!this.elements.outputShape || !this.elements.outputShapeCard) return;
+    if (!this.elements.outputShape || !this.elements.outputShapeWrap) return;
 
     const t = this.task || {};
     const spec = t.output_spec || null;
@@ -6353,17 +6372,16 @@ export class WorkspaceTaskPage {
 
     const hasAnyStructure = schemaFields.length > 0 || contractColumns.length > 0;
 
-    // Hide the entire card on free-text tasks. The "Expected output shape" panel
-    // only carries meaning when the task declares a JSON schema or CSV contract;
-    // a developer-flavored empty state ("add a spec to enforce a JSON shape…")
-    // doesn't belong on the Overview tab, which is otherwise kept to the
-    // non-technical essentials. The spec is still editable from the task modal.
+    // Hide just the subsection on free-text tasks. The "Expected output shape"
+    // panel only carries meaning when the task declares a JSON schema or CSV
+    // contract; a developer-flavored empty state doesn't belong here. The
+    // surrounding Automation & output card stays governed by renderSchedule.
     if (!hasAnyStructure) {
-      this.elements.outputShapeCard.hidden = true;
+      this.elements.outputShapeWrap.hidden = true;
       this.elements.outputShape.innerHTML = '';
       return;
     }
-    this.elements.outputShapeCard.hidden = false;
+    this.elements.outputShapeWrap.hidden = false;
 
     const includedMetadata = metadataFields.filter((field) => field.include);
     const summaryStats = [
@@ -8099,15 +8117,16 @@ export class WorkspaceTaskPage {
     const history = Array.isArray(this.task?.execution_history) ? this.task.execution_history : [];
     const executionCount = Number(this.task?.execution_count) || 0;
     const failureCount = Number(this.task?.failure_count) || 0;
-    // The card is now Automation, not just Schedule, so an output contract
-    // or configured storage destination is enough to surface it even when
-    // the task has never run on a cadence.
+    // The card is now "Automation & output", not just Schedule, so an output
+    // contract, configured storage destination, or a declared output shape is
+    // enough to surface it even when the task has never run on a cadence.
     const storageOwner = this.getTaskResultStorageTask();
     const hasContract = Array.isArray(storageOwner?.output_contract?.columns) && storageOwner.output_contract.columns.length > 0;
     const hasStorage = Boolean(storageOwner?.result_storage?.enabled);
     const editingColumns = Array.isArray(this.resultContractDraft);
+    const hasStructuredOutput = this.hasStructuredOutputShape();
 
-    if (!hasSchedule && history.length === 0 && executionCount === 0 && !hasContract && !hasStorage && !editingColumns) {
+    if (!hasSchedule && history.length === 0 && executionCount === 0 && !hasContract && !hasStorage && !editingColumns && !hasStructuredOutput) {
       this.elements.scheduleCard.hidden = true;
       this.elements.schedule.innerHTML = '';
       this.renderAutomationSections();
@@ -8145,7 +8164,12 @@ export class WorkspaceTaskPage {
       stats.push({ label: 'Mac Wake', value: `${this.task?.wake_lead_minutes || 5} min before` });
     }
 
-    const statsHtml = `
+    // Only show the run stats once there's schedule or run activity. A task
+    // that only surfaces this card because it declares an output shape (or a
+    // storage destination) hasn't run on a cadence, so a "Total Runs: 0 /
+    // Failures: 0" block would just be noise.
+    const showStats = hasSchedule || executionCount > 0 || failureCount > 0 || history.length > 0;
+    const statsHtml = showStats ? `
       <div class="workspace-task-schedule-stats">
         ${stats.map((s) => `
           <div class="workspace-task-schedule-stat">
@@ -8154,7 +8178,7 @@ export class WorkspaceTaskPage {
           </div>
         `).join('')}
       </div>
-    `;
+    ` : '';
 
     const bannerHtml = hasSchedule ? `
       <div class="workspace-task-schedule-banner" data-state="${scheduleEnabled ? 'enabled' : 'paused'}">

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -3873,14 +3873,38 @@ export class WorkspaceTaskPage {
   renderResultArtifact(artifact) {
     if (!artifact || !Array.isArray(artifact.columns) || !Array.isArray(artifact.rows)) return '';
 
-    const columns = artifact.columns;
+    const rawColumns = artifact.columns;
     const rows = artifact.rows;
-    const previewRows = rows.slice(0, 12);
+
+    // The preview shows only the task's actual output columns. Run bookkeeping
+    // (run_id, executed_at, status, duration_ms, validation / storage status)
+    // is still written to the CSV but dropped from the on-page preview, where
+    // it was audit noise that buried the real data off-screen.
+    const metaNames = new Set(
+      this.getOutputSpecMetadataFields().map((field) => String(field.name || '').trim().toLowerCase())
+    );
+    ['run_id', 'executed_at', 'status', 'duration_ms', 'validation_status', 'storage_status']
+      .forEach((name) => metaNames.add(name));
+    const isRunMetaColumn = (column) => metaNames.has(String(column || '').trim().toLowerCase());
+    const dataColumns = rawColumns.filter((column) => !isRunMetaColumn(column));
+    // Guard: if a task somehow declares only run metadata, keep showing every
+    // column rather than rendering an empty table.
+    const columns = dataColumns.length > 0 ? dataColumns : rawColumns;
+    const hiddenMetaCount = dataColumns.length > 0 ? rawColumns.length - dataColumns.length : 0;
+
+    const previewRows = rows.slice(0, 5);
     const hiddenRows = Math.max(0, rows.length - previewRows.length);
     const sourceLabel = this.getArtifactSourceLabel(artifact.source);
     const rowLabel = `${rows.length} row${rows.length === 1 ? '' : 's'}`;
-    const columnLabel = `${columns.length} column${columns.length === 1 ? '' : 's'}`;
+    // The badge counts the full CSV (data + run-info), matching the row badge;
+    // the footer note explains the columns the preview omits.
+    const columnLabel = `${rawColumns.length} column${rawColumns.length === 1 ? '' : 's'}`;
     const savingLabel = this.resultArtifactNoteSaving ? 'Saving...' : 'Save CSV note';
+
+    const truncationParts = [];
+    if (hiddenRows > 0) truncationParts.push(`${hiddenRows} more row${hiddenRows === 1 ? '' : 's'}`);
+    if (hiddenMetaCount > 0) truncationParts.push(`${hiddenMetaCount} run-info column${hiddenMetaCount === 1 ? '' : 's'}`);
+    const truncationNote = truncationParts.length ? `${truncationParts.join(' · ')} in CSV` : '';
 
     const headHtml = columns
       .map((column) => `<th scope="col">${this.escapeHtml(column)}</th>`)
@@ -4030,7 +4054,7 @@ export class WorkspaceTaskPage {
             <tbody>${rowsHtml}</tbody>
           </table>
         </div>
-        ${hiddenRows > 0 ? `<div class="workspace-task-result-artifact-truncation">${this.escapeHtml(`${hiddenRows} more row${hiddenRows === 1 ? '' : 's'} in CSV`)}</div>` : ''}
+        ${truncationNote ? `<div class="workspace-task-result-artifact-truncation">${this.escapeHtml(truncationNote)}</div>` : ''}
       </section>
     `;
   }

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -942,11 +942,6 @@ export class WorkspaceTaskPage {
       detailsEditBtn: document.getElementById('workspace-task-details-edit'),
       status: document.getElementById('workspace-task-status'),
       heroActions: document.getElementById('workspace-task-hero-actions'),
-      heroPriority: document.getElementById('workspace-task-hero-priority'),
-      heroPriorityCopy: document.getElementById('workspace-task-hero-priority-copy'),
-      heroPriorityReason: document.getElementById('workspace-task-hero-priority-reason'),
-      heroPriorityReasonText: document.getElementById('workspace-task-hero-priority-reason-text'),
-      heroPriorityActions: document.getElementById('workspace-task-hero-priority-actions'),
       overview: document.getElementById('workspace-task-overview'),
       heroAgentWrap: document.getElementById('workspace-task-hero-agent-wrap'),
       heroAgent: document.getElementById('workspace-task-hero-agent'),
@@ -1078,10 +1073,7 @@ export class WorkspaceTaskPage {
       assistRetryBtn: document.getElementById('workspace-task-assist-retry'),
       assistContinueBtn: document.getElementById('workspace-task-assist-continue'),
       assistSwitchBtn: document.getElementById('workspace-task-assist-switch'),
-      assistFailBtn: document.getElementById('workspace-task-assist-fail'),
-      assistPanel: document.getElementById('workspace-task-assist-panel'),
-      assistBackdrop: document.getElementById('workspace-task-assist-backdrop'),
-      assistCloseBtn: document.getElementById('workspace-task-assist-close')
+      assistFailBtn: document.getElementById('workspace-task-assist-fail')
     };
   }
 
@@ -1219,13 +1211,6 @@ export class WorkspaceTaskPage {
     this.elements.assistSwitchBtn?.addEventListener('click', () => this.submitTaskAssist('switch_agent_retry'));
     this.elements.assistFailBtn?.addEventListener('click', () => this.submitTaskAssist('mark_failed'));
     this.elements.assistAgent?.addEventListener('change', () => this.updateAssistSwitchButtonState());
-    this.elements.assistCloseBtn?.addEventListener('click', () => this.toggleAssistPanel(false));
-    this.elements.assistBackdrop?.addEventListener('click', () => this.toggleAssistPanel(false));
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && this.elements.assistPanel && !this.elements.assistPanel.hidden) {
-        this.toggleAssistPanel(false);
-      }
-    });
   }
 
   async loadData() {
@@ -2364,7 +2349,6 @@ export class WorkspaceTaskPage {
     dispatch('hero', () => this.renderHero(statusInfo));
     dispatch('heroActions', () => this.renderHeroActions(statusInfo));
     dispatch('heroAgent', () => this.renderHeroAgent(statusInfo));
-    dispatch('heroPriority', () => this.renderHeroPriority(statusInfo));
     dispatch('overview', () => this.renderOverview());
     dispatch('relationships', () => this.renderRelationships());
     dispatch('workflow', () => this.renderWorkflow());
@@ -2451,7 +2435,6 @@ export class WorkspaceTaskPage {
         t.id, t.to, t.status,
         (this.availableAgents || []).map((a) => a?.name || '').sort().join('|'),
       ]),
-      heroPriority: JSON.stringify([sigStatusInfo, sigBlocked]),
       overview: JSON.stringify([
         t.id, t.from, t.to, t.execution_mode, t.orchestration_mode,
         t.template_ref, t.timeout, t.progress?.percentage, t.current_run_id, t.details,
@@ -2801,127 +2784,6 @@ export class WorkspaceTaskPage {
       if (this._renderCache) delete this._renderCache.heroActions;
       this.renderHeroActions(this.getTaskStatusPresentation());
     }
-  }
-
-  renderHeroPriority(statusInfo) {
-    if (!this.elements.heroPriority || !this.elements.heroPriorityCopy || !this.elements.heroPriorityActions) {
-      return;
-    }
-
-    const blocked = statusInfo.isBlocked && this.currentBlockedTask;
-    if (!blocked) {
-      this.elements.heroPriority.hidden = true;
-      this.elements.heroPriorityCopy.textContent = '';
-      if (this.elements.heroPriorityReason) {
-        this.elements.heroPriorityReason.hidden = true;
-      }
-      if (this.elements.heroPriorityReasonText) {
-        this.elements.heroPriorityReasonText.textContent = '';
-      }
-      this.elements.heroPriorityActions.innerHTML = '';
-      return;
-    }
-
-    const workflowStep = this.currentBlockedTask?.workflowStep || null;
-    const hasAgentResponse = Boolean(String(this.currentBlockedTask?.response || '').trim());
-    const secondaryLabel = hasAgentResponse ? 'View Agent Request' : 'More Context';
-
-    this.elements.heroPriority.hidden = false;
-    const summary = this.getBlockedHeroSummary(workflowStep);
-    this.elements.heroPriorityCopy.textContent = summary;
-
-    // Show the raw blocked reason inline only when it adds information beyond
-    // the summary (which often is just the agent's question). This lets users
-    // see *why* the task is paused without scrolling to the assist card.
-    const rawReason = String(this.currentBlockedTask?.reason || '').trim();
-    const showReason = Boolean(rawReason) && rawReason !== summary;
-    if (this.elements.heroPriorityReason && this.elements.heroPriorityReasonText) {
-      if (showReason) {
-        this.elements.heroPriorityReasonText.textContent = rawReason;
-        this.elements.heroPriorityReason.hidden = false;
-      } else {
-        this.elements.heroPriorityReasonText.textContent = '';
-        this.elements.heroPriorityReason.hidden = true;
-      }
-    }
-    this.elements.heroPriorityActions.innerHTML = `
-      <button type="button" class="workspace-task-page-hero-btn workspace-task-page-hero-btn-primary" data-hero-priority-action="assist">
-        ${this.escapeHtml(this.getBlockedHeroPrimaryActionLabel(workflowStep))}
-      </button>
-      <button type="button" class="workspace-task-page-hero-btn" data-hero-priority-action="context">
-        ${this.escapeHtml(secondaryLabel)}
-      </button>
-    `;
-
-    this.elements.heroPriorityActions.querySelectorAll('[data-hero-priority-action]').forEach((button) => {
-      button.addEventListener('click', () => {
-        const action = String(button.getAttribute('data-hero-priority-action') || '').trim();
-        if (action === 'assist') {
-          // The banner is now the sole entry into the assist panel (the
-          // floating Respond button has been retired). Open the panel and
-          // hand focus to its first interactive element after the slide-in
-          // animation has settled.
-          this.toggleAssistPanel(true);
-          window.setTimeout(() => {
-            const target = this.getAssistFocusTarget();
-            if (target && typeof target.focus === 'function') {
-              target.focus({ preventScroll: true });
-            }
-          }, 360);
-          return;
-        }
-        if (action === 'context') {
-          const focusTarget = this.elements.blockedRequestToggle && !this.elements.blockedRequestToggle.classList.contains('d-none')
-            ? this.elements.blockedRequestToggle
-            : null;
-          this.scrollToSection(this.elements.blockedContextCard, { focusTarget });
-        }
-      });
-    });
-  }
-
-  getBlockedHeroSummary(workflowStep) {
-    const question = String(this.currentBlockedTask?.question || '').trim();
-    if (question) {
-      return question;
-    }
-    return this.getAssistNeedsSummary(workflowStep);
-  }
-
-  getBlockedHeroPrimaryActionLabel(workflowStep) {
-    if (this.currentBlockedTask?.reasonCode === 'assigned_agent_missing' &&
-        this.isAssistActionSuggested('switch_agent_retry') &&
-        !this.isAssistActionSuggested('continue_with_instruction')) {
-      return 'Switch Agent';
-    }
-    if (workflowStep?.stepType === 'ask_form') {
-      return 'Answer Questions';
-    }
-    if (workflowStep?.stepType === 'ask_choice') {
-      return 'Choose Next Step';
-    }
-    return 'Review And Continue';
-  }
-
-  scrollToSection(element, { focusTarget = null } = {}) {
-    if (!element) return;
-
-    element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-
-    const target = typeof focusTarget === 'function' ? focusTarget() : focusTarget;
-    if (!target || typeof target.focus !== 'function') return;
-
-    window.setTimeout(() => {
-      target.focus({ preventScroll: true });
-    }, 180);
-  }
-
-  getAssistFocusTarget() {
-    if (!this.elements.assistCard) return this.elements.assistContinueBtn || null;
-
-    return this.elements.assistCard.querySelector(
-      '[data-assist-choice-id]:not([disabled]), [data-assist-field-id]:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled])'
-    ) || this.elements.assistContinueBtn || null;
   }
 
   renderOverview() {
@@ -8376,12 +8238,15 @@ export class WorkspaceTaskPage {
   renderBlockedState(statusInfo) {
     const blocked = statusInfo.isBlocked && this.currentBlockedTask;
 
+    // The respond UI is an inline card at the top of the flow (no slide-out).
+    // Toggle it with the blocked state; renderAssistCard fills its content.
     if (!blocked) {
-      this.toggleAssistPanel(false);
+      if (this.elements.assistCard) this.elements.assistCard.hidden = true;
       if (this.elements.blockedContextCard) this.elements.blockedContextCard.hidden = true;
       return;
     }
 
+    if (this.elements.assistCard) this.elements.assistCard.hidden = false;
     this.renderBlockedContext();
     this.renderAssistCard();
   }
@@ -9066,28 +8931,6 @@ export class WorkspaceTaskPage {
     this.renderBlockedContext();
   }
 
-  toggleAssistPanel(open) {
-    const panel = this.elements.assistPanel;
-    if (!panel) return;
-
-    clearTimeout(this._assistPanelCloseTimer);
-
-    if (open) {
-      panel.hidden = false;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          panel.classList.add('is-open');
-        });
-      });
-      document.body.style.overflow = 'hidden';
-    } else {
-      if (panel.hidden) return;
-      panel.classList.remove('is-open');
-      this._assistPanelCloseTimer = setTimeout(() => { panel.hidden = true; }, 340);
-      document.body.style.overflow = '';
-    }
-  }
-
   setAssistButtonsDisabled(disabled) {
     [
       this.elements.assistRetryBtn,
@@ -9335,7 +9178,8 @@ export class WorkspaceTaskPage {
       }
 
       this.notify('success', 'Task updated');
-      this.toggleAssistPanel(false);
+      // No explicit close: the inline respond card hides itself on the next
+      // render (renderBlockedState) once loadData shows the task is unblocked.
       if (this.elements.assistMessage) {
         this.elements.assistMessage.value = '';
       }

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -4977,6 +4977,12 @@ export class WorkspaceTaskPage {
     const defaultPathHint = defaultPath
       ? `<span class="workspace-task-automation-storage-path" title="${this.escapeHtml(defaultPath)}">${this.escapeHtml(defaultPath)}</span>`
       : '';
+    const openFolderLabel = this.fileManagerActionLabel();
+    const openFolderBtn = `
+      <button type="button" class="workspace-task-automation-storage-open-btn" data-action="open-output-dir" title="${this.escapeHtml(openFolderLabel)}" aria-label="${this.escapeHtml(openFolderLabel)}">
+        <i class="bi bi-folder2-open" aria-hidden="true"></i>
+        <span>${this.escapeHtml(openFolderLabel)}</span>
+      </button>`;
     const fileName = String(storage.file_name || '').trim() || this.defaultAppendCsvFilename(owner);
 
     container.innerHTML = `
@@ -4985,7 +4991,7 @@ export class WorkspaceTaskPage {
         <div class="workspace-task-automation-storage-options" role="radiogroup" aria-label="Storage destination">
           <label class="workspace-task-automation-storage-option">
             <input type="radio" name="workspace-task-automation-storage-target" value="default"${target === 'default' ? ' checked' : ''} />
-            <span>Default output folder${defaultPathHint}</span>
+            <span>Default output folder${defaultPathHint}${openFolderBtn}</span>
             <input type="text" data-role="automation-storage-filename" class="workspace-task-automation-storage-input" placeholder="file name (e.g. nyc_pollen.csv)" value="${this.escapeHtml(fileName)}" aria-label="CSV file name" />
           </label>
           <label class="workspace-task-automation-storage-option${storeOptions ? '' : ' is-disabled'}">
@@ -5020,6 +5026,54 @@ export class WorkspaceTaskPage {
     container
       .querySelector('[data-action="open-automation-storage-modal"]')
       ?.addEventListener('click', () => this.openTaskStorageEditor());
+    container
+      .querySelector('[data-action="open-output-dir"]')
+      ?.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.openWorkspaceOutputDir();
+      });
+  }
+
+  // fileManagerActionLabel returns a platform-appropriate label for buttons
+  // that reveal a path in the OS file manager.
+  fileManagerActionLabel() {
+    const platform = (navigator.platform || navigator.userAgent || '').toLowerCase();
+    if (platform.includes('mac')) return 'Open in Finder';
+    if (platform.includes('win')) return 'Open in Explorer';
+    return 'Open folder';
+  }
+
+  // openWorkspaceOutputDir asks the server to open this workspace's default
+  // outputs folder in the local file manager. The dir is created lazily if it
+  // doesn't exist yet.
+  async openWorkspaceOutputDir() {
+    if (!this.workspaceId) return;
+    try {
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/output-dir/open`,
+        { method: 'POST' }
+      );
+      if (!response.ok) {
+        const message = await this.extractErrorMessage(response).catch(() => '');
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+    } catch (err) {
+      if (window.Toast && typeof window.Toast.error === 'function') {
+        window.Toast.error(`Couldn't open output folder: ${err.message || err}`);
+      } else {
+        console.error('Failed to open output folder', err);
+      }
+    }
+  }
+
+  async extractErrorMessage(response) {
+    try {
+      const data = await response.json();
+      return data?.error || data?.message || '';
+    } catch (_) {
+      return '';
+    }
   }
 
   // saveAutomationStorageDestination reads the inline destination editor and

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -970,6 +970,8 @@ export class WorkspaceTaskPage {
       relationshipsCard: document.getElementById('workspace-task-relationships-card'),
       relationships: document.getElementById('workspace-task-relationships'),
       outputCard: document.getElementById('workspace-task-output-card'),
+      outputShapeCard: document.getElementById('workspace-task-output-shape-card'),
+      outputShape: document.getElementById('workspace-task-output-shape'),
       outputCopyBtn: document.getElementById('workspace-task-output-copy'),
       outputSaveNoteBtn: document.getElementById('workspace-task-output-save-note'),
       outputCreateSkillBtn: document.getElementById('workspace-task-output-create-skill'),
@@ -2398,6 +2400,7 @@ export class WorkspaceTaskPage {
     dispatch('relationships', () => this.renderRelationships());
     dispatch('workflow', () => this.renderWorkflow());
     dispatch('output', () => this.renderOutput());
+    dispatch('outputShape', () => this.renderTaskOutputShape());
     dispatch('workspaceRuns', () => this.renderWorkspaceRunsCard());
     dispatch('runs', () => this.renderRunsCard());
     dispatch('schedule', () => this.renderSchedule());
@@ -2513,6 +2516,12 @@ export class WorkspaceTaskPage {
         t.execution_history?.[t.execution_history.length - 1]?.status || '',
         t.execution_history?.[t.execution_history.length - 1]?.summary || '',
         t.execution_history?.[t.execution_history.length - 1]?.result || '',
+      ]),
+      outputShape: JSON.stringify([
+        t.id,
+        t.output_spec || null,
+        t.output_schema || null,
+        t.output_contract || null,
       ]),
       workspaceRuns: JSON.stringify([
         t.id,
@@ -6322,6 +6331,122 @@ export class WorkspaceTaskPage {
       return;
     }
     await this.copyToClipboard(sectionText, 'Section copied');
+  }
+
+  // renderTaskOutputShape paints the "Expected output shape" card with the
+  // task's declared schema fields, CSV contract columns, and the run-info
+  // metadata flagged for CSV inclusion. Falls back to an empty-state when
+  // no structured spec is configured (LLM returns free text).
+  renderTaskOutputShape() {
+    if (!this.elements.outputShape || !this.elements.outputShapeCard) return;
+
+    const t = this.task || {};
+    const spec = t.output_spec || null;
+    const schemaSource = (spec && spec.schema) || t.output_schema || null;
+    const contractSource = (spec && spec.contract) || t.output_contract || null;
+
+    const schemaFields = Array.isArray(schemaSource?.fields) ? schemaSource.fields : [];
+    const contractColumns = Array.isArray(contractSource?.columns) ? contractSource.columns : [];
+    const metadataFields = this.getOutputSpecMetadataFields(spec);
+
+    const hasAnyStructure = schemaFields.length > 0 || contractColumns.length > 0;
+
+    if (!hasAnyStructure) {
+      this.elements.outputShape.innerHTML = `
+        <div class="workspace-task-output-shape-empty">
+          <strong>Free-text output</strong>
+          The task currently has no structured output spec. The agent returns natural language and the result is stored on each run record as-is.
+          Add a spec in Automation &gt; Advanced settings to enforce a JSON shape and project results into CSV columns.
+        </div>`;
+      return;
+    }
+
+    const includedMetadata = metadataFields.filter((field) => field.include);
+    const summaryStats = [
+      ['Assistant fields', schemaFields.length ? `${schemaFields.length}` : 'none'],
+      ['CSV columns', contractColumns.length ? `${contractColumns.length}` : 'none'],
+      ['Run info in CSV', includedMetadata.length ? `${includedMetadata.length} of ${metadataFields.length}` : 'hidden'],
+    ];
+    const summaryHtml = `
+      <div class="workspace-task-output-shape-summary">
+        ${summaryStats.map(([label, value]) => `
+          <div class="workspace-task-output-shape-stat">
+            <span>${this.escapeHtml(label)}</span>
+            <strong>${this.escapeHtml(value)}</strong>
+          </div>
+        `).join('')}
+      </div>`;
+
+    const schemaBlock = schemaFields.length ? `
+      <div class="workspace-task-output-shape-block">
+        <div class="workspace-task-output-shape-block-header">
+          <span>Assistant fields (JSON shape returned by the agent)</span>
+          ${schemaSource?.name ? `<span class="workspace-task-output-shape-block-meta">${this.escapeHtml(schemaSource.name)}</span>` : ''}
+        </div>
+        <table class="workspace-task-output-shape-table">
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Type</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${schemaFields.map((field) => `
+              <tr>
+                <td>${this.escapeHtml(String(field?.name || ''))}</td>
+                <td class="workspace-task-output-shape-col-type">${this.escapeHtml(String(field?.type || 'string'))}</td>
+                <td class="workspace-task-output-shape-col-required ${field?.required ? '' : 'is-optional'}">${field?.required ? 'required' : 'optional'}</td>
+                <td>${this.escapeHtml(String(field?.description || ''))}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>` : '';
+
+    const contractBlock = contractColumns.length ? `
+      <div class="workspace-task-output-shape-block">
+        <div class="workspace-task-output-shape-block-header">
+          <span>CSV columns (row shape stored on append)</span>
+          ${contractSource?.version ? `<span class="workspace-task-output-shape-block-meta">${this.escapeHtml(contractSource.version)}</span>` : ''}
+        </div>
+        <table class="workspace-task-output-shape-table">
+          <thead>
+            <tr>
+              <th>Column</th>
+              <th>Type</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${contractColumns.map((column) => `
+              <tr>
+                <td>${this.escapeHtml(String(column?.name || ''))}</td>
+                <td class="workspace-task-output-shape-col-type">${this.escapeHtml(String(column?.type || 'string'))}</td>
+                <td class="workspace-task-output-shape-col-required ${column?.required ? '' : 'is-optional'}">${column?.required ? 'required' : 'optional'}</td>
+                <td>${this.escapeHtml(String(column?.description || ''))}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>` : '';
+
+    const metadataBlock = metadataFields.length ? `
+      <div class="workspace-task-output-shape-block">
+        <div class="workspace-task-output-shape-block-header">
+          <span>Run info appended to each row</span>
+          <span class="workspace-task-output-shape-block-meta">${this.escapeHtml(`${includedMetadata.length} of ${metadataFields.length} included`)}</span>
+        </div>
+        <div class="workspace-task-output-shape-metadata">
+          ${metadataFields.map((field) => `
+            <span class="workspace-task-output-shape-chip" data-included="${Boolean(field.include)}" title="${field.include ? 'Included in CSV row' : 'Hidden from CSV (kept on run artifact only)'}">${this.escapeHtml(field.name)}</span>
+          `).join('')}
+        </div>
+      </div>` : '';
+
+    this.elements.outputShape.innerHTML = [summaryHtml, schemaBlock, contractBlock, metadataBlock].filter(Boolean).join('');
   }
 
   renderOutput() {

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -4119,29 +4119,6 @@ export class WorkspaceTaskPage {
     return Array.from(byName.values());
   }
 
-  renderOutputSpecOverview(spec) {
-    if (!spec) return '';
-    const fields = this.getOutputSpecSchemaFields(spec);
-    const columns = Array.isArray(spec?.contract?.columns) ? spec.contract.columns : [];
-    const metadataFields = this.getOutputSpecMetadataFields(spec);
-    const metadataIncluded = metadataFields.filter((field) => field.include).map((field) => field.name);
-    return `
-      <div class="workspace-task-output-spec-overview">
-        <div class="workspace-task-output-spec-stat">
-          <span>Assistant fields</span>
-          <strong>${this.escapeHtml(`${fields.length} field${fields.length === 1 ? '' : 's'}`)}</strong>
-        </div>
-        <div class="workspace-task-output-spec-stat">
-          <span>CSV columns</span>
-          <strong>${this.escapeHtml(`${columns.length} column${columns.length === 1 ? '' : 's'}`)}</strong>
-        </div>
-        <div class="workspace-task-output-spec-stat">
-          <span>Run info</span>
-          <strong>${this.escapeHtml(metadataIncluded.length ? metadataIncluded.join(', ') : 'hidden')}</strong>
-        </div>
-      </div>`;
-  }
-
   renderOutputSpecMetadataEditor() {
     const fields = this.getOutputSpecMetadataFields(this.resultOutputSpecDraft || this.getActiveOutputSpec());
     return `
@@ -4166,8 +4143,6 @@ export class WorkspaceTaskPage {
     const editing = Array.isArray(this.resultContractDraft);
     const columns = this.getResultContractColumns();
     if (!editing && columns.length > 0) {
-      const activeSpec = this.getActiveOutputSpec();
-      const version = String(activeSpec?.version || this.getTaskResultStorageTask()?.output_contract?.version || '').trim();
       const preview = columns
         .map((column) => String(column?.name || '').trim())
         .filter(Boolean)
@@ -4177,11 +4152,10 @@ export class WorkspaceTaskPage {
       return `
         <div class="workspace-task-result-contract" data-state="view">
           <div class="workspace-task-result-contract-summary">
-            <span class="workspace-task-page-mini-label">Each run returns${version ? ` · ${this.escapeHtml(version)}` : ''}</span>
+            <span class="workspace-task-page-mini-label">Each run returns</span>
             <span class="workspace-task-result-contract-summary-list">${this.escapeHtml(preview + overflow)}</span>
-            <span class="workspace-task-result-contract-projection">Stored as CSV columns (plus run info)</span>
+            <span class="workspace-task-result-contract-projection">Saved as a JSON record per run · run info (run_id, executed_at, status…) is added automatically · export to CSV anytime</span>
           </div>
-          ${this.renderOutputSpecOverview(activeSpec)}
           <button type="button" class="workspace-task-page-text-button" data-action="edit-result-contract">Edit fields</button>
         </div>`;
     }
@@ -4816,8 +4790,8 @@ export class WorkspaceTaskPage {
       <label class="workspace-task-automation-storage-toggle">
         <input type="checkbox" data-action="toggle-csv-storage"${ctx.configured ? ' checked' : ''}${busy ? ' disabled' : ''} />
         <span>
-          <strong>Store each run of this task to CSV</strong>
-          <span class="workspace-task-automation-storage-help">Turns on Append mode so every run becomes a row in a shared CSV file.</span>
+          <strong>Save each run of this task to a dataset</strong>
+          <span class="workspace-task-automation-storage-help">Turns on Append mode so every run is saved as a record in a shared JSONL file (export to CSV anytime).</span>
         </span>
       </label>`;
     container.innerHTML = toggleHtml + (ctx.configured ? this.renderResultContractBlock() : '');

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -938,6 +938,9 @@ export class WorkspaceTaskPage {
       copyIdBtn: document.getElementById('workspace-task-copy-id'),
       copyLinkBtn: document.getElementById('workspace-task-copy-link'),
       deleteBtn: document.getElementById('workspace-task-delete'),
+      heroOverflow: document.querySelector('.workspace-task-hero-overflow'),
+      heroOverflowToggle: document.getElementById('workspace-task-hero-overflow-toggle'),
+      heroOverflowMenu: document.getElementById('workspace-task-hero-overflow-menu'),
       subtitle: document.getElementById('workspace-task-subtitle'),
       detailsEditBtn: document.getElementById('workspace-task-details-edit'),
       status: document.getElementById('workspace-task-status'),
@@ -1126,8 +1129,29 @@ export class WorkspaceTaskPage {
     this.elements.followupSubmit?.addEventListener('click', () => this.submitFollowupTask());
     this.elements.followupDetailsToggle?.addEventListener('click', () => this.toggleFollowupDetails());
     this.elements.copyIdBtn?.addEventListener('click', () => this.copyToClipboard(this.taskId, 'Task ID copied'));
-    this.elements.copyLinkBtn?.addEventListener('click', () => this.copyToClipboard(window.location.href, 'Link copied'));
-    this.elements.deleteBtn?.addEventListener('click', () => this.deleteTask());
+    this.elements.copyLinkBtn?.addEventListener('click', () => {
+      this.copyToClipboard(window.location.href, 'Link copied');
+      this.setHeroOverflowOpen(false);
+    });
+    this.elements.deleteBtn?.addEventListener('click', () => {
+      this.setHeroOverflowOpen(false);
+      this.deleteTask();
+    });
+    this.elements.heroOverflowToggle?.addEventListener('click', (event) => {
+      event.stopPropagation();
+      this.setHeroOverflowOpen(this.elements.heroOverflow?.dataset.open !== 'true');
+    });
+    document.addEventListener('click', (event) => {
+      if (this.elements.heroOverflow?.dataset.open !== 'true') return;
+      if (this.elements.heroOverflow.contains(event.target)) return;
+      this.setHeroOverflowOpen(false);
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && this.elements.heroOverflow?.dataset.open === 'true') {
+        this.setHeroOverflowOpen(false);
+        this.elements.heroOverflowToggle?.focus();
+      }
+    });
     this.elements.outputCopyBtn?.addEventListener('click', () => {
       this.copyCurrentResult();
       this.setOutputOverflowOpen(false);
@@ -1810,6 +1834,19 @@ export class WorkspaceTaskPage {
       this.render();
     }
     return this.task;
+  }
+
+  // setHeroOverflowOpen toggles the hero "more actions" menu (Copy link,
+  // Delete). CSS-positioned (the hero doesn't clip it), so this only syncs the
+  // data-open / aria-expanded / hidden state.
+  setHeroOverflowOpen(open) {
+    const container = this.elements.heroOverflow;
+    const toggle = this.elements.heroOverflowToggle;
+    const menu = this.elements.heroOverflowMenu;
+    if (!container || !toggle || !menu) return;
+    container.dataset.open = open ? 'true' : 'false';
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    menu.hidden = !open;
   }
 
   // setOutputOverflowOpen drives the demoted-actions popover (Copy,
@@ -2791,17 +2828,24 @@ export class WorkspaceTaskPage {
 
     const progress = this.task?.progress;
     const isBlocked = Boolean(this.currentBlockedTask);
+    const status = String(this.task?.status || '').trim().toLowerCase();
 
-    // Keep the default Overview to the essentials a non-technical user cares
-    // about. Configuration internals (execution mode, orchestration mode,
-    // template ref) are intentionally omitted here — they remain in the
-    // Developer tab's Technical details (raw context).
-    const items = [
-      {
+    // Keep the overview to the essentials a non-technical user cares about.
+    // Configuration internals (execution mode, orchestration mode, template
+    // ref) are intentionally omitted here — they remain in the collapsed
+    // Developer details (raw context).
+    const items = [];
+
+    // Agent is shown as the hero picker whenever the task is reassignable
+    // (not running, not blocked). Only repeat it in the overview grid when
+    // that picker is hidden, so the agent is visible exactly once.
+    const agentShownInHero = status !== 'in_progress' && !isBlocked;
+    if (!agentShownInHero) {
+      items.push({
         title: 'Agent',
         value: String(this.task?.to || 'Unassigned').trim() || 'Unassigned'
-      }
-    ];
+      });
+    }
 
     // "Requested By" is only meaningful when something other than the
     // workspace itself created the task; hide the noisy default.

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -865,12 +865,6 @@ export class WorkspaceTaskPage {
     // so users can tell a still-spinning task is making progress.
     this._latestActivity = null;
     this._activityTickHandle = null;
-    // Tab state (Overview / Activity / Developer). Defaults to Overview but
-    // auto-switches to Activity for failed/cancelled/timeout tasks on first
-    // load so debugging starts in the right place. _taskTabUserPicked turns
-    // true once a user clicks a tab, suppressing further auto-switching.
-    this._taskTab = 'overview';
-    this._taskTabUserPicked = false;
     // Follow-up form lives inline under the result card; only one instance
     // open at a time. _followupSubmitting prevents double-submits.
     this._followupOpen = false;
@@ -1063,13 +1057,6 @@ export class WorkspaceTaskPage {
       scheduleRemoveBtn: document.getElementById('workspace-task-schedule-remove'),
       contextCard: document.getElementById('workspace-task-context-card'),
       context: document.getElementById('workspace-task-context'),
-      tabButtons: Array.from(document.querySelectorAll('.workspace-task-page-tab')),
-      tabPanes: {
-        overview: document.getElementById('workspace-task-tab-overview'),
-        activity: document.getElementById('workspace-task-tab-activity'),
-        developer: document.getElementById('workspace-task-tab-developer')
-      },
-      activityEmpty: document.getElementById('workspace-task-activity-empty'),
       blockedContextCard: document.getElementById('workspace-task-blocked-context-card'),
       blockedReason: document.getElementById('workspace-task-blocked-reason'),
       blockedRequestWrap: document.getElementById('workspace-task-blocked-request-wrap'),
@@ -1128,18 +1115,6 @@ export class WorkspaceTaskPage {
         btn.addEventListener('click', () => {
           const next = btn.getAttribute('data-runs-tab') || 'runs';
           this.setRunsTab(next);
-        });
-      });
-    }
-    if (Array.isArray(this.elements.tabButtons)) {
-      this.elements.tabButtons.forEach((btn) => {
-        btn.addEventListener('click', () => {
-          const next = btn.getAttribute('data-task-tab') || 'overview';
-          // Sticky for the rest of the session: once the user picks a tab,
-          // don't fight them by auto-switching back to a status-based default
-          // on the next data refresh.
-          this._taskTabUserPicked = true;
-          this.setTaskTab(next);
         });
       });
     }
@@ -2369,14 +2344,6 @@ export class WorkspaceTaskPage {
     this.taskAssistResponseExpanded = false;
     this.assistReviewMode = false;
 
-    // Pick a default tab on first render based on task status. After the user
-    // clicks a tab we never override their choice.
-    if (!this._taskTabUserPicked) {
-      this.setTaskTab(this.defaultTaskTab());
-    } else {
-      this.refreshTaskTabEmptyStates();
-    }
-
     // Selective rendering: each sub-render is only invoked when its inputs
     // actually changed since the previous render. The first render after
     // page load (or after forceFullRender()) fills the cache and triggers
@@ -2408,10 +2375,6 @@ export class WorkspaceTaskPage {
     dispatch('schedule', () => this.renderSchedule());
     dispatch('context', () => this.renderContext());
     dispatch('blockedState', () => this.renderBlockedState(statusInfo));
-
-    // Tab visibility depends on which cards ended up hidden after the
-    // sub-renders — refresh the per-tab empty placeholders here.
-    this.refreshTaskTabEmptyStates();
   }
 
   // forceFullRender clears the per-section input cache so the next render()
@@ -4679,7 +4642,6 @@ export class WorkspaceTaskPage {
       try {
         if (this._renderCache) delete this._renderCache.schedule;
         this.renderSchedule();
-        this.refreshTaskTabEmptyStates();
         return;
       } catch (error) {
         console.warn('Failed to re-render Automation card; falling back to data reload:', error);
@@ -8386,79 +8348,6 @@ export class WorkspaceTaskPage {
     this.renderRunsCard();
   }
 
-  // defaultTaskTab returns which top-level tab should be active for a fresh
-  // page load given the task's current status. Failed/cancelled/timeout
-  // surface Activity (so debugging starts on the run history) and everything
-  // else opens to Overview.
-  defaultTaskTab() {
-    const status = String(this.task?.status || '').trim().toLowerCase();
-    if (status === 'failed' || status === 'cancelled' || status === 'timeout') {
-      return 'activity';
-    }
-    return 'overview';
-  }
-
-  setTaskTab(name) {
-    const valid = ['overview', 'activity', 'developer'];
-    const next = valid.includes(name) ? name : 'overview';
-    this._taskTab = next;
-
-    if (Array.isArray(this.elements.tabButtons)) {
-      this.elements.tabButtons.forEach((btn) => {
-        const isActive = btn.getAttribute('data-task-tab') === next;
-        btn.classList.toggle('is-active', isActive);
-        btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
-      });
-    }
-
-    const panes = this.elements.tabPanes || {};
-    for (const key of valid) {
-      const pane = panes[key];
-      if (!pane) continue;
-      const isActive = key === next;
-      pane.hidden = !isActive;
-      pane.classList.toggle('is-active', isActive);
-    }
-
-    this.refreshTaskTabEmptyStates();
-  }
-
-  // refreshTaskTabEmptyStates shows a small "nothing yet" message inside
-  // Activity / Developer when their cards are all hidden — without it those
-  // tabs would render as empty whitespace and feel broken.
-  refreshTaskTabEmptyStates() {
-    const visible = (el) => el && !el.hidden;
-
-    // Run details (workspace-task-runs-card) moved to the Developer tab, so it
-    // no longer counts toward Activity's populated state.
-    const activityCards = [
-      document.getElementById('workspace-task-workspace-runs-card'),
-      document.getElementById('workspace-task-relationships-card'),
-      document.getElementById('workspace-task-workflow-card')
-    ];
-    const populatedActivityCount = activityCards.filter(visible).length;
-
-    if (this.elements.activityEmpty) {
-      this.elements.activityEmpty.hidden = populatedActivityCount > 0;
-    }
-
-    // Mirror the populated-subcard count onto the Activity tab button so
-    // the user can tell from the tab row whether anything's worth opening,
-    // rather than having to click in to find empty placeholders.
-    const activityCount = document.getElementById('workspace-task-tab-activity-count');
-    if (activityCount) {
-      if (populatedActivityCount > 0) {
-        activityCount.hidden = false;
-        activityCount.textContent = String(populatedActivityCount);
-      } else {
-        activityCount.hidden = true;
-        activityCount.textContent = '';
-      }
-    }
-
-    // The Developer tab always has the Task ID card, so it never needs an
-    // empty-state placeholder.
-  }
 
   renderContext() {
     if (!this.elements.context || !this.elements.contextCard) return;

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -6300,7 +6300,6 @@ export class WorkspaceTaskPage {
 
     const schemaFields = Array.isArray(schemaSource?.fields) ? schemaSource.fields : [];
     const contractColumns = Array.isArray(contractSource?.columns) ? contractSource.columns : [];
-    const metadataFields = this.getOutputSpecMetadataFields(spec);
 
     const hasAnyStructure = schemaFields.length > 0 || contractColumns.length > 0;
 
@@ -6315,92 +6314,35 @@ export class WorkspaceTaskPage {
     }
     this.elements.outputShapeWrap.hidden = false;
 
-    const includedMetadata = metadataFields.filter((field) => field.include);
-    const summaryStats = [
-      ['Assistant fields', schemaFields.length ? `${schemaFields.length}` : 'none'],
-      ['CSV columns', contractColumns.length ? `${contractColumns.length}` : 'none'],
-      ['Run info in CSV', includedMetadata.length ? `${includedMetadata.length} of ${metadataFields.length}` : 'hidden'],
-    ];
-    const summaryHtml = `
-      <div class="workspace-task-output-shape-summary">
-        ${summaryStats.map(([label, value]) => `
-          <div class="workspace-task-output-shape-stat">
-            <span>${this.escapeHtml(label)}</span>
-            <strong>${this.escapeHtml(value)}</strong>
-          </div>
-        `).join('')}
-      </div>`;
+    // One shape, schema-first. The JSON schema is the canonical record shape;
+    // fall back to the legacy CSV contract columns only for tasks that predate
+    // the schema. The old separate "CSV columns" and "Run info" tables are
+    // gone — CSV is derived from these fields at export time, so repeating them
+    // here was the duplication.
+    const shapeFields = (schemaFields.length ? schemaFields : contractColumns).map((field) => ({
+      name: String(field?.name || ''),
+      type: String(field?.type || 'string'),
+      required: Boolean(field?.required),
+      description: String(field?.description || ''),
+    }));
 
-    const schemaBlock = schemaFields.length ? `
-      <div class="workspace-task-output-shape-block">
-        <div class="workspace-task-output-shape-block-header">
-          <span>Assistant fields (JSON shape returned by the agent)</span>
-          ${schemaSource?.name ? `<span class="workspace-task-output-shape-block-meta">${this.escapeHtml(schemaSource.name)}</span>` : ''}
-        </div>
-        <table class="workspace-task-output-shape-table">
-          <thead>
-            <tr>
-              <th>Field</th>
-              <th>Type</th>
-              <th>Required</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${schemaFields.map((field) => `
-              <tr>
-                <td>${this.escapeHtml(String(field?.name || ''))}</td>
-                <td class="workspace-task-output-shape-col-type">${this.escapeHtml(String(field?.type || 'string'))}</td>
-                <td class="workspace-task-output-shape-col-required ${field?.required ? '' : 'is-optional'}">${field?.required ? 'required' : 'optional'}</td>
-                <td>${this.escapeHtml(String(field?.description || ''))}</td>
-              </tr>
-            `).join('')}
-          </tbody>
-        </table>
-      </div>` : '';
+    const rowsHtml = shapeFields.map((field) => `
+      <tr>
+        <td>${this.escapeHtml(field.name)}</td>
+        <td class="workspace-task-output-shape-col-type">${this.escapeHtml(field.type)}</td>
+        <td class="workspace-task-output-shape-col-required ${field.required ? '' : 'is-optional'}">${field.required ? 'required' : 'optional'}</td>
+        <td>${this.escapeHtml(field.description)}</td>
+      </tr>
+    `).join('');
 
-    const contractBlock = contractColumns.length ? `
-      <div class="workspace-task-output-shape-block">
-        <div class="workspace-task-output-shape-block-header">
-          <span>CSV columns (row shape stored on append)</span>
-          ${contractSource?.version ? `<span class="workspace-task-output-shape-block-meta">${this.escapeHtml(contractSource.version)}</span>` : ''}
-        </div>
-        <table class="workspace-task-output-shape-table">
-          <thead>
-            <tr>
-              <th>Column</th>
-              <th>Type</th>
-              <th>Required</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${contractColumns.map((column) => `
-              <tr>
-                <td>${this.escapeHtml(String(column?.name || ''))}</td>
-                <td class="workspace-task-output-shape-col-type">${this.escapeHtml(String(column?.type || 'string'))}</td>
-                <td class="workspace-task-output-shape-col-required ${column?.required ? '' : 'is-optional'}">${column?.required ? 'required' : 'optional'}</td>
-                <td>${this.escapeHtml(String(column?.description || ''))}</td>
-              </tr>
-            `).join('')}
-          </tbody>
-        </table>
-      </div>` : '';
-
-    const metadataBlock = metadataFields.length ? `
-      <div class="workspace-task-output-shape-block">
-        <div class="workspace-task-output-shape-block-header">
-          <span>Run info appended to each row</span>
-          <span class="workspace-task-output-shape-block-meta">${this.escapeHtml(`${includedMetadata.length} of ${metadataFields.length} included`)}</span>
-        </div>
-        <div class="workspace-task-output-shape-metadata">
-          ${metadataFields.map((field) => `
-            <span class="workspace-task-output-shape-chip" data-included="${Boolean(field.include)}" title="${field.include ? 'Included in CSV row' : 'Hidden from CSV (kept on run artifact only)'}">${this.escapeHtml(field.name)}</span>
-          `).join('')}
-        </div>
-      </div>` : '';
-
-    this.elements.outputShape.innerHTML = [summaryHtml, schemaBlock, contractBlock, metadataBlock].filter(Boolean).join('');
+    this.elements.outputShape.innerHTML = `
+      <p class="workspace-task-output-shape-note">Each run is stored as a JSON record with these fields. Use <strong>Export CSV</strong> on the dataset for a spreadsheet — its columns are derived from these fields, plus run info (run_id, executed_at, status…).</p>
+      <table class="workspace-task-output-shape-table">
+        <thead>
+          <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
+        </thead>
+        <tbody>${rowsHtml}</tbody>
+      </table>`;
   }
 
   renderOutput() {

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -1032,6 +1032,7 @@ export class WorkspaceTaskPage {
       automationColumns: document.getElementById('workspace-task-automation-columns'),
       automationStorage: document.getElementById('workspace-task-automation-storage'),
       scheduleCardEditBtn: document.getElementById('workspace-task-schedule-card-edit'),
+      scheduleOpenFolderBtn: document.getElementById('workspace-task-schedule-open-folder'),
       scheduleModal: document.getElementById('workspace-task-schedule-modal'),
       scheduleModalHeading: document.getElementById('workspace-task-schedule-heading'),
       scheduleModalMeta: document.getElementById('workspace-task-schedule-modal-meta'),
@@ -1216,6 +1217,7 @@ export class WorkspaceTaskPage {
     this.elements.workflowAddStepBtn?.addEventListener('click', () => this.handleAddStep());
     this.elements.workflowRunAllBtn?.addEventListener('click', () => this.handleRunAllSteps());
     this.elements.scheduleCardEditBtn?.addEventListener('click', () => this.openScheduleModal());
+    this.elements.scheduleOpenFolderBtn?.addEventListener('click', () => this.openWorkspaceOutputDir());
     this.elements.scheduleTypeInput?.addEventListener('change', () => this.updateScheduleModalFields());
     this.elements.scheduleWakeMacInput?.addEventListener('change', () => this.updateScheduleModalFields());
     [
@@ -6351,15 +6353,17 @@ export class WorkspaceTaskPage {
 
     const hasAnyStructure = schemaFields.length > 0 || contractColumns.length > 0;
 
+    // Hide the entire card on free-text tasks. The "Expected output shape" panel
+    // only carries meaning when the task declares a JSON schema or CSV contract;
+    // a developer-flavored empty state ("add a spec to enforce a JSON shape…")
+    // doesn't belong on the Overview tab, which is otherwise kept to the
+    // non-technical essentials. The spec is still editable from the task modal.
     if (!hasAnyStructure) {
-      this.elements.outputShape.innerHTML = `
-        <div class="workspace-task-output-shape-empty">
-          <strong>Free-text output</strong>
-          The task currently has no structured output spec. The agent returns natural language and the result is stored on each run record as-is.
-          Add a spec in Automation &gt; Advanced settings to enforce a JSON shape and project results into CSV columns.
-        </div>`;
+      this.elements.outputShapeCard.hidden = true;
+      this.elements.outputShape.innerHTML = '';
       return;
     }
+    this.elements.outputShapeCard.hidden = false;
 
     const includedMetadata = metadataFields.filter((field) => field.include);
     const summaryStats = [
@@ -8111,6 +8115,22 @@ export class WorkspaceTaskPage {
     }
 
     this.elements.scheduleCard.hidden = false;
+
+    // Surface the "Open output folder" action in the card header whenever the
+    // task writes to the workspace's default output folder. Store-node and
+    // explicit-path destinations are skipped because openWorkspaceOutputDir
+    // only reveals the default folder; for those the buried per-destination
+    // control in Advanced > storage remains the right entry point.
+    if (this.elements.scheduleOpenFolderBtn) {
+      const storage = storageOwner?.result_storage || null;
+      const usesDefaultOutputDir = Boolean(storage?.enabled)
+        && !String(storage.store_node_id || '').trim()
+        && String(storage.storage_target || '').trim() !== 'workspace_folder'
+        && !String(storage.file_path || '').trim();
+      this.elements.scheduleOpenFolderBtn.hidden = !usesDefaultOutputDir;
+      const labelSpan = this.elements.scheduleOpenFolderBtn.querySelector('span');
+      if (labelSpan) labelSpan.textContent = this.fileManagerActionLabel();
+    }
 
     const stats = [];
     stats.push({ label: 'Total Runs', value: String(executionCount) });

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -6398,13 +6398,31 @@ export class WorkspaceTaskPage {
     if (reviewPanel) {
       blocks.push(reviewPanel);
     }
-    if (artifact) {
-      blocks.push(this.renderResultArtifact(artifact));
-    }
     if (result) {
       blocks.push(`
         <div class="workspace-task-page-mini-label">Result</div>
         ${this.renderMarkdownOrPre(result)}
+      `);
+    }
+    // The accumulated run-history dataset (the CSV across every run) is
+    // secondary to the latest result, so tuck it into a disclosure: collapsed
+    // when there's a result to lead with, expanded when the dataset is the only
+    // output this task produced.
+    if (artifact) {
+      const datasetRows = Array.isArray(artifact.rows) ? artifact.rows.length : 0;
+      const datasetCols = Array.isArray(artifact.columns) ? artifact.columns.length : 0;
+      const datasetMeta = [
+        datasetRows ? `${datasetRows} row${datasetRows === 1 ? '' : 's'}` : '',
+        datasetCols ? `${datasetCols} column${datasetCols === 1 ? '' : 's'}` : '',
+      ].filter(Boolean).join(' · ');
+      blocks.push(`
+        <details class="workspace-task-result-artifact-disclosure"${result ? '' : ' open'}>
+          <summary class="workspace-task-result-artifact-summary">
+            <span class="workspace-task-result-artifact-summary-title">${this.escapeHtml(artifact.title || 'Dataset')}</span>
+            ${datasetMeta ? `<span class="workspace-task-result-artifact-summary-meta">${this.escapeHtml(datasetMeta)}</span>` : ''}
+          </summary>
+          ${this.renderResultArtifact(artifact)}
+        </details>
       `);
     }
     // Entry point to structure a plain-text result into CSV columns. The

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -4030,6 +4030,10 @@ export class WorkspaceTaskPage {
             <h3>${this.escapeHtml(artifact.title || 'CSV-ready result')}</h3>
           </div>
           <div class="workspace-task-result-artifact-actions">
+            <button type="button" class="modern-btn modern-btn-secondary workspace-task-output-action-btn" data-action="export-result-artifact-csv" title="Download the full stored dataset as a CSV spreadsheet">
+              <i class="bi bi-download" aria-hidden="true"></i>
+              <span>Export CSV</span>
+            </button>
             <button type="button" class="modern-btn modern-btn-secondary workspace-task-output-action-btn" data-action="copy-result-artifact-csv">
               <i class="bi bi-clipboard" aria-hidden="true"></i>
               <span>Copy CSV</span>
@@ -4409,6 +4413,9 @@ export class WorkspaceTaskPage {
     const root = this.elements.output;
     if (!root) return;
 
+    root
+      .querySelector('[data-action="export-result-artifact-csv"]')
+      ?.addEventListener('click', () => this.exportResultArtifactCSV());
     root
       .querySelector('[data-action="copy-result-artifact-csv"]')
       ?.addEventListener('click', () => this.copyCurrentArtifactCSV());
@@ -5671,6 +5678,38 @@ export class WorkspaceTaskPage {
       return;
     }
     await this.copyToClipboard(csv, 'CSV copied');
+  }
+
+  // exportResultArtifactCSV downloads the full stored dataset as a CSV. The
+  // canonical dataset is JSONL on disk; the server derives a spreadsheet CSV
+  // on demand (data columns first). Unlike "Copy CSV" — which copies the
+  // in-page preview — this is the authoritative file with every appended run.
+  async exportResultArtifactCSV() {
+    if (!this.workspaceId || !this.taskId) return;
+    const url = `/api/workspaces/${encodeURIComponent(this.workspaceId)}/tasks/${encodeURIComponent(this.taskId)}/results/export-csv`;
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        const message = await this.extractErrorMessage(response).catch(() => '');
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      const blob = await response.blob();
+      const disposition = response.headers.get('Content-Disposition') || '';
+      const match = /filename="?([^"]+)"?/i.exec(disposition);
+      const filename = (match && match[1]) || `${this.taskId}.csv`;
+
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(objectUrl);
+      this.notify('success', 'CSV exported');
+    } catch (err) {
+      this.notify('error', `Couldn't export CSV: ${err.message || err}`);
+    }
   }
 
   setResultArtifactNoteSaving(saving) {

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -72,6 +72,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/layout/head.tmpl",
 		"templates/components/sidebar.tmpl",
 		"templates/components/workspace-hub.tmpl",
+		"templates/components/support-chat.tmpl",
 		"templates/components/dashboard.tmpl",
 		"templates/components/session-modals.tmpl",
 		"templates/components/search-palette.tmpl",

--- a/internal/web/templates/components/support-chat.tmpl
+++ b/internal/web/templates/components/support-chat.tmpl
@@ -1,0 +1,43 @@
+{{define "support-chat.tmpl"}}
+<!-- Floating Support Chat Widget -->
+<div id="hubSupportChat" class="hub-support-chat" data-state="closed" aria-live="polite">
+  <div id="hubSupportChatPanel" class="hub-support-chat-panel" role="dialog" aria-labelledby="hubSupportChatTitle" aria-hidden="true">
+    <header class="hub-support-chat-header">
+      <div class="hub-support-chat-header-text">
+        <span id="hubSupportChatTitle" class="hub-support-chat-title">Workspace Assistant</span>
+        <span id="hubSupportChatSubtitle" class="hub-support-chat-subtitle">Ask anything about this workspace</span>
+      </div>
+      <button type="button" id="hubSupportChatCloseBtn" class="hub-support-chat-close" aria-label="Close chat">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </header>
+    <div id="hubSupportChatBody" class="hub-support-chat-body" role="log" aria-live="polite">
+      <div class="hub-support-chat-empty">
+        <div class="hub-support-chat-empty-title">Hi! How can I help?</div>
+        <div class="hub-support-chat-empty-sub">I have full context on this workspace.</div>
+      </div>
+    </div>
+    <form id="hubSupportChatForm" class="hub-support-chat-form" autocomplete="off">
+      <textarea id="hubSupportChatInput" class="hub-support-chat-input" rows="1" placeholder="Type a message..." aria-label="Chat message"></textarea>
+      <button type="submit" id="hubSupportChatSendBtn" class="hub-support-chat-send" aria-label="Send">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="22" y1="2" x2="11" y2="13"></line>
+          <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+        </svg>
+      </button>
+    </form>
+  </div>
+  <button type="button" id="hubSupportChatLauncher" class="hub-support-chat-launcher" aria-label="Open support chat" aria-expanded="false">
+    <svg class="hub-support-chat-launcher-icon hub-support-chat-launcher-icon-bubble" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path>
+    </svg>
+    <svg class="hub-support-chat-launcher-icon hub-support-chat-launcher-icon-close" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18"></line>
+      <line x1="6" y1="6" x2="18" y2="18"></line>
+    </svg>
+  </button>
+</div>
+{{end}}

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -922,6 +922,8 @@
     </div>
   </div>
 
+  {{template "support-chat.tmpl" .}}
+
   <!-- Workspace Group Modal -->
   <div class="modal fade" id="hubWorkspaceMoveModal" tabindex="-1" aria-labelledby="hubWorkspaceMoveModalTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-sm">

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -1111,6 +1111,8 @@
   <!-- Shared modals (includes Add Agent modal used by Assistant) -->
   {{template "modals.tmpl" .}}
 
+  {{template "support-chat.tmpl" .}}
+
   <!-- Workspace Entry Thinking Modal -->
   <div class="modal fade" id="homeAssistantThinkingModal" tabindex="-1"
        aria-labelledby="homeAssistantThinkingModalLabel" aria-hidden="true">
@@ -7826,6 +7828,7 @@
   <script src="/js/modules/workspace-hub-notes.js"></script>
   <script src="/js/modules/workspace-hub-files.js"></script>
   <script src="/js/modules/workspace-mission.js"></script>
+  <script src="/js/modules/workspace-hub-support-chat.js"></script>
 
   <!-- Workspace Detail Page -->
   <script type="module">

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -127,16 +127,11 @@
 
         <div id="workspace-task-page-content" class="workspace-task-page-layout" hidden>
           <main class="workspace-task-page-main">
-            <div class="workspace-task-page-tabs" role="tablist" aria-label="Task sections">
-              <button type="button" class="workspace-task-page-tab is-active" data-task-tab="overview" role="tab" aria-selected="true" aria-controls="workspace-task-tab-overview" id="workspace-task-tab-button-overview">Overview</button>
-              <button type="button" class="workspace-task-page-tab" data-task-tab="activity" role="tab" aria-selected="false" aria-controls="workspace-task-tab-activity" id="workspace-task-tab-button-activity">
-                <span>Activity</span>
-                <span id="workspace-task-tab-activity-count" class="workspace-task-page-tab-count" hidden aria-hidden="true"></span>
-              </button>
-              <button type="button" class="workspace-task-page-tab" data-task-tab="developer" role="tab" aria-selected="false" aria-controls="workspace-task-tab-developer" id="workspace-task-tab-button-developer">Developer</button>
-            </div>
-
-            <div id="workspace-task-tab-overview" class="workspace-task-tab-pane is-active" role="tabpanel" aria-labelledby="workspace-task-tab-button-overview">
+            <!-- Single flow: the 3-tab structure (Overview / Activity /
+                 Developer) was removed in the simplification pass. Cards now
+                 stack in one scroll; each self-hides when it has nothing to
+                 show, and the developer-facing cards are grouped in a collapsed
+                 disclosure at the bottom. -->
               <section class="workspace-task-page-card">
                 <div class="workspace-task-page-card-header">
                   <div>
@@ -308,9 +303,7 @@
                   </div>
                 </details>
               </section>
-            </div>
 
-            <div id="workspace-task-tab-activity" class="workspace-task-tab-pane" role="tabpanel" aria-labelledby="workspace-task-tab-button-activity" hidden>
               <section id="workspace-task-workspace-runs-card" class="workspace-task-page-card" hidden>
                 <div class="workspace-task-page-card-header">
                   <div>
@@ -349,18 +342,17 @@
                 <div id="workspace-task-workflow-steps" class="workspace-task-workflow-list"></div>
               </section>
 
-              <div id="workspace-task-activity-empty" class="workspace-task-page-card workspace-task-tab-empty" hidden>
-                <p class="workspace-task-tab-empty-copy">Run history and execution trace will appear here once this task runs.</p>
-              </div>
-            </div>
+              <!-- Developer-facing cards (raw IDs, run trace, technical context)
+                   grouped and collapsed by default so they stay out of the way
+                   of the everyday task view. -->
+              <details class="workspace-task-developer-group">
+                <summary class="workspace-task-developer-summary">Developer details</summary>
 
-            <div id="workspace-task-tab-developer" class="workspace-task-tab-pane" role="tabpanel" aria-labelledby="workspace-task-tab-button-developer" hidden>
-              <section class="workspace-task-page-card">
-                <div class="workspace-task-page-card-header">
-                  <div>
-                    <div class="workspace-task-page-card-kicker">Developer</div>
-                    <h2>Task ID</h2>
-                  </div>
+                <section class="workspace-task-page-card">
+                  <div class="workspace-task-page-card-header">
+                    <div>
+                      <h2>Task ID</h2>
+                    </div>
                   <button
                     type="button"
                     id="workspace-task-copy-id"
@@ -409,7 +401,7 @@
                 </div>
                 <div id="workspace-task-context"></div>
               </section>
-            </div>
+              </details>
           </main>
         </div>
 
@@ -1160,81 +1152,46 @@
       background: rgba(248, 113, 113, 0.08);
     }
 
-    .workspace-task-page-tabs {
-      display: inline-flex;
-      gap: 0.35rem;
-      padding: 0.35rem;
-      border-radius: 14px;
-      background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
-      border: 1px solid var(--border-color);
+    /* Collapsible "Developer details" group (replaces the old Developer tab).
+       Borderless so the flat cards inside don't become boxes-in-a-box; the
+       summary is a quiet toggle and the cards stack below it when open. */
+    .workspace-task-developer-summary {
+      list-style: none;
+      cursor: pointer;
       width: fit-content;
-    }
-
-    .workspace-task-page-tab {
-      appearance: none;
+      padding: 0.4rem 0;
+      color: var(--text-secondary);
+      font-size: 0.92rem;
+      font-weight: 700;
       display: inline-flex;
       align-items: center;
       gap: 0.45rem;
-      border: 1px solid transparent;
-      background: transparent;
-      color: var(--text-secondary);
-      font-size: 0.85rem;
-      font-weight: 600;
-      padding: 0.5rem 1rem;
-      border-radius: 10px;
-      cursor: pointer;
-      transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
     }
 
-    .workspace-task-page-tab:hover {
-      color: var(--text-primary);
+    .workspace-task-developer-summary::-webkit-details-marker {
+      display: none;
     }
 
-    .workspace-task-page-tab.is-active {
-      background: var(--bg-primary);
-      border-color: var(--border-color);
-      color: var(--text-primary);
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+    .workspace-task-developer-summary::before {
+      content: "▸";
+      font-size: 0.8em;
+      transition: transform 0.15s ease;
     }
 
-    .workspace-task-page-tab-count {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 1.3rem;
-      padding: 0 0.35rem;
-      border-radius: 999px;
-      background: color-mix(in srgb, var(--text-secondary) 18%, transparent);
-      color: var(--text-secondary);
-      font-size: 0.68rem;
-      font-weight: 700;
-      font-variant-numeric: tabular-nums;
+    .workspace-task-developer-group[open] .workspace-task-developer-summary::before {
+      transform: rotate(90deg);
     }
 
-    .workspace-task-page-tab.is-active .workspace-task-page-tab-count {
-      background: color-mix(in srgb, var(--primary-color) 22%, transparent);
-      color: var(--primary-color);
+    .workspace-task-developer-group[open] .workspace-task-developer-summary {
+      margin-bottom: 1.25rem;
     }
 
-    .workspace-task-tab-pane {
-      display: flex;
-      flex-direction: column;
-      gap: 1.25rem;
+    .workspace-task-developer-group > .workspace-task-page-card {
+      margin-bottom: 1.25rem;
     }
 
-    .workspace-task-tab-pane[hidden] {
-      display: none !important;
-    }
-
-    .workspace-task-tab-empty {
-      padding: 1.5rem;
-      text-align: center;
-      color: var(--text-secondary);
-    }
-
-    .workspace-task-tab-empty-copy {
-      margin: 0;
-      font-size: 0.9rem;
+    .workspace-task-developer-group > .workspace-task-page-card:last-of-type {
+      margin-bottom: 0;
     }
 
     /* Simplification pass: flat card — single surface, hairline border, no

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -2239,6 +2239,31 @@
       word-break: break-all;
     }
 
+    .workspace-task-automation-storage-open-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      margin-top: 0.3rem;
+      padding: 0.2rem 0.55rem;
+      border-radius: 6px;
+      border: 1px solid var(--border-color);
+      background: var(--bg-primary);
+      color: var(--text-primary, var(--primary-color));
+      font-size: 0.74rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background-color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .workspace-task-automation-storage-open-btn:hover {
+      background: color-mix(in srgb, var(--primary-color) 8%, var(--bg-primary));
+      border-color: color-mix(in srgb, var(--primary-color) 40%, var(--border-color));
+    }
+
+    .workspace-task-automation-storage-open-btn i {
+      font-size: 0.85rem;
+    }
+
     .workspace-task-automation-storage-select,
     .workspace-task-automation-storage-input {
       grid-column: 1 / -1;

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -1627,6 +1627,47 @@
       font-weight: 700;
     }
 
+    /* Collapsed wrapper for the run-history dataset, so the Result leads and
+       the CSV preview stays tucked away. Borderless — the artifact section
+       inside keeps its own surface, so there's no box-in-box. */
+    .workspace-task-result-artifact-summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: baseline;
+      gap: 0.55rem;
+      width: fit-content;
+      padding: 0.4rem 0;
+      color: var(--text-primary);
+      font-size: 0.92rem;
+      font-weight: 700;
+    }
+
+    .workspace-task-result-artifact-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .workspace-task-result-artifact-summary::before {
+      content: "▸";
+      color: var(--text-secondary);
+      font-size: 0.8em;
+      transition: transform 0.15s ease;
+    }
+
+    .workspace-task-result-artifact-disclosure[open] .workspace-task-result-artifact-summary::before {
+      transform: rotate(90deg);
+    }
+
+    .workspace-task-result-artifact-disclosure[open] .workspace-task-result-artifact-summary {
+      margin-bottom: 0.75rem;
+    }
+
+    .workspace-task-result-artifact-summary-meta {
+      color: var(--text-secondary);
+      font-weight: 600;
+      font-size: 0.82rem;
+    }
+
     .workspace-task-result-artifact {
       margin-bottom: 1rem;
       padding: 1rem;

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -264,26 +264,30 @@
                 </div>
               </section>
 
-              <section id="workspace-task-output-shape-card" class="workspace-task-page-card">
-                <div class="workspace-task-page-card-header">
-                  <div>
-                    <div class="workspace-task-page-card-kicker">Output</div>
-                    <h2>Expected output shape</h2>
-                  </div>
-                </div>
-                <div id="workspace-task-output-shape" class="workspace-task-output-shape"></div>
-              </section>
-
+              <!-- Automation card (cadence + where results are stored) leads the
+                   output-config group; the more technical "Expected output
+                   shape" schema follows it so the human-facing Result above
+                   stays the focus for non-technical users. -->
               <section id="workspace-task-schedule-card" class="workspace-task-page-card" hidden>
                 <div class="workspace-task-page-card-header">
                   <div>
                     <div class="workspace-task-page-card-kicker">Automation</div>
                     <h2>Schedule &amp; saved results</h2>
                   </div>
-                  <button type="button" id="workspace-task-schedule-card-edit" class="modern-btn modern-btn-secondary workspace-task-schedule-edit-btn">
-                    <i class="bi bi-calendar2-week" aria-hidden="true"></i>
-                    <span>Edit schedule</span>
-                  </button>
+                  <div class="workspace-task-schedule-header-actions">
+                    <!-- Lifted out of Advanced > storage so a task that writes
+                         to the default output folder exposes the reveal action
+                         at the card level. Toggled by renderSchedule based on
+                         whether storage targets the default folder. -->
+                    <button type="button" id="workspace-task-schedule-open-folder" class="modern-btn modern-btn-secondary workspace-task-schedule-edit-btn" hidden>
+                      <i class="bi bi-folder2-open" aria-hidden="true"></i>
+                      <span>Open output folder</span>
+                    </button>
+                    <button type="button" id="workspace-task-schedule-card-edit" class="modern-btn modern-btn-secondary workspace-task-schedule-edit-btn">
+                      <i class="bi bi-calendar2-week" aria-hidden="true"></i>
+                      <span>Edit schedule</span>
+                    </button>
+                  </div>
                 </div>
                 <div id="workspace-task-schedule" class="workspace-task-schedule-content"></div>
                 <div id="workspace-task-automation-summary" class="workspace-task-automation-summary"></div>
@@ -294,6 +298,19 @@
                     <div id="workspace-task-automation-storage" class="workspace-task-automation-section"></div>
                   </div>
                 </details>
+              </section>
+
+              <!-- Hidden by default; renderTaskOutputShape reveals it only when
+                   the task declares a structured schema / CSV contract. Free-text
+                   tasks never show this card. -->
+              <section id="workspace-task-output-shape-card" class="workspace-task-page-card" hidden>
+                <div class="workspace-task-page-card-header">
+                  <div>
+                    <div class="workspace-task-page-card-kicker">Output</div>
+                    <h2>Expected output shape</h2>
+                  </div>
+                </div>
+                <div id="workspace-task-output-shape" class="workspace-task-output-shape"></div>
               </section>
             </div>
 
@@ -1259,6 +1276,14 @@
       justify-content: space-between;
       gap: 1rem;
       margin-bottom: 1rem;
+    }
+
+    .workspace-task-schedule-header-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      flex-shrink: 0;
     }
 
     .workspace-task-page-card-header.is-output-menu-open {
@@ -2393,23 +2418,6 @@
     .workspace-task-output-shape-chip[data-included="false"] {
       opacity: 0.5;
       text-decoration: line-through;
-    }
-
-    .workspace-task-output-shape-empty {
-      padding: 0.9rem;
-      border-radius: 10px;
-      border: 1px dashed var(--border-color);
-      background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
-      color: var(--text-secondary, #6b7280);
-      font-size: 0.86rem;
-      line-height: 1.45;
-    }
-
-    .workspace-task-output-shape-empty strong {
-      display: block;
-      color: var(--text-primary);
-      font-size: 0.92rem;
-      margin-bottom: 0.2rem;
     }
 
     .workspace-task-automation-storage-select,

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -503,30 +503,23 @@
       min-height: calc(100vh - 72px);
     }
 
+    /* Simplification pass: the hero is a flat header now — no radial-glow
+       gradient, no decorative ::after blob, no heavy drop shadow. A single
+       surface color and a hairline border. */
     .workspace-task-page-hero {
       position: relative;
       display: grid;
       grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
       gap: 1.5rem;
-      padding: 1.6rem 1.75rem;
-      border-radius: 30px;
-      border: 1px solid color-mix(in srgb, var(--primary-color) 18%, var(--border-color));
-      background:
-        radial-gradient(circle at top right, color-mix(in srgb, var(--primary-color) 16%, transparent), transparent 42%),
-        linear-gradient(135deg, color-mix(in srgb, var(--bg-secondary) 84%, transparent), var(--bg-primary));
-      box-shadow: 0 28px 60px rgba(10, 10, 10, 0.14);
+      padding: 1.4rem 1.5rem;
+      border-radius: 16px;
+      border: 1px solid var(--border-color);
+      background: var(--bg-secondary);
       overflow: hidden;
     }
 
     .workspace-task-page-hero::after {
-      content: "";
-      position: absolute;
-      inset: auto -8% -40% auto;
-      width: 280px;
-      height: 280px;
-      border-radius: 50%;
-      background: radial-gradient(circle, color-mix(in srgb, var(--primary-color) 18%, transparent), transparent 68%);
-      pointer-events: none;
+      display: none;
     }
 
     .workspace-task-page-hero-copy,
@@ -557,13 +550,21 @@
       color: var(--primary-color);
     }
 
-    .workspace-task-page-card-kicker,
     .workspace-task-page-mini-label {
       color: var(--accent-gold, #d3a94f);
       text-transform: uppercase;
       letter-spacing: 0.16em;
       font-size: 0.74rem;
       font-weight: 800;
+    }
+
+    /* Card "kicker" eyebrows removed in the simplification pass: each card's
+       <h2> carries the heading on its own, so the gold all-caps label above it
+       was redundant chrome (and 12 of them scattered gold accents across the
+       page). Hidden in CSS rather than editing 12 template call sites now; the
+       markup is dropped when the sections are restructured. */
+    .workspace-task-page-card-kicker {
+      display: none;
     }
 
     .workspace-task-page-breadcrumbs {
@@ -579,8 +580,8 @@
     .workspace-task-page-title {
       margin: 0;
       font-family: "Fraunces", serif;
-      font-size: clamp(2rem, 4vw, 3.1rem);
-      line-height: 1.02;
+      font-size: clamp(1.5rem, 2.5vw, 2.1rem);
+      line-height: 1.12;
       color: var(--text-primary);
       overflow-wrap: anywhere;
       cursor: text;
@@ -704,9 +705,9 @@
       background: transparent;
       color: var(--text-primary);
       font-family: "Fraunces", serif;
-      font-size: clamp(2rem, 4vw, 3.1rem);
+      font-size: clamp(1.5rem, 2.5vw, 2.1rem);
       font-weight: 700;
-      line-height: 1.02;
+      line-height: 1.12;
       resize: none;
       overflow: hidden;
       box-shadow: none;
@@ -967,10 +968,9 @@
       align-items: center;
       flex-wrap: wrap;
       padding: 1rem 1.25rem;
-      border-radius: 22px;
+      border-radius: 14px;
       border: 1px solid rgba(194, 132, 11, 0.32);
-      background: linear-gradient(180deg, rgba(245, 158, 11, 0.14), rgba(245, 158, 11, 0.05));
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+      background: rgba(245, 158, 11, 0.1);
     }
 
     .workspace-task-hero-priority-body {
@@ -1241,25 +1241,19 @@
       font-size: 0.9rem;
     }
 
+    /* Simplification pass: flat card — single surface, hairline border, no
+       gradient fill, no gradient ::before wash, no drop shadow. */
     .workspace-task-page-card {
       position: relative;
       padding: 1.3rem 1.35rem;
-      border-radius: 28px;
-      border: 1px solid color-mix(in srgb, var(--border-color) 86%, transparent);
-      background:
-        linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 82%, transparent), color-mix(in srgb, var(--bg-primary) 94%, transparent));
-      box-shadow: 0 18px 38px rgba(10, 10, 10, 0.08);
+      border-radius: 16px;
+      border: 1px solid var(--border-color);
+      background: var(--bg-secondary);
       overflow: hidden;
     }
 
     .workspace-task-page-card::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background:
-        linear-gradient(120deg, color-mix(in srgb, var(--primary-color) 8%, transparent), transparent 45%);
-      pointer-events: none;
-      opacity: 0.9;
+      display: none;
     }
 
     .workspace-task-page-card > * {
@@ -1291,9 +1285,9 @@
     }
 
     .workspace-task-page-card-header h2 {
-      margin: 0.28rem 0 0;
+      margin: 0;
       font-family: "Fraunces", serif;
-      font-size: 1.35rem;
+      font-size: 1.2rem;
       color: var(--text-primary);
     }
 
@@ -3195,11 +3189,11 @@
       gap: 0.85rem;
     }
 
+    /* Simplification pass: overview entries are plain label/value blocks now,
+       not rounded boxes inside the card (the box-in-box read busy). The grid
+       gap provides the separation. */
     .workspace-task-overview-item {
-      padding: 0.95rem 1rem;
-      border-radius: 20px;
-      background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
-      border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
+      padding: 0.35rem 0;
     }
 
     .workspace-task-overview-item.full {
@@ -3308,7 +3302,7 @@
     .workspace-task-page-code-block {
       margin: 0;
       padding: 1rem 1.05rem;
-      border-radius: 20px;
+      border-radius: 12px;
       border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
       background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
       color: var(--text-primary);
@@ -3326,7 +3320,7 @@
 
     .workspace-task-page-prose {
       padding: 0.8rem 1.05rem;
-      border-radius: 20px;
+      border-radius: 12px;
       border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
       background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
       color: var(--text-primary);

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -264,15 +264,15 @@
                 </div>
               </section>
 
-              <!-- Automation card (cadence + where results are stored) leads the
-                   output-config group; the more technical "Expected output
-                   shape" schema follows it so the human-facing Result above
-                   stays the focus for non-technical users. -->
+              <!-- Single "Automation & output" card: how/when the task runs,
+                   where results are saved, and (for structured tasks) the shape
+                   of those results. The schedule card id is kept so renderSchedule
+                   still owns this card's visibility; renderSchedule's visibility
+                   union now also accounts for a structured output spec. -->
               <section id="workspace-task-schedule-card" class="workspace-task-page-card" hidden>
                 <div class="workspace-task-page-card-header">
                   <div>
-                    <div class="workspace-task-page-card-kicker">Automation</div>
-                    <h2>Schedule &amp; saved results</h2>
+                    <h2>Automation &amp; output</h2>
                   </div>
                   <div class="workspace-task-schedule-header-actions">
                     <!-- Lifted out of Advanced > storage so a task that writes
@@ -291,6 +291,15 @@
                 </div>
                 <div id="workspace-task-schedule" class="workspace-task-schedule-content"></div>
                 <div id="workspace-task-automation-summary" class="workspace-task-automation-summary"></div>
+
+                <!-- Expected output shape, folded in as a subsection. Hidden by
+                     default; renderTaskOutputShape reveals it only when the task
+                     declares a structured schema / CSV contract. -->
+                <div id="workspace-task-output-shape-wrap" class="workspace-task-output-shape-section" hidden>
+                  <h3 class="workspace-task-page-subheading">Expected output shape</h3>
+                  <div id="workspace-task-output-shape" class="workspace-task-output-shape"></div>
+                </div>
+
                 <details class="workspace-task-advanced">
                   <summary class="workspace-task-advanced-summary">Advanced settings</summary>
                   <div class="workspace-task-advanced-body">
@@ -298,19 +307,6 @@
                     <div id="workspace-task-automation-storage" class="workspace-task-automation-section"></div>
                   </div>
                 </details>
-              </section>
-
-              <!-- Hidden by default; renderTaskOutputShape reveals it only when
-                   the task declares a structured schema / CSV contract. Free-text
-                   tasks never show this card. -->
-              <section id="workspace-task-output-shape-card" class="workspace-task-page-card" hidden>
-                <div class="workspace-task-page-card-header">
-                  <div>
-                    <div class="workspace-task-page-card-kicker">Output</div>
-                    <h2>Expected output shape</h2>
-                  </div>
-                </div>
-                <div id="workspace-task-output-shape" class="workspace-task-output-shape"></div>
               </section>
             </div>
 
@@ -1278,6 +1274,22 @@
       align-items: center;
       gap: 0.5rem;
       flex-shrink: 0;
+    }
+
+    /* Subsections inside a card (e.g. "Expected output shape" folded into the
+       Automation & output card) are separated by a hairline rule and a small
+       serif subheading rather than getting their own card. */
+    .workspace-task-output-shape-section {
+      margin-top: 1.1rem;
+      padding-top: 1.1rem;
+      border-top: 1px solid var(--border-color);
+    }
+
+    .workspace-task-page-subheading {
+      margin: 0 0 0.6rem;
+      font-family: "Fraunces", serif;
+      font-size: 1.02rem;
+      color: var(--text-primary);
     }
 
     .workspace-task-page-card-header.is-output-menu-open {

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -264,6 +264,16 @@
                 </div>
               </section>
 
+              <section id="workspace-task-output-shape-card" class="workspace-task-page-card">
+                <div class="workspace-task-page-card-header">
+                  <div>
+                    <div class="workspace-task-page-card-kicker">Output</div>
+                    <h2>Expected output shape</h2>
+                  </div>
+                </div>
+                <div id="workspace-task-output-shape" class="workspace-task-output-shape"></div>
+              </section>
+
               <section id="workspace-task-schedule-card" class="workspace-task-page-card" hidden>
                 <div class="workspace-task-page-card-header">
                   <div>
@@ -2262,6 +2272,144 @@
 
     .workspace-task-automation-storage-open-btn i {
       font-size: 0.85rem;
+    }
+
+    .workspace-task-output-shape {
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+    }
+
+    .workspace-task-output-shape-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.5rem;
+    }
+
+    .workspace-task-output-shape-stat {
+      padding: 0.55rem 0.75rem;
+      border-radius: 10px;
+      background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+      border: 1px solid var(--border-color);
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+    }
+
+    .workspace-task-output-shape-stat span {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-secondary, #6b7280);
+    }
+
+    .workspace-task-output-shape-stat strong {
+      font-size: 0.92rem;
+      color: var(--text-primary);
+    }
+
+    .workspace-task-output-shape-block {
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .workspace-task-output-shape-block-header {
+      padding: 0.5rem 0.75rem;
+      background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+      border-bottom: 1px solid var(--border-color);
+      font-size: 0.78rem;
+      font-weight: 700;
+      color: var(--text-primary);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .workspace-task-output-shape-block-meta {
+      font-size: 0.72rem;
+      font-weight: 500;
+      color: var(--text-secondary, #6b7280);
+    }
+
+    .workspace-task-output-shape-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.82rem;
+    }
+
+    .workspace-task-output-shape-table th,
+    .workspace-task-output-shape-table td {
+      text-align: left;
+      padding: 0.4rem 0.75rem;
+      border-top: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+      vertical-align: top;
+    }
+
+    .workspace-task-output-shape-table th {
+      border-top: none;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-secondary, #6b7280);
+      background: color-mix(in srgb, var(--bg-primary) 98%, transparent);
+    }
+
+    .workspace-task-output-shape-table .workspace-task-output-shape-col-type {
+      color: var(--text-secondary, #6b7280);
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+      font-size: 0.75rem;
+    }
+
+    .workspace-task-output-shape-table .workspace-task-output-shape-col-required {
+      color: var(--primary-color);
+      font-weight: 700;
+      font-size: 0.72rem;
+    }
+
+    .workspace-task-output-shape-table .workspace-task-output-shape-col-required.is-optional {
+      color: var(--text-secondary, #6b7280);
+      font-weight: 500;
+    }
+
+    .workspace-task-output-shape-metadata {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      padding: 0.6rem 0.75rem;
+    }
+
+    .workspace-task-output-shape-chip {
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+      border: 1px solid var(--border-color);
+      background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+      font-size: 0.74rem;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+      color: var(--text-primary);
+    }
+
+    .workspace-task-output-shape-chip[data-included="false"] {
+      opacity: 0.5;
+      text-decoration: line-through;
+    }
+
+    .workspace-task-output-shape-empty {
+      padding: 0.9rem;
+      border-radius: 10px;
+      border: 1px dashed var(--border-color);
+      background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+      color: var(--text-secondary, #6b7280);
+      font-size: 0.86rem;
+      line-height: 1.45;
+    }
+
+    .workspace-task-output-shape-empty strong {
+      display: block;
+      color: var(--text-primary);
+      font-size: 0.92rem;
+      margin-bottom: 0.2rem;
     }
 
     .workspace-task-automation-storage-select,

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -83,27 +83,9 @@
           </div>
         </section>
 
-        <!-- Full-width Action Required banner. Previously this lived inside
-             the hero's narrow right column where the CTA buttons collided
-             with the status badge and agent picker. Promoted to a sibling
-             of the hero so the "you need to do something" state takes the
-             page's full width and reads as the primary call to action. -->
-        <aside
-          id="workspace-task-hero-priority"
-          class="workspace-task-hero-priority"
-          role="region"
-          aria-label="Action required"
-          hidden>
-          <div class="workspace-task-hero-priority-body">
-            <div class="workspace-task-hero-priority-kicker">Action Required</div>
-            <div id="workspace-task-hero-priority-copy" class="workspace-task-hero-priority-copy"></div>
-            <div id="workspace-task-hero-priority-reason" class="workspace-task-hero-priority-reason" hidden>
-              <span class="workspace-task-hero-priority-reason-label">Reason</span>
-              <span id="workspace-task-hero-priority-reason-text" class="workspace-task-hero-priority-reason-text"></span>
-            </div>
-          </div>
-          <div id="workspace-task-hero-priority-actions" class="workspace-task-hero-priority-actions"></div>
-        </aside>
+        <!-- The full-width "Action Required" banner was retired: when a task is
+             blocked the inline respond card (top of the main flow) now carries
+             that role on its own. -->
 
         <div id="workspace-task-page-alert" class="workspace-task-page-alert d-none" role="alert"></div>
 
@@ -127,6 +109,78 @@
 
         <div id="workspace-task-page-content" class="workspace-task-page-layout" hidden>
           <main class="workspace-task-page-main">
+            <!-- Inline respond card (focus zone). Shown only while the task is
+                 blocked / waiting for input; renderBlockedState toggles its
+                 visibility. Replaces the old slide-out assist panel and the
+                 separate Action Required banner. Every inner element id is
+                 preserved so the existing assist handlers keep working. -->
+            <section id="workspace-task-assist-card" class="workspace-task-page-card workspace-task-assist-card-inline" hidden>
+              <div class="workspace-task-assist-panel-header">
+                <div>
+                  <div class="workspace-task-assist-kicker">Action Required</div>
+                  <h2>Unblock this task</h2>
+                </div>
+              </div>
+
+              <div class="workspace-task-assist-panel-body">
+                <div class="workspace-task-assist-summary-grid">
+                  <article class="workspace-task-assist-summary-card">
+                    <div class="workspace-task-assist-summary-title">What It Knows</div>
+                    <div id="workspace-task-assist-known" class="workspace-task-assist-summary-copy"></div>
+                  </article>
+                  <article class="workspace-task-assist-summary-card">
+                    <div class="workspace-task-assist-summary-title">What It Needs</div>
+                    <div id="workspace-task-assist-needs" class="workspace-task-assist-summary-copy"></div>
+                  </article>
+                  <article class="workspace-task-assist-summary-card">
+                    <div class="workspace-task-assist-summary-title">What Happens Next</div>
+                    <div id="workspace-task-assist-next" class="workspace-task-assist-summary-copy"></div>
+                  </article>
+                </div>
+
+                <div id="workspace-task-assist-question-wrap" class="workspace-task-assist-question-wrap d-none">
+                  <div class="workspace-task-page-mini-label">Question</div>
+                  <div id="workspace-task-assist-question" class="workspace-task-page-copy-block"></div>
+                </div>
+
+                <div id="workspace-task-assist-form-wrap" class="workspace-task-assist-form-wrap d-none">
+                  <div class="workspace-task-page-mini-label">Requested details</div>
+                  <div id="workspace-task-assist-form-fields" class="workspace-task-assist-form-fields"></div>
+                </div>
+
+                <div class="workspace-task-assist-extra">
+                  <label class="form-label" for="workspace-task-assist-message">Extra guidance for the agent</label>
+                  <textarea id="workspace-task-assist-message" class="form-control" rows="3" placeholder="Add clarification, constraints, or context before continuing..."></textarea>
+                </div>
+
+                <div class="workspace-task-assist-actions-primary">
+                  <button type="button" id="workspace-task-assist-continue" class="modern-btn modern-btn-primary workspace-task-assist-continue-btn">Continue</button>
+                </div>
+
+                <!-- Recovery actions live alongside Continue rather than behind
+                     a "More actions" disclosure. The most common stuck-task
+                     remediation (reassign or fail-out) shouldn't require an
+                     extra click to reveal. -->
+                <div class="workspace-task-assist-more-actions">
+                  <div class="workspace-task-assist-more-content">
+                    <div class="workspace-task-assist-switch">
+                      <label class="form-label" for="workspace-task-assist-agent">Reassign agent</label>
+                      <div class="workspace-task-assist-switch-row">
+                        <select id="workspace-task-assist-agent" class="form-select">
+                          <option value="">Keep current assignment</option>
+                        </select>
+                        <button type="button" id="workspace-task-assist-switch" class="modern-btn modern-btn-secondary">Switch + Retry</button>
+                      </div>
+                    </div>
+                    <div class="workspace-task-assist-secondary-actions">
+                      <button type="button" id="workspace-task-assist-retry" class="modern-btn modern-btn-secondary">Retry Task</button>
+                      <button type="button" id="workspace-task-assist-fail" class="workspace-task-page-text-button workspace-task-assist-fail">Mark as Failed</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
             <!-- Single flow: the 3-tab structure (Overview / Activity /
                  Developer) was removed in the simplification pass. Cards now
                  stack in one scroll; each self-hides when it has nothing to
@@ -405,79 +459,10 @@
           </main>
         </div>
 
-        <!-- Slide-out assist panel (opened from the Action Required banner CTA) -->
-        <div id="workspace-task-assist-panel" class="workspace-task-assist-panel" hidden>
-          <div id="workspace-task-assist-backdrop" class="workspace-task-assist-backdrop"></div>
-          <div class="workspace-task-assist-panel-content" id="workspace-task-assist-card">
-            <div class="workspace-task-assist-panel-header">
-              <div>
-                <div class="workspace-task-page-card-kicker">Need Your Input</div>
-                <h2>Unblock this task</h2>
-              </div>
-              <button type="button" id="workspace-task-assist-close" class="workspace-task-assist-panel-close" aria-label="Close panel">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/></svg>
-              </button>
-            </div>
+        <!-- The slide-out assist panel was retired; its card now renders
+             inline at the top of the main flow (see #workspace-task-assist-card
+             above). -->
 
-            <div class="workspace-task-assist-panel-body">
-              <div class="workspace-task-assist-summary-grid">
-                <article class="workspace-task-assist-summary-card">
-                  <div class="workspace-task-assist-summary-title">What It Knows</div>
-                  <div id="workspace-task-assist-known" class="workspace-task-assist-summary-copy"></div>
-                </article>
-                <article class="workspace-task-assist-summary-card">
-                  <div class="workspace-task-assist-summary-title">What It Needs</div>
-                  <div id="workspace-task-assist-needs" class="workspace-task-assist-summary-copy"></div>
-                </article>
-                <article class="workspace-task-assist-summary-card">
-                  <div class="workspace-task-assist-summary-title">What Happens Next</div>
-                  <div id="workspace-task-assist-next" class="workspace-task-assist-summary-copy"></div>
-                </article>
-              </div>
-
-              <div id="workspace-task-assist-question-wrap" class="workspace-task-assist-question-wrap d-none">
-                <div class="workspace-task-page-mini-label">Question</div>
-                <div id="workspace-task-assist-question" class="workspace-task-page-copy-block"></div>
-              </div>
-
-              <div id="workspace-task-assist-form-wrap" class="workspace-task-assist-form-wrap d-none">
-                <div class="workspace-task-page-mini-label">Requested details</div>
-                <div id="workspace-task-assist-form-fields" class="workspace-task-assist-form-fields"></div>
-              </div>
-
-              <div class="workspace-task-assist-extra">
-                <label class="form-label" for="workspace-task-assist-message">Extra guidance for the agent</label>
-                <textarea id="workspace-task-assist-message" class="form-control" rows="3" placeholder="Add clarification, constraints, or context before continuing..."></textarea>
-              </div>
-
-              <div class="workspace-task-assist-actions-primary">
-                <button type="button" id="workspace-task-assist-continue" class="modern-btn modern-btn-primary workspace-task-assist-continue-btn">Continue</button>
-              </div>
-
-              <!-- Recovery actions live alongside Continue rather than
-                   behind a "More actions" disclosure. The most common
-                   stuck-task remediation (reassign or fail-out) shouldn't
-                   require an extra click to reveal. -->
-              <div class="workspace-task-assist-more-actions">
-                <div class="workspace-task-assist-more-content">
-                  <div class="workspace-task-assist-switch">
-                    <label class="form-label" for="workspace-task-assist-agent">Reassign agent</label>
-                    <div class="workspace-task-assist-switch-row">
-                      <select id="workspace-task-assist-agent" class="form-select">
-                        <option value="">Keep current assignment</option>
-                      </select>
-                      <button type="button" id="workspace-task-assist-switch" class="modern-btn modern-btn-secondary">Switch + Retry</button>
-                    </div>
-                  </div>
-                  <div class="workspace-task-assist-secondary-actions">
-                    <button type="button" id="workspace-task-assist-retry" class="modern-btn modern-btn-secondary">Retry Task</button>
-                    <button type="button" id="workspace-task-assist-fail" class="workspace-task-page-text-button workspace-task-assist-fail">Mark as Failed</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -949,90 +934,31 @@
       justify-content: flex-end;
     }
 
-    .workspace-task-hero-priority {
-      width: 100%;
-      display: flex;
-      gap: 1.25rem;
-      align-items: center;
-      flex-wrap: wrap;
-      padding: 1rem 1.25rem;
-      border-radius: 14px;
-      border: 1px solid rgba(194, 132, 11, 0.32);
-      background: rgba(245, 158, 11, 0.1);
+    /* Inline respond card "action required" accent (replaces the retired
+       Action Required banner). Layered on the flat card base so a blocked
+       task's respond card reads as the priority item without reintroducing
+       heavy chrome. */
+    .workspace-task-assist-card-inline {
+      border-color: rgba(194, 132, 11, 0.45);
+      background: rgba(245, 158, 11, 0.06);
     }
 
-    .workspace-task-hero-priority-body {
-      display: grid;
-      gap: 0.55rem;
-      flex: 1 1 22rem;
-      min-width: 0;
+    [data-bs-theme="dark"] .workspace-task-assist-card-inline {
+      border-color: rgba(245, 158, 11, 0.4);
+      background: rgba(245, 158, 11, 0.08);
     }
 
-    .workspace-task-hero-priority-kicker {
+    .workspace-task-assist-kicker {
       color: #9a6700;
       font-size: 0.72rem;
       font-weight: 800;
       letter-spacing: 0.1em;
       text-transform: uppercase;
+      margin-bottom: 0.15rem;
     }
 
-    .workspace-task-hero-priority-copy {
-      color: var(--text-primary);
-      font-size: 0.94rem;
-      line-height: 1.55;
-    }
-
-    .workspace-task-hero-priority-reason {
-      display: flex;
-      gap: 0.5rem;
-      align-items: flex-start;
-      padding: 0.55rem 0.7rem;
-      border-radius: 12px;
-      border: 1px solid rgba(194, 132, 11, 0.32);
-      background: rgba(255, 255, 255, 0.55);
-      font-size: 0.86rem;
-      line-height: 1.45;
-      color: var(--text-primary);
-    }
-
-    [data-bs-theme="dark"] .workspace-task-hero-priority-reason {
-      border-color: rgba(245, 158, 11, 0.35);
-      background: rgba(20, 14, 4, 0.72);
-      color: var(--text-primary);
-    }
-
-    .workspace-task-hero-priority-reason-label {
-      flex: 0 0 auto;
-      font-size: 0.66rem;
-      font-weight: 800;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      color: #7a4f00;
-      padding-top: 0.12rem;
-    }
-
-    [data-bs-theme="dark"] .workspace-task-hero-priority-reason-label {
+    [data-bs-theme="dark"] .workspace-task-assist-kicker {
       color: #f5b441;
-    }
-
-    .workspace-task-hero-priority-reason-text {
-      flex: 1 1 auto;
-      word-break: break-word;
-    }
-
-    .workspace-task-hero-priority-actions {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: flex-end;
-      gap: 0.55rem;
-      flex: 0 1 auto;
-    }
-
-    @media (max-width: 720px) {
-      .workspace-task-hero-priority-actions {
-        justify-content: flex-start;
-        width: 100%;
-      }
     }
 
     .workspace-task-page-hero-btn {
@@ -4868,85 +4794,27 @@
       text-decoration: underline;
     }
 
-    /* Slide-out assist panel */
-    .workspace-task-assist-panel {
-      position: fixed;
-      inset: 0;
-      z-index: 1050;
-      display: flex;
-      justify-content: flex-end;
-    }
-
-    .workspace-task-assist-backdrop {
-      position: absolute;
-      inset: 0;
-      background: rgba(10, 10, 10, 0.4);
-      opacity: 0;
-      transition: opacity 0.25s ease;
-    }
-
-    .workspace-task-assist-panel.is-open .workspace-task-assist-backdrop {
-      opacity: 1;
-    }
-
-    .workspace-task-assist-panel-content {
-      position: relative;
-      width: min(480px, 92vw);
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      background: var(--bg-primary);
-      border-left: 1px solid var(--border-color);
-      box-shadow: -12px 0 40px rgba(10, 10, 10, 0.14);
-      transform: translateX(100%);
-      transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
-    }
-
-    .workspace-task-assist-panel.is-open .workspace-task-assist-panel-content {
-      transform: translateX(0);
-    }
-
+    /* Inline respond card header + body (the assist UI; formerly a slide-out
+       panel, now a flat card in the main flow). */
     .workspace-task-assist-panel-header {
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
       gap: 1rem;
-      padding: 1.25rem 1.35rem;
-      border-bottom: 1px solid var(--border-color);
-      flex-shrink: 0;
+      margin-bottom: 1rem;
     }
 
     .workspace-task-assist-panel-header h2 {
-      margin: 0.28rem 0 0;
+      margin: 0;
       font-family: "Fraunces", serif;
-      font-size: 1.25rem;
+      font-size: 1.2rem;
       color: var(--text-primary);
-    }
-
-    .workspace-task-assist-panel-close {
-      flex: 0 0 auto;
-      width: 2.2rem;
-      height: 2.2rem;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border: 1px solid var(--border-color);
-      border-radius: 999px;
-      background: transparent;
-      color: var(--text-secondary);
-      cursor: pointer;
-      transition: color 0.14s ease, border-color 0.14s ease;
-    }
-
-    .workspace-task-assist-panel-close:hover {
-      color: var(--text-primary);
-      border-color: color-mix(in srgb, var(--primary-color) 38%, var(--border-color));
     }
 
     .workspace-task-assist-panel-body {
-      flex: 1;
-      overflow-y: auto;
-      padding: 1.25rem 1.35rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.1rem;
     }
 
     .workspace-task-page-loading-layout {

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -2291,6 +2291,13 @@
       gap: 0.9rem;
     }
 
+    .workspace-task-output-shape-note {
+      margin: 0 0 0.75rem;
+      color: var(--text-secondary);
+      font-size: 0.86rem;
+      line-height: 1.5;
+    }
+
     .workspace-task-output-shape-summary {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -36,27 +36,34 @@
                 tabindex="0"
                 role="button"
                 aria-label="Edit task title">Loading task...</h1>
+              <!-- Copy link + Delete folded into a single overflow menu so the
+                   title row stays clean and the destructive Delete is one step
+                   removed from an accidental click. The button ids are kept so
+                   their existing handlers still bind. -->
               <div class="workspace-task-page-title-actions">
-                <button
-                  type="button"
-                  id="workspace-task-copy-link"
-                  class="workspace-task-page-icon-btn"
-                  aria-label="Copy link to task"
-                  title="Copy link to task">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M10.59,13.41C11,13.8 11,14.44 10.59,14.83C10.2,15.22 9.56,15.22 9.17,14.83C7.22,12.88 7.22,9.71 9.17,7.76L12.71,4.22C14.66,2.27 17.83,2.27 19.78,4.22C21.73,6.17 21.73,9.34 19.78,11.29L18.29,12.78C18.3,11.96 18.17,11.14 17.89,10.36L18.36,9.88C19.54,8.71 19.54,6.81 18.36,5.64C17.19,4.46 15.29,4.46 14.12,5.64L10.59,9.17C9.41,10.34 9.41,12.24 10.59,13.41M13.41,9.17C13.8,8.78 14.44,8.78 14.83,9.17C16.78,11.12 16.78,14.29 14.83,16.24L11.29,19.78C9.34,21.73 6.17,21.73 4.22,19.78C2.27,17.83 2.27,14.66 4.22,12.71L5.71,11.22C5.7,12.04 5.83,12.86 6.11,13.64L5.64,14.12C4.46,15.29 4.46,17.19 5.64,18.36C6.81,19.54 8.71,19.54 9.88,18.36L13.41,14.83C14.59,13.66 14.59,11.76 13.41,10.59C13,10.2 13,9.56 13.41,9.17Z"/>
-                  </svg>
-                </button>
-                <button
-                  type="button"
-                  id="workspace-task-delete"
-                  class="workspace-task-page-icon-btn workspace-task-page-icon-btn-danger"
-                  aria-label="Delete task"
-                  title="Delete task">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
-                  </svg>
-                </button>
+                <div class="workspace-task-hero-overflow" data-open="false">
+                  <button
+                    type="button"
+                    id="workspace-task-hero-overflow-toggle"
+                    class="workspace-task-page-icon-btn"
+                    aria-haspopup="menu"
+                    aria-expanded="false"
+                    aria-controls="workspace-task-hero-overflow-menu"
+                    aria-label="More task actions"
+                    title="More actions">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z"/></svg>
+                  </button>
+                  <div id="workspace-task-hero-overflow-menu" class="workspace-task-hero-overflow-menu" role="menu" hidden>
+                    <button type="button" id="workspace-task-copy-link" class="workspace-task-hero-overflow-item" role="menuitem">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M10.59,13.41C11,13.8 11,14.44 10.59,14.83C10.2,15.22 9.56,15.22 9.17,14.83C7.22,12.88 7.22,9.71 9.17,7.76L12.71,4.22C14.66,2.27 17.83,2.27 19.78,4.22C21.73,6.17 21.73,9.34 19.78,11.29L18.29,12.78C18.3,11.96 18.17,11.14 17.89,10.36L18.36,9.88C19.54,8.71 19.54,6.81 18.36,5.64C17.19,4.46 15.29,4.46 14.12,5.64L10.59,9.17C9.41,10.34 9.41,12.24 10.59,13.41M13.41,9.17C13.8,8.78 14.44,8.78 14.83,9.17C16.78,11.12 16.78,14.29 14.83,16.24L11.29,19.78C9.34,21.73 6.17,21.73 4.22,19.78C2.27,17.83 2.27,14.66 4.22,12.71L5.71,11.22C5.7,12.04 5.83,12.86 6.11,13.64L5.64,14.12C4.46,15.29 4.46,17.19 5.64,18.36C6.81,19.54 8.71,19.54 9.88,18.36L13.41,14.83C14.59,13.66 14.59,11.76 13.41,10.59C13,10.2 13,9.56 13.41,9.17Z"/></svg>
+                      <span>Copy link</span>
+                    </button>
+                    <button type="button" id="workspace-task-delete" class="workspace-task-hero-overflow-item workspace-task-hero-overflow-item-danger" role="menuitem">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/></svg>
+                      <span>Delete task</span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="workspace-task-page-subtitle-row">
@@ -581,6 +588,55 @@
       gap: 0.35rem;
       margin-top: 0.45rem;
       flex-shrink: 0;
+    }
+
+    /* Hero "more actions" overflow menu (Copy link, Delete). */
+    .workspace-task-hero-overflow {
+      position: relative;
+    }
+
+    .workspace-task-hero-overflow-menu {
+      position: absolute;
+      top: calc(100% + 0.4rem);
+      right: 0;
+      z-index: 20;
+      min-width: 11rem;
+      padding: 0.35rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      background: var(--bg-primary);
+      box-shadow: 0 10px 30px rgba(10, 10, 10, 0.16);
+    }
+
+    .workspace-task-hero-overflow-item {
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      width: 100%;
+      padding: 0.5rem 0.65rem;
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: var(--text-primary);
+      font-size: 0.88rem;
+      font-weight: 600;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    .workspace-task-hero-overflow-item:hover {
+      background: color-mix(in srgb, var(--primary-color) 10%, var(--bg-primary));
+    }
+
+    .workspace-task-hero-overflow-item-danger {
+      color: #c23b3b;
+    }
+
+    .workspace-task-hero-overflow-item-danger:hover {
+      background: rgba(194, 59, 59, 0.1);
     }
 
     .workspace-task-page-icon-btn {

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -6163,6 +6163,8 @@
   {{template "task-modal" .}}
   {{template "session-modals.tmpl" .}}
 
+  {{template "support-chat.tmpl" .}}
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
   <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
@@ -6188,6 +6190,7 @@
   <script src="/js/file-manager.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/modules/workspace-realtime.js"></script>
+  <script src="/js/modules/workspace-hub-support-chat.js"></script>
   <script>
     if (typeof themeManager !== 'undefined' && themeManager && typeof themeManager.initialize === 'function') {
       themeManager.initialize();

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -3134,21 +3134,22 @@
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
 
+    /* A compact single-column list: each entry stacks its label above the
+       value, separated by hairline rules so the list reads as a tidy table
+       without the blank half-rows the old 2-column grid left with sparse data. */
     .workspace-task-overview-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.85rem;
+      display: flex;
+      flex-direction: column;
     }
 
-    /* Simplification pass: overview entries are plain label/value blocks now,
-       not rounded boxes inside the card (the box-in-box read busy). The grid
-       gap provides the separation. */
     .workspace-task-overview-item {
-      padding: 0.35rem 0;
+      padding: 0.6rem 0;
+      border-top: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
     }
 
-    .workspace-task-overview-item.full {
-      grid-column: 1 / -1;
+    .workspace-task-overview-item:first-child {
+      border-top: 0;
+      padding-top: 0;
     }
 
     .workspace-task-overview-disclosure {
@@ -3191,12 +3192,12 @@
       display: flex;
       align-items: center;
       gap: 0.4rem;
+      margin-bottom: 0.3rem;
       color: var(--text-secondary);
       font-size: 0.8rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      margin-bottom: 0.4rem;
     }
 
     .workspace-task-overview-edit-btn {
@@ -3234,8 +3235,8 @@
 
     .workspace-task-overview-value {
       color: var(--text-primary);
-      font-size: 0.98rem;
-      line-height: 1.6;
+      font-size: 0.95rem;
+      line-height: 1.55;
       white-space: pre-wrap;
       word-break: break-word;
     }

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -122,6 +122,7 @@
   <script src="/js/modules/workspace-hub-panels.js"></script>
   <script src="/js/modules/workspace-hub.js"></script>
   <script src="/js/modules/workspace-hub-board.js"></script>
+  <script src="/js/modules/workspace-hub-support-chat.js"></script>
   <script src="/js/modules/workspace-sync.js"></script>
 </body>
 </html>

--- a/internal/workspace/executor.go
+++ b/internal/workspace/executor.go
@@ -669,9 +669,11 @@ func autoStoreTaskResult(ctx context.Context, ws *Workspace, task *Task, result 
 		format = "text"
 	}
 	writeMode := strings.ToLower(strings.TrimSpace(storage.WriteMode))
-	appendCSV := writeMode == "append"
-	if appendCSV {
-		format = "csv"
+	appendMode := writeMode == "append"
+	if appendMode {
+		// Append datasets are JSONL (canonical); a spreadsheet CSV is produced
+		// on demand via export rather than appended live.
+		format = "jsonl"
 	}
 	ext := "txt"
 	switch format {
@@ -681,6 +683,8 @@ func autoStoreTaskResult(ctx context.Context, ws *Workspace, task *Task, result 
 		ext = "md"
 	case "csv":
 		ext = "csv"
+	case "jsonl":
+		ext = "jsonl"
 	}
 
 	// Generate task name slug for filename
@@ -702,20 +706,21 @@ func autoStoreTaskResult(ctx context.Context, ws *Workspace, task *Task, result 
 	}
 
 	filename := fmt.Sprintf("%s_%s.%s", sanitized, timestamp, ext)
-	if appendCSV {
-		// Honors a user-set storage.FileName; otherwise derives from the
-		// task description.
-		filename = AppendCSVFileName(task, storage)
+	if appendMode {
+		// Honors a user-set storage.FileName; otherwise derives from the task
+		// description. Append datasets are JSONL.
+		filename = AppendJSONLFileName(task, storage)
 	}
 
 	// Prepare data for storage
 	dataToStore := result
-	if appendCSV {
-		if validation.ValidationStatus == TaskValidationPassed && contractCSV != "" {
-			dataToStore = contractCSV
-		} else {
-			dataToStore = TaskResultToCSV(task, result, timestamp, "")
+	if appendMode {
+		jsonlData, buildErr := BuildAppendJSONL(task, result, validation)
+		if buildErr != nil {
+			logger.Error("Failed to build JSONL for append", logger.Fields{"task_id": task.ID, "err": buildErr})
+			return
 		}
+		dataToStore = jsonlData
 	} else if format == "json" {
 		jsonData := map[string]any{
 			"task_id":     task.ID,
@@ -759,36 +764,14 @@ func autoStoreTaskResult(ctx context.Context, ws *Workspace, task *Task, result 
 		if storage.FilePath != "" {
 			storeFilePath = storage.FilePath
 		}
-		if appendCSV {
+		if appendMode {
 			storeNodeCopy := *storeNode
 			storeNodeCopy.WriteMode = "append"
-			storeNodeCopy.Format = "csv"
-			payload, err := csvWithoutHeaderForExistingStoreStrictWithResolver(storeNode, workspaceStore, ws.ID, storeFilePath, dataToStore)
-			if err != nil {
-				// Lever B: reproject into the store file's existing columns and
-				// retry once before holding the run for manual review. Only
-				// reconcile fallback rows (contractCSV == ""); a designed
-				// contract's mismatch stays a hard review.
-				if reCSV, ok := reprojectResultForAppendMismatch(ctx, task, result, err, assistant, contractCSV == ""); ok {
-					if rePayload, retryErr := csvWithoutHeaderForExistingStoreStrictWithResolver(storeNode, workspaceStore, ws.ID, storeFilePath, reCSV); retryErr == nil {
-						payload = rePayload
-						err = nil
-					}
-				}
-			}
-			if err != nil {
-				if recordCSVHeaderMismatchValidation(ws, task, workspaceStore, validation, err) {
-					return
-				}
-				logger.Error("Failed to prepare task result CSV append for store node", logger.Fields{
-					"task_id":       task.ID,
-					"store_node_id": storeNode.ID,
-					"filename":      storeFilePath,
-					"err":           err,
-				})
-				return
-			}
-			if err := WriteToStoreForWorkspace(&storeNodeCopy, workspaceStore, ws.ID, storeFilePath, payload); err != nil {
+			storeNodeCopy.Format = "jsonl"
+			// JSONL needs no header reconciliation — each line is a
+			// self-describing record — so the records are appended directly
+			// (no CSV header strip, no reproject-on-mismatch).
+			if err := WriteToStoreForWorkspace(&storeNodeCopy, workspaceStore, ws.ID, storeFilePath, dataToStore); err != nil {
 				logger.Error("Failed to append task result to store node", logger.Fields{
 					"task_id":       task.ID,
 					"store_node_id": storeNode.ID,
@@ -894,36 +877,16 @@ func autoStoreTaskResult(ctx context.Context, ws *Workspace, task *Task, result 
 		return
 	}
 
-	if appendCSV {
-		if err := AppendCSVToFileStrict(filePath, dataToStore); err != nil {
-			// Lever B: when the row doesn't match the destination's existing
-			// header, reproject into those columns and retry once before
-			// holding the run for manual review. Only reconcile fallback rows
-			// (contractCSV == ""); a designed contract's mismatch stays a hard
-			// review so we don't discard the user's chosen columns.
-			if reCSV, ok := reprojectResultForAppendMismatch(ctx, task, result, err, assistant, contractCSV == ""); ok {
-				if retryErr := AppendCSVToFileStrict(filePath, reCSV); retryErr == nil {
-					logger.Info("Task result reprojected to destination columns and appended", logger.Fields{
-						"task_id":   task.ID,
-						"file_path": filePath,
-					})
-					validation.StorageStatus = TaskStorageAppended
-					validation.Errors = nil
-					recordTaskStorageValidation(ws, task, workspaceStore, validation)
-					return
-				}
-			}
-			if recordCSVHeaderMismatchValidation(ws, task, workspaceStore, validation, err) {
-				return
-			}
-			logger.Error("Failed to append task result to CSV file", logger.Fields{
+	if appendMode {
+		if err := AppendJSONLToFile(filePath, dataToStore); err != nil {
+			logger.Error("Failed to append task result to JSONL file", logger.Fields{
 				"task_id":   task.ID,
 				"file_path": filePath,
 				"err":       err,
 			})
 			return
 		}
-		logger.Info("Task result appended to CSV file", logger.Fields{
+		logger.Info("Task result appended to JSONL file", logger.Fields{
 			"task_id":   task.ID,
 			"file_path": filePath,
 		})

--- a/internal/workspace/file_sync.go
+++ b/internal/workspace/file_sync.go
@@ -295,7 +295,10 @@ func resultStorageWorkspaceFilePath(task *Task, storage *ResultStorageConfig) st
 
 	relativePath := strings.TrimSpace(storage.FilePath)
 	filename := ""
-	if strings.EqualFold(strings.TrimSpace(storage.WriteMode), "append") || strings.EqualFold(strings.TrimSpace(storage.Format), "csv") {
+	if strings.EqualFold(strings.TrimSpace(storage.WriteMode), "append") {
+		// Append datasets are JSONL; track the .jsonl file for sync.
+		filename = AppendJSONLFileName(task, storage)
+	} else if strings.EqualFold(strings.TrimSpace(storage.Format), "csv") {
 		filename = AppendCSVFileName(task, storage)
 	} else if strings.TrimSpace(storage.FileName) != "" {
 		filename = filepath.Base(filepath.Clean(storage.FileName))

--- a/internal/workspace/http_handlers_store.go
+++ b/internal/workspace/http_handlers_store.go
@@ -553,3 +553,62 @@ func (h *HTTPHandler) GetWorkspaceOutputDir(w http.ResponseWriter, r *http.Reque
 		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
 	}
 }
+
+// OpenWorkspaceOutputDir handles POST /api/workspaces/:id/output-dir/open
+//
+// Opens the workspace's default outputs folder in the OS file manager
+// (Finder on macOS, Explorer on Windows). Creates the directory if it
+// doesn't exist yet so the user can drop files in immediately.
+func (h *HTTPHandler) OpenWorkspaceOutputDir(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/api/workspaces/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 1 {
+		orihttp.BadRequest(w, "Invalid URL format")
+		return
+	}
+	workspaceID := parts[0]
+
+	workspace, err := h.store.Get(workspaceID)
+	if err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace not found: %v", err))
+		return
+	}
+
+	outputDir := h.store.GetOutputsPath(workspaceID)
+	if outputDir == "" {
+		baseOutputDir, derr := platform.GetDefaultOutputDir()
+		if derr != nil {
+			baseOutputDir = "outputs"
+			logger.Warn("Failed to get default output dir, using fallback", logger.Fields{"error": derr})
+		}
+		outputDir = filepath.Join(baseOutputDir, workspace.Name)
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to create output directory: %v", err))
+		return
+	}
+
+	if err := platform.OpenFolder(outputDir); err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to open output directory: %v", err))
+		return
+	}
+
+	logger.Info("Opened workspace output directory", logger.Fields{
+		"workspace_id": workspaceID,
+		"path":         outputDir,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(map[string]any{
+		"output_dir":   outputDir,
+		"workspace_id": workspaceID,
+	}); encErr != nil {
+		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
+	}
+}

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -476,6 +476,14 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 
 	appendedRows := csvRowCount(csvData)
 
+	// The dataset is JSONL; convert the CSV payload to JSONL records at the
+	// append boundary so this path writes the same .jsonl the executor does.
+	jsonlData, convErr := CSVToJSONL(csvData)
+	if convErr != nil {
+		orihttp.BadRequest(w, fmt.Sprintf("Could not parse rows to append: %v", convErr))
+		return
+	}
+
 	if storeNodeID != "" {
 		var storeNode *StoreNode
 		for i := range ws.StoreNodes {
@@ -490,16 +498,12 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 		}
 		storeFilePath := filePath
 		if storeFilePath == "" {
-			storeFilePath = AppendCSVFileName(task, storageCfg)
+			storeFilePath = AppendJSONLFileName(task, storageCfg)
 		}
 		nodeCopy := *storeNode
 		nodeCopy.WriteMode = "append"
-		nodeCopy.Format = "csv"
-		payload, err := CSVWithoutHeaderForExistingStoreStrictInWorkspace(storeNode, h.store, ws.ID, storeFilePath, csvData)
-		if err != nil {
-			payload = csvWithoutHeader(csvData)
-		}
-		if err := WriteToStoreForWorkspace(&nodeCopy, h.store, ws.ID, storeFilePath, payload); err != nil {
+		nodeCopy.Format = "jsonl"
+		if err := WriteToStoreForWorkspace(&nodeCopy, h.store, ws.ID, storeFilePath, jsonlData); err != nil {
 			logger.Error("Failed to append task result to store node", logger.Fields{
 				"task_id":       task.ID,
 				"store_node_id": storeNode.ID,
@@ -533,9 +537,9 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 		}
 		relativeFilePath := filePath
 		if relativeFilePath == "" {
-			relativeFilePath = AppendCSVFileName(task, storageCfg)
+			relativeFilePath = AppendJSONLFileName(task, storageCfg)
 		} else if strings.HasSuffix(relativeFilePath, "/") || !strings.Contains(filepath.Base(relativeFilePath), ".") {
-			relativeFilePath = filepath.Join(relativeFilePath, AppendCSVFileName(task, storageCfg))
+			relativeFilePath = filepath.Join(relativeFilePath, AppendJSONLFileName(task, storageCfg))
 		}
 		finalPath, err := BuildFinalPath(baseDir, relativeFilePath)
 		if err != nil {
@@ -552,13 +556,13 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 			}
 			baseOutputDir = filepath.Join(fallback, ws.Name)
 		}
-		filePath = filepath.Join(baseOutputDir, AppendCSVFileName(task, storageCfg))
+		filePath = filepath.Join(baseOutputDir, AppendJSONLFileName(task, storageCfg))
 	} else if strings.HasSuffix(filePath, "/") || !strings.Contains(filepath.Base(filePath), ".") {
-		filePath = filepath.Join(filePath, AppendCSVFileName(task, storageCfg))
+		filePath = filepath.Join(filePath, AppendJSONLFileName(task, storageCfg))
 	}
 
-	if err := AppendCSVToFile(filePath, csvData); err != nil {
-		logger.Error("Failed to append task result CSV to file", logger.Fields{
+	if err := AppendJSONLToFile(filePath, jsonlData); err != nil {
+		logger.Error("Failed to append task result to JSONL file", logger.Fields{
 			"task_id":   task.ID,
 			"file_path": filePath,
 			"err":       err,

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -460,8 +460,14 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 	storeNodeID := strings.TrimSpace(req.StoreNodeID)
 	filePath := strings.TrimSpace(req.FilePath)
 
+	// Derive the dataset filename from the storage OWNER (the workflow's last
+	// subtask when the task has subtasks), not the URL task — that's where the
+	// executor writes and where export reads, so a description-derived filename
+	// must resolve identically across all three paths.
 	var storageCfg *ResultStorageConfig
+	storageOwner := task
 	if owner := ResolveTaskResultStorageOwner(ws, task); owner != nil {
+		storageOwner = owner
 		storageCfg = owner.ResultStorage
 	}
 
@@ -498,7 +504,7 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 		}
 		storeFilePath := filePath
 		if storeFilePath == "" {
-			storeFilePath = AppendJSONLFileName(task, storageCfg)
+			storeFilePath = AppendJSONLFileName(storageOwner, storageCfg)
 		}
 		nodeCopy := *storeNode
 		nodeCopy.WriteMode = "append"
@@ -537,9 +543,9 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 		}
 		relativeFilePath := filePath
 		if relativeFilePath == "" {
-			relativeFilePath = AppendJSONLFileName(task, storageCfg)
+			relativeFilePath = AppendJSONLFileName(storageOwner, storageCfg)
 		} else if strings.HasSuffix(relativeFilePath, "/") || !strings.Contains(filepath.Base(relativeFilePath), ".") {
-			relativeFilePath = filepath.Join(relativeFilePath, AppendJSONLFileName(task, storageCfg))
+			relativeFilePath = filepath.Join(relativeFilePath, AppendJSONLFileName(storageOwner, storageCfg))
 		}
 		finalPath, err := BuildFinalPath(baseDir, relativeFilePath)
 		if err != nil {
@@ -556,9 +562,9 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 			}
 			baseOutputDir = filepath.Join(fallback, ws.Name)
 		}
-		filePath = filepath.Join(baseOutputDir, AppendJSONLFileName(task, storageCfg))
+		filePath = filepath.Join(baseOutputDir, AppendJSONLFileName(storageOwner, storageCfg))
 	} else if strings.HasSuffix(filePath, "/") || !strings.Contains(filepath.Base(filePath), ".") {
-		filePath = filepath.Join(filePath, AppendJSONLFileName(task, storageCfg))
+		filePath = filepath.Join(filePath, AppendJSONLFileName(storageOwner, storageCfg))
 	}
 
 	if err := AppendJSONLToFile(filePath, jsonlData); err != nil {

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -571,6 +572,179 @@ func (h *HTTPHandler) AppendResultToCSV(w http.ResponseWriter, r *http.Request) 
 		"file_path":     filePath,
 		"label":         filepath.Base(filePath),
 	})
+}
+
+// ExportResultCSV handles GET /api/workspaces/:id/tasks/:task_id/results/export-csv.
+// The canonical append dataset is JSONL; this derives a spreadsheet-friendly CSV
+// from it on demand (data columns first, run metadata after) and returns it as a
+// download. The .jsonl file on disk is never modified.
+func (h *HTTPHandler) ExportResultCSV(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+
+	// URL: /api/workspaces/{workspace_id}/tasks/{task_id}/results/export-csv
+	path := strings.TrimPrefix(r.URL.Path, "/api/workspaces/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 5 {
+		orihttp.BadRequest(w, "Invalid URL format")
+		return
+	}
+	workspaceID := parts[0]
+	taskID := parts[2]
+
+	ws, err := h.store.Get(workspaceID)
+	if err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace not found: %v", err))
+		return
+	}
+
+	var task *Task
+	for i := range ws.Tasks {
+		if ws.Tasks[i].ID == taskID {
+			task = &ws.Tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		orihttp.NotFound(w, "Task not found")
+		return
+	}
+
+	owner := ResolveTaskResultStorageOwner(ws, task)
+	if owner == nil {
+		owner = task
+	}
+	storage := owner.ResultStorage
+	if storage == nil || !storage.Enabled || !strings.EqualFold(strings.TrimSpace(storage.WriteMode), "append") {
+		orihttp.BadRequest(w, "Task does not have an appended dataset to export")
+		return
+	}
+
+	filePath, err := h.resolveTaskResultJSONLPath(ws, owner, storage)
+	if err != nil {
+		orihttp.BadRequest(w, fmt.Sprintf("Could not resolve dataset file: %v", err))
+		return
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			orihttp.NotFound(w, "No dataset has been written yet")
+			return
+		}
+		orihttp.InternalError(w, fmt.Sprintf("Read dataset failed: %v", err))
+		return
+	}
+
+	csvData, err := ExportCSVFromJSONL(string(content), taskExportPreferredColumns(owner))
+	if err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Export failed: %v", err))
+		return
+	}
+
+	downloadName := strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath)) + ".csv"
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+	_, _ = w.Write([]byte(csvData))
+}
+
+// resolveTaskResultJSONLPath resolves the local .jsonl file a task's append
+// dataset is written to, mirroring the destination resolution the executor and
+// manual-append handler use (store node, workspace folder, explicit path, or
+// the workspace's default output folder).
+func (h *HTTPHandler) resolveTaskResultJSONLPath(ws *Workspace, owner *Task, storage *ResultStorageConfig) (string, error) {
+	explicit := strings.TrimSpace(storage.FilePath)
+	jsonlName := AppendJSONLFileName(owner, storage)
+
+	if strings.TrimSpace(storage.StoreNodeID) != "" {
+		var storeNode *StoreNode
+		for i := range ws.StoreNodes {
+			if ws.StoreNodes[i].ID == storage.StoreNodeID || ws.StoreNodes[i].CanvasNodeID == storage.StoreNodeID {
+				storeNode = &ws.StoreNodes[i]
+				break
+			}
+		}
+		if storeNode == nil {
+			return "", fmt.Errorf("store node not found")
+		}
+		storeFilePath := explicit
+		if storeFilePath == "" {
+			storeFilePath = jsonlName
+		}
+		return BuildFinalStorePath(storeNode, h.store, ws.ID, storeFilePath)
+	}
+
+	if ResultStorageUsesWorkspaceFolder(storage) {
+		baseDir, _, err := ResolveWorkspaceFolderBaseDir(h.store, ws.ID, storage.WorkspaceFolder)
+		if err != nil {
+			return "", err
+		}
+		relativeFilePath := explicit
+		if relativeFilePath == "" {
+			relativeFilePath = jsonlName
+		} else if strings.HasSuffix(relativeFilePath, "/") || !strings.Contains(filepath.Base(relativeFilePath), ".") {
+			relativeFilePath = filepath.Join(relativeFilePath, jsonlName)
+		}
+		return BuildFinalPath(baseDir, relativeFilePath)
+	}
+
+	if explicit != "" {
+		if strings.HasSuffix(explicit, "/") || !strings.Contains(filepath.Base(explicit), ".") {
+			return filepath.Join(explicit, jsonlName), nil
+		}
+		return explicit, nil
+	}
+
+	baseOutputDir := h.store.GetOutputsPath(ws.ID)
+	if baseOutputDir == "" {
+		fallback, err := platform.GetDefaultOutputDir()
+		if err != nil {
+			fallback = "outputs"
+		}
+		baseOutputDir = filepath.Join(fallback, ws.Name)
+	}
+	return filepath.Join(baseOutputDir, jsonlName), nil
+}
+
+// taskExportPreferredColumns returns the task's declared output columns in
+// order, so the exported CSV leads with the data the task produces and trails
+// the run metadata.
+func taskExportPreferredColumns(task *Task) []string {
+	if task == nil {
+		return nil
+	}
+	appendName := func(cols []string, name string) []string {
+		if name = strings.TrimSpace(name); name != "" {
+			return append(cols, name)
+		}
+		return cols
+	}
+	if task.OutputSpec != nil {
+		if task.OutputSpec.Schema != nil && len(task.OutputSpec.Schema.Fields) > 0 {
+			cols := make([]string, 0, len(task.OutputSpec.Schema.Fields))
+			for _, field := range task.OutputSpec.Schema.Fields {
+				cols = appendName(cols, field.Name)
+			}
+			return cols
+		}
+		if task.OutputSpec.Contract != nil && len(task.OutputSpec.Contract.Columns) > 0 {
+			cols := make([]string, 0, len(task.OutputSpec.Contract.Columns))
+			for _, column := range task.OutputSpec.Contract.Columns {
+				cols = appendName(cols, column.Name)
+			}
+			return cols
+		}
+	}
+	if task.OutputContract != nil && len(task.OutputContract.Columns) > 0 {
+		cols := make([]string, 0, len(task.OutputContract.Columns))
+		for _, column := range task.OutputContract.Columns {
+			cols = appendName(cols, column.Name)
+		}
+		return cols
+	}
+	return nil
 }
 
 // csvRowCount counts data rows in a CSV string, excluding the header.

--- a/internal/workspace/http_handlers_task_append_csv_test.go
+++ b/internal/workspace/http_handlers_task_append_csv_test.go
@@ -66,14 +66,12 @@ func TestHTTPHandler_AppendResultToCSV_UsesTaskStorage(t *testing.T) {
 		t.Fatalf("label=%q, want runs.csv", resp.Label)
 	}
 
-	contents, err := os.ReadFile(storedPath)
-	if err != nil {
-		t.Fatalf("read csv: %v", err)
+	records := readAppendedJSONL(t, storedPath)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 appended record, got %d", len(records))
 	}
-	got := strings.TrimSpace(string(contents))
-	want := "timestamp,value\n2026-05-20,high"
-	if got != want {
-		t.Fatalf("csv contents=%q, want %q", got, want)
+	if records[0]["timestamp"] != "2026-05-20" || records[0]["value"] != "high" {
+		t.Fatalf("record = %#v", records[0])
 	}
 
 	// Second append should not duplicate the header.
@@ -87,15 +85,37 @@ func TestHTTPHandler_AppendResultToCSV_UsesTaskStorage(t *testing.T) {
 		t.Fatalf("status2=%d body=%s", rec2.Code, rec2.Body.String())
 	}
 
-	contents2, err := os.ReadFile(storedPath)
+	records2 := readAppendedJSONL(t, storedPath)
+	if len(records2) != 2 {
+		t.Fatalf("expected 2 records after second append, got %d", len(records2))
+	}
+	if records2[1]["timestamp"] != "2026-05-21" || records2[1]["value"] != "low" {
+		t.Fatalf("second record = %#v", records2[1])
+	}
+}
+
+// readAppendedJSONL reads a .jsonl dataset file and parses each line into a
+// record. The manual-append / approve paths now write JSONL (converted from
+// the CSV they receive), so these tests assert records rather than CSV text.
+func readAppendedJSONL(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("re-read csv: %v", err)
+		t.Fatalf("read jsonl: %v", err)
 	}
-	got2 := strings.TrimSpace(string(contents2))
-	want2 := "timestamp,value\n2026-05-20,high\n2026-05-21,low"
-	if got2 != want2 {
-		t.Fatalf("csv contents after second append=%q, want %q", got2, want2)
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("line %q is not JSON: %v", line, err)
+		}
+		records = append(records, record)
 	}
+	return records
 }
 
 func TestHTTPHandler_AppendResultToCSV_UsesWorkspaceFolderStorage(t *testing.T) {
@@ -152,12 +172,9 @@ func TestHTTPHandler_AppendResultToCSV_UsesWorkspaceFolderStorage(t *testing.T) 
 	if resp.Label != "runs.csv" {
 		t.Fatalf("label=%q, want runs.csv", resp.Label)
 	}
-	contents, err := os.ReadFile(wantPath)
-	if err != nil {
-		t.Fatalf("read csv: %v", err)
-	}
-	if strings.TrimSpace(string(contents)) != "timestamp,value\n2026-05-26,high" {
-		t.Fatalf("unexpected csv contents: %q", string(contents))
+	records := readAppendedJSONL(t, wantPath)
+	if len(records) != 1 || records[0]["timestamp"] != "2026-05-26" || records[0]["value"] != "high" {
+		t.Fatalf("unexpected appended records: %#v", records)
 	}
 
 	treeReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID+"/files/tree", nil)
@@ -224,12 +241,9 @@ func TestHTTPHandler_AppendResultToCSV_UsesWorkspaceFolderStoreNode(t *testing.T
 	}
 
 	wantPath := filepath.Join(store.GetFilesPath(ws.ID), "exports", "runs.csv")
-	contents, err := os.ReadFile(wantPath)
-	if err != nil {
-		t.Fatalf("read csv: %v", err)
-	}
-	if strings.TrimSpace(string(contents)) != "timestamp,value\n2026-05-26,stored" {
-		t.Fatalf("unexpected csv contents: %q", string(contents))
+	records := readAppendedJSONL(t, wantPath)
+	if len(records) != 1 || records[0]["timestamp"] != "2026-05-26" || records[0]["value"] != "stored" {
+		t.Fatalf("unexpected appended records: %#v", records)
 	}
 
 	updated, err := store.Get(ws.ID)
@@ -281,12 +295,9 @@ func TestHTTPHandler_AppendResultToCSV_OneShotCustomPath(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	contents, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("read csv: %v", err)
-	}
-	if strings.TrimSpace(string(contents)) != "name,score\nalpha,9" {
-		t.Fatalf("unexpected csv contents: %q", string(contents))
+	records := readAppendedJSONL(t, targetPath)
+	if len(records) != 1 || records[0]["name"] != "alpha" || records[0]["score"] != "9" {
+		t.Fatalf("unexpected appended records: %#v", records)
 	}
 }
 

--- a/internal/workspace/http_handlers_task_export_csv_test.go
+++ b/internal/workspace/http_handlers_task_export_csv_test.go
@@ -1,0 +1,126 @@
+package workspace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHTTPHandler_ExportResultCSV(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "runs.jsonl")
+	content := `{"date":"2026-05-09","value":"7","run_id":"r1"}` + "\n" +
+		`{"date":"2026-05-10","value":"5","run_id":"r2"}` + "\n"
+	if err := os.WriteFile(jsonlPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	ws := &Workspace{
+		ID:     "ws-1",
+		Name:   "Demo",
+		Status: StatusActive,
+		Tasks: []Task{{
+			ID:          "task-1",
+			Description: "Pollen",
+			ResultStorage: &ResultStorageConfig{
+				Enabled:   true,
+				WriteMode: "append",
+				FilePath:  jsonlPath,
+			},
+			OutputContract: &TaskOutputContract{
+				Columns: []TaskOutputContractColumn{{Name: "date"}, {Name: "value"}},
+			},
+		}},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/workspaces/ws-1/tasks/task-1/results/export-csv", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ExportResultCSV(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+		t.Errorf("content-type = %q, want text/csv", ct)
+	}
+	lines := strings.Split(strings.TrimSpace(rec.Body.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 rows, got %d: %q", len(lines), rec.Body.String())
+	}
+	if lines[0] != "date,value,run_id" {
+		t.Errorf("header = %q, want declared columns first then run metadata", lines[0])
+	}
+	if lines[1] != "2026-05-09,7,r1" {
+		t.Errorf("first row = %q", lines[1])
+	}
+}
+
+func TestHTTPHandler_ExportResultCSV_NoDatasetYet(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	dir := t.TempDir()
+	ws := &Workspace{
+		ID:     "ws-1",
+		Name:   "Demo",
+		Status: StatusActive,
+		Tasks: []Task{{
+			ID:          "task-1",
+			Description: "Pollen",
+			ResultStorage: &ResultStorageConfig{
+				Enabled:   true,
+				WriteMode: "append",
+				FilePath:  filepath.Join(dir, "missing.jsonl"),
+			},
+		}},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/workspaces/ws-1/tasks/task-1/results/export-csv", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ExportResultCSV(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for missing dataset", rec.Code)
+	}
+}
+
+func TestHTTPHandler_ExportResultCSV_RejectsNonAppendTask(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:     "ws-1",
+		Name:   "Demo",
+		Status: StatusActive,
+		Tasks:  []Task{{ID: "task-1", Description: "One-off"}},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/workspaces/ws-1/tasks/task-1/results/export-csv", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ExportResultCSV(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 when there is no append dataset", rec.Code)
+	}
+}

--- a/internal/workspace/output_contract_test.go
+++ b/internal/workspace/output_contract_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -244,11 +245,19 @@ func TestAutoStoreResult_AppendCSVUsesContractAndRecordsValidation(t *testing.T)
 
 	data, err := os.ReadFile(task.ResultStorage.FilePath)
 	if err != nil {
-		t.Fatalf("read csv: %v", err)
+		t.Fatalf("read jsonl: %v", err)
 	}
-	want := "date,location,pollen_count,high\n2026-05-20,NYC,8,true"
-	if string(data) != want {
-		t.Fatalf("csv = %q, want %q", string(data), want)
+	var record map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record); err != nil {
+		t.Fatalf("append output is not JSONL: %v (%q)", err, string(data))
+	}
+	for _, key := range []string{"date", "location", "pollen_count", "high"} {
+		if _, ok := record[key]; !ok {
+			t.Errorf("appended record missing contract field %q: %#v", key, record)
+		}
+	}
+	if record["run_id"] != "run-1" || record["status"] != "success" {
+		t.Errorf("appended record missing run metadata: %#v", record)
 	}
 
 	updated, err := store.Get(ws.ID)
@@ -330,10 +339,14 @@ func TestAutoStoreResult_NoContractKeepsExistingAppendBehavior(t *testing.T) {
 
 	data, err := os.ReadFile(task.ResultStorage.FilePath)
 	if err != nil {
-		t.Fatalf("read csv: %v", err)
+		t.Fatalf("read jsonl: %v", err)
 	}
-	if !strings.Contains(string(data), "task_id,description,timestamp,agent,result") {
-		t.Fatalf("expected legacy fallback csv, got %q", string(data))
+	var record map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record); err != nil {
+		t.Fatalf("fallback output is not JSONL: %v (%q)", err, string(data))
+	}
+	if record["result"] != "Pollen is high." || record["task_id"] != "task-1" {
+		t.Fatalf("expected fallback record with raw result, got %#v", record)
 	}
 
 	updated, err := store.Get(ws.ID)

--- a/internal/workspace/store_operations.go
+++ b/internal/workspace/store_operations.go
@@ -208,7 +208,7 @@ func formatData(data string, format string) ([]byte, error) {
 		}
 		return formatted, nil
 
-	case "text", "markdown", "csv":
+	case "text", "markdown", "csv", "jsonl":
 		// Return as-is, preserve newlines
 		return []byte(data), nil
 

--- a/internal/workspace/store_operations.go
+++ b/internal/workspace/store_operations.go
@@ -288,8 +288,10 @@ func writeToStoreAtBaseDir(node *StoreNode, baseDir, filePath, data string) erro
 		}
 		defer func() { _ = f.Close() }()
 
-		if info, err := f.Stat(); err == nil && info.Size() > 0 {
-			// Add newline separator before appending
+		if info, err := f.Stat(); err == nil && info.Size() > 0 && node.Format != "jsonl" {
+			// CSV/text rows aren't newline-terminated, so separate them. JSONL
+			// records already end in '\n', so a separator here would insert a
+			// blank line between records.
 			if _, err := f.Write([]byte("\n")); err != nil {
 				return fmt.Errorf("failed to write newline separator: %w", err)
 			}

--- a/internal/workspace/task_output_normalization_test.go
+++ b/internal/workspace/task_output_normalization_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -138,16 +139,19 @@ func (f *fakeTaskOutputSpecAssistant) RepairTaskOutputSpec(_ context.Context, _ 
 	return f.repairResult, f.repairErr
 }
 
-func TestAutoStoreResult_OutputSpecBlocksCSVHeaderMismatch(t *testing.T) {
+// JSONL append has no header to reconcile, so a passing run is appended as a
+// new record regardless of what the destination file already contains — the
+// CSV header-mismatch "needs review" path no longer applies to appends.
+func TestAutoStoreResult_AppendsJSONLRecordOnPass(t *testing.T) {
 	dir := t.TempDir()
-	filePath := filepath.Join(dir, "pollen.csv")
-	if err := os.WriteFile(filePath, []byte("other,header\n1,2"), 0644); err != nil {
-		t.Fatalf("write existing csv: %v", err)
+	filePath := filepath.Join(dir, "pollen.jsonl")
+	// A pre-existing record (even with different keys) must not block the append.
+	if err := os.WriteFile(filePath, []byte(`{"other":"row"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write existing jsonl: %v", err)
 	}
 	task := structuredPollenTaskForNormalization()
 	task.ResultStorage = &ResultStorageConfig{
 		Enabled:   true,
-		Format:    "csv",
 		WriteMode: "append",
 		FilePath:  filePath,
 	}
@@ -163,11 +167,23 @@ func TestAutoStoreResult_OutputSpecBlocksCSVHeaderMismatch(t *testing.T) {
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		t.Fatalf("read csv: %v", err)
+		t.Fatalf("read jsonl: %v", err)
 	}
-	if strings.TrimSpace(string(data)) != "other,header\n1,2" {
-		t.Fatalf("csv should not be appended on mismatch, got %q", string(data))
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected existing + appended line, got %d: %q", len(lines), string(data))
 	}
+	var appended map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &appended); err != nil {
+		t.Fatalf("appended line is not JSON: %v", err)
+	}
+	if appended["forecast_date"] != "2026-05-21" {
+		t.Errorf("appended record missing data field: %#v", appended)
+	}
+	if appended["run_id"] != "run-1" || appended["status"] != "success" {
+		t.Errorf("appended record missing run metadata: %#v", appended)
+	}
+
 	updated, err := store.Get(ws.ID)
 	if err != nil {
 		t.Fatalf("reload workspace: %v", err)
@@ -177,17 +193,8 @@ func TestAutoStoreResult_OutputSpecBlocksCSVHeaderMismatch(t *testing.T) {
 		t.Fatalf("get task: %v", err)
 	}
 	validation := updatedTask.ExecutionHistory[len(updatedTask.ExecutionHistory)-1].Validation
-	if validation == nil || validation.ValidationStatus != TaskValidationNeedsReview || validation.StorageStatus != TaskStorageSkippedInvalid {
-		t.Fatalf("validation=%+v, want needs_review/skipped_invalid", validation)
-	}
-	if len(validation.Errors) == 0 || validation.Errors[0].Code != "csv_header_mismatch" {
-		t.Fatalf("expected csv_header_mismatch, got %+v", validation.Errors)
-	}
-	if strings.Join(validation.Errors[0].Expected, ",") != "run_id,executed_at,status,duration_ms,forecast_date,pollen_count,top_allergens" {
-		t.Fatalf("expected header metadata, got %+v", validation.Errors[0].Expected)
-	}
-	if strings.Join(validation.Errors[0].Actual, ",") != "other,header" {
-		t.Fatalf("actual header = %+v, want other/header", validation.Errors[0].Actual)
+	if validation == nil || validation.ValidationStatus != TaskValidationPassed || validation.StorageStatus != TaskStorageAppended {
+		t.Fatalf("validation=%+v, want passed/appended", validation)
 	}
 }
 

--- a/internal/workspace/task_result_storage_jsonl.go
+++ b/internal/workspace/task_result_storage_jsonl.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bufio"
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -213,6 +214,42 @@ func MarshalJSONLRecords(records []map[string]any) (string, error) {
 		buffer.WriteByte('\n')
 	}
 	return buffer.String(), nil
+}
+
+// CSVToJSONL converts a CSV payload (header row + data rows) into JSONL: one
+// JSON object per data row, keyed by the header columns. Used by the manual
+// "append now" and approve-held-run paths, which still build CSV upstream —
+// converting at the append boundary lets them write the canonical .jsonl
+// without reworking their CSV-shaped request/validation flow. Values are kept
+// as strings (the CSV export re-stringifies anyway).
+func CSVToJSONL(csvData string) (string, error) {
+	trimmed := strings.TrimSpace(csvData)
+	if trimmed == "" {
+		return "", nil
+	}
+	reader := csv.NewReader(strings.NewReader(trimmed))
+	reader.FieldsPerRecord = -1
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return "", err
+	}
+	if len(rows) < 2 {
+		return "", nil
+	}
+	header := rows[0]
+	records := make([]map[string]any, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		record := make(map[string]any, len(header))
+		for i, column := range header {
+			value := ""
+			if i < len(row) {
+				value = row[i]
+			}
+			record[strings.TrimSpace(column)] = value
+		}
+		records = append(records, record)
+	}
+	return MarshalJSONLRecords(records)
 }
 
 // AppendJSONLToFile appends one or more JSONL records to filePath, creating the

--- a/internal/workspace/task_result_storage_jsonl.go
+++ b/internal/workspace/task_result_storage_jsonl.go
@@ -1,0 +1,271 @@
+package workspace
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// JSONL (newline-delimited JSON) is the canonical append format for recurring
+// task output: each run appends one JSON object per data record. Unlike the
+// CSV path it needs no header, no column contract, and no header-mismatch
+// reconciliation — every record carries its own keys. CSV is produced on
+// demand from the JSONL via ExportCSVFromJSONL.
+
+// AppendJSONLFileName returns the file an append run writes to within the
+// default/derived output folder: the user's custom FileName (normalized to
+// .jsonl) when set, otherwise a slug derived from the task description.
+func AppendJSONLFileName(task *Task, storage *ResultStorageConfig) string {
+	if storage != nil {
+		if custom := sanitizeAppendFileName(storage.FileName, "jsonl"); custom != "" {
+			return custom
+		}
+	}
+	return appendFileSlug(taskAppendSlugSource(task)) + ".jsonl"
+}
+
+// sanitizeAppendFileName strips any directory component and forces the given
+// extension, keeping the write inside the chosen folder. Returns "" when the
+// name has no usable characters.
+func sanitizeAppendFileName(name, ext string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	name = filepath.Base(filepath.Clean(name))
+	lower := strings.ToLower(name)
+	for _, known := range []string{".jsonl", ".csv", ".json"} {
+		if strings.HasSuffix(lower, known) {
+			name = name[:len(name)-len(known)]
+			break
+		}
+	}
+	slug := appendFileSlug(name)
+	if slug == "" {
+		return ""
+	}
+	return slug + "." + ext
+}
+
+func taskAppendSlugSource(task *Task) string {
+	if task == nil {
+		return ""
+	}
+	name := task.Description
+	if len(name) > 30 {
+		name = name[:30]
+	}
+	return name
+}
+
+// appendFileSlug reduces a name to a filename-safe slug (letters, digits, '_',
+// '-'; spaces become underscores). Falls back to "task" when empty.
+func appendFileSlug(name string) string {
+	var slug strings.Builder
+	for _, r := range name {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-':
+			slug.WriteRune(r)
+		case r == ' ':
+			slug.WriteByte('_')
+		}
+	}
+	if slug.Len() == 0 {
+		return "task"
+	}
+	return slug.String()
+}
+
+// TaskResultToJSONLRecords extracts the run's data records from the task's
+// structured output (or its decoded JSON result) and merges the supplied run
+// metadata into each. An array result yields one record per element; an object
+// yields a single record. When there is no structured output it falls back to a
+// single record wrapping the raw result, so a run is never dropped. Existing
+// data keys are never overwritten by metadata.
+func TaskResultToJSONLRecords(task *Task, result string, metadata map[string]any) []map[string]any {
+	records := taskStructuredRecords(task, result)
+	if len(records) == 0 {
+		record := map[string]any{"result": strings.TrimSpace(result)}
+		if task != nil {
+			record["task_id"] = task.ID
+			record["description"] = task.Description
+		}
+		records = []map[string]any{record}
+	}
+
+	if len(metadata) > 0 {
+		for _, record := range records {
+			for key, value := range metadata {
+				if _, exists := record[key]; exists {
+					continue
+				}
+				record[key] = value
+			}
+		}
+	}
+	return records
+}
+
+// taskStructuredRecords pulls structured records from Context["structured_output"]
+// first (set by output normalization), then falls back to decoding the result
+// string as JSON. Mirrors taskStructuredRowsForCSV but keeps values as-is.
+func taskStructuredRecords(task *Task, result string) []map[string]any {
+	if task != nil && task.Context != nil {
+		if output, ok := task.Context["structured_output"]; ok {
+			if records := structuredRecordsFromValue(output); len(records) > 0 {
+				return records
+			}
+		}
+	}
+
+	var decoded any
+	decoder := json.NewDecoder(strings.NewReader(strings.TrimSpace(result)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil
+	}
+	return structuredRecordsFromValue(decoded)
+}
+
+// structuredRecordsFromValue normalizes a decoded JSON value into a slice of
+// record objects. Arrays of objects map element-for-element; a wrapper object
+// is unwrapped via a "data"/"rows"/"items" key when present; a plain object is
+// a single record. Anything else yields nil.
+func structuredRecordsFromValue(value any) []map[string]any {
+	switch typed := value.(type) {
+	case []any:
+		records := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			object, ok := item.(map[string]any)
+			if !ok {
+				return nil
+			}
+			records = append(records, object)
+		}
+		return records
+	case map[string]any:
+		for _, key := range []string{"data", "rows", "items"} {
+			if nested, ok := typed[key]; ok {
+				if records := structuredRecordsFromValue(nested); len(records) > 0 {
+					return records
+				}
+			}
+		}
+		return []map[string]any{typed}
+	default:
+		return nil
+	}
+}
+
+// MarshalJSONLRecords renders records as newline-delimited JSON: one compact
+// object per line, with a trailing newline after each.
+func MarshalJSONLRecords(records []map[string]any) (string, error) {
+	var buffer bytes.Buffer
+	for _, record := range records {
+		data, err := json.Marshal(record)
+		if err != nil {
+			return "", err
+		}
+		buffer.Write(data)
+		buffer.WriteByte('\n')
+	}
+	return buffer.String(), nil
+}
+
+// AppendJSONLToFile appends one or more JSONL records to filePath, creating the
+// file and parent directory as needed. No header is written — each line is a
+// self-describing record — which is what makes the append path simpler than CSV.
+func AppendJSONLToFile(filePath, content string) error {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	_, err = file.WriteString(trimmed + "\n")
+	return err
+}
+
+// ExportCSVFromJSONL derives a CSV from JSONL content on demand. preferred lists
+// the columns that should lead (e.g. the task's output-schema fields, in order);
+// any remaining keys across the records are appended after them, sorted. Missing
+// cells are written empty. This is how the spreadsheet-friendly CSV view is
+// produced without maintaining a separate CSV-append contract.
+func ExportCSVFromJSONL(jsonlContent string, preferred []string) (string, error) {
+	rows := []map[string]string{}
+
+	scanner := bufio.NewScanner(strings.NewReader(jsonlContent))
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(strings.NewReader(line))
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil {
+			return "", fmt.Errorf("invalid JSONL on line %d: %w", lineNumber, err)
+		}
+		rows = append(rows, csvRowFromMap(object))
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if len(rows) == 0 {
+		return "", nil
+	}
+
+	return writeCSV(exportColumns(preferred, rows), rows), nil
+}
+
+// exportColumns orders CSV export columns: the preferred (schema) columns first,
+// then any other keys present in the data, sorted, so data leads and run
+// bookkeeping trails (the same data-first ordering the on-page preview uses).
+func exportColumns(preferred []string, rows []map[string]string) []string {
+	seen := make(map[string]struct{})
+	columns := []string{}
+	add := func(column string) {
+		column = strings.TrimSpace(column)
+		if column == "" {
+			return
+		}
+		key := strings.ToLower(column)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		columns = append(columns, column)
+	}
+
+	for _, column := range preferred {
+		add(column)
+	}
+
+	remaining := []string{}
+	for _, row := range rows {
+		for key := range row {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+	for _, key := range remaining {
+		add(key)
+	}
+	return columns
+}

--- a/internal/workspace/task_result_storage_jsonl.go
+++ b/internal/workspace/task_result_storage_jsonl.go
@@ -162,6 +162,44 @@ func structuredRecordsFromValue(value any) []map[string]any {
 	}
 }
 
+// BuildAppendJSONL produces the newline-delimited JSON a run appends to its
+// dataset file. It prefers the validated/normalized record from output-spec
+// validation (so it matches what schema validation accepted) and otherwise
+// extracts records from the task's structured output or raw result. Run
+// metadata (run_id, executed_at, status, duration_ms, and validation/storage
+// status) is merged into every record without overwriting data fields. This is
+// the JSONL counterpart to the contractCSV the storage path used to build.
+func BuildAppendJSONL(task *Task, result string, validation *TaskValidationResult) (string, error) {
+	metadata := map[string]any{}
+	for key, value := range latestTaskOutputMetadata(task) {
+		metadata[key] = value
+	}
+	if validation != nil {
+		if status := strings.TrimSpace(string(validation.ValidationStatus)); status != "" {
+			metadata["validation_status"] = status
+		}
+		if status := strings.TrimSpace(string(validation.StorageStatus)); status != "" {
+			metadata["storage_status"] = status
+		}
+	}
+
+	if validation != nil && validation.NormalizedRow != nil {
+		record := cloneTaskOutputNormalizedRow(validation.NormalizedRow)
+		if record == nil {
+			record = map[string]any{}
+		}
+		for key, value := range metadata {
+			if _, exists := record[key]; exists {
+				continue
+			}
+			record[key] = value
+		}
+		return MarshalJSONLRecords([]map[string]any{record})
+	}
+
+	return MarshalJSONLRecords(TaskResultToJSONLRecords(task, result, metadata))
+}
+
 // MarshalJSONLRecords renders records as newline-delimited JSON: one compact
 // object per line, with a trailing newline after each.
 func MarshalJSONLRecords(records []map[string]any) (string, error) {

--- a/internal/workspace/task_result_storage_jsonl_test.go
+++ b/internal/workspace/task_result_storage_jsonl_test.go
@@ -191,6 +191,32 @@ func TestBuildAppendJSONLFallsBackToResult(t *testing.T) {
 	}
 }
 
+func TestCSVToJSONL(t *testing.T) {
+	out, err := CSVToJSONL("date,value\n2026-05-09,7\n2026-05-10,5")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 records, got %d: %q", len(lines), out)
+	}
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if first["date"] != "2026-05-09" || first["value"] != "7" {
+		t.Errorf("record = %#v", first)
+	}
+
+	empty, err := CSVToJSONL("date,value")
+	if err != nil {
+		t.Fatalf("header-only: %v", err)
+	}
+	if strings.TrimSpace(empty) != "" {
+		t.Errorf("header-only CSV should yield no records, got %q", empty)
+	}
+}
+
 func TestAppendJSONLFileName(t *testing.T) {
 	custom := AppendJSONLFileName(nil, &ResultStorageConfig{FileName: "My Runs.csv"})
 	if custom != "My_Runs.jsonl" {

--- a/internal/workspace/task_result_storage_jsonl_test.go
+++ b/internal/workspace/task_result_storage_jsonl_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,6 +149,45 @@ func TestExportCSVFromJSONLRejectsBadLine(t *testing.T) {
 	_, err := ExportCSVFromJSONL("{\"ok\":1}\nnot json", nil)
 	if err == nil {
 		t.Fatal("expected an error for a malformed JSONL line")
+	}
+}
+
+func TestBuildAppendJSONLUsesValidatedRow(t *testing.T) {
+	validation := &TaskValidationResult{
+		ValidationStatus: TaskValidationPassed,
+		NormalizedRow:    map[string]any{"date": "2026-05-09", "pollen_index": "7"},
+	}
+	out, err := BuildAppendJSONL(&Task{ID: "t"}, "ignored raw result", validation)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	line := strings.TrimSpace(out)
+	if strings.Count(line, "\n") != 0 {
+		t.Fatalf("expected a single JSONL line, got %q", out)
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(line), &record); err != nil {
+		t.Fatalf("invalid JSONL: %v", err)
+	}
+	if record["date"] != "2026-05-09" || record["pollen_index"] != "7" {
+		t.Errorf("validated row not carried through: %#v", record)
+	}
+	if record["validation_status"] != string(TaskValidationPassed) {
+		t.Errorf("validation_status not merged: %#v", record)
+	}
+}
+
+func TestBuildAppendJSONLFallsBackToResult(t *testing.T) {
+	out, err := BuildAppendJSONL(&Task{ID: "t"}, `{"date":"2026-05-12","level":"low"}`, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &record); err != nil {
+		t.Fatalf("invalid JSONL: %v", err)
+	}
+	if record["date"] != "2026-05-12" || record["level"] != "low" {
+		t.Errorf("fallback did not extract result fields: %#v", record)
 	}
 }
 

--- a/internal/workspace/task_result_storage_jsonl_test.go
+++ b/internal/workspace/task_result_storage_jsonl_test.go
@@ -1,0 +1,169 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTaskResultToJSONLRecordsArrayMergesMetadata(t *testing.T) {
+	task := &Task{
+		ID:          "task-1",
+		Description: "pollen",
+		Context: map[string]any{
+			"structured_output": []any{
+				map[string]any{"date": "2026-05-09", "pollen_index": "7"},
+				map[string]any{"date": "2026-05-10", "pollen_index": "5"},
+			},
+		},
+	}
+	metadata := map[string]any{"run_id": "run-9", "status": "success"}
+
+	records := TaskResultToJSONLRecords(task, "", metadata)
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	for i, record := range records {
+		if record["run_id"] != "run-9" {
+			t.Errorf("record %d missing merged run_id: %#v", i, record)
+		}
+		if record["status"] != "success" {
+			t.Errorf("record %d missing merged status: %#v", i, record)
+		}
+		if record["date"] == nil {
+			t.Errorf("record %d lost its data field: %#v", i, record)
+		}
+	}
+}
+
+func TestTaskResultToJSONLRecordsDoesNotClobberData(t *testing.T) {
+	task := &Task{
+		Context: map[string]any{
+			"structured_output": map[string]any{"status": "high", "value": "9"},
+		},
+	}
+	records := TaskResultToJSONLRecords(task, "", map[string]any{"status": "success"})
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0]["status"] != "high" {
+		t.Errorf("metadata clobbered a data field; got status=%v", records[0]["status"])
+	}
+}
+
+func TestTaskResultToJSONLRecordsDecodesResultJSON(t *testing.T) {
+	task := &Task{ID: "t"}
+	records := TaskResultToJSONLRecords(task, `{"date":"2026-05-12","level":"low"}`, nil)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0]["date"] != "2026-05-12" {
+		t.Errorf("expected decoded date, got %#v", records[0])
+	}
+}
+
+func TestTaskResultToJSONLRecordsFallbackWrapsRawResult(t *testing.T) {
+	task := &Task{ID: "task-7", Description: "summary"}
+	records := TaskResultToJSONLRecords(task, "just some prose, not JSON", map[string]any{"run_id": "r1"})
+	if len(records) != 1 {
+		t.Fatalf("expected 1 fallback record, got %d", len(records))
+	}
+	rec := records[0]
+	if rec["result"] != "just some prose, not JSON" {
+		t.Errorf("fallback should carry raw result, got %#v", rec)
+	}
+	if rec["task_id"] != "task-7" || rec["run_id"] != "r1" {
+		t.Errorf("fallback missing task_id/metadata: %#v", rec)
+	}
+}
+
+func TestAppendJSONLToFileAppendsLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.jsonl")
+
+	first, err := MarshalJSONLRecords([]map[string]any{{"a": 1}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := AppendJSONLToFile(path, first); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	second, err := MarshalJSONLRecords([]map[string]any{{"a": 2}, {"a": 3}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := AppendJSONLToFile(path, second); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 JSONL lines, got %d: %q", len(lines), string(data))
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "{") || !strings.HasSuffix(line, "}") {
+			t.Errorf("line is not a JSON object: %q", line)
+		}
+	}
+}
+
+func TestExportCSVFromJSONLLeadsWithPreferredColumns(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"date":"2026-05-09","value":"7","run_id":"r1"}`,
+		`{"date":"2026-05-10","value":"5","run_id":"r2"}`,
+	}, "\n")
+
+	csv, err := ExportCSVFromJSONL(jsonl, []string{"date", "value"})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(csv), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header + 2 rows, got %d: %q", len(lines), csv)
+	}
+	if lines[0] != "date,value,run_id" {
+		t.Errorf("expected data-first header, got %q", lines[0])
+	}
+	if lines[1] != "2026-05-09,7,r1" {
+		t.Errorf("unexpected first row: %q", lines[1])
+	}
+}
+
+func TestExportCSVFromJSONLEmptyIsEmpty(t *testing.T) {
+	csv, err := ExportCSVFromJSONL("   \n  ", nil)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if strings.TrimSpace(csv) != "" {
+		t.Errorf("expected empty CSV for empty JSONL, got %q", csv)
+	}
+}
+
+func TestExportCSVFromJSONLRejectsBadLine(t *testing.T) {
+	_, err := ExportCSVFromJSONL("{\"ok\":1}\nnot json", nil)
+	if err == nil {
+		t.Fatal("expected an error for a malformed JSONL line")
+	}
+}
+
+func TestAppendJSONLFileName(t *testing.T) {
+	custom := AppendJSONLFileName(nil, &ResultStorageConfig{FileName: "My Runs.csv"})
+	if custom != "My_Runs.jsonl" {
+		t.Errorf("custom name should normalize to .jsonl, got %q", custom)
+	}
+
+	derived := AppendJSONLFileName(&Task{Description: "Daily pollen report"}, nil)
+	if derived != "Daily_pollen_report.jsonl" {
+		t.Errorf("derived name unexpected: %q", derived)
+	}
+
+	fallback := AppendJSONLFileName(&Task{Description: "***"}, nil)
+	if fallback != "task.jsonl" {
+		t.Errorf("expected fallback task.jsonl, got %q", fallback)
+	}
+}


### PR DESCRIPTION
## Summary

Targets **`dev`** (integration). Two big themes on the task-details page and its result-storage backend:

1. **Task-details page redesign** — strip decorative chrome, collapse the 3-tab layout into a single calm flow, bring the blocked-task respond UI inline, tidy the result/dataset area.
2. **Result storage: CSV → JSONL** — JSONL is the canonical append format (each run = one JSON record), with a spreadsheet **CSV produced on demand** via export. Verified end-to-end on real data.

## 1. Task-details page redesign

- **Flat visual system** — drop gradients / glow blobs / big shadows, the 12 gold "kicker" eyebrows, and 11 corner radii → one calm scale.
- **Single flow, no tabs** — Overview / Activity / Developer tabs removed; cards stack in one scroll (each self-hides when empty), Developer in a collapsed disclosure.
- **Inline respond** — the blocked-task "Unblock this task" UI is now an inline card; the slide-out panel **and** the separate Action Required banner are retired.
- **Result/dataset tidy** — result leads; the run-history dataset is a collapsed disclosure; the preview shows data columns only; an **Export CSV** download was added.
- De-dup Agent, fold hero icon buttons into a `⋯` menu, merge Schedule + output-shape into one "Automation & output" card, fix the "What this task does" spacing/whitespace.

## 2. Result storage: CSV → JSONL

- **Canonical JSONL** — `autoStoreTaskResult`, the manual "append now" path, and the approve-held-run path all append `<name>.jsonl`. Schema validation still gates writes; the CSV header-mismatch / reproject machinery is gone (JSONL records are self-describing).
- **On-demand CSV export** — `GET …/results/export-csv` derives a spreadsheet CSV from the JSONL (data columns first, run metadata after).
- **UI reframed to JSONL** — output-shape cards collapsed to one schema-driven table; "Store each run to CSV" → "Save each run to a dataset (JSONL)"; destination filenames enforce `.jsonl`.
- Store nodes gained `jsonl` as a passthrough format. Existing `.csv` datasets freeze (JSONL-only going forward).

### Verified on real data
A scheduled run wrote a valid `.jsonl` (data fields + run metadata); the export endpoint returned `200 text/csv` with data-first columns; the manual-append path wrote JSONL to the same file with **no stray `.csv`**.

## Also included (not yet in dev)

Floating / per-surface / task-aware support chat, the test-CLI wired to the real HTTP API, and the earlier "reveal outputs folder" + "expected output shape" task-page additions.

## Tests

`go build ./...` clean; `internal/workspace` + `internal/orchestrationhttp` green (new JSONL primitives, export endpoint, updated append/review assertions). JS parses; templates embed.

## Follow-up (not in this PR)

The backend `output_contract` / mappings / metadata-policy data model is now vestigial (no longer surfaced; JSONL uses the schema-validated record) but still present — retiring it is a dedicated, test-heavy pass best done on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
