### PR TITLE
feat(workspace): undoable workspace deletion — Trash, Undo, auto-purge

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -10,7 +10,7 @@ import (
 
 // schemaVersion is the current database schema version.
 // Increment this when adding new migrations.
-const schemaVersion = 22
+const schemaVersion = 23
 
 // migrate runs all pending migrations to bring the database up to the current schema.
 func (db *DB) migrate(ctx context.Context) error {
@@ -109,6 +109,8 @@ func (db *DB) runMigration(ctx context.Context, version int) error {
 		return db.migration021WorkspaceRunTaskOutput(ctx)
 	case 22:
 		return db.migration022WorkspaceFolders(ctx)
+	case 23:
+		return db.migration023WorkspaceTrash(ctx)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -1082,6 +1084,25 @@ func (db *DB) migration022WorkspaceFolders(ctx context.Context) error {
 		WHERE folders_json IS NULL OR TRIM(folders_json) = ''
 	`); err != nil {
 		return fmt.Errorf("failed to backfill workspace folders: %w", err)
+	}
+	return nil
+}
+
+// migration023WorkspaceTrash adds a nullable deleted_at column used to soft-delete
+// (Trash) workspaces. A non-NULL value marks the workspace as trashed and records
+// when it entered the Trash, which drives the 30-day auto-purge.
+func (db *DB) migration023WorkspaceTrash(ctx context.Context) error {
+	exists, err := db.tableExists(ctx, "workspaces")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE workspaces ADD COLUMN deleted_at DATETIME
+	`); err != nil && !isDuplicateColumnError(err) {
+		return fmt.Errorf("failed to add workspace deleted_at column: %w", err)
 	}
 	return nil
 }

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -319,6 +319,17 @@ func (b *ServerBuilder) createDomainFacades() {
 		b.workspaceOrchestrator,
 	)
 
+	// Background auto-purger for workspaces left in Trash beyond the retention
+	// window. Shares the WorkspacePurger teardown with the manual permanent-delete
+	// path. Started/stopped by the workflow facade lifecycle.
+	if b.sessionStore != nil {
+		b.server.Workflow.TrashPurger = sessionhttp.NewTrashPurger(
+			b.sessionStore,
+			b.workspaceFileStore,
+			b.st,
+		)
+	}
+
 	// Integration System Facade
 	b.server.Integration = NewIntegrationSystemFacade(
 		b.mcpRegistry,

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -69,6 +69,7 @@ type WorkflowSystemFacade struct {
 	NotificationService   *workspace.NotificationService
 	DirectorySync         *workspace.DirectorySyncManager
 	WorkspaceOrchestrator *workspace.Orchestrator
+	TrashPurger           *sessionhttp.TrashPurger
 }
 
 // IntegrationSystemFacade manages external integrations (MCP, updates)
@@ -276,10 +277,16 @@ func (w *WorkflowSystemFacade) Start() {
 	if w.DirectorySync != nil {
 		w.DirectorySync.Start()
 	}
+	if w.TrashPurger != nil {
+		w.TrashPurger.Start()
+	}
 }
 
 // Shutdown gracefully shuts down all workflow system background services
 func (w *WorkflowSystemFacade) Shutdown() {
+	if w.TrashPurger != nil {
+		w.TrashPurger.Stop()
+	}
 	if w.DirectorySync != nil {
 		w.DirectorySync.Stop()
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -579,6 +579,13 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		})
 		mux.HandleFunc("/api/folders", s.Handlers.Session.HandleWorkspaces)
 
+		// Workspace Trash (soft delete). Registered as explicit method+path patterns
+		// so they take precedence over the "/api/workspaces/" subtree handler — the
+		// per-workspace attachment "/trash" route inside handleWorkspaceAPI would
+		// otherwise capture GET /api/workspaces/trash.
+		mux.HandleFunc("GET /api/workspaces/trash", s.Handlers.Session.HandleWorkspaces)
+		mux.HandleFunc("POST /api/workspaces/{workspaceID}/restore", s.Handlers.Session.HandleWorkspaces)
+
 		// Workspace routes (unified workspace API)
 		mux.HandleFunc("/api/workspaces", s.handleWorkspaceCollectionAPI)
 		mux.HandleFunc("/api/workspaces/", s.handleWorkspaceAPI)

--- a/internal/session/hybrid_store.go
+++ b/internal/session/hybrid_store.go
@@ -291,7 +291,7 @@ func (h *hybridStore) UpdateWorkspace(ctx context.Context, workspace *Workspace)
 	return h.sqlite.UpdateWorkspace(ctx, workspace)
 }
 
-// DeleteWorkspace removes a workspace.
+// DeleteWorkspace permanently removes a workspace (hard delete).
 func (h *hybridStore) DeleteWorkspace(ctx context.Context, id string) error {
 	if err := h.sqlite.DeleteWorkspace(ctx, id); err != nil {
 		return err
@@ -299,6 +299,27 @@ func (h *hybridStore) DeleteWorkspace(ctx context.Context, id string) error {
 
 	h.clearCachedWorkspaceReference(id)
 	return nil
+}
+
+// TrashWorkspace soft-deletes a workspace. Sessions keep their workspace link
+// (so Restore preserves them), so no cached session references are cleared.
+func (h *hybridStore) TrashWorkspace(ctx context.Context, id string, includeDescendants bool) error {
+	return h.sqlite.TrashWorkspace(ctx, id, includeDescendants)
+}
+
+// RestoreWorkspace brings a trashed workspace and its trashed descendants back.
+func (h *hybridStore) RestoreWorkspace(ctx context.Context, id string) error {
+	return h.sqlite.RestoreWorkspace(ctx, id)
+}
+
+// ReparentChildrenToRoot moves the direct children of parentID to root level.
+func (h *hybridStore) ReparentChildrenToRoot(ctx context.Context, parentID string) error {
+	return h.sqlite.ReparentChildrenToRoot(ctx, parentID)
+}
+
+// ListTrashedWorkspaces returns soft-deleted workspaces, most recent first.
+func (h *hybridStore) ListTrashedWorkspaces(ctx context.Context) ([]Workspace, error) {
+	return h.sqlite.ListTrashedWorkspaces(ctx)
 }
 
 // DeleteSessionsByWorkspace deletes all sessions belonging to a workspace.

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -141,6 +141,10 @@ const (
 	WorkspaceStatusCompleted WorkspaceStatus = "completed"
 	WorkspaceStatusFailed    WorkspaceStatus = "failed"
 	WorkspaceStatusCancelled WorkspaceStatus = "cancelled"
+	// WorkspaceStatusTrashed marks a soft-deleted workspace. Trashed workspaces
+	// are hidden from the hub and skipped by the scheduler, but their files and
+	// sessions are preserved until permanent deletion or auto-purge.
+	WorkspaceStatusTrashed WorkspaceStatus = "trashed"
 )
 
 // WorkspaceKind describes whether a record is a real workspace or an
@@ -292,6 +296,10 @@ type Workspace struct {
 
 	// Status is the current state of the workspace.
 	Status WorkspaceStatus `json:"status,omitempty"`
+
+	// DeletedAt is set when the workspace is moved to Trash (soft delete).
+	// Nil for active workspaces. Used to drive the 30-day auto-purge.
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 
 	// Version is a monotonic counter bumped on every save; used to detect lost writes.
 	Version int64 `json:"version,omitempty"`

--- a/internal/session/sqlite_workspace_store.go
+++ b/internal/session/sqlite_workspace_store.go
@@ -107,6 +107,21 @@ func assignWorkspaceTimes(workspace *Workspace, createdAtRaw, updatedAtRaw any) 
 	return nil
 }
 
+// assignWorkspaceDeletedAt parses a nullable deleted_at column value onto the
+// workspace. A nil raw value (NULL column) leaves DeletedAt unset.
+func assignWorkspaceDeletedAt(workspace *Workspace, deletedAtRaw any) error {
+	if deletedAtRaw == nil {
+		workspace.DeletedAt = nil
+		return nil
+	}
+	deletedAt, err := parseSQLiteTime(deletedAtRaw)
+	if err != nil {
+		return fmt.Errorf("deleted_at: %w", err)
+	}
+	workspace.DeletedAt = &deletedAt
+	return nil
+}
+
 // serializeWorkspaceFields converts workspace fields to JSON for database storage.
 // This centralizes the serialization logic used by both Create and Update operations.
 func serializeWorkspaceFields(workspace *Workspace) workspaceJSONFields {
@@ -290,18 +305,19 @@ func (s *SQLiteStore) GetWorkspace(ctx context.Context, id string) (*Workspace, 
 	var agentSkillAccessJSON sql.NullString
 	var createdAtRaw any
 	var updatedAtRaw any
+	var deletedAtRaw any
 
 	err := s.db.QueryRowContext(ctx, `
 		SELECT id, name, kind, description, parent_id, order_index, color, session_count, created_at, updated_at,
 			agents, agent_instances, shared_data, status, layout,
 			messages_json, tasks_json, attachments_json, folders_json, scheduled_tasks_json, store_nodes_json, workflows_json, directory_references_json,
-			mcp_bindings_json, agent_mcp_access_json, skill_bindings_json, agent_skill_access_json, version
+			mcp_bindings_json, agent_mcp_access_json, skill_bindings_json, agent_skill_access_json, version, deleted_at
 		FROM workspaces WHERE id = ?
 	`, id).Scan(&workspace.ID, &workspace.Name, &kind, &description, &parentID, &workspace.OrderIndex, &color,
 		&workspace.SessionCount, &createdAtRaw, &updatedAtRaw,
 		&agentsJSON, &agentInstancesJSON, &sharedDataJSON, &status, &layoutJSON,
 		&messagesJSON, &tasksJSON, &attachmentsJSON, &foldersJSON, &scheduledTasksJSON, &storeNodesJSON, &workflowsJSON, &directoryReferencesJSON,
-		&mcpBindingsJSON, &agentMCPAccessJSON, &skillBindingsJSON, &agentSkillAccessJSON, &workspace.Version)
+		&mcpBindingsJSON, &agentMCPAccessJSON, &skillBindingsJSON, &agentSkillAccessJSON, &workspace.Version, &deletedAtRaw)
 
 	if err == sql.ErrNoRows {
 		return nil, ErrWorkspaceNotFound
@@ -311,6 +327,9 @@ func (s *SQLiteStore) GetWorkspace(ctx context.Context, id string) (*Workspace, 
 	}
 	if err := assignWorkspaceTimes(workspace, createdAtRaw, updatedAtRaw); err != nil {
 		return nil, fmt.Errorf("failed to parse workspace timestamps: %w", err)
+	}
+	if err := assignWorkspaceDeletedAt(workspace, deletedAtRaw); err != nil {
+		return nil, fmt.Errorf("failed to parse workspace deleted_at: %w", err)
 	}
 
 	workspace.Description = description.String
@@ -408,7 +427,10 @@ func (s *SQLiteStore) UpdateWorkspace(ctx context.Context, workspace *Workspace)
 	return nil
 }
 
-// DeleteWorkspace removes a workspace, moving sessions and subworkspaces to root.
+// DeleteWorkspace permanently removes a workspace row, moving sessions and
+// subworkspaces to root. This is the hard-delete primitive; it is used only by
+// the permanent-delete and auto-purge paths. Day-to-day deletion goes through
+// TrashWorkspace (soft delete).
 func (s *SQLiteStore) DeleteWorkspace(ctx context.Context, id string) error {
 	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
 		// Check workspace exists
@@ -441,6 +463,148 @@ func (s *SQLiteStore) DeleteWorkspace(ctx context.Context, id string) error {
 
 		return nil
 	})
+}
+
+// TrashWorkspace soft-deletes a workspace by marking it trashed and recording
+// the deletion time. Sessions, child workspaces, files, and the entry agent are
+// left untouched so the workspace can be restored. When includeDescendants is
+// true, all descendant workspaces are trashed too (the subtree moves to Trash as
+// a unit); parent_id links are preserved so RestoreWorkspace can rebuild it.
+func (s *SQLiteStore) TrashWorkspace(ctx context.Context, id string, includeDescendants bool) error {
+	ids := []string{id}
+	if includeDescendants {
+		descendants, err := s.GetSubworkspaceIDs(ctx, id)
+		if err != nil {
+			return fmt.Errorf("failed to collect subworkspaces: %w", err)
+		}
+		ids = append(ids, descendants...)
+	}
+
+	now := time.Now().UTC()
+	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		// Update the primary workspace first so we can detect a missing row.
+		result, err := tx.ExecContext(ctx,
+			"UPDATE workspaces SET status = ?, deleted_at = ?, updated_at = ? WHERE id = ?",
+			WorkspaceStatusTrashed, now, now, id)
+		if err != nil {
+			return fmt.Errorf("failed to trash workspace: %w", err)
+		}
+		if err := database.CheckRowsAffectedWithError(result, "workspace", ErrWorkspaceNotFound); err != nil {
+			return err
+		}
+
+		// Trash any descendants in the same batch. Skip rows already trashed so
+		// their original deletion time (and purge clock) is preserved.
+		for _, wid := range ids[1:] {
+			if _, err := tx.ExecContext(ctx,
+				"UPDATE workspaces SET status = ?, deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
+				WorkspaceStatusTrashed, now, now, wid); err != nil {
+				return fmt.Errorf("failed to trash subworkspace: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// RestoreWorkspace brings a trashed workspace (and any of its currently-trashed
+// descendants) back to active, clearing the deletion time. parent_id links were
+// preserved on trash, so the subtree reappears intact.
+func (s *SQLiteStore) RestoreWorkspace(ctx context.Context, id string) error {
+	descendants, err := s.GetSubworkspaceIDs(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to collect subworkspaces: %w", err)
+	}
+
+	now := time.Now().UTC()
+	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx,
+			"UPDATE workspaces SET status = ?, deleted_at = NULL, updated_at = ? WHERE id = ? AND deleted_at IS NOT NULL",
+			WorkspaceStatusActive, now, id)
+		if err != nil {
+			return fmt.Errorf("failed to restore workspace: %w", err)
+		}
+		if err := database.CheckRowsAffectedWithError(result, "workspace", ErrWorkspaceNotFound); err != nil {
+			return err
+		}
+
+		// Restore descendants that are currently trashed.
+		for _, wid := range descendants {
+			if _, err := tx.ExecContext(ctx,
+				"UPDATE workspaces SET status = ?, deleted_at = NULL, updated_at = ? WHERE id = ? AND deleted_at IS NOT NULL",
+				WorkspaceStatusActive, now, wid); err != nil {
+				return fmt.Errorf("failed to restore subworkspace: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// ReparentChildrenToRoot moves the direct children of parentID to the root level
+// (parent_id = NULL). Used by the "trash group only" flow to keep children active
+// while the group container itself is trashed.
+func (s *SQLiteStore) ReparentChildrenToRoot(ctx context.Context, parentID string) error {
+	_, err := s.db.ExecContext(ctx, "UPDATE workspaces SET parent_id = NULL WHERE parent_id = ?", parentID)
+	if err != nil {
+		return fmt.Errorf("failed to reparent children: %w", err)
+	}
+	return nil
+}
+
+// ListTrashedWorkspaces returns soft-deleted workspaces, most recently trashed
+// first. Used to render the Trash view and to drive the auto-purge.
+func (s *SQLiteStore) ListTrashedWorkspaces(ctx context.Context) ([]Workspace, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, kind, description, parent_id, order_index, color, session_count, created_at, updated_at,
+			agents, agent_instances, status, version, deleted_at
+		FROM workspaces
+		WHERE deleted_at IS NOT NULL
+		ORDER BY deleted_at DESC, name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list trashed workspaces: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	workspaces := make([]Workspace, 0)
+	for rows.Next() {
+		var workspace Workspace
+		var parentID, color, description, kind sql.NullString
+		var agentsJSON, agentInstancesJSON, status sql.NullString
+		var createdAtRaw any
+		var updatedAtRaw any
+		var deletedAtRaw any
+
+		if err := rows.Scan(&workspace.ID, &workspace.Name, &kind, &description, &parentID, &workspace.OrderIndex, &color,
+			&workspace.SessionCount, &createdAtRaw, &updatedAtRaw,
+			&agentsJSON, &agentInstancesJSON, &status, &workspace.Version, &deletedAtRaw); err != nil {
+			return nil, fmt.Errorf("failed to scan trashed workspace: %w", err)
+		}
+		if err := assignWorkspaceTimes(&workspace, createdAtRaw, updatedAtRaw); err != nil {
+			return nil, fmt.Errorf("failed to parse workspace timestamps: %w", err)
+		}
+		if err := assignWorkspaceDeletedAt(&workspace, deletedAtRaw); err != nil {
+			return nil, fmt.Errorf("failed to parse workspace deleted_at: %w", err)
+		}
+
+		workspace.Kind = NormalizeWorkspaceKind(kind.String)
+		workspace.Description = description.String
+		workspace.ParentID = parentID.String
+		workspace.Color = color.String
+
+		if agentsJSON.Valid && agentsJSON.String != "" {
+			_ = json.Unmarshal([]byte(agentsJSON.String), &workspace.Agents)
+		}
+		if agentInstancesJSON.Valid && agentInstancesJSON.String != "" {
+			_ = json.Unmarshal([]byte(agentInstancesJSON.String), &workspace.AgentInstances)
+		}
+		if status.Valid && status.String != "" {
+			workspace.Status = WorkspaceStatus(status.String)
+		}
+
+		workspaces = append(workspaces, workspace)
+	}
+
+	return workspaces, nil
 }
 
 // DeleteSessionsByWorkspace deletes all sessions (and their messages/tool_calls) belonging to a workspace.
@@ -492,6 +656,7 @@ func (s *SQLiteStore) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
 		SELECT id, name, kind, description, parent_id, order_index, color, session_count, created_at, updated_at,
 			agents, agent_instances, status, version
 		FROM workspaces
+		WHERE deleted_at IS NULL
 		ORDER BY COALESCE(parent_id, ''), order_index ASC, name ASC
 	`)
 	if err != nil {

--- a/internal/session/sqlite_workspace_trash_test.go
+++ b/internal/session/sqlite_workspace_trash_test.go
@@ -1,0 +1,184 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func mustCreateWorkspace(t *testing.T, store *SQLiteStore, ctx context.Context, id, name, parentID string) {
+	t.Helper()
+	ws := &Workspace{
+		ID:        id,
+		Name:      name,
+		ParentID:  parentID,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := store.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("Failed to create workspace %s: %v", id, err)
+	}
+}
+
+func TestSQLiteStore_TrashWorkspace_SoftDelete(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewSQLiteStore(db)
+	ctx := context.Background()
+
+	mustCreateWorkspace(t, store, ctx, "ws1", "WS1", "")
+
+	if err := store.TrashWorkspace(ctx, "ws1", true); err != nil {
+		t.Fatalf("TrashWorkspace failed: %v", err)
+	}
+
+	// GetWorkspace still finds it, now trashed with a deletion time.
+	got, err := store.GetWorkspace(ctx, "ws1")
+	if err != nil {
+		t.Fatalf("GetWorkspace failed: %v", err)
+	}
+	if got.Status != WorkspaceStatusTrashed {
+		t.Errorf("expected status %q, got %q", WorkspaceStatusTrashed, got.Status)
+	}
+	if got.DeletedAt == nil {
+		t.Errorf("expected DeletedAt to be set")
+	}
+
+	// Excluded from the active list.
+	active, err := store.ListWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspaces failed: %v", err)
+	}
+	if len(active) != 0 {
+		t.Errorf("expected 0 active workspaces, got %d", len(active))
+	}
+
+	// Present in the trash list with its deletion time.
+	trashed, err := store.ListTrashedWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListTrashedWorkspaces failed: %v", err)
+	}
+	if len(trashed) != 1 || trashed[0].ID != "ws1" {
+		t.Fatalf("expected 1 trashed workspace ws1, got %+v", trashed)
+	}
+	if trashed[0].DeletedAt == nil {
+		t.Errorf("expected DeletedAt in trash listing")
+	}
+}
+
+func TestSQLiteStore_TrashAndRestore_Subtree(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewSQLiteStore(db)
+	ctx := context.Background()
+
+	mustCreateWorkspace(t, store, ctx, "parent", "Parent", "")
+	mustCreateWorkspace(t, store, ctx, "child", "Child", "parent")
+
+	// Trash the whole subtree.
+	if err := store.TrashWorkspace(ctx, "parent", true); err != nil {
+		t.Fatalf("TrashWorkspace failed: %v", err)
+	}
+
+	active, _ := store.ListWorkspaces(ctx)
+	if len(active) != 0 {
+		t.Errorf("expected 0 active workspaces after subtree trash, got %d", len(active))
+	}
+	trashed, _ := store.ListTrashedWorkspaces(ctx)
+	if len(trashed) != 2 {
+		t.Errorf("expected 2 trashed workspaces, got %d", len(trashed))
+	}
+
+	// The parent link is preserved so the subtree can be rebuilt on restore.
+	child, err := store.GetWorkspace(ctx, "child")
+	if err != nil {
+		t.Fatalf("GetWorkspace(child) failed: %v", err)
+	}
+	if child.ParentID != "parent" {
+		t.Errorf("expected child parent_id preserved as 'parent', got %q", child.ParentID)
+	}
+
+	// Restore the parent — the trashed subtree comes back active.
+	if err := store.RestoreWorkspace(ctx, "parent"); err != nil {
+		t.Fatalf("RestoreWorkspace failed: %v", err)
+	}
+
+	active, _ = store.ListWorkspaces(ctx)
+	if len(active) != 2 {
+		t.Errorf("expected 2 active workspaces after restore, got %d", len(active))
+	}
+	for _, id := range []string{"parent", "child"} {
+		ws, err := store.GetWorkspace(ctx, id)
+		if err != nil {
+			t.Fatalf("GetWorkspace(%s) failed: %v", id, err)
+		}
+		if ws.Status != WorkspaceStatusActive {
+			t.Errorf("%s: expected status active after restore, got %q", id, ws.Status)
+		}
+		if ws.DeletedAt != nil {
+			t.Errorf("%s: expected DeletedAt cleared after restore", id)
+		}
+	}
+}
+
+func TestSQLiteStore_TrashGroupOnly_ReparentsChildren(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewSQLiteStore(db)
+	ctx := context.Background()
+
+	mustCreateWorkspace(t, store, ctx, "group", "Group", "")
+	mustCreateWorkspace(t, store, ctx, "child", "Child", "group")
+
+	// "Trash group only": children move to root, then the group is trashed.
+	if err := store.ReparentChildrenToRoot(ctx, "group"); err != nil {
+		t.Fatalf("ReparentChildrenToRoot failed: %v", err)
+	}
+	if err := store.TrashWorkspace(ctx, "group", false); err != nil {
+		t.Fatalf("TrashWorkspace failed: %v", err)
+	}
+
+	// The group is trashed.
+	group, err := store.GetWorkspace(ctx, "group")
+	if err != nil {
+		t.Fatalf("GetWorkspace(group) failed: %v", err)
+	}
+	if group.Status != WorkspaceStatusTrashed {
+		t.Errorf("expected group trashed, got status %q", group.Status)
+	}
+
+	// The child stays active and is now at root.
+	child, err := store.GetWorkspace(ctx, "child")
+	if err != nil {
+		t.Fatalf("GetWorkspace(child) failed: %v", err)
+	}
+	if child.ParentID != "" {
+		t.Errorf("expected child reparented to root, got parent_id %q", child.ParentID)
+	}
+	if child.Status == WorkspaceStatusTrashed {
+		t.Errorf("expected child to stay active, got trashed")
+	}
+
+	active, _ := store.ListWorkspaces(ctx)
+	if len(active) != 1 || active[0].ID != "child" {
+		t.Errorf("expected only child active, got %+v", active)
+	}
+	trashed, _ := store.ListTrashedWorkspaces(ctx)
+	if len(trashed) != 1 || trashed[0].ID != "group" {
+		t.Errorf("expected only group trashed, got %+v", trashed)
+	}
+}
+
+func TestSQLiteStore_RestoreWorkspace_NotTrashedReturnsNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewSQLiteStore(db)
+	ctx := context.Background()
+
+	mustCreateWorkspace(t, store, ctx, "ws1", "WS1", "")
+
+	// Restoring an active (non-trashed) workspace affects no rows.
+	if err := store.RestoreWorkspace(ctx, "ws1"); err != ErrWorkspaceNotFound {
+		t.Errorf("expected ErrWorkspaceNotFound restoring an active workspace, got %v", err)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -86,13 +86,28 @@ type WorkspaceStore interface {
 	// Returns ErrWorkspaceNotFound if the workspace doesn't exist.
 	UpdateWorkspace(ctx context.Context, workspace *Workspace) error
 
-	// DeleteWorkspace removes a workspace.
+	// DeleteWorkspace permanently removes a workspace (hard delete).
 	// Sessions in the workspace are moved to root (workspace_id set to empty).
 	// Subworkspaces are also moved to root (parent_id set to empty).
 	// Returns ErrWorkspaceNotFound if the workspace doesn't exist.
 	DeleteWorkspace(ctx context.Context, id string) error
 
-	// ListWorkspaces returns all workspaces as a flat list.
+	// TrashWorkspace soft-deletes a workspace (move to Trash), preserving its
+	// sessions, files, and entry agent. When includeDescendants is true the whole
+	// subtree is trashed together. Returns ErrWorkspaceNotFound if missing.
+	TrashWorkspace(ctx context.Context, id string, includeDescendants bool) error
+
+	// RestoreWorkspace brings a trashed workspace (and its trashed descendants)
+	// back to active. Returns ErrWorkspaceNotFound if the workspace is not trashed.
+	RestoreWorkspace(ctx context.Context, id string) error
+
+	// ReparentChildrenToRoot moves the direct children of parentID to root level.
+	ReparentChildrenToRoot(ctx context.Context, parentID string) error
+
+	// ListTrashedWorkspaces returns soft-deleted workspaces, most recent first.
+	ListTrashedWorkspaces(ctx context.Context) ([]Workspace, error)
+
+	// ListWorkspaces returns all active (non-trashed) workspaces as a flat list.
 	ListWorkspaces(ctx context.Context) ([]Workspace, error)
 
 	// GetWorkspaceTree returns workspaces organized as a tree structure.

--- a/internal/sessionhttp/workspace_delete_entry_agent_test.go
+++ b/internal/sessionhttp/workspace_delete_entry_agent_test.go
@@ -11,8 +11,10 @@ import (
 	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
 )
 
-// TestDeleteWorkspace_DeletesEntryAgent verifies that deleting a workspace
-// also deletes its designated entry agent from the agent store.
+// TestDeleteWorkspace_DeletesEntryAgent verifies that permanently deleting a
+// workspace also deletes its designated entry agent from the agent store.
+// (The default delete moves the workspace to Trash and preserves the agent so
+// it can be restored — see TestTrashWorkspace_PreservesEntryAgent.)
 func TestDeleteWorkspace_DeletesEntryAgent(t *testing.T) {
 	handler, cleanup := createTestHandler(t)
 	defer cleanup()
@@ -56,8 +58,9 @@ func TestDeleteWorkspace_DeletesEntryAgent(t *testing.T) {
 		t.Fatalf("expected entry agent to exist before workspace deletion")
 	}
 
-	// Delete the workspace (confirm=true to skip the session-count prompt).
-	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+workspaceID+"?confirm=true", bytes.NewReader(nil))
+	// Permanently delete the workspace (confirm=true skips the session-count
+	// prompt; permanent=true performs the hard delete rather than trashing).
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+workspaceID+"?confirm=true&permanent=true", bytes.NewReader(nil))
 	w := httptest.NewRecorder()
 	handler.HandleWorkspaces(w, req)
 
@@ -68,6 +71,59 @@ func TestDeleteWorkspace_DeletesEntryAgent(t *testing.T) {
 	// Entry agent should be gone from the agent store.
 	if _, ok := handler.agentStore.GetAgent(entryAgentName); ok {
 		t.Fatalf("expected entry agent %q to be deleted with workspace", entryAgentName)
+	}
+}
+
+// TestTrashWorkspace_PreservesEntryAgent verifies that the default delete moves
+// the workspace to Trash without removing its entry agent, so a later restore
+// keeps the agent intact.
+func TestTrashWorkspace_PreservesEntryAgent(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	wsStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = wsStore.Close() }()
+	handler.SetWorkspaceStore(wsStore)
+
+	workspaceID := createTestWorkspace(t, handler, "Travel Plans")
+
+	entryAgentName := "Travel Plans Manager"
+	if err := handler.agentStore.CreateAgent(entryAgentName, &agentstore.CreateAgentConfig{
+		Type: agent.TypeGeneral,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	folderWS, err := wsStore.Get(workspaceID)
+	if err != nil {
+		t.Fatalf("Get workspace from folder store: %v", err)
+	}
+	folderWS.AgentInstances = []agentworkspace.AgentInstance{
+		{ID: "inst-1", Name: entryAgentName, EntryPoint: true},
+	}
+	if folderWS.SharedData == nil {
+		folderWS.SharedData = map[string]any{}
+	}
+	folderWS.SharedData["entry_agent_name"] = entryAgentName
+	if err := wsStore.Save(folderWS); err != nil {
+		t.Fatalf("Save workspace: %v", err)
+	}
+
+	// Default delete (no permanent flag) — moves to Trash.
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+workspaceID+"?confirm=true", bytes.NewReader(nil))
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on trash, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Entry agent must still exist after trashing.
+	if _, ok := handler.agentStore.GetAgent(entryAgentName); !ok {
+		t.Fatalf("expected entry agent %q to be preserved when workspace is trashed", entryAgentName)
 	}
 }
 

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -53,6 +53,9 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 	case "sync":
 		h.handleWorkspaceSync(w, r)
 		return
+	case "trash":
+		h.listTrashedWorkspaces(w, r)
+		return
 	}
 
 	// Handle sub-paths like {id}/agents, {id}/layout
@@ -76,6 +79,9 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 			return
 		case "rename":
 			h.handleWorkspaceRename(w, r, id)
+			return
+		case "restore":
+			h.restoreWorkspace(w, r, id)
 			return
 		}
 	}
@@ -626,14 +632,25 @@ func (h *Handler) updateWorkspace(w http.ResponseWriter, r *http.Request, id str
 }
 
 // deleteWorkspace handles DELETE /api/workspaces/{id}.
+//
+// By default the workspace is moved to Trash (soft delete): its sessions, files,
+// and entry agent are preserved so it can be restored, and it is auto-purged
+// after the retention period. Permanent deletion is opt-in via ?permanent=true.
+//
 // Query params:
-//   - delete_sessions=true: also delete all sessions belonging to this workspace.
-//     If false or absent, sessions are unlinked (workspace_id set to NULL).
-//   - confirm=true: required to proceed with deletion (if absent, returns session count for confirmation).
+//   - confirm=true: required to proceed (if absent, returns the session count for
+//     a confirmation prompt).
+//   - permanent=true: hard-delete now instead of trashing — removes the on-disk
+//     folder and entry agent (and, with delete_sessions=true, the sessions).
+//   - delete_sessions=true: permanent deletes only; delete the workspace's
+//     sessions instead of unlinking them to root.
+//   - scope=group-only: trash a group/parent but keep its children (move them to
+//     root). The default trashes the whole subtree together.
 func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 
-	// Check workspace exists
+	// Check workspace exists. GetWorkspace returns trashed workspaces too, so this
+	// also covers "Delete permanently" requests coming from the Trash view.
 	ws, err := h.store.GetWorkspace(ctx, id)
 	if err == session.ErrWorkspaceNotFound {
 		_ = orihttp.RespondNotFound(w, "Workspace not found")
@@ -658,67 +675,149 @@ func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, id str
 		return
 	}
 
-	deleteSessions := r.URL.Query().Get("delete_sessions") == "true"
-
-	// Capture the entry agent name before deletion so it can be cleaned up.
-	entryAgentName := ""
-	if h.workspaceStore != nil && ws.Kind != session.WorkspaceKindGroup {
-		if folderWS, ferr := h.workspaceStore.Get(id); ferr == nil && folderWS != nil {
-			entryAgentName = strings.TrimSpace(folderWS.EntryAgentName())
-		}
-	}
-
-	// Handle session cleanup
-	if deleteSessions {
-		if err := h.store.DeleteSessionsByWorkspace(ctx, id); err != nil {
-			logger.Error("Failed to delete sessions for workspace", logger.Fields{"id": id, "error": err})
-			_ = orihttp.RespondInternalError(w, "Failed to delete workspace sessions")
+	// Permanent (hard) delete path — shared with the background auto-purger.
+	if r.URL.Query().Get("permanent") == "true" {
+		deleteSessions := r.URL.Query().Get("delete_sessions") == "true"
+		purger := NewWorkspacePurger(h.store, h.workspaceStore, h.agentStore)
+		if err := purger.Purge(ctx, ws, deleteSessions); err != nil {
+			logger.Error("Failed to permanently delete workspace", logger.Fields{"id": id, "error": err})
+			_ = orihttp.RespondInternalError(w, "Failed to delete workspace")
 			return
 		}
-	} else {
-		if err := h.store.UnlinkSessionsFromWorkspace(ctx, id); err != nil {
-			logger.Error("Failed to unlink sessions from workspace", logger.Fields{"id": id, "error": err})
-			_ = orihttp.RespondInternalError(w, "Failed to unlink workspace sessions")
-			return
-		}
-	}
-
-	// Delete the workspace
-	if err := h.store.DeleteWorkspace(ctx, id); err != nil {
-		logger.Error("Failed to delete workspace", logger.Fields{"id": id, "error": err})
-		_ = orihttp.RespondInternalError(w, "Failed to delete workspace")
+		logger.Info("Workspace permanently deleted", logger.Fields{"id": id, "delete_sessions": deleteSessions})
+		orihttp.RespondNoContent(w)
 		return
 	}
 
-	// Also delete from folder-based store if available
-	if h.workspaceStore != nil && ws.Kind != session.WorkspaceKindGroup {
-		if err := h.workspaceStore.Delete(id); err != nil {
-			logger.Warn("Failed to delete workspace folder", logger.Fields{"id": id, "error": err})
-			// Non-fatal: SQLite deletion succeeded
+	// Soft delete (move to Trash). "group-only" trashes just this node and keeps
+	// its children active by moving them to root; otherwise the whole subtree is
+	// trashed together so Restore can rebuild it.
+	groupOnly := r.URL.Query().Get("scope") == "group-only"
+
+	// Collect the ids that will be trashed so their folder-store status can be
+	// mirrored (the scheduler skips non-active workspaces). For group-only the
+	// children move out first, so only this node is trashed.
+	trashedIDs := []string{id}
+	if !groupOnly {
+		if descendants, derr := h.store.GetSubworkspaceIDs(ctx, id); derr == nil {
+			trashedIDs = append(trashedIDs, descendants...)
 		}
 	}
 
-	// Delete the workspace's entry agent so it no longer lingers in the agent
-	// store after its parent workspace is gone. Non-fatal on failure.
-	if entryAgentName != "" && h.agentStore != nil {
-		if _, exists := h.agentStore.GetAgent(entryAgentName); exists {
-			if err := h.agentStore.DeleteAgent(entryAgentName); err != nil {
-				logger.Warn("Failed to delete workspace entry agent", logger.Fields{
-					"workspace_id": id,
-					"agent":        entryAgentName,
-					"error":        err,
-				})
-			} else {
-				logger.Info("Deleted workspace entry agent", logger.Fields{
-					"workspace_id": id,
-					"agent":        entryAgentName,
-				})
-			}
+	if groupOnly {
+		if err := h.store.ReparentChildrenToRoot(ctx, id); err != nil {
+			logger.Error("Failed to reparent children before trashing group", logger.Fields{"id": id, "error": err})
+			_ = orihttp.RespondInternalError(w, "Failed to move workspace to Trash")
+			return
 		}
 	}
 
-	logger.Info("Workspace deleted", logger.Fields{"id": id, "delete_sessions": deleteSessions})
+	if err := h.store.TrashWorkspace(ctx, id, !groupOnly); err != nil {
+		if err == session.ErrWorkspaceNotFound {
+			_ = orihttp.RespondNotFound(w, "Workspace not found")
+			return
+		}
+		logger.Error("Failed to trash workspace", logger.Fields{"id": id, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to move workspace to Trash")
+		return
+	}
 
+	h.setFolderWorkspaceStatus(trashedIDs, agentworkspace.StatusTrashed)
+
+	logger.Info("Workspace moved to Trash", logger.Fields{"id": id, "scope_group_only": groupOnly})
+	orihttp.RespondNoContent(w)
+}
+
+// setFolderWorkspaceStatus mirrors a status into the folder-based store for the
+// given workspace ids. The scheduler and other active-only paths skip non-active
+// workspaces, so this keeps a trashed workspace from running scheduled tasks (and
+// restores it on un-trash). Best-effort: ids without a folder entry (e.g. groups)
+// are ignored.
+func (h *Handler) setFolderWorkspaceStatus(ids []string, status agentworkspace.WorkspaceStatus) {
+	if h.workspaceStore == nil {
+		return
+	}
+	for _, id := range ids {
+		_ = h.workspaceStore.Update(id, func(fws *agentworkspace.Workspace) error {
+			fws.SetStatus(status)
+			return nil
+		})
+	}
+}
+
+// listTrashedWorkspaces handles GET /api/workspaces/trash. It returns the
+// soft-deleted workspaces (most recently trashed first) together with when each
+// will be auto-purged, so the Trash view can show time remaining.
+func (h *Handler) listTrashedWorkspaces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+
+	workspaces, err := h.store.ListTrashedWorkspaces(r.Context())
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		logger.Error("Failed to list trashed workspaces", logger.Fields{"error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to list trashed workspaces")
+		return
+	}
+
+	items := make([]map[string]any, 0, len(workspaces))
+	for i := range workspaces {
+		ws := &workspaces[i]
+		item := map[string]any{
+			"id":            ws.ID,
+			"name":          ws.Name,
+			"kind":          ws.Kind,
+			"parent_id":     ws.ParentID,
+			"color":         ws.Color,
+			"session_count": ws.SessionCount,
+		}
+		if ws.DeletedAt != nil {
+			item["deleted_at"] = ws.DeletedAt.UTC().Format(time.RFC3339)
+			item["purge_at"] = ws.DeletedAt.Add(TrashRetention).UTC().Format(time.RFC3339)
+		}
+		items = append(items, item)
+	}
+
+	orihttp.WriteJSON(w, map[string]any{
+		"workspaces":        items,
+		"retention_seconds": int(TrashRetention.Seconds()),
+	})
+}
+
+// restoreWorkspace handles POST /api/workspaces/{id}/restore. It brings a trashed
+// workspace (and any of its trashed descendants) back to active.
+func (h *Handler) restoreWorkspace(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Collect the subtree before restoring so the folder-store status can be
+	// mirrored back to active (parent_id links are preserved while trashed).
+	restoredIDs := []string{id}
+	if descendants, derr := h.store.GetSubworkspaceIDs(ctx, id); derr == nil {
+		restoredIDs = append(restoredIDs, descendants...)
+	}
+
+	if err := h.store.RestoreWorkspace(ctx, id); err != nil {
+		if err == session.ErrWorkspaceNotFound {
+			_ = orihttp.RespondNotFound(w, "Workspace not found in Trash")
+			return
+		}
+		logger.Error("Failed to restore workspace", logger.Fields{"id": id, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to restore workspace")
+		return
+	}
+
+	h.setFolderWorkspaceStatus(restoredIDs, agentworkspace.StatusActive)
+
+	logger.Info("Workspace restored from Trash", logger.Fields{"id": id})
 	orihttp.RespondNoContent(w)
 }
 

--- a/internal/sessionhttp/workspace_purge.go
+++ b/internal/sessionhttp/workspace_purge.go
@@ -1,0 +1,98 @@
+package sessionhttp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// TrashRetention is how long a workspace stays in Trash before it is eligible for
+// automatic permanent deletion. It is shared by the Trash listing (to show
+// time-until-purge) and the background auto-purger (to decide what to remove).
+const TrashRetention = 30 * 24 * time.Hour
+
+// WorkspacePurger performs the permanent, destructive teardown of a workspace:
+// its sessions (optionally), its database row, its on-disk folder, and its entry
+// agent. It is the single source of truth shared by the HTTP "delete permanently"
+// path (deleteWorkspace with ?permanent=true) and the background trash
+// auto-purger, so both behave identically.
+type WorkspacePurger struct {
+	store          session.HybridStore
+	workspaceStore *workspace.FileStore // optional folder-based store
+	agentStore     store.Store          // optional agent store
+}
+
+// NewWorkspacePurger builds a purger from the underlying stores. workspaceStore
+// and agentStore may be nil, in which case folder and entry-agent cleanup are
+// skipped (the database row is still removed).
+func NewWorkspacePurger(s session.HybridStore, ws *workspace.FileStore, agents store.Store) *WorkspacePurger {
+	return &WorkspacePurger{store: s, workspaceStore: ws, agentStore: agents}
+}
+
+// Purge permanently removes ws. When deleteSessions is true the workspace's
+// sessions (and their messages/tool calls) are deleted; otherwise they are
+// unlinked to root. Folder and entry-agent cleanup are best-effort and logged
+// (non-fatal) once the database row has been removed. Group workspaces have no
+// folder or entry agent, so those steps are skipped for them.
+func (p *WorkspacePurger) Purge(ctx context.Context, ws *session.Workspace, deleteSessions bool) error {
+	id := ws.ID
+
+	// Capture the entry agent name before deletion so it can be cleaned up.
+	entryAgentName := ""
+	if p.workspaceStore != nil && ws.Kind != session.WorkspaceKindGroup {
+		if folderWS, ferr := p.workspaceStore.Get(id); ferr == nil && folderWS != nil {
+			entryAgentName = strings.TrimSpace(folderWS.EntryAgentName())
+		}
+	}
+
+	// Handle session cleanup.
+	if deleteSessions {
+		if err := p.store.DeleteSessionsByWorkspace(ctx, id); err != nil {
+			return fmt.Errorf("failed to delete workspace sessions: %w", err)
+		}
+	} else {
+		if err := p.store.UnlinkSessionsFromWorkspace(ctx, id); err != nil {
+			return fmt.Errorf("failed to unlink workspace sessions: %w", err)
+		}
+	}
+
+	// Permanently delete the workspace row.
+	if err := p.store.DeleteWorkspace(ctx, id); err != nil {
+		return fmt.Errorf("failed to delete workspace: %w", err)
+	}
+
+	// Delete the on-disk folder. Best-effort: the row deletion already succeeded,
+	// and the folder store never removes folders outside the workspace root.
+	if p.workspaceStore != nil && ws.Kind != session.WorkspaceKindGroup {
+		if err := p.workspaceStore.Delete(id); err != nil {
+			logger.Warn("Failed to delete workspace folder", logger.Fields{"id": id, "error": err})
+		}
+	}
+
+	// Delete the workspace's entry agent so it no longer lingers in the agent
+	// store. Best-effort on failure.
+	if entryAgentName != "" && p.agentStore != nil {
+		if _, exists := p.agentStore.GetAgent(entryAgentName); exists {
+			if err := p.agentStore.DeleteAgent(entryAgentName); err != nil {
+				logger.Warn("Failed to delete workspace entry agent", logger.Fields{
+					"workspace_id": id,
+					"agent":        entryAgentName,
+					"error":        err,
+				})
+			} else {
+				logger.Info("Deleted workspace entry agent", logger.Fields{
+					"workspace_id": id,
+					"agent":        entryAgentName,
+				})
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/sessionhttp/workspace_trash_http_test.go
+++ b/internal/sessionhttp/workspace_trash_http_test.go
@@ -1,0 +1,121 @@
+package sessionhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+)
+
+func trashListIDs(t *testing.T, handler *Handler) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/trash", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from trash listing, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Workspaces []struct {
+			ID string `json:"id"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode trash listing: %v", err)
+	}
+	ids := make([]string, 0, len(resp.Workspaces))
+	for _, ws := range resp.Workspaces {
+		ids = append(ids, ws.ID)
+	}
+	return ids
+}
+
+func activeWorkspaceIDs(t *testing.T, handler *Handler) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from workspace listing, got %d: %s", w.Code, w.Body.String())
+	}
+	// The list endpoint returns {"workspaces": [...], "folders": [...]}.
+	var resp struct {
+		Workspaces []struct {
+			ID string `json:"id"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode workspace listing: %v", err)
+	}
+	ids := make([]string, 0, len(resp.Workspaces))
+	for _, ws := range resp.Workspaces {
+		ids = append(ids, ws.ID)
+	}
+	return ids
+}
+
+// TestWorkspaceTrashRoundTrip exercises the trash → list → restore HTTP dispatch
+// through HandleWorkspaces: a default delete trashes (and hides) the workspace,
+// it appears in the trash listing, and restoring brings it back to the active set.
+func TestWorkspaceTrashRoundTrip(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	id := createTestWorkspace(t, handler, "Round Trip")
+
+	// Default delete moves the workspace to Trash.
+	delReq := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+id+"?confirm=true", nil)
+	delResp := httptest.NewRecorder()
+	handler.HandleWorkspaces(delResp, delReq)
+	if delResp.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on trash, got %d: %s", delResp.Code, delResp.Body.String())
+	}
+
+	// It should be hidden from the active list and present in Trash.
+	if slices.Contains(activeWorkspaceIDs(t, handler), id) {
+		t.Errorf("trashed workspace should not appear in active list")
+	}
+	if !slices.Contains(trashListIDs(t, handler), id) {
+		t.Errorf("trashed workspace should appear in trash listing")
+	}
+
+	// Restore it.
+	restoreReq := httptest.NewRequest(http.MethodPost, "/api/workspaces/"+id+"/restore", nil)
+	restoreResp := httptest.NewRecorder()
+	handler.HandleWorkspaces(restoreResp, restoreReq)
+	if restoreResp.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on restore, got %d: %s", restoreResp.Code, restoreResp.Body.String())
+	}
+
+	// Back in the active list, gone from Trash.
+	if !slices.Contains(activeWorkspaceIDs(t, handler), id) {
+		t.Errorf("restored workspace should appear in active list")
+	}
+	if slices.Contains(trashListIDs(t, handler), id) {
+		t.Errorf("restored workspace should no longer be in trash listing")
+	}
+}
+
+// TestWorkspacePermanentDeleteFromTrash verifies the permanent path removes the
+// workspace entirely (not in active list, not in Trash).
+func TestWorkspacePermanentDeleteFromTrash(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	id := createTestWorkspace(t, handler, "Permanent")
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+id+"?confirm=true&permanent=true", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on permanent delete, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if slices.Contains(activeWorkspaceIDs(t, handler), id) {
+		t.Errorf("permanently deleted workspace should not be in active list")
+	}
+	if slices.Contains(trashListIDs(t, handler), id) {
+		t.Errorf("permanently deleted workspace should not be in trash listing")
+	}
+}

--- a/internal/sessionhttp/workspace_trash_purger.go
+++ b/internal/sessionhttp/workspace_trash_purger.go
@@ -1,0 +1,120 @@
+package sessionhttp
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// defaultTrashPurgeInterval is how often the auto-purger scans the Trash. Scans
+// are cheap (a single indexed query plus teardown of expired rows), so running a
+// few times a day keeps workspaces from lingering long past their purge time
+// without meaningful cost.
+const defaultTrashPurgeInterval = 6 * time.Hour
+
+// TrashPurger is a background service that permanently deletes workspaces left in
+// Trash longer than TrashRetention. It is the automatic counterpart to the manual
+// "Delete permanently" action and shares the same WorkspacePurger teardown.
+type TrashPurger struct {
+	store     session.HybridStore
+	purger    *WorkspacePurger
+	interval  time.Duration
+	retention time.Duration
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+// NewTrashPurger builds an auto-purger over the given stores. workspaceStore and
+// agentStore may be nil (folder/entry-agent cleanup is then skipped).
+func NewTrashPurger(s session.HybridStore, workspaceStore *workspace.FileStore, agentStore store.Store) *TrashPurger {
+	return &TrashPurger{
+		store:     s,
+		purger:    NewWorkspacePurger(s, workspaceStore, agentStore),
+		interval:  defaultTrashPurgeInterval,
+		retention: TrashRetention,
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+// Start launches the background loop. It is a no-op when the purger or its store
+// is nil, so callers don't need to guard optional wiring.
+func (p *TrashPurger) Start() {
+	if p == nil || p.store == nil {
+		return
+	}
+	go p.run()
+}
+
+func (p *TrashPurger) run() {
+	defer close(p.doneCh)
+
+	// Run once shortly after startup so already-expired items don't wait a whole
+	// interval for their first scan.
+	initial := time.NewTimer(time.Minute)
+	defer initial.Stop()
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-initial.C:
+			p.purgeExpired()
+		case <-ticker.C:
+			p.purgeExpired()
+		}
+	}
+}
+
+// Stop signals the loop to exit and waits briefly for it to finish.
+func (p *TrashPurger) Stop() {
+	if p == nil {
+		return
+	}
+	p.stopOnce.Do(func() { close(p.stopCh) })
+	select {
+	case <-p.doneCh:
+	case <-time.After(5 * time.Second):
+	}
+}
+
+// purgeExpired permanently deletes every trashed workspace whose deletion time is
+// older than the retention window. Sessions are deleted too: the workspace is
+// being removed entirely, so nothing should be left orphaned at root.
+func (p *TrashPurger) purgeExpired() {
+	ctx := context.Background()
+
+	workspaces, err := p.store.ListTrashedWorkspaces(ctx)
+	if err != nil {
+		logger.Warn("Trash purge: failed to list trashed workspaces", logger.Fields{"error": err})
+		return
+	}
+
+	cutoff := time.Now().Add(-p.retention)
+	purged := 0
+	for i := range workspaces {
+		ws := &workspaces[i]
+		if ws.DeletedAt == nil || ws.DeletedAt.After(cutoff) {
+			continue
+		}
+		if err := p.purger.Purge(ctx, ws, true); err != nil {
+			logger.Warn("Trash purge: failed to purge workspace", logger.Fields{"id": ws.ID, "error": err})
+			continue
+		}
+		purged++
+	}
+
+	if purged > 0 {
+		logger.Info("Trash purge complete", logger.Fields{"purged": purged, "retention": p.retention.String()})
+	}
+}

--- a/internal/sessionhttp/workspace_trash_purger_test.go
+++ b/internal/sessionhttp/workspace_trash_purger_test.go
@@ -1,0 +1,76 @@
+package sessionhttp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+func newPurgerTestStore(t *testing.T) (session.HybridStore, func()) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := database.Open(ctx, &database.Config{InMemory: true})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	return session.NewHybridStoreWithDB(db, 100), func() { _ = db.Close() }
+}
+
+func trashTestWorkspace(t *testing.T, store session.HybridStore, ctx context.Context, id string) {
+	t.Helper()
+	ws := &session.Workspace{ID: id, Name: id, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := store.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("failed to create workspace %s: %v", id, err)
+	}
+	if err := store.TrashWorkspace(ctx, id, true); err != nil {
+		t.Fatalf("failed to trash workspace %s: %v", id, err)
+	}
+}
+
+func TestTrashPurger_PurgesExpired(t *testing.T) {
+	store, cleanup := newPurgerTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	trashTestWorkspace(t, store, ctx, "old")
+
+	// Negative retention makes the cutoff in the future, so anything already in
+	// Trash is treated as expired.
+	purger := NewTrashPurger(store, nil, nil)
+	purger.retention = -time.Hour
+	purger.purgeExpired()
+
+	trashed, err := store.ListTrashedWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListTrashedWorkspaces failed: %v", err)
+	}
+	if len(trashed) != 0 {
+		t.Errorf("expected expired workspace to be purged, %d remain", len(trashed))
+	}
+	if _, err := store.GetWorkspace(ctx, "old"); err != session.ErrWorkspaceNotFound {
+		t.Errorf("expected purged workspace to be gone, got err %v", err)
+	}
+}
+
+func TestTrashPurger_KeepsWithinRetention(t *testing.T) {
+	store, cleanup := newPurgerTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	trashTestWorkspace(t, store, ctx, "recent")
+
+	// Default retention (30 days) — a just-trashed workspace must not be purged.
+	purger := NewTrashPurger(store, nil, nil)
+	purger.purgeExpired()
+
+	trashed, err := store.ListTrashedWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListTrashedWorkspaces failed: %v", err)
+	}
+	if len(trashed) != 1 {
+		t.Errorf("expected recently trashed workspace to be kept, got %d", len(trashed))
+	}
+}

--- a/internal/web/static/css/common.css
+++ b/internal/web/static/css/common.css
@@ -1672,6 +1672,31 @@ h3, .h3 {
     outline-offset: 2px;
 }
 
+/* Toast action button (e.g. Undo) */
+.toast-action {
+    flex-shrink: 0;
+    align-self: center;
+    padding: 5px 12px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--primary-color);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.toast-action:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.toast-action:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
 /* Toast progress bar */
 .toast-progress {
     position: absolute;

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -2675,6 +2675,65 @@ button.hub-stat[hidden] {
   gap: 0.5rem;
 }
 
+/* Recently deleted banner (persistent Undo for the latest Trash action) */
+.launcher-recently-deleted {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: rgba(31, 107, 78, 0.08);
+  border: 1px solid rgba(31, 107, 78, 0.25);
+  border-radius: var(--radius-md);
+}
+
+.launcher-recently-deleted[hidden] {
+  display: none;
+}
+
+.launcher-recently-deleted-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.launcher-recently-deleted-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launcher-recently-deleted-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.launcher-recently-deleted-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.launcher-recently-deleted-dismiss:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
 @media (max-width: 1200px) {
   .launcher-overview-content {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/internal/web/static/js/modules/toast.js
+++ b/internal/web/static/js/modules/toast.js
@@ -58,12 +58,19 @@ const Toast = (function() {
     const icon = getIcon(type);
     const title = options.title || type.charAt(0).toUpperCase() + type.slice(1);
 
+    // Optional action button (e.g. an "Undo" affordance). The click handler is
+    // wired up in show() once the element exists in the DOM.
+    const actionHtml = options.action && options.action.label
+      ? `<button type="button" class="toast-action">${escapeHtml(options.action.label)}</button>`
+      : '';
+
     toast.innerHTML = `
       <div class="toast-icon">${icon}</div>
       <div class="toast-content">
         <div class="toast-title">${escapeHtml(title)}</div>
         <div class="toast-message">${escapeHtml(message)}</div>
       </div>
+      ${actionHtml}
       <button type="button" class="toast-close" aria-label="Close notification">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
@@ -109,6 +116,20 @@ const Toast = (function() {
     // Setup close button
     const closeBtn = toast.querySelector('.toast-close');
     closeBtn.addEventListener('click', () => dismiss(toast));
+
+    // Setup optional action button. Invokes the handler then dismisses the toast.
+    if (options.action && typeof options.action.onClick === 'function') {
+      const actionBtn = toast.querySelector('.toast-action');
+      if (actionBtn) {
+        actionBtn.addEventListener('click', () => {
+          try {
+            options.action.onClick();
+          } finally {
+            dismiss(toast);
+          }
+        });
+      }
+    }
 
     // Setup progress bar animation
     const progress = toast.querySelector('.toast-progress');

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -1820,7 +1820,6 @@ console.log('[workspace-hub.js] FILE LOADED');
     if (opts.permanent) params.set('permanent', 'true');
     if (opts.scope) params.set('scope', opts.scope);
     const query = params.toString();
-    const verb = opts.permanent ? 'deleted' : 'moved to Trash';
 
     try {
       for (const id of ids) {
@@ -1832,7 +1831,22 @@ console.log('[workspace-hub.js] FILE LOADED');
       }
 
       if (window.Toast) {
-        window.Toast.success(ids.length > 1 ? `Workspaces ${verb}` : `Workspace ${verb}`);
+        if (opts.permanent) {
+          window.Toast.success(ids.length > 1 ? 'Workspaces deleted' : 'Workspace deleted');
+        } else {
+          // Trash is reversible — offer an immediate Undo that restores what was
+          // just trashed (the Trash view remains available for later restores).
+          const trashedIds = ids.slice();
+          window.Toast.show(
+            ids.length > 1 ? `${ids.length} workspaces moved to Trash` : 'Workspace moved to Trash',
+            'success',
+            {
+              title: 'Moved to Trash',
+              duration: 8000,
+              action: { label: 'Undo', onClick: () => { void undoTrash(trashedIds); } }
+            }
+          );
+        }
       }
 
       state.selectedWorkspaces = new Set();
@@ -1841,6 +1855,26 @@ console.log('[workspace-hub.js] FILE LOADED');
     } catch (err) {
       console.error('Failed to delete workspaces:', err);
       if (window.Toast) window.Toast.error(opts.permanent ? 'Failed to delete workspaces' : 'Failed to move workspaces to Trash');
+    }
+  }
+
+  // Restore workspaces straight from the "Moved to Trash" Undo toast. Mirrors the
+  // Trash view's Restore, but skips the modal so undo is one click.
+  async function undoTrash(ids) {
+    if (!ids || ids.length === 0) return;
+    try {
+      for (const id of ids) {
+        const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}/restore`, { method: 'POST' });
+        if (!response.ok && response.status !== 404) {
+          const text = await response.text();
+          throw new Error(text || 'Failed to restore workspace');
+        }
+      }
+      if (window.Toast) window.Toast.success(ids.length > 1 ? 'Workspaces restored' : 'Workspace restored');
+      await loadWorkspaces();
+    } catch (err) {
+      console.error('Failed to undo trash:', err);
+      if (window.Toast) window.Toast.error('Failed to restore workspace');
     }
   }
 

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -123,6 +123,11 @@ console.log('[workspace-hub.js] FILE LOADED');
     launcherDeleteGroupCount: document.getElementById('launcherDeleteGroupCount'),
     launcherDeleteGroupOnlyBtn: document.getElementById('launcherDeleteGroupOnlyBtn'),
     launcherDeleteGroupAllBtn: document.getElementById('launcherDeleteGroupAllBtn'),
+    launcherTrashBtn: document.getElementById('launcherTrashBtn'),
+    launcherTrashModal: document.getElementById('launcherTrashModal'),
+    launcherTrashList: document.getElementById('launcherTrashList'),
+    launcherTrashEmptyState: document.getElementById('launcherTrashEmptyState'),
+    launcherEmptyTrashBtn: document.getElementById('launcherEmptyTrashBtn'),
     launcherTabWorkspaces: document.getElementById('launcherTabWorkspaces'),
     launcherTabSummary: document.getElementById('launcherTabSummary'),
     launcherWorkspacesPanel: document.getElementById('launcherWorkspacesPanel'),
@@ -1807,27 +1812,35 @@ console.log('[workspace-hub.js] FILE LOADED');
     return isGroupWorkspace(state.workspaceMap.get(workspaceId));
   }
 
-  async function deleteWorkspacesByIds(ids) {
+  async function deleteWorkspacesByIds(ids, opts = {}) {
     const state = window.WorkspaceHubState.getState();
     if (!ids || ids.length === 0) return;
 
+    const params = new URLSearchParams({ confirm: 'true' });
+    if (opts.permanent) params.set('permanent', 'true');
+    if (opts.scope) params.set('scope', opts.scope);
+    const query = params.toString();
+    const verb = opts.permanent ? 'deleted' : 'moved to Trash';
+
     try {
       for (const id of ids) {
-        const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}?confirm=true`, { method: 'DELETE' });
+        const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}?${query}`, { method: 'DELETE' });
         if (!response.ok && response.status !== 404) {
           const text = await response.text();
           throw new Error(text || 'Failed to delete workspace');
         }
       }
 
-      if (window.Toast) window.Toast.success(ids.length > 1 ? 'Workspaces deleted' : 'Workspace deleted');
+      if (window.Toast) {
+        window.Toast.success(ids.length > 1 ? `Workspaces ${verb}` : `Workspace ${verb}`);
+      }
 
       state.selectedWorkspaces = new Set();
       setLauncherSelectionMode(false);
       await loadWorkspaces();
     } catch (err) {
       console.error('Failed to delete workspaces:', err);
-      if (window.Toast) window.Toast.error('Failed to delete workspaces');
+      if (window.Toast) window.Toast.error(opts.permanent ? 'Failed to delete workspaces' : 'Failed to move workspaces to Trash');
     }
   }
 
@@ -1838,11 +1851,11 @@ console.log('[workspace-hub.js] FILE LOADED');
     const childCount = descendants.length;
 
     if (!elements.launcherDeleteGroupModal || typeof bootstrap === 'undefined' || !bootstrap.Modal) {
-      const deleteAll = confirm(`"${workspace?.name || 'Group'}" has ${childCount} sub-workspace(s).\n\nClick OK to delete the group and all contents (workspace folders and files will be permanently removed from disk).\nClick Cancel to delete only the parent group.`);
+      const deleteAll = confirm(`"${workspace?.name || 'Group'}" has ${childCount} sub-workspace(s).\n\nClick OK to move the group and everything inside to Trash.\nClick Cancel to trash only the group (children move to root and stay active).\n\nTrashed workspaces can be restored within 30 days.`);
       if (deleteAll) {
-        void deleteGroupAndContents(workspaceId);
-      } else {
         void deleteWorkspacesByIds([workspaceId]);
+      } else {
+        void deleteWorkspacesByIds([workspaceId], { scope: 'group-only' });
       }
       return;
     }
@@ -1859,13 +1872,6 @@ console.log('[workspace-hub.js] FILE LOADED');
     modal.show();
   }
 
-  async function deleteGroupAndContents(workspaceId) {
-    const state = window.WorkspaceHubState.getState();
-    const ids = collectWorkspaceDescendantIds(state.workspaces || [], workspaceId, { includeRoot: true });
-    const ordered = ids.slice().reverse();
-    await deleteWorkspacesByIds(ordered);
-  }
-
   function handleDeleteGroupChoice(includeChildren) {
     const workspaceId = pendingDeleteGroupId;
     pendingDeleteGroupId = null;
@@ -1877,9 +1883,10 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
 
     if (includeChildren) {
-      void deleteGroupAndContents(workspaceId);
-    } else {
+      // Default scope trashes the whole subtree together so it can be restored as a unit.
       void deleteWorkspacesByIds([workspaceId]);
+    } else {
+      void deleteWorkspacesByIds([workspaceId], { scope: 'group-only' });
     }
   }
 
@@ -1892,9 +1899,130 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
 
     const label = getWorkspaceLabel(workspaceId);
-    if (!confirm(`Delete "${label}"?\n\nThis will permanently remove the workspace folder and all its contents (files, notes, etc.) from disk. This action cannot be undone.`)) return;
+    if (!confirm(`Move "${label}" to Trash?\n\nIts files, notes, and sessions are kept and can be restored from Trash for 30 days, after which it is permanently deleted.`)) return;
 
     void deleteWorkspacesByIds([workspaceId]);
+  }
+
+  // ---- Trash view ----
+
+  async function openTrashModal() {
+    if (!elements.launcherTrashModal || typeof bootstrap === 'undefined' || !bootstrap.Modal) return;
+    const modal = bootstrap.Modal.getInstance(elements.launcherTrashModal) || new bootstrap.Modal(elements.launcherTrashModal);
+    await loadTrash();
+    modal.show();
+  }
+
+  async function fetchTrashItems() {
+    const response = await fetch('/api/workspaces/trash');
+    if (!response.ok) throw new Error('Failed to load trash');
+    const data = await response.json();
+    return Array.isArray(data?.workspaces) ? data.workspaces : [];
+  }
+
+  async function loadTrash() {
+    if (!elements.launcherTrashList) return;
+    try {
+      renderTrash(await fetchTrashItems());
+    } catch (err) {
+      console.error('Failed to load trash:', err);
+      if (window.Toast) window.Toast.error('Failed to load Trash');
+      renderTrash([]);
+    }
+  }
+
+  function trashDaysLeft(purgeAt) {
+    if (!purgeAt) return null;
+    const ms = new Date(purgeAt).getTime() - Date.now();
+    if (Number.isNaN(ms)) return null;
+    return Math.max(0, Math.ceil(ms / (24 * 60 * 60 * 1000)));
+  }
+
+  function renderTrash(items) {
+    const list = elements.launcherTrashList;
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (elements.launcherTrashEmptyState) {
+      elements.launcherTrashEmptyState.style.display = items.length === 0 ? '' : 'none';
+    }
+    if (elements.launcherEmptyTrashBtn) {
+      elements.launcherEmptyTrashBtn.disabled = items.length === 0;
+    }
+    if (items.length === 0) return;
+
+    items.forEach((item) => {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:0.75rem;padding:0.5rem 0;border-bottom:1px solid var(--border-color);';
+
+      const daysLeft = trashDaysLeft(item.purge_at);
+      const metaParts = [];
+      if (item.kind === 'group') metaParts.push('Group');
+      if (typeof item.session_count === 'number' && item.session_count > 0) {
+        metaParts.push(`${item.session_count} session${item.session_count === 1 ? '' : 's'}`);
+      }
+      if (daysLeft !== null) {
+        metaParts.push(daysLeft === 0 ? 'purges today' : `${daysLeft} day${daysLeft === 1 ? '' : 's'} left`);
+      }
+
+      row.innerHTML = `
+        <div style="min-width:0;">
+          <div style="color:var(--text-primary);font-size:13px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(item.name || 'Untitled')}</div>
+          <div style="color:var(--text-secondary);font-size:11px;">${escapeHtml(metaParts.join(' · '))}</div>
+        </div>
+        <div style="display:flex;gap:0.5rem;flex-shrink:0;">
+          <button class="modern-btn modern-btn-secondary modern-btn-sm" type="button" data-trash-restore="${escapeHtml(item.id)}">Restore</button>
+          <button class="modern-btn modern-btn-danger modern-btn-sm" type="button" data-trash-delete="${escapeHtml(item.id)}">Delete Permanently</button>
+        </div>
+      `;
+      list.appendChild(row);
+    });
+
+    list.querySelectorAll('[data-trash-restore]').forEach((btn) => {
+      btn.addEventListener('click', () => restoreTrashedWorkspace(btn.getAttribute('data-trash-restore')));
+    });
+    list.querySelectorAll('[data-trash-delete]').forEach((btn) => {
+      btn.addEventListener('click', () => permanentlyDeleteTrashedWorkspace(btn.getAttribute('data-trash-delete')));
+    });
+  }
+
+  async function restoreTrashedWorkspace(id) {
+    if (!id) return;
+    try {
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}/restore`, { method: 'POST' });
+      if (!response.ok && response.status !== 404) {
+        const text = await response.text();
+        throw new Error(text || 'Failed to restore');
+      }
+      if (window.Toast) window.Toast.success('Workspace restored');
+      await loadTrash();
+      await loadWorkspaces();
+    } catch (err) {
+      console.error('Failed to restore workspace:', err);
+      if (window.Toast) window.Toast.error('Failed to restore workspace');
+    }
+  }
+
+  async function permanentlyDeleteTrashedWorkspace(id) {
+    if (!id) return;
+    if (!confirm('Permanently delete this workspace?\n\nIts folder, files, notes, and sessions will be removed from disk. This cannot be undone.')) return;
+    await deleteWorkspacesByIds([id], { permanent: true });
+    await loadTrash();
+  }
+
+  async function emptyTrash() {
+    let items = [];
+    try {
+      items = await fetchTrashItems();
+    } catch (err) {
+      if (window.Toast) window.Toast.error('Failed to load Trash');
+      return;
+    }
+    if (items.length === 0) return;
+    if (!confirm(`Permanently delete all ${items.length} workspace(s) in Trash?\n\nThis cannot be undone.`)) return;
+    const ids = items.map((it) => it.id).filter(Boolean);
+    await deleteWorkspacesByIds(ids, { permanent: true });
+    await loadTrash();
   }
 
   async function deleteSelectedWorkspaces() {
@@ -1902,7 +2030,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     const selected = Array.from(state.selectedWorkspaces || []);
     if (selected.length === 0) return;
 
-    if (!confirm(`Delete ${selected.length} workspace(s)?\n\nThis will permanently remove the workspace folders and all their contents (files, notes, etc.) from disk. This action cannot be undone.`)) {
+    if (!confirm(`Move ${selected.length} workspace(s) to Trash?\n\nTheir files, notes, and sessions are kept and can be restored from Trash for 30 days.`)) {
       return;
     }
 
@@ -2816,6 +2944,14 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     if (elements.launcherDeleteGroupAllBtn) {
       elements.launcherDeleteGroupAllBtn.addEventListener('click', () => handleDeleteGroupChoice(true));
+    }
+
+    if (elements.launcherTrashBtn) {
+      elements.launcherTrashBtn.addEventListener('click', () => openTrashModal());
+    }
+
+    if (elements.launcherEmptyTrashBtn) {
+      elements.launcherEmptyTrashBtn.addEventListener('click', () => emptyTrash());
     }
 
     if (elements.newSessionBtn) {

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -128,6 +128,11 @@ console.log('[workspace-hub.js] FILE LOADED');
     launcherTrashList: document.getElementById('launcherTrashList'),
     launcherTrashEmptyState: document.getElementById('launcherTrashEmptyState'),
     launcherEmptyTrashBtn: document.getElementById('launcherEmptyTrashBtn'),
+    launcherRecentlyDeleted: document.getElementById('launcherRecentlyDeleted'),
+    launcherRecentlyDeletedText: document.getElementById('launcherRecentlyDeletedText'),
+    launcherRecentlyDeletedUndoBtn: document.getElementById('launcherRecentlyDeletedUndoBtn'),
+    launcherRecentlyDeletedViewBtn: document.getElementById('launcherRecentlyDeletedViewBtn'),
+    launcherRecentlyDeletedDismissBtn: document.getElementById('launcherRecentlyDeletedDismissBtn'),
     launcherTabWorkspaces: document.getElementById('launcherTabWorkspaces'),
     launcherTabSummary: document.getElementById('launcherTabSummary'),
     launcherWorkspacesPanel: document.getElementById('launcherWorkspacesPanel'),
@@ -226,6 +231,11 @@ console.log('[workspace-hub.js] FILE LOADED');
   const { formatDate, flattenWorkspaces, collectWorkspaceDescendantIds } = window.WorkspaceHubUtils;
 
   let pendingDeleteGroupId = null;
+  // Tracks the latest Trash action so the hub can show a persistent
+  // "Recently deleted — Undo" banner. Persisted to localStorage so it survives
+  // reloads; validated against the live Trash list on load. Shape: { ids, label }.
+  const RECENTLY_DELETED_KEY = 'ori.workspaceHub.recentlyDeleted';
+  let pendingUndo = null;
   let launcherOverviewRequestSeq = 0;
   let launcherOverviewRefreshTimer = null;
   let launcherTaskBadgeByWorkspace = new Map();
@@ -1830,15 +1840,19 @@ console.log('[workspace-hub.js] FILE LOADED');
         }
       }
 
-      if (window.Toast) {
-        if (opts.permanent) {
-          window.Toast.success(ids.length > 1 ? 'Workspaces deleted' : 'Workspace deleted');
-        } else {
-          // Trash is reversible — offer an immediate Undo that restores what was
-          // just trashed (the Trash view remains available for later restores).
-          const trashedIds = ids.slice();
+      if (!opts.permanent) {
+        // Trash is reversible. Capture a label before reload (state still has the
+        // workspace), surface a transient Undo toast, and set the persistent
+        // "Recently deleted" banner so the undo survives the 8s toast window.
+        const trashedIds = ids.slice();
+        const label = trashedIds.length === 1
+          ? `"${getWorkspaceLabel(trashedIds[0])}"`
+          : `${trashedIds.length} workspaces`;
+        setPendingUndo(trashedIds, label);
+
+        if (window.Toast) {
           window.Toast.show(
-            ids.length > 1 ? `${ids.length} workspaces moved to Trash` : 'Workspace moved to Trash',
+            trashedIds.length > 1 ? `${trashedIds.length} workspaces moved to Trash` : 'Workspace moved to Trash',
             'success',
             {
               title: 'Moved to Trash',
@@ -1847,6 +1861,8 @@ console.log('[workspace-hub.js] FILE LOADED');
             }
           );
         }
+      } else if (window.Toast) {
+        window.Toast.success(ids.length > 1 ? 'Workspaces deleted' : 'Workspace deleted');
       }
 
       state.selectedWorkspaces = new Set();
@@ -1858,8 +1874,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
   }
 
-  // Restore workspaces straight from the "Moved to Trash" Undo toast. Mirrors the
-  // Trash view's Restore, but skips the modal so undo is one click.
+  // Restore workspaces straight from the "Moved to Trash" Undo toast or the
+  // persistent banner. Mirrors the Trash view's Restore, but skips the modal so
+  // undo is one click.
   async function undoTrash(ids) {
     if (!ids || ids.length === 0) return;
     try {
@@ -1871,10 +1888,86 @@ console.log('[workspace-hub.js] FILE LOADED');
         }
       }
       if (window.Toast) window.Toast.success(ids.length > 1 ? 'Workspaces restored' : 'Workspace restored');
+      clearPendingUndo();
       await loadWorkspaces();
     } catch (err) {
       console.error('Failed to undo trash:', err);
       if (window.Toast) window.Toast.error('Failed to restore workspace');
+    }
+  }
+
+  // ---- Persistent "Recently deleted" banner ----
+
+  function setPendingUndo(ids, label) {
+    pendingUndo = { ids: ids.slice(), label };
+    try {
+      localStorage.setItem(RECENTLY_DELETED_KEY, JSON.stringify(pendingUndo));
+    } catch (_) { /* localStorage may be unavailable; banner still works in-session */ }
+    renderRecentlyDeletedBanner();
+  }
+
+  function clearPendingUndo() {
+    pendingUndo = null;
+    try {
+      localStorage.removeItem(RECENTLY_DELETED_KEY);
+    } catch (_) { /* ignore */ }
+    renderRecentlyDeletedBanner();
+  }
+
+  function loadPendingUndoFromStorage() {
+    try {
+      const raw = localStorage.getItem(RECENTLY_DELETED_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (parsed && Array.isArray(parsed.ids) && parsed.ids.length > 0) {
+        pendingUndo = { ids: parsed.ids, label: parsed.label || `${parsed.ids.length} workspaces` };
+      }
+    } catch (_) { pendingUndo = null; }
+  }
+
+  function renderRecentlyDeletedBanner() {
+    const banner = elements.launcherRecentlyDeleted;
+    if (!banner) return;
+    if (!pendingUndo || !pendingUndo.ids || pendingUndo.ids.length === 0) {
+      banner.hidden = true;
+      return;
+    }
+    if (elements.launcherRecentlyDeletedText) {
+      elements.launcherRecentlyDeletedText.textContent = `Recently deleted ${pendingUndo.label}`;
+    }
+    banner.hidden = false;
+  }
+
+  // Reconcile the banner with the live Trash list: drop any ids that are no
+  // longer trashed (restored elsewhere or purged) so the banner never offers a
+  // stale undo. Runs on each hub load.
+  async function refreshRecentlyDeletedBanner() {
+    if (!pendingUndo || !pendingUndo.ids || pendingUndo.ids.length === 0) {
+      renderRecentlyDeletedBanner();
+      return;
+    }
+    try {
+      const trashed = await fetchTrashItems();
+      const trashedIds = new Set(trashed.map((it) => it.id));
+      const stillTrashed = pendingUndo.ids.filter((id) => trashedIds.has(id));
+      if (stillTrashed.length === 0) {
+        clearPendingUndo();
+        return;
+      }
+      if (stillTrashed.length !== pendingUndo.ids.length) {
+        // Some were already restored/purged — keep the banner for the rest.
+        pendingUndo.ids = stillTrashed;
+        if (stillTrashed.length === 1) {
+          pendingUndo.label = `"${trashed.find((it) => it.id === stillTrashed[0])?.name || 'workspace'}"`;
+        } else {
+          pendingUndo.label = `${stillTrashed.length} workspaces`;
+        }
+        try { localStorage.setItem(RECENTLY_DELETED_KEY, JSON.stringify(pendingUndo)); } catch (_) { /* ignore */ }
+      }
+      renderRecentlyDeletedBanner();
+    } catch (err) {
+      // On failure, keep whatever we have rather than hiding a valid undo.
+      renderRecentlyDeletedBanner();
     }
   }
 
@@ -2596,6 +2689,9 @@ console.log('[workspace-hub.js] FILE LOADED');
 
       // Always show the launcher - workspace details are now on separate pages
       showLauncher();
+
+      // Keep the persistent "Recently deleted" banner in sync with the Trash.
+      void refreshRecentlyDeletedBanner();
     } catch (error) {
       console.error('Workspace hub failed to load workspaces:', error);
       showLauncher();
@@ -2988,6 +3084,22 @@ console.log('[workspace-hub.js] FILE LOADED');
       elements.launcherEmptyTrashBtn.addEventListener('click', () => emptyTrash());
     }
 
+    if (elements.launcherRecentlyDeletedUndoBtn) {
+      elements.launcherRecentlyDeletedUndoBtn.addEventListener('click', () => {
+        if (pendingUndo && pendingUndo.ids.length) void undoTrash(pendingUndo.ids.slice());
+      });
+    }
+
+    if (elements.launcherRecentlyDeletedViewBtn) {
+      elements.launcherRecentlyDeletedViewBtn.addEventListener('click', () => openTrashModal());
+    }
+
+    if (elements.launcherRecentlyDeletedDismissBtn) {
+      // Dismiss only hides the banner; the workspaces stay in Trash, recoverable
+      // from the Trash view until they are purged.
+      elements.launcherRecentlyDeletedDismissBtn.addEventListener('click', () => clearPendingUndo());
+    }
+
     if (elements.newSessionBtn) {
       elements.newSessionBtn.addEventListener('click', () => {
         if (!state.selectedId) return;
@@ -3129,6 +3241,9 @@ console.log('[workspace-hub.js] FILE LOADED');
   setLauncherWorkspaceRootEditorOpen(false);
   initLauncherOverviewExpandedState();
   initLauncherTabState();
+  // Rehydrate the "Recently deleted" banner so an undo offered before a reload
+  // survives it; loadWorkspaces() then validates it against the live Trash.
+  loadPendingUndoFromStorage();
 
   // Keyboard shortcuts for workspace selection
   document.addEventListener('keydown', (e) => {

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -92,6 +92,22 @@
       </div>
 
       <section id="launcherWorkspacesPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabWorkspaces">
+        <!-- Recently deleted banner (persistent undo for the latest Trash action) -->
+        <div id="launcherRecentlyDeleted" class="launcher-recently-deleted" role="status" aria-live="polite" hidden>
+          <svg class="launcher-recently-deleted-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+          </svg>
+          <span id="launcherRecentlyDeletedText" class="launcher-recently-deleted-text">Recently deleted</span>
+          <div class="launcher-recently-deleted-actions">
+            <button id="launcherRecentlyDeletedUndoBtn" class="modern-btn modern-btn-primary modern-btn-sm" type="button">Undo</button>
+            <button id="launcherRecentlyDeletedViewBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button">View Trash</button>
+            <button id="launcherRecentlyDeletedDismissBtn" class="launcher-recently-deleted-dismiss" type="button" aria-label="Dismiss">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+              </svg>
+            </button>
+          </div>
+        </div>
         <!-- Selection Bar (shows only in selection mode) -->
         <div id="launcherSelectionBar" class="launcher-selection-bar" hidden>
           <span id="launcherSelectionCount" class="launcher-selection-count">0 selected</span>

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -63,6 +63,11 @@
               <path d="M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"/>
             </svg>
           </button>
+          <button id="launcherTrashBtn" class="modern-btn modern-btn-secondary modern-btn-icon" type="button" title="Trash" aria-label="View trashed workspaces">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+            </svg>
+          </button>
         </div>
       </div>
       <div class="launcher-tabs" role="tablist" aria-label="Launcher views">
@@ -214,24 +219,46 @@
     <div class="modal-dialog modal-dialog-centered modal-sm">
       <div class="modal-content" style="background: var(--bg-primary); border: 1px solid var(--border-color);">
         <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
-          <h6 class="modal-title" id="launcherDeleteGroupModalTitle" style="color: var(--text-primary);">Delete Group</h6>
+          <h6 class="modal-title" id="launcherDeleteGroupModalTitle" style="color: var(--text-primary);">Move Group to Trash</h6>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <p style="margin-bottom: 0.5rem; color: var(--text-primary);">
-            Delete "<span id="launcherDeleteGroupName">Group</span>"?
+            Move "<span id="launcherDeleteGroupName">Group</span>" to Trash?
           </p>
           <p style="margin-bottom: 0.5rem; font-size: 12px; color: var(--text-secondary);">
             This group contains <span id="launcherDeleteGroupCount">0</span> workspace(s).
           </p>
           <p style="font-size: 12px; color: var(--text-secondary);">
-            Choose whether to delete just the group (children move to root) or delete everything inside.
+            Choose whether to trash just the group (children move to root and stay active) or trash everything inside. You can restore from Trash within 30 days.
           </p>
         </div>
         <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
           <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="button" id="launcherDeleteGroupOnlyBtn" class="modern-btn modern-btn-secondary">Delete Group Only</button>
-          <button type="button" id="launcherDeleteGroupAllBtn" class="modern-btn modern-btn-danger">Delete Group + Contents</button>
+          <button type="button" id="launcherDeleteGroupOnlyBtn" class="modern-btn modern-btn-secondary">Trash Group Only</button>
+          <button type="button" id="launcherDeleteGroupAllBtn" class="modern-btn modern-btn-danger">Trash Everything</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="launcherTrashModal" tabindex="-1" aria-labelledby="launcherTrashModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content" style="background: var(--bg-primary); border: 1px solid var(--border-color);">
+        <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
+          <h6 class="modal-title" id="launcherTrashModalTitle" style="color: var(--text-primary);">Trash</h6>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p style="margin-bottom: 0.75rem; font-size: 12px; color: var(--text-secondary);">
+            Trashed workspaces are kept for 30 days, then permanently deleted. Restore one to bring it back with all its files and sessions.
+          </p>
+          <div id="launcherTrashList" class="launcher-trash-list"></div>
+          <div id="launcherTrashEmptyState" class="launcher-empty" style="display: none;">Trash is empty.</div>
+        </div>
+        <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
+          <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="button" id="launcherEmptyTrashBtn" class="modern-btn modern-btn-danger" disabled>Empty Trash</button>
         </div>
       </div>
     </div>

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -16,6 +16,10 @@ const (
 	StatusCompleted WorkspaceStatus = "completed"
 	StatusFailed    WorkspaceStatus = "failed"
 	StatusCancelled WorkspaceStatus = "cancelled"
+	// StatusTrashed marks a soft-deleted (Trashed) workspace. The scheduler and
+	// other active-only paths already skip non-active workspaces, so a trashed
+	// workspace stops running scheduled tasks while its files are preserved.
+	StatusTrashed WorkspaceStatus = "trashed"
 )
 
 // MessageType represents the type of inter-agent message


### PR DESCRIPTION
## Summary
Makes workspace deletion in the hub **undoable**. Deleting now moves a workspace to **Trash** (soft delete) instead of permanently wiping it; files, sessions, sub-workspaces, and the entry agent are preserved and restorable. Trashed workspaces auto-purge after 30 days. Permanent deletion is opt-in.

## Changes
- **Schema**: migration 023 adds nullable `deleted_at`; new `trashed` workspace status.
- **Store**: `TrashWorkspace` (subtree-aware, preserves parent_id/sessions), `RestoreWorkspace`, `ListTrashedWorkspaces`, `ReparentChildrenToRoot`; `ListWorkspaces` excludes trashed so the hub and scheduler skip them.
- **Shared teardown**: extracted `WorkspacePurger`, reused by the permanent-delete path and a background `TrashPurger` (30-day retention, wired into the workflow facade lifecycle).
- **HTTP**: `DELETE` trashes by default; `?permanent=true` hard-deletes; `?scope=group-only` for groups. New `GET /api/workspaces/trash` and `POST /api/workspaces/{id}/restore`.
- **Frontend**: \"Move to Trash\" copy, relabeled group modal, a **Trash** view (Restore / Delete Permanently / Empty Trash), an **Undo** toast, and a persistent **\"Recently deleted — Undo\"** banner in the hub.

## Test plan
- `go build ./... && go vet ./... && go test ./internal/session/... ./internal/sessionhttp/... ./internal/database/...` — all green.
- Store tests: trash/restore/subtree/group-only, ListWorkspaces excludes trashed; HTTP round-trip (trash→list→restore) + permanent delete; purger retention.
- Manual: trash a workspace → hidden from hub, present in Trash, folder still on disk → Restore brings it back intact → Delete Permanently removes the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)