### PR TITLE
fix(filewatcher): stop reporting benign Unwatch removals as errors

### DIFF
--- a/internal/filewatcher/watcher.go
+++ b/internal/filewatcher/watcher.go
@@ -2,6 +2,7 @@ package filewatcher
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -126,16 +127,38 @@ func (w *Watcher) Unwatch(sessionID string) error {
 		return nil
 	}
 
-	// Remove from fsnotify
-	if err := w.fsWatcher.Remove(path); err != nil {
-		logger.Error("Failed to remove watcher", logger.Fields{
-			"session_id": sessionID,
-			"path":       path,
-			"error":      err,
-		})
+	delete(w.sessions, sessionID)
+
+	// Multiple sessions can watch the same folder. Only remove the OS-level watch
+	// once the last session for this path is gone, otherwise the second Unwatch
+	// would try to remove an already-removed watch.
+	stillWatched := false
+	for _, p := range w.sessions {
+		if p == path {
+			stillWatched = true
+			break
+		}
 	}
 
-	delete(w.sessions, sessionID)
+	if !stillWatched {
+		if err := w.fsWatcher.Remove(path); err != nil {
+			// fsnotify auto-removes a watch when its directory is deleted, so a
+			// "non-existent watch" here is expected and harmless — the watch is
+			// already gone, which is the desired end state. Surface other errors.
+			if errors.Is(err, fsnotify.ErrNonExistentWatch) {
+				logger.Debug("Watch already removed before Unwatch", logger.Fields{
+					"session_id": sessionID,
+					"path":       path,
+				})
+			} else {
+				logger.Warn("Failed to remove watcher", logger.Fields{
+					"session_id": sessionID,
+					"path":       path,
+					"error":      err,
+				})
+			}
+		}
+	}
 
 	logger.Info("Stopped watching session folder", logger.Fields{
 		"session_id": sessionID,

--- a/internal/filewatcher/watcher_test.go
+++ b/internal/filewatcher/watcher_test.go
@@ -52,6 +52,69 @@ func TestWatcher_WatchUnwatch(t *testing.T) {
 	}
 }
 
+func TestWatcher_UnwatchSharedPath(t *testing.T) {
+	w, err := NewWatcher(DefaultWatcherConfig())
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	tmpDir, err := os.MkdirTemp("", "watcher-shared-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Two sessions watching the same folder.
+	if err := w.Watch("session-1", tmpDir); err != nil {
+		t.Fatalf("failed to watch session-1: %v", err)
+	}
+	if err := w.Watch("session-2", tmpDir); err != nil {
+		t.Fatalf("failed to watch session-2: %v", err)
+	}
+
+	// Unwatching the first must not remove the shared OS-level watch, and the
+	// second Unwatch must not error on an already-removed watch.
+	if err := w.Unwatch("session-1"); err != nil {
+		t.Fatalf("unwatch session-1: %v", err)
+	}
+	if err := w.Unwatch("session-2"); err != nil {
+		t.Fatalf("unwatch session-2: %v", err)
+	}
+
+	if w.IsWatching("session-1") || w.IsWatching("session-2") {
+		t.Error("no sessions should remain watched")
+	}
+}
+
+func TestWatcher_UnwatchDeletedFolder(t *testing.T) {
+	w, err := NewWatcher(DefaultWatcherConfig())
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	tmpDir, err := os.MkdirTemp("", "watcher-deleted-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	if err := w.Watch("session-1", tmpDir); err != nil {
+		t.Fatalf("failed to watch: %v", err)
+	}
+
+	// Deleting the folder makes fsnotify auto-drop the watch; Unwatch must still
+	// succeed (the "non-existent watch" error is treated as benign).
+	_ = os.RemoveAll(tmpDir)
+
+	if err := w.Unwatch("session-1"); err != nil {
+		t.Fatalf("unwatch after folder delete should not error: %v", err)
+	}
+	if w.IsWatching("session-1") {
+		t.Error("session-1 should no longer be watched")
+	}
+}
+
 func TestWatcher_WatchedSessions(t *testing.T) {
 	w, err := NewWatcher(DefaultWatcherConfig())
 	if err != nil {


### PR DESCRIPTION
## Summary
`Watcher.Unwatch` logged \"Failed to remove watcher\" at ERROR for two harmless cases, spamming logs whenever a workspace folder was closed or deleted (e.g. `…/Ori Workspaces/test12`):
- **shared paths** — multiple sessions can watch the same folder; the second `Remove` failed with \"can't remove non-existent watch\".
- **deleted folders** — fsnotify auto-removes the watch when its directory is deleted, so a later `Remove` hit the same error.

## Fix
Remove the OS-level watch only when the last session for a path leaves, and treat `fsnotify.ErrNonExistentWatch` as expected (logged at Debug). Other removal errors still log at Warn.

## Test plan
- Added `TestWatcher_UnwatchSharedPath` and `TestWatcher_UnwatchDeletedFolder`.
- `go build ./internal/filewatcher/... && go vet ./internal/filewatcher/... && go test ./internal/filewatcher/...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)