### PR TITLE
feat(frontend): task details UI — web-search provenance, merged brief/result card, act on highlighted result

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,6 +160,7 @@ export default defineConfig([
       'internal/web/static/js/modules/workspace-detail-skills.js',
       'internal/web/static/js/modules/workspace-task.js',
       'internal/web/static/js/modules/workspace-task-execution-views.js',
+      'internal/web/static/js/modules/workspace-task-result-actions.js',
       'internal/web/static/js/modules/workspace-task-skill-draft.js',
       'internal/web/static/js/modules/relative-time.js',
       'internal/web/static/js/modules/relative-time.test.js',

--- a/internal/web/static/js/modules/workspace-task-execution-views.js
+++ b/internal/web/static/js/modules/workspace-task-execution-views.js
@@ -150,6 +150,39 @@ export const taskExecutionViewsMethods = {
     return Array.from(byName.values());
   },
 
+  // Gather the lowercased names of every tool this task invoked, drawing from
+  // both the persisted execution_trace (via getToolUsageSummary) and any live
+  // task events. Either source can be the only one populated depending on
+  // whether the run finished and was persisted, so we union both.
+  collectUsedToolNames() {
+    const names = new Set();
+    this.getToolUsageSummary().forEach((tool) => {
+      const name = String(tool?.name || '').trim().toLowerCase();
+      if (name) names.add(name);
+    });
+    this.getCurrentTaskEvents().forEach((event) => {
+      const data = getTaskEventData(event);
+      const name = String(data?.tool_name || '').trim().toLowerCase();
+      if (name) names.add(name);
+    });
+    return names;
+  },
+
+  isWebSearchToolName(name) {
+    const normalized = String(name || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+    if (!normalized) return false;
+    return normalized === 'web_search' ||
+      normalized === 'websearch' ||
+      normalized.includes('web_search');
+  },
+
+  usedWebSearch() {
+    for (const name of this.collectUsedToolNames()) {
+      if (this.isWebSearchToolName(name)) return true;
+    }
+    return false;
+  },
+
   isToolTraceEntry(entry) {
     const status = String(entry?.status || entry?.type || '').trim().toLowerCase();
     const title = String(entry?.title || '').trim().toLowerCase();

--- a/internal/web/static/js/modules/workspace-task-result-actions.js
+++ b/internal/web/static/js/modules/workspace-task-result-actions.js
@@ -51,7 +51,7 @@ export const taskResultActionsMethods = {
     const selection = window.getSelection();
     if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
 
-    const text = String(selection.toString() || '').replace(/ /g, ' ').trim();
+    const text = String(selection.toString() || '').replace(/\u00a0/g, ' ').trim();
     if (text.length < 3) return null;
 
     const container = this.elements.output;
@@ -295,7 +295,7 @@ export const taskResultActionsMethods = {
   // A self-contained dialog (no Bootstrap dependency) for turning a highlighted
   // excerpt into a child subtask or a standalone follow-up. "ask" mode reuses
   // the same form, pre-framed as a question with quick presets.
-  openSelectionTaskDialog({ text, title, mode = 'spawn' } = {}) {
+  openSelectionTaskDialog({ text, mode = 'spawn' } = {}) {
     const selection = String(text || '').trim();
     if (!selection) return;
     if (!this.task?.id) {

--- a/internal/web/static/js/modules/workspace-task-result-actions.js
+++ b/internal/web/static/js/modules/workspace-task-result-actions.js
@@ -1,0 +1,482 @@
+// Selection-driven result actions for WorkspaceTaskPage.
+//
+// These methods are mixed onto WorkspaceTaskPage.prototype via Object.assign
+// in workspace-task.js (same pattern as workspace-task-execution-views.js).
+// They let a reader highlight any portion of a task result and act on just
+// that span — rather than treating the whole result as one block.
+//
+// Pass 1 wires the floating popover and the three actions that reuse existing
+// flows: Copy, Save as note, and Research (the existing research modal). The
+// spawn/ask dialog (highlight -> subtask | follow-up) and the per-item hover
+// buttons are layered on in later passes.
+
+import { summarizeText } from './workspace-task.js';
+
+export const taskResultActionsMethods = {
+  // Attach the selection listeners once. this.elements.output (#workspace-task-
+  // output) is a stable container whose innerHTML is replaced on each render,
+  // so a single delegated listener survives re-renders.
+  initResultSelectionActions() {
+    if (this._resultSelectionActionsBound) return;
+    const container = this.elements.output;
+    if (!container) return;
+    this._resultSelectionActionsBound = true;
+
+    this.boundResultSelectionEvent = (event) => this.handleResultSelectionEvent(event);
+    this.boundResultSelectionDismiss = (event) => {
+      if (this.resultSelectionPopover && this.resultSelectionPopover.contains(event.target)) return;
+      this.closeResultActionPopover();
+    };
+    this.boundResultSelectionReposition = () => this.closeResultActionPopover();
+
+    container.addEventListener('mouseup', this.boundResultSelectionEvent);
+    container.addEventListener('keyup', this.boundResultSelectionEvent);
+  },
+
+  handleResultSelectionEvent(_event) {
+    // Defer a tick so window.getSelection() reflects the finished selection.
+    window.setTimeout(() => {
+      const info = this.getResultSelectionInfo();
+      if (!info) {
+        this.closeResultActionPopover();
+        return;
+      }
+      this.showResultActionPopover(info);
+    }, 0);
+  },
+
+  // Returns { text, title, rect } when there's a non-trivial selection wholly
+  // inside the result body, otherwise null.
+  getResultSelectionInfo() {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+
+    const text = String(selection.toString() || '').replace(/ /g, ' ').trim();
+    if (text.length < 3) return null;
+
+    const container = this.elements.output;
+    if (!container) return null;
+
+    const range = selection.getRangeAt(0);
+    const anchor = range.commonAncestorContainer;
+    const anchorEl = anchor && anchor.nodeType === Node.ELEMENT_NODE ? anchor : anchor?.parentElement;
+    if (!anchorEl || !container.contains(anchorEl)) return null;
+
+    const rect = range.getBoundingClientRect();
+    if (!rect || (rect.width === 0 && rect.height === 0)) return null;
+
+    return { text, title: this.deriveSelectionTitle(text), rect };
+  },
+
+  deriveSelectionTitle(text) {
+    const firstLine = String(text || '')
+      .split('\n')
+      .map((line) => line.trim())
+      .find(Boolean) || String(text || '');
+    return summarizeText(firstLine, 80);
+  },
+
+  showResultActionPopover({ text, title, rect }) {
+    this.closeResultActionPopover();
+
+    const menu = document.createElement('div');
+    menu.className = 'workspace-task-selection-popover';
+    menu.setAttribute('role', 'toolbar');
+    menu.setAttribute('aria-label', 'Actions for the selected result text');
+    menu.innerHTML = `
+      <button type="button" class="workspace-task-selection-action" data-selection-action="spawn" title="Turn the selection into a subtask or follow-up task">
+        <i class="bi bi-diagram-2" aria-hidden="true"></i><span>Task</span>
+      </button>
+      <button type="button" class="workspace-task-selection-action" data-selection-action="research" title="Research or verify this">
+        <i class="bi bi-search" aria-hidden="true"></i><span>Research</span>
+      </button>
+      <button type="button" class="workspace-task-selection-action" data-selection-action="ask" title="Ask the agent about this">
+        <i class="bi bi-chat-dots" aria-hidden="true"></i><span>Ask</span>
+      </button>
+      <button type="button" class="workspace-task-selection-action" data-selection-action="note" title="Save the selection as a note">
+        <i class="bi bi-journal-plus" aria-hidden="true"></i><span>Note</span>
+      </button>
+      <button type="button" class="workspace-task-selection-action" data-selection-action="copy" title="Copy the selection">
+        <i class="bi bi-clipboard" aria-hidden="true"></i><span>Copy</span>
+      </button>
+    `;
+
+    document.body.appendChild(menu);
+    this.resultSelectionPopover = menu;
+    this.positionResultActionPopover(menu, rect);
+
+    menu.querySelectorAll('[data-selection-action]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = btn.getAttribute('data-selection-action') || '';
+        this.closeResultActionPopover();
+        void this.handleResultSelectionAction(action, { text, title });
+      });
+    });
+
+    // Defer wiring the dismiss listeners so the click/mousedown that produced
+    // the selection doesn't immediately close the popover.
+    window.setTimeout(() => {
+      document.addEventListener('mousedown', this.boundResultSelectionDismiss, true);
+      window.addEventListener('scroll', this.boundResultSelectionReposition, true);
+      window.addEventListener('resize', this.boundResultSelectionReposition, true);
+    }, 0);
+  },
+
+  positionResultActionPopover(menu, rect) {
+    const pad = 10;
+    const gap = 8;
+    const menuRect = menu.getBoundingClientRect();
+
+    let top = rect.top - menuRect.height - gap;
+    if (top < pad) top = rect.bottom + gap; // flip below when there's no room above
+
+    let left = rect.left + rect.width / 2 - menuRect.width / 2;
+    left = Math.min(Math.max(left, pad), Math.max(pad, window.innerWidth - menuRect.width - pad));
+    top = Math.min(Math.max(top, pad), Math.max(pad, window.innerHeight - menuRect.height - pad));
+
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+  },
+
+  closeResultActionPopover() {
+    if (this.resultSelectionPopover) {
+      this.resultSelectionPopover.remove();
+      this.resultSelectionPopover = null;
+    }
+    document.removeEventListener('mousedown', this.boundResultSelectionDismiss, true);
+    window.removeEventListener('scroll', this.boundResultSelectionReposition, true);
+    window.removeEventListener('resize', this.boundResultSelectionReposition, true);
+  },
+
+  async handleResultSelectionAction(action, { text, title } = {}) {
+    const selection = String(text || '').trim();
+    if (!selection) return;
+
+    switch (action) {
+      case 'copy':
+        await this.copyToClipboard(selection, 'Selection copied');
+        return;
+      case 'note':
+        await this.saveResultSelectionAsNote(selection, title);
+        return;
+      case 'research':
+        this.researchResultSelection(selection, title);
+        return;
+      case 'spawn':
+        this.openSelectionTaskDialog({ text: selection, title, mode: 'spawn' });
+        return;
+      case 'ask':
+        this.openSelectionTaskDialog({ text: selection, title, mode: 'ask' });
+        return;
+      default:
+        return;
+    }
+  },
+
+  // Opens the existing research modal seeded with the highlighted text. The
+  // modal/submit path accepts a null section (sectionId becomes ''), so no
+  // DOM section element is required.
+  researchResultSelection(text, title) {
+    if (typeof this.buildResultResearchDraft !== 'function' || typeof this.openResultResearchModal !== 'function') {
+      this.notify('error', 'Research is not available on this page.');
+      return;
+    }
+    const sectionTitle = title || this.deriveSelectionTitle(text);
+    const draft = this.buildResultResearchDraft(null, sectionTitle, text);
+    this.openResultResearchModal(draft);
+  },
+
+  async saveResultSelectionAsNote(text, title) {
+    if (!this.workspaceId) {
+      this.notify('error', 'Workspace is not loaded yet — try again in a moment.');
+      return;
+    }
+    const name = (title || this.deriveSelectionTitle(text) || 'Result excerpt').trim();
+    const sourceLabel = typeof this.getTaskDisplayLabel === 'function' ? this.getTaskDisplayLabel() : '';
+    const sourceId = String(this.task?.id || this.taskId || '').trim();
+    const footerParts = [sourceLabel ? `From task: ${sourceLabel}` : '', sourceId ? `(${sourceId})` : '']
+      .filter(Boolean)
+      .join(' ');
+    const content = footerParts ? `${text}\n\n---\n${footerParts}` : text;
+
+    try {
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}/notes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, content })
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(this.parseResponseError(errorText, 'Failed to save selection as note.'));
+      }
+      this.notify('success', 'Selection saved as a note');
+    } catch (error) {
+      console.error('Failed to save selection as note:', error);
+      this.notify('error', error?.message || 'Failed to save selection as note');
+    }
+  },
+
+  // The next subtask_index for a child created under this task: one past the
+  // highest existing index so it sorts to the end of the step list.
+  getNextSubtaskIndex() {
+    const subtasks = typeof this.getSubtasks === 'function' ? this.getSubtasks() : [];
+    const maxIndex = (Array.isArray(subtasks) ? subtasks : []).reduce((max, item) => {
+      const index = Number(item?.subtask_index);
+      return Number.isFinite(index) && index > max ? index : max;
+    }, 0);
+    return maxIndex + 1;
+  },
+
+  buildSelectionDialogAgentOptions(selectedAgent = '') {
+    const normalizedSelected = String(selectedAgent || '').trim();
+    const names = typeof this.getAssignableAgentNames === 'function'
+      ? this.getAssignableAgentNames(normalizedSelected)
+      : [];
+    const options = ['<option value="">Unassigned (manual task)</option>'];
+    names.forEach((agentName) => {
+      const name = String(agentName || '').trim();
+      if (!name) return;
+      const selected = name.toLowerCase() === normalizedSelected.toLowerCase() ? ' selected' : '';
+      options.push(`<option value="${this.escapeHtml(name)}"${selected}>${this.escapeHtml(name)}</option>`);
+    });
+    return options.join('');
+  },
+
+  // A self-contained dialog (no Bootstrap dependency) for turning a highlighted
+  // excerpt into a child subtask or a standalone follow-up. "ask" mode reuses
+  // the same form, pre-framed as a question with quick presets.
+  openSelectionTaskDialog({ text, title, mode = 'spawn' } = {}) {
+    const selection = String(text || '').trim();
+    if (!selection) return;
+    if (!this.task?.id) {
+      this.notify('error', 'Source task is not loaded yet — try again in a moment.');
+      return;
+    }
+    this.closeSelectionTaskDialog();
+
+    const isAsk = mode === 'ask';
+    const currentAgent = String(this.task?.to || '').trim();
+    const defaultAgent = currentAgent && currentAgent.toLowerCase() !== 'unassigned' ? currentAgent : '';
+    // A question is usually standalone; an extracted action usually belongs to
+    // this task. Default accordingly, but the choice is always shown.
+    const defaultRelationship = isAsk ? 'followup' : 'subtask';
+    const excerpt = summarizeText(selection, 280);
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'workspace-task-selection-dialog-backdrop';
+    backdrop.innerHTML = `
+      <div class="workspace-task-selection-dialog" role="dialog" aria-modal="true" aria-label="${isAsk ? 'Ask about the selection' : 'Create a task from the selection'}">
+        <div class="workspace-task-selection-dialog-head">
+          <h3>${isAsk ? 'Ask about this' : 'Create a task from this'}</h3>
+          <button type="button" class="workspace-task-selection-dialog-close" data-dialog-action="cancel" aria-label="Close">
+            <i class="bi bi-x-lg" aria-hidden="true"></i>
+          </button>
+        </div>
+        <blockquote class="workspace-task-selection-dialog-excerpt">${this.escapeHtml(excerpt)}</blockquote>
+
+        <div class="workspace-task-selection-dialog-field">
+          <span class="workspace-task-selection-dialog-label">Add as</span>
+          <div class="workspace-task-selection-dialog-segmented" role="radiogroup" aria-label="Task relationship">
+            <label class="workspace-task-selection-dialog-segment">
+              <input type="radio" name="selection-task-relationship" value="subtask"${defaultRelationship === 'subtask' ? ' checked' : ''} />
+              <span>Subtask of this task</span>
+            </label>
+            <label class="workspace-task-selection-dialog-segment">
+              <input type="radio" name="selection-task-relationship" value="followup"${defaultRelationship === 'followup' ? ' checked' : ''} />
+              <span>Standalone follow-up</span>
+            </label>
+          </div>
+        </div>
+
+        ${isAsk ? `
+        <div class="workspace-task-selection-dialog-presets" role="group" aria-label="Question presets">
+          <button type="button" class="workspace-task-selection-dialog-preset" data-preset="Explain this in more detail.">Explain</button>
+          <button type="button" class="workspace-task-selection-dialog-preset" data-preset="Verify this and cite sources.">Verify</button>
+          <button type="button" class="workspace-task-selection-dialog-preset" data-preset="Summarize this concisely.">Summarize</button>
+        </div>` : ''}
+
+        <label class="workspace-task-selection-dialog-field">
+          <span class="workspace-task-selection-dialog-label">${isAsk ? 'What do you want to ask?' : 'What should the task do?'}</span>
+          <textarea class="form-control" data-dialog-field="description" rows="3" placeholder="${isAsk ? 'e.g. Explain this in more detail.' : 'Describe the task'}"></textarea>
+        </label>
+
+        <label class="workspace-task-selection-dialog-field">
+          <span class="workspace-task-selection-dialog-label">Assign to</span>
+          <select class="form-select" data-dialog-field="agent">${this.buildSelectionDialogAgentOptions(defaultAgent)}</select>
+        </label>
+
+        <label class="workspace-task-selection-dialog-check">
+          <input type="checkbox" data-dialog-field="run-now"${isAsk ? ' checked' : ''} />
+          <span>Run it now</span>
+        </label>
+
+        <div class="workspace-task-selection-dialog-error" data-dialog-field="error" hidden></div>
+
+        <div class="workspace-task-selection-dialog-actions">
+          <button type="button" class="modern-btn modern-btn-secondary" data-dialog-action="cancel">Cancel</button>
+          <button type="button" class="modern-btn modern-btn-primary" data-dialog-action="submit">
+            <span>${isAsk ? 'Ask' : 'Create task'}</span>
+          </button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(backdrop);
+    this.selectionTaskDialog = backdrop;
+
+    const descriptionInput = backdrop.querySelector('[data-dialog-field="description"]');
+    if (descriptionInput && !isAsk) descriptionInput.value = selection;
+
+    backdrop.querySelectorAll('[data-preset]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        if (descriptionInput) {
+          descriptionInput.value = btn.getAttribute('data-preset') || '';
+          descriptionInput.focus();
+        }
+      });
+    });
+
+    backdrop.querySelectorAll('[data-dialog-action="cancel"]').forEach((btn) => {
+      btn.addEventListener('click', () => this.closeSelectionTaskDialog());
+    });
+    backdrop.querySelector('[data-dialog-action="submit"]')?.addEventListener('click', () => {
+      void this.submitSelectionTaskDialog(selection, mode);
+    });
+
+    backdrop.addEventListener('mousedown', (event) => {
+      if (event.target === backdrop) this.closeSelectionTaskDialog();
+    });
+    this.boundSelectionDialogKeydown = (event) => {
+      if (event.key === 'Escape') this.closeSelectionTaskDialog();
+    };
+    document.addEventListener('keydown', this.boundSelectionDialogKeydown, true);
+
+    window.requestAnimationFrame(() => descriptionInput?.focus());
+  },
+
+  closeSelectionTaskDialog() {
+    if (this._selectionTaskSubmitting) return;
+    if (this.selectionTaskDialog) {
+      this.selectionTaskDialog.remove();
+      this.selectionTaskDialog = null;
+    }
+    if (this.boundSelectionDialogKeydown) {
+      document.removeEventListener('keydown', this.boundSelectionDialogKeydown, true);
+      this.boundSelectionDialogKeydown = null;
+    }
+  },
+
+  setSelectionDialogError(message) {
+    const errorEl = this.selectionTaskDialog?.querySelector('[data-dialog-field="error"]');
+    if (!errorEl) return;
+    if (message) {
+      errorEl.textContent = message;
+      errorEl.hidden = false;
+    } else {
+      errorEl.textContent = '';
+      errorEl.hidden = true;
+    }
+  },
+
+  async submitSelectionTaskDialog(selection, mode) {
+    if (this._selectionTaskSubmitting) return;
+    const dialog = this.selectionTaskDialog;
+    if (!dialog) return;
+
+    const description = String(dialog.querySelector('[data-dialog-field="description"]')?.value || '').trim();
+    if (!description) {
+      this.setSelectionDialogError(mode === 'ask' ? 'Type a question first.' : 'Describe what the task should do.');
+      dialog.querySelector('[data-dialog-field="description"]')?.focus();
+      return;
+    }
+    if (!this.task?.id) {
+      this.setSelectionDialogError('Source task is not loaded yet — try again in a moment.');
+      return;
+    }
+    this.setSelectionDialogError('');
+
+    const relationship = String(dialog.querySelector('input[name="selection-task-relationship"]:checked')?.value || 'subtask');
+    const isSubtask = relationship === 'subtask';
+    const agent = String(dialog.querySelector('[data-dialog-field="agent"]')?.value || '').trim();
+    const runNow = Boolean(dialog.querySelector('[data-dialog-field="run-now"]')?.checked);
+
+    const sourceLabel = typeof this.getTaskDisplayLabel === 'function' ? this.getTaskDisplayLabel() : '';
+    const sourceId = String(this.task.id);
+    const details = [
+      `Created from a highlighted excerpt of ${sourceLabel ? `"${sourceLabel}"` : 'a task'} (${sourceId}):`,
+      '',
+      `"${selection}"`
+    ].join('\n');
+
+    const payload = {
+      workspace_id: this.workspaceId,
+      description,
+      details,
+      status: 'pending',
+      to: agent || undefined,
+      input_task_ids: [sourceId]
+    };
+    if (isSubtask) {
+      payload.parent_task_id = sourceId;
+      payload.subtask_index = this.getNextSubtaskIndex();
+    }
+
+    const submitBtn = dialog.querySelector('[data-dialog-action="submit"]');
+    const submitText = submitBtn?.querySelector('span');
+    const originalText = submitText?.textContent || 'Create task';
+    this._selectionTaskSubmitting = true;
+    if (submitBtn) submitBtn.disabled = true;
+    if (submitText) submitText.textContent = runNow ? 'Creating & running…' : 'Creating…';
+
+    try {
+      const response = await fetch('/api/orchestration/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(this.parseResponseError(text, 'Failed to create task.'));
+      }
+      const created = await response.json().catch(() => ({}));
+      const newTaskId = String(created?.task?.id || created?.id || '').trim();
+
+      if (runNow && newTaskId) {
+        const executeResponse = await fetch('/api/orchestration/tasks/execute', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ task_id: newTaskId })
+        });
+        if (!executeResponse.ok) {
+          const text = await executeResponse.text();
+          throw new Error(this.parseResponseError(text, 'Task was created but could not be started.'));
+        }
+      }
+
+      this._selectionTaskSubmitting = false;
+      this.closeSelectionTaskDialog();
+      this.notify('success', isSubtask ? 'Subtask created' : 'Follow-up task created');
+
+      // A subtask belongs to this task's graph, so refresh in place to surface
+      // it in the step list. A standalone follow-up is its own task, so send
+      // the user there to run/edit it (matching the existing follow-up flow).
+      if (isSubtask) {
+        if (typeof this.refreshAfterStepChange === 'function') {
+          await this.refreshAfterStepChange();
+        } else {
+          await this.loadData();
+        }
+      } else if (newTaskId) {
+        window.location.href = this.getTaskHref(newTaskId);
+      }
+    } catch (error) {
+      console.error('Failed to create task from selection:', error);
+      this._selectionTaskSubmitting = false;
+      this.setSelectionDialogError(error?.message || 'Failed to create task.');
+    } finally {
+      this._selectionTaskSubmitting = false;
+      if (submitBtn) submitBtn.disabled = false;
+      if (submitText) submitText.textContent = originalText;
+    }
+  },
+};

--- a/internal/web/static/js/modules/workspace-task-result-actions.js
+++ b/internal/web/static/js/modules/workspace-task-result-actions.js
@@ -76,6 +76,56 @@ export const taskResultActionsMethods = {
     return summarizeText(firstLine, 80);
   },
 
+  // Discoverable per-item triggers: results are often lists (or bold-led
+  // paragraphs) with no Markdown headings, so the heading-based section
+  // enhancer never fires. Here we attach a hover-revealed button to each list
+  // item / bold-led paragraph that opens the same popover, anchored to the
+  // item — so a reader doesn't have to manually select to act on one item.
+  enhanceResultItems() {
+    // renderOutput rebuilds the result DOM on each call, which would orphan a
+    // popover anchored to a now-removed trigger; close it before re-enhancing.
+    this.closeResultActionPopover();
+    const prose = this.elements.output?.querySelector?.('.workspace-task-page-prose');
+    if (!prose) return;
+
+    const candidates = [];
+    prose.querySelectorAll('li').forEach((li) => candidates.push(li));
+    prose.querySelectorAll(':scope > p').forEach((p) => {
+      if (p.firstElementChild && p.firstElementChild.tagName === 'STRONG') candidates.push(p);
+    });
+
+    candidates.forEach((item) => {
+      if (item.dataset.resultItemEnhanced === 'true') return;
+      const text = String(item.textContent || '').replace(/\s+/g, ' ').trim();
+      if (text.length < 8) return; // skip trivial markers / empty wrappers
+
+      item.dataset.resultItemEnhanced = 'true';
+      item.classList.add('workspace-task-result-item');
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'workspace-task-result-item-action';
+      button.title = 'Actions for this item';
+      button.setAttribute('aria-label', 'Actions for this item');
+      button.innerHTML = '<i class="bi bi-three-dots" aria-hidden="true"></i>';
+
+      // Stop the button's mouse events from reaching the result container's
+      // selection listener — otherwise its mouseup would see a collapsed
+      // selection and immediately close the popover we just opened.
+      ['mousedown', 'mouseup'].forEach((type) => {
+        button.addEventListener(type, (event) => event.stopPropagation());
+      });
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const rect = button.getBoundingClientRect();
+        this.showResultActionPopover({ text, title: this.deriveSelectionTitle(text), rect });
+      });
+
+      item.appendChild(button);
+    });
+  },
+
   showResultActionPopover({ text, title, rect }) {
     this.closeResultActionPopover();
 

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -6466,6 +6466,7 @@ export class WorkspaceTaskPage {
     }
 
     const blocks = [];
+    blocks.push(this.renderWebSearchBadge());
     const latestStorageStatus = this.renderLatestStorageStatus();
     if (latestStorageStatus) {
       blocks.push(latestStorageStatus);
@@ -6530,6 +6531,28 @@ export class WorkspaceTaskPage {
     this.enhanceResultSections();
     this.updateResultActionButtons(result || error, Boolean(result));
     this.renderResultNoteStatus();
+  }
+
+  // A pill at the top of the Result card stating whether this task's answer was
+  // backed by a web search. usedWebSearch() inspects the tool-usage trace, so
+  // the "used" notification only shows when the web_search tool actually ran;
+  // otherwise we surface an explicit "No web search" tag so a reader never has
+  // to guess whether the result drew on live web sources.
+  renderWebSearchBadge() {
+    if (this.usedWebSearch()) {
+      return `
+        <div class="workspace-task-websearch-badge" data-state="used" role="status">
+          <i class="bi bi-globe2" aria-hidden="true"></i>
+          <span>Web search used</span>
+        </div>
+      `;
+    }
+    return `
+      <div class="workspace-task-websearch-badge" data-state="unused" role="status">
+        <i class="bi bi-slash-circle" aria-hidden="true"></i>
+        <span>No web search</span>
+      </div>
+    `;
   }
 
   renderLatestStorageStatus() {

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -6552,6 +6552,7 @@ export class WorkspaceTaskPage {
     this.bindResultArtifactActions();
     this.bindOutputReviewActions();
     this.enhanceResultSections();
+    this.enhanceResultItems();
     this.updateResultActionButtons(result || error, Boolean(result));
     this.renderResultNoteStatus();
   }

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -2995,47 +2995,68 @@ export class WorkspaceTaskPage {
         value: detailsValue || 'No extra task details were provided.',
         full: true,
         editable: true,
+        isBrief: true,
         disclosure: isBlocked,
         disclosureHint: 'Hidden while this task is waiting for input.'
       });
     }
 
-    this.elements.overview.innerHTML = items.map((item) => {
-      if (item.disclosure) {
+    // The brief ("what this task does") leads the card so a reader starts with
+    // intent; the run metadata (status, reference URL, agent, …) collapses into
+    // a compact meta row beneath it instead of a tall stack of labelled rows.
+    const briefItem = items.find((item) => item.isBrief);
+    const metaItems = items.filter((item) => !item.isBrief);
+
+    const renderBriefLead = () => {
+      if (!briefItem) return '';
+      // Blocked tasks keep the brief behind a disclosure (it can duplicate the
+      // pause reason); just promoted into the lead slot.
+      if (briefItem.disclosure) {
         return `
-          <article class="workspace-task-overview-item${item.full ? ' full' : ''}">
+          <div class="workspace-task-overview-item workspace-task-brief-lead full">
             <details class="workspace-task-overview-disclosure">
               <summary class="workspace-task-overview-disclosure-toggle">
-                <span class="workspace-task-overview-disclosure-heading">${this.escapeHtml(item.title)}</span>
-                <span class="workspace-task-overview-disclosure-hint">${this.escapeHtml(item.disclosureHint || '')}</span>
+                <span class="workspace-task-overview-disclosure-heading">${this.escapeHtml(briefItem.title)}</span>
+                <span class="workspace-task-overview-disclosure-hint">${this.escapeHtml(briefItem.disclosureHint || '')}</span>
               </summary>
               <div class="workspace-task-overview-disclosure-body">
-                <div class="workspace-task-overview-title">
-                  Task Details
-                  ${renderEditButton(item)}
-                </div>
-                <div class="workspace-task-overview-value">${this.escapeHtml(item.value)}</div>
+                <div class="workspace-task-overview-value">${this.escapeHtml(briefItem.value)}</div>
               </div>
             </details>
-          </article>
+          </div>
         `;
       }
+      // No label: the card kicker ("Task") + heading ("What this task does")
+      // already name this content, so the brief speaks for itself. The edit
+      // pencil is absolutely positioned (CSS) and revealed on hover; the
+      // .workspace-task-overview-item + .workspace-task-overview-value classes
+      // are preserved so startDetailsEdit keeps working unchanged.
+      return `
+        <div class="workspace-task-overview-item workspace-task-brief-lead full">
+          ${renderEditButton(briefItem)}
+          <div class="workspace-task-overview-value workspace-task-brief-lead-value">${this.escapeHtml(briefItem.value)}</div>
+        </div>
+      `;
+    };
 
-      // Build the value HTML separately and inline it with no surrounding
-      // whitespace: the value uses white-space: pre-wrap (to preserve real line
-      // breaks in a multi-line Task Details brief), so any newlines/indentation
-      // between the <div> tags and ${...} would render as stray blank lines and
-      // a leading indent.
+    const renderMetaEntry = (item) => {
       const valueHtml = item.href
         ? `<a href="${this.escapeHtml(item.href)}" class="workspace-task-overview-link"${item.external ? ' target="_blank" rel="noopener noreferrer"' : ''}>${this.escapeHtml(item.value)}</a>`
         : this.escapeHtml(item.value);
       return `
-        <article class="workspace-task-overview-item${item.full ? ' full' : ''}">
-          <div class="workspace-task-overview-title">${this.escapeHtml(item.title)}${renderEditButton(item)}</div>
-          <div class="workspace-task-overview-value">${valueHtml}</div>
-        </article>
+        <span class="workspace-task-brief-meta-item">
+          <span class="workspace-task-brief-meta-label">${this.escapeHtml(item.title)}</span>
+          <span class="workspace-task-brief-meta-value">${valueHtml}</span>
+          ${renderEditButton(item)}
+        </span>
       `;
-    }).join('');
+    };
+
+    const metaHtml = metaItems.length
+      ? `<div class="workspace-task-brief-meta">${metaItems.map(renderMetaEntry).join('')}</div>`
+      : '';
+
+    this.elements.overview.innerHTML = renderBriefLead() + metaHtml;
 
     this.elements.overview.querySelectorAll('[data-edit-field]').forEach((btn) => {
       btn.addEventListener('click', () => {

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -11,6 +11,7 @@ import {
   rowsToCSV,
 } from './task-result-artifacts.js';
 import { taskSkillDraftMethods } from './workspace-task-skill-draft.js';
+import { taskResultActionsMethods } from './workspace-task-result-actions.js';
 import { showCanvasAgentPicker } from './agent-canvas-dialogs.js';
 
 const escapeTaskHtml = window.escapeHtml || function fallbackEscapeHtml(value) {
@@ -1157,6 +1158,7 @@ export class WorkspaceTaskPage {
       this.setOutputOverflowOpen(false);
     });
     this.elements.outputSaveNoteBtn?.addEventListener('click', () => this.saveCurrentResultAsNote());
+    this.initResultSelectionActions();
     this.elements.outputCreateSkillBtn?.addEventListener('click', () => {
       this.openSkillDraftModal();
       this.setOutputOverflowOpen(false);
@@ -9409,4 +9411,5 @@ Object.assign(
   WorkspaceTaskPage.prototype,
   taskExecutionViewsMethods,
   taskSkillDraftMethods,
+  taskResultActionsMethods,
 );

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -1629,6 +1629,40 @@
       font-weight: 700;
     }
 
+    /* Web-search provenance pill at the top of the Result card. Two states:
+       "used" reads as a positive notification (web sources were consulted),
+       "unused" is a muted tag so the absence of web search is stated plainly
+       rather than left ambiguous. */
+    .workspace-task-websearch-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      width: fit-content;
+      margin-bottom: 0.85rem;
+      padding: 0.34rem 0.65rem;
+      border-radius: 999px;
+      border: 1px solid var(--border-color);
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+    }
+
+    .workspace-task-websearch-badge i {
+      font-size: 0.9rem;
+    }
+
+    .workspace-task-websearch-badge[data-state="used"] {
+      border-color: color-mix(in srgb, var(--success-color, #16a34a) 45%, var(--border-color));
+      background: color-mix(in srgb, var(--success-color, #16a34a) 12%, var(--bg-primary));
+      color: color-mix(in srgb, var(--success-color, #16a34a) 78%, var(--text-primary));
+    }
+
+    .workspace-task-websearch-badge[data-state="unused"] {
+      border-color: var(--border-color);
+      background: color-mix(in srgb, var(--text-muted, #6b7280) 8%, var(--bg-primary));
+      color: var(--text-secondary);
+    }
+
     /* Collapsed wrapper for the run-history dataset, so the Result leads and
        the CSV preview stays tucked away. Borderless — the artifact section
        inside keeps its own surface, so there's no box-in-box. */

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -193,37 +193,23 @@
                  stack in one scroll; each self-hides when it has nothing to
                  show, and the developer-facing cards are grouped in a collapsed
                  disclosure at the bottom. -->
-              <section class="workspace-task-page-card">
+              <!-- Merged card: the task brief ("what this task does") leads,
+                   then the latest result follows below a hairline divider so a
+                   reader flows from intent → outcome in one panel. The result
+                   block keeps its #workspace-task-output-card id (now a div, not
+                   a section) so renderOutput's .hidden toggle hides just the
+                   result portion while the brief above stays visible. -->
+              <section class="workspace-task-page-card workspace-task-brief-card">
                 <div class="workspace-task-page-card-header">
                   <div>
-                    <div class="workspace-task-page-card-kicker">Overview</div>
+                    <div class="workspace-task-page-card-kicker">Task</div>
                     <h2>What this task does</h2>
                   </div>
                 </div>
                 <div id="workspace-task-overview" class="workspace-task-overview-grid"></div>
-              </section>
 
-              <section id="workspace-task-blocked-context-card" class="workspace-task-page-card" hidden>
-                <div class="workspace-task-page-card-header">
-                  <div>
-                    <div class="workspace-task-page-card-kicker">Blocked Context</div>
-                    <h2>Why the task paused</h2>
-                  </div>
-                </div>
-                <div class="workspace-task-blocked-reason">
-                  <div class="workspace-task-page-mini-label">Pause reason</div>
-                  <div id="workspace-task-blocked-reason" class="workspace-task-page-copy-block"></div>
-                </div>
-                <div id="workspace-task-blocked-request-wrap" class="workspace-task-blocked-request-wrap d-none">
-                  <div class="workspace-task-page-mini-label">Agent request</div>
-                  <div id="workspace-task-blocked-request-preview" class="workspace-task-page-copy-block"></div>
-                  <button type="button" id="workspace-task-blocked-request-toggle" class="workspace-task-page-text-button d-none" aria-expanded="false">View full request</button>
-                  <pre id="workspace-task-blocked-request" class="workspace-task-page-code-block d-none"></pre>
-                </div>
-              </section>
-
-              <section id="workspace-task-output-card" class="workspace-task-page-card" hidden>
-                <div class="workspace-task-page-card-header">
+                <div id="workspace-task-output-card" class="workspace-task-result-block" hidden>
+                  <div class="workspace-task-page-card-header workspace-task-result-block-header">
                   <div>
                     <div class="workspace-task-page-card-kicker">Result</div>
                     <h2>Latest result</h2>
@@ -317,6 +303,26 @@
                       <span>Create follow-up</span>
                     </button>
                   </div>
+                </div>
+                </div>
+              </section>
+
+              <section id="workspace-task-blocked-context-card" class="workspace-task-page-card" hidden>
+                <div class="workspace-task-page-card-header">
+                  <div>
+                    <div class="workspace-task-page-card-kicker">Blocked Context</div>
+                    <h2>Why the task paused</h2>
+                  </div>
+                </div>
+                <div class="workspace-task-blocked-reason">
+                  <div class="workspace-task-page-mini-label">Pause reason</div>
+                  <div id="workspace-task-blocked-reason" class="workspace-task-page-copy-block"></div>
+                </div>
+                <div id="workspace-task-blocked-request-wrap" class="workspace-task-blocked-request-wrap d-none">
+                  <div class="workspace-task-page-mini-label">Agent request</div>
+                  <div id="workspace-task-blocked-request-preview" class="workspace-task-page-copy-block"></div>
+                  <button type="button" id="workspace-task-blocked-request-toggle" class="workspace-task-page-text-button d-none" aria-expanded="false">View full request</button>
+                  <pre id="workspace-task-blocked-request" class="workspace-task-page-code-block d-none"></pre>
                 </div>
               </section>
 
@@ -3332,6 +3338,97 @@
 
     .workspace-task-overview-link:hover {
       color: var(--primary-color);
+    }
+
+    /* --- Merged brief + result card -------------------------------------- */
+
+    /* The brief leads the card: larger primary-colour text with no label
+       (the card kicker/heading already name it). position: relative anchors
+       the hover-revealed edit pencil to the top-right; padding-right keeps
+       wrapped text clear of it. */
+    .workspace-task-brief-lead {
+      position: relative;
+      padding-top: 0;
+      padding-right: 1.8rem;
+      border-top: 0;
+    }
+
+    .workspace-task-brief-lead-value {
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+
+    .workspace-task-brief-lead > .workspace-task-overview-edit-btn {
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+
+    /* Compact meta row: status, reference URL, agent, … as inline
+       "LABEL value" pairs separated by middots, replacing the tall stack of
+       bordered rows so the facts read in one glance. */
+    .workspace-task-brief-meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      row-gap: 0.45rem;
+      margin-top: 0.9rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+    }
+
+    .workspace-task-brief-meta-item {
+      position: relative;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.35rem;
+    }
+
+    .workspace-task-brief-meta-item:not(:last-child)::after {
+      content: "·";
+      margin: 0 0.55rem;
+      color: var(--text-secondary);
+    }
+
+    .workspace-task-brief-meta-label {
+      color: var(--text-secondary);
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .workspace-task-brief-meta-value {
+      color: var(--text-primary);
+      font-size: 0.88rem;
+      word-break: break-word;
+    }
+
+    .workspace-task-brief-meta-item .workspace-task-overview-edit-btn {
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+
+    .workspace-task-brief-meta-item:hover .workspace-task-overview-edit-btn,
+    .workspace-task-brief-meta-item:focus-within .workspace-task-overview-edit-btn {
+      opacity: 1;
+    }
+
+    /* The result block sits inside the same card as the brief, divided by a
+       hairline rather than a card gap. [hidden] keeps it (and its divider)
+       out until there's a result, so a brief-only card has no dangling rule. */
+    .workspace-task-result-block {
+      margin-top: 1.25rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border-color);
+    }
+
+    .workspace-task-result-block[hidden] {
+      display: none;
+    }
+
+    .workspace-task-result-block-header {
+      margin-bottom: 0.85rem;
     }
 
     .workspace-task-page-copy-block,

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -3668,6 +3668,202 @@
       outline: none;
     }
 
+    /* Floating toolbar shown when text inside a result is highlighted, so a
+       reader can act on just that span. position: fixed + JS-set top/left
+       (from the selection's bounding rect) keeps it anchored to the
+       selection and clear of the card's overflow clipping. */
+    .workspace-task-selection-popover {
+      position: fixed;
+      z-index: 10070;
+      display: flex;
+      gap: 0.15rem;
+      padding: 0.28rem;
+      border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+      border-radius: 12px;
+      background: color-mix(in srgb, var(--bg-primary) 98%, transparent);
+      box-shadow: 0 14px 36px rgba(10, 10, 10, 0.26);
+    }
+
+    .workspace-task-selection-action {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.4rem 0.6rem;
+      border: none;
+      border-radius: 9px;
+      background: transparent;
+      color: var(--text-primary);
+      font-size: 0.82rem;
+      font-weight: 700;
+      line-height: 1;
+      white-space: nowrap;
+      cursor: pointer;
+    }
+
+    .workspace-task-selection-action i {
+      font-size: 0.92rem;
+    }
+
+    .workspace-task-selection-action:hover,
+    .workspace-task-selection-action:focus-visible {
+      background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+      color: var(--primary-color);
+      outline: none;
+    }
+
+    /* Dialog shown when turning a selection into a subtask/follow-up or asking
+       about it. Self-contained (injected into <body>), so it carries its own
+       backdrop + centred card rather than relying on Bootstrap's modal. */
+    .workspace-task-selection-dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 10080;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.25rem;
+      background: rgba(8, 8, 10, 0.55);
+    }
+
+    .workspace-task-selection-dialog {
+      width: min(34rem, 100%);
+      max-height: calc(100vh - 2.5rem);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+      padding: 1.25rem;
+      border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+      border-radius: 16px;
+      background: var(--bg-primary);
+      box-shadow: 0 24px 60px rgba(8, 8, 10, 0.4);
+    }
+
+    .workspace-task-selection-dialog-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .workspace-task-selection-dialog-head h3 {
+      margin: 0;
+      font-family: "Fraunces", serif;
+      font-size: 1.15rem;
+      color: var(--text-primary);
+    }
+
+    .workspace-task-selection-dialog-close {
+      border: none;
+      background: none;
+      color: var(--text-secondary);
+      cursor: pointer;
+      padding: 0.2rem;
+      line-height: 1;
+    }
+
+    .workspace-task-selection-dialog-close:hover {
+      color: var(--text-primary);
+    }
+
+    .workspace-task-selection-dialog-excerpt {
+      margin: 0;
+      padding: 0.65rem 0.8rem;
+      border-left: 3px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+      border-radius: 0 8px 8px 0;
+      background: color-mix(in srgb, var(--primary-color) 7%, transparent);
+      color: var(--text-secondary);
+      font-size: 0.86rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .workspace-task-selection-dialog-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .workspace-task-selection-dialog-label {
+      color: var(--text-secondary);
+      font-size: 0.74rem;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .workspace-task-selection-dialog-segmented {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .workspace-task-selection-dialog-segment {
+      flex: 1 1 12rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.55rem 0.7rem;
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+      cursor: pointer;
+      color: var(--text-primary);
+      font-size: 0.88rem;
+      font-weight: 700;
+    }
+
+    .workspace-task-selection-dialog-segment:has(input:checked) {
+      border-color: color-mix(in srgb, var(--primary-color) 55%, var(--border-color));
+      background: color-mix(in srgb, var(--primary-color) 10%, transparent);
+      color: var(--primary-color);
+    }
+
+    .workspace-task-selection-dialog-presets {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+
+    .workspace-task-selection-dialog-preset {
+      padding: 0.32rem 0.7rem;
+      border: 1px solid var(--border-color);
+      border-radius: 999px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .workspace-task-selection-dialog-preset:hover {
+      border-color: color-mix(in srgb, var(--primary-color) 45%, var(--border-color));
+      color: var(--primary-color);
+    }
+
+    .workspace-task-selection-dialog-check {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-primary);
+      font-size: 0.9rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .workspace-task-selection-dialog-error {
+      color: var(--danger-color, #dc2626);
+      font-size: 0.84rem;
+      font-weight: 700;
+    }
+
+    .workspace-task-selection-dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      margin-top: 0.2rem;
+    }
+
     .workspace-task-page-text-button {
       margin-top: 0.75rem;
       border: none;

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -3577,6 +3577,52 @@
       outline-offset: 2px;
     }
 
+    /* Per-item action trigger (list items / bold-led paragraphs). Mirrors the
+       section action, but sits in a reserved RIGHT gutter so it never overlaps
+       the item text, and is revealed on hover/focus. */
+    .workspace-task-result-item {
+      position: relative;
+      padding-right: 2.4rem;
+    }
+
+    .workspace-task-result-item-action {
+      position: absolute;
+      top: 0.05rem;
+      right: 0;
+      z-index: 2;
+      width: 1.75rem;
+      height: 1.75rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid color-mix(in srgb, var(--primary-color) 24%, var(--border-color));
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+      color: var(--primary-color);
+      box-shadow: 0 8px 18px rgba(10, 10, 10, 0.08);
+      opacity: 0;
+      transform: translateX(0.25rem);
+      cursor: pointer;
+      transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+    }
+
+    .workspace-task-result-item:hover .workspace-task-result-item-action,
+    .workspace-task-result-item:focus-within .workspace-task-result-item-action,
+    .workspace-task-result-item-action:focus-visible {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    .workspace-task-result-item-action:hover {
+      border-color: color-mix(in srgb, var(--primary-color) 48%, var(--border-color));
+      background: color-mix(in srgb, var(--primary-color) 12%, var(--bg-primary));
+    }
+
+    .workspace-task-result-item-action:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--primary-color) 52%, transparent);
+      outline-offset: 2px;
+    }
+
     .workspace-task-result-section-action:disabled {
       cursor: wait;
       opacity: 1;


### PR DESCRIPTION
## Summary

Several task-details UI improvements. All changes are frontend
(`internal/web/static/js/modules/workspace-task*.js` and
`internal/web/templates/pages/workspace-task.tmpl`, plus a new module
`internal/web/static/js/modules/workspace-task-result-actions.js`).

1. **Web-search provenance badge** — the task Result card now shows a
   "Web search used" notification (when the `web_search` tool ran) or a muted
   "No web search" tag otherwise. Detection unions tool names from the persisted
   `execution_trace` and live task events.

2. **Merged brief + result card** — the "What this task does" (Overview) and
   "Latest result" cards were combined into one panel: it leads with the task
   brief, collapses status / reference-URL / agent into a compact meta row, and
   shows the result below a hairline divider. The blocked-context card moved
   after it. Inline details editing and the reference-URL modal trigger are
   preserved.

3. **Act on highlighted portions of a result** — highlighting any text in a
   result (or hovering a list item / bold-led paragraph) shows a floating
   toolbar:
   - **Task** → dialog to turn the selection into a child subtask OR a standalone
     follow-up (chosen per-create), with agent picker + run-now.
   - **Ask** → same dialog pre-framed as a question (Explain / Verify / Summarize
     presets).
   - **Research** → reuses the existing research modal seeded with the selection.
   - **Note** → saves just the selection as a workspace note.
   - **Copy**

   Subtasks POST with `parent_task_id` + `subtask_index` and refresh in place;
   follow-ups carry the result as input and navigate to the new task.

## Verification

Commands run from the repo root:

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — the changed packages pass, including `go test ./internal/web/`
  (which parses the modified template). The only failures observed in the full
  run are pre-existing, environment-only flakes unrelated to this frontend
  branch: `tests/e2e/TestSettingsEndpoint` ("agent not found" against a stale
  shared e2e data dir) and the `tests/user/workflows` tests when the
  `bin/ori-agent` binary isn't yet built — those workflow tests pass once the
  binary exists. No test files are changed in this branch.
- Frontend: `node --check` on all changed JS modules — pass; `npm run lint`
  (eslint) — the three changed modules
  (`workspace-task.js`, `workspace-task-execution-views.js`,
  `workspace-task-result-actions.js`) are clean. (The single remaining repo-wide
  eslint error is the pre-existing `eslint.config.js` self-parse quirk that also
  exists on `dev`.) This branch also adds the new module to the eslint module
  allowlist and fixes two lint defects it surfaced (an escaped NBSP in the
  selection regex and an unused `title` param).

> Note: the new interactive selection UI has been verified only at the
> syntax / build / template-parse level (`node --check`, `go test ./internal/web/`,
> `go build`). It has **not** yet been click-tested in a live browser.
