### PR TITLE
fix(frontend): workspace UI polish — task card, notes multi-select, slimmer navbar

### DIFF
--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -1232,15 +1232,24 @@
 
     var available = Boolean(els.thinkingModal);
     var embeddedPanel = isHomeAssistantEmbeddedPanel();
-    button.classList.toggle('d-none', !available);
-    button.disabled = !available;
+    // The navbar launcher is redundant on embedded-panel (workspace) pages,
+    // where the floating Workspace Assistant button already opens the chat;
+    // hide it there so it doesn't widen the nav bar. It remains the
+    // "Task Activity" launcher on other pages.
+    var visible = available && !embeddedPanel;
+    button.classList.toggle('d-none', !visible);
+    button.disabled = !visible;
 
     if (!available) {
       button.setAttribute('aria-hidden', 'true');
       return;
     }
 
-    button.removeAttribute('aria-hidden');
+    if (visible) {
+      button.removeAttribute('aria-hidden');
+    } else {
+      button.setAttribute('aria-hidden', 'true');
+    }
     if (embeddedPanel && !button.dataset.homeAssistantPanelBound) {
       button.dataset.homeAssistantPanelBound = 'true';
       button.removeAttribute('data-bs-toggle');

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -203,6 +203,8 @@ export class WorkspaceDetailPage {
     this.sessionsLoadFailed = false;
     this.files = [];
     this.notes = [];
+    // IDs of notes currently checked for bulk copy/delete actions.
+    this.selectedNoteIds = new Set();
     this.directories = [];
     this.schedules = [];
     this.children = [];
@@ -1023,8 +1025,8 @@ export class WorkspaceDetailPage {
       copyNotesBtn: document.getElementById('workspace-detail-copy-notes'),
       copyAllNotesBtn: document.getElementById('workspace-detail-copy-all-notes'),
       selectAllNotesBtn: document.getElementById('workspace-detail-select-all-notes'),
+      deleteSelectedNotesBtn: document.getElementById('workspace-detail-delete-selected-notes'),
       notesActions: document.getElementById('workspace-detail-notes-actions'),
-      notesCombinedText: document.getElementById('workspace-detail-notes-combined'),
       viewAllNotesLink: document.getElementById('workspace-detail-view-all-notes'),
       addDirectoryBtn: document.getElementById('workspace-detail-add-directory'),
       addMcpBtn: document.getElementById('workspace-detail-add-mcp'),
@@ -1370,8 +1372,9 @@ export class WorkspaceDetailPage {
     // Note buttons
     this.elements.addNoteBtn?.addEventListener('click', () => this.showNoteModal());
     this.elements.copyNotesBtn?.addEventListener('click', () => this.copyAllNotesToClipboard());
-    this.elements.copyAllNotesBtn?.addEventListener('click', () => this.copyAllNotesToClipboard());
-    this.elements.selectAllNotesBtn?.addEventListener('click', () => this.selectAllNotesText());
+    this.elements.selectAllNotesBtn?.addEventListener('click', () => this.toggleSelectAllNotes());
+    this.elements.copyAllNotesBtn?.addEventListener('click', () => this.copySelectedNotesToClipboard());
+    this.elements.deleteSelectedNotesBtn?.addEventListener('click', () => this.deleteSelectedNotes());
 
     // "View all" -> workspace notes app. The href is set here (not in the
     // template) because the workspace ID isn't known at server-render time.
@@ -13085,7 +13088,11 @@ export class WorkspaceDetailPage {
   renderNotes() {
     if (!this.elements.notesList) return;
 
-    this.setCombinedNotesText('');
+    // Drop selections for notes that no longer exist (e.g. after a reload).
+    const existingIds = new Set(this.notes.map(note => String(note.id)));
+    this.selectedNoteIds.forEach(id => {
+      if (!existingIds.has(id)) this.selectedNoteIds.delete(id);
+    });
 
     if (this.notes.length === 0) {
       this.elements.notesList.innerHTML = '<div class="workspace-detail-empty">No notes yet.</div>';
@@ -13099,8 +13106,15 @@ export class WorkspaceDetailPage {
         const preview = note.preview || note.content || '';
         const noteUrl = `/notes/${encodeURIComponent(note.id)}`;
         const vaultReference = this.normalizeVaultReference(note.vault_reference);
+        const isSelected = this.selectedNoteIds.has(String(note.id));
         return `
-	      <div class="workspace-detail-item" data-note-id="${note.id}">
+	      <div class="workspace-detail-item workspace-detail-note-item${isSelected ? ' is-selected' : ''}" data-note-id="${note.id}">
+	        <label class="workspace-detail-note-select-label" title="Select note" onclick="event.stopPropagation()">
+	          <input type="checkbox" class="workspace-detail-note-select" data-note-id="${note.id}" ${isSelected ? 'checked' : ''}
+	                 aria-label="Select note ${this.escapeHtml(title)}"
+	                 onclick="event.stopPropagation()"
+	                 onchange="window.workspaceDetail?.toggleNoteSelection('${note.id}', this.checked)">
+	        </label>
 	        ${
             vaultReference
               ? `
@@ -14414,31 +14428,182 @@ export class WorkspaceDetailPage {
 
   updateCopyNotesButtonState(isBusy = false) {
     const hasNotes = Array.isArray(this.notes) && this.notes.length > 0;
-    const disabled = Boolean(isBusy) || !hasNotes;
-    const copyTitle = isBusy
-      ? 'Copying notes...'
-      : hasNotes
-        ? 'Copy all note contents'
-        : 'No notes to copy';
 
-    [this.elements.copyNotesBtn, this.elements.copyAllNotesBtn].forEach(button => {
-      if (!button) return;
-      button.disabled = disabled;
-      button.title = copyTitle;
-    });
-
-    if (this.elements.selectAllNotesBtn) {
-      this.elements.selectAllNotesBtn.disabled = disabled;
-      this.elements.selectAllNotesBtn.title = isBusy
-        ? 'Loading notes...'
+    // Header "copy all" icon copies every note regardless of selection.
+    if (this.elements.copyNotesBtn) {
+      this.elements.copyNotesBtn.disabled = Boolean(isBusy) || !hasNotes;
+      this.elements.copyNotesBtn.title = isBusy
+        ? 'Copying notes...'
         : hasNotes
-          ? 'Select all note contents'
-          : 'No notes to select';
+          ? 'Copy all note contents'
+          : 'No notes to copy';
     }
 
     if (this.elements.notesActions) {
       this.elements.notesActions.hidden = !hasNotes;
     }
+
+    this.updateNotesSelectionUI(Boolean(isBusy));
+  }
+
+  /**
+   * Sync the selection-aware controls (Select all toggle, Copy (N),
+   * Delete (N)) and the per-card highlight/checkbox state to the current
+   * `selectedNoteIds` set.
+   */
+  updateNotesSelectionUI(isBusy = false) {
+    const notes = Array.isArray(this.notes) ? this.notes : [];
+    const total = notes.length;
+    const selectedCount = notes.reduce(
+      (count, note) => (this.selectedNoteIds.has(String(note.id)) ? count + 1 : count),
+      0
+    );
+    const allSelected = total > 0 && selectedCount === total;
+
+    if (this.elements.selectAllNotesBtn) {
+      const btn = this.elements.selectAllNotesBtn;
+      btn.disabled = isBusy || total === 0;
+      btn.textContent = allSelected ? 'Deselect all' : 'Select all';
+      btn.setAttribute('aria-pressed', allSelected ? 'true' : 'false');
+      btn.title = total === 0
+        ? 'No notes to select'
+        : allSelected
+          ? 'Clear selection'
+          : 'Select every note';
+    }
+
+    if (this.elements.copyAllNotesBtn) {
+      const btn = this.elements.copyAllNotesBtn;
+      btn.disabled = isBusy || selectedCount === 0;
+      btn.textContent = selectedCount > 0 ? `Copy (${selectedCount})` : 'Copy';
+      btn.title = selectedCount === 0
+        ? 'Select notes to copy'
+        : `Copy ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`;
+    }
+
+    if (this.elements.deleteSelectedNotesBtn) {
+      const btn = this.elements.deleteSelectedNotesBtn;
+      btn.disabled = isBusy || selectedCount === 0;
+      btn.textContent = selectedCount > 0 ? `Delete (${selectedCount})` : 'Delete';
+      btn.title = selectedCount === 0
+        ? 'Select notes to delete'
+        : `Delete ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`;
+    }
+
+    // Keep card highlight + checkbox state in sync without a full re-render.
+    if (this.elements.notesList) {
+      this.elements.notesList
+        .querySelectorAll('.workspace-detail-note-item[data-note-id]')
+        .forEach(item => {
+          const id = String(item.getAttribute('data-note-id'));
+          const selected = this.selectedNoteIds.has(id);
+          item.classList.toggle('is-selected', selected);
+          const checkbox = item.querySelector('.workspace-detail-note-select');
+          if (checkbox) checkbox.checked = selected;
+        });
+    }
+  }
+
+  toggleNoteSelection(noteId, checked) {
+    const id = String(noteId || '').trim();
+    if (!id) return;
+    if (checked) {
+      this.selectedNoteIds.add(id);
+    } else {
+      this.selectedNoteIds.delete(id);
+    }
+    this.updateNotesSelectionUI();
+  }
+
+  toggleSelectAllNotes() {
+    const notes = Array.isArray(this.notes) ? this.notes : [];
+    if (notes.length === 0) return;
+    const allSelected = notes.every(note => this.selectedNoteIds.has(String(note.id)));
+    if (allSelected) {
+      this.selectedNoteIds.clear();
+    } else {
+      notes.forEach(note => this.selectedNoteIds.add(String(note.id)));
+    }
+    this.updateNotesSelectionUI();
+  }
+
+  getSelectedNotes() {
+    const notes = Array.isArray(this.notes) ? this.notes : [];
+    return notes.filter(note => this.selectedNoteIds.has(String(note.id)));
+  }
+
+  async copySelectedNotesToClipboard() {
+    const selected = this.getSelectedNotes();
+    if (selected.length === 0) {
+      if (window.Toast) window.Toast.error('No notes selected');
+      return;
+    }
+
+    this.updateCopyNotesButtonState(true);
+    try {
+      await this.writeClipboardText(await this.buildAllNotesText(selected));
+      const message = `Copied ${selected.length} note${selected.length === 1 ? '' : 's'} to clipboard`;
+      if (typeof window.notifyToast === 'function') {
+        window.notifyToast(message, 'success');
+      } else if (window.Toast) {
+        window.Toast.success(message);
+      }
+    } catch (error) {
+      console.error('Failed to copy notes:', error);
+      if (typeof window.notifyToast === 'function') {
+        window.notifyToast('Failed to copy notes', 'error');
+      } else if (window.Toast) {
+        window.Toast.error('Failed to copy notes');
+      }
+    } finally {
+      this.updateCopyNotesButtonState(false);
+    }
+  }
+
+  async deleteSelectedNotes() {
+    const selected = this.getSelectedNotes();
+    if (selected.length === 0) {
+      if (window.Toast) window.Toast.error('No notes selected');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete ${selected.length} note${selected.length === 1 ? '' : 's'}? This cannot be undone.`
+    );
+    if (!confirmed) return;
+
+    this.updateCopyNotesButtonState(true);
+    let failures = 0;
+    for (const note of selected) {
+      try {
+        const response = await fetch(`/api/notes/${encodeURIComponent(note.id)}`, {
+          method: 'DELETE'
+        });
+        if (response.ok) {
+          this.selectedNoteIds.delete(String(note.id));
+        } else {
+          failures++;
+        }
+      } catch (error) {
+        console.error('Failed to delete note:', error);
+        failures++;
+      }
+    }
+
+    const deleted = selected.length - failures;
+    if (deleted > 0) {
+      const message = `Deleted ${deleted} note${deleted === 1 ? '' : 's'}`;
+      if (typeof window.notifyToast === 'function') {
+        window.notifyToast(message, 'success');
+      } else if (window.Toast) {
+        window.Toast.success(message);
+      }
+    }
+    if (failures > 0 && window.Toast) {
+      window.Toast.error(`Failed to delete ${failures} note${failures === 1 ? '' : 's'}`);
+    }
+
+    await this.loadNotes();
   }
 
   async writeClipboardText(text) {
@@ -14462,9 +14627,10 @@ export class WorkspaceDetailPage {
     if (!copied) throw new Error('Copy command failed');
   }
 
-  async buildAllNotesText() {
+  async buildAllNotesText(noteList = this.notes) {
+    const list = Array.isArray(noteList) ? noteList : [];
     const sections = await Promise.all(
-      this.notes.map(async (note, index) => {
+      list.map(async (note, index) => {
         const noteId = String(note?.id || '').trim();
         const title =
           String(note?.name || note?.title || `Note ${index + 1}`).trim() || `Note ${index + 1}`;
@@ -14491,40 +14657,6 @@ export class WorkspaceDetailPage {
     );
 
     return sections.join('\n\n---\n\n');
-  }
-
-  setCombinedNotesText(text) {
-    const field = this.elements.notesCombinedText;
-    if (!field) return;
-
-    field.value = text || '';
-    field.hidden = !text;
-  }
-
-  async selectAllNotesText() {
-    if (!this.notes || this.notes.length === 0) {
-      this.updateCopyNotesButtonState(false);
-      if (window.Toast) window.Toast.error('No notes to select');
-      return;
-    }
-
-    this.updateCopyNotesButtonState(true);
-    try {
-      const text = await this.buildAllNotesText();
-      this.setCombinedNotesText(text);
-      const field = this.elements.notesCombinedText;
-      if (field) {
-        field.focus();
-        field.select();
-        field.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      }
-      if (window.Toast) window.Toast.success('All note contents selected');
-    } catch (error) {
-      console.error('Failed to select notes:', error);
-      if (window.Toast) window.Toast.error('Failed to select notes');
-    } finally {
-      this.updateCopyNotesButtonState(false);
-    }
   }
 
   async copyAllNotesToClipboard() {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -4326,16 +4326,15 @@
 
     .workspace-detail-agent-sections {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      /* A single Tasks section per card — give it the full card width so long
+         task/step titles have room to breathe before truncating. minmax(0, 1fr)
+         keeps the track shrinkable so the title ellipsis still works. */
+      grid-template-columns: minmax(0, 1fr);
       gap: 0.55rem;
     }
 
     @media (max-width: 900px) {
       .workspace-detail-agent-info-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .workspace-detail-agent-sections {
         grid-template-columns: 1fr;
       }
     }
@@ -4346,6 +4345,11 @@
       border-radius: 8px;
       padding: 0.5rem;
       min-height: 120px;
+      /* Grid items default to min-width: auto, which lets a long nowrap task
+         title blow the 1fr track wider than the panel and force horizontal
+         scrolling. min-width: 0 lets the track shrink so the title's
+         text-overflow: ellipsis takes effect instead. */
+      min-width: 0;
       display: flex;
       flex-direction: column;
       gap: 0.4rem;

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -988,10 +988,10 @@
               </div>
               <div class="workspace-detail-panel-body" role="region" tabindex="0" aria-label="Notes panel content">
                 <div id="workspace-detail-notes-actions" class="workspace-detail-notes-actions" hidden>
-                  <button id="workspace-detail-copy-all-notes" class="workspace-detail-notes-action" type="button" aria-label="Copy all note contents" disabled>Copy all</button>
-                  <button id="workspace-detail-select-all-notes" class="workspace-detail-notes-action" type="button" aria-label="Select all note contents" disabled>Select all</button>
+                  <button id="workspace-detail-select-all-notes" class="workspace-detail-notes-action" type="button" aria-pressed="false" aria-label="Select all notes" disabled>Select all</button>
+                  <button id="workspace-detail-copy-all-notes" class="workspace-detail-notes-action" type="button" aria-label="Copy selected notes" disabled>Copy</button>
+                  <button id="workspace-detail-delete-selected-notes" class="workspace-detail-notes-action workspace-detail-notes-action-danger" type="button" aria-label="Delete selected notes" disabled>Delete</button>
                 </div>
-                <textarea id="workspace-detail-notes-combined" class="workspace-detail-notes-combined" readonly hidden aria-label="All note contents"></textarea>
                 <div id="workspace-detail-notes-list" class="workspace-detail-list">
                   <div class="workspace-detail-empty">No notes yet.</div>
                 </div>
@@ -3334,20 +3334,48 @@
       opacity: 0.55;
     }
 
-    .workspace-detail-notes-combined {
-      width: 100%;
-      min-height: 180px;
-      margin-top: 0.5rem;
-      padding: 0.65rem 0.75rem;
-      border: 1px solid var(--border-color);
-      border-radius: 6px;
-      background: var(--bg-primary);
-      color: var(--text-primary);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-      font-size: 0.76rem;
-      line-height: 1.45;
-      resize: vertical;
-      white-space: pre-wrap;
+    .workspace-detail-notes-action-danger {
+      color: #f87171;
+      border-color: rgba(248, 113, 113, 0.4);
+    }
+
+    .workspace-detail-notes-action-danger:hover:not(:disabled) {
+      background: rgba(248, 113, 113, 0.14);
+      border-color: #f87171;
+      color: #fca5a5;
+    }
+
+    /* Multi-select checkbox shown on each note card. Lives in the item's
+       left gutter (the item reserves padding-left for it). The compound
+       .workspace-detail-item.workspace-detail-note-item selector keeps these
+       rules ahead of the base .workspace-detail-item padding/background, which
+       is declared later in the stylesheet. */
+    .workspace-detail-item.workspace-detail-note-item {
+      padding-left: 2.2rem;
+    }
+
+    .workspace-detail-note-select-label {
+      position: absolute;
+      left: 0.6rem;
+      top: 0.58rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 2;
+      cursor: pointer;
+    }
+
+    .workspace-detail-note-select {
+      width: 15px;
+      height: 15px;
+      margin: 0;
+      cursor: pointer;
+      accent-color: var(--primary-color);
+    }
+
+    .workspace-detail-item.workspace-detail-note-item.is-selected {
+      border-color: var(--primary-color);
+      background: rgba(var(--primary-color-rgb, 255, 138, 86), 0.10);
     }
 
     .workspace-detail-agent-grid {


### PR DESCRIPTION
## Summary

Three focused frontend fixes for the workspace detail UI, all verified live (Playwright, dark + Retina).

- **Task card no longer scrolls horizontally** — `.workspace-detail-agent-section` is a grid item that defaulted to `min-width: auto`, letting long workflow/step titles blow the track past the panel. Added `min-width: 0` so the existing `text-overflow: ellipsis` activates, and collapsed the one-section sidebar grid from two columns to a single `minmax(0, 1fr)` so the task list uses the full card width.
- **Notes multi-select** — replaced the old "Select all" (which dumped every note's text into a hidden textarea and selected that text) with real selection of note items: a checkbox + selected highlight per card, a Select all / Deselect all toggle, and selection-aware **Copy (N)** / **Delete (N)** bulk actions (Delete confirms, then reloads). The header copy icon still copies all notes.
- **Slimmer navbar** — the navbar "Workspace Assistant" launcher was redundant on workspace pages (it only opened the floating bottom-right assistant) and widened the nav row enough to wrap. It's now hidden on embedded-panel pages while remaining the "Task Activity" launcher elsewhere.

## Commits
- `fix(frontend): stop workspace task card from scrolling horizontally`
- `feat(frontend): multi-select notes for bulk copy and delete`
- `fix(frontend): hide redundant Workspace Assistant navbar button`

## Testing
- ESLint clean on changed JS modules; `node --check` syntax OK
- `go build ./cmd/server` OK; `go test ./internal/web/...` passing
- Reproduced and visually verified each change in a running server via Playwright (dark theme, Retina)

🤖 Generated with [Claude Code](https://claude.com/claude-code)