### PR TITLE
feat(frontend): improve home dashboard layout and first-run flow

### DIFF
--- a/internal/web/static/css/common.css
+++ b/internal/web/static/css/common.css
@@ -1844,7 +1844,7 @@ h3, .h3 {
    ============================================ */
 
 .dashboard-shell-minimal {
-    max-width: 980px;
+    max-width: 1200px;
     margin: 0 auto;
 }
 
@@ -1855,7 +1855,7 @@ h3, .h3 {
 }
 
 .home-assistant-minimal-wrap {
-    max-width: 860px;
+    max-width: 920px;
     margin: 0 auto;
     display: flex;
     flex-direction: column;
@@ -1895,6 +1895,30 @@ h3, .h3 {
     margin-top: 0.35rem;
 }
 
+/* First-run secondary path — the structured "create a workspace" route,
+   ranked clearly below the Ask box rather than as a competing hero card. */
+.home-assistant-secondary {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted, var(--text-secondary));
+}
+
+.home-assistant-secondary-link {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.home-assistant-secondary-link:hover,
+.home-assistant-secondary-link:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
 /* =============================================================================
    Home dashboard — suggested prompt chips + adaptive dashboard sections
    ============================================================================= */
@@ -1931,7 +1955,7 @@ h3, .h3 {
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
-    max-width: 1180px;
+    max-width: none;
     margin: 0 auto;
 }
 
@@ -1964,11 +1988,11 @@ h3, .h3 {
 
 .home-section-title {
     margin: 0;
-    font-size: 0.85rem;
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    color: var(--text-primary);
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .home-section-link {
@@ -2041,10 +2065,33 @@ h3, .h3 {
     outline: none;
 }
 
+/* Card header: colored monogram avatar + workspace name, for quick scanning. */
+.home-workspace-card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.home-workspace-card-avatar {
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    display: grid;
+    place-items: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #fff;
+    background: hsl(var(--ws-hue, 160) 42% 42%);
+}
+
 .home-workspace-card-name {
     font-weight: 600;
     font-size: 0.95rem;
     color: var(--text-primary);
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -2172,55 +2219,7 @@ h3, .h3 {
     grid-column: 2 / 3;
 }
 
-/* First-run hero (shown when the user has zero workspaces). */
-.home-first-run-hero {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1.5rem;
-}
-
-.home-first-run-title {
-    color: var(--text-primary);
-    font-size: 2.2rem;
-    line-height: 1.08;
-    letter-spacing: 0;
-    text-wrap: balance;
-}
-
-.home-first-run-hero-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    max-width: 620px;
-}
-
-.home-first-run-subtitle {
-    max-width: 56ch;
-    color: var(--text-secondary);
-    font-size: 0.95rem;
-    line-height: 1.5;
-}
-
-.home-first-run-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-    flex-shrink: 0;
-}
-
 @media (max-width: 768px) {
-    .home-first-run-hero {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .home-first-run-actions {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .home-first-run-title,
     .home-assistant-minimal-title {
         font-size: 1.6rem;
     }

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -1403,7 +1403,7 @@
 
   function buildHomeAssistantPlaceholder(routeContext) {
     if (!routeContext) {
-      return document.getElementById('homeFirstRunHero') ? 'Plan a product launch…' : 'Ask Ori to do something…';
+      return document.querySelector('#homeAssistantCard[data-first-run="true"]') ? 'Plan a product launch…' : 'Ask Ori to do something…';
     }
     var displayName = getWorkspaceHomeAssistantDisplayName();
     var workspaceMode = getWorkspacePromptMode();
@@ -1417,7 +1417,7 @@
       if (workspaceMode === 'note') return 'Save a workspace note… (/task creates a task, /chat asks)';
       return 'Create a task for ' + displayName + '… (/chat asks, /note saves a note)';
     }
-    return document.getElementById('homeFirstRunHero') ? 'Plan a product launch…' : 'Ask Ori to do something…';
+    return document.querySelector('#homeAssistantCard[data-first-run="true"]') ? 'Plan a product launch…' : 'Ask Ori to do something…';
   }
 
   function renderHomeAssistantWorkspaceIdentity(routeContext) {

--- a/internal/web/static/js/modules/home-dashboard.js
+++ b/internal/web/static/js/modules/home-dashboard.js
@@ -129,6 +129,25 @@
     }
   }
 
+  // Deterministic accent hue (0–359) derived from a workspace's id/name, so
+  // each card gets a stable, recognizable color chip without persisting one.
+  function wsHue(seed) {
+    const s = String(seed || '');
+    let h = 0;
+    for (let i = 0; i < s.length; i++) {
+      h = (h * 31 + s.charCodeAt(i)) >>> 0;
+    }
+    return h % 360;
+  }
+
+  // 1–2 letter monogram from a workspace name for the card avatar.
+  function wsInitials(name) {
+    const parts = String(name || '').trim().split(/[\s._-]+/).filter(Boolean);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+
   function renderWorkspaceCards(workspaces) {
     const cards = workspaces.map((ws) => {
       const id = escapeHtml(ws.id || '');
@@ -138,9 +157,14 @@
       // `agent_instances` isn't on the list endpoint; fall back to `agents`.
       const agentCount = Array.isArray(ws.agents) ? ws.agents.length : 0;
       const countLabel = agentCount === 1 ? '1 agent' : `${agentCount} agents`;
+      const hue = wsHue(ws.id || ws.name || '');
+      const initials = escapeHtml(wsInitials(ws.name || ''));
       return `
-        <a href="/workspaces/${id}" class="home-workspace-card" data-role="workspace-card">
-          <div class="home-workspace-card-name">${name}</div>
+        <a href="/workspaces/${id}" class="home-workspace-card" data-role="workspace-card" style="--ws-hue: ${hue};">
+          <div class="home-workspace-card-head">
+            <span class="home-workspace-card-avatar" aria-hidden="true">${initials}</span>
+            <div class="home-workspace-card-name">${name}</div>
+          </div>
           ${desc ? `<div class="home-workspace-card-desc">${desc}</div>` : ''}
           <div class="home-workspace-card-meta">
             <span class="home-workspace-card-agents">${escapeHtml(countLabel)}</span>
@@ -313,18 +337,12 @@
   // ----- First-run actions -----
 
   function wireFirstRunActions() {
+    // First run now has a single secondary CTA (Create a workspace); the Ask
+    // box itself is the "describe a project" path, so there's no separate
+    // ask button to wire anymore.
     const startBtn = document.getElementById('homeFirstRunStart');
     if (startBtn) {
       startBtn.addEventListener('click', () => fireTTFA('first-run-start'));
-    }
-
-    const askBtn = document.getElementById('homeFirstRunAskBtn');
-    const input = document.getElementById('homeAssistantInput');
-    if (askBtn && input) {
-      askBtn.addEventListener('click', () => {
-        fireTTFA('first-run-ask');
-        input.focus();
-      });
     }
   }
 

--- a/internal/web/templates/components/dashboard.tmpl
+++ b/internal/web/templates/components/dashboard.tmpl
@@ -1,25 +1,11 @@
 <!-- Ori Dashboard - Prompt-first layout -->
 <div class="container-fluid py-5 dashboard-shell dashboard-shell-minimal">
-  {{if .Extra.IsFirstRun}}
-  <section id="homeFirstRunHero" class="modern-card p-4 p-md-5 mb-4 home-first-run-hero" aria-labelledby="homeFirstRunTitle">
-    <div class="home-first-run-hero-copy">
-      <div class="home-assistant-minimal-label">Start Here</div>
-      <h1 id="homeFirstRunTitle" class="home-first-run-title mb-0">Create your first workspace</h1>
-      <p class="home-first-run-subtitle mb-0">A workspace gives Ori the project, files, and tasks it needs to help you well.</p>
-    </div>
-    <div class="home-first-run-actions">
-      <a id="homeFirstRunStart" href="/workspaces?create=1" class="modern-btn modern-btn-primary home-first-run-cta-btn">Create Workspace</a>
-      <button id="homeFirstRunAskBtn" type="button" class="modern-btn modern-btn-secondary">Describe a Project Instead</button>
-    </div>
-  </section>
-  {{end}}
-
-  <div id="homeAssistantCard" class="modern-card p-4 p-md-5 mb-4 dashboard-home-card dashboard-home-card-minimal">
+  <div id="homeAssistantCard" class="modern-card p-4 p-md-5 mb-4 dashboard-home-card dashboard-home-card-minimal" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}">
     <div class="home-assistant-minimal-wrap">
-      <div class="home-assistant-minimal-label">Ask Ori</div>
-      <h1 class="home-assistant-minimal-title mb-0">{{if .Extra.IsFirstRun}}Or describe what you want help with{{else}}What should Ori do?{{end}}</h1>
+      <div class="home-assistant-minimal-label">{{if .Extra.IsFirstRun}}Welcome{{else}}Ask Ori{{end}}</div>
+      <h1 class="home-assistant-minimal-title mb-0">{{if .Extra.IsFirstRun}}What do you want to get done?{{else}}What should Ori do?{{end}}</h1>
       <p class="home-assistant-minimal-subtitle mb-0">
-        {{if .Extra.IsFirstRun}}Ori can turn a rough idea into a workspace-ready plan.{{else}}Enter a task and follow live progress in the thinking modal.{{end}}
+        {{if .Extra.IsFirstRun}}Describe a task and Ori turns it into a plan — or create a workspace to keep a project's tasks, notes, and files together.{{else}}Enter a task and Ori plans it, then runs it — showing each step as it goes.{{end}}
       </p>
       <form id="homeAssistantForm" class="home-assistant-form home-assistant-form-minimal">
         <label for="homeAssistantInput" class="visually-hidden">Ask Ori</label>
@@ -42,6 +28,16 @@
         <button type="button" class="home-prompt-chip" data-prompt="What should I work on today?">What should I work on today?</button>
         {{end}}
       </div>
+      {{if .Extra.IsFirstRun}}
+      <!-- First run: one secondary path to the structured route. The Ask box
+           above is the primary action; this offers the workspace flow without a
+           second competing hero card. -->
+      <div class="home-assistant-secondary">
+        <span class="home-assistant-secondary-or">or</span>
+        <a id="homeFirstRunStart" href="/workspaces?create=1" class="home-assistant-secondary-link">Create a workspace</a>
+        <span class="home-assistant-secondary-hint">to organize a project's tasks, notes, and files</span>
+      </div>
+      {{end}}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

A first pass on home-page usability following a design review. The page looked professional but felt sparse and hard to navigate. This change is **frontend embedded assets only** (CSS / JS / template) — no Go code.

1. **Layout + hierarchy** (`common.css`): widened the content shell 980px → 1200px to remove the large empty side gutters; section headings ("Recent workspaces", "Upcoming", "Recent activity") changed from tiny faint uppercase labels to 1rem normal-case primary-text, so the dashboard reads as real content.
2. **Merged the duplicate first-run CTAs** (`dashboard.tmpl`, `home-dashboard.js`, `dashboard.js`): the two competing hero cards ("Create your first workspace" + "Or describe what you want…") are now one card — the Ask box is primary, with a single secondary "Create a workspace" link. First-run detection was repointed from the deleted `#homeFirstRunHero` to a `data-first-run` flag, and the now-dead `.home-first-run-*` CSS was removed. Also dropped "thinking modal" jargon from the returning-user prompt subtitle.
3. **Workspace-card identity** (`home-dashboard.js`, `common.css`): recent-workspace cards now show a deterministic colored monogram avatar for quick scanning.

### Files changed (+99 / −86)
- `internal/web/static/css/common.css`
- `internal/web/static/js/modules/dashboard.js`
- `internal/web/static/js/modules/home-dashboard.js`
- `internal/web/templates/components/dashboard.tmpl`

## Verification

Commands run against this branch (from repo root):

- `go build ./...` — clean (assets are `go:embed`-ed; binary rebuilt).
- `go vet ./...` — clean.
- `npx eslint internal/web/static/js/modules/dashboard.js internal/web/static/js/modules/home-dashboard.js` — passed (exit 0). This is the CI lint gate (`npm run lint` = `eslint internal/web/static/js/`). Prettier warnings on these files are pre-existing and not part of the CI gate.
- `go test ./...` — one pre-existing failure (`tests/e2e` `TestSettingsEndpoint`, `404 "agent not found"`). Confirmed it fails identically on the clean `dev` baseline (`e1b5405c`) and is unrelated to this asset-only change.
- Visually verified the rendered page via headless Chrome in light and dark themes, in both first-run and populated states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)