### PR TITLE
feat(chat): default workspace chat to the workspace entry agent

### DIFF
--- a/internal/chathttp/commands_agent.go
+++ b/internal/chathttp/commands_agent.go
@@ -14,10 +14,14 @@ import (
 )
 
 func commandSessionModeLabel(resolution executionAgentResolution) string {
-	if resolution.isAssistantMode() {
+	switch {
+	case resolution.isAssistantMode():
 		return "Assistant"
+	case resolution.isWorkspaceEntryDefault():
+		return "Workspace entry agent"
+	default:
+		return "Pinned specialist"
 	}
-	return "Pinned specialist"
 }
 
 func commandExecutionAgentLabel(resolution executionAgentResolution) string {

--- a/internal/chathttp/commands_agent_test.go
+++ b/internal/chathttp/commands_agent_test.go
@@ -73,6 +73,26 @@ func TestHandleAgentsList_MarksAssistantWithoutCurrentMarker(t *testing.T) {
 	}
 }
 
+func TestCommandSessionModeLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		res  executionAgentResolution
+		want string
+	}{
+		{"assistant default", executionAgentResolution{Name: assistantExecutionAgentName, Source: executionAgentSourceAssistantDefault}, "Assistant"},
+		{"workspace entry default", executionAgentResolution{Name: "Workspace Manager", Source: executionAgentSourceWorkspaceEntry}, "Workspace entry agent"},
+		{"pinned via session binding", executionAgentResolution{Name: "Specialist", Source: executionAgentSourceSessionBinding}, "Pinned specialist"},
+		{"pinned via request override", executionAgentResolution{Name: "Specialist", Source: executionAgentSourceRequestOverride}, "Pinned specialist"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commandSessionModeLabel(tc.res); got != tc.want {
+				t.Fatalf("commandSessionModeLabel(%s) = %q, want %q", tc.res.Source, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHandleAgentStatus_UsesAssistantTerminology(t *testing.T) {
 	ch := newCommandHandlerForAgentTests()
 

--- a/internal/chathttp/execution_agent_resolver.go
+++ b/internal/chathttp/execution_agent_resolver.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"strings"
 
+	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 type chatSessionLookup interface {
 	GetSession(ctx context.Context, id string) (*session.Session, error)
+}
+
+// workspaceEntryLookup resolves a workspace by ID and reads its on-disk agent
+// snapshots so the chat resolver can default to the workspace's entry agent.
+// Implemented by workspace.Store.
+type workspaceEntryLookup interface {
+	Get(id string) (*workspace.Workspace, error)
+	GetWorkspaceAgent(workspaceID, agentName string) (*agent.Agent, bool, error)
 }
 
 type executionAgentSource string
@@ -18,6 +28,7 @@ const (
 	assistantExecutionAgentName                               = "Ori"
 	executionAgentSourceSessionBinding   executionAgentSource = "session_binding"
 	executionAgentSourceRequestOverride  executionAgentSource = "request_override"
+	executionAgentSourceWorkspaceEntry   executionAgentSource = "workspace_entry"
 	executionAgentSourceAssistantDefault executionAgentSource = "assistant_default"
 	executionAgentSourceFallbackFirst    executionAgentSource = "fallback_first_available"
 	executionAgentSourceUnavailable      executionAgentSource = "unresolved"
@@ -36,7 +47,15 @@ func (r executionAgentResolution) isResolved() bool {
 	return strings.TrimSpace(r.Name) != ""
 }
 
+// isAssistantMode reports whether the resolution represents the generic system
+// assistant rather than a concrete agent the user is talking to directly. A
+// workspace entry agent is a real agent, so it is never assistant mode — this
+// keeps workspace chats from being intercepted by the global assistant→
+// specialist handoff router.
 func (r executionAgentResolution) isAssistantMode() bool {
+	if r.Source == executionAgentSourceWorkspaceEntry {
+		return false
+	}
 	if !r.isResolved() {
 		return true
 	}
@@ -44,6 +63,12 @@ func (r executionAgentResolution) isAssistantMode() bool {
 		return true
 	}
 	return strings.EqualFold(strings.TrimSpace(r.Name), assistantExecutionAgentName)
+}
+
+// isWorkspaceEntryDefault reports whether the resolution defaulted to the
+// workspace's entry agent (as opposed to an explicit session/request binding).
+func (r executionAgentResolution) isWorkspaceEntryDefault() bool {
+	return r.Source == executionAgentSourceWorkspaceEntry
 }
 
 func agentExists(agentStore store.Store, agentName string) bool {
@@ -55,13 +80,54 @@ func agentExists(agentStore store.Store, agentName string) bool {
 	return ok && ag != nil
 }
 
+// resolveWorkspaceEntryAgentName returns the workspace's entry agent name when
+// it resolves to a runnable agent in the agent store, otherwise "".
+func resolveWorkspaceEntryAgentName(
+	workspaceLookup workspaceEntryLookup,
+	agentStore store.Store,
+	workspaceID string,
+) string {
+	if workspaceLookup == nil {
+		return ""
+	}
+
+	ws, err := workspaceLookup.Get(strings.TrimSpace(workspaceID))
+	if err != nil || ws == nil {
+		return ""
+	}
+
+	entry := strings.TrimSpace(ws.EntryAgentName())
+	if entry == "" {
+		return ""
+	}
+
+	// The entry agent is runnable if the global registry knows it, or if the
+	// workspace carries an on-disk agent snapshot. The chat runtime resolver
+	// (like task execution) resolves workspace agents snapshot-first, so a
+	// snapshot-only entry agent still answers — mirror that here rather than
+	// blocking the chat as "missing".
+	if agentExists(agentStore, entry) {
+		return entry
+	}
+	if _, ok, err := workspaceLookup.GetWorkspaceAgent(strings.TrimSpace(workspaceID), entry); err == nil && ok {
+		return entry
+	}
+
+	return ""
+}
+
 func resolveExecutionAgentName(
 	ctx context.Context,
 	sessionLookup chatSessionLookup,
 	agentStore store.Store,
+	workspaceLookup workspaceEntryLookup,
 	sessionID string,
 	requestedAgentName string,
+	workspaceID string,
 ) executionAgentResolution {
+	// 1. Honor an explicit session<->agent binding. This covers Direct agent
+	//    chat and workspace sessions already bound to their entry agent at
+	//    creation time.
 	if sessionLookup != nil && strings.TrimSpace(sessionID) != "" {
 		if sess, err := sessionLookup.GetSession(ctx, sessionID); err == nil && sess != nil {
 			if sessionAgent := strings.TrimSpace(sess.AgentName); sessionAgent != "" {
@@ -75,6 +141,7 @@ func resolveExecutionAgentName(
 		}
 	}
 
+	// 2. Honor an explicit per-request agent override.
 	if requested := strings.TrimSpace(requestedAgentName); requested != "" {
 		if agentExists(agentStore, requested) {
 			return executionAgentResolution{
@@ -84,6 +151,22 @@ func resolveExecutionAgentName(
 		}
 	}
 
+	// 3. Inside a workspace, the default conversational partner is the
+	//    workspace's entry agent. The generic system assistant is never used as
+	//    a workspace default: if the entry agent can't be resolved we leave the
+	//    resolution unresolved so the caller surfaces an actionable
+	//    "add an entry agent" error rather than silently answering as Ori.
+	if strings.TrimSpace(workspaceID) != "" {
+		if entry := resolveWorkspaceEntryAgentName(workspaceLookup, agentStore, workspaceID); entry != "" {
+			return executionAgentResolution{
+				Name:   entry,
+				Source: executionAgentSourceWorkspaceEntry,
+			}
+		}
+		return executionAgentResolution{Source: executionAgentSourceUnavailable}
+	}
+
+	// 4. Outside any workspace, fall back to the global system assistant (Ori).
 	if agentStore == nil {
 		return executionAgentResolution{Source: executionAgentSourceUnavailable}
 	}
@@ -102,9 +185,18 @@ func (h *Handler) resolveExecutionAgentName(
 	ctx context.Context,
 	sessionID string,
 	requestedAgentName string,
+	workspaceID string,
 ) executionAgentResolution {
 	if h == nil {
 		return executionAgentResolution{Source: executionAgentSourceUnavailable}
 	}
-	return resolveExecutionAgentName(ctx, h.sessionStore, h.store, sessionID, requestedAgentName)
+	return resolveExecutionAgentName(
+		ctx,
+		h.sessionStore,
+		h.store,
+		h.workspaceStore,
+		sessionID,
+		requestedAgentName,
+		workspaceID,
+	)
 }

--- a/internal/chathttp/execution_agent_resolver.go
+++ b/internal/chathttp/execution_agent_resolver.go
@@ -91,7 +91,9 @@ func resolveWorkspaceEntryAgentName(
 		return ""
 	}
 
-	ws, err := workspaceLookup.Get(strings.TrimSpace(workspaceID))
+	workspaceID = strings.TrimSpace(workspaceID)
+
+	ws, err := workspaceLookup.Get(workspaceID)
 	if err != nil || ws == nil {
 		return ""
 	}
@@ -109,7 +111,7 @@ func resolveWorkspaceEntryAgentName(
 	if agentExists(agentStore, entry) {
 		return entry
 	}
-	if _, ok, err := workspaceLookup.GetWorkspaceAgent(strings.TrimSpace(workspaceID), entry); err == nil && ok {
+	if _, ok, err := workspaceLookup.GetWorkspaceAgent(workspaceID, entry); err == nil && ok {
 		return entry
 	}
 

--- a/internal/chathttp/execution_agent_resolver_test.go
+++ b/internal/chathttp/execution_agent_resolver_test.go
@@ -2,10 +2,12 @@ package chathttp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 type executionAgentSessionLookupStub struct {
@@ -22,6 +24,45 @@ func (s *executionAgentSessionLookupStub) GetSession(_ context.Context, id strin
 	return nil, session.ErrSessionNotFound
 }
 
+type workspaceEntryLookupStub struct {
+	workspaces map[string]*workspace.Workspace
+	// snapshots maps workspaceID -> agentName -> on-disk agent snapshot.
+	snapshots map[string]map[string]*agent.Agent
+}
+
+func (s *workspaceEntryLookupStub) Get(id string) (*workspace.Workspace, error) {
+	if s == nil {
+		return nil, errors.New("workspace lookup unavailable")
+	}
+	if ws, ok := s.workspaces[id]; ok {
+		return ws, nil
+	}
+	return nil, errors.New("workspace not found")
+}
+
+func (s *workspaceEntryLookupStub) GetWorkspaceAgent(workspaceID, agentName string) (*agent.Agent, bool, error) {
+	if s == nil {
+		return nil, false, nil
+	}
+	if byWorkspace, ok := s.snapshots[workspaceID]; ok {
+		if ag, ok := byWorkspace[agentName]; ok {
+			return ag, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// newWorkspaceWithEntryAgent builds a workspace whose entry agent is the named
+// agent, via an entry-point agent instance.
+func newWorkspaceWithEntryAgent(entryAgent string) *workspace.Workspace {
+	return &workspace.Workspace{
+		AgentInstances: []workspace.AgentInstance{
+			{Name: entryAgent, EntryPoint: true},
+		},
+		Agents: []string{entryAgent},
+	}
+}
+
 func TestResolveExecutionAgentName_PrefersSessionBinding(t *testing.T) {
 	sessionLookup := &executionAgentSessionLookupStub{
 		sessions: map[string]*session.Session{
@@ -30,7 +71,7 @@ func TestResolveExecutionAgentName_PrefersSessionBinding(t *testing.T) {
 	}
 	agentStore := newPreflightStore("Session Agent", nil)
 
-	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, "sess-1", "Requested Agent")
+	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, nil, "sess-1", "Requested Agent", "")
 
 	if resolution.Name != "Session Agent" {
 		t.Fatalf("expected session-bound agent, got %q", resolution.Name)
@@ -46,7 +87,7 @@ func TestResolveExecutionAgentName_PrefersSessionBinding(t *testing.T) {
 func TestResolveExecutionAgentName_UsesRequestOverrideBeforeCompatibilityFallback(t *testing.T) {
 	agentStore := newPreflightStore("Requested Agent", nil)
 
-	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, "", "Requested Agent")
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, nil, "", "Requested Agent", "")
 
 	if resolution.Name != "Requested Agent" {
 		t.Fatalf("expected request agent, got %q", resolution.Name)
@@ -73,7 +114,7 @@ func TestResolveExecutionAgentName_SkipsMissingSessionBindingAndUsesRequestOverr
 		names: []string{"Requested Agent", assistantExecutionAgentName},
 	}
 
-	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, "sess-1", "Requested Agent")
+	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, nil, "sess-1", "Requested Agent", "")
 
 	if resolution.Name != "Requested Agent" {
 		t.Fatalf("expected request override after stale session binding, got %q", resolution.Name)
@@ -96,7 +137,7 @@ func TestResolveExecutionAgentName_SkipsMissingSessionBindingAndFallsBackToAssis
 		names: []string{assistantExecutionAgentName},
 	}
 
-	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, "sess-1", "")
+	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, nil, "sess-1", "", "")
 
 	if resolution.Name != assistantExecutionAgentName {
 		t.Fatalf("expected assistant fallback after stale session binding, got %q", resolution.Name)
@@ -114,7 +155,7 @@ func TestResolveExecutionAgentName_SkipsMissingRequestOverrideAndFallsBackToAssi
 		names: []string{assistantExecutionAgentName},
 	}
 
-	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, "", "Missing Agent")
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, nil, "", "Missing Agent", "")
 
 	if resolution.Name != assistantExecutionAgentName {
 		t.Fatalf("expected assistant fallback after stale request override, got %q", resolution.Name)
@@ -133,7 +174,7 @@ func TestResolveExecutionAgentName_PrefersAssistantDefaultOverCurrentAgent(t *te
 		names: []string{"Specialist", assistantExecutionAgentName},
 	}
 
-	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, "", "")
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, nil, "", "", "")
 
 	if resolution.Name != assistantExecutionAgentName {
 		t.Fatalf("expected Assistant runtime %q, got %q", assistantExecutionAgentName, resolution.Name)
@@ -149,7 +190,7 @@ func TestResolveExecutionAgentName_PrefersAssistantDefaultOverCurrentAgent(t *te
 func TestResolveExecutionAgentName_ReturnsUnresolvedWhenAssistantIsMissing(t *testing.T) {
 	agentStore := newPreflightStore("Fallback Agent", nil)
 
-	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, "", "")
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, nil, "", "", "")
 
 	if resolution.isResolved() {
 		t.Fatalf("expected unresolved result, got %q", resolution.Name)
@@ -160,12 +201,132 @@ func TestResolveExecutionAgentName_ReturnsUnresolvedWhenAssistantIsMissing(t *te
 }
 
 func TestResolveExecutionAgentName_ReturnsUnresolvedWhenNoAgentIsAvailable(t *testing.T) {
-	resolution := resolveExecutionAgentName(context.Background(), nil, nil, "", "")
+	resolution := resolveExecutionAgentName(context.Background(), nil, nil, nil, "", "", "")
 
 	if resolution.isResolved() {
 		t.Fatalf("expected unresolved result, got %q", resolution.Name)
 	}
 	if resolution.Source != executionAgentSourceUnavailable {
 		t.Fatalf("expected source %q, got %q", executionAgentSourceUnavailable, resolution.Source)
+	}
+}
+
+func TestResolveExecutionAgentName_WorkspaceDefaultsToEntryAgent(t *testing.T) {
+	// Both the entry agent and the global assistant exist in the store; inside a
+	// workspace the entry agent must win.
+	agentStore := &preflightStore{
+		agents: map[string]*agent.Agent{
+			"Workspace Manager":         {},
+			assistantExecutionAgentName: {},
+		},
+		names: []string{"Workspace Manager", assistantExecutionAgentName},
+	}
+	wsLookup := &workspaceEntryLookupStub{
+		workspaces: map[string]*workspace.Workspace{
+			"ws-1": newWorkspaceWithEntryAgent("Workspace Manager"),
+		},
+	}
+
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, wsLookup, "", "", "ws-1")
+
+	if resolution.Name != "Workspace Manager" {
+		t.Fatalf("expected workspace entry agent, got %q", resolution.Name)
+	}
+	if resolution.Source != executionAgentSourceWorkspaceEntry {
+		t.Fatalf("expected source %q, got %q", executionAgentSourceWorkspaceEntry, resolution.Source)
+	}
+	if resolution.isAssistantMode() {
+		t.Fatal("workspace entry agent must not be treated as Assistant mode")
+	}
+	if !resolution.isWorkspaceEntryDefault() {
+		t.Fatal("expected isWorkspaceEntryDefault to be true")
+	}
+}
+
+func TestResolveExecutionAgentName_WorkspaceNeverFallsBackToAssistant(t *testing.T) {
+	// The global assistant exists, but the workspace's entry agent is missing
+	// from the store AND has no on-disk snapshot. Inside a workspace we must NOT
+	// silently answer as Ori.
+	agentStore := &preflightStore{
+		agents: map[string]*agent.Agent{
+			assistantExecutionAgentName: {},
+		},
+		names: []string{assistantExecutionAgentName},
+	}
+	wsLookup := &workspaceEntryLookupStub{
+		workspaces: map[string]*workspace.Workspace{
+			"ws-1": newWorkspaceWithEntryAgent("Missing Manager"),
+		},
+	}
+
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, wsLookup, "", "", "ws-1")
+
+	if resolution.isResolved() {
+		t.Fatalf("expected unresolved inside workspace with missing entry agent, got %q", resolution.Name)
+	}
+	if resolution.Source != executionAgentSourceUnavailable {
+		t.Fatalf("expected source %q, got %q", executionAgentSourceUnavailable, resolution.Source)
+	}
+}
+
+func TestResolveExecutionAgentName_WorkspaceResolvesEntryAgentFromSnapshot(t *testing.T) {
+	// The entry agent is absent from the global registry but the workspace has
+	// an on-disk snapshot. The chat runtime resolves workspace agents
+	// snapshot-first, so the entry agent must still resolve (not be reported as
+	// missing) — this is the testjdas/test123 case.
+	agentStore := &preflightStore{
+		agents: map[string]*agent.Agent{
+			assistantExecutionAgentName: {},
+		},
+		names: []string{assistantExecutionAgentName},
+	}
+	wsLookup := &workspaceEntryLookupStub{
+		workspaces: map[string]*workspace.Workspace{
+			"ws-1": newWorkspaceWithEntryAgent("Workspace Manager"),
+		},
+		snapshots: map[string]map[string]*agent.Agent{
+			"ws-1": {"Workspace Manager": {}},
+		},
+	}
+
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, wsLookup, "", "", "ws-1")
+
+	if resolution.Name != "Workspace Manager" {
+		t.Fatalf("expected snapshot-backed entry agent, got %q", resolution.Name)
+	}
+	if resolution.Source != executionAgentSourceWorkspaceEntry {
+		t.Fatalf("expected source %q, got %q", executionAgentSourceWorkspaceEntry, resolution.Source)
+	}
+	if resolution.isAssistantMode() {
+		t.Fatal("snapshot-backed entry agent must not be treated as Assistant mode")
+	}
+}
+
+func TestResolveExecutionAgentName_WorkspaceSessionBindingWinsOverEntryAgent(t *testing.T) {
+	sessionLookup := &executionAgentSessionLookupStub{
+		sessions: map[string]*session.Session{
+			"sess-1": {AgentName: "Pinned Specialist"},
+		},
+	}
+	agentStore := &preflightStore{
+		agents: map[string]*agent.Agent{
+			"Pinned Specialist": {},
+			"Workspace Manager": {},
+		},
+		names: []string{"Pinned Specialist", "Workspace Manager"},
+	}
+	wsLookup := &workspaceEntryLookupStub{
+		workspaces: map[string]*workspace.Workspace{
+			"ws-1": newWorkspaceWithEntryAgent("Workspace Manager"),
+		},
+	}
+
+	resolution := resolveExecutionAgentName(context.Background(), sessionLookup, agentStore, wsLookup, "sess-1", "", "ws-1")
+
+	if resolution.Name != "Pinned Specialist" {
+		t.Fatalf("expected pinned session agent to win over entry agent, got %q", resolution.Name)
+	}
+	if resolution.Source != executionAgentSourceSessionBinding {
+		t.Fatalf("expected source %q, got %q", executionAgentSourceSessionBinding, resolution.Source)
 	}
 }

--- a/internal/chathttp/execution_agent_resolver_test.go
+++ b/internal/chathttp/execution_agent_resolver_test.go
@@ -269,6 +269,32 @@ func TestResolveExecutionAgentName_WorkspaceNeverFallsBackToAssistant(t *testing
 	}
 }
 
+func TestResolveExecutionAgentName_WorkspaceWithNoEntryAgentConfigured(t *testing.T) {
+	// The workspace exists but has no entry agent assigned at all
+	// (EntryAgentName() == ""). It must stay unresolved (so the caller surfaces
+	// the workspace error) and never fall back to the global assistant.
+	agentStore := &preflightStore{
+		agents: map[string]*agent.Agent{
+			assistantExecutionAgentName: {},
+		},
+		names: []string{assistantExecutionAgentName},
+	}
+	wsLookup := &workspaceEntryLookupStub{
+		workspaces: map[string]*workspace.Workspace{
+			"ws-1": {}, // empty workspace: no agents, no entry agent
+		},
+	}
+
+	resolution := resolveExecutionAgentName(context.Background(), nil, agentStore, wsLookup, "", "", "ws-1")
+
+	if resolution.isResolved() {
+		t.Fatalf("expected unresolved for workspace with no entry agent, got %q", resolution.Name)
+	}
+	if resolution.Source != executionAgentSourceUnavailable {
+		t.Fatalf("expected source %q, got %q", executionAgentSourceUnavailable, resolution.Source)
+	}
+}
+
 func TestResolveExecutionAgentName_WorkspaceResolvesEntryAgentFromSnapshot(t *testing.T) {
 	// The entry agent is absent from the global registry but the workspace has
 	// an on-disk snapshot. The chat runtime resolves workspace agents

--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -831,7 +831,7 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		"file_count": len(req.Files),
 		"session_id": sessionID,
 	})
-	executionAgent := h.resolveExecutionAgentName(r.Context(), sessionID, req.AgentName)
+	executionAgent := h.resolveExecutionAgentName(r.Context(), sessionID, req.AgentName, normalizedRouteContext.WorkspaceID)
 	if executionAgent.usesCompatibilityFallback() {
 		logger.Info("Chat request used compatibility execution-agent fallback", logger.Fields{
 			"agent_name": executionAgent.Name,
@@ -848,11 +848,17 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	if !executionAgent.isResolved() {
+		responseText := "❌ **Error**: Assistant is unavailable because no execution agent is configured. Configure a System Model so Assistant can be created, or use a session pinned to a specific agent."
+		reason := "no execution agent resolved"
+		if strings.TrimSpace(normalizedRouteContext.WorkspaceID) != "" {
+			responseText = "❌ **Error**: This workspace has no runnable entry agent. Add or repair the workspace's entry agent, then try again."
+			reason = "workspace has no runnable entry agent"
+		}
 		writeJSONResponse(w, attachRouteMetadata(map[string]any{
-			"response": "❌ **Error**: Assistant is unavailable because no execution agent is configured. Configure a System Model so Assistant can be created, or use a session pinned to a specific agent.",
+			"response": responseText,
 		}, chatRouteMetadata{
 			Mode:   routeModeAssistantChat,
-			Reason: "no execution agent resolved",
+			Reason: reason,
 		}))
 		return
 	}

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -1088,11 +1088,14 @@ const sessionManager = {
     this.chatAutoMode = (mode === 'auto');
 
     if (mode === 'auto') {
+      // Inside a workspace, "auto" means the workspace entry agent — not the
+      // generic system assistant — so label it as a plain chat.
+      const inWorkspace = Boolean(document.getElementById('chatWorkspaceSelect')?.value);
       if (this.chatLlmAvailable) {
         if (manualSection) manualSection.classList.add('d-none');
         if (autoSection) autoSection.classList.remove('d-none');
         if (llmWarning) llmWarning.classList.add('d-none');
-        if (createBtnText) createBtnText.textContent = 'Start Assistant';
+        if (createBtnText) createBtnText.textContent = inWorkspace ? 'Start Chat' : 'Start Assistant';
       } else {
         // LLM not available - show warning with action button
         if (manualSection) manualSection.classList.add('d-none');
@@ -1137,7 +1140,7 @@ const sessionManager = {
     if (!autoModeText) return;
 
     if (workspaceId) {
-      autoModeText.textContent = 'Assistant stays in this workspace and uses workspace context by default. Switch to Direct agent chat only when you want a specific agent profile.';
+      autoModeText.textContent = "You'll chat with this workspace's entry agent, which has the workspace context by default. Switch to Direct agent chat to talk to a different workspace agent.";
       return;
     }
 
@@ -1377,7 +1380,7 @@ const sessionManager = {
       if (!agentName) {
         if (window.Toast) {
           Toast.warning(workspaceId
-            ? 'No direct-chat agent is available in this workspace. Add an agent or use Assistant.'
+            ? "No direct-chat agent is available in this workspace. Add an agent, or switch to auto mode to use the workspace's entry agent."
             : 'No direct-chat agent is available. Add an agent or use Assistant.');
         }
         return;

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -1077,8 +1077,10 @@ const sessionManager = {
     }
   },
 
-  // Handle chat mode toggle change
-  handleChatModeChange(mode) {
+  // Handle chat mode toggle change. workspaceId, when provided by the caller,
+  // is the source of truth for workspace context (modal setup runs before the
+  // workspace <select> is populated); omit it to fall back to the live select.
+  handleChatModeChange(mode, workspaceId) {
     const manualSection = document.getElementById('chatManualSection');
     const autoSection = document.getElementById('chatAutoSection');
     const llmWarning = document.getElementById('chatLlmNotAvailableWarning');
@@ -1089,8 +1091,11 @@ const sessionManager = {
 
     if (mode === 'auto') {
       // Inside a workspace, "auto" means the workspace entry agent — not the
-      // generic system assistant — so label it as a plain chat.
-      const inWorkspace = Boolean(document.getElementById('chatWorkspaceSelect')?.value);
+      // generic system assistant — so label it as a plain chat. Prefer the
+      // explicit workspaceId; fall back to the live select for user toggles.
+      const inWorkspace = workspaceId !== undefined
+        ? Boolean(String(workspaceId).trim())
+        : Boolean(document.getElementById('chatWorkspaceSelect')?.value);
       if (this.chatLlmAvailable) {
         if (manualSection) manualSection.classList.add('d-none');
         if (autoSection) autoSection.classList.remove('d-none');
@@ -1163,16 +1168,17 @@ const sessionManager = {
       await this.checkChatLlmAvailability();
 
       // Default to Auto mode if System Model is configured, otherwise Manual
+      // (no workspace pre-selected here, so pass '' explicitly).
       if (this.chatSystemModelConfigured && this.chatLlmAvailable) {
         this.chatAutoMode = true;
         const autoRadio = document.getElementById('chatConfigModeAuto');
         if (autoRadio) autoRadio.checked = true;
-        this.handleChatModeChange('auto');
+        this.handleChatModeChange('auto', '');
       } else {
         this.chatAutoMode = false;
         const manualRadio = document.getElementById('chatConfigModeManual');
         if (manualRadio) manualRadio.checked = true;
-        this.handleChatModeChange('manual');
+        this.handleChatModeChange('manual', '');
       }
 
       // Clear initial message textareas
@@ -1235,17 +1241,19 @@ const sessionManager = {
       // Check LLM availability to determine default mode
       await this.checkChatLlmAvailability();
 
-      // Default to Auto mode if System Model is configured, otherwise Manual
+      // Default to Auto mode if System Model is configured, otherwise Manual.
+      // Pass workspaceId explicitly: this runs before the workspace <select>
+      // is populated, so a DOM read here would be stale.
       if (this.chatSystemModelConfigured && this.chatLlmAvailable) {
         this.chatAutoMode = true;
         const autoRadio = document.getElementById('chatConfigModeAuto');
         if (autoRadio) autoRadio.checked = true;
-        this.handleChatModeChange('auto');
+        this.handleChatModeChange('auto', workspaceId);
       } else {
         this.chatAutoMode = false;
         const manualRadio = document.getElementById('chatConfigModeManual');
         if (manualRadio) manualRadio.checked = true;
-        this.handleChatModeChange('manual');
+        this.handleChatModeChange('manual', workspaceId);
       }
 
       // Clear initial message textareas

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -14216,12 +14216,17 @@ export class WorkspaceDetailPage {
    */
   async createSimpleSession(openChat = true) {
     try {
+      // Inside a workspace the chat runs as the workspace's entry agent (the
+      // backend binds it when agent_name is omitted). Title the session after
+      // the entry agent so the UI reflects who you're talking to instead of a
+      // generic "Assistant".
+      const entryAgentName = String(this.workspace?.entry_agent_name || '').trim();
       const response = await fetch('/api/sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           folder_id: this.workspaceId,
-          title: 'Assistant'
+          title: entryAgentName || 'Workspace chat'
         })
       });
 
@@ -14230,7 +14235,7 @@ export class WorkspaceDetailPage {
       const payload = await response.json();
       const session = payload?.session || payload;
       if (!session?.id) throw new Error('Invalid session response');
-      if (window.Toast) window.Toast.success('Assistant session created');
+      if (window.Toast) window.Toast.success('Chat session created');
       await this.loadSessions();
 
       // Open the session


### PR DESCRIPTION
## Summary

Workspace chat now defaults to the **workspace's entry agent** (the workspace manager) instead of the generic global system assistant ("Ori"), and the generic Ori/Assistant mode is retired inside workspaces. **Global (non-workspace) chat is unchanged.**

**Why:** Opening a chat inside a workspace silently routed to the global "Ori" coordinator rather than the workspace's own entry agent. The entry-agent concept already existed everywhere else (task routing, diagnostics, session-create defaults), but the interactive chat resolver was workspace-blind.

## Key changes

- **`internal/chathttp/execution_agent_resolver.go`** — `resolveExecutionAgentName` now takes the route `workspace_id`. Resolution order: session binding → request override → workspace entry agent → (global Ori only when there is no workspace) → unresolved. Inside a workspace it never falls back to Ori. The entry agent is accepted if it exists in the global agent registry **or** as an on-disk workspace snapshot (`GetWorkspaceAgent`), matching the runtime resolver's snapshot-first behavior — so snapshot-only workspaces can still chat instead of erroring.
- **`internal/chathttp/handlers.go`** — threads `workspace_id` into the resolver; returns an actionable "This workspace has no runnable entry agent" error inside a workspace with no resolvable entry agent (instead of silently using Ori).
- **`internal/chathttp/commands_agent.go`** — `/agent` reports a workspace entry agent as "Workspace entry agent" rather than "Pinned specialist".
- **Frontend (`sessions.js`, `workspace-detail.js`)** — workspace chat sessions are titled after the entry agent; mode copy/labels reframed away from generic "Assistant".
- **Tests** — resolver workspace/snapshot cases added, plus a `commandSessionModeLabel` label test.

## Verification

Run from repo root on this branch:

- `go build ./...` — pass
- `go vet ./...` — clean
- `go test ./internal/chathttp/ ./internal/sessionhttp/` — pass
- `npm ci && npm run lint` (eslint over changed `internal/web/static/js/`) — clean
- `go test ./...` — only failure is the pre-existing, unrelated `tests/e2e/TestSettingsEndpoint` (404 "agent not found"; needs a seeded agent). It exists on `dev` and this branch touches neither `tests/e2e` nor settings code, so it is a known false positive.

Manually verified by running the server and driving `POST /api/chat`:
- workspace-with-entry resolves to its entry agent;
- snapshot-only entry agent (deleted from global registry) still resolves from the snapshot;
- no-entry-agent workspace returns the new actionable error;
- global chat unchanged;
- Direct-agent override still wins.

## Note for reviewer

This branch is currently **1 commit behind `dev`** (`#61` workspace UI polish), and that commit overlaps all four of this branch's frontend files (`workspace-hub.css`, `workspace-detail.js`, `workspace-detail.test.js`, `workspace-detail.tmpl`). A `dev`→branch merge may need conflict resolution before merging — left to the human merger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
