### PR TITLE
Workspace hub: launcher tree view, group details page, and workspace-aware linked folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Run frontend lint
         run: npm run lint
 
+      - name: Run frontend module tests
+        run: npm run test:modules
+
   test-unit:
     name: Unit Tests
     runs-on: ${{ matrix.os }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -142,6 +142,7 @@ export default defineConfig([
       'internal/web/static/js/modules/smartOnboarding.js',
       'internal/web/static/js/modules/studio-dashboard.js',
       'internal/web/static/js/modules/studio.js',
+      'internal/web/static/js/modules/group-detail.js',
       'internal/web/static/js/modules/workspace-detail.js',
       'internal/web/static/js/modules/workspace-detail-directory-explorer.js',
       'internal/web/static/js/modules/workspace-detail-file-modal.js',

--- a/internal/server/group_detail_test.go
+++ b/internal/server/group_detail_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// TestIsGroupWorkspace verifies the routing branch used by serveWorkspaceDetail:
+// group IDs are detected as groups, while concrete workspaces, missing IDs, and
+// an unavailable store are not (so they keep the standard workspace-detail path).
+func TestIsGroupWorkspace(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.Open(ctx, &database.Config{InMemory: true})
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := session.NewHybridStoreWithDB(db, 50)
+	now := time.Now()
+
+	createWorkspace(t, ctx, store, &session.Workspace{
+		ID: "grp", Name: "Clients", Kind: session.WorkspaceKindGroup,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	createWorkspace(t, ctx, store, &session.Workspace{
+		ID: "ws", Name: "Project", Kind: session.WorkspaceKindWorkspace,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	s := &Server{Storage: &StorageSystemFacade{SessionStore: store}}
+
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"group is detected", "grp", true},
+		{"concrete workspace is not a group", "ws", false},
+		{"missing id is not a group", "does-not-exist", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.isGroupWorkspace(tc.id); got != tc.want {
+				t.Errorf("isGroupWorkspace(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+
+	// An unavailable store must never panic and must report false.
+	empty := &Server{Storage: &StorageSystemFacade{}}
+	if empty.isGroupWorkspace("grp") {
+		t.Errorf("isGroupWorkspace with nil SessionStore = true, want false")
+	}
+}
+
+func createWorkspace(t *testing.T, ctx context.Context, store session.HybridStore, ws *session.Workspace) {
+	t.Helper()
+	if err := store.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("create workspace %q: %v", ws.ID, err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -423,12 +423,48 @@ func (s *Server) serveFocusedNotePage(w http.ResponseWriter, noteID string) {
 }
 
 func (s *Server) serveWorkspaceDetail(w http.ResponseWriter, workspaceID string) {
+	// Groups reuse the /workspaces/{id} path but render a dedicated details
+	// page. Detect the kind server-side; concrete workspaces, missing IDs, and
+	// an unavailable store all fall through to the standard workspace detail
+	// page, preserving existing behavior (FR4/FR5/FR6). The group page itself
+	// handles the trashed/not-found case client-side.
+	if s.isGroupWorkspace(workspaceID) {
+		s.serveGroupDetail(w, workspaceID)
+		return
+	}
+
 	data := s.prepareBasePageData("workspaces")
 	data.Title = "Workspace - Ori Agent"
 	data.BrandText = "Ori Agent"
 	data.ShowSidebarToggle = true
 	data.Extra["WorkspaceID"] = workspaceID
 	s.renderAndWritePage(w, "workspace-detail", data)
+}
+
+// isGroupWorkspace reports whether workspaceID refers to a group workspace.
+// Missing workspaces, concrete workspaces, and an unavailable session store all
+// return false so the caller keeps the standard workspace-detail behavior.
+func (s *Server) isGroupWorkspace(workspaceID string) bool {
+	if s.Storage == nil || s.Storage.SessionStore == nil {
+		return false
+	}
+	ws, err := s.Storage.SessionStore.GetWorkspace(context.Background(), workspaceID)
+	if err != nil || ws == nil {
+		return false
+	}
+	return ws.IsGroup()
+}
+
+// serveGroupDetail renders the dedicated group details page. The page is
+// client-rendered; it derives the group ID from the URL and loads data via the
+// workspace API, showing a not-found state if the group is missing or trashed.
+func (s *Server) serveGroupDetail(w http.ResponseWriter, groupID string) {
+	data := s.prepareBasePageData("workspaces")
+	data.Title = "Group - Ori Agent"
+	data.BrandText = "Ori Agent"
+	data.ShowSidebarToggle = true
+	data.Extra["WorkspaceID"] = groupID
+	s.renderAndWritePage(w, "group-detail", data)
 }
 
 func (s *Server) serveWorkspaceDiagnostics(w http.ResponseWriter, workspaceID string) {

--- a/internal/sessionhttp/workspace_group_test.go
+++ b/internal/sessionhttp/workspace_group_test.go
@@ -79,6 +79,62 @@ func TestCreateGroupCreatesFolderOnDisk(t *testing.T) {
 	}
 }
 
+func renameWorkspaceViaAPI(t *testing.T, handler *Handler, id, name string, wantCode int) {
+	t.Helper()
+	body := `{"name":"` + name + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/"+id+"/rename", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != wantCode {
+		t.Fatalf("rename %s: got %d, want %d: %s", id, w.Code, wantCode, w.Body.String())
+	}
+}
+
+// TestRenameGroupRenamesFolderOnDisk verifies the rename handler now renames a
+// group's backing folder (previously skipped for groups) and updates the DB
+// display name, with the file store resolving the group to its new path.
+func TestRenameGroupRenamesFolderOnDisk(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create workspace file store: %v", err)
+	}
+	handler.SetWorkspaceStore(fileStore)
+
+	groupID := createTestGroup(t, handler, "BK Nerds")
+	oldPath := filepath.Join(baseDir, "bk-nerds")
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("expected group folder at %s: %v", oldPath, err)
+	}
+
+	renameWorkspaceViaAPI(t, handler, groupID, "BK Wizards", http.StatusOK)
+
+	// DB display name updated.
+	ws, err := handler.store.GetWorkspace(context.Background(), groupID)
+	if err != nil {
+		t.Fatalf("load renamed group: %v", err)
+	}
+	if ws.Name != "BK Wizards" {
+		t.Fatalf("group name = %q, want %q", ws.Name, "BK Wizards")
+	}
+
+	// Folder renamed on disk: new slug exists, old slug gone.
+	newPath := filepath.Join(baseDir, "bk-wizards")
+	if info, err := os.Stat(newPath); err != nil || !info.IsDir() {
+		t.Fatalf("expected renamed group folder at %s, err=%v", newPath, err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("expected old group folder %s to be gone, err=%v", oldPath, err)
+	}
+	if got := mustHandlerFolderPath(t, fileStore, groupID); filepath.Clean(got) != filepath.Clean(newPath) {
+		t.Fatalf("group folder path = %q, want %q", got, newPath)
+	}
+}
+
 func mustHandlerFolderPath(t *testing.T, fs *agentworkspace.FileStore, id string) string {
 	t.Helper()
 	p, err := fs.GetFolderPath(id)

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -1396,8 +1396,17 @@ func (h *Handler) handleWorkspaceRename(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	// Rename the folder if folder-based store is available
-	if h.workspaceStore != nil && ws.Kind != session.WorkspaceKindGroup {
+	// Rename the backing folder when this workspace is tracked by the folder
+	// store. This now includes groups (a group is a folder that may physically
+	// contain members); RenameWithSlug rewrites nested members' paths. DB-only
+	// workspaces have no folder to rename and are skipped.
+	folderTracked := false
+	if h.workspaceStore != nil {
+		if existing, getErr := h.workspaceStore.Get(id); getErr == nil && existing != nil {
+			folderTracked = true
+		}
+	}
+	if folderTracked {
 		if err := h.workspaceStore.RenameWithSlug(id, req.Name, targetSlug); err != nil {
 			ws.Name = oldName
 			ws.FolderSlug = oldFolderSlug

--- a/internal/web/static/css/group-detail.css
+++ b/internal/web/static/css/group-detail.css
@@ -81,3 +81,125 @@
   border-color: var(--text-primary, #111);
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.12);
 }
+
+.group-member-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.group-member-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+}
+
+.group-member-open {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.group-member-kind {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary, #6c757d);
+  flex: 0 0 auto;
+}
+
+.group-member-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.group-member-desc,
+.group-member-meta {
+  color: var(--text-secondary, #6c757d);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.group-member-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex: 0 0 auto;
+}
+
+.group-member-move,
+.group-member-remove {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--surface, #fff);
+  color: var(--text-secondary, #6c757d);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.45rem;
+}
+
+.group-member-move[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.group-add-picker {
+  padding: 0.5rem;
+  border: 1px dashed var(--border, #e5e7eb);
+  border-radius: 8px;
+}
+
+.group-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.group-task-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.45rem 0.625rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.group-task-row:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.03));
+}
+
+.group-task-desc {
+  font-weight: 500;
+}
+
+.group-task-meta {
+  font-size: 0.78rem;
+  color: var(--text-secondary, #6c757d);
+}
+
+.group-detail-subtitle {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary, #6c757d);
+  margin-bottom: 0.5rem;
+}

--- a/internal/web/static/css/group-detail.css
+++ b/internal/web/static/css/group-detail.css
@@ -1,0 +1,83 @@
+/* Group Details Page
+   Styles for /workspaces/{id} when the workspace is a group. Reuses the shared
+   .modern-card / Bootstrap utilities; this file holds only group-specific bits. */
+
+.group-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.group-detail-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.group-detail-color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background: var(--accent, #6c757d);
+  flex: 0 0 auto;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.group-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary, #6c757d);
+  font-size: 0.875rem;
+}
+
+.group-detail-section {
+  margin-bottom: 1.5rem;
+}
+
+.group-detail-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.group-detail-empty {
+  color: var(--text-secondary, #6c757d);
+  font-size: 0.9rem;
+  padding: 0.75rem 0;
+}
+
+.group-detail-hint {
+  color: var(--text-secondary, #6c757d);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+#group-not-found {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.group-color-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.65rem;
+  line-height: 1;
+  color: var(--text-secondary, #6c757d);
+  background: var(--surface, #fff);
+}
+
+.group-color-btn.is-none {
+  border: 1px dashed var(--border, #ccc);
+}
+
+.group-color-btn.is-selected {
+  border-color: var(--text-primary, #111);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.12);
+}

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -2793,6 +2793,214 @@ button.hub-stat[hidden] {
   outline-offset: 6px;
 }
 
+.launcher-grid.is-tree-view {
+  display: block;
+}
+
+.launcher-tree {
+  width: 100%;
+  min-width: 0;
+  padding: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.launcher-tree-node {
+  min-width: 0;
+}
+
+.launcher-tree-children[hidden] {
+  display: none;
+}
+
+.launcher-tree-row {
+  position: relative;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  padding: 0.2rem 0.2rem 0.2rem calc(0.35rem + (var(--launcher-tree-depth, 0) * 1.2rem));
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.14s ease, border-color 0.14s ease, box-shadow 0.14s ease;
+}
+
+.launcher-tree-row:hover {
+  background: rgba(31, 107, 78, 0.07);
+  border-color: rgba(31, 107, 78, 0.18);
+}
+
+.launcher-tree-row:focus-visible {
+  outline: 2px solid var(--accent-primary, #1F6B4E);
+  outline-offset: 1px;
+  background: rgba(31, 107, 78, 0.09);
+}
+
+.launcher-tree-row[data-select-mode="1"] {
+  background: rgba(31, 107, 78, 0.035);
+}
+
+.launcher-tree-row.is-revealed {
+  box-shadow: 0 0 0 2px rgba(31, 107, 78, 0.32);
+}
+
+.launcher-tree-checkbox,
+.launcher-tree-checkbox-placeholder {
+  position: relative;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.launcher-tree-checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.launcher-tree-caret,
+.launcher-tree-caret-placeholder {
+  position: static;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.launcher-tree-row .launcher-tree-caret.launcher-group-toggle {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  position: static;
+  top: auto;
+  right: auto;
+  transform: none;
+}
+
+.launcher-tree-row .launcher-tree-caret.launcher-group-toggle:hover {
+  background: rgba(31, 107, 78, 0.1);
+  color: var(--text-primary);
+  border-color: transparent;
+}
+
+.launcher-tree-icon {
+  flex: 0 0 14px;
+  color: var(--text-secondary);
+}
+
+.launcher-tree-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.launcher-tree-delete.launcher-card-delete {
+  position: static;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  margin-left: auto;
+  border-radius: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transform: none;
+}
+
+.launcher-tree-row:hover .launcher-tree-delete,
+.launcher-tree-row:focus-within .launcher-tree-delete,
+.launcher-tree-delete:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.launcher-tree-row.is-drop-into {
+  border-color: rgba(31, 107, 78, 0.55);
+  background: rgba(31, 107, 78, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(31, 107, 78, 0.22);
+}
+
+.launcher-tree-row.is-drop-before::before,
+.launcher-tree-row.is-drop-after::after {
+  content: '';
+  position: absolute;
+  left: calc(0.35rem + (var(--launcher-tree-depth, 0) * 1.2rem));
+  right: 0.35rem;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent-primary, #1F6B4E);
+  box-shadow: 0 0 0 2px rgba(31, 107, 78, 0.16);
+}
+
+.launcher-tree-row.is-drop-before::before {
+  top: -2px;
+}
+
+.launcher-tree-row.is-drop-after::after {
+  bottom: -2px;
+}
+
+.launcher-tree-row.is-dragging {
+  opacity: 0.55;
+  cursor: grabbing;
+}
+
+.launcher-tree-empty-group {
+  margin-left: calc(0.35rem + (var(--launcher-tree-depth, 0) * 1.2rem));
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.launcher-tree-empty-group.is-drag-over,
+.launcher-tree-children.is-drag-over {
+  border-radius: 6px;
+  background: rgba(31, 107, 78, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(31, 107, 78, 0.18);
+}
+
+@media (max-width: 640px) {
+  .launcher-view-toggle {
+    width: 100%;
+    order: 3;
+  }
+
+  .launcher-view-toggle .hub-view-btn {
+    flex: 1 1 0;
+    justify-content: center;
+  }
+
+  .launcher-tree-row {
+    gap: 0.28rem;
+    padding-left: calc(0.3rem + (var(--launcher-tree-depth, 0) * 0.9rem));
+  }
+
+  .launcher-tree-row.is-drop-before::before,
+  .launcher-tree-row.is-drop-after::after {
+    left: calc(0.3rem + (var(--launcher-tree-depth, 0) * 0.9rem));
+  }
+}
+
 /* Grouped launcher sections */
 .launcher-group {
   display: flex;

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -2841,10 +2841,6 @@ button.hub-stat[hidden] {
   background: rgba(31, 107, 78, 0.09);
 }
 
-.launcher-tree-row[data-select-mode="1"] {
-  background: rgba(31, 107, 78, 0.035);
-}
-
 .launcher-tree-row.is-revealed {
   box-shadow: 0 0 0 2px rgba(31, 107, 78, 0.32);
 }
@@ -3170,12 +3166,8 @@ button.hub-stat[hidden] {
   outline-offset: 2px;
 }
 
-.launcher-card-item[data-select-mode="1"] {
+.launcher-card-item.has-selection-checkbox {
   padding-left: 2.4rem;
-}
-
-.launcher-group-header[data-select-mode="1"] {
-  padding-left: 1rem;
 }
 
 .launcher-card-checkbox {

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -3208,18 +3208,21 @@ button.hub-stat[hidden] {
   position: relative;
 }
 
-.launcher-card-checkbox input:focus + .launcher-card-checkmark {
+.launcher-card-checkbox input:focus + .launcher-card-checkmark,
+.launcher-tree-checkbox input:focus + .launcher-card-checkmark {
   outline: none;
   border-color: var(--accent-primary, #1F6B4E);
   box-shadow: 0 0 0 2px rgba(31, 107, 78, 0.25);
 }
 
-.launcher-card-checkbox input:checked + .launcher-card-checkmark {
+.launcher-card-checkbox input:checked + .launcher-card-checkmark,
+.launcher-tree-checkbox input:checked + .launcher-card-checkmark {
   background: rgba(31, 107, 78, 0.18);
   border-color: rgba(31, 107, 78, 0.6);
 }
 
-.launcher-card-checkbox input:checked + .launcher-card-checkmark::after {
+.launcher-card-checkbox input:checked + .launcher-card-checkmark::after,
+.launcher-tree-checkbox input:checked + .launcher-card-checkmark::after {
   content: '';
   position: absolute;
   left: 5px;

--- a/internal/web/static/js/modules/group-detail.js
+++ b/internal/web/static/js/modules/group-detail.js
@@ -48,6 +48,38 @@ export function directMembers(group) {
   return group && Array.isArray(group.children) ? group.children : [];
 }
 
+export function flattenTree(nodes) {
+  const out = [];
+  const walk = (list) => (list || []).forEach((node) => {
+    if (!node || !node.id) return;
+    out.push(node);
+    walk(node.children);
+  });
+  walk(nodes);
+  return out;
+}
+
+export function collectDescendantIds(node) {
+  const ids = new Set();
+  const walk = (n) => (n && Array.isArray(n.children) ? n.children : []).forEach((child) => {
+    if (!child || !child.id) return;
+    ids.add(child.id);
+    walk(child);
+  });
+  walk(node);
+  return ids;
+}
+
+// Workspaces/groups eligible to be added to `group`: everything except the
+// group itself, its descendants (which already include current direct members).
+// Move-ineligible linked workspaces are rejected server-side and surfaced then.
+export function eligibleAddTargets(tree, group) {
+  if (!group || !group.id) return [];
+  const excluded = collectDescendantIds(group);
+  excluded.add(group.id);
+  return flattenTree(tree).filter((node) => !excluded.has(node.id));
+}
+
 export function formatMemberCount(count) {
   return `${count} member${count === 1 ? '' : 's'}`;
 }
@@ -67,6 +99,78 @@ export function metadataChanges(group, next) {
   };
 }
 
+// --- Task roll-up helpers ------------------------------------------------------
+
+export const OPEN_TASK_STATUSES = new Set(['pending', 'assigned', 'in_progress', 'waiting_for_choice']);
+
+export function normalizeStatus(status) {
+  return String(status || '').trim().toLowerCase();
+}
+
+export function isOpenTask(task) {
+  return OPEN_TASK_STATUSES.has(normalizeStatus(task && task.status));
+}
+
+export function isScheduledTask(task) {
+  return !!(task && task.schedule);
+}
+
+// Earliest created_at (ms) a task may have to pass a date-range filter; null = any.
+export function taskCreatedCutoff(range, now = Date.now()) {
+  if (range === 'today') {
+    const d = new Date(now);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+  if (range === '7d') return now - 7 * 24 * 60 * 60 * 1000;
+  if (range === '30d') return now - 30 * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+// filters: { status: 'default'|'all'|<status>, member: 'all'|<id>, dateRange: 'any'|'today'|'7d'|'30d' }.
+// The default status view is the open + scheduled roll-up.
+export function taskMatchesFilters(task, filters = {}, now = Date.now()) {
+  if (!task) return false;
+  const status = filters.status || 'default';
+  if (status === 'default') {
+    if (!isOpenTask(task) && !isScheduledTask(task)) return false;
+  } else if (status !== 'all' && normalizeStatus(task.status) !== status) {
+    return false;
+  }
+
+  if (filters.member && filters.member !== 'all' && (task.__workspaceId || task.workspace_id) !== filters.member) {
+    return false;
+  }
+
+  const cutoff = taskCreatedCutoff(filters.dateRange || 'any', now);
+  if (cutoff !== null) {
+    const created = Date.parse(task.created_at);
+    if (Number.isNaN(created) || created < cutoff) return false;
+  }
+  return true;
+}
+
+// Sort the roll-up newest-first by created_at.
+export function sortTasksForRollup(tasks) {
+  return [...(tasks || [])].sort((a, b) => (Date.parse(b.created_at) || 0) - (Date.parse(a.created_at) || 0));
+}
+
+// --- Notes/files helpers -------------------------------------------------------
+
+// A workspace canvas attachment counts as a "file" when it carries file metadata.
+export function isFileAttachment(attachment) {
+  const meta = attachment && attachment.file_meta;
+  return !!(meta && (meta.name || meta.url));
+}
+
+export function extractFileItems(attachments) {
+  return (attachments || []).filter(isFileAttachment).map((attachment) => ({
+    id: attachment.id,
+    title: attachment.title || attachment.file_meta.name || 'File',
+    url: attachment.file_meta.url || '',
+  }));
+}
+
 // --- Page controller -----------------------------------------------------------
 
 export class GroupDetailPage {
@@ -76,11 +180,15 @@ export class GroupDetailPage {
     this.tree = [];
     this.els = {};
     this.selectedColor = '';
+    this.allTasks = [];
+    this.taskLoadFailures = 0;
+    this.taskFilters = { status: 'default', member: 'all', dateRange: 'any' };
   }
 
   async init() {
     this.cacheElements();
     this.bindEditForm();
+    this.bindMemberControls();
     await this.load();
   }
 
@@ -96,6 +204,14 @@ export class GroupDetailPage {
       memberCount: document.getElementById('group-member-count'),
       description: document.getElementById('group-description'),
       membersList: document.getElementById('group-members-list'),
+      membersError: document.getElementById('group-members-error'),
+      addMemberBtn: document.getElementById('group-add-member-btn'),
+      createMemberBtn: document.getElementById('group-create-member-btn'),
+      addPicker: document.getElementById('group-add-member-picker'),
+      createForm: document.getElementById('group-create-member-form'),
+      createName: document.getElementById('group-create-name'),
+      createDescription: document.getElementById('group-create-description'),
+      createCancel: document.getElementById('group-create-cancel'),
       tasksList: document.getElementById('group-tasks-list'),
       notesFilesList: document.getElementById('group-notes-files-list'),
       editBtn: document.getElementById('group-edit-btn'),
@@ -125,7 +241,10 @@ export class GroupDetailPage {
       this.group = node;
       document.title = `${node.name || 'Group'} - Ori Agent`;
       this.renderHeader();
+      this.renderMembers();
       this.renderSectionPlaceholders();
+      void this.loadTasks();
+      void this.loadNotesFiles();
     } catch (err) {
       console.error('Failed to load group:', err);
       this.showNotFound();
@@ -288,12 +407,380 @@ export class GroupDetailPage {
     return res;
   }
 
-  // Placeholder section bodies; replaced with real renderers in later tasks
-  // (members: 4.0, tasks: 5.0, notes/files: 6.0).
+  // --- Members (list, open, add, remove, reorder) ------------------------------
+
+  bindMemberControls() {
+    const { addMemberBtn, createMemberBtn, createForm, createCancel } = this.els;
+    if (addMemberBtn) addMemberBtn.addEventListener('click', () => this.openAddPicker());
+    if (createMemberBtn) createMemberBtn.addEventListener('click', () => this.openCreateMember());
+    if (createCancel) createCancel.addEventListener('click', () => this.closeCreateMember());
+    if (createForm) {
+      createForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        void this.createMember();
+      });
+    }
+  }
+
+  renderMembers() {
+    const container = this.els.membersList;
+    if (!container) return;
+
+    if (this.els.addMemberBtn) this.els.addMemberBtn.hidden = false;
+    if (this.els.createMemberBtn) this.els.createMemberBtn.hidden = false;
+    this.hideMembersError();
+
+    const members = directMembers(this.group);
+    if (members.length === 0) {
+      container.innerHTML = '<div class="group-detail-empty">No members yet. Add an existing workspace or create a new one.</div>';
+      return;
+    }
+
+    container.innerHTML = `<div class="group-member-list" role="list">${members.map((member, index) => this.memberRowHtml(member, index, members.length)).join('')}</div>`;
+    this.bindMemberActions();
+  }
+
+  memberRowHtml(member, index, total) {
+    const isGroup = isGroupNode(member);
+    const name = member.name || (isGroup ? 'Untitled Group' : 'Untitled Workspace');
+    const kindLabel = isGroup ? 'Group' : 'Workspace';
+    const meta = isGroup
+      ? formatMemberCount(directMembers(member).length)
+      : (member.status ? `Status: ${member.status}` : '');
+    const desc = member.description || '';
+    const safeId = escapeHtml(member.id);
+    const safeName = escapeHtml(name);
+
+    return `
+      <div class="group-member-row" role="listitem">
+        <button type="button" class="group-member-open" data-member-id="${safeId}" aria-label="Open ${safeName}">
+          <span class="group-member-kind">${kindLabel}</span>
+          <span class="group-member-name">${safeName}</span>
+          ${desc ? `<span class="group-member-desc">${escapeHtml(desc)}</span>` : ''}
+          ${meta ? `<span class="group-member-meta">${escapeHtml(meta)}</span>` : ''}
+        </button>
+        <div class="group-member-actions">
+          <button type="button" class="group-member-move" data-member-up="${safeId}" aria-label="Move ${safeName} up"${index === 0 ? ' disabled' : ''}>&uarr;</button>
+          <button type="button" class="group-member-move" data-member-down="${safeId}" aria-label="Move ${safeName} down"${index === total - 1 ? ' disabled' : ''}>&darr;</button>
+          <button type="button" class="group-member-remove" data-member-remove="${safeId}" aria-label="Remove ${safeName} from group">Remove</button>
+        </div>
+      </div>`;
+  }
+
+  bindMemberActions() {
+    const container = this.els.membersList;
+    if (!container) return;
+    container.querySelectorAll('[data-member-id]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        window.location.href = `/workspaces/${encodeURIComponent(btn.getAttribute('data-member-id'))}`;
+      });
+    });
+    container.querySelectorAll('[data-member-remove]').forEach((btn) => {
+      btn.addEventListener('click', () => void this.removeMember(btn.getAttribute('data-member-remove')));
+    });
+    container.querySelectorAll('[data-member-up]').forEach((btn) => {
+      btn.addEventListener('click', () => void this.moveMember(btn.getAttribute('data-member-up'), 'up'));
+    });
+    container.querySelectorAll('[data-member-down]').forEach((btn) => {
+      btn.addEventListener('click', () => void this.moveMember(btn.getAttribute('data-member-down'), 'down'));
+    });
+  }
+
+  async removeMember(memberId) {
+    if (!memberId) return;
+    // Removal moves the member to this group's parent (root if top-level); it
+    // never deletes the workspace/group.
+    const newParent = this.group.parent_id || '';
+    try {
+      await this.putJson(`/api/workspaces/${encodeURIComponent(memberId)}`, 'PATCH', { parent_id: newParent }, 'Failed to remove member');
+      await this.load();
+    } catch (err) {
+      console.error('Failed to remove member:', err);
+      this.showMembersError(err.message || 'Failed to remove member.');
+    }
+  }
+
+  async moveMember(memberId, direction) {
+    const members = directMembers(this.group).slice();
+    const i = members.findIndex((m) => m && m.id === memberId);
+    const j = direction === 'up' ? i - 1 : i + 1;
+    if (i < 0 || j < 0 || j >= members.length) return;
+    [members[i], members[j]] = [members[j], members[i]];
+
+    try {
+      // Persist a sequential order_index for the new order.
+      for (let k = 0; k < members.length; k += 1) {
+        await this.putJson(`/api/workspaces/${encodeURIComponent(members[k].id)}`, 'PATCH', { order_index: k + 1 }, 'Failed to reorder members');
+      }
+      await this.load();
+    } catch (err) {
+      console.error('Failed to reorder members:', err);
+      this.showMembersError(err.message || 'Failed to reorder members.');
+      // Reload so the UI matches the persisted state after a partial failure.
+      await this.load();
+    }
+  }
+
+  openAddPicker() {
+    const picker = this.els.addPicker;
+    if (!picker) return;
+    const targets = eligibleAddTargets(this.tree, this.group);
+    if (targets.length === 0) {
+      picker.innerHTML = '<div class="group-detail-empty">No eligible workspaces to add.</div>';
+      picker.hidden = false;
+      return;
+    }
+    const options = targets
+      .map((t) => `<option value="${escapeHtml(t.id)}">${escapeHtml(t.name || t.id)}${isGroupNode(t) ? ' (group)' : ''}</option>`)
+      .join('');
+    picker.innerHTML = `
+      <div class="d-flex gap-2 align-items-center">
+        <select id="group-add-select" class="form-select form-select-sm" aria-label="Workspace to add">${options}</select>
+        <button id="group-add-confirm" type="button" class="modern-btn modern-btn-primary">Add</button>
+        <button id="group-add-cancel" type="button" class="modern-btn modern-btn-secondary">Cancel</button>
+      </div>`;
+    picker.hidden = false;
+    picker.querySelector('#group-add-confirm').addEventListener('click', () => {
+      const sel = picker.querySelector('#group-add-select');
+      void this.addMember(sel && sel.value);
+    });
+    picker.querySelector('#group-add-cancel').addEventListener('click', () => {
+      picker.hidden = true;
+    });
+  }
+
+  async addMember(memberId) {
+    if (!memberId) return;
+    try {
+      await this.putJson(`/api/workspaces/${encodeURIComponent(memberId)}`, 'PATCH', { parent_id: this.groupId }, 'Failed to add member');
+      if (this.els.addPicker) this.els.addPicker.hidden = true;
+      await this.load();
+    } catch (err) {
+      console.error('Failed to add member:', err);
+      this.showMembersError(err.message || 'Failed to add member.');
+    }
+  }
+
+  // Create a new workspace directly into this group. Uses a self-contained
+  // inline form that POSTs to the same /api/workspaces endpoint with parent_id
+  // set to this group, so the new workspace lands as a direct member.
+  openCreateMember() {
+    if (this.els.addPicker) this.els.addPicker.hidden = true;
+    if (!this.els.createForm) return;
+    if (this.els.createName) this.els.createName.value = '';
+    if (this.els.createDescription) this.els.createDescription.value = '';
+    this.hideMembersError();
+    this.els.createForm.hidden = false;
+    if (this.els.createName) this.els.createName.focus();
+  }
+
+  closeCreateMember() {
+    if (this.els.createForm) this.els.createForm.hidden = true;
+  }
+
+  async createMember() {
+    const name = (this.els.createName?.value || '').trim();
+    const description = this.els.createDescription?.value || '';
+    if (!name) {
+      this.showMembersError('Workspace name is required.');
+      this.els.createName?.focus();
+      return;
+    }
+    try {
+      await this.putJson('/api/workspaces', 'POST', { name, description, parent_id: this.groupId }, 'Failed to create workspace');
+      this.closeCreateMember();
+      await this.load();
+    } catch (err) {
+      console.error('Failed to create workspace:', err);
+      this.showMembersError(err.message || 'Failed to create workspace.');
+    }
+  }
+
+  showMembersError(message) {
+    if (!this.els.membersError) return;
+    this.els.membersError.textContent = message;
+    this.els.membersError.hidden = false;
+  }
+
+  hideMembersError() {
+    if (this.els.membersError) this.els.membersError.hidden = true;
+  }
+
   renderSectionPlaceholders() {
-    const placeholder = '<div class="group-detail-empty">Coming soon.</div>';
-    if (this.els.membersList) this.els.membersList.innerHTML = placeholder;
-    if (this.els.tasksList) this.els.tasksList.innerHTML = placeholder;
-    if (this.els.notesFilesList) this.els.notesFilesList.innerHTML = placeholder;
+    if (this.els.tasksList) this.els.tasksList.innerHTML = '<div class="group-detail-empty">Loading tasks…</div>';
+    if (this.els.notesFilesList) this.els.notesFilesList.innerHTML = '<div class="group-detail-empty">Loading notes &amp; files…</div>';
+  }
+
+  // --- Notes & files roll-up (direct concrete members only) --------------------
+
+  async loadNotesFiles() {
+    if (!this.els.notesFilesList || !this.group) return;
+    const members = directMembers(this.group).filter((m) => !isGroupNode(m));
+
+    const noteResults = await Promise.allSettled(members.map(async (member) => {
+      const res = await fetch(`/api/workspaces/${encodeURIComponent(member.id)}/notes`);
+      if (!res.ok) throw new Error(`notes fetch failed: ${res.status}`);
+      const data = await res.json();
+      return (data.notes || []).map((note) => ({ ...note, __wsId: member.id, __wsName: member.name || member.id }));
+    }));
+
+    const fileResults = await Promise.allSettled(members.map(async (member) => {
+      const res = await fetch(`/api/workspaces/${encodeURIComponent(member.id)}`);
+      if (!res.ok) throw new Error(`files fetch failed: ${res.status}`);
+      const data = await res.json();
+      const attachments = data.attachments || (data.workspace && data.workspace.attachments) || [];
+      return extractFileItems(attachments).map((file) => ({ ...file, __wsId: member.id, __wsName: member.name || member.id }));
+    }));
+
+    const notes = [];
+    const files = [];
+    let failures = 0;
+    noteResults.forEach((r) => (r.status === 'fulfilled' ? notes.push(...r.value) : (failures += 1)));
+    fileResults.forEach((r) => (r.status === 'fulfilled' ? files.push(...r.value) : (failures += 1)));
+
+    this.renderNotesFiles(notes, files, failures);
+  }
+
+  renderNotesFiles(notes, files, failures) {
+    const container = this.els.notesFilesList;
+    if (!container) return;
+    const hasSubgroups = directMembers(this.group).some(isGroupNode);
+
+    const notesHtml = notes.length === 0
+      ? '<div class="group-detail-empty">No notes.</div>'
+      : `<div class="group-task-list" role="list">${notes.map((note) => this.noteRowHtml(note)).join('')}</div>`;
+    const filesHtml = files.length === 0
+      ? '<div class="group-detail-empty">No files.</div>'
+      : `<div class="group-task-list" role="list">${files.map((file) => this.fileRowHtml(file)).join('')}</div>`;
+
+    container.innerHTML = `
+      ${failures > 0 ? '<div class="text-warning small mb-2" role="alert">Some members’ notes or files could not be loaded.</div>' : ''}
+      ${hasSubgroups ? '<div class="group-detail-hint">Notes and files from member sub-groups are not included.</div>' : ''}
+      <h3 class="group-detail-subtitle">Notes</h3>
+      ${notesHtml}
+      <h3 class="group-detail-subtitle mt-3">Files</h3>
+      ${filesHtml}
+    `;
+  }
+
+  noteRowHtml(note) {
+    const wsId = note.__wsId || note.workspace_id;
+    const link = `/workspaces/${encodeURIComponent(wsId)}/notes/${encodeURIComponent(note.id)}`;
+    return `
+      <a class="group-task-row" role="listitem" href="${escapeHtml(link)}">
+        <span class="group-task-desc">${escapeHtml(note.name || 'Untitled note')}</span>
+        <span class="group-task-meta">${escapeHtml(note.__wsName || '')}</span>
+      </a>`;
+  }
+
+  fileRowHtml(file) {
+    const href = file.url || `/workspaces/${encodeURIComponent(file.__wsId)}`;
+    return `
+      <a class="group-task-row" role="listitem" href="${escapeHtml(href)}">
+        <span class="group-task-desc">${escapeHtml(file.title || 'File')}</span>
+        <span class="group-task-meta">${escapeHtml(file.__wsName || '')}</span>
+      </a>`;
+  }
+
+  // --- Tasks roll-up (default open + scheduled; status/created-date/member filters)
+
+  async loadTasks() {
+    if (!this.els.tasksList || !this.group) return;
+
+    // Direct concrete workspace members only; sub-group tasks are excluded in v1.
+    const members = directMembers(this.group).filter((m) => !isGroupNode(m));
+    const results = await Promise.allSettled(members.map(async (member) => {
+      const res = await fetch(`/api/orchestration/tasks?workspace_id=${encodeURIComponent(member.id)}`);
+      if (!res.ok) throw new Error(`tasks fetch failed: ${res.status}`);
+      const data = await res.json();
+      return (data.tasks || []).map((task) => ({
+        ...task,
+        __workspaceId: member.id,
+        __workspaceName: member.name || member.id,
+      }));
+    }));
+
+    const all = [];
+    let failures = 0;
+    results.forEach((r) => {
+      if (r.status === 'fulfilled') all.push(...r.value);
+      else failures += 1;
+    });
+    this.allTasks = all;
+    this.taskLoadFailures = failures;
+    this.renderTasks();
+  }
+
+  renderTasks() {
+    const container = this.els.tasksList;
+    if (!container) return;
+
+    const filtered = sortTasksForRollup(this.allTasks.filter((task) => taskMatchesFilters(task, this.taskFilters)));
+    const hasSubgroups = directMembers(this.group).some(isGroupNode);
+
+    container.innerHTML = `
+      ${this.taskFiltersHtml()}
+      ${this.taskLoadFailures > 0 ? '<div class="text-warning small mb-2" role="alert">Some members’ tasks could not be loaded.</div>' : ''}
+      ${hasSubgroups ? '<div class="group-detail-hint">Tasks from member sub-groups are not included.</div>' : ''}
+      ${filtered.length === 0
+        ? '<div class="group-detail-empty">No tasks match the current filters.</div>'
+        : `<div class="group-task-list" role="list">${filtered.map((task) => this.taskRowHtml(task)).join('')}</div>`}
+    `;
+    this.bindTaskFilters();
+  }
+
+  taskFiltersHtml() {
+    const members = directMembers(this.group).filter((m) => !isGroupNode(m));
+    const statuses = ['pending', 'assigned', 'in_progress', 'waiting_for_choice', 'completed', 'failed', 'cancelled'];
+    const sel = (cond) => (cond ? ' selected' : '');
+    const statusOptions = [
+      `<option value="default"${sel(this.taskFilters.status === 'default')}>Open + scheduled</option>`,
+      `<option value="all"${sel(this.taskFilters.status === 'all')}>All statuses</option>`,
+      ...statuses.map((s) => `<option value="${s}"${sel(this.taskFilters.status === s)}>${s}</option>`),
+    ].join('');
+    const memberOptions = [
+      `<option value="all"${sel(this.taskFilters.member === 'all')}>All members</option>`,
+      ...members.map((m) => `<option value="${escapeHtml(m.id)}"${sel(this.taskFilters.member === m.id)}>${escapeHtml(m.name || m.id)}</option>`),
+    ].join('');
+    const dates = [['any', 'Any time'], ['today', 'Created today'], ['7d', 'Created last 7 days'], ['30d', 'Created last 30 days']];
+    const dateOptions = dates.map(([v, l]) => `<option value="${v}"${sel(this.taskFilters.dateRange === v)}>${l}</option>`).join('');
+
+    return `
+      <div class="group-task-filters d-flex gap-2 flex-wrap mb-2">
+        <select id="group-task-status" class="form-select form-select-sm" aria-label="Filter tasks by status">${statusOptions}</select>
+        <select id="group-task-member" class="form-select form-select-sm" aria-label="Filter tasks by member workspace">${memberOptions}</select>
+        <select id="group-task-date" class="form-select form-select-sm" aria-label="Filter tasks by created date">${dateOptions}</select>
+      </div>`;
+  }
+
+  bindTaskFilters() {
+    const container = this.els.tasksList;
+    if (!container) return;
+    const bind = (id, key) => {
+      const el = container.querySelector(`#${id}`);
+      if (el) {
+        el.addEventListener('change', () => {
+          this.taskFilters[key] = el.value;
+          this.renderTasks();
+        });
+      }
+    };
+    bind('group-task-status', 'status');
+    bind('group-task-member', 'member');
+    bind('group-task-date', 'dateRange');
+  }
+
+  taskRowHtml(task) {
+    const desc = task.description || 'Untitled task';
+    const status = normalizeStatus(task.status);
+    const wsName = task.__workspaceName || '';
+    const scheduled = isScheduledTask(task) ? ' · scheduled' : '';
+    const wsId = task.__workspaceId || task.workspace_id;
+    const link = `/workspaces/${encodeURIComponent(wsId)}/task/${encodeURIComponent(task.id)}`;
+    return `
+      <a class="group-task-row" role="listitem" href="${escapeHtml(link)}">
+        <span class="group-task-desc">${escapeHtml(desc)}</span>
+        <span class="group-task-meta">${escapeHtml(wsName)} · ${escapeHtml(status)}${scheduled}</span>
+      </a>`;
   }
 }

--- a/internal/web/static/js/modules/group-detail.js
+++ b/internal/web/static/js/modules/group-detail.js
@@ -1,0 +1,299 @@
+/**
+ * Group Details Page
+ *
+ * Renders the dedicated details view for a group workspace at /workspaces/{id}.
+ * The page is client-rendered: it derives the group ID from the URL, loads the
+ * workspace tree, and renders the group header plus (in later tasks) member,
+ * task, and notes/files sections. Shows a not-found state when the id is missing,
+ * trashed, or not a group.
+ *
+ * @module group-detail
+ */
+
+// --- Pure helpers (exported for unit testing) ----------------------------------
+
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function normalizeWorkspaceKind(kind) {
+  return String(kind || '').trim().toLowerCase() === 'group' ? 'group' : 'workspace';
+}
+
+export function isGroupNode(node) {
+  return !!node && normalizeWorkspaceKind(node.kind) === 'group';
+}
+
+// Depth-first search for a node by id across a nested workspace tree.
+export function findWorkspaceNode(nodes, id) {
+  if (!id) return null;
+  const stack = Array.isArray(nodes) ? [...nodes] : [];
+  while (stack.length > 0) {
+    const node = stack.shift();
+    if (!node) continue;
+    if (node.id === id) return node;
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      stack.unshift(...node.children);
+    }
+  }
+  return null;
+}
+
+export function directMembers(group) {
+  return group && Array.isArray(group.children) ? group.children : [];
+}
+
+export function formatMemberCount(count) {
+  return `${count} member${count === 1 ? '' : 's'}`;
+}
+
+// Color choices for group metadata editing ('' = no color).
+export const GROUP_COLOR_PRESETS = ['', '#ef4444', '#f59e0b', '#10b981', '#3b82f6', '#8b5cf6', '#ec4899', '#6b7280'];
+
+// Decide which save calls an edit needs: the name uses the rename endpoint,
+// description/color use PATCH. Returns flags so callers only hit changed paths.
+export function metadataChanges(group, next) {
+  const cur = group || {};
+  return {
+    nameChanged: String(next.name ?? '') !== String(cur.name ?? ''),
+    metaChanged:
+      String(next.description ?? '') !== String(cur.description ?? '') ||
+      String(next.color ?? '') !== String(cur.color ?? ''),
+  };
+}
+
+// --- Page controller -----------------------------------------------------------
+
+export class GroupDetailPage {
+  constructor(groupId) {
+    this.groupId = groupId;
+    this.group = null;
+    this.tree = [];
+    this.els = {};
+    this.selectedColor = '';
+  }
+
+  async init() {
+    this.cacheElements();
+    this.bindEditForm();
+    await this.load();
+  }
+
+  cacheElements() {
+    this.els = {
+      view: document.getElementById('group-detail-view'),
+      notFound: document.getElementById('group-not-found'),
+      title: document.getElementById('group-title'),
+      breadcrumbName: document.getElementById('group-breadcrumb-name'),
+      parentCrumb: document.getElementById('group-parent-crumb'),
+      parentLink: document.getElementById('group-parent-link'),
+      colorSwatch: document.getElementById('group-color-swatch'),
+      memberCount: document.getElementById('group-member-count'),
+      description: document.getElementById('group-description'),
+      membersList: document.getElementById('group-members-list'),
+      tasksList: document.getElementById('group-tasks-list'),
+      notesFilesList: document.getElementById('group-notes-files-list'),
+      editBtn: document.getElementById('group-edit-btn'),
+      editForm: document.getElementById('group-edit-form'),
+      editName: document.getElementById('group-edit-name'),
+      editDescription: document.getElementById('group-edit-description'),
+      editColors: document.getElementById('group-edit-colors'),
+      editError: document.getElementById('group-edit-error'),
+      editSave: document.getElementById('group-edit-save'),
+      editCancel: document.getElementById('group-edit-cancel'),
+    };
+  }
+
+  async load() {
+    try {
+      const res = await fetch('/api/workspaces?tree=true');
+      if (!res.ok) throw new Error(`tree fetch failed: ${res.status}`);
+      const data = await res.json();
+      this.tree = data.workspaces || data.folders || [];
+
+      const node = findWorkspaceNode(this.tree, this.groupId);
+      if (!isGroupNode(node)) {
+        this.showNotFound();
+        return;
+      }
+
+      this.group = node;
+      document.title = `${node.name || 'Group'} - Ori Agent`;
+      this.renderHeader();
+      this.renderSectionPlaceholders();
+    } catch (err) {
+      console.error('Failed to load group:', err);
+      this.showNotFound();
+    }
+  }
+
+  showNotFound() {
+    if (this.els.view) this.els.view.hidden = true;
+    if (this.els.notFound) this.els.notFound.hidden = false;
+  }
+
+  renderHeader() {
+    const g = this.group;
+    const members = directMembers(g);
+    const name = g.name || 'Untitled Group';
+
+    if (this.els.title) this.els.title.textContent = name;
+    if (this.els.breadcrumbName) this.els.breadcrumbName.textContent = name;
+    if (this.els.memberCount) this.els.memberCount.textContent = formatMemberCount(members.length);
+    if (this.els.description) {
+      this.els.description.textContent = g.description || 'No description';
+    }
+    if (this.els.colorSwatch) {
+      this.els.colorSwatch.style.setProperty('--accent', g.color || '#6c757d');
+    }
+
+    // Parent-group breadcrumb (only when nested).
+    if (this.els.parentCrumb && this.els.parentLink) {
+      if (g.parent_id) {
+        const parent = findWorkspaceNode(this.tree, g.parent_id);
+        this.els.parentLink.href = `/workspaces/${encodeURIComponent(g.parent_id)}`;
+        this.els.parentLink.textContent = (parent && parent.name) ? parent.name : 'Parent group';
+        this.els.parentCrumb.hidden = false;
+      } else {
+        this.els.parentCrumb.hidden = true;
+      }
+    }
+
+    if (this.els.editBtn) this.els.editBtn.hidden = false;
+  }
+
+  // --- Metadata editing (name via rename endpoint; description/color via PATCH)
+
+  bindEditForm() {
+    const { editBtn, editForm, editCancel } = this.els;
+    if (editBtn) editBtn.addEventListener('click', () => this.openEditForm());
+    if (editCancel) editCancel.addEventListener('click', () => this.closeEditForm());
+    if (editForm) {
+      editForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        void this.saveMetadata();
+      });
+    }
+  }
+
+  openEditForm() {
+    if (!this.group || !this.els.editForm) return;
+    this.selectedColor = this.group.color || '';
+    if (this.els.editName) this.els.editName.value = this.group.name || '';
+    if (this.els.editDescription) this.els.editDescription.value = this.group.description || '';
+    this.renderColorSwatches();
+    this.hideEditError();
+    this.els.editForm.hidden = false;
+    if (this.els.editName) this.els.editName.focus();
+  }
+
+  closeEditForm() {
+    if (this.els.editForm) this.els.editForm.hidden = true;
+    this.hideEditError();
+  }
+
+  renderColorSwatches() {
+    const container = this.els.editColors;
+    if (!container) return;
+    container.innerHTML = '';
+    GROUP_COLOR_PRESETS.forEach((color) => {
+      const isSelected = color === this.selectedColor;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = `group-color-btn${isSelected ? ' is-selected' : ''}${color ? '' : ' is-none'}`;
+      btn.setAttribute('aria-label', color ? `Color ${color}` : 'No color');
+      btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+      if (color) {
+        btn.style.background = color;
+      } else {
+        btn.textContent = 'None';
+      }
+      btn.addEventListener('click', () => {
+        this.selectedColor = color;
+        this.renderColorSwatches();
+      });
+      container.appendChild(btn);
+    });
+  }
+
+  showEditError(message) {
+    if (!this.els.editError) return;
+    this.els.editError.textContent = message;
+    this.els.editError.hidden = false;
+  }
+
+  hideEditError() {
+    if (this.els.editError) this.els.editError.hidden = true;
+  }
+
+  setEditBusy(busy) {
+    if (this.els.editSave) {
+      this.els.editSave.disabled = busy;
+      this.els.editSave.textContent = busy ? 'Saving...' : 'Save';
+    }
+  }
+
+  async saveMetadata() {
+    if (!this.group) return;
+
+    const name = (this.els.editName?.value || '').trim();
+    const description = this.els.editDescription?.value || '';
+    const color = this.selectedColor || '';
+
+    if (!name) {
+      this.showEditError('Name is required.');
+      this.els.editName?.focus();
+      return;
+    }
+
+    const { nameChanged, metaChanged } = metadataChanges(this.group, { name, description, color });
+    if (!nameChanged && !metaChanged) {
+      this.closeEditForm();
+      return;
+    }
+
+    this.setEditBusy(true);
+    try {
+      if (nameChanged) {
+        await this.putJson(`/api/workspaces/${encodeURIComponent(this.groupId)}/rename`, 'POST', { name }, 'Failed to rename group');
+      }
+      if (metaChanged) {
+        await this.putJson(`/api/workspaces/${encodeURIComponent(this.groupId)}`, 'PATCH', { description, color }, 'Failed to update group');
+      }
+      this.closeEditForm();
+      await this.load();
+    } catch (err) {
+      console.error('Failed to save group metadata:', err);
+      this.showEditError(err.message || 'Failed to save changes.');
+    } finally {
+      this.setEditBusy(false);
+    }
+  }
+
+  async putJson(url, method, body, failMessage) {
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(text || failMessage);
+    }
+    return res;
+  }
+
+  // Placeholder section bodies; replaced with real renderers in later tasks
+  // (members: 4.0, tasks: 5.0, notes/files: 6.0).
+  renderSectionPlaceholders() {
+    const placeholder = '<div class="group-detail-empty">Coming soon.</div>';
+    if (this.els.membersList) this.els.membersList.innerHTML = placeholder;
+    if (this.els.tasksList) this.els.tasksList.innerHTML = placeholder;
+    if (this.els.notesFilesList) this.els.notesFilesList.innerHTML = placeholder;
+  }
+}

--- a/internal/web/static/js/modules/group-detail.test.js
+++ b/internal/web/static/js/modules/group-detail.test.js
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  escapeHtml,
+  normalizeWorkspaceKind,
+  isGroupNode,
+  findWorkspaceNode,
+  directMembers,
+  formatMemberCount,
+  metadataChanges,
+} from './group-detail.js';
+
+const tree = [
+  {
+    id: 'g1',
+    kind: 'group',
+    name: 'Clients',
+    children: [
+      { id: 'w1', kind: 'workspace', name: 'Acme' },
+      {
+        id: 'g2',
+        kind: 'group',
+        name: 'Archive',
+        children: [{ id: 'w2', kind: 'workspace', name: 'Old' }],
+      },
+    ],
+  },
+  { id: 'w3', kind: 'workspace', name: 'Personal' },
+];
+
+test('normalizeWorkspaceKind maps only "group" to group', () => {
+  assert.equal(normalizeWorkspaceKind('group'), 'group');
+  assert.equal(normalizeWorkspaceKind(' GROUP '), 'group');
+  assert.equal(normalizeWorkspaceKind('workspace'), 'workspace');
+  assert.equal(normalizeWorkspaceKind(undefined), 'workspace');
+});
+
+test('isGroupNode reflects the node kind', () => {
+  assert.equal(isGroupNode({ kind: 'group' }), true);
+  assert.equal(isGroupNode({ kind: 'workspace' }), false);
+  assert.equal(isGroupNode(null), false);
+});
+
+test('findWorkspaceNode locates nodes at any depth', () => {
+  assert.equal(findWorkspaceNode(tree, 'g1').name, 'Clients');
+  assert.equal(findWorkspaceNode(tree, 'w2').name, 'Old');
+  assert.equal(findWorkspaceNode(tree, 'g2').name, 'Archive');
+  assert.equal(findWorkspaceNode(tree, 'missing'), null);
+  assert.equal(findWorkspaceNode(tree, ''), null);
+});
+
+test('directMembers returns the group children', () => {
+  const g = findWorkspaceNode(tree, 'g1');
+  assert.deepEqual(directMembers(g).map((m) => m.id), ['w1', 'g2']);
+  assert.deepEqual(directMembers({}), []);
+});
+
+test('formatMemberCount pluralizes', () => {
+  assert.equal(formatMemberCount(0), '0 members');
+  assert.equal(formatMemberCount(1), '1 member');
+  assert.equal(formatMemberCount(3), '3 members');
+});
+
+test('escapeHtml escapes markup', () => {
+  assert.equal(escapeHtml('<b>&"\''), '&lt;b&gt;&amp;&quot;&#39;');
+});
+
+test('metadataChanges flags only the fields that changed', () => {
+  const group = { name: 'Clients', description: 'VIP', color: '#3b82f6' };
+
+  assert.deepEqual(metadataChanges(group, { name: 'Clients', description: 'VIP', color: '#3b82f6' }), {
+    nameChanged: false,
+    metaChanged: false,
+  });
+  assert.deepEqual(metadataChanges(group, { name: 'Renamed', description: 'VIP', color: '#3b82f6' }), {
+    nameChanged: true,
+    metaChanged: false,
+  });
+  assert.deepEqual(metadataChanges(group, { name: 'Clients', description: 'New', color: '#3b82f6' }), {
+    nameChanged: false,
+    metaChanged: true,
+  });
+  assert.deepEqual(metadataChanges(group, { name: 'Clients', description: 'VIP', color: '' }), {
+    nameChanged: false,
+    metaChanged: true,
+  });
+  // Missing fields are treated as empty strings, not changes.
+  assert.deepEqual(metadataChanges({ name: 'X' }, { name: 'X' }), {
+    nameChanged: false,
+    metaChanged: false,
+  });
+});

--- a/internal/web/static/js/modules/group-detail.test.js
+++ b/internal/web/static/js/modules/group-detail.test.js
@@ -8,6 +8,16 @@ import {
   directMembers,
   formatMemberCount,
   metadataChanges,
+  flattenTree,
+  collectDescendantIds,
+  eligibleAddTargets,
+  isOpenTask,
+  isScheduledTask,
+  taskCreatedCutoff,
+  taskMatchesFilters,
+  sortTasksForRollup,
+  isFileAttachment,
+  extractFileItems,
 } from './group-detail.js';
 
 const tree = [
@@ -63,6 +73,94 @@ test('formatMemberCount pluralizes', () => {
 
 test('escapeHtml escapes markup', () => {
   assert.equal(escapeHtml('<b>&"\''), '&lt;b&gt;&amp;&quot;&#39;');
+});
+
+test('isOpenTask / isScheduledTask classify the roll-up defaults', () => {
+  assert.equal(isOpenTask({ status: 'in_progress' }), true);
+  assert.equal(isOpenTask({ status: 'IN_PROGRESS' }), true);
+  assert.equal(isOpenTask({ status: 'completed' }), false);
+  assert.equal(isScheduledTask({ schedule: { cron: '* * * * *' } }), true);
+  assert.equal(isScheduledTask({ status: 'completed' }), false);
+});
+
+test('taskCreatedCutoff returns range boundaries', () => {
+  const now = Date.parse('2026-06-08T12:00:00Z');
+  assert.equal(taskCreatedCutoff('any', now), null);
+  assert.equal(taskCreatedCutoff('7d', now), now - 7 * 86400000);
+  assert.equal(taskCreatedCutoff('30d', now), now - 30 * 86400000);
+  assert.ok(taskCreatedCutoff('today', now) <= now);
+});
+
+test('taskMatchesFilters applies status, member, and created-date filters', () => {
+  const now = Date.parse('2026-06-08T12:00:00Z');
+  // created_at relative to `now` so date-range assertions are timezone-robust.
+  const open = { status: 'pending', __workspaceId: 'w1', created_at: new Date(now).toISOString() };
+  const done = { status: 'completed', __workspaceId: 'w2', created_at: '2026-01-01T00:00:00Z' };
+  const sched = { status: 'completed', schedule: { cron: '0 9 * * *' }, __workspaceId: 'w1', created_at: new Date(now).toISOString() };
+
+  // Default = open + scheduled.
+  assert.equal(taskMatchesFilters(open, { status: 'default' }, now), true);
+  assert.equal(taskMatchesFilters(sched, { status: 'default' }, now), true);
+  assert.equal(taskMatchesFilters(done, { status: 'default' }, now), false);
+
+  // Explicit status.
+  assert.equal(taskMatchesFilters(done, { status: 'completed' }, now), true);
+  assert.equal(taskMatchesFilters(open, { status: 'completed' }, now), false);
+  assert.equal(taskMatchesFilters(done, { status: 'all' }, now), true);
+
+  // Member filter.
+  assert.equal(taskMatchesFilters(open, { status: 'all', member: 'w1' }, now), true);
+  assert.equal(taskMatchesFilters(open, { status: 'all', member: 'w2' }, now), false);
+
+  // Created-date filter.
+  assert.equal(taskMatchesFilters(open, { status: 'all', dateRange: 'today' }, now), true);
+  assert.equal(taskMatchesFilters(done, { status: 'all', dateRange: '30d' }, now), false);
+});
+
+test('sortTasksForRollup orders newest-first by created_at', () => {
+  const tasks = [
+    { id: 'a', created_at: '2026-01-01T00:00:00Z' },
+    { id: 'b', created_at: '2026-06-01T00:00:00Z' },
+    { id: 'c', created_at: '2026-03-01T00:00:00Z' },
+  ];
+  assert.deepEqual(sortTasksForRollup(tasks).map((t) => t.id), ['b', 'c', 'a']);
+});
+
+test('isFileAttachment / extractFileItems pick file attachments', () => {
+  const attachments = [
+    { id: 'n1', title: 'A note', type: 'note' },
+    { id: 'f1', title: 'Spec', type: 'doc', file_meta: { name: 'spec.pdf', url: '/files/spec.pdf' } },
+    { id: 'f2', type: 'image', file_meta: { name: 'pic.png' } },
+    { id: 'l1', title: 'Link', type: 'link', link_url: 'https://example.com' },
+  ];
+  assert.equal(isFileAttachment(attachments[1]), true);
+  assert.equal(isFileAttachment(attachments[0]), false);
+  assert.equal(isFileAttachment(null), false);
+
+  const files = extractFileItems(attachments);
+  assert.deepEqual(files, [
+    { id: 'f1', title: 'Spec', url: '/files/spec.pdf' },
+    { id: 'f2', title: 'pic.png', url: '' },
+  ]);
+});
+
+test('flattenTree and collectDescendantIds walk the hierarchy', () => {
+  assert.deepEqual(flattenTree(tree).map((n) => n.id), ['g1', 'w1', 'g2', 'w2', 'w3']);
+  const g1 = findWorkspaceNode(tree, 'g1');
+  assert.deepEqual([...collectDescendantIds(g1)].sort(), ['g2', 'w1', 'w2']);
+  assert.deepEqual([...collectDescendantIds({ id: 'leaf' })], []);
+});
+
+test('eligibleAddTargets excludes the group, its descendants, and direct members', () => {
+  const g1 = findWorkspaceNode(tree, 'g1');
+  // g1 contains w1 + g2(>w2); eligible = everything else (w3 only).
+  assert.deepEqual(eligibleAddTargets(tree, g1).map((n) => n.id), ['w3']);
+
+  const g2 = findWorkspaceNode(tree, 'g2');
+  // g2 contains w2; eligible = g1, w1, w3 (g2 and w2 excluded).
+  assert.deepEqual(eligibleAddTargets(tree, g2).map((n) => n.id), ['g1', 'w1', 'w3']);
+
+  assert.deepEqual(eligibleAddTargets(tree, null), []);
 });
 
 test('metadataChanges flags only the fields that changed', () => {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3160,23 +3160,32 @@ const sessionManager = {
     }
     if (parentSelect) {
       const optionsHtml = ['<option value="">No group</option>'];
-      const flattened = [];
+      const groups = [];
       const walk = (nodes, depth) => {
         (nodes || []).forEach((node) => {
           if (!node || !node.id) return;
           if (String(node.kind || '').trim() === 'group') {
-            flattened.push({ id: node.id, name: node.name || node.id, depth });
+            groups.push({ id: node.id, name: node.name || node.id, depth });
           }
           walk(node.children || [], depth + 1);
         });
       };
       walk(this.folders || [], 0);
-      flattened.forEach((folder) => {
+      groups.forEach((folder) => {
         const indent = folder.depth > 0 ? `${'--'.repeat(folder.depth)} ` : '';
         optionsHtml.push(`<option value="${this.escapeHtml(folder.id)}">${this.escapeHtml(indent + folder.name)}</option>`);
       });
       parentSelect.innerHTML = optionsHtml.join('');
       parentSelect.value = '';
+      parentSelect.disabled = groups.length === 0;
+      parentSelect.setAttribute('aria-disabled', groups.length > 0 ? 'false' : 'true');
+
+      const parentHelp = document.getElementById('folderParentHelp');
+      if (parentHelp) {
+        parentHelp.textContent = groups.length > 0
+          ? 'Optional. Choose an organization-only group for this workspace.'
+          : 'No groups yet. Select workspaces in the launcher and click Group to create one.';
+      }
     }
     document.querySelectorAll('#addFolderModal .folder-color-btn').forEach((btn) => btn.classList.remove('active'));
     const defaultColorBtn = document.querySelector('#addFolderModal .folder-color-btn[data-color=""]')

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3159,33 +3159,11 @@ const sessionManager = {
       if (contextInput) contextInput.value = '';
     }
     if (parentSelect) {
-      const optionsHtml = ['<option value="">No group</option>'];
-      const groups = [];
-      const walk = (nodes, depth) => {
-        (nodes || []).forEach((node) => {
-          if (!node || !node.id) return;
-          if (String(node.kind || '').trim() === 'group') {
-            groups.push({ id: node.id, name: node.name || node.id, depth });
-          }
-          walk(node.children || [], depth + 1);
-        });
-      };
-      walk(this.folders || [], 0);
-      groups.forEach((folder) => {
-        const indent = folder.depth > 0 ? `${'--'.repeat(folder.depth)} ` : '';
-        optionsHtml.push(`<option value="${this.escapeHtml(folder.id)}">${this.escapeHtml(indent + folder.name)}</option>`);
-      });
-      parentSelect.innerHTML = optionsHtml.join('');
+      const groupOptions = window.WorkspaceGroupOptions;
+      const groups = groupOptions.collectWorkspaceGroupOptions(this.folders || []);
+      parentSelect.innerHTML = groupOptions.renderWorkspaceParentOptions(groups);
       parentSelect.value = '';
-      parentSelect.disabled = groups.length === 0;
-      parentSelect.setAttribute('aria-disabled', groups.length > 0 ? 'false' : 'true');
-
-      const parentHelp = document.getElementById('folderParentHelp');
-      if (parentHelp) {
-        parentHelp.textContent = groups.length > 0
-          ? 'Optional. Choose an organization-only group for this workspace.'
-          : 'No groups yet. Select workspaces in the launcher and click Group to create one.';
-      }
+      groupOptions.setWorkspaceParentSelectState(parentSelect, groups.length);
     }
     document.querySelectorAll('#addFolderModal .folder-color-btn').forEach((btn) => btn.classList.remove('active'));
     const defaultColorBtn = document.querySelector('#addFolderModal .folder-color-btn[data-color=""]')

--- a/internal/web/static/js/modules/workspace-create.js
+++ b/internal/web/static/js/modules/workspace-create.js
@@ -389,6 +389,49 @@ function openCreateWorkspaceModal(options = {}) {
   modal.show();
 }
 
+function collectWorkspaceGroupOptions(nodes) {
+  const groups = [];
+
+  (function walk(items, depth) {
+    (items || []).forEach((node) => {
+      if (!node || !node.id) return;
+      if (String(node.kind || '').trim() === 'group') {
+        groups.push({ id: node.id, name: node.name || node.id, depth });
+      }
+      if (Array.isArray(node.children) && node.children.length > 0) {
+        walk(node.children, depth + 1);
+      }
+    });
+  })(nodes, 0);
+
+  return groups;
+}
+
+function renderWorkspaceParentOptions(groups) {
+  const options = ['<option value="">No group</option>'];
+
+  groups.forEach((group) => {
+    const indent = group.depth > 0 ? `${'--'.repeat(group.depth)} ` : '';
+    options.push(`<option value="${escapeHtml(group.id)}">${escapeHtml(indent + group.name)}</option>`);
+  });
+
+  return options.join('');
+}
+
+function setWorkspaceParentSelectState(select, groupCount) {
+  const help = document.getElementById('folderParentHelp');
+  const hasGroups = groupCount > 0;
+
+  select.disabled = !hasGroups;
+  select.setAttribute('aria-disabled', hasGroups ? 'false' : 'true');
+
+  if (help) {
+    help.textContent = hasGroups
+      ? 'Optional. Choose an organization-only group for this workspace.'
+      : 'No groups yet. Select workspaces in the launcher and click Group to create one.';
+  }
+}
+
 async function populateWorkspaceParentSelect() {
   const select = document.getElementById('folderParentSelect');
   if (!select) return;
@@ -398,31 +441,16 @@ async function populateWorkspaceParentSelect() {
     if (!response.ok) throw new Error('Failed to load workspaces');
     const data = await response.json();
     const tree = data.folders || [];
+    const groups = collectWorkspaceGroupOptions(tree);
 
-    const flattened = [];
-    (function walk(nodes, depth) {
-      (nodes || []).forEach((node) => {
-        if (!node || !node.id) return;
-        flattened.push({ id: node.id, name: node.name || node.id, depth });
-        if (node.children && node.children.length > 0) {
-          walk(node.children, depth + 1);
-        }
-      });
-    })(tree, 0);
-
-    const options = ['<option value="">No group</option>'];
-    flattened.forEach((ws) => {
-      if (String(ws.kind || '').trim() !== 'group') return;
-      const indent = ws.depth > 0 ? `${'--'.repeat(ws.depth)} ` : '';
-      options.push(`<option value="${escapeHtml(ws.id)}">${escapeHtml(indent + ws.name)}</option>`);
-    });
-
-    select.innerHTML = options.join('');
+    select.innerHTML = renderWorkspaceParentOptions(groups);
     select.value = '';
+    setWorkspaceParentSelectState(select, groups.length);
   } catch (err) {
     console.error('Failed to populate parent select:', err);
     select.innerHTML = '<option value="">No group</option>';
     select.value = '';
+    setWorkspaceParentSelectState(select, 0);
   }
 }
 
@@ -749,6 +777,11 @@ function initializeWorkspaceCreationListeners() {
 window.openCreateWorkspaceModal = openCreateWorkspaceModal;
 window.toggleAgent = toggleAgent;
 window.setAvailableAgents = setAvailableAgents;
+window.WorkspaceCreate = window.WorkspaceCreate || {};
+window.WorkspaceCreate.__test = {
+  collectWorkspaceGroupOptions,
+  renderWorkspaceParentOptions
+};
 
 // Initialize on DOM ready
 document.addEventListener('DOMContentLoaded', initializeWorkspaceCreationListeners);

--- a/internal/web/static/js/modules/workspace-create.js
+++ b/internal/web/static/js/modules/workspace-create.js
@@ -389,68 +389,27 @@ function openCreateWorkspaceModal(options = {}) {
   modal.show();
 }
 
-function collectWorkspaceGroupOptions(nodes) {
-  const groups = [];
-
-  (function walk(items, depth) {
-    (items || []).forEach((node) => {
-      if (!node || !node.id) return;
-      if (String(node.kind || '').trim() === 'group') {
-        groups.push({ id: node.id, name: node.name || node.id, depth });
-      }
-      if (Array.isArray(node.children) && node.children.length > 0) {
-        walk(node.children, depth + 1);
-      }
-    });
-  })(nodes, 0);
-
-  return groups;
-}
-
-function renderWorkspaceParentOptions(groups) {
-  const options = ['<option value="">No group</option>'];
-
-  groups.forEach((group) => {
-    const indent = group.depth > 0 ? `${'--'.repeat(group.depth)} ` : '';
-    options.push(`<option value="${escapeHtml(group.id)}">${escapeHtml(indent + group.name)}</option>`);
-  });
-
-  return options.join('');
-}
-
-function setWorkspaceParentSelectState(select, groupCount) {
-  const help = document.getElementById('folderParentHelp');
-  const hasGroups = groupCount > 0;
-
-  select.disabled = !hasGroups;
-  select.setAttribute('aria-disabled', hasGroups ? 'false' : 'true');
-
-  if (help) {
-    help.textContent = hasGroups
-      ? 'Optional. Choose an organization-only group for this workspace.'
-      : 'No groups yet. Select workspaces in the launcher and click Group to create one.';
-  }
-}
-
 async function populateWorkspaceParentSelect() {
   const select = document.getElementById('folderParentSelect');
   if (!select) return;
+
+  const groupOptions = window.WorkspaceGroupOptions;
 
   try {
     const response = await fetch('/api/workspaces?tree=true');
     if (!response.ok) throw new Error('Failed to load workspaces');
     const data = await response.json();
     const tree = data.folders || [];
-    const groups = collectWorkspaceGroupOptions(tree);
+    const groups = groupOptions.collectWorkspaceGroupOptions(tree);
 
-    select.innerHTML = renderWorkspaceParentOptions(groups);
+    select.innerHTML = groupOptions.renderWorkspaceParentOptions(groups);
     select.value = '';
-    setWorkspaceParentSelectState(select, groups.length);
+    groupOptions.setWorkspaceParentSelectState(select, groups.length);
   } catch (err) {
     console.error('Failed to populate parent select:', err);
     select.innerHTML = '<option value="">No group</option>';
     select.value = '';
-    setWorkspaceParentSelectState(select, 0);
+    groupOptions.setWorkspaceParentSelectState(select, 0);
   }
 }
 
@@ -779,8 +738,8 @@ window.toggleAgent = toggleAgent;
 window.setAvailableAgents = setAvailableAgents;
 window.WorkspaceCreate = window.WorkspaceCreate || {};
 window.WorkspaceCreate.__test = {
-  collectWorkspaceGroupOptions,
-  renderWorkspaceParentOptions
+  collectWorkspaceGroupOptions: window.WorkspaceGroupOptions.collectWorkspaceGroupOptions,
+  renderWorkspaceParentOptions: window.WorkspaceGroupOptions.renderWorkspaceParentOptions
 };
 
 // Initialize on DOM ready

--- a/internal/web/static/js/modules/workspace-create.test.js
+++ b/internal/web/static/js/modules/workspace-create.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function loadWorkspaceCreate() {
+  const source = readFileSync(new URL('./workspace-create.js', import.meta.url), 'utf8');
+  const window = {
+    addEventListener: () => {},
+    availableAgents: [],
+    selectedAgents: new Set()
+  };
+  const document = {
+    addEventListener: () => {},
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => []
+  };
+  const context = {
+    bootstrap: {},
+    console,
+    document,
+    escapeHtml,
+    requestAnimationFrame: () => {},
+    window
+  };
+
+  vm.runInNewContext(source, context, { filename: 'workspace-create.js' });
+  return window.WorkspaceCreate.__test;
+}
+
+test('workspace create group options include only organization groups with depth', () => {
+  const helpers = loadWorkspaceCreate();
+  const groups = helpers.collectWorkspaceGroupOptions([
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Clients',
+      children: [
+        { id: 'workspace-1', kind: 'workspace', name: 'Client A' },
+        {
+          id: 'group-2',
+          kind: 'group',
+          name: 'Archive',
+          children: [
+            { id: 'workspace-2', kind: 'workspace', name: 'Old Work' }
+          ]
+        }
+      ]
+    },
+    { id: 'workspace-3', kind: 'workspace', name: 'Personal' }
+  ]);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(groups)), [
+    { id: 'group-1', name: 'Clients', depth: 0 },
+    { id: 'group-2', name: 'Archive', depth: 1 }
+  ]);
+});
+
+test('workspace create group options render safe select options', () => {
+  const helpers = loadWorkspaceCreate();
+  const html = helpers.renderWorkspaceParentOptions([
+    { id: 'group-1', name: 'Clients', depth: 0 },
+    { id: 'group-2', name: 'Nested & Saved', depth: 1 }
+  ]);
+
+  assert.match(html, /<option value="">No group<\/option>/);
+  assert.match(html, /<option value="group-1">Clients<\/option>/);
+  assert.match(html, /<option value="group-2">-- Nested &amp; Saved<\/option>/);
+});

--- a/internal/web/static/js/modules/workspace-detail-directory-explorer.js
+++ b/internal/web/static/js/modules/workspace-detail-directory-explorer.js
@@ -28,6 +28,20 @@ function formatDate(dateString) {
   return date.toLocaleDateString();
 }
 
+// describeDirectoryEntry decides how a directory tree node should be presented:
+// when the server flagged it as a registered workspace folder, it becomes an
+// openable workspace reference (label = registered name, link to /workspaces/id).
+// Pure + exported for unit testing.
+export function describeDirectoryEntry(node) {
+  const isWorkspace = !!(node && node.isWorkspace && node.workspaceId);
+  const fallback = (node && (node.name || node.path)) || 'Untitled';
+  return {
+    isWorkspace,
+    openHref: isWorkspace ? `/workspaces/${encodeURIComponent(node.workspaceId)}` : '',
+    label: isWorkspace && node.workspaceName ? node.workspaceName : fallback,
+  };
+}
+
 export class WorkspaceDirectoryExplorer {
   constructor(host) {
     this.host = host;
@@ -400,7 +414,10 @@ export class WorkspaceDirectoryExplorer {
             isDir: Boolean(item?.is_dir),
             size: Number(item?.size) || 0,
             modTime: item?.mod_time || '',
-            status: item?.status || ''
+            status: item?.status || '',
+            isWorkspace: Boolean(item?.is_workspace),
+            workspaceId: item?.workspace_id || '',
+            workspaceName: item?.workspace_name || ''
           };
         })
         .filter(Boolean);
@@ -526,6 +543,11 @@ export class WorkspaceDirectoryExplorer {
         dirNode.folderId = entry.folderId || dirNode.folderId;
         dirNode.source = entry.source || dirNode.source;
         dirNode.url = entry.url || dirNode.url;
+        if (entry.isWorkspace) {
+          dirNode.isWorkspace = true;
+          dirNode.workspaceId = entry.workspaceId || dirNode.workspaceId;
+          dirNode.workspaceName = entry.workspaceName || dirNode.workspaceName;
+        }
         return;
       }
 
@@ -766,6 +788,7 @@ export class WorkspaceDirectoryExplorer {
   renderTreeNode(node, depth, forceExpanded) {
     const encodedPath = this.encodeDataPath(node.path);
     const isDirectory = node.type === 'dir';
+    const workspaceRef = describeDirectoryEntry(node);
     const isExpanded =
       isDirectory && (forceExpanded || this.expandedPaths.has(node.path));
     const isSelected = isDirectory
@@ -810,8 +833,17 @@ export class WorkspaceDirectoryExplorer {
       ? ` draggable="true" data-attachment-id="${this.encodeDataPath(node.attachmentId)}"`
       : '';
 
+    const openWorkspaceLink = workspaceRef.isWorkspace
+      ? `
+          <a class="workspace-directory-open-ws"
+             href="${workspaceRef.openHref}"
+             data-action="open-workspace"
+             aria-label="Open workspace ${this.host.escapeHtml(workspaceRef.label)}">Open workspace</a>
+        `
+      : '';
+
     return `
-      <div class="workspace-directory-tree-node ${isSelected ? 'is-selected' : ''} ${isMissing ? 'is-missing' : ''}">
+      <div class="workspace-directory-tree-node ${isSelected ? 'is-selected' : ''} ${isMissing ? 'is-missing' : ''} ${workspaceRef.isWorkspace ? 'is-workspace' : ''}">
         <div class="workspace-directory-tree-row" style="--tree-depth:${depth};">
           ${toggleButton}
           <button type="button"
@@ -820,9 +852,11 @@ export class WorkspaceDirectoryExplorer {
                   data-path="${encodedPath}"
                   data-type="${isDirectory ? 'dir' : 'file'}"${dragAttrs}>
             <span class="workspace-directory-tree-icon">${icon}</span>
-            <span class="workspace-directory-tree-label">${this.host.escapeHtml(node.name || node.path || 'Untitled')}</span>
+            <span class="workspace-directory-tree-label">${this.host.escapeHtml(workspaceRef.label)}</span>
+            ${workspaceRef.isWorkspace ? '<span class="workspace-directory-tree-badge">Workspace</span>' : ''}
             <span class="workspace-directory-tree-meta">${this.host.escapeHtml(metaText)}</span>
           </button>
+          ${openWorkspaceLink}
         </div>
         ${childrenHtml}
       </div>

--- a/internal/web/static/js/modules/workspace-detail-directory-explorer.test.js
+++ b/internal/web/static/js/modules/workspace-detail-directory-explorer.test.js
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { describeDirectoryEntry } from './workspace-detail-directory-explorer.js';
+
+test('describeDirectoryEntry marks a registered workspace folder as openable', () => {
+  const node = { name: 'member-folder', isWorkspace: true, workspaceId: 'ws-123', workspaceName: 'Clients' };
+  const d = describeDirectoryEntry(node);
+  assert.equal(d.isWorkspace, true);
+  assert.equal(d.openHref, '/workspaces/ws-123');
+  // Prefers the registered workspace name over the folder name.
+  assert.equal(d.label, 'Clients');
+});
+
+test('describeDirectoryEntry falls back to the folder name when unnamed', () => {
+  const d = describeDirectoryEntry({ name: 'member-folder', isWorkspace: true, workspaceId: 'ws-9' });
+  assert.equal(d.label, 'member-folder');
+  assert.equal(d.openHref, '/workspaces/ws-9');
+});
+
+test('describeDirectoryEntry leaves ordinary folders/files untouched', () => {
+  for (const node of [
+    { name: 'docs' },
+    { name: 'flagged-but-no-id', isWorkspace: true },
+    { name: 'notes.txt', isWorkspace: false },
+    null,
+  ]) {
+    const d = describeDirectoryEntry(node);
+    assert.equal(d.isWorkspace, false);
+    assert.equal(d.openHref, '');
+  }
+  assert.equal(describeDirectoryEntry({ name: 'docs' }).label, 'docs');
+  assert.equal(describeDirectoryEntry(null).label, 'Untitled');
+});
+
+test('describeDirectoryEntry encodes the workspace id in the href', () => {
+  const d = describeDirectoryEntry({ isWorkspace: true, workspaceId: 'a b/c', name: 'x' });
+  assert.equal(d.openHref, '/workspaces/a%20b%2Fc');
+});

--- a/internal/web/static/js/modules/workspace-group-options.js
+++ b/internal/web/static/js/modules/workspace-group-options.js
@@ -1,0 +1,72 @@
+/**
+ * Workspace Group Options — shared parent-group <select> helpers
+ *
+ * Builds the "parent group" <select> used by both the workspace-hub create
+ * modal (workspace-create.js → populateWorkspaceParentSelect) and the sessions
+ * create-folder modal (sessions.js → resetAddWorkspaceModalForm). Centralizing
+ * the walk/render/disable logic keeps the two modals in sync.
+ *
+ * Exposes window.WorkspaceGroupOptions:
+ *   - collectWorkspaceGroupOptions(nodes)       → [{ id, name, depth }]
+ *   - renderWorkspaceParentOptions(groups)      → <option> markup string
+ *   - setWorkspaceParentSelectState(select, n)  → toggles disabled + help text
+ *
+ * @module workspace-group-options
+ */
+(function () {
+  'use strict';
+
+  // Walk a workspace tree and collect organization-only groups (kind ===
+  // 'group'), tracking nesting depth so options can be indented.
+  function collectWorkspaceGroupOptions(nodes) {
+    const groups = [];
+
+    (function walk(items, depth) {
+      (items || []).forEach((node) => {
+        if (!node || !node.id) return;
+        if (String(node.kind || '').trim() === 'group') {
+          groups.push({ id: node.id, name: node.name || node.id, depth });
+        }
+        if (Array.isArray(node.children) && node.children.length > 0) {
+          walk(node.children, depth + 1);
+        }
+      });
+    })(nodes, 0);
+
+    return groups;
+  }
+
+  function renderWorkspaceParentOptions(groups) {
+    const options = ['<option value="">No group</option>'];
+
+    (groups || []).forEach((group) => {
+      const indent = group.depth > 0 ? `${'--'.repeat(group.depth)} ` : '';
+      options.push(`<option value="${escapeHtml(group.id)}">${escapeHtml(indent + group.name)}</option>`);
+    });
+
+    return options.join('');
+  }
+
+  function setWorkspaceParentSelectState(select, groupCount) {
+    if (!select) return;
+
+    const hasGroups = groupCount > 0;
+    // A native <select> exposes its disabled state to assistive tech
+    // automatically, so toggling `disabled` is enough (no redundant
+    // aria-disabled attribute).
+    select.disabled = !hasGroups;
+
+    const help = document.getElementById('folderParentHelp');
+    if (help) {
+      help.textContent = hasGroups
+        ? 'Optional. Choose an organization-only group for this workspace.'
+        : 'No groups yet. Select workspaces in the launcher and click Group to create one.';
+    }
+  }
+
+  window.WorkspaceGroupOptions = {
+    collectWorkspaceGroupOptions,
+    renderWorkspaceParentOptions,
+    setWorkspaceParentSelectState
+  };
+})();

--- a/internal/web/static/js/modules/workspace-group-options.test.js
+++ b/internal/web/static/js/modules/workspace-group-options.test.js
@@ -12,39 +12,21 @@ function escapeHtml(value) {
     .replace(/'/g, '&#39;');
 }
 
-function loadWorkspaceCreate() {
-  const source = readFileSync(new URL('./workspace-create.js', import.meta.url), 'utf8');
-  const window = {
-    addEventListener: () => {},
-    availableAgents: [],
-    selectedAgents: new Set()
-  };
+function loadGroupOptions(documentOverrides = {}) {
+  const window = {};
   const document = {
-    addEventListener: () => {},
     getElementById: () => null,
-    querySelector: () => null,
-    querySelectorAll: () => []
+    ...documentOverrides
   };
-  const context = {
-    bootstrap: {},
-    console,
-    document,
-    escapeHtml,
-    requestAnimationFrame: () => {},
-    window
-  };
+  const context = { console, document, escapeHtml, window };
 
-  // workspace-create.js delegates to the shared WorkspaceGroupOptions module,
-  // so load it into the same context first.
-  const sharedSource = readFileSync(new URL('./workspace-group-options.js', import.meta.url), 'utf8');
-  vm.runInNewContext(sharedSource, context, { filename: 'workspace-group-options.js' });
-
-  vm.runInNewContext(source, context, { filename: 'workspace-create.js' });
-  return window.WorkspaceCreate.__test;
+  const source = readFileSync(new URL('./workspace-group-options.js', import.meta.url), 'utf8');
+  vm.runInNewContext(source, context, { filename: 'workspace-group-options.js' });
+  return window.WorkspaceGroupOptions;
 }
 
-test('workspace create group options include only organization groups with depth', () => {
-  const helpers = loadWorkspaceCreate();
+test('collectWorkspaceGroupOptions returns only groups with nesting depth', () => {
+  const helpers = loadGroupOptions();
   const groups = helpers.collectWorkspaceGroupOptions([
     {
       id: 'group-1',
@@ -71,8 +53,8 @@ test('workspace create group options include only organization groups with depth
   ]);
 });
 
-test('workspace create group options render safe select options', () => {
-  const helpers = loadWorkspaceCreate();
+test('renderWorkspaceParentOptions escapes names and indents nested groups', () => {
+  const helpers = loadGroupOptions();
   const html = helpers.renderWorkspaceParentOptions([
     { id: 'group-1', name: 'Clients', depth: 0 },
     { id: 'group-2', name: 'Nested & Saved', depth: 1 }
@@ -81,4 +63,26 @@ test('workspace create group options render safe select options', () => {
   assert.match(html, /<option value="">No group<\/option>/);
   assert.match(html, /<option value="group-1">Clients<\/option>/);
   assert.match(html, /<option value="group-2">-- Nested &amp; Saved<\/option>/);
+});
+
+test('setWorkspaceParentSelectState toggles disabled without aria-disabled', () => {
+  const helpAttrs = {};
+  const helpEl = { set textContent(value) { helpAttrs.text = value; } };
+  const helpers = loadGroupOptions({ getElementById: (id) => (id === 'folderParentHelp' ? helpEl : null) });
+
+  const attrs = {};
+  const select = {
+    disabled: false,
+    setAttribute: (name, value) => { attrs[name] = value; }
+  };
+
+  helpers.setWorkspaceParentSelectState(select, 0);
+  assert.equal(select.disabled, true);
+  assert.equal(attrs['aria-disabled'], undefined);
+  assert.match(helpAttrs.text, /No groups yet/);
+
+  helpers.setWorkspaceParentSelectState(select, 2);
+  assert.equal(select.disabled, false);
+  assert.equal(attrs['aria-disabled'], undefined);
+  assert.match(helpAttrs.text, /Choose an organization-only group/);
 });

--- a/internal/web/static/js/modules/workspace-hub-state.js
+++ b/internal/web/static/js/modules/workspace-hub-state.js
@@ -21,7 +21,6 @@
     workspaces: [],
     workspaceMap: new Map(),
     selectedId: null,
-    launcherSelectionMode: false,
     selectedWorkspaces: new Set(),
     launcherCollapsedGroups: new Set(),
     launcherJustExpandedGroups: new Set(),

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -1390,7 +1390,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       `;
 
       const groupHeader = `
-        <div class="launcher-card-item launcher-group-header" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="group" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group ${escapeHtml(row.name || 'Group')}" aria-expanded="${isCollapsed ? 'false' : 'true'}">
+        <div class="launcher-card-item launcher-group-header" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="group" aria-label="Open group ${escapeHtml(row.name || 'Group')}">
           <button class="launcher-card-delete" type="button" draggable="false" data-workspace-delete="${escapeHtml(row.id)}" title="Delete group" aria-label="Delete group">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
@@ -1506,7 +1506,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     return `
       <div class="launcher-tree-node${isGroup ? ' is-group' : ' is-workspace'}${isCollapsed ? ' is-collapsed' : ''}">
-        <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
+        <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? 'Open group' : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
           ${checkbox}
           ${caret}
           ${renderLauncherTreeIcon(isGroup ? 'group' : 'workspace')}
@@ -1560,16 +1560,13 @@ console.log('[workspace-hub.js] FILE LOADED');
     if (!elements.launcherGrid) return;
 
     elements.launcherGrid.querySelectorAll('[data-workspace-id]').forEach((card) => {
-      card.addEventListener('click', (e) => {
-        const workspaceId = card.dataset.workspaceId;
-        const workspaceKind = normalizeWorkspaceKind(card.dataset.workspaceKind);
-        if (workspaceKind === 'group') {
-          e.preventDefault();
-          toggleGroupCollapsed(workspaceId);
-          return;
-        }
-
-        navigateToWorkspace(workspaceId);
+      // Clicking a row opens its detail page — a workspace opens its workspace
+      // detail, a group opens its group details page (both live at
+      // /workspaces/{id}; the server branches on kind). The caret
+      // (data-group-toggle), checkboxes, and delete button each stopPropagation
+      // so they keep their own behavior and never trigger navigation.
+      card.addEventListener('click', () => {
+        navigateToWorkspace(card.dataset.workspaceId);
       });
 
       card.addEventListener('keydown', (e) => {

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -23,6 +23,9 @@ console.log('[workspace-hub.js] FILE LOADED');
   const hubEl = document.getElementById('workspaceHub');
   const OVERVIEW_EXPANDED_STORAGE_KEY = 'oriWorkspaceHubOverviewExpanded';
   const LAUNCHER_TAB_STORAGE_KEY = 'oriWorkspaceHubLauncherTab';
+  const LAUNCHER_VIEW_STORAGE_KEY = 'oriWorkspaceHubLauncherView';
+  const LAUNCHER_VIEW_CARDS = 'cards';
+  const LAUNCHER_VIEW_TREE = 'tree';
   console.log('[workspace-hub] hubEl exists:', !!hubEl);
   if (!hubEl) return;
 
@@ -95,6 +98,8 @@ console.log('[workspace-hub.js] FILE LOADED');
     launcher: document.getElementById('workspaceLauncher'),
     launcherGrid: document.getElementById('launcherGrid'),
     launcherEmpty: document.getElementById('launcherEmptyState'),
+    launcherViewCardsBtn: document.getElementById('launcherViewCards'),
+    launcherViewTreeBtn: document.getElementById('launcherViewTree'),
     launcherWorkspaceRootPath: document.getElementById('launcherWorkspaceRootPath'),
     launcherWorkspaceRootSummary: document.getElementById('launcherWorkspaceRootSummary'),
     launcherWorkspaceRootMeta: document.getElementById('launcherWorkspaceRootMeta'),
@@ -233,6 +238,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   let launcherOverviewRefreshTimer = null;
   let launcherTaskBadgeByWorkspace = new Map();
   let launcherActiveTab = 'workspaces';
+  let launcherActiveView = LAUNCHER_VIEW_CARDS;
   let launcherWorkspaceRootState = null;
   let launcherWorkspaceRootEditorOpen = false;
 
@@ -709,6 +715,74 @@ console.log('[workspace-hub.js] FILE LOADED');
     setLauncherTab(saved === 'summary' ? 'summary' : 'workspaces', { force: true });
   }
 
+  function normalizeLauncherView(value) {
+    return String(value || '').trim().toLowerCase() === LAUNCHER_VIEW_TREE
+      ? LAUNCHER_VIEW_TREE
+      : LAUNCHER_VIEW_CARDS;
+  }
+
+  function getLauncherViewPreference() {
+    try {
+      const saved = localStorage.getItem(LAUNCHER_VIEW_STORAGE_KEY);
+      const normalized = normalizeLauncherView(saved);
+      if (saved && saved !== normalized) {
+        localStorage.setItem(LAUNCHER_VIEW_STORAGE_KEY, normalized);
+      }
+      return normalized;
+    } catch (err) {
+      return LAUNCHER_VIEW_CARDS;
+    }
+  }
+
+  function setLauncherViewPreference(view) {
+    const normalized = normalizeLauncherView(view);
+    try {
+      localStorage.setItem(LAUNCHER_VIEW_STORAGE_KEY, normalized);
+    } catch (err) {
+      // no-op: storage may be unavailable
+    }
+    return normalized;
+  }
+
+  function updateLauncherViewToggle(view) {
+    const activeView = normalizeLauncherView(view);
+    if (hubEl) {
+      hubEl.dataset.launcherView = activeView;
+    }
+    if (elements.launcherViewCardsBtn) {
+      const isActive = activeView === LAUNCHER_VIEW_CARDS;
+      elements.launcherViewCardsBtn.classList.toggle('is-active', isActive);
+      elements.launcherViewCardsBtn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+    if (elements.launcherViewTreeBtn) {
+      const isActive = activeView === LAUNCHER_VIEW_TREE;
+      elements.launcherViewTreeBtn.classList.toggle('is-active', isActive);
+      elements.launcherViewTreeBtn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
+  function rerenderLauncherFromState() {
+    const state = window.WorkspaceHubState.getState();
+    renderLauncherActiveView(flattenWorkspaces(state.workspaces || []));
+  }
+
+  function setLauncherViewMode(view, options = {}) {
+    const shouldPersist = options.persist !== false;
+    const shouldRender = options.render !== false;
+    launcherActiveView = shouldPersist
+      ? setLauncherViewPreference(view)
+      : normalizeLauncherView(view);
+    updateLauncherViewToggle(launcherActiveView);
+    if (shouldRender) {
+      rerenderLauncherFromState();
+    }
+    return launcherActiveView;
+  }
+
+  function initLauncherViewState() {
+    setLauncherViewMode(getLauncherViewPreference(), { persist: false, render: false });
+  }
+
   function navigateToWorkspace(workspaceId) {
     if (!workspaceId) return;
     window.location.href = `/workspaces/${encodeURIComponent(workspaceId)}`;
@@ -894,7 +968,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       }
       if (hubEl.dataset.state === 'launcher') {
         const state = window.WorkspaceHubState.getState();
-        renderLauncher(flattenWorkspaces(state.workspaces || []));
+        renderLauncherActiveView(flattenWorkspaces(state.workspaces || []));
       }
       return;
     }
@@ -1180,7 +1254,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     if (hubEl.dataset.state === 'launcher') {
       const state = window.WorkspaceHubState.getState();
-      renderLauncher(flattenWorkspaces(state.workspaces || []));
+      renderLauncherActiveView(flattenWorkspaces(state.workspaces || []));
     }
 
     bindLauncherOverviewLinks();
@@ -1219,10 +1293,11 @@ console.log('[workspace-hub.js] FILE LOADED');
    * Render launcher grid
    * @param {Array} flattened - Flattened workspace list
    */
-  function renderLauncher(flattened) {
+  function renderLauncherCards(flattened) {
     if (!elements.launcherGrid || !elements.launcherEmpty) return;
 
     const state = window.WorkspaceHubState.getState();
+    elements.launcherGrid.classList.remove('is-tree-view');
 
     if (flattened.length === 0) {
       elements.launcherGrid.innerHTML = '';
@@ -1362,6 +1437,123 @@ console.log('[workspace-hub.js] FILE LOADED');
     }).join('');
 
     elements.launcherGrid.innerHTML = html;
+    bindLauncherInteractions();
+  }
+
+  function renderLauncherTree(flattened) {
+    if (!elements.launcherGrid || !elements.launcherEmpty) return;
+
+    const state = window.WorkspaceHubState.getState();
+    const tree = Array.isArray(state.workspaces) ? state.workspaces : [];
+    elements.launcherGrid.classList.add('is-tree-view');
+
+    if (tree.length === 0) {
+      elements.launcherGrid.innerHTML = '';
+      elements.launcherEmpty.style.display = 'flex';
+      return;
+    }
+
+    elements.launcherEmpty.style.display = 'none';
+
+    const selectionMode = !!state.launcherSelectionMode;
+    const selectedSet = state.selectedWorkspaces || new Set();
+    const flattenedMap = new Map((flattened || []).map((ws) => [ws.id, ws]));
+
+    function renderTreeIcon(kind) {
+      if (kind === 'group') {
+        return `
+          <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/>
+          </svg>
+        `;
+      }
+      return `
+        <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13Z"/>
+        </svg>
+      `;
+    }
+
+    function renderTreeNode(workspace, depth, siblings, siblingIndex) {
+      if (!workspace || !workspace.id) return '';
+
+      const row = flattenedMap.get(workspace.id) || workspace;
+      const isGroup = isGroupWorkspace(row) || (Array.isArray(workspace.children) && workspace.children.length > 0);
+      const isCollapsed = isGroup && state.launcherCollapsedGroups && state.launcherCollapsedGroups.has(row.id);
+      const children = Array.isArray(workspace.children) ? workspace.children : [];
+      const nextSibling = Array.isArray(siblings) ? siblings[siblingIndex + 1] : null;
+      const rowName = row.name || (isGroup ? 'Group' : 'Untitled Workspace');
+      const safeId = escapeHtml(row.id);
+      const safeParentId = escapeHtml(row.parent_id || '');
+      const safeNextSiblingId = escapeHtml(nextSibling && nextSibling.id ? nextSibling.id : '');
+      const safeName = escapeHtml(rowName);
+      const deleteTitle = isGroup ? 'Delete group' : 'Delete workspace';
+      const checkbox = selectionMode
+        ? (!isGroup ? `
+          <label class="launcher-tree-checkbox" aria-label="Select workspace ${safeName}">
+            <input type="checkbox" data-workspace-checkbox="${safeId}" ${selectedSet.has(row.id) ? 'checked' : ''} />
+            <span class="launcher-card-checkmark" aria-hidden="true"></span>
+          </label>
+        ` : '<span class="launcher-tree-checkbox-placeholder" aria-hidden="true"></span>')
+        : '';
+      const caret = isGroup ? `
+        <button class="launcher-tree-caret launcher-group-toggle ${isCollapsed ? 'is-collapsed' : ''}" type="button" data-group-toggle="${safeId}" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group" aria-expanded="${isCollapsed ? 'false' : 'true'}" title="${isCollapsed ? 'Expand' : 'Collapse'}">
+          <svg class="launcher-group-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M7,10L12,15L17,10H7Z"/>
+          </svg>
+        </button>
+      ` : '<span class="launcher-tree-caret-placeholder" aria-hidden="true"></span>';
+      const deleteButton = `
+        <button class="launcher-tree-delete launcher-card-delete" type="button" draggable="false" data-workspace-delete="${safeId}" title="${deleteTitle}" aria-label="${deleteTitle}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+          </svg>
+        </button>
+      `;
+
+      const childHtml = children.map((child, index) => renderTreeNode(child, depth + 1, children, index)).join('');
+      const emptyHint = isGroup && children.length === 0
+        ? `<div class="launcher-tree-empty-group" role="group" data-group-children="${safeId}" style="--launcher-tree-depth: ${depth + 1}">Drop workspaces here</div>`
+        : '';
+      const childrenWrapper = isGroup ? `
+        <div class="launcher-tree-children${children.length === 0 ? ' is-empty' : ''}" role="group" ${isCollapsed ? 'hidden' : ''} data-group-children="${safeId}">
+          ${childHtml || emptyHint}
+        </div>
+      ` : '';
+
+      return `
+        <div class="launcher-tree-node${isGroup ? ' is-group' : ' is-workspace'}${isCollapsed ? ' is-collapsed' : ''}">
+          <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-select-mode="${selectionMode ? '1' : '0'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
+            ${checkbox}
+            ${caret}
+            ${renderTreeIcon(isGroup ? 'group' : 'workspace')}
+            <span class="launcher-tree-name" title="${safeName}">${safeName}</span>
+            ${deleteButton}
+          </div>
+          ${childrenWrapper}
+        </div>
+      `;
+    }
+
+    elements.launcherGrid.innerHTML = `
+      <div class="launcher-tree" role="tree" aria-label="Workspaces">
+        ${tree.map((workspace, index) => renderTreeNode(workspace, 0, tree, index)).join('')}
+      </div>
+    `;
+    bindLauncherInteractions();
+  }
+
+  function renderLauncherActiveView(flattened) {
+    updateLauncherViewToggle(launcherActiveView);
+    if (launcherActiveView === LAUNCHER_VIEW_TREE) {
+      renderLauncherTree(flattened);
+      return;
+    }
+    renderLauncherCards(flattened);
+  }
+
+  function bindLauncherInteractions() {
+    if (!elements.launcherGrid) return;
 
     elements.launcherGrid.querySelectorAll('[data-workspace-id]').forEach((card) => {
       card.addEventListener('click', (e) => {
@@ -1406,6 +1598,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       });
 
       card.addEventListener('keydown', (e) => {
+        if (shouldIgnoreLauncherTreeKeyboardEvent(e)) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           card.click();
@@ -1463,7 +1656,176 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     updateLauncherSelectionUI();
     bindLauncherDragEvents();
+    bindLauncherTreeKeyboardEvents();
     animateLauncherGroupReveal();
+  }
+
+  function getVisibleLauncherTreeRows() {
+    if (!elements.launcherGrid) return [];
+    return Array.from(elements.launcherGrid.querySelectorAll('.launcher-tree-row[data-workspace-id]'))
+      .filter((row) => !row.closest('[hidden]'));
+  }
+
+  function focusLauncherTreeRow(row) {
+    if (!row) return;
+    getVisibleLauncherTreeRows().forEach((item) => {
+      item.tabIndex = item === row ? 0 : -1;
+    });
+    row.focus();
+  }
+
+  function focusLauncherTreeRowById(workspaceId) {
+    if (!elements.launcherGrid || !workspaceId) return;
+    const safeId = (window.CSS && window.CSS.escape) ? window.CSS.escape(workspaceId) : workspaceId;
+    const row = elements.launcherGrid.querySelector(`.launcher-tree-row[data-workspace-id="${safeId}"]`);
+    focusLauncherTreeRow(row);
+  }
+
+  function syncLauncherTreeRovingTabIndex() {
+    const rows = getVisibleLauncherTreeRows();
+    if (rows.length === 0) return;
+    const activeRow = rows.includes(document.activeElement) ? document.activeElement : rows[0];
+    rows.forEach((row) => {
+      row.tabIndex = row === activeRow ? 0 : -1;
+    });
+  }
+
+  function getLauncherTreeParentRow(row) {
+    const node = row?.closest('.launcher-tree-node');
+    if (!node) return null;
+    const parentChildren = node.parentElement?.closest('.launcher-tree-children');
+    const parentNode = parentChildren?.closest('.launcher-tree-node');
+    return parentNode?.querySelector(':scope > .launcher-tree-row') || null;
+  }
+
+  function shouldIgnoreLauncherTreeKeyboardEvent(event) {
+    const target = event?.target;
+    if (!target || target === event.currentTarget) return false;
+
+    const tagName = String(target.tagName || '').toUpperCase();
+    if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(tagName)) return true;
+    if (target.isContentEditable) return true;
+
+    if (typeof target.closest === 'function') {
+      return !!target.closest('input, textarea, select, button, [contenteditable="true"], [role="textbox"], .modal.show, [aria-modal="true"]');
+    }
+
+    return false;
+  }
+
+  function bindLauncherTreeKeyboardEvents() {
+    const rows = getVisibleLauncherTreeRows();
+    if (rows.length === 0) return;
+
+    syncLauncherTreeRovingTabIndex();
+
+    rows.forEach((row) => {
+      row.addEventListener('keydown', (e) => {
+        if (shouldIgnoreLauncherTreeKeyboardEvent(e)) return;
+
+        const key = e.key;
+        if (!['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'h', 'j', 'k', 'l'].includes(key)) {
+          return;
+        }
+
+        const currentRows = getVisibleLauncherTreeRows();
+        const currentIndex = currentRows.indexOf(row);
+        const workspaceId = row.dataset.workspaceId;
+        const workspaceKind = normalizeWorkspaceKind(row.dataset.workspaceKind);
+        const isExpanded = row.getAttribute('aria-expanded') === 'true';
+
+        if (key === 'ArrowDown' || key === 'j') {
+          e.preventDefault();
+          focusLauncherTreeRow(currentRows[Math.min(currentIndex + 1, currentRows.length - 1)]);
+          return;
+        }
+
+        if (key === 'ArrowUp' || key === 'k') {
+          e.preventDefault();
+          focusLauncherTreeRow(currentRows[Math.max(currentIndex - 1, 0)]);
+          return;
+        }
+
+        if ((key === 'ArrowRight' || key === 'l') && workspaceKind === 'group' && !isExpanded) {
+          e.preventDefault();
+          toggleGroupCollapsed(workspaceId, { focusAfterRender: true });
+          return;
+        }
+
+        if (key === 'ArrowLeft' || key === 'h') {
+          if (workspaceKind === 'group' && isExpanded) {
+            e.preventDefault();
+            toggleGroupCollapsed(workspaceId, { focusAfterRender: true });
+            return;
+          }
+
+          const parentRow = getLauncherTreeParentRow(row);
+          if (parentRow) {
+            e.preventDefault();
+            focusLauncherTreeRow(parentRow);
+          }
+        }
+      });
+    });
+  }
+
+  function clearLauncherTreeDropIndicators() {
+    if (!elements.launcherGrid) return;
+    elements.launcherGrid.querySelectorAll('.launcher-tree-row').forEach((row) => {
+      row.classList.remove('is-drop-before', 'is-drop-after', 'is-drop-into');
+    });
+  }
+
+  function getLauncherTreeDropIntent(row, event) {
+    if (!row || !row.classList.contains('launcher-tree-row')) return null;
+    const rect = row.getBoundingClientRect();
+    if (!rect || rect.height <= 0) return null;
+
+    const offsetY = event.clientY - rect.top;
+    const edgeSize = Math.max(6, Math.min(12, rect.height * 0.28));
+    const workspaceKind = normalizeWorkspaceKind(row.dataset.workspaceKind);
+
+    if (offsetY <= edgeSize) {
+      return {
+        type: 'before',
+        targetParentId: row.dataset.parentId || '',
+        insertBeforeId: row.dataset.workspaceId || ''
+      };
+    }
+
+    if (offsetY >= rect.height - edgeSize) {
+      return {
+        type: 'after',
+        targetParentId: row.dataset.parentId || '',
+        insertBeforeId: row.dataset.nextSiblingId || ''
+      };
+    }
+
+    if (workspaceKind === 'group') {
+      return {
+        type: 'into',
+        targetParentId: row.dataset.workspaceId || '',
+        insertBeforeId: ''
+      };
+    }
+
+    return {
+      type: 'before',
+      targetParentId: row.dataset.parentId || '',
+      insertBeforeId: row.dataset.workspaceId || ''
+    };
+  }
+
+  function applyLauncherTreeDropIndicator(row, intent) {
+    if (!row || !intent) return;
+    clearLauncherTreeDropIndicators();
+    if (intent.type === 'before') {
+      row.classList.add('is-drop-before');
+    } else if (intent.type === 'after') {
+      row.classList.add('is-drop-after');
+    } else if (intent.type === 'into') {
+      row.classList.add('is-drop-into');
+    }
   }
 
   function animateLauncherGroupReveal() {
@@ -1475,8 +1837,8 @@ console.log('[workspace-hub.js] FILE LOADED');
     state.launcherJustExpandedGroups = new Set();
 
     ids.forEach((id) => {
-      const safeId = (window.CSS && CSS.escape) ? CSS.escape(id) : id;
-      const header = elements.launcherGrid.querySelector(`.launcher-group-header[data-workspace-id="${safeId}"]`);
+      const safeId = (window.CSS && window.CSS.escape) ? window.CSS.escape(id) : id;
+      const header = elements.launcherGrid.querySelector(`[data-workspace-id="${safeId}"]`);
       const grid = elements.launcherGrid.querySelector(`[data-group-children="${safeId}"]`);
       if (header) header.classList.add('is-revealed');
       if (grid) grid.classList.add('is-revealed');
@@ -1489,15 +1851,15 @@ console.log('[workspace-hub.js] FILE LOADED');
   }
 
   function bindLauncherDragEvents() {
-    const items = elements.launcherGrid.querySelectorAll('.launcher-card-item');
+    const items = elements.launcherGrid.querySelectorAll('[data-workspace-id][draggable="true"]');
     const rootDrop = elements.launcherRootDropZone;
     const rootGrid = elements.launcherGrid;
 
     const isRootGridTarget = (eventTarget) => {
       if (!eventTarget) return false;
       if (!rootGrid || rootGrid !== eventTarget && !rootGrid.contains(eventTarget)) return false;
-      if (eventTarget.closest('.launcher-card-item')) return false;
-      if (eventTarget.closest('.launcher-group-grid')) return false;
+      if (eventTarget.closest('[data-workspace-id]')) return false;
+      if (eventTarget.closest('[data-group-children]')) return false;
       return true;
     };
 
@@ -1565,6 +1927,7 @@ console.log('[workspace-hub.js] FILE LOADED');
         e.currentTarget.classList.remove('is-dragging');
         // Clean up any remaining drag-over classes
         items.forEach(i => i.classList.remove('is-drag-over'));
+        clearLauncherTreeDropIndicators();
         if (rootDrop) {
           rootDrop.classList.remove('is-drag-over');
           rootDrop.classList.remove('is-active');
@@ -1577,28 +1940,44 @@ console.log('[workspace-hub.js] FILE LOADED');
 
       item.addEventListener('dragover', (e) => {
         e.preventDefault(); // Allow drop
-        const draggedId = document.querySelector('.launcher-card-item.is-dragging')?.dataset.workspaceId;
+        const draggedId = elements.launcherGrid.querySelector('[data-workspace-id].is-dragging')?.dataset.workspaceId;
         const targetId = e.currentTarget.dataset.workspaceId;
-        
+
         // Don't highlight if dragging over itself
         if (draggedId === targetId) return;
-        
+
         e.dataTransfer.dropEffect = 'move';
+        const treeIntent = getLauncherTreeDropIntent(e.currentTarget, e);
+        if (treeIntent) {
+          applyLauncherTreeDropIndicator(e.currentTarget, treeIntent);
+          return;
+        }
         e.currentTarget.classList.add('is-drag-over');
       });
 
       item.addEventListener('dragleave', (e) => {
         e.currentTarget.classList.remove('is-drag-over');
+        if (e.currentTarget.classList.contains('launcher-tree-row')) {
+          e.currentTarget.classList.remove('is-drop-before', 'is-drop-after', 'is-drop-into');
+        }
       });
 
       item.addEventListener('drop', (e) => {
         e.preventDefault();
+        e.stopPropagation();
         e.currentTarget.classList.remove('is-drag-over');
+        clearLauncherTreeDropIndicators();
 
         const draggedId = e.dataTransfer.getData('text/plain');
         const targetId = e.currentTarget.dataset.workspaceId;
 
         if (!draggedId || !targetId || draggedId === targetId) return;
+
+        const treeIntent = getLauncherTreeDropIntent(e.currentTarget, e);
+        if (treeIntent) {
+          reorderWorkspace(draggedId, treeIntent.targetParentId, treeIntent.insertBeforeId);
+          return;
+        }
 
         const targetParentId = getWorkspaceParentId(targetId);
         reorderWorkspace(draggedId, targetParentId, targetId);
@@ -1673,7 +2052,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
   }
 
-  function toggleGroupCollapsed(workspaceId) {
+  function toggleGroupCollapsed(workspaceId, options = {}) {
     const state = window.WorkspaceHubState.getState();
     if (!state.launcherCollapsedGroups) state.launcherCollapsedGroups = new Set();
 
@@ -1683,7 +2062,10 @@ console.log('[workspace-hub.js] FILE LOADED');
     state.launcherCollapsedGroups = next;
 
     const flattened = flattenWorkspaces(state.workspaces || []);
-    renderLauncher(flattened);
+    renderLauncherActiveView(flattened);
+    if (options.focusAfterRender) {
+      focusLauncherTreeRowById(workspaceId);
+    }
   }
 
   function setLauncherSelectionMode(enabled) {
@@ -1704,7 +2086,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     // Re-render launcher to show/hide checkboxes
     const flattened = flattenWorkspaces(state.workspaces || []);
-    renderLauncher(flattened);
+    renderLauncherActiveView(flattened);
   }
 
   function toggleLauncherWorkspaceSelection(workspaceId, { force } = {}) {
@@ -1719,7 +2101,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     state.selectedWorkspaces = next;
 
     // Visual update
-    const card = elements.launcherGrid.querySelector(`.launcher-card-item[data-workspace-id="${workspaceId}"]`);
+    const card = elements.launcherGrid.querySelector(`[data-workspace-id="${workspaceId}"]`);
     if (card) {
       const checkbox = card.querySelector('input[type="checkbox"]');
       if (checkbox) {
@@ -2342,7 +2724,7 @@ console.log('[workspace-hub.js] FILE LOADED');
           if (workspace) {
             renderWorkspaceSummary(workspace);
           }
-          renderLauncher(flattenWorkspaces(state.workspaces || []));
+          renderLauncherActiveView(flattenWorkspaces(state.workspaces || []));
 
           if (window.Toast) {
             if (field === 'name') {
@@ -2656,7 +3038,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       state.workspaceMap = new Map(flattened.map((workspace) => [workspace.id, workspace]));
 
       populateWorkspaceSelect(flattened);
-      renderLauncher(flattened);
+      renderLauncherActiveView(flattened);
 
       // Always show the launcher - workspace details are now on separate pages
       showLauncher();
@@ -3015,6 +3397,14 @@ console.log('[workspace-hub.js] FILE LOADED');
       elements.launcherTabSummary.addEventListener('click', () => setLauncherTab('summary'));
     }
 
+    if (elements.launcherViewCardsBtn) {
+      elements.launcherViewCardsBtn.addEventListener('click', () => setLauncherViewMode(LAUNCHER_VIEW_CARDS));
+    }
+
+    if (elements.launcherViewTreeBtn) {
+      elements.launcherViewTreeBtn.addEventListener('click', () => setLauncherViewMode(LAUNCHER_VIEW_TREE));
+    }
+
     if (elements.launcherSelectModeBtn) {
       elements.launcherSelectModeBtn.addEventListener('click', () => {
         const state = window.WorkspaceHubState.getState();
@@ -3193,6 +3583,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   setLauncherWorkspaceRootEditorOpen(false);
   initLauncherOverviewExpandedState();
   initLauncherTabState();
+  initLauncherViewState();
 
   // Keyboard shortcuts for workspace selection
   document.addEventListener('keydown', (e) => {
@@ -3223,6 +3614,18 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   window.WorkspaceHub = window.WorkspaceHub || {};
   window.WorkspaceHub.loadWorkspaces = loadWorkspaces;
+  window.WorkspaceHub.__test = {
+    getLauncherTreeDropIntent,
+    getLauncherViewPreference,
+    bindLauncherTreeKeyboardEvents,
+    focusLauncherTreeRow,
+    getVisibleLauncherTreeRows,
+    normalizeLauncherView,
+    renderLauncherTree,
+    setLauncherViewPreference,
+    setLauncherViewMode,
+    shouldIgnoreLauncherTreeKeyboardEvent
+  };
 
   if (!hubEl.dataset.launcherSelect) {
     hubEl.dataset.launcherSelect = 'false';

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -114,7 +114,6 @@ console.log('[workspace-hub.js] FILE LOADED');
     launcherRefreshBtn: document.getElementById('launcherRefreshBtn'),
     launcherRescanBtn: document.getElementById('launcherRescanBtn'),
     launcherUndoBtn: document.getElementById('launcherUndoBtn'),
-    launcherSelectModeBtn: document.getElementById('launcherSelectModeBtn'),
     launcherGroupSelectedBtn: document.getElementById('launcherGroupSelectedBtn'),
     launcherDeleteSelectedBtn: document.getElementById('launcherDeleteSelectedBtn'),
     launcherCancelSelectionBtn: document.getElementById('launcherCancelSelectionBtn'),
@@ -692,8 +691,8 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     if (nextTab === 'summary') {
       const state = window.WorkspaceHubState.getState();
-      if (state.launcherSelectionMode) {
-        setLauncherSelectionMode(false);
+      if (hasLauncherSelection()) {
+        clearLauncherSelection();
       }
       if (elements.launcherOverviewDetails && elements.launcherOverviewDetails.hidden) {
         setLauncherOverviewExpanded(true);
@@ -1307,7 +1306,6 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     elements.launcherEmpty.style.display = 'none';
 
-    const selectionMode = !!state.launcherSelectionMode;
     const selectedSet = state.selectedWorkspaces || new Set();
 
     const flattenedMap = new Map((flattened || []).map((ws) => [ws.id, ws]));
@@ -1336,12 +1334,12 @@ console.log('[workspace-hub.js] FILE LOADED');
       `;
 
       const checked = selectedSet.has(row.id);
-      const checkbox = selectionMode ? `
+      const checkbox = `
           <label class="launcher-card-checkbox" aria-label="Select workspace ${escapeHtml(row.name || row.id)}">
             <input type="checkbox" data-workspace-checkbox="${escapeHtml(row.id)}" ${checked ? 'checked' : ''} />
             <span class="launcher-card-checkmark" aria-hidden="true"></span>
           </label>
-      ` : '';
+      `;
 
       const deleteButton = `
         <button class="launcher-card-delete" type="button" draggable="false" data-workspace-delete="${escapeHtml(row.id)}" title="${deleteTitle}" aria-label="${deleteTitle}">
@@ -1352,7 +1350,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       `;
 
       return `
-        <div class="launcher-card-item" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="workspace" data-select-mode="${selectionMode ? '1' : '0'}" data-folder-linked="${folderDisplay.linked ? '1' : '0'}" ${accentStyle} aria-label="Open workspace ${escapeHtml(row.name || 'Untitled Workspace')} with ${escapeHtml(folderDisplay.ariaLabel)}">
+        <div class="launcher-card-item has-selection-checkbox" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="workspace" data-folder-linked="${folderDisplay.linked ? '1' : '0'}" ${accentStyle} aria-label="Open workspace ${escapeHtml(row.name || 'Untitled Workspace')} with ${escapeHtml(folderDisplay.ariaLabel)}">
           ${checkbox}
           ${deleteButton}
           <div class="launcher-card-title-row">
@@ -1392,7 +1390,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       `;
 
       const groupHeader = `
-        <div class="launcher-card-item launcher-group-header" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="group" data-select-mode="${selectionMode ? '1' : '0'}" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group ${escapeHtml(row.name || 'Group')}" aria-expanded="${isCollapsed ? 'false' : 'true'}">
+        <div class="launcher-card-item launcher-group-header" role="button" tabindex="0" draggable="true" data-workspace-id="${escapeHtml(row.id)}" data-workspace-kind="group" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group ${escapeHtml(row.name || 'Group')}" aria-expanded="${isCollapsed ? 'false' : 'true'}">
           <button class="launcher-card-delete" type="button" draggable="false" data-workspace-delete="${escapeHtml(row.id)}" title="Delete group" aria-label="Delete group">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
@@ -1455,7 +1453,6 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     elements.launcherEmpty.style.display = 'none';
 
-    const selectionMode = !!state.launcherSelectionMode;
     const selectedSet = state.selectedWorkspaces || new Set();
     const flattenedMap = new Map((flattened || []).map((ws) => [ws.id, ws]));
 
@@ -1488,14 +1485,12 @@ console.log('[workspace-hub.js] FILE LOADED');
       const safeNextSiblingId = escapeHtml(nextSibling && nextSibling.id ? nextSibling.id : '');
       const safeName = escapeHtml(rowName);
       const deleteTitle = isGroup ? 'Delete group' : 'Delete workspace';
-      const checkbox = selectionMode
-        ? (!isGroup ? `
+      const checkbox = !isGroup ? `
           <label class="launcher-tree-checkbox" aria-label="Select workspace ${safeName}">
             <input type="checkbox" data-workspace-checkbox="${safeId}" ${selectedSet.has(row.id) ? 'checked' : ''} />
             <span class="launcher-card-checkmark" aria-hidden="true"></span>
           </label>
-        ` : '<span class="launcher-tree-checkbox-placeholder" aria-hidden="true"></span>')
-        : '';
+        ` : '<span class="launcher-tree-checkbox-placeholder" aria-hidden="true"></span>';
       const caret = isGroup ? `
         <button class="launcher-tree-caret launcher-group-toggle ${isCollapsed ? 'is-collapsed' : ''}" type="button" data-group-toggle="${safeId}" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group" aria-expanded="${isCollapsed ? 'false' : 'true'}" title="${isCollapsed ? 'Expand' : 'Collapse'}">
           <svg class="launcher-group-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -1523,7 +1518,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
       return `
         <div class="launcher-tree-node${isGroup ? ' is-group' : ' is-workspace'}${isCollapsed ? ' is-collapsed' : ''}">
-          <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-select-mode="${selectionMode ? '1' : '0'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
+          <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
             ${checkbox}
             ${caret}
             ${renderTreeIcon(isGroup ? 'group' : 'workspace')}
@@ -1559,35 +1554,6 @@ console.log('[workspace-hub.js] FILE LOADED');
       card.addEventListener('click', (e) => {
         const workspaceId = card.dataset.workspaceId;
         const workspaceKind = normalizeWorkspaceKind(card.dataset.workspaceKind);
-        const isSelectMode = card.dataset.selectMode === '1';
-
-        // Cmd/Ctrl+click for quick multi-select (even outside selection mode)
-        if (e.metaKey || e.ctrlKey) {
-          if (workspaceKind === 'group') {
-            e.preventDefault();
-            toggleGroupCollapsed(workspaceId);
-            return;
-          }
-          e.preventDefault();
-          // Auto-enable selection mode if not already enabled
-          if (!window.WorkspaceHubState.getState().launcherSelectionMode) {
-            setLauncherSelectionMode(true);
-          }
-          toggleLauncherWorkspaceSelection(workspaceId);
-          return;
-        }
-
-        if (isSelectMode) {
-          if (workspaceKind === 'group') {
-            e.preventDefault();
-            toggleGroupCollapsed(workspaceId);
-            return;
-          }
-          e.preventDefault();
-          toggleLauncherWorkspaceSelection(workspaceId);
-          return;
-        }
-
         if (workspaceKind === 'group') {
           e.preventDefault();
           toggleGroupCollapsed(workspaceId);
@@ -1612,6 +1578,10 @@ console.log('[workspace-hub.js] FILE LOADED');
         const id = e.target.getAttribute('data-workspace-checkbox');
         toggleLauncherWorkspaceSelection(id, { force: e.target.checked });
       });
+    });
+
+    elements.launcherGrid.querySelectorAll('.launcher-card-checkbox, .launcher-tree-checkbox').forEach((checkboxShell) => {
+      checkboxShell.addEventListener('click', (e) => e.stopPropagation());
     });
 
     elements.launcherGrid.querySelectorAll('[data-group-toggle]').forEach((btn) => {
@@ -1908,9 +1878,8 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     items.forEach(item => {
       item.addEventListener('dragstart', (e) => {
-        // Only allow dragging if NOT in selection mode
-        const state = window.WorkspaceHubState.getState();
-        if (state.launcherSelectionMode) {
+        // Keep checkbox selection and drag reordering as separate interactions.
+        if (hasLauncherSelection()) {
           e.preventDefault();
           return;
         }
@@ -2068,25 +2037,20 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
   }
 
-  function setLauncherSelectionMode(enabled) {
+  function hasLauncherSelection() {
     const state = window.WorkspaceHubState.getState();
-    state.launcherSelectionMode = !!enabled;
-    if (!state.launcherSelectionMode) {
-      state.selectedWorkspaces = new Set();
-    }
+    return !!(state.selectedWorkspaces && state.selectedWorkspaces.size > 0);
+  }
 
-    hubEl.dataset.launcherSelect = state.launcherSelectionMode ? 'true' : 'false';
+  function clearLauncherSelection({ render = true } = {}) {
+    const state = window.WorkspaceHubState.getState();
+    state.selectedWorkspaces = new Set();
+    updateLauncherSelectionUI();
 
-    if (elements.launcherSelectionBar) {
-      elements.launcherSelectionBar.hidden = !state.launcherSelectionMode;
+    if (render) {
+      const flattened = flattenWorkspaces(state.workspaces || []);
+      renderLauncherActiveView(flattened);
     }
-    if (elements.launcherSelectModeBtn) {
-      elements.launcherSelectModeBtn.classList.toggle('is-active', state.launcherSelectionMode);
-    }
-
-    // Re-render launcher to show/hide checkboxes
-    const flattened = flattenWorkspaces(state.workspaces || []);
-    renderLauncherActiveView(flattened);
   }
 
   function toggleLauncherWorkspaceSelection(workspaceId, { force } = {}) {
@@ -2125,6 +2089,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
     if (elements.launcherDeleteSelectedBtn) {
       elements.launcherDeleteSelectedBtn.disabled = selectedCount === 0;
+    }
+    if (elements.launcherSelectionBar) {
+      elements.launcherSelectionBar.hidden = selectedCount === 0;
     }
   }
 
@@ -2254,7 +2221,6 @@ console.log('[workspace-hub.js] FILE LOADED');
   }
 
   async function deleteWorkspacesByIds(ids) {
-    const state = window.WorkspaceHubState.getState();
     if (!ids || ids.length === 0) return;
 
     try {
@@ -2268,8 +2234,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
       if (window.Toast) window.Toast.success(ids.length > 1 ? 'Workspaces deleted' : 'Workspace deleted');
 
-      state.selectedWorkspaces = new Set();
-      setLauncherSelectionMode(false);
+      clearLauncherSelection({ render: false });
       await loadWorkspaces();
     } catch (err) {
       console.error('Failed to delete workspaces:', err);
@@ -2566,7 +2531,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       if (elements.launcherGroupDescriptionInput) elements.launcherGroupDescriptionInput.value = '';
 
       // Reset selection + refresh
-      setLauncherSelectionMode(false);
+      clearLauncherSelection({ render: false });
       await loadWorkspaces();
     } catch (err) {
       console.error('Failed to create group:', err);
@@ -2905,9 +2870,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     const workspace = state.workspaceMap.get(workspaceId);
     if (!workspace) return;
 
-    // Leaving launcher selection mode
-    if (state.launcherSelectionMode) {
-      setLauncherSelectionMode(false);
+    // Leaving the launcher clears any pending checkbox selection.
+    if (hasLauncherSelection()) {
+      clearLauncherSelection({ render: false });
     }
 
     window.WorkspaceHubState.stopRealtime();
@@ -2964,8 +2929,8 @@ console.log('[workspace-hub.js] FILE LOADED');
   function showLauncher() {
     const state = window.WorkspaceHubState.getState();
 
-    if (state.launcherSelectionMode) {
-      setLauncherSelectionMode(false);
+    if (hasLauncherSelection()) {
+      clearLauncherSelection({ render: false });
     }
 
     window.WorkspaceHubState.stopRealtime();
@@ -3405,15 +3370,8 @@ console.log('[workspace-hub.js] FILE LOADED');
       elements.launcherViewTreeBtn.addEventListener('click', () => setLauncherViewMode(LAUNCHER_VIEW_TREE));
     }
 
-    if (elements.launcherSelectModeBtn) {
-      elements.launcherSelectModeBtn.addEventListener('click', () => {
-        const state = window.WorkspaceHubState.getState();
-        setLauncherSelectionMode(!state.launcherSelectionMode);
-      });
-    }
-
     if (elements.launcherCancelSelectionBtn) {
-      elements.launcherCancelSelectionBtn.addEventListener('click', () => setLauncherSelectionMode(false));
+      elements.launcherCancelSelectionBtn.addEventListener('click', () => clearLauncherSelection());
     }
 
     if (elements.launcherGroupSelectedBtn && elements.launcherGroupModal) {
@@ -3585,12 +3543,11 @@ console.log('[workspace-hub.js] FILE LOADED');
   initLauncherTabState();
   initLauncherViewState();
 
-  // Keyboard shortcuts for workspace selection
+  // Keyboard shortcuts for checked launcher workspaces.
   document.addEventListener('keydown', (e) => {
     // Cmd/Ctrl+G to group selected workspaces
     if ((e.metaKey || e.ctrlKey) && e.key === 'g') {
-      const state = window.WorkspaceHubState.getState();
-      if (state.launcherSelectionMode && state.selectedWorkspaces && state.selectedWorkspaces.size > 0) {
+      if (hasLauncherSelection()) {
         e.preventDefault();
         // Open group modal
         if (elements.launcherGroupModal && typeof bootstrap !== 'undefined' && bootstrap.Modal) {
@@ -3602,12 +3559,11 @@ console.log('[workspace-hub.js] FILE LOADED');
       }
     }
 
-    // Escape to exit selection mode
+    // Escape clears checked launcher workspaces.
     if (e.key === 'Escape') {
-      const state = window.WorkspaceHubState.getState();
-      if (state.launcherSelectionMode) {
+      if (hasLauncherSelection()) {
         e.preventDefault();
-        setLauncherSelectionMode(false);
+        clearLauncherSelection();
       }
     }
   });
@@ -3621,15 +3577,13 @@ console.log('[workspace-hub.js] FILE LOADED');
     focusLauncherTreeRow,
     getVisibleLauncherTreeRows,
     normalizeLauncherView,
+    bindLauncherInteractions,
+    renderLauncherCards,
     renderLauncherTree,
     setLauncherViewPreference,
     setLauncherViewMode,
     shouldIgnoreLauncherTreeKeyboardEvent
   };
-
-  if (!hubEl.dataset.launcherSelect) {
-    hubEl.dataset.launcherSelect = 'false';
-  }
 
   loadWorkspaces();
 })();

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -1438,6 +1438,86 @@ console.log('[workspace-hub.js] FILE LOADED');
     bindLauncherInteractions();
   }
 
+  // Tree-row icons never change between renders, so cache them once instead of
+  // rebuilding the markup on every node.
+  const LAUNCHER_TREE_GROUP_ICON = `
+    <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/>
+    </svg>
+  `;
+  const LAUNCHER_TREE_WORKSPACE_ICON = `
+    <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13Z"/>
+    </svg>
+  `;
+
+  function renderLauncherTreeIcon(kind) {
+    return kind === 'group' ? LAUNCHER_TREE_GROUP_ICON : LAUNCHER_TREE_WORKSPACE_ICON;
+  }
+
+  // Render a single tree node (and its descendants). Hoisted to module scope so
+  // it isn't re-allocated on every renderLauncherTree call; per-render data is
+  // threaded through `ctx` ({ state, selectedSet, flattenedMap }).
+  function renderLauncherTreeNode(workspace, depth, siblings, siblingIndex, ctx) {
+    if (!workspace || !workspace.id) return '';
+
+    const { state, selectedSet, flattenedMap } = ctx;
+    const row = flattenedMap.get(workspace.id) || workspace;
+    const isGroup = isGroupWorkspace(row) || (Array.isArray(workspace.children) && workspace.children.length > 0);
+    const isCollapsed = isGroup && state.launcherCollapsedGroups && state.launcherCollapsedGroups.has(row.id);
+    const children = Array.isArray(workspace.children) ? workspace.children : [];
+    const nextSibling = Array.isArray(siblings) ? siblings[siblingIndex + 1] : null;
+    const rowName = row.name || (isGroup ? 'Group' : 'Untitled Workspace');
+    const safeId = escapeHtml(row.id);
+    const safeParentId = escapeHtml(row.parent_id || '');
+    const safeNextSiblingId = escapeHtml(nextSibling && nextSibling.id ? nextSibling.id : '');
+    const safeName = escapeHtml(rowName);
+    const deleteTitle = isGroup ? 'Delete group' : 'Delete workspace';
+    const checkbox = !isGroup ? `
+        <label class="launcher-tree-checkbox" aria-label="Select workspace ${safeName}">
+          <input type="checkbox" data-workspace-checkbox="${safeId}" ${selectedSet.has(row.id) ? 'checked' : ''} />
+          <span class="launcher-card-checkmark" aria-hidden="true"></span>
+        </label>
+      ` : '<span class="launcher-tree-checkbox-placeholder" aria-hidden="true"></span>';
+    const caret = isGroup ? `
+      <button class="launcher-tree-caret launcher-group-toggle ${isCollapsed ? 'is-collapsed' : ''}" type="button" data-group-toggle="${safeId}" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group" aria-expanded="${isCollapsed ? 'false' : 'true'}" title="${isCollapsed ? 'Expand' : 'Collapse'}">
+        <svg class="launcher-group-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M7,10L12,15L17,10H7Z"/>
+        </svg>
+      </button>
+    ` : '<span class="launcher-tree-caret-placeholder" aria-hidden="true"></span>';
+    const deleteButton = `
+      <button class="launcher-tree-delete launcher-card-delete" type="button" draggable="false" data-workspace-delete="${safeId}" title="${deleteTitle}" aria-label="${deleteTitle}">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+        </svg>
+      </button>
+    `;
+
+    const childHtml = children.map((child, index) => renderLauncherTreeNode(child, depth + 1, children, index, ctx)).join('');
+    const emptyHint = isGroup && children.length === 0
+      ? `<div class="launcher-tree-empty-group" role="group" data-group-children="${safeId}" style="--launcher-tree-depth: ${depth + 1}">Drop workspaces here</div>`
+      : '';
+    const childrenWrapper = isGroup ? `
+      <div class="launcher-tree-children${children.length === 0 ? ' is-empty' : ''}" role="group" ${isCollapsed ? 'hidden' : ''} data-group-children="${safeId}">
+        ${childHtml || emptyHint}
+      </div>
+    ` : '';
+
+    return `
+      <div class="launcher-tree-node${isGroup ? ' is-group' : ' is-workspace'}${isCollapsed ? ' is-collapsed' : ''}">
+        <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
+          ${checkbox}
+          ${caret}
+          ${renderLauncherTreeIcon(isGroup ? 'group' : 'workspace')}
+          <span class="launcher-tree-name" title="${safeName}">${safeName}</span>
+          ${deleteButton}
+        </div>
+        ${childrenWrapper}
+      </div>
+    `;
+  }
+
   function renderLauncherTree(flattened) {
     if (!elements.launcherGrid || !elements.launcherEmpty) return;
 
@@ -1453,86 +1533,15 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     elements.launcherEmpty.style.display = 'none';
 
-    const selectedSet = state.selectedWorkspaces || new Set();
-    const flattenedMap = new Map((flattened || []).map((ws) => [ws.id, ws]));
-
-    function renderTreeIcon(kind) {
-      if (kind === 'group') {
-        return `
-          <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/>
-          </svg>
-        `;
-      }
-      return `
-        <svg class="launcher-tree-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13Z"/>
-        </svg>
-      `;
-    }
-
-    function renderTreeNode(workspace, depth, siblings, siblingIndex) {
-      if (!workspace || !workspace.id) return '';
-
-      const row = flattenedMap.get(workspace.id) || workspace;
-      const isGroup = isGroupWorkspace(row) || (Array.isArray(workspace.children) && workspace.children.length > 0);
-      const isCollapsed = isGroup && state.launcherCollapsedGroups && state.launcherCollapsedGroups.has(row.id);
-      const children = Array.isArray(workspace.children) ? workspace.children : [];
-      const nextSibling = Array.isArray(siblings) ? siblings[siblingIndex + 1] : null;
-      const rowName = row.name || (isGroup ? 'Group' : 'Untitled Workspace');
-      const safeId = escapeHtml(row.id);
-      const safeParentId = escapeHtml(row.parent_id || '');
-      const safeNextSiblingId = escapeHtml(nextSibling && nextSibling.id ? nextSibling.id : '');
-      const safeName = escapeHtml(rowName);
-      const deleteTitle = isGroup ? 'Delete group' : 'Delete workspace';
-      const checkbox = !isGroup ? `
-          <label class="launcher-tree-checkbox" aria-label="Select workspace ${safeName}">
-            <input type="checkbox" data-workspace-checkbox="${safeId}" ${selectedSet.has(row.id) ? 'checked' : ''} />
-            <span class="launcher-card-checkmark" aria-hidden="true"></span>
-          </label>
-        ` : '<span class="launcher-tree-checkbox-placeholder" aria-hidden="true"></span>';
-      const caret = isGroup ? `
-        <button class="launcher-tree-caret launcher-group-toggle ${isCollapsed ? 'is-collapsed' : ''}" type="button" data-group-toggle="${safeId}" aria-label="${isCollapsed ? 'Expand' : 'Collapse'} group" aria-expanded="${isCollapsed ? 'false' : 'true'}" title="${isCollapsed ? 'Expand' : 'Collapse'}">
-          <svg class="launcher-group-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M7,10L12,15L17,10H7Z"/>
-          </svg>
-        </button>
-      ` : '<span class="launcher-tree-caret-placeholder" aria-hidden="true"></span>';
-      const deleteButton = `
-        <button class="launcher-tree-delete launcher-card-delete" type="button" draggable="false" data-workspace-delete="${safeId}" title="${deleteTitle}" aria-label="${deleteTitle}">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
-          </svg>
-        </button>
-      `;
-
-      const childHtml = children.map((child, index) => renderTreeNode(child, depth + 1, children, index)).join('');
-      const emptyHint = isGroup && children.length === 0
-        ? `<div class="launcher-tree-empty-group" role="group" data-group-children="${safeId}" style="--launcher-tree-depth: ${depth + 1}">Drop workspaces here</div>`
-        : '';
-      const childrenWrapper = isGroup ? `
-        <div class="launcher-tree-children${children.length === 0 ? ' is-empty' : ''}" role="group" ${isCollapsed ? 'hidden' : ''} data-group-children="${safeId}">
-          ${childHtml || emptyHint}
-        </div>
-      ` : '';
-
-      return `
-        <div class="launcher-tree-node${isGroup ? ' is-group' : ' is-workspace'}${isCollapsed ? ' is-collapsed' : ''}">
-          <div class="launcher-tree-row" role="treeitem" tabindex="0" draggable="true" data-workspace-id="${safeId}" data-workspace-kind="${isGroup ? 'group' : 'workspace'}" data-parent-id="${safeParentId}" data-next-sibling-id="${safeNextSiblingId}" ${isGroup ? `aria-expanded="${isCollapsed ? 'false' : 'true'}"` : ''} aria-label="${isGroup ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open workspace'} ${safeName}" style="--launcher-tree-depth: ${depth}">
-            ${checkbox}
-            ${caret}
-            ${renderTreeIcon(isGroup ? 'group' : 'workspace')}
-            <span class="launcher-tree-name" title="${safeName}">${safeName}</span>
-            ${deleteButton}
-          </div>
-          ${childrenWrapper}
-        </div>
-      `;
-    }
+    const ctx = {
+      state,
+      selectedSet: state.selectedWorkspaces || new Set(),
+      flattenedMap: new Map((flattened || []).map((ws) => [ws.id, ws]))
+    };
 
     elements.launcherGrid.innerHTML = `
       <div class="launcher-tree" role="tree" aria-label="Workspaces">
-        ${tree.map((workspace, index) => renderTreeNode(workspace, 0, tree, index)).join('')}
+        ${tree.map((workspace, index) => renderLauncherTreeNode(workspace, 0, tree, index, ctx)).join('')}
       </div>
     `;
     bindLauncherInteractions();
@@ -1644,9 +1653,19 @@ console.log('[workspace-hub.js] FILE LOADED');
     row.focus();
   }
 
+  // Escape a value for safe use inside a double-quoted attribute selector.
+  // Prefers CSS.escape; the fallback escapes the double-quote so an id that
+  // happens to contain one can't break out of the [attr="..."] selector.
+  function escapeAttrSelectorValue(value) {
+    const str = String(value);
+    return (window.CSS && typeof window.CSS.escape === 'function')
+      ? window.CSS.escape(str)
+      : str.replace(/"/g, '\\"');
+  }
+
   function focusLauncherTreeRowById(workspaceId) {
     if (!elements.launcherGrid || !workspaceId) return;
-    const safeId = (window.CSS && window.CSS.escape) ? window.CSS.escape(workspaceId) : workspaceId;
+    const safeId = escapeAttrSelectorValue(workspaceId);
     const row = elements.launcherGrid.querySelector(`.launcher-tree-row[data-workspace-id="${safeId}"]`);
     focusLauncherTreeRow(row);
   }
@@ -1807,7 +1826,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     state.launcherJustExpandedGroups = new Set();
 
     ids.forEach((id) => {
-      const safeId = (window.CSS && window.CSS.escape) ? window.CSS.escape(id) : id;
+      const safeId = escapeAttrSelectorValue(id);
       const header = elements.launcherGrid.querySelector(`[data-workspace-id="${safeId}"]`);
       const grid = elements.launcherGrid.querySelector(`[data-group-children="${safeId}"]`);
       if (header) header.classList.add('is-revealed');

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -1,0 +1,372 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function createClassList() {
+  const values = new Set();
+  return {
+    add: (...classes) => classes.forEach((className) => values.add(className)),
+    remove: (...classes) => classes.forEach((className) => values.delete(className)),
+    contains: (className) => values.has(className),
+    toggle: (className, force) => {
+      const enabled = typeof force === 'boolean' ? force : !values.has(className);
+      if (enabled) values.add(className);
+      else values.delete(className);
+      return enabled;
+    },
+    toString: () => Array.from(values).join(' ')
+  };
+}
+
+function createElement(id = '') {
+  const attributes = new Map();
+  return {
+    id,
+    classList: createClassList(),
+    dataset: {},
+    disabled: false,
+    hidden: false,
+    innerHTML: '',
+    style: {},
+    textContent: '',
+    value: '',
+    addEventListener: () => {},
+    blur: () => {},
+    focus: () => {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    removeAttribute: (name) => attributes.delete(name),
+    setAttribute: (name, value) => attributes.set(name, String(value)),
+    getAttribute: (name) => attributes.get(name) || null
+  };
+}
+
+function flattenWorkspaces(workspaces, depth = 0, parentId = '') {
+  const flattened = [];
+  (workspaces || []).forEach((workspace) => {
+    if (!workspace) return;
+    const row = { ...workspace, depth, parent_id: workspace.parent_id || parentId };
+    flattened.push(row);
+    if (Array.isArray(workspace.children)) {
+      flattened.push(...flattenWorkspaces(workspace.children, depth + 1, workspace.id));
+    }
+  });
+  return flattened;
+}
+
+function createKeyboardRow({ id, kind = 'workspace', expanded = null, hidden = false, parentRow = null } = {}) {
+  const listeners = new Map();
+  const row = {
+    dataset: { workspaceId: id, workspaceKind: kind },
+    focused: false,
+    tabIndex: 0,
+    addEventListener: (type, handler) => listeners.set(type, handler),
+    closest: (selector) => {
+      if (selector === '[hidden]') return hidden ? { hidden: true } : null;
+      if (selector === '.launcher-tree-node') return row._node;
+      return null;
+    },
+    dispatchKey: (key, target = row) => {
+      const event = {
+        currentTarget: row,
+        key,
+        prevented: false,
+        target,
+        preventDefault() {
+          this.prevented = true;
+        }
+      };
+      const handler = listeners.get('keydown');
+      if (handler) handler(event);
+      return event;
+    },
+    focus: () => {
+      row.focused = true;
+    },
+    getAttribute: (name) => (name === 'aria-expanded' ? expanded : null)
+  };
+
+  const parentChildren = parentRow
+    ? { closest: (selector) => (selector === '.launcher-tree-node' ? parentRow._node : null) }
+    : null;
+
+  row._node = {
+    parentElement: {
+      closest: (selector) => (selector === '.launcher-tree-children' ? parentChildren : null)
+    },
+    querySelector: (selector) => (selector === ':scope > .launcher-tree-row' ? row : null)
+  };
+
+  return row;
+}
+
+function loadWorkspaceHub(overrides = {}) {
+  const source = readFileSync(new URL('./workspace-hub.js', import.meta.url), 'utf8');
+  const elements = new Map();
+  const hubEl = createElement('workspaceHub');
+  const launcherGrid = createElement('launcherGrid');
+  const launcherEmpty = createElement('launcherEmptyState');
+  const launcherViewCards = createElement('launcherViewCards');
+  const launcherViewTree = createElement('launcherViewTree');
+
+  elements.set('workspaceHub', hubEl);
+  elements.set('launcherGrid', launcherGrid);
+  elements.set('launcherEmptyState', launcherEmpty);
+  elements.set('launcherViewCards', launcherViewCards);
+  elements.set('launcherViewTree', launcherViewTree);
+
+  const state = {
+    launcherCollapsedGroups: new Set(),
+    launcherJustExpandedGroups: new Set(),
+    launcherSelectionMode: false,
+    selectedWorkspaces: new Set(),
+    workspaceMap: new Map(),
+    workspaces: [],
+    ...overrides.state
+  };
+
+  const storage = new Map(Object.entries(overrides.localStorage || {}));
+  const sessionStorageMap = new Map();
+  const window = {
+    CSS: { escape: (value) => String(value).replace(/"/g, '\\"') },
+    EventBus: null,
+    Toast: { error: () => {}, success: () => {} },
+    WorkspaceHubFiles: {
+      bindFileUploadEvents: () => {},
+      clearFileAttachmentState: () => {},
+      loadFiles: async () => {},
+      renderFiles: () => {}
+    },
+    WorkspaceHubModals: { bindModalEvents: () => {} },
+    WorkspaceHubNotes: {
+      createNewNote: () => {},
+      loadNotes: async () => {},
+      renderNotes: () => {}
+    },
+    WorkspaceHubSelection: { toggleSelectionMode: () => {} },
+    WorkspaceHubSessions: {
+      loadSessions: async () => {},
+      renderSessions: () => {}
+    },
+    WorkspaceHubSmartInput: {
+      bindEvents: () => {},
+      clearField: () => {},
+      resetPrompt: () => {},
+      setEnabled: () => {},
+      setStatus: () => {}
+    },
+    WorkspaceHubState: {
+      getState: () => state,
+      getStorageKey: () => 'oriWorkspaceHubSelectedId',
+      getTasksAbortController: () => null,
+      initElements: () => {},
+      setTasksAbortController: () => {},
+      setUIState: () => {},
+      shouldRefreshForEvent: () => false,
+      stopRealtime: () => {}
+    },
+    WorkspaceHubTasks: {
+      bulkDeleteTasks: () => {},
+      loadTasks: async () => {},
+      renderStats: () => {},
+      renderTasksList: () => {},
+      resetTaskFilters: () => {}
+    },
+    WorkspaceHubUtils: {
+      collectWorkspaceDescendantIds: () => [],
+      flattenWorkspaces,
+      formatDate: (value) => String(value || '')
+    },
+    addEventListener: () => {},
+    clearTimeout,
+    confirm: () => false,
+    localStorage: {
+      getItem: (key) => storage.get(key) || null,
+      setItem: (key, value) => storage.set(key, String(value))
+    },
+    location: { href: '' },
+    sessionStorage: {
+      getItem: (key) => sessionStorageMap.get(key) || null,
+      removeItem: (key) => sessionStorageMap.delete(key),
+      setItem: (key, value) => sessionStorageMap.set(key, String(value))
+    },
+    setTimeout
+  };
+
+  const document = {
+    activeElement: null,
+    addEventListener: () => {},
+    getElementById: (id) => elements.get(id) || null,
+    querySelector: (selector) => selector === '.workspace-hub-header .hub-title-text' ? createElement('headerTitle') : null,
+    querySelectorAll: () => []
+  };
+
+  const context = {
+    bootstrap: {},
+    clearTimeout,
+    console,
+    document,
+    escapeHtml,
+    fetch: async (url) => {
+      if (String(url).includes('/api/workspaces?tree=true')) {
+        return { ok: true, json: async () => ({ folders: state.workspaces }) };
+      }
+      return { ok: true, json: async () => ({ path: '/tmp/workspaces' }), text: async () => '' };
+    },
+    localStorage: window.localStorage,
+    sessionStorage: window.sessionStorage,
+    setTimeout,
+    window
+  };
+
+  vm.runInNewContext(source, context, { filename: 'workspace-hub.js' });
+
+  return {
+    helpers: window.WorkspaceHub.__test,
+    launcherEmpty,
+    launcherGrid,
+    launcherViewCards,
+    launcherViewTree,
+    state,
+    storage
+  };
+}
+
+test('launcher view preference defaults to cards and persists valid values', () => {
+  const { helpers, storage } = loadWorkspaceHub();
+
+  assert.equal(helpers.normalizeLauncherView('tree'), 'tree');
+  assert.equal(helpers.normalizeLauncherView('invalid'), 'cards');
+  assert.equal(helpers.getLauncherViewPreference(), 'cards');
+  assert.equal(helpers.setLauncherViewPreference('tree'), 'tree');
+  assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'tree');
+});
+
+test('launcher tree renders minimal hierarchy and workspace-only selection checkboxes', () => {
+  const workspaces = [
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Platform',
+      children: [
+        { id: 'workspace-1', kind: 'workspace', name: 'API', parent_id: 'group-1' },
+        { id: 'group-2', kind: 'group', name: 'Empty Group', parent_id: 'group-1', children: [] }
+      ]
+    }
+  ];
+  const flattened = flattenWorkspaces(workspaces);
+  const { helpers, launcherEmpty, launcherGrid, state } = loadWorkspaceHub({
+    state: {
+      launcherCollapsedGroups: new Set(['group-2']),
+      launcherSelectionMode: true,
+      selectedWorkspaces: new Set(['workspace-1']),
+      workspaces
+    }
+  });
+
+  helpers.renderLauncherTree(flattened);
+
+  assert.equal(launcherEmpty.style.display, 'none');
+  assert.match(launcherGrid.innerHTML, /class="launcher-tree"/);
+  assert.match(launcherGrid.innerHTML, /role="treeitem"/);
+  assert.match(launcherGrid.innerHTML, /data-workspace-id="group-1"/);
+  assert.match(launcherGrid.innerHTML, /aria-expanded="true"/);
+  assert.match(launcherGrid.innerHTML, /data-workspace-checkbox="workspace-1" checked/);
+  assert.match(launcherGrid.innerHTML, /launcher-tree-checkbox-placeholder/);
+  assert.match(launcherGrid.innerHTML, /Drop workspaces here/);
+  assert.doesNotMatch(launcherGrid.innerHTML, /No description yet/);
+  assert.equal(state.workspaces, workspaces);
+});
+
+test('launcher tree keyboard helpers move focus and ignore embedded controls', () => {
+  const { helpers, launcherGrid, state } = loadWorkspaceHub({
+    state: {
+      launcherCollapsedGroups: new Set(['group-1'])
+    }
+  });
+  const groupRow = createKeyboardRow({ id: 'group-1', kind: 'group', expanded: 'false' });
+  const workspaceRow = createKeyboardRow({ id: 'workspace-1', parentRow: groupRow });
+  const rows = [groupRow, workspaceRow];
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '.launcher-tree-row[data-workspace-id]') return rows;
+    return [];
+  };
+
+  helpers.bindLauncherTreeKeyboardEvents();
+
+  assert.equal(groupRow.tabIndex, 0);
+  assert.equal(workspaceRow.tabIndex, -1);
+
+  const downEvent = groupRow.dispatchKey('j');
+  assert.equal(downEvent.prevented, true);
+  assert.equal(groupRow.tabIndex, -1);
+  assert.equal(workspaceRow.tabIndex, 0);
+  assert.equal(workspaceRow.focused, true);
+
+  const upEvent = workspaceRow.dispatchKey('ArrowUp');
+  assert.equal(upEvent.prevented, true);
+  assert.equal(groupRow.tabIndex, 0);
+  assert.equal(workspaceRow.tabIndex, -1);
+  assert.equal(groupRow.focused, true);
+
+  const parentEvent = workspaceRow.dispatchKey('h');
+  assert.equal(parentEvent.prevented, true);
+  assert.equal(groupRow.tabIndex, 0);
+
+  const expandEvent = groupRow.dispatchKey('l');
+  assert.equal(expandEvent.prevented, true);
+  assert.equal(state.launcherCollapsedGroups.has('group-1'), false);
+
+  const inputEvent = groupRow.dispatchKey('j', { tagName: 'INPUT', closest: () => null });
+  assert.equal(inputEvent.prevented, false);
+  assert.equal(groupRow.tabIndex, 0);
+
+  const modalEvent = groupRow.dispatchKey('k', {
+    tagName: 'SPAN',
+    closest: (selector) => selector.includes('.modal.show') ? { className: 'modal show' } : null
+  });
+  assert.equal(modalEvent.prevented, false);
+});
+
+test('launcher tree drop intent maps edge and middle regions', () => {
+  const { helpers } = loadWorkspaceHub();
+  const row = {
+    classList: { contains: (className) => className === 'launcher-tree-row' },
+    dataset: {
+      nextSiblingId: 'workspace-next',
+      parentId: 'group-parent',
+      workspaceId: 'group-target',
+      workspaceKind: 'group'
+    },
+    getBoundingClientRect: () => ({ top: 100, height: 30 })
+  };
+
+  assert.equal(
+    JSON.stringify(helpers.getLauncherTreeDropIntent(row, { clientY: 101 })),
+    JSON.stringify({ type: 'before', targetParentId: 'group-parent', insertBeforeId: 'group-target' })
+  );
+  assert.equal(
+    JSON.stringify(helpers.getLauncherTreeDropIntent(row, { clientY: 115 })),
+    JSON.stringify({ type: 'into', targetParentId: 'group-target', insertBeforeId: '' })
+  );
+  assert.equal(
+    JSON.stringify(helpers.getLauncherTreeDropIntent(row, { clientY: 129 })),
+    JSON.stringify({ type: 'after', targetParentId: 'group-parent', insertBeforeId: 'workspace-next' })
+  );
+
+  row.dataset.nextSiblingId = '';
+  assert.equal(
+    JSON.stringify(helpers.getLauncherTreeDropIntent(row, { clientY: 129 })),
+    JSON.stringify({ type: 'after', targetParentId: 'group-parent', insertBeforeId: '' })
+  );
+});

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -360,6 +360,55 @@ test('launcher checkbox click handlers select without triggering workspace navig
   assert.equal(window.location.href, '/workspaces/workspace-1');
 });
 
+test('launcher group row opens details on click while the caret toggles collapse', () => {
+  const listenerElement = (overrides = {}) => {
+    const listeners = new Map();
+    return {
+      addEventListener: (type, handler) => listeners.set(type, handler),
+      dispatch: (type, event = {}) => listeners.get(type)?.(event),
+      listeners,
+      ...overrides
+    };
+  };
+
+  const groupRow = listenerElement({
+    dataset: { workspaceId: 'group-1', workspaceKind: 'group' }
+  });
+  const caretBtn = listenerElement({
+    getAttribute: (name) => (name === 'data-group-toggle' ? 'group-1' : null)
+  });
+
+  const { helpers, launcherGrid, state, window } = loadWorkspaceHub({
+    state: { workspaces: [{ id: 'group-1', kind: 'group', name: 'Clients', children: [] }] }
+  });
+
+  launcherGrid.querySelector = () => null;
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '[data-workspace-id]') return [groupRow];
+    if (selector === '[data-group-toggle]') return [caretBtn];
+    return [];
+  };
+
+  helpers.bindLauncherInteractions();
+
+  // Clicking the group's name/body opens its details page.
+  groupRow.dispatch('click', {});
+  assert.equal(window.location.href, '/workspaces/group-1');
+
+  // The caret toggles collapse, stops propagation, and must not navigate.
+  window.location.href = '';
+  const caretClick = {
+    prevented: false,
+    stopped: false,
+    preventDefault() { this.prevented = true; },
+    stopPropagation() { this.stopped = true; }
+  };
+  caretBtn.dispatch('click', caretClick);
+  assert.equal(caretClick.stopped, true);
+  assert.equal(window.location.href, '');
+  assert.equal(state.launcherCollapsedGroups.has('group-1'), true);
+});
+
 test('launcher tree keyboard helpers move focus and ignore embedded controls', () => {
   const { helpers, launcherGrid, state } = loadWorkspaceHub({
     state: {

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -128,7 +128,6 @@ function loadWorkspaceHub(overrides = {}) {
   const state = {
     launcherCollapsedGroups: new Set(),
     launcherJustExpandedGroups: new Set(),
-    launcherSelectionMode: false,
     selectedWorkspaces: new Set(),
     workspaceMap: new Map(),
     workspaces: [],
@@ -238,7 +237,8 @@ function loadWorkspaceHub(overrides = {}) {
     launcherViewCards,
     launcherViewTree,
     state,
-    storage
+    storage,
+    window
   };
 }
 
@@ -252,7 +252,7 @@ test('launcher view preference defaults to cards and persists valid values', () 
   assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'tree');
 });
 
-test('launcher tree renders minimal hierarchy and workspace-only selection checkboxes', () => {
+test('launcher tree renders minimal hierarchy with always-available workspace checkboxes', () => {
   const workspaces = [
     {
       id: 'group-1',
@@ -268,7 +268,6 @@ test('launcher tree renders minimal hierarchy and workspace-only selection check
   const { helpers, launcherEmpty, launcherGrid, state } = loadWorkspaceHub({
     state: {
       launcherCollapsedGroups: new Set(['group-2']),
-      launcherSelectionMode: true,
       selectedWorkspaces: new Set(['workspace-1']),
       workspaces
     }
@@ -281,11 +280,84 @@ test('launcher tree renders minimal hierarchy and workspace-only selection check
   assert.match(launcherGrid.innerHTML, /role="treeitem"/);
   assert.match(launcherGrid.innerHTML, /data-workspace-id="group-1"/);
   assert.match(launcherGrid.innerHTML, /aria-expanded="true"/);
+  assert.match(launcherGrid.innerHTML, /class="launcher-tree-checkbox"/);
   assert.match(launcherGrid.innerHTML, /data-workspace-checkbox="workspace-1" checked/);
   assert.match(launcherGrid.innerHTML, /launcher-tree-checkbox-placeholder/);
+  assert.doesNotMatch(launcherGrid.innerHTML, /data-select-mode/);
   assert.match(launcherGrid.innerHTML, /Drop workspaces here/);
   assert.doesNotMatch(launcherGrid.innerHTML, /No description yet/);
   assert.equal(state.workspaces, workspaces);
+});
+
+test('launcher cards render always-available workspace checkboxes without select-mode attributes', () => {
+  const workspaces = [
+    { id: 'workspace-1', kind: 'workspace', name: 'API', description: 'Backend work' },
+    { id: 'workspace-2', kind: 'workspace', name: 'UI' }
+  ];
+  const flattened = flattenWorkspaces(workspaces);
+  const { helpers, launcherEmpty, launcherGrid } = loadWorkspaceHub({
+    state: {
+      selectedWorkspaces: new Set(['workspace-2']),
+      workspaces
+    }
+  });
+
+  helpers.renderLauncherCards(flattened);
+
+  assert.equal(launcherEmpty.style.display, 'none');
+  assert.match(launcherGrid.innerHTML, /launcher-card-item has-selection-checkbox/);
+  assert.match(launcherGrid.innerHTML, /class="launcher-card-checkbox"/);
+  assert.match(launcherGrid.innerHTML, /data-workspace-checkbox="workspace-1"/);
+  assert.match(launcherGrid.innerHTML, /data-workspace-checkbox="workspace-2" checked/);
+  assert.doesNotMatch(launcherGrid.innerHTML, /data-select-mode/);
+});
+
+test('launcher checkbox click handlers select without triggering workspace navigation', () => {
+  const listenerElement = (overrides = {}) => {
+    const listeners = new Map();
+    return {
+      addEventListener: (type, handler) => listeners.set(type, handler),
+      dispatch: (type, event = {}) => listeners.get(type)?.(event),
+      listeners,
+      ...overrides
+    };
+  };
+  const workspaceRow = listenerElement({
+    dataset: { workspaceId: 'workspace-1', workspaceKind: 'workspace' }
+  });
+  const checkbox = listenerElement({
+    checked: true,
+    getAttribute: (name) => (name === 'data-workspace-checkbox' ? 'workspace-1' : null)
+  });
+  const checkboxShell = listenerElement();
+  const { helpers, launcherGrid, state, window } = loadWorkspaceHub();
+
+  launcherGrid.querySelector = () => null;
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '[data-workspace-id]') return [workspaceRow];
+    if (selector === '[data-workspace-checkbox]') return [checkbox];
+    if (selector === '.launcher-card-checkbox, .launcher-tree-checkbox') return [checkboxShell];
+    return [];
+  };
+
+  helpers.bindLauncherInteractions();
+
+  const shellClick = {
+    stopped: false,
+    stopPropagation() {
+      this.stopped = true;
+    }
+  };
+  checkboxShell.dispatch('click', shellClick);
+  assert.equal(shellClick.stopped, true);
+  assert.equal(window.location.href, '');
+
+  checkbox.dispatch('change', { target: checkbox });
+  assert.equal(state.selectedWorkspaces.has('workspace-1'), true);
+  assert.equal(window.location.href, '');
+
+  workspaceRow.dispatch('click', {});
+  assert.equal(window.location.href, '/workspaces/workspace-1');
 });
 
 test('launcher tree keyboard helpers move focus and ignore embedded controls', () => {

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -98,6 +98,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/workspaces-hub.tmpl",
 		"templates/pages/workspace-canvas.tmpl",
 		"templates/pages/workspace-detail.tmpl",
+		"templates/pages/group-detail.tmpl",
 		"templates/pages/workspace-diagnostics.tmpl",
 		"templates/pages/workspace-task.tmpl",
 		"templates/pages/workspace-run.tmpl",
@@ -140,6 +141,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["workspaces-hub"] = tmpl
 	tr.templates["workspace-canvas"] = tmpl
 	tr.templates["workspace-detail"] = tmpl
+	tr.templates["group-detail"] = tmpl
 	tr.templates["workspace-diagnostics"] = tmpl
 	tr.templates["workspace-task"] = tmpl
 	tr.templates["workspace-run"] = tmpl
@@ -173,7 +175,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "models", "review", "agents-detail", "agents-edit", "agents-create", "skills", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "group-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "models", "review", "agents-detail", "agents-edit", "agents-create", "skills", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -54,17 +54,15 @@
             Import Folder
           </button>
           <div class="hub-view-toggle launcher-view-toggle" role="tablist" aria-label="Launcher view mode">
-            <button id="launcherViewCards" class="modern-btn modern-btn-secondary hub-view-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="launcherGrid" title="Cards View" data-launcher-view="cards">
+            <button id="launcherViewCards" class="modern-btn modern-btn-secondary hub-view-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="launcherGrid" aria-label="Cards view" title="Cards View" data-launcher-view="cards">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M4,5H10V11H4V5M14,5H20V11H14V5M4,13H10V19H4V13M14,13H20V19H14V13Z"/>
               </svg>
-              <span class="hub-view-btn-label">Cards</span>
             </button>
-            <button id="launcherViewTree" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherGrid" title="Tree View" data-launcher-view="tree">
+            <button id="launcherViewTree" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherGrid" aria-label="Tree view" title="Tree View" data-launcher-view="tree">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M3,5H9V7H5V17H9V19H3V5M11,5H21V9H11V5M11,10H21V14H11V10M11,15H21V19H11V15Z"/>
               </svg>
-              <span class="hub-view-btn-label">Tree</span>
             </button>
           </div>
           <button id="launcherRefreshBtn" class="modern-btn modern-btn-secondary modern-btn-icon" type="button" title="Refresh" aria-label="Refresh workspaces">

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -53,6 +53,20 @@
             </svg>
             Import Folder
           </button>
+          <div class="hub-view-toggle launcher-view-toggle" role="tablist" aria-label="Launcher view mode">
+            <button id="launcherViewCards" class="modern-btn modern-btn-secondary hub-view-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="launcherGrid" title="Cards View" data-launcher-view="cards">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M4,5H10V11H4V5M14,5H20V11H14V5M4,13H10V19H4V13M14,13H20V19H14V13Z"/>
+              </svg>
+              <span class="hub-view-btn-label">Cards</span>
+            </button>
+            <button id="launcherViewTree" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherGrid" title="Tree View" data-launcher-view="tree">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M3,5H9V7H5V17H9V19H3V5M11,5H21V9H11V5M11,10H21V14H11V10M11,15H21V19H11V15Z"/>
+              </svg>
+              <span class="hub-view-btn-label">Tree</span>
+            </button>
+          </div>
           <button id="launcherRefreshBtn" class="modern-btn modern-btn-secondary modern-btn-icon" type="button" title="Refresh" aria-label="Refresh workspaces">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/>

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -83,11 +83,6 @@
             </svg>
             <span class="launcher-undo-count" aria-hidden="true" hidden></span>
           </button>
-          <button id="launcherSelectModeBtn" class="modern-btn modern-btn-secondary modern-btn-icon" type="button" title="Select workspaces to group" aria-label="Select workspaces to group">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"/>
-            </svg>
-          </button>
         </div>
       </div>
       <div class="launcher-tabs" role="tablist" aria-label="Launcher views">
@@ -112,7 +107,7 @@
       </div>
 
       <section id="launcherWorkspacesPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabWorkspaces">
-        <!-- Selection Bar (shows only in selection mode) -->
+        <!-- Selection Bar (shows when workspace checkboxes are selected) -->
         <div id="launcherSelectionBar" class="launcher-selection-bar" hidden>
           <span id="launcherSelectionCount" class="launcher-selection-count">0 selected</span>
           <div class="launcher-selection-actions">

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -76,10 +76,10 @@
             </div>
 
             <label for="folderParentSelect" style="font-size: 12px; color: var(--text-secondary);">Group (optional)</label>
-            <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select parent workspace">
+            <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select workspace group" aria-describedby="folderParentHelp">
               <option value="">No group</option>
             </select>
-            <div style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
+            <div id="folderParentHelp" style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
               Optional. Choose an organization-only group for this workspace.
             </div>
 

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1588,6 +1588,7 @@
     <script src="/js/utils/dom-utils.js"></script>
     <script src="/js/modules/toast.js"></script>
     <script src="/js/modules/workspace-bootstrap-review.js"></script>
+    <script src="/js/modules/workspace-group-options.js"></script>
     <script src="/js/modules/sessions.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/modules/agents.js"></script>

--- a/internal/web/templates/pages/group-detail.tmpl
+++ b/internal/web/templates/pages/group-detail.tmpl
@@ -83,7 +83,31 @@
 
           <!-- Members -->
           <section class="modern-card p-3 group-detail-section" aria-labelledby="group-members-heading">
-            <h2 class="group-detail-section-title" id="group-members-heading">Members</h2>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <h2 class="group-detail-section-title mb-0" id="group-members-heading">Members</h2>
+              <div class="d-flex gap-2">
+                <button id="group-add-member-btn" type="button" class="modern-btn modern-btn-secondary" hidden>Add existing</button>
+                <button id="group-create-member-btn" type="button" class="modern-btn modern-btn-primary" hidden>Create new</button>
+              </div>
+            </div>
+            <div id="group-members-error" class="text-danger small mb-2" role="alert" hidden></div>
+            <div id="group-add-member-picker" class="group-add-picker mb-2" hidden></div>
+
+            <form id="group-create-member-form" class="group-add-picker mb-2" hidden>
+              <div class="mb-2">
+                <label class="form-label" for="group-create-name">New workspace name</label>
+                <input type="text" class="form-control form-control-sm" id="group-create-name" maxlength="200" required>
+              </div>
+              <div class="mb-2">
+                <label class="form-label" for="group-create-description">Description</label>
+                <input type="text" class="form-control form-control-sm" id="group-create-description" maxlength="500">
+              </div>
+              <div class="d-flex gap-2">
+                <button type="submit" id="group-create-submit" class="modern-btn modern-btn-primary">Create</button>
+                <button type="button" id="group-create-cancel" class="modern-btn modern-btn-secondary">Cancel</button>
+              </div>
+            </form>
+
             <div id="group-members-list"></div>
           </section>
 

--- a/internal/web/templates/pages/group-detail.tmpl
+++ b/internal/web/templates/pages/group-detail.tmpl
@@ -1,0 +1,126 @@
+{{define "group-detail"}}
+<!DOCTYPE html>
+<html data-bs-theme="light">
+{{template "head.tmpl" .}}
+<link href="/css/group-detail.css" rel="stylesheet">
+
+<body class="bg-light">
+  {{template "navbar.tmpl" .}}
+
+  <div class="main-content-wrapper">
+    {{template "sidebar.tmpl" .}}
+
+    <div class="main-content">
+      <div class="container-fluid py-4">
+
+        <!-- Not-found state (group missing, trashed, or not a group) -->
+        <div id="group-not-found" class="modern-card" hidden>
+          <h2 class="h5 mb-2">Group not found</h2>
+          <p class="text-secondary mb-3">This group may have been deleted or moved.</p>
+          <a href="/workspaces" class="modern-btn modern-btn-primary">Back to Workspaces</a>
+        </div>
+
+        <div id="group-detail-view">
+          <!-- Header Card -->
+          <div class="modern-card p-3 mb-3">
+            <div class="group-detail-header">
+              <div class="d-flex align-items-center gap-3">
+                <a href="/workspaces" class="modern-btn modern-btn-secondary">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                    <path d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"/>
+                  </svg>
+                  Workspaces
+                </a>
+
+                <nav aria-label="breadcrumb">
+                  <ol class="breadcrumb mb-0" style="font-size: 0.875rem;">
+                    <li class="breadcrumb-item"><a href="/workspaces" style="color: var(--text-secondary); text-decoration: none;">Workspaces</a></li>
+                    <li class="breadcrumb-item" id="group-parent-crumb" hidden><a id="group-parent-link" href="#" style="color: var(--text-secondary); text-decoration: none;">Parent group</a></li>
+                    <li class="breadcrumb-item active" aria-current="page" id="group-breadcrumb-name">Loading...</li>
+                  </ol>
+                </nav>
+              </div>
+
+              <div class="d-flex align-items-center gap-2">
+                <button id="group-edit-btn" type="button" class="modern-btn modern-btn-secondary" hidden>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                    <path d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"/>
+                  </svg>
+                  Edit
+                </button>
+              </div>
+            </div>
+
+            <div class="mt-3">
+              <div class="group-detail-title-row">
+                <span class="group-detail-color-swatch" id="group-color-swatch" aria-hidden="true"></span>
+                <h1 class="h4 mb-0" id="group-title">Loading...</h1>
+                <span class="group-detail-meta" id="group-member-count">—</span>
+              </div>
+              <p class="text-secondary mb-0 mt-2" id="group-description"></p>
+
+              <form id="group-edit-form" class="mt-3" hidden>
+                <div class="mb-2">
+                  <label class="form-label" for="group-edit-name">Name</label>
+                  <input type="text" class="form-control" id="group-edit-name" maxlength="200" required>
+                </div>
+                <div class="mb-2">
+                  <label class="form-label" for="group-edit-description">Description</label>
+                  <textarea class="form-control" id="group-edit-description" rows="2"></textarea>
+                </div>
+                <div class="mb-2">
+                  <span class="form-label d-block">Color</span>
+                  <div id="group-edit-colors" class="d-flex gap-2 flex-wrap" role="group" aria-label="Group color"></div>
+                </div>
+                <div id="group-edit-error" class="text-danger small mb-2" role="alert" hidden></div>
+                <div class="d-flex gap-2">
+                  <button type="submit" id="group-edit-save" class="modern-btn modern-btn-primary">Save</button>
+                  <button type="button" id="group-edit-cancel" class="modern-btn modern-btn-secondary">Cancel</button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <!-- Members -->
+          <section class="modern-card p-3 group-detail-section" aria-labelledby="group-members-heading">
+            <h2 class="group-detail-section-title" id="group-members-heading">Members</h2>
+            <div id="group-members-list"></div>
+          </section>
+
+          <!-- Tasks roll-up -->
+          <section class="modern-card p-3 group-detail-section" aria-labelledby="group-tasks-heading">
+            <h2 class="group-detail-section-title" id="group-tasks-heading">Tasks</h2>
+            <div id="group-tasks-list"></div>
+          </section>
+
+          <!-- Notes & Files roll-up -->
+          <section class="modern-card p-3 group-detail-section" aria-labelledby="group-notes-files-heading">
+            <h2 class="group-detail-section-title" id="group-notes-files-heading">Notes &amp; Files</h2>
+            <div id="group-notes-files-list"></div>
+          </section>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module">
+    import { GroupDetailPage } from '/js/modules/group-detail.js';
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      const groupId = "{{.Extra.WorkspaceID}}";
+      if (!groupId) {
+        return;
+      }
+      const page = new GroupDetailPage(groupId);
+      try {
+        await page.init();
+      } catch (error) {
+        console.error('Failed to initialize group details page:', error);
+      }
+    });
+  </script>
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -709,6 +709,7 @@
   <script src="/js/modules/apikey.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script src="/js/modules/workspace-group-options.js"></script>
   <script src="/js/modules/sessions.js"></script>
   <script src="/js/modules/dashboard.js"></script>
   <script src="/js/modules/sidebar.js"></script>

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -7596,6 +7596,32 @@
       text-align: right;
     }
 
+    .workspace-directory-tree-badge {
+      flex-shrink: 0;
+      font-size: 0.55rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 0.05rem 0.3rem;
+      border-radius: 4px;
+      background: rgba(56, 189, 248, 0.18);
+      color: var(--text-secondary);
+    }
+
+    .workspace-directory-open-ws {
+      flex-shrink: 0;
+      font-size: 0.62rem;
+      white-space: nowrap;
+      padding: 0.1rem 0.4rem;
+      border-radius: 4px;
+      text-decoration: none;
+      color: var(--text-secondary);
+      border: 1px solid rgba(255, 166, 110, 0.45);
+    }
+
+    .workspace-directory-open-ws:hover {
+      background: rgba(255, 166, 110, 0.15);
+    }
+
     .workspace-directory-tree-node.is-selected > .workspace-directory-tree-row .workspace-directory-tree-main {
       background: linear-gradient(90deg, rgba(255, 166, 110, 0.24), rgba(56, 189, 248, 0.16));
       border: 1px solid rgba(255, 166, 110, 0.45);

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -7940,6 +7940,7 @@
   <script src="/js/modules/location.js"></script>
   <script src="/js/modules/task-modal-controller.js"></script>
   <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script src="/js/modules/workspace-group-options.js"></script>
   <script src="/js/modules/sessions.js"></script>
   <script src="/js/modules/dashboard.js"></script>
   <script src="/js/modules/toast.js"></script>

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -6674,6 +6674,7 @@
   <script src="/js/modules/location.js"></script>
   <script src="/js/modules/task-modal-controller.js"></script>
   <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script src="/js/modules/workspace-group-options.js"></script>
   <script src="/js/modules/sessions.js"></script>
   <script src="/js/modules/dashboard.js"></script>
   <script src="/js/modules/toast.js"></script>

--- a/internal/web/templates/pages/workspaces-hub.tmpl
+++ b/internal/web/templates/pages/workspaces-hub.tmpl
@@ -84,6 +84,7 @@
   <script src="/js/modules/workspace-listing.js?v=1732920000"></script>
   <script src="/js/modules/workspace-agent-modals.js?v=1764212000"></script>
   <script src="/js/modules/workspace-templates.js?v=1764212001"></script>
+  <script src="/js/modules/workspace-group-options.js"></script>
   <script src="/js/modules/workspace-create.js?v=1764212001"></script>
 
 

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -57,6 +57,7 @@
   <script src="/js/modules/location.js"></script>
   <script src="/js/modules/task-modal-controller.js"></script>
   <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script src="/js/modules/workspace-group-options.js"></script>
   <script src="/js/modules/sessions.js"></script>
   <script src="/js/modules/dashboard.js"></script>
   <script src="/js/modules/toast.js"></script>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -1,6 +1,9 @@
 package web
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestLoadTemplates_Parses confirms every embedded template parses cleanly.
 // Catches malformed Go template syntax in the .tmpl files at test time
@@ -9,5 +12,34 @@ func TestLoadTemplates_Parses(t *testing.T) {
 	r := NewTemplateRenderer()
 	if err := r.LoadTemplates(); err != nil {
 		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+}
+
+// TestRenderGroupDetailPage confirms the group-detail page is registered and
+// renders with the server-injected group ID and its scaffold markers.
+func TestRenderGroupDetailPage(t *testing.T) {
+	r := NewTemplateRenderer()
+	if err := r.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+
+	data := TemplateData{
+		Title: "Group - Ori Agent",
+		Extra: map[string]any{"WorkspaceID": "grp-123"},
+	}
+	html, err := r.RenderTemplate("group-detail", data)
+	if err != nil {
+		t.Fatalf("RenderTemplate(group-detail) failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`id="group-detail-view"`,
+		`id="group-not-found"`,
+		"/js/modules/group-detail.js",
+		"grp-123",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered group-detail page missing %q", want)
+		}
 	}
 }

--- a/internal/workspace/http_handlers_directory.go
+++ b/internal/workspace/http_handlers_directory.go
@@ -346,6 +346,12 @@ func (h *HTTPHandler) ListDirectoryFiles(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Surface nested registered workspaces in this linked folder as openable
+	// references (workspace-aware linked folders).
+	if dir, dErr := workspace.GetDirectoryReference(dirID); dErr == nil {
+		annotateWorkspaceEntries(h.store, dir.Path, files)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	if encErr := json.NewEncoder(w).Encode(map[string]any{
 		"files":        files,

--- a/internal/workspace/linked_folder_workspace_test.go
+++ b/internal/workspace/linked_folder_workspace_test.go
@@ -1,0 +1,79 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeWorkspaceConfig(t *testing.T, dir, id, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	data, err := newTestWorkspace(id, name).ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, WorkspaceConfigFile), data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", WorkspaceConfigFile, err)
+	}
+}
+
+func TestReadWorkspaceFolderMeta(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkspaceConfig(t, filepath.Join(dir, "ws"), "ws-1", "A Workspace")
+
+	id, name, ok := readWorkspaceFolderMeta(filepath.Join(dir, "ws"))
+	if !ok || id != "ws-1" || name != "A Workspace" {
+		t.Fatalf("readWorkspaceFolderMeta(ws) = (%q, %q, %v), want (ws-1, A Workspace, true)", id, name, ok)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, "plain"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := readWorkspaceFolderMeta(filepath.Join(dir, "plain")); ok {
+		t.Fatalf("plain folder (no %s) reported as a workspace", WorkspaceConfigFile)
+	}
+}
+
+// TestAnnotateWorkspaceEntries covers registered-only detection: a registered
+// workspace folder is annotated (with the registered name), while an
+// unregistered workspace.json folder, a plain folder, and files are left alone.
+func TestAnnotateWorkspaceEntries(t *testing.T) {
+	linked := t.TempDir()
+	// member/ is a registered workspace folder; its on-disk name differs from the
+	// registered name to prove we surface the authoritative registered name.
+	writeWorkspaceConfig(t, filepath.Join(linked, "member"), "reg-1", "Member On Disk")
+	// stray/ has a workspace.json but the id is not registered.
+	writeWorkspaceConfig(t, filepath.Join(linked, "stray"), "unreg-1", "Stray")
+	if err := os.MkdirAll(filepath.Join(linked, "plain"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := newTestWorkspaceStore(t, newTestWorkspace("reg-1", "Registered WS"))
+
+	files := []FileInfo{
+		{Name: "member", RelativePath: "member", IsDir: true},
+		{Name: "stray", RelativePath: "stray", IsDir: true},
+		{Name: "plain", RelativePath: "plain", IsDir: true},
+		{Name: "notes.txt", RelativePath: "notes.txt", IsDir: false},
+	}
+	annotateWorkspaceEntries(store, linked, files)
+
+	if !files[0].IsWorkspace || files[0].WorkspaceID != "reg-1" {
+		t.Fatalf("member should be annotated as registered workspace reg-1, got %+v", files[0])
+	}
+	if files[0].WorkspaceName != "Registered WS" {
+		t.Fatalf("member WorkspaceName = %q, want registered name %q", files[0].WorkspaceName, "Registered WS")
+	}
+	if files[1].IsWorkspace {
+		t.Fatalf("unregistered stray folder must not be annotated, got %+v", files[1])
+	}
+	if files[2].IsWorkspace {
+		t.Fatalf("plain folder must not be annotated")
+	}
+	if files[3].IsWorkspace {
+		t.Fatalf("non-directory entry must not be annotated")
+	}
+}

--- a/internal/workspace/rename_test.go
+++ b/internal/workspace/rename_test.go
@@ -1,0 +1,64 @@
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestRenameWithSlug_RenamesGroupFolderAndRewritesMembers verifies that renaming
+// a group folder (which physically contains a nested member) moves the folder on
+// disk AND rewrites the member's path mapping, so members are not orphaned. This
+// is the safety guarantee that lets the rename handler rename group folders.
+func TestRenameWithSlug_RenamesGroupFolderAndRewritesMembers(t *testing.T) {
+	dir := t.TempDir()
+	st, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	saveWorkspaceUnder(t, st, "group-1", "Group", "")
+	saveWorkspaceUnder(t, st, "alpha", "Alpha", "")
+	if _, err := st.MoveWorkspaceFolder("alpha", "group-1"); err != nil {
+		t.Fatalf("MoveWorkspaceFolder: %v", err)
+	}
+	// Sanity: alpha is nested under the group's original "group" slug.
+	assertWorkspaceAt(t, st, "alpha", filepath.Join(dir, "group", SubWorkspacesDir, "alpha"))
+
+	// Rename the group: its folder slug changes from "group" to "renamed-group".
+	if err := st.RenameWithSlug("group-1", "Renamed Group", ""); err != nil {
+		t.Fatalf("RenameWithSlug: %v", err)
+	}
+
+	// The group folder moved, and the nested member moved with it (path rewritten).
+	assertWorkspaceAt(t, st, "group-1", filepath.Join(dir, "renamed-group"))
+	assertWorkspaceAt(t, st, "alpha", filepath.Join(dir, "renamed-group", SubWorkspacesDir, "alpha"))
+
+	if ws, ok := st.cache["group-1"]; !ok || ws.Name != "Renamed Group" {
+		t.Fatalf("group-1 name = %q, want %q", st.cache["group-1"].Name, "Renamed Group")
+	}
+}
+
+// TestRenameWithSlug_DisplayNameOnlyKeepsMembers verifies that a rename which
+// does not change the slug (e.g. only letter-case/display tweaks resolving to the
+// same slug) leaves nested members in place.
+func TestRenameWithSlug_DisplayNameOnlyKeepsMembers(t *testing.T) {
+	dir := t.TempDir()
+	st, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	saveWorkspaceUnder(t, st, "group-1", "Group", "")
+	saveWorkspaceUnder(t, st, "alpha", "Alpha", "")
+	if _, err := st.MoveWorkspaceFolder("alpha", "group-1"); err != nil {
+		t.Fatalf("MoveWorkspaceFolder: %v", err)
+	}
+
+	// Keep the same slug ("group") while changing the display name.
+	if err := st.RenameWithSlug("group-1", "Group", "group"); err != nil {
+		t.Fatalf("RenameWithSlug: %v", err)
+	}
+
+	assertWorkspaceAt(t, st, "group-1", filepath.Join(dir, "group"))
+	assertWorkspaceAt(t, st, "alpha", filepath.Join(dir, "group", SubWorkspacesDir, "alpha"))
+}

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -951,6 +951,27 @@ func (s *FileStore) RenameWithSlug(id, newName, requestedSlug string) error {
 		})
 	}
 
+	// Renaming the folder physically moved every nested member with it (e.g. a
+	// group folder containing members under sub-workspaces/), so rewrite each
+	// descendant's path prefix from the old folder root to the new one. This
+	// mirrors MoveWorkspaceFolder; without it, members of a renamed group keep
+	// stale path mappings and become orphaned.
+	for descID := range s.collectDescendantsLocked(id) {
+		oldDescRel, ok := s.idToPath[descID]
+		if !ok {
+			continue
+		}
+		rel, err := filepath.Rel(oldRelPath, oldDescRel)
+		if err != nil {
+			continue
+		}
+		newDescRel := filepath.Join(newRelPath, rel)
+		s.idToPath[descID] = newDescRel
+		if dws, ok := s.cache[descID]; ok {
+			s.registerIndexLocked(dws, newDescRel)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/workspace/workspace_directories.go
+++ b/internal/workspace/workspace_directories.go
@@ -156,6 +156,56 @@ func (w *Workspace) ListDirectoryFiles(dirID string) ([]FileInfo, error) {
 	return files, nil
 }
 
+// readWorkspaceFolderMeta reports whether absPath is a workspace folder — i.e.
+// it directly contains a workspace.json — and, if so, returns the workspace id
+// and name read from it. Filesystem-only; the caller decides whether the id is
+// registered. Any read/parse error is treated as "not a workspace folder".
+func readWorkspaceFolderMeta(absPath string) (id, name string, ok bool) {
+	data, err := os.ReadFile(filepath.Join(absPath, WorkspaceConfigFile))
+	if err != nil {
+		return "", "", false
+	}
+	ws, err := FromJSON(data)
+	if err != nil || ws == nil || ws.ID == "" {
+		return "", "", false
+	}
+	return ws.ID, ws.Name, true
+}
+
+// annotateWorkspaceEntries marks directory entries that are themselves
+// registered workspace folders so the linked-folder explorer can surface them
+// as openable workspace references. basePath is the linked directory root;
+// entries' RelativePath values are relative to it. Only directories whose
+// workspace.json id is registered in store are annotated; everything else is
+// left as an ordinary folder. Detection never fails the listing.
+func annotateWorkspaceEntries(store Store, basePath string, files []FileInfo) {
+	if store == nil {
+		return
+	}
+	for i := range files {
+		if !files[i].IsDir {
+			continue
+		}
+		id, folderName, ok := readWorkspaceFolderMeta(filepath.Join(basePath, files[i].RelativePath))
+		if !ok {
+			continue
+		}
+		registered, err := store.Get(id)
+		if err != nil || registered == nil {
+			// Has a workspace.json but isn't registered in this app — treat it
+			// as an ordinary folder (registered-only).
+			continue
+		}
+		files[i].IsWorkspace = true
+		files[i].WorkspaceID = id
+		// Prefer the authoritative registered name; fall back to the folder's.
+		files[i].WorkspaceName = registered.Name
+		if files[i].WorkspaceName == "" {
+			files[i].WorkspaceName = folderName
+		}
+	}
+}
+
 // ReadDirectoryFile reads the content of a file in a directory reference
 func (w *Workspace) ReadDirectoryFile(dirID string, relativePath string) ([]byte, error) {
 	dir, err := w.GetDirectoryReference(dirID)

--- a/internal/workspace/workspace_directories.go
+++ b/internal/workspace/workspace_directories.go
@@ -161,7 +161,11 @@ func (w *Workspace) ListDirectoryFiles(dirID string) ([]FileInfo, error) {
 // and name read from it. Filesystem-only; the caller decides whether the id is
 // registered. Any read/parse error is treated as "not a workspace folder".
 func readWorkspaceFolderMeta(absPath string) (id, name string, ok bool) {
-	data, err := os.ReadFile(filepath.Join(absPath, WorkspaceConfigFile))
+	// absPath is enumerated by walking the linked directory itself (filepath.Walk
+	// + filepath.Rel keep every entry inside that directory), and only the fixed
+	// workspace.json filename is appended — so this cannot read outside the
+	// linked folder the user explicitly attached.
+	data, err := os.ReadFile(filepath.Join(absPath, WorkspaceConfigFile)) // #nosec G304 G703
 	if err != nil {
 		return "", "", false
 	}

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -749,6 +749,12 @@ type FileInfo struct {
 	ModTime      time.Time  `json:"mod_time"`                // Last modification time
 	DeletedAt    *time.Time `json:"deleted_at,omitempty"`    // Soft-delete timestamp when the item is trashed
 	Status       string     `json:"status,omitempty"`        // e.g. "missing" when an attachment's file is absent on disk
+	// Workspace reference: set when this directory entry is itself a registered
+	// workspace folder (it contains a workspace.json with a known id). Lets
+	// linked folders surface nested workspaces as openable references.
+	IsWorkspace   bool   `json:"is_workspace,omitempty"`
+	WorkspaceID   string `json:"workspace_id,omitempty"`
+	WorkspaceName string `json:"workspace_name,omitempty"`
 }
 
 // CreateWorkspaceParams contains parameters for creating a new workspace

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint internal/web/static/js/ --fix",
     "format": "prettier --write 'internal/web/static/**/*.{js,css,html}'",
     "format:check": "prettier --check 'internal/web/static/**/*.{js,css,html}'",
+    "test:modules": "node --test internal/web/static/js/modules/*.test.js",
     "test": "playwright test",
     "test:smoke": "playwright test tests/smoke.spec.ts",
     "test:headed": "playwright test --headed",


### PR DESCRIPTION
This branch grew past the original launcher tree view into three related pieces of workspace-hub work. Opening as one PR per request.

> Heads up for reviewers: the original launcher tree view was already approved; this PR now also contains the **Group Details Page** and **Workspace-Aware Linked Folders** features below (commits `09e412f5`, `a4a52ac8`, `40bb7712`), which warrant a fresh look — especially the folder-rename data-layer change.

## 1. Launcher tree view (+ review fixes)
- Cards/Tree launcher toggle with nested grouping; persistent selection checkboxes; create-modal group population.
- Follow-up review fixes: shared `workspace-group-options.js` (de-dup), attribute-selector escaping, hoisted tree renderers.

## 2. Group Details Page
A dedicated page for a group workspace, reached by clicking a group in the launcher.
- **Routing:** `/workspaces/{id}` branches on group kind to a new `group-detail` page; concrete workspaces and missing IDs keep the standard workspace-detail path.
- **Launcher:** clicking a group's name/body opens its page; the caret still toggles collapse (card + tree).
- **Header/metadata:** inline edit (name → rename, description/color → PATCH).
- **Group folder rename (data-layer):** the rename handler now renames a group's backing folder, and `RenameWithSlug` rewrites nested members' paths (mirroring `MoveWorkspaceFolder`) so members aren't orphaned.
- **Members:** list, open, add existing (eligibility-filtered), create new (inline → `parent_id`), remove (un-group), reorder (`order_index`).
- **Roll-ups:** tasks (default open+scheduled, with status / created-date / member filters) and notes/files across direct concrete members, with sub-group exclusion + partial-failure handling.

## 3. Workspace-Aware Linked Folders
- The Workspace Details "Linked Folders" explorer now surfaces nested **registered** workspaces (e.g. a group folder's `sub-workspaces/`) as openable references instead of opaque directories.
- Additive: `FileInfo` gains `is_workspace`/`workspace_id`/`workspace_name`; annotated only when `store.Get(id)` confirms registration; "Open workspace" → `/workspaces/{id}`.

## Verification
- `go build ./...`, `go test` (server/sessionhttp/workspace/web), `npm run lint`, and `npm run test:modules` (375) all pass.
- New tests: route branching, group folder rename + member-path rewrite, launcher open-vs-collapse, group-detail helpers (members/tasks/notes), and linked-folder detection + render helper.
- Group page verified headlessly against a running server (header/members/tasks-filters/notes render, zero JS errors). Linked-folders verified end-to-end (a real group folder linked into another workspace flags the member with the correct id/name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
