### PR TITLE
feat(home-assistant): home-page inline harness for app introspection & navigation

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -196,6 +196,90 @@ Classify a home page assistant prompt and find the best matching existing agent.
 }
 ```
 
+### Ask Home Assistant (Inline Harness)
+
+Answer an app-introspection or app-navigation prompt inline. The server builds a
+cross-workspace **home snapshot** (workspaces, windowed task activity, recent
+sessions, open Action Center opportunities, usage), runs the system model with
+read-only `home_*` tools, and returns a written answer plus grounded next-step
+actions. Used by the home page "Ask Ori" panel when
+`/api/home-assistant/route` classifies the prompt as `app_introspection` or
+`app_navigation` (route mode `home_inline`).
+
+**Endpoint:** `POST /api/home-assistant/ask`
+
+**Request Body:**
+```json
+{
+  "prompt": "Summarize this week's task activity",
+  "intent": "app_introspection",
+  "date_window": "this_week",
+  "context": { "surface": "home", "page_path": "/" }
+}
+```
+
+**Parameters:**
+- `prompt` (required): Natural language question about the user's own Ori data, or a navigation request.
+- `intent` (optional): `app_introspection` or `app_navigation`. Defaults to `app_introspection`.
+- `date_window` (optional): `today`, `this_week`, or `this_month`. When omitted, the server picks a default from prompt phrasing (recap/summary asks → `this_week`; status asks → `today`).
+- `context` (optional): Same shape as `/api/home-assistant/route` (`surface`, `page_path`, `workspace_id`, …).
+- `confirmed_action` (optional): Present only when re-submitting a confirmed mutation (see confirmation flow below).
+
+**Response:**
+```json
+{
+  "response": "This week you have 2 active workspaces and 5 tasks: 3 completed, 2 in progress…",
+  "intent": "app_introspection",
+  "snapshot_meta": {
+    "window": "this_week",
+    "window_label": "this week (Jun 1 – Jun 8)",
+    "workspace_count": 2,
+    "task_count": 5,
+    "session_count": 4,
+    "opportunity_count": 1,
+    "degraded": [],
+    "truncated": []
+  },
+  "actions": [
+    { "id": "open-ws-ws-1", "type": "open_workspace", "label": "Open Launch Plan", "href": "/workspaces/ws-1", "workspace_id": "ws-1" },
+    { "id": "nav-action-center", "type": "navigate", "label": "Review 1 opportunity", "href": "/action-center" }
+  ]
+}
+```
+
+**Response fields:**
+- `response`: The assistant's written answer. Always present and renderable, even on degraded data or when the model is unavailable.
+- `intent`: The intent the harness answered as.
+- `snapshot_meta`: Section counts plus `degraded` (sections whose data source was unavailable) and `truncated` (sections capped — more is available via the tools).
+- `actions`: Validated next-step action descriptors (see schema below). Navigation/`open_*` actions are read-only; `create_*` / `start_task` carry `requires_confirmation`.
+- `requires_confirmation` / `confirmation`: Present when the prompt is an explicit mutation request awaiting confirmation.
+
+**Action schema:**
+- `id`: Stable action id.
+- `type`: One of `navigate`, `open_workspace`, `open_task`, `open_session`, `create_workspace`, `create_task`, `start_task`, `ask_followup`.
+- `label`: Button label.
+- `href` (optional): Destination for navigation/`open_*` actions.
+- `workspace_id` / `task_id` / `session_id` (optional): Resolved target ids.
+- `requires_confirmation` (optional): `true` for state-changing actions.
+- `confirmation_summary` / `arguments` (optional): Confirmation copy and payload.
+
+**Confirmation flow (mutations):**
+An explicit mutation request (e.g. `"create a workspace called Q3 Planning"`) returns a confirmation instead of acting:
+```json
+{
+  "response": "Create a new workspace named \"Q3 Planning\"?",
+  "intent": "app_introspection",
+  "requires_confirmation": true,
+  "confirmation": {
+    "action_id": "create-workspace",
+    "action_type": "create_workspace",
+    "summary": "Create a new workspace named \"Q3 Planning\"?",
+    "arguments": { "name": "Q3 Planning" }
+  }
+}
+```
+The client confirms by re-calling the endpoint with `confirmed_action` set to a `HomeAction` of that type and arguments. The server executes only known mutation types after confirmation; the model is never given write tools.
+
 ## Settings API
 
 ### Get Agent Settings

--- a/internal/agenthttp/home_assistant_app_intent_test.go
+++ b/internal/agenthttp/home_assistant_app_intent_test.go
@@ -1,0 +1,55 @@
+package agenthttp
+
+import "testing"
+
+// TestClassifyHomeIntentPrecedence covers the FR #4 precedence examples plus the
+// new app_introspection / app_navigation intents, and confirms existing intents
+// are preserved.
+func TestClassifyHomeIntentPrecedence(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	resolver := newHomeWorkspaceResolverForTest(t, st,
+		newHomeWorkspaceResolverTestWorkspace("ws-q3", "Q3 Planning", "Quarterly planning"),
+	)
+	h := NewHomeAssistantRouteHandler(st)
+	h.SetWorkspaceResolver(resolver)
+
+	cases := []struct {
+		prompt string
+		want   string
+	}{
+		{"summarize this week's task activity", "app_introspection"},
+		{"what did I work on this week", "app_introspection"},
+		{"how many tasks are pending", "app_introspection"},
+		{"where do I manage MCP connectors?", "app_navigation"},
+		{"open Action Center", "app_navigation"},
+		{"open the Q3 Planning workspace", "app_navigation"},
+		{"open Safari", "app_launch"},
+		{"create workspace called Q3 Roadmap", "workspace_create"},
+		{"what's the weather in Tokyo", "utility_direct"},
+	}
+	for _, tc := range cases {
+		if got := h.classifyHomeIntent(tc.prompt); got.Key != tc.want {
+			t.Errorf("classifyHomeIntent(%q) = %q, want %q", tc.prompt, got.Key, tc.want)
+		}
+	}
+}
+
+// TestRoutePromptInlineModeForAppIntents confirms the route response selects the
+// inline route mode for the two app intents.
+func TestRoutePromptInlineModeForAppIntents(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	resolver := newHomeWorkspaceResolverForTest(t, st)
+	h := NewHomeAssistantRouteHandler(st)
+	h.SetWorkspaceResolver(resolver)
+
+	resp, err := h.RoutePrompt("summarize this week's task activity", nil)
+	if err != nil {
+		t.Fatalf("RoutePrompt: %v", err)
+	}
+	if resp.Intent != "app_introspection" {
+		t.Fatalf("intent = %q, want app_introspection", resp.Intent)
+	}
+	if resp.RouteMode != homeAssistantRouteModeInline {
+		t.Errorf("route_mode = %q, want %q", resp.RouteMode, homeAssistantRouteModeInline)
+	}
+}

--- a/internal/agenthttp/home_assistant_ask.go
+++ b/internal/agenthttp/home_assistant_ask.go
@@ -1,0 +1,427 @@
+package agenthttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+const homeMaxToolRounds = 4
+
+var errHomeModelNotConfigured = errors.New("system model is not configured")
+
+// Home action types (PRD 4.5 / 5.1).
+const (
+	HomeActionNavigate        = "navigate"
+	HomeActionOpenWorkspace   = "open_workspace"
+	HomeActionOpenTask        = "open_task"
+	HomeActionOpenSession     = "open_session"
+	HomeActionCreateWorkspace = "create_workspace"
+	HomeActionCreateTask      = "create_task"
+	HomeActionStartTask       = "start_task"
+	HomeActionAskFollowup     = "ask_followup"
+)
+
+// homeMutatingActionTypes are the only action types that change state and thus
+// require confirmation before execution.
+var homeMutatingActionTypes = map[string]bool{
+	HomeActionCreateWorkspace: true,
+	HomeActionCreateTask:      true,
+	HomeActionStartTask:       true,
+}
+
+// HomeAction is a serializable next-step action descriptor returned to the
+// frontend, which validates it before turning it into a button.
+type HomeAction struct {
+	ID                   string         `json:"id"`
+	Type                 string         `json:"type"`
+	Label                string         `json:"label"`
+	Href                 string         `json:"href,omitempty"`
+	WorkspaceID          string         `json:"workspace_id,omitempty"`
+	TaskID               string         `json:"task_id,omitempty"`
+	SessionID            string         `json:"session_id,omitempty"`
+	RequiresConfirmation bool           `json:"requires_confirmation,omitempty"`
+	ConfirmationSummary  string         `json:"confirmation_summary,omitempty"`
+	Arguments            map[string]any `json:"arguments,omitempty"`
+}
+
+// HomeActionConfirmation describes a pending mutation awaiting the user's
+// explicit confirmation (PRD 4.6 / FR #25).
+type HomeActionConfirmation struct {
+	ActionID   string         `json:"action_id"`
+	ActionType string         `json:"action_type"`
+	Summary    string         `json:"summary"`
+	Arguments  map[string]any `json:"arguments,omitempty"`
+}
+
+// HomeAssistantAskRequest is the body for POST /api/home-assistant/ask.
+type HomeAssistantAskRequest struct {
+	Prompt          string                     `json:"prompt"`
+	Intent          string                     `json:"intent"`
+	Context         *HomeAssistantRouteContext `json:"context,omitempty"`
+	DateWindow      string                     `json:"date_window,omitempty"`
+	ConfirmedAction *HomeAction                `json:"confirmed_action,omitempty"`
+}
+
+// HomeAssistantAskResponse is the response for POST /api/home-assistant/ask.
+type HomeAssistantAskResponse struct {
+	Response             string                  `json:"response"`
+	Intent               string                  `json:"intent"`
+	SnapshotMeta         *HomeSnapshotMeta       `json:"snapshot_meta,omitempty"`
+	Actions              []HomeAction            `json:"actions,omitempty"`
+	RequiresConfirmation bool                    `json:"requires_confirmation,omitempty"`
+	Confirmation         *HomeActionConfirmation `json:"confirmation,omitempty"`
+}
+
+// HomeActionMutator executes confirmed state-changing actions. The server wires a
+// real implementation; a nil mutator degrades mutations gracefully.
+type HomeActionMutator interface {
+	CreateWorkspace(ctx context.Context, name, description string) (workspaceID, href string, err error)
+	CreateTask(ctx context.Context, workspaceID, description string) (taskID, href string, err error)
+	StartTask(ctx context.Context, workspaceID, taskID string) (href string, err error)
+}
+
+type homeAskSystemModelReader interface {
+	GetSystemModel() (provider, model string)
+}
+
+// HomeAskTrace is one home-harness telemetry record (FR #28).
+type HomeAskTrace struct {
+	Prompt        string
+	Intent        string
+	Window        string
+	Outcome       string // answered | confirmation_required | mutation_executed | model_unavailable
+	ActionCount   int
+	ConfirmedType string
+	Degraded      []string
+}
+
+type homeAskTraceEmitter interface {
+	RecordAskOutcome(ctx context.Context, trace HomeAskTrace)
+}
+
+// HomeAssistantAskHandler owns the home harness: snapshot construction, the
+// engineered system prompt, read-only tool registration, model execution, and
+// response/action generation. POST /api/home-assistant/ask.
+type HomeAssistantAskHandler struct {
+	Sources     HomeSnapshotSources
+	LLMFactory  *llm.Factory
+	SystemModel homeAskSystemModelReader
+	Mutator     HomeActionMutator
+	Trace       homeAskTraceEmitter
+	now         func() time.Time
+}
+
+// NewHomeAssistantAskHandler builds the handler from its data sources.
+func NewHomeAssistantAskHandler(sources HomeSnapshotSources, factory *llm.Factory, systemModel homeAskSystemModelReader) *HomeAssistantAskHandler {
+	now := sources.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &HomeAssistantAskHandler{Sources: sources, LLMFactory: factory, SystemModel: systemModel, now: now}
+}
+
+// SetMutator wires the confirmed-action executor.
+func (h *HomeAssistantAskHandler) SetMutator(m HomeActionMutator) { h.Mutator = m }
+
+// SetTraceEmitter wires optional telemetry.
+func (h *HomeAssistantAskHandler) SetTraceEmitter(t homeAskTraceEmitter) { h.Trace = t }
+
+func (h *HomeAssistantAskHandler) emitTrace(ctx context.Context, trace HomeAskTrace) {
+	if h.Trace != nil {
+		h.Trace.RecordAskOutcome(ctx, trace)
+	}
+}
+
+// AskHandler is the HTTP entrypoint.
+func (h *HomeAssistantAskHandler) AskHandler(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req HomeAssistantAskRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	resp := h.Ask(r.Context(), req)
+	orihttp.WriteJSON(w, resp)
+}
+
+// Ask runs the harness and always returns a renderable response (errors are
+// surfaced as helpful text + next-step actions rather than HTTP failures).
+func (h *HomeAssistantAskHandler) Ask(ctx context.Context, req HomeAssistantAskRequest) HomeAssistantAskResponse {
+	prompt := strings.TrimSpace(req.Prompt)
+	intent := strings.TrimSpace(req.Intent)
+	if intent == "" {
+		intent = homeAssistantAppIntrospectionIntent.Key
+	}
+
+	// Confirmed mutation path: execute only known action types (FR #24).
+	if req.ConfirmedAction != nil {
+		return h.executeConfirmedAction(ctx, intent, *req.ConfirmedAction)
+	}
+
+	if prompt == "" {
+		return HomeAssistantAskResponse{Response: "What would you like to know about your workspaces, tasks, or activity?", Intent: intent}
+	}
+
+	// Explicit, supported mutation request: ask for confirmation before doing
+	// anything (FR #24). Execution happens only on a follow-up with ConfirmedAction.
+	if conf := detectHomeMutationRequest(prompt); conf != nil {
+		h.emitTrace(ctx, HomeAskTrace{Prompt: prompt, Intent: intent, Outcome: "confirmation_required", ConfirmedType: conf.ActionType})
+		return HomeAssistantAskResponse{
+			Response:             conf.Summary,
+			Intent:               intent,
+			RequiresConfirmation: true,
+			Confirmation:         conf,
+		}
+	}
+
+	window := NormalizeHomeDateWindow(req.DateWindow, DefaultHomeDateWindowForPrompt(prompt))
+	snapshot := BuildHomeSnapshot(ctx, h.Sources, window)
+
+	answer, err := h.generateAnswer(ctx, prompt, intent, snapshot)
+	if err != nil {
+		return h.modelUnavailableResponse(ctx, prompt, intent, snapshot, err)
+	}
+
+	actions := h.buildNextStepActions(intent, prompt, snapshot)
+	meta := snapshot.Meta
+	h.emitTrace(ctx, HomeAskTrace{Prompt: prompt, Intent: intent, Window: string(window), Outcome: "answered", ActionCount: len(actions), Degraded: meta.Degraded})
+	return HomeAssistantAskResponse{
+		Response:     strings.TrimSpace(answer),
+		Intent:       intent,
+		SnapshotMeta: &meta,
+		Actions:      actions,
+	}
+}
+
+func (h *HomeAssistantAskHandler) generateAnswer(ctx context.Context, prompt, intent string, snapshot HomeSnapshot) (string, error) {
+	provider, model, err := h.resolveProvider()
+	if err != nil {
+		return "", err
+	}
+	registry := newHomeToolRegistry(h.Sources)
+	systemPrompt := buildHomeSystemPrompt()
+	userPrompt := buildHomeUserPrompt(prompt, intent, snapshot)
+
+	conversation := []llm.Message{
+		llm.NewSystemMessage(systemPrompt),
+		llm.NewUserMessage(userPrompt),
+	}
+	tools := registry.Definitions()
+
+	for round := 0; round < homeMaxToolRounds; round++ {
+		resp, chatErr := provider.Chat(ctx, llm.ChatRequest{
+			Model:       model,
+			Messages:    conversation,
+			Tools:       tools,
+			Temperature: 0.3,
+		})
+		if chatErr != nil {
+			return "", chatErr
+		}
+		if len(resp.ToolCalls) == 0 {
+			if strings.TrimSpace(resp.Content) == "" {
+				return "I couldn't find anything to report for that.", nil
+			}
+			return resp.Content, nil
+		}
+
+		calls := make([]llm.ToolCall, len(resp.ToolCalls))
+		copy(calls, resp.ToolCalls)
+		for i := range calls {
+			if strings.TrimSpace(calls[i].ID) == "" {
+				calls[i].ID = fmt.Sprintf("tool_%d_%d", round+1, i+1)
+			}
+		}
+		conversation = append(conversation, llm.Message{Role: llm.RoleAssistant, Content: resp.Content, ToolCalls: calls})
+		for i, tc := range calls {
+			result, toolErr := registry.Execute(ctx, resp.ToolCalls[i].Name, resp.ToolCalls[i].Arguments)
+			if toolErr != nil {
+				result = "ERROR: " + toolErr.Error()
+			}
+			conversation = append(conversation, llm.NewToolMessage(tc.ID, result))
+		}
+	}
+	// Tool budget exhausted: make one final tool-free attempt for a summary.
+	resp, chatErr := provider.Chat(ctx, llm.ChatRequest{Model: model, Messages: conversation, Temperature: 0.3})
+	if chatErr != nil {
+		return "", chatErr
+	}
+	if strings.TrimSpace(resp.Content) == "" {
+		return "I gathered some data but couldn't compose a final summary. Try narrowing the question.", nil
+	}
+	return resp.Content, nil
+}
+
+func (h *HomeAssistantAskHandler) resolveProvider() (llm.Provider, string, error) {
+	if h.LLMFactory == nil || h.SystemModel == nil {
+		return nil, "", errHomeModelNotConfigured
+	}
+	providerName, model := h.SystemModel.GetSystemModel()
+	if strings.TrimSpace(providerName) == "" {
+		return nil, "", errHomeModelNotConfigured
+	}
+	provider, err := h.LLMFactory.GetProvider(providerName)
+	if err != nil {
+		return nil, "", err
+	}
+	if strings.TrimSpace(model) == "" {
+		if models := provider.DefaultModels(); len(models) > 0 {
+			model = models[0]
+		}
+	}
+	return provider, model, nil
+}
+
+func (h *HomeAssistantAskHandler) modelUnavailableResponse(ctx context.Context, prompt, intent string, snapshot HomeSnapshot, err error) HomeAssistantAskResponse {
+	meta := snapshot.Meta
+	msg := "I can't reach the system model right now, so I can't compose a written summary. "
+	if errors.Is(err, errHomeModelNotConfigured) {
+		msg = "No system model is configured yet, so I can't answer in writing. Set one up in Settings and try again. "
+	}
+	msg += "Here's what I can point you to from your data: " + describeSnapshotBriefly(snapshot)
+	actions := []HomeAction{{
+		ID:    "nav-settings",
+		Type:  HomeActionNavigate,
+		Label: "Go to Settings",
+		Href:  "/settings",
+	}}
+	actions = append(actions, h.buildNextStepActions(intent, "", snapshot)...)
+	h.emitTrace(ctx, HomeAskTrace{Prompt: prompt, Intent: intent, Window: string(meta.Window), Outcome: "model_unavailable", ActionCount: len(actions), Degraded: meta.Degraded})
+	return HomeAssistantAskResponse{Response: msg, Intent: intent, SnapshotMeta: &meta, Actions: actions}
+}
+
+func describeSnapshotBriefly(s HomeSnapshot) string {
+	parts := []string{
+		fmt.Sprintf("%d workspace(s)", s.Meta.WorkspaceCount),
+		fmt.Sprintf("%d task(s) active %s", s.Meta.TaskCount, s.Meta.WindowLabel),
+	}
+	if s.Meta.OpportunityCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d open opportunity(ies)", s.Meta.OpportunityCount))
+	}
+	return strings.Join(parts, ", ") + "."
+}
+
+// executeConfirmedAction performs a previously-confirmed mutation. Non-mutating
+// types must never reach here (the frontend executes navigation directly).
+func (h *HomeAssistantAskHandler) executeConfirmedAction(ctx context.Context, intent string, action HomeAction) HomeAssistantAskResponse {
+	if !homeMutatingActionTypes[action.Type] {
+		return HomeAssistantAskResponse{Response: "That action doesn't require confirmation.", Intent: intent}
+	}
+	if h.Mutator == nil {
+		return HomeAssistantAskResponse{Response: "I can't perform that change in this build yet.", Intent: intent}
+	}
+	args := action.Arguments
+	switch action.Type {
+	case HomeActionCreateWorkspace:
+		name := actionArgString(args, "name")
+		if name == "" {
+			return HomeAssistantAskResponse{Response: "I need a name to create a workspace.", Intent: intent}
+		}
+		id, href, err := h.Mutator.CreateWorkspace(ctx, name, actionArgString(args, "description"))
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't create the workspace: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionCreateWorkspace)
+		return HomeAssistantAskResponse{
+			Response: fmt.Sprintf("Created workspace %q. Opening it now.", name),
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-created-ws", Type: HomeActionOpenWorkspace, Label: "Open " + name, Href: href, WorkspaceID: id}},
+		}
+	case HomeActionCreateTask:
+		wsID := firstNonEmpty(action.WorkspaceID, actionArgString(args, "workspace_id"))
+		desc := actionArgString(args, "description")
+		if wsID == "" || desc == "" {
+			return HomeAssistantAskResponse{Response: "I need a workspace and a description to create a task.", Intent: intent}
+		}
+		id, href, err := h.Mutator.CreateTask(ctx, wsID, desc)
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't create the task: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionCreateTask)
+		return HomeAssistantAskResponse{
+			Response: "Created the task.",
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-created-task", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID, TaskID: id}},
+		}
+	case HomeActionStartTask:
+		wsID := firstNonEmpty(action.WorkspaceID, actionArgString(args, "workspace_id"))
+		taskID := firstNonEmpty(action.TaskID, actionArgString(args, "task_id"))
+		if wsID == "" || taskID == "" {
+			return HomeAssistantAskResponse{Response: "I need a workspace and task to start.", Intent: intent}
+		}
+		href, err := h.Mutator.StartTask(ctx, wsID, taskID)
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't start the task: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionStartTask)
+		return HomeAssistantAskResponse{
+			Response: "Started the task.",
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-started-task", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID, TaskID: taskID}},
+		}
+	}
+	return HomeAssistantAskResponse{Response: "Unsupported action.", Intent: intent}
+}
+
+func (h *HomeAssistantAskHandler) recordMutation(ctx context.Context, intent, actionType string) {
+	h.emitTrace(ctx, HomeAskTrace{Intent: intent, Outcome: "mutation_executed", ActionCount: 1, ConfirmedType: actionType})
+}
+
+func actionArgString(args map[string]any, key string) string {
+	if args == nil {
+		return ""
+	}
+	if v, ok := args[key]; ok {
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// detectHomeMutationRequest recognizes an explicit, supported mutation request in
+// the prompt and returns a confirmation to present before executing (FR #24). v1
+// recognizes "create/new/make a workspace called|named X".
+func detectHomeMutationRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" {
+		return nil
+	}
+	if !(strings.HasPrefix(lower, "create ") || strings.HasPrefix(lower, "new ") || strings.HasPrefix(lower, "make ") || strings.HasPrefix(lower, "add ")) {
+		return nil
+	}
+	for _, marker := range []string{"workspace called ", "workspace named "} {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			continue
+		}
+		name := strings.TrimSpace(trimmed[idx+len(marker):])
+		name = strings.Trim(name, " .\"'")
+		if name == "" {
+			continue
+		}
+		return &HomeActionConfirmation{
+			ActionID:   "create-workspace",
+			ActionType: HomeActionCreateWorkspace,
+			Summary:    fmt.Sprintf("Create a new workspace named %q?", name),
+			Arguments:  map[string]any{"name": name},
+		}
+	}
+	return nil
+}

--- a/internal/agenthttp/home_assistant_ask_prompt.go
+++ b/internal/agenthttp/home_assistant_ask_prompt.go
@@ -1,0 +1,99 @@
+package agenthttp
+
+import (
+	"fmt"
+	"strings"
+)
+
+const homeMaxNextStepActions = 4
+
+// buildHomeSystemPrompt is the engineered system prompt for the home harness,
+// the app-scoped analogue of buildTaskSystemPrompt (PRD FR #16).
+func buildHomeSystemPrompt() string {
+	var b strings.Builder
+	b.WriteString("You are Ori's home assistant. You answer questions about the user's own Ori app — their workspaces, tasks, sessions, Action Center opportunities, and usage — and you help them navigate the app. ")
+	b.WriteString("You are given a \"Home Snapshot\" of the user's app-wide state and a \"Navigation Catalog\" of the app's pages. ")
+	b.WriteString("Treat the Home Snapshot as the source of truth for questions about the user's activity and data; use the exact counts and names from it. ")
+	b.WriteString("When a snapshot section is marked truncated, or the user asks for detail beyond it, call the read-only home_* tools (home_workspaces, home_tasks, home_sessions, home_opportunities, home_usage) to read full state. ")
+	b.WriteString("Never invent workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
+	b.WriteString("For navigation questions, only reference destinations that appear in the Navigation Catalog; never invent a URL or page name. ")
+	b.WriteString("Be concise and skimmable: lead with the key counts, then a few highlights. ")
+	b.WriteString("When helpful, end with a brief suggestion of a concrete next step. ")
+	b.WriteString("Do not output raw JSON or tool results as your final answer; write a short natural-language summary.")
+	return b.String()
+}
+
+// buildHomeUserPrompt assembles the user turn: the request plus the injected
+// snapshot and navigation catalog.
+func buildHomeUserPrompt(prompt, intent string, snapshot HomeSnapshot) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "User request: %s\n\n", strings.TrimSpace(prompt))
+	fmt.Fprintf(&b, "(classified intent: %s)\n\n", intent)
+	b.WriteString(snapshot.PromptText())
+	b.WriteString("\n\n## Navigation Catalog\n\n")
+	b.WriteString("These are the only app destinations you may reference for navigation:\n")
+	for _, entry := range homeNavCatalog {
+		fmt.Fprintf(&b, "- %s (%s): %s\n", entry.Label, entry.Href, entry.Description)
+	}
+	return b.String()
+}
+
+// buildNextStepActions deterministically derives grounded next-step actions from
+// real data (PRD 4.5). Actions are not produced by the model; navigation/open_*
+// actions are read-only, and any create_* action carries requires_confirmation.
+func (h *HomeAssistantAskHandler) buildNextStepActions(intent, prompt string, snapshot HomeSnapshot) []HomeAction {
+	var actions []HomeAction
+	seen := map[string]bool{}
+	add := func(a HomeAction) {
+		if len(actions) >= homeMaxNextStepActions {
+			return
+		}
+		key := a.Type + "|" + a.Href + "|" + a.WorkspaceID
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		actions = append(actions, a)
+	}
+
+	if intent == homeAssistantAppNavigationIntent.Key {
+		if entry, ok := MatchNavEntryInPrompt(prompt); ok {
+			add(HomeAction{ID: "nav-" + entry.Key, Type: HomeActionNavigate, Label: "Open " + entry.Label, Href: entry.Href})
+		}
+		if id, name, ok := matchWorkspaceInPrompt(h.Sources.Workspaces, prompt); ok {
+			add(HomeAction{ID: "open-ws-" + id, Type: HomeActionOpenWorkspace, Label: "Open " + name, Href: workspaceHref(id), WorkspaceID: id})
+		}
+	}
+
+	// Empty state: guide first-run users to create a workspace.
+	if snapshot.Meta.WorkspaceCount == 0 {
+		add(HomeAction{ID: "nav-create-first-ws", Type: HomeActionNavigate, Label: "Create your first workspace", Href: "/workspaces"})
+		return actions
+	}
+
+	// Introspection: surface the most recently active workspaces.
+	if intent == homeAssistantAppIntrospectionIntent.Key {
+		for _, ws := range snapshot.Workspaces {
+			add(HomeAction{ID: "open-ws-" + ws.ID, Type: HomeActionOpenWorkspace, Label: "Open " + ws.Name, Href: workspaceHref(ws.ID), WorkspaceID: ws.ID})
+			if len(actions) >= 3 {
+				break
+			}
+		}
+		if snapshot.Meta.OpportunityCount > 0 {
+			add(HomeAction{ID: "nav-action-center", Type: HomeActionNavigate, Label: fmt.Sprintf("Review %d opportunit%s", snapshot.Meta.OpportunityCount, plural(snapshot.Meta.OpportunityCount, "y", "ies")), Href: "/action-center"})
+		}
+	}
+
+	return actions
+}
+
+func workspaceHref(id string) string {
+	return "/workspaces/" + id
+}
+
+func plural(n int, singular, pluralForm string) string {
+	if n == 1 {
+		return singular
+	}
+	return pluralForm
+}

--- a/internal/agenthttp/home_assistant_ask_test.go
+++ b/internal/agenthttp/home_assistant_ask_test.go
@@ -1,0 +1,191 @@
+package agenthttp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// --- fakes for the ask handler ---
+
+type fakeProvider struct {
+	content string
+}
+
+func (f *fakeProvider) Chat(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	return &llm.ChatResponse{Content: f.content}, nil
+}
+func (f *fakeProvider) StreamChat(_ context.Context, _ llm.ChatRequest) (llm.StreamReader, error) {
+	return nil, errors.New("unused")
+}
+func (f *fakeProvider) Name() string           { return "fake" }
+func (f *fakeProvider) Type() llm.ProviderType { return llm.ProviderTypeLocal }
+func (f *fakeProvider) Capabilities() llm.ProviderCapabilities {
+	return llm.ProviderCapabilities{SupportsTools: true}
+}
+func (f *fakeProvider) ValidateConfig(_ llm.ProviderConfig) error { return nil }
+func (f *fakeProvider) DefaultModels() []string                   { return []string{"fake-model"} }
+
+type stubSystemModel struct {
+	provider string
+	model    string
+}
+
+func (s stubSystemModel) GetSystemModel() (string, string) { return s.provider, s.model }
+
+type fakeMutator struct {
+	created string
+}
+
+func (m *fakeMutator) CreateWorkspace(_ context.Context, name, _ string) (string, string, error) {
+	m.created = name
+	return "ws-new", "/workspaces/ws-new", nil
+}
+func (m *fakeMutator) CreateTask(_ context.Context, wsID, _ string) (string, string, error) {
+	return "t1", "/workspaces/" + wsID, nil
+}
+func (m *fakeMutator) StartTask(_ context.Context, wsID, _ string) (string, error) {
+	return "/workspaces/" + wsID, nil
+}
+
+func newAskHandlerWithProvider(t *testing.T, content string) *HomeAssistantAskHandler {
+	t.Helper()
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Alpha", []workspace.Task{
+		{Description: "do x", Status: workspace.TaskStatusInProgress, CreatedAt: time.Now()},
+	})
+	factory := llm.NewFactory()
+	factory.Register("fake", &fakeProvider{content: content})
+	return NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Now: time.Now},
+		factory,
+		stubSystemModel{provider: "fake", model: "fake-model"},
+	)
+}
+
+func TestAsk_IntrospectionAnswerWithGroundedActions(t *testing.T) {
+	h := newAskHandlerWithProvider(t, "You have 1 workspace and 1 active task.")
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{Prompt: "summarize my activity", Intent: "app_introspection"})
+
+	if resp.Response != "You have 1 workspace and 1 active task." {
+		t.Errorf("response = %q", resp.Response)
+	}
+	if resp.SnapshotMeta == nil || resp.SnapshotMeta.WorkspaceCount != 1 {
+		t.Fatalf("snapshot meta missing/wrong: %+v", resp.SnapshotMeta)
+	}
+	foundOpen := false
+	for _, a := range resp.Actions {
+		if a.RequiresConfirmation {
+			t.Errorf("introspection action unexpectedly requires confirmation: %+v", a)
+		}
+		if a.Type == HomeActionOpenWorkspace && a.Href == "/workspaces/ws-1" {
+			foundOpen = true
+		}
+	}
+	if !foundOpen {
+		t.Errorf("expected grounded open_workspace action, got %+v", resp.Actions)
+	}
+}
+
+func TestAsk_ConfirmationRequiredForCreateWorkspace(t *testing.T) {
+	h := newAskHandlerWithProvider(t, "irrelevant")
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{Prompt: "create a workspace called Beta", Intent: "app_introspection"})
+
+	if !resp.RequiresConfirmation || resp.Confirmation == nil {
+		t.Fatalf("expected confirmation, got %+v", resp)
+	}
+	if resp.Confirmation.ActionType != HomeActionCreateWorkspace {
+		t.Errorf("action type = %q, want %q", resp.Confirmation.ActionType, HomeActionCreateWorkspace)
+	}
+	if name, _ := resp.Confirmation.Arguments["name"].(string); name != "Beta" {
+		t.Errorf("name arg = %v, want Beta", resp.Confirmation.Arguments["name"])
+	}
+}
+
+func TestAsk_ExecuteConfirmedCreateWorkspace(t *testing.T) {
+	h := newAskHandlerWithProvider(t, "irrelevant")
+	mut := &fakeMutator{}
+	h.SetMutator(mut)
+
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Intent:          "app_introspection",
+		ConfirmedAction: &HomeAction{Type: HomeActionCreateWorkspace, Arguments: map[string]any{"name": "Beta"}},
+	})
+	if mut.created != "Beta" {
+		t.Errorf("CreateWorkspace not called with Beta: %q", mut.created)
+	}
+	foundOpen := false
+	for _, a := range resp.Actions {
+		if a.Type == HomeActionOpenWorkspace && a.Href == "/workspaces/ws-new" {
+			foundOpen = true
+		}
+	}
+	if !foundOpen {
+		t.Errorf("expected open_workspace action after create, got %+v", resp.Actions)
+	}
+}
+
+func TestAsk_ModelUnavailableGuidesToSettings(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	h := NewHomeAssistantAskHandler(HomeSnapshotSources{Workspaces: store, Now: time.Now}, nil, nil)
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{Prompt: "summarize my activity", Intent: "app_introspection"})
+
+	if resp.Response == "" {
+		t.Error("expected a graceful message when the model is unavailable")
+	}
+	foundSettings := false
+	for _, a := range resp.Actions {
+		if a.Href == "/settings" {
+			foundSettings = true
+		}
+	}
+	if !foundSettings {
+		t.Errorf("expected a Settings next-step action, got %+v", resp.Actions)
+	}
+}
+
+type spyTraceEmitter struct {
+	traces []HomeAskTrace
+}
+
+func (s *spyTraceEmitter) RecordAskOutcome(_ context.Context, t HomeAskTrace) {
+	s.traces = append(s.traces, t)
+}
+
+func TestAsk_EmitsTelemetry(t *testing.T) {
+	h := newAskHandlerWithProvider(t, "ok")
+	spy := &spyTraceEmitter{}
+	h.SetTraceEmitter(spy)
+
+	h.Ask(context.Background(), HomeAssistantAskRequest{Prompt: "summarize my activity", Intent: "app_introspection"})
+	if len(spy.traces) != 1 || spy.traces[0].Outcome != "answered" {
+		t.Fatalf("expected one 'answered' trace, got %+v", spy.traces)
+	}
+	if spy.traces[0].Intent != "app_introspection" || spy.traces[0].Prompt != "summarize my activity" {
+		t.Errorf("trace fields not recorded: %+v", spy.traces[0])
+	}
+
+	spy2 := &spyTraceEmitter{}
+	h.SetTraceEmitter(spy2)
+	h.Ask(context.Background(), HomeAssistantAskRequest{Prompt: "create a workspace called Beta", Intent: "app_introspection"})
+	if len(spy2.traces) != 1 || spy2.traces[0].Outcome != "confirmation_required" || spy2.traces[0].ConfirmedType != HomeActionCreateWorkspace {
+		t.Fatalf("expected confirmation_required trace, got %+v", spy2.traces)
+	}
+}
+
+func TestNavigateAndOpenSessionAreNotMutating(t *testing.T) {
+	for _, typ := range []string{HomeActionNavigate, HomeActionOpenSession, HomeActionOpenWorkspace, HomeActionOpenTask} {
+		if homeMutatingActionTypes[typ] {
+			t.Errorf("%q must not be a mutating (confirmation-required) action", typ)
+		}
+	}
+	for _, typ := range []string{HomeActionCreateWorkspace, HomeActionCreateTask, HomeActionStartTask} {
+		if !homeMutatingActionTypes[typ] {
+			t.Errorf("%q must be a mutating action", typ)
+		}
+	}
+}

--- a/internal/agenthttp/home_assistant_ask_trace.go
+++ b/internal/agenthttp/home_assistant_ask_trace.go
@@ -1,0 +1,32 @@
+package agenthttp
+
+import (
+	"context"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+)
+
+// LoggingHomeAskTraceEmitter records home-harness outcomes as structured logs
+// under the home_assistant.ask scope, mirroring the route-intake trace logging in
+// TraceHandler. It deliberately does not persist into the route-intake table,
+// which feeds workspace-correction learning and would be polluted by inline asks.
+type LoggingHomeAskTraceEmitter struct{}
+
+// NewLoggingHomeAskTraceEmitter returns the default home-harness telemetry emitter.
+func NewLoggingHomeAskTraceEmitter() *LoggingHomeAskTraceEmitter {
+	return &LoggingHomeAskTraceEmitter{}
+}
+
+// RecordAskOutcome emits one structured telemetry line per home-harness outcome.
+func (e *LoggingHomeAskTraceEmitter) RecordAskOutcome(_ context.Context, trace HomeAskTrace) {
+	logger.Info("Home assistant ask", logger.Fields{
+		"scope":          "home_assistant.ask",
+		"prompt":         trace.Prompt,
+		"intent":         trace.Intent,
+		"window":         trace.Window,
+		"outcome":        trace.Outcome,
+		"action_count":   trace.ActionCount,
+		"confirmed_type": trace.ConfirmedType,
+		"degraded":       append([]string(nil), trace.Degraded...),
+	})
+}

--- a/internal/agenthttp/home_assistant_route.go
+++ b/internal/agenthttp/home_assistant_route.go
@@ -134,6 +134,11 @@ const (
 	homeAssistantHandoffAssistant  = "assistant"
 	homeAssistantHandoffSpecialist = "specialist"
 	homeAssistantHandoffTool       = "tool"
+
+	// homeAssistantRouteModeInline signals the frontend to answer the prompt
+	// inline via the home harness (POST /api/home-assistant/ask) instead of
+	// routing to an agent or workspace.
+	homeAssistantRouteModeInline = "home_inline"
 )
 
 var (
@@ -207,6 +212,28 @@ var (
 		SuggestedName:    "Task Assistant",
 		MinScore:         3,
 	}
+	// homeAssistantAppIntrospectionIntent matches questions about the user's own
+	// Ori data (activity/summary/recap over tasks, sessions, workspaces, usage).
+	// Answered inline by the home harness.
+	homeAssistantAppIntrospectionIntent = homeAssistantIntent{
+		Key:            "app_introspection",
+		Label:          "app activity",
+		PreferredTypes: []string{"general"},
+		DefaultType:    "general",
+		SuggestedName:  systemAssistantAgentName,
+		MinScore:       3,
+	}
+	// homeAssistantAppNavigationIntent matches "where/how do I…/open <feature>"
+	// requests about app features and locations. Answered inline + grounded in the
+	// navigation catalog.
+	homeAssistantAppNavigationIntent = homeAssistantIntent{
+		Key:            "app_navigation",
+		Label:          "app navigation",
+		PreferredTypes: []string{"general"},
+		DefaultType:    "general",
+		SuggestedName:  systemAssistantAgentName,
+		MinScore:       3,
+	}
 	homeAssistantSpecificIntents = []homeAssistantIntent{
 		homeAssistantUtilityIntent,
 		homeAssistantTravelIntent,
@@ -270,7 +297,7 @@ func (h *HomeAssistantRouteHandler) RoutePrompt(prompt string, context *HomeAssi
 	}
 
 	routeContext := normalizeHomeAssistantRouteContext(context)
-	intent := detectHomeAssistantIntent(prompt)
+	intent := h.classifyHomeIntent(prompt)
 	intentVariant := detectHomeAssistantIntentVariant(prompt, intent, routeContext)
 	workspaceRecommended := shouldRecommendWorkspace(prompt, intent)
 	routeMode, targetSurface := determineRouteModeAndTargetSurface(intent, intentVariant, routeContext, workspaceRecommended)
@@ -372,6 +399,99 @@ func detectHomeAssistantIntent(prompt string) homeAssistantIntent {
 	}
 
 	return selectedIntent
+}
+
+// classifyHomeIntent layers the app_introspection / app_navigation intents on top
+// of detectHomeAssistantIntent. It only overrides the generic fallback and the
+// app_launch case, so specific intents (utility/calendar/email/travel/
+// workspace_create) keep their precedence (FR #4). app_navigation beats
+// app_launch when the "open …" target is a known app feature or a real workspace
+// ("open Action Center" / "open the Q3 Planning workspace"), while "open Safari"
+// stays app_launch.
+func (h *HomeAssistantRouteHandler) classifyHomeIntent(prompt string) homeAssistantIntent {
+	base := detectHomeAssistantIntent(prompt)
+	switch base.Key {
+	case homeAssistantDefaultIntent.Key:
+		if h.isAppNavigationPrompt(prompt) {
+			return homeAssistantAppNavigationIntent
+		}
+		if isAppIntrospectionPrompt(prompt) {
+			return homeAssistantAppIntrospectionIntent
+		}
+	case homeAssistantAppLaunchIntent.Key:
+		if h.isAppNavigationPrompt(prompt) {
+			return homeAssistantAppNavigationIntent
+		}
+	}
+	return base
+}
+
+func (h *HomeAssistantRouteHandler) workspaceStoreOrNil() workspace.Store {
+	if h == nil || h.WorkspaceResolver == nil {
+		return nil
+	}
+	return h.WorkspaceResolver.WorkspaceStore
+}
+
+// isAppNavigationPrompt reports whether the prompt is asking to find/open an app
+// destination: it needs a navigation cue plus a real target (a catalog feature or
+// an existing workspace name). Requiring a real target keeps introspection asks
+// like "summarize my mcp usage" out of navigation.
+func (h *HomeAssistantRouteHandler) isAppNavigationPrompt(prompt string) bool {
+	if !hasNavigationCue(prompt) {
+		return false
+	}
+	if promptMatchesNavCatalog(prompt) {
+		return true
+	}
+	return promptMentionsWorkspaceByName(h.workspaceStoreOrNil(), prompt)
+}
+
+func hasNavigationCue(prompt string) bool {
+	p := normalizeRouteToken(prompt)
+	for _, cue := range []string{
+		"where", "how do i", "how can i", "how to", "take me to", "go to",
+		"navigate", "open", "show me", "which page", "what page", "find the",
+		"get to", "bring up",
+	} {
+		if strings.Contains(p, cue) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAppIntrospectionPrompt reports whether the prompt asks about the user's own
+// Ori data/activity.
+func isAppIntrospectionPrompt(prompt string) bool {
+	p := normalizeRouteToken(prompt)
+	if p == "" {
+		return false
+	}
+	for _, phrase := range []string{
+		"task activity", "my tasks", "my workspaces", "my sessions", "my activity",
+		"what did i work on", "what have i been working", "what's pending", "whats pending",
+		"how many tasks", "recap", "across my workspaces", "all my workspaces", "my recent",
+	} {
+		if strings.Contains(p, phrase) {
+			return true
+		}
+	}
+	hasVerb := containsAnyToken(p, []string{"summarize", "summary", "overview", "recap", "report", "review", "status"})
+	hasNoun := containsAnyToken(p, []string{
+		"task", "tasks", "workspace", "workspaces", "session", "sessions",
+		"activity", "opportunity", "opportunities", "usage", "cost", "spending",
+	})
+	return hasVerb && hasNoun
+}
+
+func containsAnyToken(normalizedPrompt string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(normalizedPrompt, n) {
+			return true
+		}
+	}
+	return false
 }
 
 func detectHomeAssistantIntentVariant(prompt string, intent homeAssistantIntent, context normalizedHomeAssistantRouteContext) string {
@@ -841,6 +961,9 @@ func (c normalizedHomeAssistantRouteContext) hasWorkspaceSurfaceContext() bool {
 }
 
 func determineRouteModeAndTargetSurface(intent homeAssistantIntent, intentVariant string, context normalizedHomeAssistantRouteContext, workspaceRecommended bool) (string, string) {
+	if intent.Key == homeAssistantAppIntrospectionIntent.Key || intent.Key == homeAssistantAppNavigationIntent.Key {
+		return homeAssistantRouteModeInline, "current"
+	}
 	if intent.Key == homeAssistantUtilityIntent.Key {
 		return "utility_direct", "current"
 	}
@@ -877,6 +1000,8 @@ func determineRoutingPolicy(
 	}
 
 	switch intent.Key {
+	case homeAssistantAppIntrospectionIntent.Key, homeAssistantAppNavigationIntent.Key:
+		return homeAssistantPolicyAssistantOnly
 	case homeAssistantUtilityIntent.Key, homeAssistantWorkspaceCreateIntent.Key:
 		return homeAssistantPolicyAssistantOnly
 	case homeAssistantEmailIntent.Key, homeAssistantAppLaunchIntent.Key:

--- a/internal/agenthttp/home_nav_catalog.go
+++ b/internal/agenthttp/home_nav_catalog.go
@@ -1,0 +1,218 @@
+package agenthttp
+
+import (
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// HomeNavEntry is one destination in the app navigation catalog. The catalog is
+// the single source of truth for navigation answers and `navigate` actions
+// (PRD 4.8): the harness may only emit static destinations that exist here, or
+// dynamic destinations resolved to a real workspace/session/task id.
+type HomeNavEntry struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Href        string `json:"href"`
+	Description string `json:"description"`
+	// Aliases are phrases a user might say to mean this destination. Used for
+	// "open X" disambiguation and for grounding navigation answers.
+	Aliases []string `json:"-"`
+}
+
+// homeNavCatalog is kept in sync with the page routes registered in
+// internal/server/routes.go. home_nav_catalog_test.go asserts every Href maps to
+// a registered route.
+var homeNavCatalog = []HomeNavEntry{
+	{
+		Key:         "home",
+		Label:       "Home",
+		Href:        "/",
+		Description: "The dashboard with Ask Ori, recent workspaces, upcoming tasks, and recent activity.",
+		Aliases:     []string{"home", "dashboard", "start page", "main page"},
+	},
+	{
+		Key:         "agents",
+		Label:       "Agents",
+		Href:        "/agents",
+		Description: "Create, configure, and manage your agents (model, system prompt, tools).",
+		Aliases:     []string{"agents", "agent", "my agents", "agent list"},
+	},
+	{
+		Key:         "workspaces",
+		Label:       "Workspaces",
+		Href:        "/workspaces",
+		Description: "Browse and open workspaces — collaborative spaces with tasks, notes, files, and sessions.",
+		Aliases:     []string{"workspaces", "workspace", "my workspaces", "workspace list"},
+	},
+	{
+		Key:         "action-center",
+		Label:       "Action Center",
+		Href:        "/action-center",
+		Description: "Review opportunities surfaced across workspaces and decide what to act on next.",
+		Aliases:     []string{"action center", "action-center", "actions", "opportunities", "action centre"},
+	},
+	{
+		Key:         "vaults",
+		Label:       "Vaults",
+		Href:        "/vaults",
+		Description: "Manage stored secrets and credentials used by agents and connectors.",
+		Aliases:     []string{"vaults", "vault", "secrets", "credentials", "api keys vault"},
+	},
+	{
+		Key:         "mcp",
+		Label:       "MCP",
+		Href:        "/mcp",
+		Description: "Configure Model Context Protocol connectors (MCP servers) that provide external tools.",
+		Aliases:     []string{"mcp", "mcp settings", "mcp page", "mcp connectors", "mcp servers", "connectors"},
+	},
+	{
+		Key:         "settings",
+		Label:       "Settings",
+		Href:        "/settings",
+		Description: "Global configuration: API keys, LLM provider, system model, and preferences.",
+		Aliases:     []string{"settings", "preferences", "configuration", "config", "api keys"},
+	},
+	{
+		Key:         "usage",
+		Label:       "Usage",
+		Href:        "/usage",
+		Description: "Track LLM usage and cost across providers, models, and agents.",
+		Aliases:     []string{"usage", "cost", "costs", "spending", "billing", "usage and cost"},
+	},
+}
+
+// HomeNavCatalog returns a copy of the navigation catalog.
+func HomeNavCatalog() []HomeNavEntry {
+	out := make([]HomeNavEntry, len(homeNavCatalog))
+	copy(out, homeNavCatalog)
+	return out
+}
+
+// FindHomeNavEntry resolves a phrase to a catalog entry by exact label/alias
+// match (case-insensitive). Returns false when nothing matches; callers must not
+// invent a destination.
+func FindHomeNavEntry(query string) (HomeNavEntry, bool) {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return HomeNavEntry{}, false
+	}
+	q = strings.Trim(q, " .,!?:;\"'")
+	q = strings.TrimPrefix(q, "the ")
+	q = strings.TrimSuffix(q, " page")
+	q = strings.TrimSpace(q)
+	for _, entry := range homeNavCatalog {
+		if strings.EqualFold(entry.Label, q) || strings.EqualFold(entry.Key, q) {
+			return entry, true
+		}
+		for _, alias := range entry.Aliases {
+			if alias == q {
+				return entry, true
+			}
+		}
+	}
+	return HomeNavEntry{}, false
+}
+
+// MatchNavEntryInPrompt returns the catalog entry whose label/alias appears in
+// the prompt, preferring the longest match. Used to build a grounded `navigate`
+// action for navigation answers.
+func MatchNavEntryInPrompt(prompt string) (HomeNavEntry, bool) {
+	p := strings.ToLower(prompt)
+	if p == "" {
+		return HomeNavEntry{}, false
+	}
+	best := HomeNavEntry{}
+	bestLen := 0
+	for _, entry := range homeNavCatalog {
+		if entry.Key == "home" {
+			continue
+		}
+		candidates := append([]string{strings.ToLower(entry.Label)}, entry.Aliases...)
+		for _, c := range candidates {
+			if len(c) >= 4 && strings.Contains(p, c) && len(c) > bestLen {
+				best = entry
+				bestLen = len(c)
+			}
+		}
+	}
+	return best, bestLen > 0
+}
+
+// matchWorkspaceInPrompt returns the id and name of a workspace whose name
+// appears in the prompt (longest match wins), so navigation answers resolve to a
+// real workspace id.
+func matchWorkspaceInPrompt(store workspace.Store, prompt string) (id, name string, ok bool) {
+	if store == nil {
+		return "", "", false
+	}
+	p := strings.ToLower(prompt)
+	ids, err := store.List()
+	if err != nil {
+		return "", "", false
+	}
+	bestLen := 0
+	for _, wsID := range ids {
+		ws, getErr := store.Get(wsID)
+		if getErr != nil || ws == nil {
+			continue
+		}
+		n := strings.ToLower(strings.TrimSpace(ws.Name))
+		if len(n) >= 3 && strings.Contains(p, n) && len(n) > bestLen {
+			id, name, bestLen = ws.ID, ws.Name, len(n)
+		}
+	}
+	return id, name, bestLen > 0
+}
+
+// promptMatchesNavCatalog reports whether the prompt mentions any catalog
+// destination (label/alias substring). Used by intent classification to route
+// "where do I…/open <feature>" asks to app_navigation.
+func promptMatchesNavCatalog(prompt string) bool {
+	p := strings.ToLower(prompt)
+	if p == "" {
+		return false
+	}
+	for _, entry := range homeNavCatalog {
+		if entry.Key == "home" {
+			continue // too generic to be a reliable signal
+		}
+		if strings.Contains(p, strings.ToLower(entry.Label)) {
+			return true
+		}
+		for _, alias := range entry.Aliases {
+			if len(alias) >= 4 && strings.Contains(p, alias) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// promptMentionsWorkspaceByName reports whether the prompt contains a phrase that
+// resolves to a real workspace name. Used so "open the Q3 Planning workspace"
+// routes to app_navigation only when that workspace actually exists.
+func promptMentionsWorkspaceByName(store workspace.Store, prompt string) bool {
+	if store == nil {
+		return false
+	}
+	p := strings.ToLower(prompt)
+	if !strings.Contains(p, "workspace") {
+		return false
+	}
+	ids, err := store.List()
+	if err != nil {
+		return false
+	}
+	for _, id := range ids {
+		ws, getErr := store.Get(id)
+		if getErr != nil || ws == nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(ws.Name))
+		if len(name) >= 3 && strings.Contains(p, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agenthttp/home_nav_catalog_test.go
+++ b/internal/agenthttp/home_nav_catalog_test.go
@@ -1,0 +1,58 @@
+package agenthttp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHomeNavCatalogHrefsAreRegisteredRoutes asserts every catalog href maps to a
+// route registered in internal/server/routes.go, keeping the catalog honest
+// (PRD 4.8 / FR #33).
+func TestHomeNavCatalogHrefsAreRegisteredRoutes(t *testing.T) {
+	routesPath := filepath.Join("..", "server", "routes.go")
+	raw, err := os.ReadFile(routesPath)
+	if err != nil {
+		t.Fatalf("read routes.go: %v", err)
+	}
+	routes := string(raw)
+	for _, entry := range HomeNavCatalog() {
+		needle := `"` + entry.Href + `"`
+		if !strings.Contains(routes, needle) {
+			t.Errorf("catalog entry %q href %q is not a registered route in routes.go", entry.Key, entry.Href)
+		}
+	}
+}
+
+func TestFindHomeNavEntry(t *testing.T) {
+	cases := map[string]string{
+		"Action Center":   "action-center",
+		"mcp connectors":  "mcp",
+		"settings":        "settings",
+		"the agents page": "agents",
+	}
+	for query, wantKey := range cases {
+		entry, ok := FindHomeNavEntry(query)
+		if !ok {
+			t.Errorf("FindHomeNavEntry(%q): expected a match", query)
+			continue
+		}
+		if entry.Key != wantKey {
+			t.Errorf("FindHomeNavEntry(%q): got %q, want %q", query, entry.Key, wantKey)
+		}
+	}
+	if _, ok := FindHomeNavEntry("definitely not a page"); ok {
+		t.Error("FindHomeNavEntry: unexpected match for unknown phrase")
+	}
+}
+
+func TestMatchNavEntryInPrompt(t *testing.T) {
+	entry, ok := MatchNavEntryInPrompt("where do I manage my mcp connectors again")
+	if !ok || entry.Key != "mcp" {
+		t.Fatalf("expected mcp match, got %q ok=%v", entry.Key, ok)
+	}
+	if _, ok := MatchNavEntryInPrompt("summarize my recent activity"); ok {
+		t.Error("did not expect a catalog match for an introspection prompt without a feature name")
+	}
+}

--- a/internal/agenthttp/home_snapshot.go
+++ b/internal/agenthttp/home_snapshot.go
@@ -1,0 +1,513 @@
+package agenthttp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// Home snapshot caps (PRD 4.2 / Resolved Decisions). These bound prompt size so a
+// large account cannot blow the context window; detail beyond the caps is fetched
+// on demand via the read-only home tools.
+const (
+	homeSnapshotMaxWorkspaces    = 25
+	homeSnapshotMaxTasks         = 40
+	homeSnapshotMaxSessions      = 20
+	homeSnapshotMaxOpportunities = 20
+	homeSnapshotPreviewLimit     = 180
+	homeSnapshotTextLimit        = 120
+)
+
+// HomeDateWindow is the activity window a snapshot is scoped to.
+type HomeDateWindow string
+
+const (
+	HomeWindowToday     HomeDateWindow = "today"
+	HomeWindowThisWeek  HomeDateWindow = "this_week"
+	HomeWindowThisMonth HomeDateWindow = "this_month"
+)
+
+// HomeSessionSummary is a workspace-agnostic recent-session record. Sessions in
+// this app are agent/folder scoped, so workspace attribution is omitted (FR #5
+// "when available").
+type HomeSessionSummary struct {
+	ID           string
+	Title        string
+	AgentName    string
+	MessageCount int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// HomeUsageSummary is a cheap usage/cost roll-up.
+type HomeUsageSummary struct {
+	TodayCost   float64
+	TodayTokens int
+	MonthCost   float64
+	MonthTokens int
+	Currency    string
+}
+
+// homeRecentSessionsReader returns recent sessions across the whole app. The
+// server wires a session-store adapter so agenthttp stays decoupled from the
+// session package.
+type homeRecentSessionsReader interface {
+	RecentSessions(ctx context.Context, limit int) ([]HomeSessionSummary, error)
+}
+
+// homeUsageReader returns a cheap usage summary. The server wires a costTracker
+// adapter. A false ok degrades the usage section rather than failing the answer.
+type homeUsageReader interface {
+	UsageSummary() (HomeUsageSummary, bool)
+}
+
+// HomeSnapshotSources bundles the data sources the snapshot aggregates. Any may
+// be nil; a nil source degrades its section instead of failing the snapshot.
+type HomeSnapshotSources struct {
+	Workspaces    workspace.Store
+	Opportunities workspace.OpportunityStore
+	Sessions      homeRecentSessionsReader
+	Usage         homeUsageReader
+	// Now allows tests to pin the clock; defaults to time.Now.
+	Now func() time.Time
+}
+
+// HomeWorkspaceSummary is a per-workspace roll-up line.
+type HomeWorkspaceSummary struct {
+	ID         string
+	Name       string
+	Status     string
+	AgentCount int
+	OpenTasks  int
+	UpdatedAt  time.Time
+}
+
+// HomeTaskSummary is a single task active within the snapshot window.
+type HomeTaskSummary struct {
+	ID            string
+	WorkspaceID   string
+	WorkspaceName string
+	Description   string
+	Status        string
+	Priority      int
+	Assignee      string
+	UpdatedAt     time.Time
+}
+
+// HomeOpportunitySummary is a single open Action Center opportunity.
+type HomeOpportunitySummary struct {
+	ID            string
+	WorkspaceID   string
+	WorkspaceName string
+	Title         string
+	Summary       string
+	Priority      string
+}
+
+// HomeSnapshotMeta records section sizes, truncation, and which sections degraded
+// (a data source failed or was unavailable). Returned to the frontend as
+// snapshot_meta and folded into the prompt.
+type HomeSnapshotMeta struct {
+	Window           HomeDateWindow `json:"window"`
+	WindowLabel      string         `json:"window_label"`
+	GeneratedAt      time.Time      `json:"generated_at"`
+	WorkspaceCount   int            `json:"workspace_count"`
+	TaskCount        int            `json:"task_count"`
+	SessionCount     int            `json:"session_count"`
+	OpportunityCount int            `json:"opportunity_count"`
+	Truncated        []string       `json:"truncated,omitempty"`
+	Degraded         []string       `json:"degraded,omitempty"`
+}
+
+// HomeSnapshot is the app-scoped analogue of the workspace task snapshot.
+type HomeSnapshot struct {
+	Meta          HomeSnapshotMeta
+	Workspaces    []HomeWorkspaceSummary
+	TaskCounts    map[string]int
+	Tasks         []HomeTaskSummary
+	Sessions      []HomeSessionSummary
+	Opportunities []HomeOpportunitySummary
+	Usage         *HomeUsageSummary
+}
+
+// NormalizeHomeDateWindow maps free-text/explicit window inputs to a canonical
+// window. An empty/unknown value resolves to defaultWindow (PRD Resolved
+// Decision #2: recap asks default this_week, status asks default today — the
+// caller picks the default from prompt phrasing).
+func NormalizeHomeDateWindow(raw string, defaultWindow HomeDateWindow) HomeDateWindow {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(raw)), " ", "_") {
+	case string(HomeWindowToday), "day", "1d":
+		return HomeWindowToday
+	case string(HomeWindowThisWeek), "week", "7d":
+		return HomeWindowThisWeek
+	case string(HomeWindowThisMonth), "month", "30d":
+		return HomeWindowThisMonth
+	default:
+		if defaultWindow == "" {
+			return HomeWindowThisWeek
+		}
+		return defaultWindow
+	}
+}
+
+// DefaultHomeDateWindowForPrompt picks the default window from prompt phrasing:
+// status-style asks scope to today, everything else (recap/summary) to this week.
+func DefaultHomeDateWindowForPrompt(prompt string) HomeDateWindow {
+	p := strings.ToLower(prompt)
+	for _, marker := range []string{"right now", "currently", "pending right now", "what's running", "whats running", "in progress now"} {
+		if strings.Contains(p, marker) {
+			return HomeWindowToday
+		}
+	}
+	return HomeWindowThisWeek
+}
+
+func resolveHomeWindowRange(window HomeDateWindow, now time.Time) (start, end time.Time, label string) {
+	end = now
+	switch window {
+	case HomeWindowToday:
+		start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		label = "today (" + start.Format("Jan 2") + ")"
+	case HomeWindowThisMonth:
+		start = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		label = "this month (" + start.Format("Jan 2") + " – " + now.Format("Jan 2") + ")"
+	default: // this_week, Monday-based
+		weekday := int(now.Weekday())
+		if weekday == 0 {
+			weekday = 7 // treat Sunday as last day of the week
+		}
+		dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		start = dayStart.AddDate(0, 0, -(weekday - 1))
+		label = "this week (" + start.Format("Jan 2") + " – " + now.Format("Jan 2") + ")"
+	}
+	return start, end, label
+}
+
+func taskActiveInWindow(t workspace.Task, start, end time.Time) bool {
+	inRange := func(ts time.Time) bool {
+		return !ts.IsZero() && !ts.Before(start) && !ts.After(end)
+	}
+	if inRange(t.CreatedAt) {
+		return true
+	}
+	if t.StartedAt != nil && inRange(*t.StartedAt) {
+		return true
+	}
+	if t.CompletedAt != nil && inRange(*t.CompletedAt) {
+		return true
+	}
+	// Always surface still-open tasks regardless of timestamps so "what's
+	// pending" stays correct even for older items.
+	switch t.Status {
+	case workspace.TaskStatusPending, workspace.TaskStatusAssigned,
+		workspace.TaskStatusInProgress, workspace.TaskStatusWaitingForChoice:
+		return true
+	}
+	return false
+}
+
+// BuildHomeSnapshot aggregates app-wide state for the home harness. It fails
+// soft: a failure or nil source degrades that section (recorded in Meta.Degraded)
+// rather than returning an error.
+func BuildHomeSnapshot(ctx context.Context, sources HomeSnapshotSources, window HomeDateWindow) HomeSnapshot {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	nowFn := sources.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn()
+	start, end, label := resolveHomeWindowRange(window, now)
+
+	snap := HomeSnapshot{
+		Meta: HomeSnapshotMeta{
+			Window:      window,
+			WindowLabel: label,
+			GeneratedAt: now,
+		},
+		TaskCounts: map[string]int{},
+	}
+
+	wsByID := map[string]string{} // id -> name, for cross-section labeling
+
+	// Workspaces + tasks.
+	if sources.Workspaces == nil {
+		snap.Meta.Degraded = append(snap.Meta.Degraded, "workspaces")
+	} else {
+		ids, err := sources.Workspaces.List()
+		if err != nil {
+			logger.Debug("home snapshot: list workspaces failed", logger.Fields{"error": err})
+			snap.Meta.Degraded = append(snap.Meta.Degraded, "workspaces")
+		} else {
+			var workspaces []*workspace.Workspace
+			for _, id := range ids {
+				ws, getErr := sources.Workspaces.Get(id)
+				if getErr != nil || ws == nil {
+					continue
+				}
+				if isGroupWorkspace(ws) {
+					continue // groups are containers, not activity sources
+				}
+				workspaces = append(workspaces, ws)
+			}
+			// Most recently updated first.
+			sort.Slice(workspaces, func(i, j int) bool {
+				return workspaces[i].UpdatedAt.After(workspaces[j].UpdatedAt)
+			})
+			snap.Meta.WorkspaceCount = len(workspaces)
+
+			var windowedTasks []HomeTaskSummary
+			for _, ws := range workspaces {
+				wsByID[ws.ID] = ws.Name
+				stats := ws.GetTaskStats()
+				for k, v := range stats {
+					snap.TaskCounts[k] += v
+				}
+				if len(snap.Workspaces) < homeSnapshotMaxWorkspaces {
+					snap.Workspaces = append(snap.Workspaces, HomeWorkspaceSummary{
+						ID:         ws.ID,
+						Name:       ws.Name,
+						Status:     string(ws.Status),
+						AgentCount: workspaceAgentCount(ws),
+						OpenTasks:  stats["pending"] + stats["assigned"] + stats["in_progress"] + stats["waiting_for_choice"],
+						UpdatedAt:  ws.UpdatedAt,
+					})
+				}
+				for _, t := range ws.Tasks {
+					if !taskActiveInWindow(t, start, end) {
+						continue
+					}
+					windowedTasks = append(windowedTasks, HomeTaskSummary{
+						ID:            t.ID,
+						WorkspaceID:   ws.ID,
+						WorkspaceName: ws.Name,
+						Description:   t.Description,
+						Status:        string(t.Status),
+						Priority:      t.Priority,
+						Assignee:      homeTaskAssignee(t),
+						UpdatedAt:     homeTaskActivityTime(t),
+					})
+				}
+			}
+			if len(snap.Workspaces) < snap.Meta.WorkspaceCount {
+				snap.Meta.Truncated = append(snap.Meta.Truncated, "workspaces")
+			}
+
+			sort.Slice(windowedTasks, func(i, j int) bool {
+				return windowedTasks[i].UpdatedAt.After(windowedTasks[j].UpdatedAt)
+			})
+			snap.Meta.TaskCount = len(windowedTasks)
+			if len(windowedTasks) > homeSnapshotMaxTasks {
+				windowedTasks = windowedTasks[:homeSnapshotMaxTasks]
+				snap.Meta.Truncated = append(snap.Meta.Truncated, "tasks")
+			}
+			snap.Tasks = windowedTasks
+
+			// Opportunities (needs the workspace list to iterate).
+			snap.Opportunities, snap.Meta.OpportunityCount = collectHomeOpportunities(sources.Opportunities, workspaces, &snap.Meta)
+		}
+	}
+
+	// Sessions (global recent).
+	if sources.Sessions == nil {
+		snap.Meta.Degraded = append(snap.Meta.Degraded, "sessions")
+	} else if sessions, err := sources.Sessions.RecentSessions(ctx, homeSnapshotMaxSessions); err != nil {
+		logger.Debug("home snapshot: recent sessions failed", logger.Fields{"error": err})
+		snap.Meta.Degraded = append(snap.Meta.Degraded, "sessions")
+	} else {
+		snap.Sessions = sessions
+		snap.Meta.SessionCount = len(sessions)
+	}
+
+	// Usage.
+	if sources.Usage == nil {
+		snap.Meta.Degraded = append(snap.Meta.Degraded, "usage")
+	} else if usage, ok := sources.Usage.UsageSummary(); ok {
+		snap.Usage = &usage
+	} else {
+		snap.Meta.Degraded = append(snap.Meta.Degraded, "usage")
+	}
+
+	return snap
+}
+
+func collectHomeOpportunities(store workspace.OpportunityStore, workspaces []*workspace.Workspace, meta *HomeSnapshotMeta) ([]HomeOpportunitySummary, int) {
+	if store == nil {
+		meta.Degraded = append(meta.Degraded, "opportunities")
+		return nil, 0
+	}
+	var out []HomeOpportunitySummary
+	total := 0
+	failed := false
+	for _, ws := range workspaces {
+		opps, err := store.List(ws.ID)
+		if err != nil {
+			failed = true
+			continue
+		}
+		for _, o := range opps {
+			if !o.IsOpen() {
+				continue
+			}
+			total++
+			if len(out) < homeSnapshotMaxOpportunities {
+				out = append(out, HomeOpportunitySummary{
+					ID:            o.ID,
+					WorkspaceID:   ws.ID,
+					WorkspaceName: ws.Name,
+					Title:         o.Title,
+					Summary:       o.Summary,
+					Priority:      o.Priority,
+				})
+			}
+		}
+	}
+	if failed && total == 0 {
+		meta.Degraded = append(meta.Degraded, "opportunities")
+	}
+	if total > len(out) {
+		meta.Truncated = append(meta.Truncated, "opportunities")
+	}
+	return out, total
+}
+
+func isGroupWorkspace(ws *workspace.Workspace) bool {
+	return strings.EqualFold(strings.TrimSpace(ws.Kind), "group")
+}
+
+func workspaceAgentCount(ws *workspace.Workspace) int {
+	if len(ws.AgentInstances) > 0 {
+		return len(ws.AgentInstances)
+	}
+	return len(ws.Agents)
+}
+
+func homeTaskAssignee(t workspace.Task) string {
+	if a := strings.TrimSpace(t.To); a != "" {
+		return a
+	}
+	if a := strings.TrimSpace(t.AssignedNodeID); a != "" {
+		return a
+	}
+	return "unassigned"
+}
+
+func homeTaskActivityTime(t workspace.Task) time.Time {
+	if t.CompletedAt != nil && !t.CompletedAt.IsZero() {
+		return *t.CompletedAt
+	}
+	if t.StartedAt != nil && !t.StartedAt.IsZero() {
+		return *t.StartedAt
+	}
+	return t.CreatedAt
+}
+
+// PromptText renders the snapshot for injection into the model prompt, mirroring
+// buildTaskWorkspaceSnapshot's bounded markdown style.
+func (s HomeSnapshot) PromptText() string {
+	var b strings.Builder
+	b.WriteString("## Home Snapshot\n\n")
+	b.WriteString("App-wide state for the current user. Window: " + s.Meta.WindowLabel + ".\n")
+	b.WriteString("Generated at " + s.Meta.GeneratedAt.UTC().Format(time.RFC3339) + ".\n")
+	if len(s.Meta.Degraded) > 0 {
+		b.WriteString("Degraded sections (data unavailable): " + strings.Join(s.Meta.Degraded, ", ") + ".\n")
+	}
+	if len(s.Meta.Truncated) > 0 {
+		b.WriteString("Truncated sections (more available via tools): " + strings.Join(s.Meta.Truncated, ", ") + ".\n")
+	}
+	b.WriteString("\n")
+
+	fmt.Fprintf(&b, "### Workspaces (%d)\n\n", s.Meta.WorkspaceCount)
+	if len(s.Workspaces) == 0 {
+		b.WriteString("- none\n")
+	}
+	for _, ws := range s.Workspaces {
+		fmt.Fprintf(&b, "- %q [%s] agents=%d open_tasks=%d updated=%s (id=%s)\n",
+			homeSnapshotClip(ws.Name, homeSnapshotTextLimit), ws.Status, ws.AgentCount, ws.OpenTasks,
+			homeSnapshotDate(ws.UpdatedAt), ws.ID)
+	}
+
+	b.WriteString("\n### Task activity\n\n")
+	b.WriteString("- Counts (all-time): " + homeTaskCountsLine(s.TaskCounts) + "\n")
+	fmt.Fprintf(&b, "- Tasks active in window: %d\n", s.Meta.TaskCount)
+	for _, t := range s.Tasks {
+		fmt.Fprintf(&b, "- [%s] %q in %q -> %s (priority %d, %s) (id=%s)\n",
+			t.Status, homeSnapshotClip(t.Description, homeSnapshotTextLimit),
+			homeSnapshotClip(t.WorkspaceName, homeSnapshotTextLimit), t.Assignee, t.Priority,
+			homeSnapshotDate(t.UpdatedAt), t.ID)
+	}
+
+	fmt.Fprintf(&b, "\n### Recent sessions (%d)\n\n", s.Meta.SessionCount)
+	if len(s.Sessions) == 0 {
+		b.WriteString("- none\n")
+	}
+	for _, sess := range s.Sessions {
+		fmt.Fprintf(&b, "- %q agent=%q messages=%d updated=%s (id=%s)\n",
+			homeSnapshotClip(sess.Title, homeSnapshotTextLimit), homeSnapshotClip(sess.AgentName, homeSnapshotTextLimit),
+			sess.MessageCount, homeSnapshotDate(sess.UpdatedAt), sess.ID)
+	}
+
+	fmt.Fprintf(&b, "\n### Open Action Center opportunities (%d)\n\n", s.Meta.OpportunityCount)
+	if len(s.Opportunities) == 0 {
+		b.WriteString("- none\n")
+	}
+	for _, o := range s.Opportunities {
+		fmt.Fprintf(&b, "- [%s] %q in %q: %s (id=%s ws=%s)\n",
+			emptyTo(o.Priority, "n/a"), homeSnapshotClip(o.Title, homeSnapshotTextLimit),
+			homeSnapshotClip(o.WorkspaceName, homeSnapshotTextLimit),
+			homeSnapshotClip(o.Summary, homeSnapshotPreviewLimit), o.ID, o.WorkspaceID)
+	}
+
+	b.WriteString("\n### Usage\n\n")
+	if s.Usage == nil {
+		b.WriteString("- unavailable\n")
+	} else {
+		cur := emptyTo(s.Usage.Currency, "USD")
+		fmt.Fprintf(&b, "- Today: %.4f %s (%d tokens)\n", s.Usage.TodayCost, cur, s.Usage.TodayTokens)
+		fmt.Fprintf(&b, "- Month-to-date: %.4f %s (%d tokens)\n", s.Usage.MonthCost, cur, s.Usage.MonthTokens)
+	}
+
+	b.WriteString("\nUse this snapshot as the source of truth for app-data questions. Call the home_* tools to read full state when a section is truncated or you need detail. Do not fabricate activity; if a section is empty or degraded, say so.\n")
+	return b.String()
+}
+
+func homeTaskCountsLine(stats map[string]int) string {
+	if len(stats) == 0 {
+		return "total=0"
+	}
+	parts := []string{fmt.Sprintf("total=%d", stats["total"])}
+	for _, key := range []string{"pending", "assigned", "in_progress", "waiting_for_choice", "completed", "failed", "cancelled", "timeout", "scheduled"} {
+		if c := stats[key]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", key, c))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func homeSnapshotDate(t time.Time) string {
+	if t.IsZero() {
+		return "n/a"
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+func homeSnapshotClip(value string, maxLen int) string {
+	cleaned := strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if maxLen > 3 && len(cleaned) > maxLen {
+		return cleaned[:maxLen-3] + "..."
+	}
+	return cleaned
+}
+
+func emptyTo(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/agenthttp/home_snapshot_test.go
+++ b/internal/agenthttp/home_snapshot_test.go
@@ -1,0 +1,167 @@
+package agenthttp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// --- shared test stubs (reused across home_* tests) ---
+
+type stubSessionsReader struct {
+	sessions []HomeSessionSummary
+	err      error
+}
+
+func (s stubSessionsReader) RecentSessions(_ context.Context, limit int) ([]HomeSessionSummary, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if limit > 0 && limit < len(s.sessions) {
+		return s.sessions[:limit], nil
+	}
+	return s.sessions, nil
+}
+
+type stubUsageReader struct {
+	summary HomeUsageSummary
+	ok      bool
+}
+
+func (u stubUsageReader) UsageSummary() (HomeUsageSummary, bool) { return u.summary, u.ok }
+
+func fixedNow() time.Time {
+	// A Wednesday so "this week" (Mon-based) has prior days inside the window.
+	return time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+}
+
+func makeTestWorkspace(t *testing.T, store workspace.Store, id, name string, tasks []workspace.Task) {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: name})
+	ws.ID = id
+	for _, task := range tasks {
+		if err := ws.AddTask(task); err != nil {
+			t.Fatalf("add task: %v", err)
+		}
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+}
+
+func TestBuildHomeSnapshot_Empty(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces: store,
+		Now:        fixedNow,
+	}, HomeWindowThisWeek)
+
+	if snap.Meta.WorkspaceCount != 0 {
+		t.Errorf("WorkspaceCount = %d, want 0", snap.Meta.WorkspaceCount)
+	}
+	if len(snap.Tasks) != 0 {
+		t.Errorf("Tasks = %d, want 0", len(snap.Tasks))
+	}
+	// nil Sessions and Usage sources degrade their sections, not the whole snapshot.
+	if !containsString(snap.Meta.Degraded, "sessions") || !containsString(snap.Meta.Degraded, "usage") {
+		t.Errorf("expected degraded sessions+usage, got %v", snap.Meta.Degraded)
+	}
+}
+
+func TestBuildHomeSnapshot_WithData(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	now := fixedNow()
+	makeTestWorkspace(t, store, "ws-1", "Alpha", []workspace.Task{
+		{Description: "recent task", Status: workspace.TaskStatusInProgress, Priority: 2, CreatedAt: now.Add(-2 * time.Hour)},
+	})
+	makeTestWorkspace(t, store, "ws-2", "Beta", []workspace.Task{
+		{Description: "old done task", Status: workspace.TaskStatusCompleted, Priority: 1, CreatedAt: now.AddDate(0, -3, 0), CompletedAt: timePtr(now.AddDate(0, -3, 0))},
+	})
+
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces:    store,
+		Opportunities: workspace.NewOpportunityStore(store),
+		Sessions:      stubSessionsReader{sessions: []HomeSessionSummary{{ID: "s1", Title: "Chat", AgentName: "Ori", MessageCount: 4, UpdatedAt: now}}},
+		Usage:         stubUsageReader{summary: HomeUsageSummary{TodayCost: 0.12, TodayTokens: 1000, MonthCost: 3.4, MonthTokens: 50000, Currency: "USD"}, ok: true},
+		Now:           fixedNow,
+	}, HomeWindowThisWeek)
+
+	if snap.Meta.WorkspaceCount != 2 {
+		t.Errorf("WorkspaceCount = %d, want 2", snap.Meta.WorkspaceCount)
+	}
+	// Only the in-window task should appear; the 3-month-old completed task is out.
+	if snap.Meta.TaskCount != 1 || len(snap.Tasks) != 1 || snap.Tasks[0].Description != "recent task" {
+		t.Errorf("expected 1 windowed task 'recent task', got count=%d tasks=%+v", snap.Meta.TaskCount, snap.Tasks)
+	}
+	if snap.Meta.SessionCount != 1 {
+		t.Errorf("SessionCount = %d, want 1", snap.Meta.SessionCount)
+	}
+	if snap.Usage == nil || snap.Usage.TodayTokens != 1000 {
+		t.Errorf("usage not populated: %+v", snap.Usage)
+	}
+	if len(snap.Meta.Degraded) != 0 {
+		t.Errorf("expected no degraded sections, got %v", snap.Meta.Degraded)
+	}
+	// Prompt text mentions the window and is non-empty.
+	if txt := snap.PromptText(); !strings.Contains(txt, "Home Snapshot") || !strings.Contains(txt, "Alpha") {
+		t.Errorf("prompt text missing expected content: %q", txt)
+	}
+}
+
+func TestBuildHomeSnapshot_DegradedUsage(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces: store,
+		Sessions:   stubSessionsReader{},
+		Usage:      stubUsageReader{ok: false},
+		Now:        fixedNow,
+	}, HomeWindowToday)
+	if snap.Usage != nil {
+		t.Error("expected nil usage when reader reports unavailable")
+	}
+	if !containsString(snap.Meta.Degraded, "usage") {
+		t.Errorf("expected degraded usage, got %v", snap.Meta.Degraded)
+	}
+}
+
+func TestBuildHomeSnapshot_SessionsErrorDegradesSection(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces: store,
+		Sessions:   stubSessionsReader{err: errors.New("boom")},
+		Now:        fixedNow,
+	}, HomeWindowThisWeek)
+	if !containsString(snap.Meta.Degraded, "sessions") {
+		t.Errorf("expected degraded sessions on error, got %v", snap.Meta.Degraded)
+	}
+}
+
+func TestNormalizeHomeDateWindow(t *testing.T) {
+	if got := NormalizeHomeDateWindow("this week", HomeWindowToday); got != HomeWindowThisWeek {
+		t.Errorf("explicit 'this week' = %q, want this_week", got)
+	}
+	if got := NormalizeHomeDateWindow("", HomeWindowToday); got != HomeWindowToday {
+		t.Errorf("empty falls back to default today, got %q", got)
+	}
+	if got := DefaultHomeDateWindowForPrompt("summarize my task activity"); got != HomeWindowThisWeek {
+		t.Errorf("recap default = %q, want this_week", got)
+	}
+	if got := DefaultHomeDateWindowForPrompt("what's running right now"); got != HomeWindowToday {
+		t.Errorf("status default = %q, want today", got)
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agenthttp/home_tools.go
+++ b/internal/agenthttp/home_tools.go
@@ -1,0 +1,381 @@
+package agenthttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+// homeToolRegistry exposes read-only, app-scoped tools the home harness lets the
+// model call on demand to read full state beyond the bounded snapshot (PRD 4.3).
+// Every tool is read-only; none mutate state. In particular home_opportunities
+// uses OpportunityStore.List and never marks opportunities seen.
+type homeToolRegistry struct {
+	sources HomeSnapshotSources
+	now     func() time.Time
+}
+
+func newHomeToolRegistry(sources HomeSnapshotSources) *homeToolRegistry {
+	now := sources.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &homeToolRegistry{sources: sources, now: now}
+}
+
+const (
+	homeToolDefaultLimit = 50
+	homeToolMaxLimit     = 100
+)
+
+// Definitions returns the LLM tool definitions for the registered read-only tools.
+func (r *homeToolRegistry) Definitions() []llm.Tool {
+	return []llm.Tool{
+		{
+			Name:        "home_workspaces",
+			Description: "List the user's workspaces (excludes group containers). Read-only.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"status": map[string]any{"type": "string", "description": "Optional status filter, e.g. active."},
+					"limit":  map[string]any{"type": "integer", "description": "Max results (default 50, max 100)."},
+				},
+			},
+		},
+		{
+			Name:        "home_tasks",
+			Description: "List tasks across all workspaces, optionally filtered by status, workspace, and activity date window. Read-only.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"status":       map[string]any{"type": "string", "description": "Optional task status filter (pending, in_progress, completed, failed, etc.)."},
+					"workspace_id": map[string]any{"type": "string", "description": "Optional workspace id filter."},
+					"date_window":  map[string]any{"type": "string", "enum": []string{"today", "this_week", "this_month"}, "description": "Optional activity window."},
+					"limit":        map[string]any{"type": "integer", "description": "Max results (default 50, max 100)."},
+				},
+			},
+		},
+		{
+			Name:        "home_sessions",
+			Description: "List recent chat sessions across the app, most recently updated first. Read-only.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"limit": map[string]any{"type": "integer", "description": "Max results (default 50, max 100)."},
+				},
+			},
+		},
+		{
+			Name:        "home_opportunities",
+			Description: "List open Action Center opportunities across workspaces. Read-only; does not mark anything as seen.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"workspace_id": map[string]any{"type": "string", "description": "Optional workspace id filter."},
+					"limit":        map[string]any{"type": "integer", "description": "Max results (default 50, max 100)."},
+				},
+			},
+		},
+		{
+			Name:        "home_usage",
+			Description: "Return a cheap usage/cost summary (today and month-to-date). Read-only.",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	}
+}
+
+// Has reports whether a tool name belongs to this registry.
+func (r *homeToolRegistry) Has(name string) bool {
+	switch name {
+	case "home_workspaces", "home_tasks", "home_sessions", "home_opportunities", "home_usage":
+		return true
+	}
+	return false
+}
+
+// Execute dispatches a tool call and returns a JSON result string.
+func (r *homeToolRegistry) Execute(ctx context.Context, name, argsJSON string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	args := parseHomeToolArgs(argsJSON)
+	switch name {
+	case "home_workspaces":
+		return r.workspaces(args)
+	case "home_tasks":
+		return r.tasks(args)
+	case "home_sessions":
+		return r.sessions(ctx, args)
+	case "home_opportunities":
+		return r.opportunities(args)
+	case "home_usage":
+		return r.usage()
+	default:
+		return "", fmt.Errorf("unknown home tool %q", name)
+	}
+}
+
+func parseHomeToolArgs(argsJSON string) map[string]any {
+	args := map[string]any{}
+	trimmed := strings.TrimSpace(argsJSON)
+	if trimmed == "" {
+		return args
+	}
+	_ = json.Unmarshal([]byte(trimmed), &args)
+	return args
+}
+
+func homeToolString(args map[string]any, key string) string {
+	if v, ok := args[key]; ok {
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+	return ""
+}
+
+func homeToolLimit(args map[string]any) int {
+	limit := homeToolDefaultLimit
+	if v, ok := args["limit"]; ok {
+		switch n := v.(type) {
+		case float64:
+			limit = int(n)
+		case int:
+			limit = n
+		case string:
+			fmt.Sscanf(n, "%d", &limit)
+		}
+	}
+	if limit <= 0 {
+		limit = homeToolDefaultLimit
+	}
+	if limit > homeToolMaxLimit {
+		limit = homeToolMaxLimit
+	}
+	return limit
+}
+
+func homeToolJSON(payload any) (string, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (r *homeToolRegistry) workspaces(args map[string]any) (string, error) {
+	if r.sources.Workspaces == nil {
+		return homeToolJSON(map[string]any{"workspaces": []any{}, "note": "workspace store unavailable"})
+	}
+	statusFilter := strings.ToLower(homeToolString(args, "status"))
+	limit := homeToolLimit(args)
+	ids, err := r.sources.Workspaces.List()
+	if err != nil {
+		return "", err
+	}
+	type row struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		AgentCount int    `json:"agent_count"`
+		OpenTasks  int    `json:"open_tasks"`
+		UpdatedAt  string `json:"updated_at"`
+	}
+	var rows []row
+	for _, id := range ids {
+		ws, getErr := r.sources.Workspaces.Get(id)
+		if getErr != nil || ws == nil || isGroupWorkspace(ws) {
+			continue
+		}
+		if statusFilter != "" && !strings.EqualFold(string(ws.Status), statusFilter) {
+			continue
+		}
+		stats := ws.GetTaskStats()
+		rows = append(rows, row{
+			ID:         ws.ID,
+			Name:       ws.Name,
+			Status:     string(ws.Status),
+			AgentCount: workspaceAgentCount(ws),
+			OpenTasks:  stats["pending"] + stats["assigned"] + stats["in_progress"] + stats["waiting_for_choice"],
+			UpdatedAt:  homeSnapshotDate(ws.UpdatedAt),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].UpdatedAt > rows[j].UpdatedAt })
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return homeToolJSON(map[string]any{"workspaces": rows, "total": total})
+}
+
+func (r *homeToolRegistry) tasks(args map[string]any) (string, error) {
+	if r.sources.Workspaces == nil {
+		return homeToolJSON(map[string]any{"tasks": []any{}, "note": "workspace store unavailable"})
+	}
+	statusFilter := strings.ToLower(homeToolString(args, "status"))
+	wsFilter := homeToolString(args, "workspace_id")
+	limit := homeToolLimit(args)
+
+	var start, end time.Time
+	windowed := false
+	if w := homeToolString(args, "date_window"); w != "" {
+		window := NormalizeHomeDateWindow(w, HomeWindowThisWeek)
+		start, end, _ = resolveHomeWindowRange(window, r.now())
+		windowed = true
+	}
+
+	ids, err := r.sources.Workspaces.List()
+	if err != nil {
+		return "", err
+	}
+	type row struct {
+		ID            string `json:"id"`
+		WorkspaceID   string `json:"workspace_id"`
+		WorkspaceName string `json:"workspace_name"`
+		Description   string `json:"description"`
+		Status        string `json:"status"`
+		Priority      int    `json:"priority"`
+		Assignee      string `json:"assignee"`
+		UpdatedAt     string `json:"updated_at"`
+	}
+	var rows []row
+	for _, id := range ids {
+		ws, getErr := r.sources.Workspaces.Get(id)
+		if getErr != nil || ws == nil || isGroupWorkspace(ws) {
+			continue
+		}
+		if wsFilter != "" && ws.ID != wsFilter {
+			continue
+		}
+		for _, t := range ws.Tasks {
+			if statusFilter != "" && !strings.EqualFold(string(t.Status), statusFilter) {
+				continue
+			}
+			if windowed && !taskActiveInWindow(t, start, end) {
+				continue
+			}
+			rows = append(rows, row{
+				ID:            t.ID,
+				WorkspaceID:   ws.ID,
+				WorkspaceName: ws.Name,
+				Description:   homeSnapshotClip(t.Description, homeSnapshotPreviewLimit),
+				Status:        string(t.Status),
+				Priority:      t.Priority,
+				Assignee:      homeTaskAssignee(t),
+				UpdatedAt:     homeSnapshotDate(homeTaskActivityTime(t)),
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].UpdatedAt > rows[j].UpdatedAt })
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return homeToolJSON(map[string]any{"tasks": rows, "total": total})
+}
+
+func (r *homeToolRegistry) sessions(ctx context.Context, args map[string]any) (string, error) {
+	if r.sources.Sessions == nil {
+		return homeToolJSON(map[string]any{"sessions": []any{}, "note": "session store unavailable"})
+	}
+	limit := homeToolLimit(args)
+	sessions, err := r.sources.Sessions.RecentSessions(ctx, limit)
+	if err != nil {
+		return "", err
+	}
+	type row struct {
+		ID           string `json:"id"`
+		Title        string `json:"title"`
+		AgentName    string `json:"agent_name"`
+		MessageCount int    `json:"message_count"`
+		UpdatedAt    string `json:"updated_at"`
+	}
+	rows := make([]row, 0, len(sessions))
+	for _, s := range sessions {
+		rows = append(rows, row{
+			ID:           s.ID,
+			Title:        s.Title,
+			AgentName:    s.AgentName,
+			MessageCount: s.MessageCount,
+			UpdatedAt:    homeSnapshotDate(s.UpdatedAt),
+		})
+	}
+	return homeToolJSON(map[string]any{"sessions": rows, "total": len(rows)})
+}
+
+func (r *homeToolRegistry) opportunities(args map[string]any) (string, error) {
+	if r.sources.Workspaces == nil || r.sources.Opportunities == nil {
+		return homeToolJSON(map[string]any{"opportunities": []any{}, "note": "opportunity store unavailable"})
+	}
+	wsFilter := homeToolString(args, "workspace_id")
+	limit := homeToolLimit(args)
+	ids, err := r.sources.Workspaces.List()
+	if err != nil {
+		return "", err
+	}
+	type row struct {
+		ID            string `json:"id"`
+		WorkspaceID   string `json:"workspace_id"`
+		WorkspaceName string `json:"workspace_name"`
+		Title         string `json:"title"`
+		Summary       string `json:"summary"`
+		Priority      string `json:"priority"`
+	}
+	var rows []row
+	for _, id := range ids {
+		ws, getErr := r.sources.Workspaces.Get(id)
+		if getErr != nil || ws == nil {
+			continue
+		}
+		if wsFilter != "" && ws.ID != wsFilter {
+			continue
+		}
+		// Read-only: List does not mark opportunities seen (unlike Get).
+		opps, listErr := r.sources.Opportunities.List(ws.ID)
+		if listErr != nil {
+			continue
+		}
+		for _, o := range opps {
+			if !o.IsOpen() {
+				continue
+			}
+			rows = append(rows, row{
+				ID:            o.ID,
+				WorkspaceID:   ws.ID,
+				WorkspaceName: ws.Name,
+				Title:         o.Title,
+				Summary:       homeSnapshotClip(o.Summary, homeSnapshotPreviewLimit),
+				Priority:      o.Priority,
+			})
+		}
+	}
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return homeToolJSON(map[string]any{"opportunities": rows, "total": total})
+}
+
+func (r *homeToolRegistry) usage() (string, error) {
+	if r.sources.Usage == nil {
+		return homeToolJSON(map[string]any{"available": false, "note": "usage unavailable"})
+	}
+	summary, ok := r.sources.Usage.UsageSummary()
+	if !ok {
+		return homeToolJSON(map[string]any{"available": false})
+	}
+	return homeToolJSON(map[string]any{
+		"available":    true,
+		"currency":     emptyTo(summary.Currency, "USD"),
+		"today_cost":   summary.TodayCost,
+		"today_tokens": summary.TodayTokens,
+		"month_cost":   summary.MonthCost,
+		"month_tokens": summary.MonthTokens,
+	})
+}

--- a/internal/agenthttp/home_tools.go
+++ b/internal/agenthttp/home_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -149,7 +150,9 @@ func homeToolLimit(args map[string]any) int {
 		case int:
 			limit = n
 		case string:
-			fmt.Sscanf(n, "%d", &limit)
+			if parsed, err := strconv.Atoi(strings.TrimSpace(n)); err == nil {
+				limit = parsed
+			}
 		}
 	}
 	if limit <= 0 {

--- a/internal/agenthttp/home_tools_test.go
+++ b/internal/agenthttp/home_tools_test.go
@@ -1,0 +1,104 @@
+package agenthttp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// spyOpportunityStore records MarkSeen calls so the test can prove the home tool
+// is read-only (unlike the Action Center Get handler, which marks seen).
+type spyOpportunityStore struct {
+	opps          map[string][]workspace.Opportunity
+	markSeenCalls int
+}
+
+func (s *spyOpportunityStore) List(workspaceID string) ([]workspace.Opportunity, error) {
+	return s.opps[workspaceID], nil
+}
+func (s *spyOpportunityStore) Get(workspaceID, opportunityID string) (workspace.Opportunity, error) {
+	return workspace.Opportunity{}, nil
+}
+func (s *spyOpportunityStore) Upsert(opp workspace.Opportunity) (workspace.Opportunity, bool, error) {
+	return opp, false, nil
+}
+func (s *spyOpportunityStore) Delete(workspaceID, opportunityID string) error { return nil }
+func (s *spyOpportunityStore) MarkSeen(workspaceID, opportunityID string) error {
+	s.markSeenCalls++
+	return nil
+}
+func (s *spyOpportunityStore) Dismiss(workspaceID, opportunityID string, reason workspace.DismissalReason) error {
+	return nil
+}
+func (s *spyOpportunityStore) Snooze(workspaceID, opportunityID string, until time.Time) error {
+	return nil
+}
+func (s *spyOpportunityStore) MarkResolved(workspaceID, opportunityID string) error { return nil }
+
+func TestHomeOpportunitiesToolIsReadOnly(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Alpha", nil)
+	spy := &spyOpportunityStore{opps: map[string][]workspace.Opportunity{
+		"ws-1": {{ID: "o1", WorkspaceID: "ws-1", Title: "Fix brand voice", Status: workspace.OpportunityNew}},
+	}}
+	reg := newHomeToolRegistry(HomeSnapshotSources{Workspaces: store, Opportunities: spy})
+
+	out, err := reg.Execute(context.Background(), "home_opportunities", "{}")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if spy.markSeenCalls != 0 {
+		t.Errorf("home_opportunities marked %d opportunities seen; must be read-only (0)", spy.markSeenCalls)
+	}
+	var parsed struct {
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Total != 1 {
+		t.Errorf("total = %d, want 1", parsed.Total)
+	}
+}
+
+func TestHomeTasksToolStatusFilter(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	now := time.Now()
+	makeTestWorkspace(t, store, "ws-1", "Alpha", []workspace.Task{
+		{Description: "a", Status: workspace.TaskStatusInProgress, CreatedAt: now},
+		{Description: "b", Status: workspace.TaskStatusCompleted, CreatedAt: now, CompletedAt: timePtr(now)},
+	})
+	reg := newHomeToolRegistry(HomeSnapshotSources{Workspaces: store})
+
+	out, err := reg.Execute(context.Background(), "home_tasks", `{"status":"completed"}`)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var parsed struct {
+		Total int `json:"total"`
+		Tasks []struct {
+			Status string `json:"status"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Total != 1 || len(parsed.Tasks) != 1 || parsed.Tasks[0].Status != "completed" {
+		t.Errorf("status filter failed: %+v", parsed)
+	}
+}
+
+func TestHomeToolRegistryHasReadOnlyToolsOnly(t *testing.T) {
+	reg := newHomeToolRegistry(HomeSnapshotSources{})
+	for _, def := range reg.Definitions() {
+		if !reg.Has(def.Name) {
+			t.Errorf("definition %q not recognized by Has()", def.Name)
+		}
+	}
+	if reg.Has("home_delete_workspace") {
+		t.Error("registry must not expose any write tool")
+	}
+}

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/johnjallday/ori-agent/internal/agenthttp"
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// homeRecentSessionsAdapter bridges the session store to the home harness's
+// recent-sessions reader, keeping agenthttp decoupled from the session package.
+type homeRecentSessionsAdapter struct {
+	store session.HybridStore
+}
+
+func (a homeRecentSessionsAdapter) RecentSessions(ctx context.Context, limit int) ([]agenthttp.HomeSessionSummary, error) {
+	if a.store == nil {
+		return nil, nil
+	}
+	res, err := a.store.ListSessions(ctx, nil, &session.ListOptions{Limit: limit, Sort: session.SortByUpdatedDesc})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+	out := make([]agenthttp.HomeSessionSummary, 0, len(res.Sessions))
+	for _, s := range res.Sessions {
+		out = append(out, agenthttp.HomeSessionSummary{
+			ID:           s.ID,
+			Title:        s.Title,
+			AgentName:    s.AgentName,
+			MessageCount: s.MessageCount,
+			CreatedAt:    s.CreatedAt,
+			UpdatedAt:    s.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+// homeUsageAdapter bridges the cost tracker to the home harness's usage reader.
+type homeUsageAdapter struct {
+	tracker *llm.CostTracker
+}
+
+func (a homeUsageAdapter) UsageSummary() (agenthttp.HomeUsageSummary, bool) {
+	if a.tracker == nil {
+		return agenthttp.HomeUsageSummary{}, false
+	}
+	today := a.tracker.GetTodayStats()
+	month := a.tracker.GetThisMonthStats()
+	currency := today.Currency
+	if currency == "" {
+		currency = month.Currency
+	}
+	return agenthttp.HomeUsageSummary{
+		TodayCost:   today.TotalCost,
+		TodayTokens: today.TotalTokens,
+		MonthCost:   month.TotalCost,
+		MonthTokens: month.TotalTokens,
+		Currency:    currency,
+	}, true
+}
+
+// homeActionMutator executes confirmed home actions (PRD 4.6). CreateWorkspace
+// and CreateTask are wired; StartTask is deferred to a follow-up (kept behind the
+// same confirmation contract, returns a clear message for now).
+type homeActionMutator struct {
+	workspaces workspace.Store
+	agents     store.Store
+}
+
+func (m homeActionMutator) defaultAgentName() string {
+	if m.agents == nil {
+		return ""
+	}
+	if _, ok := m.agents.GetAgent("Ori"); ok {
+		return "Ori"
+	}
+	if names := m.agents.ListAgents(); len(names) > 0 {
+		return names[0]
+	}
+	return ""
+}
+
+func (m homeActionMutator) CreateWorkspace(ctx context.Context, name, description string) (string, string, error) {
+	if m.workspaces == nil {
+		return "", "", fmt.Errorf("workspace store unavailable")
+	}
+	agentName := m.defaultAgentName()
+	if agentName == "" {
+		return "", "", fmt.Errorf("no agent is available to attach to the workspace")
+	}
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{
+		Name:        name,
+		Description: description,
+		Agents:      []string{agentName},
+		InitialData: map[string]any{},
+	})
+	_ = ws.SetEntryAgentName(agentName)
+	if err := m.workspaces.Save(ws); err != nil {
+		return "", "", err
+	}
+	return ws.ID, "/workspaces/" + ws.ID, nil
+}
+
+func (m homeActionMutator) CreateTask(ctx context.Context, workspaceID, description string) (string, string, error) {
+	if m.workspaces == nil {
+		return "", "", fmt.Errorf("workspace store unavailable")
+	}
+	var taskID string
+	err := m.workspaces.Update(workspaceID, func(ws *workspace.Workspace) error {
+		task := workspace.Task{
+			Description: description,
+			From:        "Ori",
+			Status:      workspace.TaskStatusPending,
+			Priority:    3,
+		}
+		if addErr := ws.AddTask(task); addErr != nil {
+			return addErr
+		}
+		if len(ws.Tasks) > 0 {
+			taskID = ws.Tasks[len(ws.Tasks)-1].ID
+		}
+		return nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return taskID, "/workspaces/" + workspaceID, nil
+}
+
+func (m homeActionMutator) StartTask(ctx context.Context, workspaceID, taskID string) (string, error) {
+	return "/workspaces/" + workspaceID, fmt.Errorf("starting a task from here isn't supported yet — open the workspace to run it")
+}
+
+// newHomeAssistantAskHandler constructs the home harness handler with its data
+// sources, model access, and confirmed-action executor.
+func (s *Server) newHomeAssistantAskHandler() *agenthttp.HomeAssistantAskHandler {
+	sources := agenthttp.HomeSnapshotSources{}
+	var llmFactory *llm.Factory
+	var systemModel interface {
+		GetSystemModel() (provider, model string)
+	}
+	if s.Storage != nil {
+		sources.Workspaces = s.Storage.WorkspaceStore
+		if s.Storage.WorkspaceStore != nil {
+			sources.Opportunities = workspace.NewOpportunityStore(s.Storage.WorkspaceStore)
+		}
+		sources.Sessions = homeRecentSessionsAdapter{store: s.Storage.SessionStore}
+	}
+	if s.Core != nil {
+		sources.Usage = homeUsageAdapter{tracker: s.Core.CostTracker}
+		llmFactory = s.Core.LLMFactory
+		if s.Core.ConfigManager != nil {
+			systemModel = s.Core.ConfigManager
+		}
+	}
+	handler := agenthttp.NewHomeAssistantAskHandler(sources, llmFactory, systemModel)
+	handler.SetTraceEmitter(agenthttp.NewLoggingHomeAskTraceEmitter())
+	if s.Storage != nil {
+		handler.SetMutator(homeActionMutator{
+			workspaces: s.Storage.WorkspaceStore,
+			agents:     s.Storage.AgentStore,
+		})
+	}
+	return handler
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -182,6 +182,10 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("/api/home-assistant/trace", homeAssistantRouteHandler.TraceHandler)
 	mux.HandleFunc("/api/home-assistant/trace/summary", homeAssistantRouteHandler.TraceSummaryHandler)
 
+	// Home harness inline endpoint: answers app-introspection / app-navigation
+	// prompts using the cross-workspace home snapshot and read-only home tools.
+	mux.HandleFunc("/api/home-assistant/ask", s.newHomeAssistantAskHandler().AskHandler)
+
 	// =============================================================================
 	// Settings and Configuration Endpoints
 	// =============================================================================

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -4052,8 +4052,13 @@
   function scoreCapabilityRequirement(promptText, requirement, intentKey) {
     if (!requirement) return 0;
     var score = scoreMCPRequirement(promptText, requirement);
+    // Only boost a requirement that already has lexical evidence in the prompt.
+    // Without the score > 0 guard, every general_task prompt scores 4 on the
+    // first general_task requirement (github_ops) even with zero phrase overlap,
+    // misrouting generic asks like "summarize this week's task activity" into a
+    // GitHub/MCP setup flow.
     var preferredIntents = Array.isArray(requirement.intents) ? requirement.intents : [];
-    if (intentKey && preferredIntents.indexOf(intentKey) >= 0) {
+    if (score > 0 && intentKey && preferredIntents.indexOf(intentKey) >= 0) {
       score += 4;
     }
     return score;

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -77,6 +77,26 @@
       defaultType: 'general',
       suggestedName: 'Task Assistant',
       tags: ['tasks', 'assistant']
+    },
+    app_introspection: {
+      key: 'app_introspection',
+      label: 'app activity',
+      keywords: [],
+      preferredPlugins: [],
+      preferredTypes: ['general'],
+      defaultType: 'general',
+      suggestedName: 'Ori',
+      tags: ['activity', 'introspection']
+    },
+    app_navigation: {
+      key: 'app_navigation',
+      label: 'app navigation',
+      keywords: [],
+      preferredPlugins: [],
+      preferredTypes: ['general'],
+      defaultType: 'general',
+      suggestedName: 'Ori',
+      tags: ['navigation']
     }
   };
 
@@ -4012,7 +4032,27 @@
       return HOME_INTENTS.app_launch;
     }
 
+    var appIntent = detectHomeAppIntentLocal(text);
+    if (appIntent) return appIntent;
+
     return selected;
+  }
+
+  // detectHomeAppIntentLocal mirrors the backend app_introspection / app_navigation
+  // heuristics for optimistic UI and the route-unavailable fallback. The backend
+  // route response remains authoritative when present.
+  function detectHomeAppIntentLocal(text) {
+    if (!text) return null;
+    var navCue = /(\bwhere\b|how do i|how to|take me to|go to|navigate|\bopen\b|show me|which page|what page)/.test(text);
+    var navTarget = /(action center|workspaces?|agents?|vaults?|settings|mcp|connectors?|usage|dashboard)/.test(text);
+    if (navCue && navTarget) return HOME_INTENTS.app_navigation;
+    if (/(task activity|my tasks|my workspaces|my sessions|my activity|how many tasks|recap|what did i work on)/.test(text)) {
+      return HOME_INTENTS.app_introspection;
+    }
+    var hasVerb = /(summarize|summary|overview|recap|report|review|status)/.test(text);
+    var hasNoun = /(task|tasks|workspace|workspaces|session|sessions|activity|opportunit|usage|cost|spending)/.test(text);
+    if (hasVerb && hasNoun) return HOME_INTENTS.app_introspection;
+    return null;
   }
 
   function normalizeMCPServerName(name) {
@@ -8538,6 +8578,165 @@
     }
   }
 
+  // Home harness inline path: answer app_introspection / app_navigation prompts
+  // by calling /api/home-assistant/ask, which builds the cross-workspace snapshot
+  // and runs the model server-side. The frontend only renders the answer and the
+  // validated next-step actions.
+  async function runHomeAssistantInline(prompt, routeContext, intent, options) {
+    var text = String(prompt || '').trim();
+    if (!text) return;
+    options = options || {};
+    var confirmedAction = options.confirmedAction || null;
+    var summaryLabel = intent === 'app_navigation' ? 'Navigation' : 'Activity';
+
+    setHomeAssistantBusy(true, confirmedAction ? 'Applying...' : 'Thinking...');
+    renderHomeAssistantActions([]);
+    setHomeAssistantRoutingSummary(
+      summaryLabel,
+      confirmedAction ? 'Applying your confirmed action...' : 'Reviewing your workspaces, tasks, and activity...'
+    );
+
+    try {
+      var payload = {
+        prompt: text,
+        intent: intent,
+        context: normalizeHomeRouteContext(routeContext)
+      };
+      if (confirmedAction) {
+        payload.confirmed_action = confirmedAction;
+      }
+
+      var data = await API.post('/api/home-assistant/ask', payload);
+      var responseText = String(data && data.response || '').trim();
+      if (responseText) {
+        appendHomeAssistantMessage('assistant', responseText);
+      }
+
+      if (data && data.requires_confirmation && data.confirmation) {
+        confirmHomeAction(data.confirmation, routeContext, intent);
+        return;
+      }
+
+      setHomeAssistantRoutingSummary(summaryLabel, formatHomeAskSummary(data));
+      var buttons = buildHomeActionButtons(data && data.actions, routeContext, intent);
+      buttons.push({ label: 'Ask Another Task', variant: 'secondary', onClick: function () { focusHomeAssistantInput(); } });
+      renderHomeAssistantActions(buttons);
+    } catch (error) {
+      dashLog.debug('Home inline ask failed', { error: error && error.message || error });
+      appendHomeAssistantMessage('assistant', 'I could not answer that right now. Please retry.');
+      setHomeAssistantRoutingSummary(summaryLabel + ' Failed', 'Could not complete the request.');
+      renderHomeAssistantActions([
+        { label: 'Retry', variant: 'primary', onClick: function () { runHomeAssistantInline(text, routeContext, intent, options); } },
+        { label: 'Ask Another Task', variant: 'secondary', onClick: function () { focusHomeAssistantInput(); } }
+      ]);
+    } finally {
+      setHomeAssistantBusy(false);
+    }
+  }
+
+  function isMutatingHomeActionType(type) {
+    return type === 'create_workspace' || type === 'create_task' || type === 'start_task';
+  }
+
+  // buildHomeActionButtons maps the backend action schema to renderHomeAssistant-
+  // Actions buttons, dropping any action whose target can't be validated (6.6).
+  function buildHomeActionButtons(actions, routeContext, intent) {
+    var buttons = [];
+    if (!Array.isArray(actions)) return buttons;
+    for (var i = 0; i < actions.length; i++) {
+      var button = mapHomeActionToButton(actions[i], routeContext, intent);
+      if (button) buttons.push(button);
+    }
+    return buttons;
+  }
+
+  function mapHomeActionToButton(action, routeContext, intent) {
+    if (!action) return null;
+    var label = String(action.label || '').trim();
+    var type = String(action.type || '').trim();
+    if (!label || !type) return null;
+
+    var navigableTypes = { navigate: 1, open_workspace: 1, open_task: 1, open_session: 1 };
+    if (navigableTypes[type]) {
+      var href = String(action.href || '').trim();
+      if (!href) return null; // can't resolve a destination -> drop
+      return {
+        label: label,
+        variant: type === 'navigate' ? 'secondary' : 'primary',
+        onClick: function () { window.location.href = href; }
+      };
+    }
+
+    if (action.requires_confirmation || isMutatingHomeActionType(type)) {
+      var confirmation = {
+        action_id: String(action.id || type),
+        action_type: type,
+        summary: String(action.confirmation_summary || ('Confirm: ' + label)),
+        arguments: action.arguments || {}
+      };
+      return {
+        label: label,
+        variant: 'primary',
+        onClick: function () { confirmHomeAction(confirmation, routeContext, intent); }
+      };
+    }
+
+    if (type === 'ask_followup') {
+      return { label: label, variant: 'secondary', onClick: function () { focusHomeAssistantInput(); } };
+    }
+    return null;
+  }
+
+  // confirmHomeAction shows an explicit confirm/cancel step before executing a
+  // state-changing action; on confirm it re-calls /ask with confirmed_action.
+  function confirmHomeAction(confirmation, routeContext, intent) {
+    appendHomeAssistantMessage('assistant', String(confirmation.summary || 'Confirm this change?'));
+    setHomeAssistantRoutingSummary('Confirm', 'Review and confirm this change.');
+    var args = confirmation.arguments || {};
+    renderHomeAssistantActions([
+      {
+        label: 'Confirm',
+        variant: 'primary',
+        onClick: function () {
+          var confirmedAction = {
+            id: confirmation.action_id,
+            type: confirmation.action_type,
+            arguments: args,
+            workspace_id: String(args.workspace_id || ''),
+            task_id: String(args.task_id || '')
+          };
+          runHomeAssistantInline(homeAssistantState.pendingPrompt, routeContext, intent, { confirmedAction: confirmedAction });
+        }
+      },
+      {
+        label: 'Cancel',
+        variant: 'secondary',
+        onClick: function () {
+          appendHomeAssistantMessage('assistant', 'Okay, I will not make that change.');
+          setHomeAssistantRoutingSummary('Cancelled', 'No changes made.');
+          renderHomeAssistantActions([{ label: 'Ask Another Task', variant: 'secondary', onClick: function () { focusHomeAssistantInput(); } }]);
+        }
+      }
+    ]);
+  }
+
+  function formatHomeAskSummary(data) {
+    var meta = data && data.snapshot_meta;
+    if (!meta) return 'Answered from your app data.';
+    var parts = [];
+    if (typeof meta.workspace_count === 'number') {
+      parts.push(meta.workspace_count + ' workspace' + (meta.workspace_count === 1 ? '' : 's'));
+    }
+    if (typeof meta.task_count === 'number') {
+      parts.push(meta.task_count + ' task' + (meta.task_count === 1 ? '' : 's') + ' ' + String(meta.window_label || 'recently'));
+    }
+    var base = parts.length ? ('From ' + parts.join(', ')) : 'Answered from your app data';
+    if (meta.degraded && meta.degraded.length) {
+      base += ' (some data unavailable)';
+    }
+    return base + '.';
+  }
+
   async function createWorkspaceChatSessionWithMessage(workspaceId, message) {
     var initialMessage = String(message || '').trim();
     var baseContext = buildHomeRouteContext();
@@ -10778,6 +10977,16 @@
         } else if (routeData.requires_creation === true) {
           useFallbackRouting = false;
         }
+      }
+
+      // Home harness inline path (hybrid): answer app activity / navigation asks
+      // here instead of routing to an agent. Backend route is authoritative; the
+      // local detector covers the route-unavailable fallback.
+      if (!inWorkspaceContext &&
+          (homeAssistantState.pendingIntent.key === 'app_introspection' ||
+           homeAssistantState.pendingIntent.key === 'app_navigation')) {
+        await runHomeAssistantInline(text, routeContext, homeAssistantState.pendingIntent.key);
+        return;
       }
 
       if (inWorkspaceContext && shouldOpenWorkspaceAssistantForRoute(routeData, routeContext)) {


### PR DESCRIPTION
## Summary

Ports the workspace-detail "harness" pattern to the home **Ask Ori** panel so it answers questions about the user's *own Ori data* and guides app navigation **inline**, instead of only routing to agents. Hybrid model: existing routing/capability/specialist flows are unchanged for real task-execution prompts.

Motivation: "Summarize this week's task activity" previously produced nonsense — it was misrouted into a GitHub/MCP setup flow and had no way to read the user's data.

## What's in here

**Bug fix (`ee3a3c6c`)** — `scoreCapabilityRequirement` gave a `+4` intent bonus with zero phrase overlap, so every generic `general_task` prompt matched `github_ops`. Now gated on an actual phrase match.

**Feature (`c1a088f3`)**
- **Home snapshot** (`home_snapshot.go`) — bounded, fail-soft cross-workspace aggregation: workspaces, windowed task activity + all-time counts, recent sessions, open Action Center opportunities, usage.
- **Read-only `home_*` tools** (`home_tools.go`) — on-demand detail; `home_opportunities` uses `List` (never marks seen).
- **Navigation catalog** (`home_nav_catalog.go`) — server-owned source of truth for navigation answers/actions; a test asserts every href maps to a registered route.
- **Ask harness** (`home_assistant_ask.go`) — `POST /api/home-assistant/ask`: engineered system prompt, model tool-loop, deterministic grounded next-step actions, and an **act-with-confirmation** contract (the model is never given write tools).
- **Intents** — `app_introspection` / `app_navigation` with FR-#4 precedence; new `home_inline` route mode.
- **Telemetry** — structured `home_assistant.ask` logs (outcome, actions, confirmed mutation type, degraded sections).
- **Frontend** (`dashboard.js`) — `runHomeAssistantInline` + branch in `handleHomeAssistantPrompt`; action rendering with target validation; confirmation UI.
- **Docs** — `/api/home-assistant/ask` added to `docs/api/API_REFERENCE.md`.

## Testing

- New unit tests: snapshot (empty/degraded/windows), tools read-only, catalog↔routes sync, intent precedence (all FR-#4 examples), ask handler + confirmation + model-unavailable + telemetry.
- `go build ./...`, `go vet`, `node --check` all clean.
- `go test ./...`: green except the known pre-existing `TestSettingsEndpoint` e2e false positive.

## Known limitations / follow-ups
- `start_task` confirmed execution is **deferred** — returns a graceful "open the workspace to run it" message (the schema + confirmation path are wired).
- Live manual smoke in the browser still recommended before merge.
- Ask telemetry is log-only by design (not persisted into the route-intake table, which feeds workspace-correction learning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)