### PR TITLE
chore(ci): bump goreleaser-action to v7 for Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: git checkout -- cmd/folder-picker/frontend/wailsjs/runtime/ go.mod go.sum 2>/dev/null || true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -79,7 +79,7 @@ jobs:
         run: git checkout -- cmd/folder-picker/frontend/wailsjs/runtime/ go.mod go.sum 2>/dev/null || true
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -141,7 +141,7 @@ jobs:
           go-version: '1.25.11'
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           install-only: true
           version: latest  # Use latest for 'ids' field support in archives


### PR DESCRIPTION
## Summary
- Bump `goreleaser/goreleaser-action` from `@v6` to `@v7` in `release.yml` (both jobs) and `smoke-tests.yml`

## Why
The v0.0.78 release run annotated: goreleaser-action@v6 runs on Node.js 20, which GitHub deprecates — actions are forced to Node 24 starting **June 16, 2026**, and Node 20 is removed from runners September 16, 2026.

v7.0.0's breaking change is exactly this migration (`feat!: node 24, update deps, rm yarn, ESM`); v7.2.2's `action.yml` declares `using: 'node24'`. The inputs we use (`distribution`, `version`, `args`, `install-only`) are unchanged between v6 and v7.

## Verification
- Workflow inputs cross-checked against v7.2.2 `action.yml`
- Release path exercises this on the next tag push; smoke-tests workflow exercises the `install-only` usage on PR/dev pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)