### PR TITLE
feat(home-assistant): create and start tasks from "Ask Ori"

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -265,7 +265,21 @@ actions. Used by the home page "Ask Ori" panel when
 - `confirmation_summary` / `arguments` (optional): Confirmation copy and payload.
 
 **Confirmation flow (mutations):**
-An explicit mutation request (e.g. `"create a workspace called Q3 Planning"`) returns a confirmation instead of acting:
+An explicit mutation request returns a confirmation instead of acting. Three
+mutations are recognized from natural language, each requiring confirmation:
+
+| Action | Example prompt | Arguments |
+| --- | --- | --- |
+| `create_workspace` | `"create a workspace called Q3 Planning"` | `name` |
+| `create_task` | `"create a task to summarize Q2 sales in Q3 Planning"` | `workspace_id`, `description` |
+| `start_task` | `"start the deploy task in Operations"` | `workspace_id`, `task_id` |
+
+Task mutations resolve the named workspace (and, for `start_task`, the target
+task) against real state before proposing; an unresolved workspace/task, an empty
+description, or an ambiguous task match falls through to the normal answer path
+rather than guessing. `start_task` uses the workspace's sole runnable task when
+the prompt doesn't name one.
+
 ```json
 {
   "response": "Create a new workspace named \"Q3 Planning\"?",
@@ -279,7 +293,7 @@ An explicit mutation request (e.g. `"create a workspace called Q3 Planning"`) re
   }
 }
 ```
-The client confirms by re-calling the endpoint with `confirmed_action` set to a `HomeAction` of that type and arguments. The server executes only known mutation types after confirmation; the model is never given write tools.
+The client confirms by re-calling the endpoint with `confirmed_action` set to a `HomeAction` of that type and arguments. The server executes only known mutation types after confirmation; the model is never given write tools. `start_task` runs the task through the same orchestrator path as the workspace UI (coordinator assignment and the delegation loop apply), executing asynchronously so the response returns immediately.
 
 ## Settings API
 

--- a/internal/agenthttp/home_assistant_ask.go
+++ b/internal/agenthttp/home_assistant_ask.go
@@ -172,7 +172,7 @@ func (h *HomeAssistantAskHandler) Ask(ctx context.Context, req HomeAssistantAskR
 
 	// Explicit, supported mutation request: ask for confirmation before doing
 	// anything (FR #24). Execution happens only on a follow-up with ConfirmedAction.
-	if conf := detectHomeMutationRequest(prompt); conf != nil {
+	if conf := h.detectHomeMutationRequest(prompt); conf != nil {
 		h.emitTrace(ctx, HomeAskTrace{Prompt: prompt, Intent: intent, Outcome: "confirmation_required", ConfirmedType: conf.ActionType})
 		return HomeAssistantAskResponse{
 			Response:             conf.Summary,
@@ -392,36 +392,4 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
-}
-
-// detectHomeMutationRequest recognizes an explicit, supported mutation request in
-// the prompt and returns a confirmation to present before executing (FR #24). v1
-// recognizes "create/new/make a workspace called|named X".
-func detectHomeMutationRequest(prompt string) *HomeActionConfirmation {
-	trimmed := strings.TrimSpace(prompt)
-	lower := strings.ToLower(trimmed)
-	if lower == "" {
-		return nil
-	}
-	if !strings.HasPrefix(lower, "create ") && !strings.HasPrefix(lower, "new ") && !strings.HasPrefix(lower, "make ") && !strings.HasPrefix(lower, "add ") {
-		return nil
-	}
-	for _, marker := range []string{"workspace called ", "workspace named "} {
-		idx := strings.Index(lower, marker)
-		if idx < 0 {
-			continue
-		}
-		name := strings.TrimSpace(trimmed[idx+len(marker):])
-		name = strings.Trim(name, " .\"'")
-		if name == "" {
-			continue
-		}
-		return &HomeActionConfirmation{
-			ActionID:   "create-workspace",
-			ActionType: HomeActionCreateWorkspace,
-			Summary:    fmt.Sprintf("Create a new workspace named %q?", name),
-			Arguments:  map[string]any{"name": name},
-		}
-	}
-	return nil
 }

--- a/internal/agenthttp/home_assistant_ask_prompt.go
+++ b/internal/agenthttp/home_assistant_ask_prompt.go
@@ -18,6 +18,8 @@ func buildHomeSystemPrompt() string {
 	b.WriteString("Never invent workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
 	b.WriteString("For navigation questions, only reference destinations that appear in the Navigation Catalog; never invent a URL or page name. ")
 	b.WriteString("Be concise and skimmable: lead with the key counts, then a few highlights. ")
+	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, and start (run) an existing task. ")
+	b.WriteString("These actions always require the user's explicit confirmation before anything happens, so when a user asks you to create or start something, confirm you can and let the confirmation step handle it. ")
 	b.WriteString("When helpful, end with a brief suggestion of a concrete next step. ")
 	b.WriteString("Do not output raw JSON or tool results as your final answer; write a short natural-language summary.")
 	return b.String()

--- a/internal/agenthttp/home_assistant_task_mutation.go
+++ b/internal/agenthttp/home_assistant_task_mutation.go
@@ -1,0 +1,251 @@
+package agenthttp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// detectHomeMutationRequest inspects a prompt for an explicit, supported
+// state-changing request and returns the confirmation to surface (FR #24). It
+// recognizes three mutations: create a workspace, create a task in an existing
+// workspace, and start an existing task. Nothing is executed here — execution
+// happens only on a follow-up request carrying the matching ConfirmedAction.
+//
+// Detection is intentionally conservative: a mutation is proposed only when the
+// verb and target are unambiguous (and, for task mutations, when the referenced
+// workspace and task actually resolve against real state). Anything short of a
+// confident match falls through to the normal answer path.
+func (h *HomeAssistantAskHandler) detectHomeMutationRequest(prompt string) *HomeActionConfirmation {
+	if conf := detectWorkspaceCreationRequest(prompt); conf != nil {
+		return conf
+	}
+	return h.detectTaskMutationRequest(prompt)
+}
+
+// detectWorkspaceCreationRequest matches "create/new/make/add a workspace
+// called/named X" and proposes a create_workspace confirmation.
+func detectWorkspaceCreationRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" {
+		return nil
+	}
+	if !hasCreateVerb(lower) {
+		return nil
+	}
+	for _, marker := range []string{"workspace called ", "workspace named "} {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			continue
+		}
+		name := strings.TrimSpace(trimmed[idx+len(marker):])
+		name = strings.Trim(name, " .\"'")
+		if name == "" {
+			continue
+		}
+		return &HomeActionConfirmation{
+			ActionID:   "create-workspace",
+			ActionType: HomeActionCreateWorkspace,
+			Summary:    fmt.Sprintf("Create a new workspace named %q?", name),
+			Arguments:  map[string]any{"name": name},
+		}
+	}
+	return nil
+}
+
+// detectTaskMutationRequest matches task creation ("create a task to X in
+// <workspace>") and task execution ("start/run the <task> task in
+// <workspace>"). Both require the named workspace to resolve to real state;
+// start additionally requires the task to resolve.
+func (h *HomeAssistantAskHandler) detectTaskMutationRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" || !strings.Contains(lower, "task") {
+		return nil
+	}
+	store := h.Sources.Workspaces
+	if store == nil {
+		return nil
+	}
+
+	createVerb := hasCreateVerb(lower)
+	startVerb := hasStartVerb(lower)
+	if !createVerb && !startVerb {
+		return nil
+	}
+
+	wsID, wsName, ok := matchWorkspaceInPrompt(store, prompt)
+	if !ok {
+		return nil
+	}
+
+	// "start" takes precedence: "run" / "start" are unambiguous execution verbs,
+	// whereas "add"/"create" only ever mean creation.
+	if startVerb {
+		return h.buildStartTaskConfirmation(store, wsID, wsName, trimmed)
+	}
+
+	desc := extractTaskDescription(trimmed, wsName)
+	if desc == "" {
+		return nil
+	}
+	return &HomeActionConfirmation{
+		ActionID:   "create-task",
+		ActionType: HomeActionCreateTask,
+		Summary:    fmt.Sprintf("Create a task in %q: %q?", wsName, desc),
+		Arguments:  map[string]any{"workspace_id": wsID, "description": desc},
+	}
+}
+
+// buildStartTaskConfirmation resolves which pending task the user wants to start
+// within the given workspace. It matches the prompt against the descriptions of
+// runnable tasks; if exactly one runnable task exists it is used directly, and
+// if several match ambiguously it declines (returns nil) so the assistant can
+// fall back to listing them instead of guessing.
+func (h *HomeAssistantAskHandler) buildStartTaskConfirmation(store workspace.Store, wsID, wsName, prompt string) *HomeActionConfirmation {
+	ws, err := store.Get(wsID)
+	if err != nil || ws == nil {
+		return nil
+	}
+
+	runnable := make([]workspace.Task, 0, len(ws.Tasks))
+	for _, t := range ws.Tasks {
+		if isRunnableTaskStatus(t.Status) {
+			runnable = append(runnable, t)
+		}
+	}
+	if len(runnable) == 0 {
+		return nil
+	}
+
+	promptTokens := tokenizePrompt(prompt)
+	bestIdx := -1
+	bestScore := 0
+	tie := false
+	for i := range runnable {
+		descTokens := tokenizePrompt(runnable[i].Description)
+		score := signalTokenOverlap(promptTokens, descTokens)
+		switch {
+		case score > bestScore:
+			bestScore, bestIdx, tie = score, i, false
+		case score == bestScore && score > 0:
+			tie = true
+		}
+	}
+
+	switch {
+	case bestScore > 0 && !tie:
+		// Confident description match.
+	case len(runnable) == 1:
+		// Only one candidate — "start the task in <workspace>" is unambiguous.
+		bestIdx = 0
+	default:
+		// No signal match, or an ambiguous tie among several tasks.
+		return nil
+	}
+
+	target := runnable[bestIdx]
+	return &HomeActionConfirmation{
+		ActionID:   "start-task",
+		ActionType: HomeActionStartTask,
+		Summary:    fmt.Sprintf("Start the task %q in %q?", truncateTaskLabel(target.Description, 80), wsName),
+		Arguments:  map[string]any{"workspace_id": wsID, "task_id": target.ID},
+	}
+}
+
+// isRunnableTaskStatus reports whether a task in this status can be (re)started
+// from the home assistant. In-progress and completed tasks are excluded; failed,
+// cancelled, and timed-out tasks may be retried.
+func isRunnableTaskStatus(status workspace.TaskStatus) bool {
+	switch status {
+	case workspace.TaskStatusInProgress, workspace.TaskStatusCompleted:
+		return false
+	default:
+		return true
+	}
+}
+
+func hasCreateVerb(lower string) bool {
+	return strings.HasPrefix(lower, "create ") ||
+		strings.HasPrefix(lower, "add ") ||
+		strings.HasPrefix(lower, "new ") ||
+		strings.HasPrefix(lower, "make ")
+}
+
+func hasStartVerb(lower string) bool {
+	return strings.HasPrefix(lower, "start ") ||
+		strings.HasPrefix(lower, "run ") ||
+		strings.HasPrefix(lower, "execute ") ||
+		strings.HasPrefix(lower, "begin ") ||
+		strings.HasPrefix(lower, "kick off ") ||
+		strings.HasPrefix(lower, "launch ")
+}
+
+// extractTaskDescription pulls the free-text task description out of a creation
+// prompt by removing the workspace mention and the leading "create a task …"
+// scaffolding. Returns "" when no description remains.
+func extractTaskDescription(prompt, wsName string) string {
+	s := stripWorkspaceMention(prompt, wsName)
+
+	lower := strings.ToLower(s)
+	idx := strings.Index(lower, "task")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(s[idx+len("task"):])
+
+	// Drop a single leading connector that links "task" to its description.
+	for _, connector := range []string{"to ", "that ", "which ", "for ", "of ", "named ", "called ", "titled ", "about "} {
+		if strings.HasPrefix(strings.ToLower(rest), connector) {
+			rest = strings.TrimSpace(rest[len(connector):])
+			break
+		}
+	}
+	rest = strings.Trim(rest, " :\"'.-")
+	return strings.TrimSpace(rest)
+}
+
+// stripWorkspaceMention removes the first reference to wsName (and the
+// surrounding "in [the] … [workspace]" connective words) from the prompt so the
+// remaining text is just the task description.
+func stripWorkspaceMention(prompt, wsName string) string {
+	wsName = strings.TrimSpace(wsName)
+	if wsName == "" {
+		return prompt
+	}
+	lower := strings.ToLower(prompt)
+	lowerName := strings.ToLower(wsName)
+
+	// Longest, most specific phrasings first so we strip the connectives too.
+	candidates := []string{
+		"in the " + lowerName + " workspace",
+		"in " + lowerName + " workspace",
+		"to the " + lowerName + " workspace",
+		"in the " + lowerName,
+		"in " + lowerName,
+		"to the " + lowerName,
+		"to " + lowerName,
+		lowerName + " workspace",
+		lowerName,
+	}
+	for _, phrase := range candidates {
+		if idx := strings.Index(lower, phrase); idx >= 0 {
+			out := prompt[:idx] + " " + prompt[idx+len(phrase):]
+			return strings.Join(strings.Fields(out), " ")
+		}
+	}
+	return prompt
+}
+
+// truncateTaskLabel shortens a task description for display in a confirmation
+// summary, appending an ellipsis when cut.
+func truncateTaskLabel(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	cut := strings.TrimSpace(s[:max])
+	return cut + "…"
+}

--- a/internal/agenthttp/home_assistant_task_mutation_test.go
+++ b/internal/agenthttp/home_assistant_task_mutation_test.go
@@ -1,0 +1,254 @@
+package agenthttp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// taskIDByDescription returns the generated ID of the task with the given
+// description in a stored workspace, so tests can assert against real IDs.
+func taskIDByDescription(t *testing.T, store workspace.Store, wsID, description string) string {
+	t.Helper()
+	ws, err := store.Get(wsID)
+	if err != nil {
+		t.Fatalf("get workspace %s: %v", wsID, err)
+	}
+	for _, task := range ws.Tasks {
+		if task.Description == description {
+			return task.ID
+		}
+	}
+	t.Fatalf("no task with description %q in workspace %s", description, wsID)
+	return ""
+}
+
+func newTaskMutationHandler(t *testing.T, store workspace.Store) *HomeAssistantAskHandler {
+	t.Helper()
+	return NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Now: time.Now},
+		nil,
+		nil,
+	)
+}
+
+func TestDetectMutation_CreateTaskInWorkspace(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Q3 Planning", nil)
+	h := newTaskMutationHandler(t, store)
+
+	conf := h.detectHomeMutationRequest("create a task to summarize Q2 sales in Q3 Planning")
+	if conf == nil {
+		t.Fatal("expected a create_task confirmation")
+	}
+	if conf.ActionType != HomeActionCreateTask {
+		t.Errorf("action type = %q, want %q", conf.ActionType, HomeActionCreateTask)
+	}
+	if got, _ := conf.Arguments["workspace_id"].(string); got != "ws-1" {
+		t.Errorf("workspace_id = %q, want ws-1", got)
+	}
+	if got, _ := conf.Arguments["description"].(string); got != "summarize Q2 sales" {
+		t.Errorf("description = %q, want %q", got, "summarize Q2 sales")
+	}
+}
+
+func TestDetectMutation_CreateTaskWithoutDescriptionDeclines(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Q3 Planning", nil)
+	h := newTaskMutationHandler(t, store)
+
+	if conf := h.detectHomeMutationRequest("add a task in Q3 Planning"); conf != nil {
+		t.Fatalf("expected no confirmation when description is empty, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_CreateTaskUnknownWorkspaceDeclines(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Q3 Planning", nil)
+	h := newTaskMutationHandler(t, store)
+
+	if conf := h.detectHomeMutationRequest("create a task to do x in Nonexistent"); conf != nil {
+		t.Fatalf("expected no confirmation for unknown workspace, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_StartTaskByDescription(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-ops", "Operations", []workspace.Task{
+		{Description: "deploy to production", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+		{Description: "rotate signing keys", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+	})
+	h := newTaskMutationHandler(t, store)
+	deployID := taskIDByDescription(t, store, "ws-ops", "deploy to production")
+
+	conf := h.detectHomeMutationRequest("start the deploy task in Operations")
+	if conf == nil {
+		t.Fatal("expected a start_task confirmation")
+	}
+	if conf.ActionType != HomeActionStartTask {
+		t.Errorf("action type = %q, want %q", conf.ActionType, HomeActionStartTask)
+	}
+	if got, _ := conf.Arguments["workspace_id"].(string); got != "ws-ops" {
+		t.Errorf("workspace_id = %q, want ws-ops", got)
+	}
+	if got, _ := conf.Arguments["task_id"].(string); got != deployID {
+		t.Errorf("task_id = %q, want %q (deploy task)", got, deployID)
+	}
+}
+
+func TestDetectMutation_StartTaskSingleRunnable(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-solo", "Solo", []workspace.Task{
+		{Description: "the only pending job", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+	})
+	h := newTaskMutationHandler(t, store)
+	onlyID := taskIDByDescription(t, store, "ws-solo", "the only pending job")
+
+	conf := h.detectHomeMutationRequest("run the task in Solo")
+	if conf == nil {
+		t.Fatal("expected a start_task confirmation for the single runnable task")
+	}
+	if got, _ := conf.Arguments["task_id"].(string); got != onlyID {
+		t.Errorf("task_id = %q, want %q", got, onlyID)
+	}
+}
+
+func TestDetectMutation_StartTaskAmbiguousDeclines(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-ops", "Operations", []workspace.Task{
+		{Description: "deploy to production", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+		{Description: "rotate signing keys", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+	})
+	h := newTaskMutationHandler(t, store)
+
+	// No descriptor that distinguishes a task, and more than one runnable task.
+	if conf := h.detectHomeMutationRequest("start a task in Operations"); conf != nil {
+		t.Fatalf("expected no confirmation for ambiguous start, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_StartTaskNoRunnableDeclines(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-done", "Archive", []workspace.Task{
+		{Description: "shipped already", Status: workspace.TaskStatusCompleted, CreatedAt: time.Now()},
+	})
+	h := newTaskMutationHandler(t, store)
+
+	if conf := h.detectHomeMutationRequest("start the shipped task in Archive"); conf != nil {
+		t.Fatalf("expected no confirmation when no runnable task exists, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_QuestionFallsThrough(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-1", "Operations", []workspace.Task{
+		{Description: "deploy to production", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+	})
+	h := newTaskMutationHandler(t, store)
+
+	for _, prompt := range []string{
+		"how many tasks are in Operations",
+		"what is the deploy task status in Operations",
+		"summarize my activity",
+	} {
+		if conf := h.detectHomeMutationRequest(prompt); conf != nil {
+			t.Errorf("prompt %q should not trigger a mutation, got %+v", prompt, conf)
+		}
+	}
+}
+
+func TestExtractTaskDescription(t *testing.T) {
+	cases := []struct {
+		prompt string
+		wsName string
+		want   string
+	}{
+		{"create a task to summarize sales in Q3 Planning", "Q3 Planning", "summarize sales"},
+		{"add task: deploy to prod in Operations", "Operations", "deploy to prod"},
+		{"new task that reviews the backlog in the Roadmap workspace", "Roadmap", "reviews the backlog"},
+		{"make a task for onboarding docs in Docs", "Docs", "onboarding docs"},
+		{"create a task in Ops", "Ops", ""},
+	}
+	for _, c := range cases {
+		if got := extractTaskDescription(c.prompt, c.wsName); got != c.want {
+			t.Errorf("extractTaskDescription(%q, %q) = %q, want %q", c.prompt, c.wsName, got, c.want)
+		}
+	}
+}
+
+func TestAsk_ConfirmAndExecuteStartTask(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspace(t, store, "ws-ops", "Operations", []workspace.Task{
+		{Description: "deploy to production", Status: workspace.TaskStatusPending, CreatedAt: time.Now()},
+	})
+	factory := llm.NewFactory()
+	factory.Register("fake", &fakeProvider{content: "irrelevant"})
+	h := NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Now: time.Now},
+		factory,
+		stubSystemModel{provider: "fake", model: "fake-model"},
+	)
+	mut := &recordingMutator{}
+	h.SetMutator(mut)
+	deployID := taskIDByDescription(t, store, "ws-ops", "deploy to production")
+
+	// 1. The natural-language request should require confirmation.
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Prompt: "start the deploy task in Operations",
+		Intent: "app_introspection",
+	})
+	if !resp.RequiresConfirmation || resp.Confirmation == nil {
+		t.Fatalf("expected a start_task confirmation, got %+v", resp)
+	}
+	if resp.Confirmation.ActionType != HomeActionStartTask {
+		t.Fatalf("confirmation type = %q, want %q", resp.Confirmation.ActionType, HomeActionStartTask)
+	}
+
+	// 2. Confirming executes the mutation against the resolved task.
+	resp2 := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Intent: "app_introspection",
+		ConfirmedAction: &HomeAction{
+			Type:      HomeActionStartTask,
+			Arguments: resp.Confirmation.Arguments,
+		},
+	})
+	if mut.startedWS != "ws-ops" || mut.startedTask != deployID {
+		t.Errorf("StartTask called with (%q, %q), want (ws-ops, %q)", mut.startedWS, mut.startedTask, deployID)
+	}
+	foundOpen := false
+	for _, a := range resp2.Actions {
+		if a.Type == HomeActionOpenWorkspace && a.WorkspaceID == "ws-ops" {
+			foundOpen = true
+		}
+	}
+	if !foundOpen {
+		t.Errorf("expected an open_workspace action after start, got %+v", resp2.Actions)
+	}
+}
+
+// recordingMutator captures the arguments passed to each mutator method.
+type recordingMutator struct {
+	startedWS      string
+	startedTask    string
+	createdTaskWS  string
+	createdTaskDsc string
+}
+
+func (m *recordingMutator) CreateWorkspace(_ context.Context, name, _ string) (string, string, error) {
+	return "ws-new", "/workspaces/ws-new", nil
+}
+
+func (m *recordingMutator) CreateTask(_ context.Context, wsID, description string) (string, string, error) {
+	m.createdTaskWS = wsID
+	m.createdTaskDsc = description
+	return "t-new", "/workspaces/" + wsID, nil
+}
+
+func (m *recordingMutator) StartTask(_ context.Context, wsID, taskID string) (string, error) {
+	m.startedWS = wsID
+	m.startedTask = taskID
+	return "/workspaces/" + wsID, nil
+}

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/johnjallday/ori-agent/internal/agenthttp"
 	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/store"
 	"github.com/johnjallday/ori-agent/internal/workspace"
@@ -66,12 +67,14 @@ func (a homeUsageAdapter) UsageSummary() (agenthttp.HomeUsageSummary, bool) {
 	}, true
 }
 
-// homeActionMutator executes confirmed home actions (PRD 4.6). CreateWorkspace
-// and CreateTask are wired; StartTask is deferred to a follow-up (kept behind the
-// same confirmation contract, returns a clear message for now).
+// homeActionMutator executes confirmed home actions (PRD 4.6). CreateWorkspace,
+// CreateTask, and StartTask are wired; StartTask runs the task through the same
+// orchestrator path the workspace UI uses, so coordinator-driven assignment and
+// the delegation loop apply identically.
 type homeActionMutator struct {
-	workspaces workspace.Store
-	agents     store.Store
+	workspaces   workspace.Store
+	agents       store.Store
+	orchestrator *workspace.Orchestrator
 }
 
 func (m homeActionMutator) defaultAgentName() string {
@@ -135,7 +138,48 @@ func (m homeActionMutator) CreateTask(ctx context.Context, workspaceID, descript
 }
 
 func (m homeActionMutator) StartTask(ctx context.Context, workspaceID, taskID string) (string, error) {
-	return "/workspaces/" + workspaceID, fmt.Errorf("starting a task from here isn't supported yet — open the workspace to run it")
+	href := "/workspaces/" + workspaceID
+	if m.workspaces == nil {
+		return href, fmt.Errorf("workspace store unavailable")
+	}
+	if m.orchestrator == nil {
+		return href, fmt.Errorf("task execution is not available right now")
+	}
+
+	ws, err := m.workspaces.Get(workspaceID)
+	if err != nil {
+		return href, fmt.Errorf("workspace not found: %w", err)
+	}
+
+	var target *workspace.Task
+	for i := range ws.Tasks {
+		if ws.Tasks[i].ID == taskID {
+			target = &ws.Tasks[i]
+			break
+		}
+	}
+	if target == nil {
+		return href, fmt.Errorf("task not found in workspace")
+	}
+	if target.Status == workspace.TaskStatusInProgress {
+		return href, fmt.Errorf("task is already running")
+	}
+	if target.Status == workspace.TaskStatusCompleted {
+		return href, fmt.Errorf("task is already completed")
+	}
+
+	// Execute asynchronously with a detached context: the HTTP request that
+	// confirmed this action returns immediately, so the task must not be
+	// cancelled when its context is torn down. Mirrors ExecuteTaskManually.
+	task := *target
+	orchestrator := m.orchestrator
+	go func() {
+		if execErr := orchestrator.ExecuteTask(context.Background(), workspaceID, task); execErr != nil {
+			logger.Error("home assistant: failed to start task", logger.Fields{"workspace_id": workspaceID, "task_id": taskID, "err": execErr})
+		}
+	}()
+
+	return href, nil
 }
 
 // newHomeAssistantAskHandler constructs the home harness handler with its data
@@ -163,10 +207,14 @@ func (s *Server) newHomeAssistantAskHandler() *agenthttp.HomeAssistantAskHandler
 	handler := agenthttp.NewHomeAssistantAskHandler(sources, llmFactory, systemModel)
 	handler.SetTraceEmitter(agenthttp.NewLoggingHomeAskTraceEmitter())
 	if s.Storage != nil {
-		handler.SetMutator(homeActionMutator{
+		mutator := homeActionMutator{
 			workspaces: s.Storage.WorkspaceStore,
 			agents:     s.Storage.AgentStore,
-		})
+		}
+		if s.Workflow != nil {
+			mutator.orchestrator = s.Workflow.WorkspaceOrchestrator
+		}
+		handler.SetMutator(mutator)
 	}
 	return handler
 }

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -168,13 +168,18 @@ func (m homeActionMutator) StartTask(ctx context.Context, workspaceID, taskID st
 		return href, fmt.Errorf("task is already completed")
 	}
 
-	// Execute asynchronously with a detached context: the HTTP request that
-	// confirmed this action returns immediately, so the task must not be
-	// cancelled when its context is torn down. Mirrors ExecuteTaskManually.
+	// Execute asynchronously. The HTTP request that confirmed this action
+	// returns immediately, so derive a context that keeps the request's values
+	// (tracing, etc.) but is not cancelled when the request ends — otherwise the
+	// task would be torn down the moment we respond.
+	execCtx := context.Background()
+	if ctx != nil {
+		execCtx = context.WithoutCancel(ctx)
+	}
 	task := *target
 	orchestrator := m.orchestrator
 	go func() {
-		if execErr := orchestrator.ExecuteTask(context.Background(), workspaceID, task); execErr != nil {
+		if execErr := orchestrator.ExecuteTask(execCtx, workspaceID, task); execErr != nil {
 			logger.Error("home assistant: failed to start task", logger.Fields{"workspace_id": workspaceID, "task_id": taskID, "err": execErr})
 		}
 	}()


### PR DESCRIPTION
## Summary

Turns the home assistant ("Ask Ori") from a read-only Q&A + workspace-creation surface into a coordinator that can **create and start tasks across any workspace** — a concrete step toward Ori acting as an AI OS that manages agents and workspaces.

Previously `create_task` and `start_task` were wired for *execution* but were **never proposed** by the harness (only `create_workspace` was detected), and the `StartTask` mutator returned a "not supported yet" error — so neither was reachable end to end.

## What changed

- **Natural-language detection** (`home_assistant_task_mutation.go`):
  - `create_task` — e.g. *"create a task to summarize Q2 sales in Q3 Planning"* → resolves the named workspace, extracts the description, proposes a confirmation.
  - `start_task` — e.g. *"start the deploy task in Operations"* → resolves the workspace, matches the task by description, uses the sole runnable task when unambiguous, and **declines on ties** so the assistant can fall back to listing tasks instead of guessing.
  - Detection is conservative: it only fires when the verb and target are unambiguous and the referenced workspace/task resolve against real state. Questions ("how many tasks…") fall through to the normal answer path.
- **Real execution** (`internal/server/home_assistant_ask.go`): `StartTask` now runs the task through the same `Orchestrator.ExecuteTask` path the workspace UI uses, so coordinator-driven assignment and the delegation loop apply identically. Execution is detached from the request context (so it isn't cancelled when the HTTP request returns) and skips in-progress/completed tasks.
- **System prompt**: notes the act-with-confirmation capability so the assistant acknowledges it can create/start things when asked directly.
- **Frontend**: already supported these action types (`isMutatingHomeActionType` + `confirmHomeAction` forward `workspace_id`/`task_id`), so no JS changes were needed.

## Confirmation contract

Unchanged: every mutation still returns `requires_confirmation` and executes only on a follow-up carrying the matching `ConfirmedAction`. Nothing runs without explicit user confirmation.

## Tests

- New detection tests: create_task (happy path, empty-description decline, unknown-workspace decline), start_task (by description, single-runnable, ambiguous decline, no-runnable decline), question fall-through, and `extractTaskDescription` cases.
- New end-to-end test: NL request → confirmation → confirmed `start_task` → mutator invoked with the resolved task.
- `go build ./...`, `go vet`, full `go test ./...`, `golangci-lint` (0 issues), and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)