### PR TITLE
feat(home-assistant): agent lifecycle management (roster, create, assign, remove) in "Ask Ori"

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -264,7 +264,7 @@ model may call are `home_workspaces`, `home_tasks`, `home_sessions`,
 
 **Action schema:**
 - `id`: Stable action id.
-- `type`: One of `navigate`, `open_workspace`, `open_task`, `open_session`, `create_workspace`, `create_task`, `start_task`, `assign_agent`, `ask_followup`.
+- `type`: One of `navigate`, `open_workspace`, `open_task`, `open_session`, `create_workspace`, `create_task`, `start_task`, `assign_agent`, `create_agent`, `remove_agent`, `ask_followup`.
 - `label`: Button label.
 - `href` (optional): Destination for navigation/`open_*` actions.
 - `workspace_id` / `task_id` / `session_id` (optional): Resolved target ids.
@@ -281,13 +281,18 @@ mutations are recognized from natural language, each requiring confirmation:
 | `create_task` | `"create a task to summarize Q2 sales in Q3 Planning"` | `workspace_id`, `description` |
 | `start_task` | `"start the deploy task in Operations"` | `workspace_id`, `task_id` |
 | `assign_agent` | `"add agent Scout to Operations"` / `"assign Scout to Operations"` | `workspace_id`, `agent_name` |
+| `create_agent` | `"create an agent called Atlas"` | `name` |
+| `remove_agent` | `"remove agent Scout from Operations"` | `workspace_id`, `agent_name` |
 
 Task and agent mutations resolve the named workspace (and the target task or
 agent) against real state before proposing; an unresolved workspace/task/agent, an
 empty description, or an ambiguous task match falls through to the normal answer
 path rather than guessing. `start_task` uses the workspace's sole runnable task
-when the prompt doesn't name one. `assign_agent` only resolves agents that exist
-in the user's roster, and the server re-validates the agent before adding it.
+when the prompt doesn't name one. `assign_agent` / `remove_agent` only resolve
+agents that exist in the user's roster, and the server re-validates before
+mutating (`create_agent` rejects a duplicate name; `remove_agent` cannot remove a
+workspace's required entry agent). Agent management covers the lifecycle: create a
+new agent, add it to a workspace, and remove it.
 
 ```json
 {

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -264,7 +264,7 @@ model may call are `home_workspaces`, `home_tasks`, `home_sessions`,
 
 **Action schema:**
 - `id`: Stable action id.
-- `type`: One of `navigate`, `open_workspace`, `open_task`, `open_session`, `create_workspace`, `create_task`, `start_task`, `ask_followup`.
+- `type`: One of `navigate`, `open_workspace`, `open_task`, `open_session`, `create_workspace`, `create_task`, `start_task`, `assign_agent`, `ask_followup`.
 - `label`: Button label.
 - `href` (optional): Destination for navigation/`open_*` actions.
 - `workspace_id` / `task_id` / `session_id` (optional): Resolved target ids.
@@ -280,12 +280,14 @@ mutations are recognized from natural language, each requiring confirmation:
 | `create_workspace` | `"create a workspace called Q3 Planning"` | `name` |
 | `create_task` | `"create a task to summarize Q2 sales in Q3 Planning"` | `workspace_id`, `description` |
 | `start_task` | `"start the deploy task in Operations"` | `workspace_id`, `task_id` |
+| `assign_agent` | `"add agent Scout to Operations"` / `"assign Scout to Operations"` | `workspace_id`, `agent_name` |
 
-Task mutations resolve the named workspace (and, for `start_task`, the target
-task) against real state before proposing; an unresolved workspace/task, an empty
-description, or an ambiguous task match falls through to the normal answer path
-rather than guessing. `start_task` uses the workspace's sole runnable task when
-the prompt doesn't name one.
+Task and agent mutations resolve the named workspace (and the target task or
+agent) against real state before proposing; an unresolved workspace/task/agent, an
+empty description, or an ambiguous task match falls through to the normal answer
+path rather than guessing. `start_task` uses the workspace's sole runnable task
+when the prompt doesn't name one. `assign_agent` only resolves agents that exist
+in the user's roster, and the server re-validates the agent before adding it.
 
 ```json
 {

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -200,12 +200,18 @@ Classify a home page assistant prompt and find the best matching existing agent.
 ### Ask Home Assistant (Inline Harness)
 
 Answer an app-introspection or app-navigation prompt inline. The server builds a
-cross-workspace **home snapshot** (workspaces, windowed task activity, recent
-sessions, open Action Center opportunities, usage), runs the system model with
-read-only `home_*` tools, and returns a written answer plus grounded next-step
-actions. Used by the home page "Ask Ori" panel when
+cross-workspace **home snapshot** (the agent roster, workspaces, windowed task
+activity, recent sessions, open Action Center opportunities, usage), runs the
+system model with read-only `home_*` tools, and returns a written answer plus
+grounded next-step actions. Used by the home page "Ask Ori" panel when
 `/api/home-assistant/route` classifies the prompt as `app_introspection` or
 `app_navigation` (route mode `home_inline`).
+
+The agent section lists each agent's type, role, model, and the workspaces that
+use it, so the assistant can answer questions like "what agents do I have", "what
+can agent X do", and "which agents aren't used anywhere". The read-only tools the
+model may call are `home_workspaces`, `home_tasks`, `home_sessions`,
+`home_opportunities`, `home_usage`, and `home_agents`.
 
 **Endpoint:** `POST /api/home-assistant/ask`
 
@@ -238,6 +244,7 @@ actions. Used by the home page "Ask Ori" panel when
     "task_count": 5,
     "session_count": 4,
     "opportunity_count": 1,
+    "agent_count": 3,
     "degraded": [],
     "truncated": []
   },

--- a/internal/agenthttp/home_agents_test.go
+++ b/internal/agenthttp/home_agents_test.go
@@ -200,6 +200,122 @@ func TestDetectMutation_AddTaskNotMisreadAsAgent(t *testing.T) {
 	}
 }
 
+func TestDetectMutation_CreateAgent(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	for _, prompt := range []string{
+		"create an agent called Atlas",
+		"make a new agent named Atlas",
+	} {
+		conf := h.detectHomeMutationRequest(prompt)
+		if conf == nil {
+			t.Fatalf("prompt %q: expected a create_agent confirmation", prompt)
+		}
+		if conf.ActionType != HomeActionCreateAgent {
+			t.Errorf("prompt %q: action type = %q, want %q", prompt, conf.ActionType, HomeActionCreateAgent)
+		}
+		if got, _ := conf.Arguments["name"].(string); got != "Atlas" {
+			t.Errorf("prompt %q: name = %q, want Atlas", prompt, got)
+		}
+	}
+}
+
+func TestDetectMutation_CreateAgentNotConfusedWithWorkspace(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	conf := h.detectHomeMutationRequest("create a workspace called Atlas")
+	if conf == nil || conf.ActionType != HomeActionCreateWorkspace {
+		t.Fatalf("expected create_workspace, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_RemoveAgent(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori", "Scout"})
+	h := NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Agents: agentRoster(), Now: fixedNow},
+		nil, nil,
+	)
+
+	conf := h.detectHomeMutationRequest("remove agent Scout from Alpha")
+	if conf == nil {
+		t.Fatal("expected a remove_agent confirmation")
+	}
+	if conf.ActionType != HomeActionRemoveAgent {
+		t.Errorf("action type = %q, want %q", conf.ActionType, HomeActionRemoveAgent)
+	}
+	if got, _ := conf.Arguments["workspace_id"].(string); got != "ws-1" {
+		t.Errorf("workspace_id = %q, want ws-1", got)
+	}
+	if got, _ := conf.Arguments["agent_name"].(string); got != "Scout" {
+		t.Errorf("agent_name = %q, want Scout", got)
+	}
+}
+
+func TestDetectMutation_RemoveTaskNotMisreadAsAgent(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori"})
+	h := NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Agents: agentRoster(), Now: fixedNow},
+		nil, nil,
+	)
+	// No roster agent named in this prompt -> must not propose remove_agent.
+	if conf := h.detectHomeMutationRequest("remove the stale task from Alpha"); conf != nil {
+		t.Fatalf("expected no confirmation, got %+v", conf)
+	}
+}
+
+func TestAsk_ConfirmAndExecuteCreateAgent(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	factory := llm.NewFactory()
+	factory.Register("fake", &fakeProvider{content: "irrelevant"})
+	h.LLMFactory = factory
+	h.SystemModel = stubSystemModel{provider: "fake", model: "fake-model"}
+	mut := &recordingMutator{}
+	h.SetMutator(mut)
+
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Prompt: "create an agent called Atlas",
+		Intent: "app_introspection",
+	})
+	if !resp.RequiresConfirmation || resp.Confirmation == nil || resp.Confirmation.ActionType != HomeActionCreateAgent {
+		t.Fatalf("expected create_agent confirmation, got %+v", resp)
+	}
+	h.Ask(context.Background(), HomeAssistantAskRequest{
+		Intent:          "app_introspection",
+		ConfirmedAction: &HomeAction{Type: HomeActionCreateAgent, Arguments: resp.Confirmation.Arguments},
+	})
+	if mut.createdAgent != "Atlas" {
+		t.Errorf("CreateAgent called with %q, want Atlas", mut.createdAgent)
+	}
+}
+
+func TestAsk_ConfirmAndExecuteRemoveAgent(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori", "Scout"})
+	factory := llm.NewFactory()
+	factory.Register("fake", &fakeProvider{content: "irrelevant"})
+	h := NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Agents: agentRoster(), Now: fixedNow},
+		factory, stubSystemModel{provider: "fake", model: "fake-model"},
+	)
+	mut := &recordingMutator{}
+	h.SetMutator(mut)
+
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Prompt: "remove agent Scout from Alpha",
+		Intent: "app_introspection",
+	})
+	if !resp.RequiresConfirmation || resp.Confirmation == nil || resp.Confirmation.ActionType != HomeActionRemoveAgent {
+		t.Fatalf("expected remove_agent confirmation, got %+v", resp)
+	}
+	h.Ask(context.Background(), HomeAssistantAskRequest{
+		Intent:          "app_introspection",
+		ConfirmedAction: &HomeAction{Type: HomeActionRemoveAgent, Arguments: resp.Confirmation.Arguments},
+	})
+	if mut.removedWS != "ws-1" || mut.removedAgent != "Scout" {
+		t.Errorf("RemoveAgent called with (%q, %q), want (ws-1, Scout)", mut.removedWS, mut.removedAgent)
+	}
+}
+
 func TestAsk_ConfirmAndExecuteAssignAgent(t *testing.T) {
 	store := workspace.NewInMemoryStore()
 	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori"})

--- a/internal/agenthttp/home_agents_test.go
+++ b/internal/agenthttp/home_agents_test.go
@@ -1,0 +1,145 @@
+package agenthttp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// makeTestWorkspaceWithAgents saves a workspace with the given agent members so
+// agent→workspace cross-referencing can be exercised.
+func makeTestWorkspaceWithAgents(t *testing.T, store workspace.Store, id, name string, agents []string) {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: name, Agents: agents})
+	ws.ID = id
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+}
+
+func agentRoster() stubAgentsReader {
+	return stubAgentsReader{ok: true, roster: []HomeAgentSummary{
+		{Name: "Ori", Type: "tool-calling", Role: "orchestrator", Model: "gpt-5", Provider: "openai", Capabilities: []string{"planning"}},
+		{Name: "Scout", Type: "research", Role: "researcher", Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		{Name: "Idle", Type: "general", Role: "assistant", Model: "gpt-5-mini", Provider: "openai"},
+	}}
+}
+
+func TestBuildHomeSnapshot_AgentWorkspaceCrossReference(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori", "Scout"})
+	makeTestWorkspaceWithAgents(t, store, "ws-2", "Beta", []string{"Ori"})
+
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces: store,
+		Agents:     agentRoster(),
+		Now:        fixedNow,
+	}, HomeWindowThisWeek)
+
+	if snap.Meta.AgentCount != 3 {
+		t.Fatalf("AgentCount = %d, want 3", snap.Meta.AgentCount)
+	}
+	byName := map[string]HomeAgentSummary{}
+	for _, a := range snap.Agents {
+		byName[a.Name] = a
+	}
+	// Ori is used in both workspaces and should sort first (most-used).
+	if snap.Agents[0].Name != "Ori" {
+		t.Errorf("expected Ori first (most used), got %q", snap.Agents[0].Name)
+	}
+	if got := byName["Ori"]; got.WorkspaceCount != 2 || len(got.Workspaces) != 2 {
+		t.Errorf("Ori workspace usage = %d %v, want 2", got.WorkspaceCount, got.Workspaces)
+	}
+	if got := byName["Scout"]; got.WorkspaceCount != 1 || got.Workspaces[0] != "Alpha" {
+		t.Errorf("Scout workspace usage = %d %v, want 1 [Alpha]", got.WorkspaceCount, got.Workspaces)
+	}
+	if got := byName["Idle"]; got.WorkspaceCount != 0 || len(got.Workspaces) != 0 {
+		t.Errorf("Idle should be used nowhere, got %d %v", got.WorkspaceCount, got.Workspaces)
+	}
+
+	if txt := snap.PromptText(); !strings.Contains(txt, "### Agents (3)") || !strings.Contains(txt, "\"Ori\"") {
+		t.Errorf("prompt text missing agents section: %q", txt)
+	}
+}
+
+func TestBuildHomeSnapshot_AgentsDegradedWhenNoReader(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	snap := BuildHomeSnapshot(context.Background(), HomeSnapshotSources{
+		Workspaces: store,
+		Now:        fixedNow,
+	}, HomeWindowThisWeek)
+	if !containsString(snap.Meta.Degraded, "agents") {
+		t.Errorf("expected agents degraded when no reader, got %v", snap.Meta.Degraded)
+	}
+}
+
+func TestHomeAgentsTool_FiltersAndUsage(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori", "Scout"})
+	makeTestWorkspaceWithAgents(t, store, "ws-2", "Beta", []string{"Ori"})
+
+	reg := newHomeToolRegistry(HomeSnapshotSources{
+		Workspaces: store,
+		Agents:     agentRoster(),
+		Now:        fixedNow,
+	})
+
+	if !reg.Has("home_agents") {
+		t.Fatal("home_agents not registered")
+	}
+
+	// No filter: all three agents, Ori first with usage 2.
+	out, err := reg.Execute(context.Background(), "home_agents", "{}")
+	if err != nil {
+		t.Fatalf("execute home_agents: %v", err)
+	}
+	var all struct {
+		Agents []struct {
+			Name           string   `json:"name"`
+			WorkspaceCount int      `json:"workspace_count"`
+			Workspaces     []string `json:"workspaces"`
+		} `json:"agents"`
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(out), &all); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, out)
+	}
+	if all.Total != 3 || len(all.Agents) != 3 {
+		t.Fatalf("expected 3 agents, got total=%d len=%d", all.Total, len(all.Agents))
+	}
+	if all.Agents[0].Name != "Ori" || all.Agents[0].WorkspaceCount != 2 {
+		t.Errorf("expected Ori first with usage 2, got %+v", all.Agents[0])
+	}
+
+	// Name filter.
+	out, _ = reg.Execute(context.Background(), "home_agents", `{"name":"sco"}`)
+	if err := json.Unmarshal([]byte(out), &all); err != nil {
+		t.Fatalf("unmarshal name filter: %v", err)
+	}
+	if all.Total != 1 || all.Agents[0].Name != "Scout" {
+		t.Errorf("name filter 'sco' should match only Scout, got %+v", all.Agents)
+	}
+
+	// workspace_id filter: only agents used by ws-2 (Ori).
+	out, _ = reg.Execute(context.Background(), "home_agents", `{"workspace_id":"ws-2"}`)
+	if err := json.Unmarshal([]byte(out), &all); err != nil {
+		t.Fatalf("unmarshal ws filter: %v", err)
+	}
+	if all.Total != 1 || all.Agents[0].Name != "Ori" {
+		t.Errorf("workspace_id filter ws-2 should match only Ori, got %+v", all.Agents)
+	}
+}
+
+func TestHomeAgentsTool_UnavailableReader(t *testing.T) {
+	reg := newHomeToolRegistry(HomeSnapshotSources{Now: fixedNow})
+	out, err := reg.Execute(context.Background(), "home_agents", "{}")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out, "unavailable") {
+		t.Errorf("expected unavailable note, got %s", out)
+	}
+}

--- a/internal/agenthttp/home_agents_test.go
+++ b/internal/agenthttp/home_agents_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
@@ -141,5 +142,105 @@ func TestHomeAgentsTool_UnavailableReader(t *testing.T) {
 	}
 	if !strings.Contains(out, "unavailable") {
 		t.Errorf("expected unavailable note, got %s", out)
+	}
+}
+
+func newAgentAssignHandler(t *testing.T) *HomeAssistantAskHandler {
+	t.Helper()
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori"})
+	return NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Agents: agentRoster(), Now: fixedNow},
+		nil,
+		nil,
+	)
+}
+
+func TestDetectMutation_AssignAgent(t *testing.T) {
+	h := newAgentAssignHandler(t)
+
+	conf := h.detectHomeMutationRequest("add agent Scout to Alpha")
+	if conf == nil {
+		t.Fatal("expected an assign_agent confirmation")
+	}
+	if conf.ActionType != HomeActionAssignAgent {
+		t.Errorf("action type = %q, want %q", conf.ActionType, HomeActionAssignAgent)
+	}
+	if got, _ := conf.Arguments["workspace_id"].(string); got != "ws-1" {
+		t.Errorf("workspace_id = %q, want ws-1", got)
+	}
+	if got, _ := conf.Arguments["agent_name"].(string); got != "Scout" {
+		t.Errorf("agent_name = %q, want Scout", got)
+	}
+}
+
+func TestDetectMutation_AssignAgentUnknownAgentDeclines(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	if conf := h.detectHomeMutationRequest("add agent Nonexistent to Alpha"); conf != nil {
+		t.Fatalf("expected no confirmation for unknown agent, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_AssignAgentUnknownWorkspaceDeclines(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	if conf := h.detectHomeMutationRequest("add agent Scout to Nowhere"); conf != nil {
+		t.Fatalf("expected no confirmation for unknown workspace, got %+v", conf)
+	}
+}
+
+func TestDetectMutation_AddTaskNotMisreadAsAgent(t *testing.T) {
+	h := newAgentAssignHandler(t)
+	// "add a task ... in <workspace>" must remain a create_task, not assign_agent.
+	conf := h.detectHomeMutationRequest("add a task to review metrics in Alpha")
+	if conf == nil {
+		t.Fatal("expected a create_task confirmation")
+	}
+	if conf.ActionType != HomeActionCreateTask {
+		t.Errorf("action type = %q, want %q", conf.ActionType, HomeActionCreateTask)
+	}
+}
+
+func TestAsk_ConfirmAndExecuteAssignAgent(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	makeTestWorkspaceWithAgents(t, store, "ws-1", "Alpha", []string{"Ori"})
+	factory := llm.NewFactory()
+	factory.Register("fake", &fakeProvider{content: "irrelevant"})
+	h := NewHomeAssistantAskHandler(
+		HomeSnapshotSources{Workspaces: store, Agents: agentRoster(), Now: fixedNow},
+		factory,
+		stubSystemModel{provider: "fake", model: "fake-model"},
+	)
+	mut := &recordingMutator{}
+	h.SetMutator(mut)
+
+	resp := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Prompt: "assign Scout to Alpha",
+		Intent: "app_introspection",
+	})
+	if !resp.RequiresConfirmation || resp.Confirmation == nil {
+		t.Fatalf("expected an assign_agent confirmation, got %+v", resp)
+	}
+	if resp.Confirmation.ActionType != HomeActionAssignAgent {
+		t.Fatalf("confirmation type = %q, want %q", resp.Confirmation.ActionType, HomeActionAssignAgent)
+	}
+
+	resp2 := h.Ask(context.Background(), HomeAssistantAskRequest{
+		Intent: "app_introspection",
+		ConfirmedAction: &HomeAction{
+			Type:      HomeActionAssignAgent,
+			Arguments: resp.Confirmation.Arguments,
+		},
+	})
+	if mut.assignedWS != "ws-1" || mut.assignedAgent != "Scout" {
+		t.Errorf("AssignAgent called with (%q, %q), want (ws-1, Scout)", mut.assignedWS, mut.assignedAgent)
+	}
+	foundOpen := false
+	for _, a := range resp2.Actions {
+		if a.Type == HomeActionOpenWorkspace && a.WorkspaceID == "ws-1" {
+			foundOpen = true
+		}
+	}
+	if !foundOpen {
+		t.Errorf("expected open_workspace action after assign, got %+v", resp2.Actions)
 	}
 }

--- a/internal/agenthttp/home_assistant_ask.go
+++ b/internal/agenthttp/home_assistant_ask.go
@@ -25,6 +25,7 @@ const (
 	HomeActionCreateWorkspace = "create_workspace"
 	HomeActionCreateTask      = "create_task"
 	HomeActionStartTask       = "start_task"
+	HomeActionAssignAgent     = "assign_agent"
 	HomeActionAskFollowup     = "ask_followup"
 )
 
@@ -34,6 +35,7 @@ var homeMutatingActionTypes = map[string]bool{
 	HomeActionCreateWorkspace: true,
 	HomeActionCreateTask:      true,
 	HomeActionStartTask:       true,
+	HomeActionAssignAgent:     true,
 }
 
 // HomeAction is a serializable next-step action descriptor returned to the
@@ -85,6 +87,7 @@ type HomeActionMutator interface {
 	CreateWorkspace(ctx context.Context, name, description string) (workspaceID, href string, err error)
 	CreateTask(ctx context.Context, workspaceID, description string) (taskID, href string, err error)
 	StartTask(ctx context.Context, workspaceID, taskID string) (href string, err error)
+	AssignAgent(ctx context.Context, workspaceID, agentName string) (href string, err error)
 }
 
 type homeAskSystemModelReader interface {
@@ -366,6 +369,22 @@ func (h *HomeAssistantAskHandler) executeConfirmedAction(ctx context.Context, in
 			Response: "Started the task.",
 			Intent:   intent,
 			Actions:  []HomeAction{{ID: "open-started-task", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID, TaskID: taskID}},
+		}
+	case HomeActionAssignAgent:
+		wsID := firstNonEmpty(action.WorkspaceID, actionArgString(args, "workspace_id"))
+		agentName := actionArgString(args, "agent_name")
+		if wsID == "" || agentName == "" {
+			return HomeAssistantAskResponse{Response: "I need a workspace and an agent to assign.", Intent: intent}
+		}
+		href, err := h.Mutator.AssignAgent(ctx, wsID, agentName)
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't assign the agent: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionAssignAgent)
+		return HomeAssistantAskResponse{
+			Response: "Assigned " + agentName + " to the workspace.",
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-assigned-ws", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID}},
 		}
 	}
 	return HomeAssistantAskResponse{Response: "Unsupported action.", Intent: intent}

--- a/internal/agenthttp/home_assistant_ask.go
+++ b/internal/agenthttp/home_assistant_ask.go
@@ -26,6 +26,8 @@ const (
 	HomeActionCreateTask      = "create_task"
 	HomeActionStartTask       = "start_task"
 	HomeActionAssignAgent     = "assign_agent"
+	HomeActionCreateAgent     = "create_agent"
+	HomeActionRemoveAgent     = "remove_agent"
 	HomeActionAskFollowup     = "ask_followup"
 )
 
@@ -36,6 +38,8 @@ var homeMutatingActionTypes = map[string]bool{
 	HomeActionCreateTask:      true,
 	HomeActionStartTask:       true,
 	HomeActionAssignAgent:     true,
+	HomeActionCreateAgent:     true,
+	HomeActionRemoveAgent:     true,
 }
 
 // HomeAction is a serializable next-step action descriptor returned to the
@@ -88,6 +92,8 @@ type HomeActionMutator interface {
 	CreateTask(ctx context.Context, workspaceID, description string) (taskID, href string, err error)
 	StartTask(ctx context.Context, workspaceID, taskID string) (href string, err error)
 	AssignAgent(ctx context.Context, workspaceID, agentName string) (href string, err error)
+	CreateAgent(ctx context.Context, name, description string) (href string, err error)
+	RemoveAgent(ctx context.Context, workspaceID, agentName string) (href string, err error)
 }
 
 type homeAskSystemModelReader interface {
@@ -385,6 +391,38 @@ func (h *HomeAssistantAskHandler) executeConfirmedAction(ctx context.Context, in
 			Response: "Assigned " + agentName + " to the workspace.",
 			Intent:   intent,
 			Actions:  []HomeAction{{ID: "open-assigned-ws", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID}},
+		}
+	case HomeActionCreateAgent:
+		name := actionArgString(args, "name")
+		description := actionArgString(args, "description")
+		if name == "" {
+			return HomeAssistantAskResponse{Response: "I need a name to create an agent.", Intent: intent}
+		}
+		href, err := h.Mutator.CreateAgent(ctx, name, description)
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't create the agent: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionCreateAgent)
+		return HomeAssistantAskResponse{
+			Response: "Created the agent " + name + ".",
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-agents", Type: HomeActionNavigate, Label: "Open Agents", Href: href}},
+		}
+	case HomeActionRemoveAgent:
+		wsID := firstNonEmpty(action.WorkspaceID, actionArgString(args, "workspace_id"))
+		agentName := actionArgString(args, "agent_name")
+		if wsID == "" || agentName == "" {
+			return HomeAssistantAskResponse{Response: "I need a workspace and an agent to remove.", Intent: intent}
+		}
+		href, err := h.Mutator.RemoveAgent(ctx, wsID, agentName)
+		if err != nil {
+			return HomeAssistantAskResponse{Response: "I couldn't remove the agent: " + err.Error(), Intent: intent}
+		}
+		h.recordMutation(ctx, intent, HomeActionRemoveAgent)
+		return HomeAssistantAskResponse{
+			Response: "Removed " + agentName + " from the workspace.",
+			Intent:   intent,
+			Actions:  []HomeAction{{ID: "open-removed-ws", Type: HomeActionOpenWorkspace, Label: "Open workspace", Href: href, WorkspaceID: wsID}},
 		}
 	}
 	return HomeAssistantAskResponse{Response: "Unsupported action.", Intent: intent}

--- a/internal/agenthttp/home_assistant_ask_prompt.go
+++ b/internal/agenthttp/home_assistant_ask_prompt.go
@@ -19,7 +19,7 @@ func buildHomeSystemPrompt() string {
 	b.WriteString("Never invent agents, workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
 	b.WriteString("For navigation questions, only reference destinations that appear in the Navigation Catalog; never invent a URL or page name. ")
 	b.WriteString("Be concise and skimmable: lead with the key counts, then a few highlights. ")
-	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, and start (run) an existing task. ")
+	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, start (run) an existing task, and add one of the user's agents to a workspace. ")
 	b.WriteString("These actions always require the user's explicit confirmation before anything happens, so when a user asks you to create or start something, confirm you can and let the confirmation step handle it. ")
 	b.WriteString("When helpful, end with a brief suggestion of a concrete next step. ")
 	b.WriteString("Do not output raw JSON or tool results as your final answer; write a short natural-language summary.")

--- a/internal/agenthttp/home_assistant_ask_prompt.go
+++ b/internal/agenthttp/home_assistant_ask_prompt.go
@@ -11,11 +11,12 @@ const homeMaxNextStepActions = 4
 // the app-scoped analogue of buildTaskSystemPrompt (PRD FR #16).
 func buildHomeSystemPrompt() string {
 	var b strings.Builder
-	b.WriteString("You are Ori's home assistant. You answer questions about the user's own Ori app — their workspaces, tasks, sessions, Action Center opportunities, and usage — and you help them navigate the app. ")
+	b.WriteString("You are Ori's home assistant. You answer questions about the user's own Ori app — their agents, workspaces, tasks, sessions, Action Center opportunities, and usage — and you help them navigate the app. ")
 	b.WriteString("You are given a \"Home Snapshot\" of the user's app-wide state and a \"Navigation Catalog\" of the app's pages. ")
 	b.WriteString("Treat the Home Snapshot as the source of truth for questions about the user's activity and data; use the exact counts and names from it. ")
-	b.WriteString("When a snapshot section is marked truncated, or the user asks for detail beyond it, call the read-only home_* tools (home_workspaces, home_tasks, home_sessions, home_opportunities, home_usage) to read full state. ")
-	b.WriteString("Never invent workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
+	b.WriteString("The snapshot includes the agent roster (each agent's type, role, model, and which workspaces use it), so you can answer \"what agents do I have\", \"what can agent X do\", and \"which agents aren't used anywhere\". ")
+	b.WriteString("When a snapshot section is marked truncated, or the user asks for detail beyond it, call the read-only home_* tools (home_workspaces, home_tasks, home_sessions, home_opportunities, home_usage, home_agents) to read full state. ")
+	b.WriteString("Never invent agents, workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
 	b.WriteString("For navigation questions, only reference destinations that appear in the Navigation Catalog; never invent a URL or page name. ")
 	b.WriteString("Be concise and skimmable: lead with the key counts, then a few highlights. ")
 	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, and start (run) an existing task. ")

--- a/internal/agenthttp/home_assistant_ask_prompt.go
+++ b/internal/agenthttp/home_assistant_ask_prompt.go
@@ -19,7 +19,7 @@ func buildHomeSystemPrompt() string {
 	b.WriteString("Never invent agents, workspaces, tasks, sessions, opportunities, or activity. If a section is empty or marked degraded (data unavailable), say so plainly instead of guessing. ")
 	b.WriteString("For navigation questions, only reference destinations that appear in the Navigation Catalog; never invent a URL or page name. ")
 	b.WriteString("Be concise and skimmable: lead with the key counts, then a few highlights. ")
-	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, start (run) an existing task, and add one of the user's agents to a workspace. ")
+	b.WriteString("Beyond answering, you can act on the user's behalf: create a workspace, create a task in an existing workspace, start (run) an existing task, create a new agent, and add or remove one of the user's agents to/from a workspace. ")
 	b.WriteString("These actions always require the user's explicit confirmation before anything happens, so when a user asks you to create or start something, confirm you can and let the confirmation step handle it. ")
 	b.WriteString("When helpful, end with a brief suggestion of a concrete next step. ")
 	b.WriteString("Do not output raw JSON or tool results as your final answer; write a short natural-language summary.")

--- a/internal/agenthttp/home_assistant_ask_test.go
+++ b/internal/agenthttp/home_assistant_ask_test.go
@@ -51,6 +51,9 @@ func (m *fakeMutator) CreateTask(_ context.Context, wsID, _ string) (string, str
 func (m *fakeMutator) StartTask(_ context.Context, wsID, _ string) (string, error) {
 	return "/workspaces/" + wsID, nil
 }
+func (m *fakeMutator) AssignAgent(_ context.Context, wsID, _ string) (string, error) {
+	return "/workspaces/" + wsID, nil
+}
 
 func newAskHandlerWithProvider(t *testing.T, content string) *HomeAssistantAskHandler {
 	t.Helper()

--- a/internal/agenthttp/home_assistant_ask_test.go
+++ b/internal/agenthttp/home_assistant_ask_test.go
@@ -54,6 +54,12 @@ func (m *fakeMutator) StartTask(_ context.Context, wsID, _ string) (string, erro
 func (m *fakeMutator) AssignAgent(_ context.Context, wsID, _ string) (string, error) {
 	return "/workspaces/" + wsID, nil
 }
+func (m *fakeMutator) CreateAgent(_ context.Context, _, _ string) (string, error) {
+	return "/agents", nil
+}
+func (m *fakeMutator) RemoveAgent(_ context.Context, wsID, _ string) (string, error) {
+	return "/workspaces/" + wsID, nil
+}
 
 func newAskHandlerWithProvider(t *testing.T, content string) *HomeAssistantAskHandler {
 	t.Helper()

--- a/internal/agenthttp/home_assistant_task_mutation.go
+++ b/internal/agenthttp/home_assistant_task_mutation.go
@@ -21,12 +21,80 @@ func (h *HomeAssistantAskHandler) detectHomeMutationRequest(prompt string) *Home
 	if conf := detectWorkspaceCreationRequest(prompt); conf != nil {
 		return conf
 	}
+	if conf := detectCreateAgentRequest(prompt); conf != nil {
+		return conf
+	}
+	if conf := h.detectRemoveAgentRequest(prompt); conf != nil {
+		return conf
+	}
 	// Agent assignment is checked before task creation: "add agent X to Y" and
 	// "add a task to Y" share the "add" verb but differ by the agent/task keyword.
 	if conf := h.detectAssignAgentRequest(prompt); conf != nil {
 		return conf
 	}
 	return h.detectTaskMutationRequest(prompt)
+}
+
+// detectCreateAgentRequest matches "create/new/make an agent called/named X" and
+// proposes a create_agent confirmation. Parallels workspace creation.
+func detectCreateAgentRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" || !hasCreateVerb(lower) {
+		return nil
+	}
+	for _, marker := range []string{"agent called ", "agent named "} {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			continue
+		}
+		name := strings.TrimSpace(trimmed[idx+len(marker):])
+		name = strings.Trim(name, " .\"'")
+		if name == "" {
+			continue
+		}
+		return &HomeActionConfirmation{
+			ActionID:   "create-agent",
+			ActionType: HomeActionCreateAgent,
+			Summary:    fmt.Sprintf("Create a new agent named %q?", name),
+			Arguments:  map[string]any{"name": name},
+		}
+	}
+	return nil
+}
+
+// detectRemoveAgentRequest matches "remove/unassign agent X from <workspace>" and
+// proposes a remove_agent confirmation. The agent (against the roster) and the
+// workspace must both resolve, otherwise it falls through.
+func (h *HomeAssistantAskHandler) detectRemoveAgentRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" {
+		return nil
+	}
+	if !strings.HasPrefix(lower, "remove ") && !strings.HasPrefix(lower, "unassign ") {
+		return nil
+	}
+	if !strings.Contains(lower, " from ") {
+		return nil
+	}
+	if h.Sources.Workspaces == nil || h.Sources.Agents == nil {
+		return nil
+	}
+	agentName, ok := matchAgentInPrompt(h.Sources.Agents, prompt)
+	if !ok {
+		return nil
+	}
+	wsID, wsName, ok := matchWorkspaceInPrompt(h.Sources.Workspaces, prompt)
+	if !ok {
+		return nil
+	}
+	return &HomeActionConfirmation{
+		ActionID:   "remove-agent",
+		ActionType: HomeActionRemoveAgent,
+		Summary:    fmt.Sprintf("Remove agent %q from workspace %q?", agentName, wsName),
+		Arguments:  map[string]any{"workspace_id": wsID, "agent_name": agentName},
+	}
 }
 
 // detectAssignAgentRequest matches "add/assign agent X to <workspace>" and

--- a/internal/agenthttp/home_assistant_task_mutation.go
+++ b/internal/agenthttp/home_assistant_task_mutation.go
@@ -21,7 +21,72 @@ func (h *HomeAssistantAskHandler) detectHomeMutationRequest(prompt string) *Home
 	if conf := detectWorkspaceCreationRequest(prompt); conf != nil {
 		return conf
 	}
+	// Agent assignment is checked before task creation: "add agent X to Y" and
+	// "add a task to Y" share the "add" verb but differ by the agent/task keyword.
+	if conf := h.detectAssignAgentRequest(prompt); conf != nil {
+		return conf
+	}
 	return h.detectTaskMutationRequest(prompt)
+}
+
+// detectAssignAgentRequest matches "add/assign agent X to <workspace>" and
+// proposes an assign_agent confirmation. Both the agent (against the roster) and
+// the workspace must resolve to real state, otherwise it falls through.
+func (h *HomeAssistantAskHandler) detectAssignAgentRequest(prompt string) *HomeActionConfirmation {
+	trimmed := strings.TrimSpace(prompt)
+	lower := strings.ToLower(trimmed)
+	if lower == "" {
+		return nil
+	}
+	assignVerb := strings.HasPrefix(lower, "assign ")
+	addVerb := strings.HasPrefix(lower, "add ") || strings.HasPrefix(lower, "put ")
+	if !assignVerb && !addVerb {
+		return nil
+	}
+	// "assign X to Y" is unambiguous; "add/put" share the "add" verb with task
+	// creation, so require the explicit "agent" keyword to disambiguate.
+	if addVerb && !strings.Contains(lower, "agent") {
+		return nil
+	}
+	if h.Sources.Workspaces == nil || h.Sources.Agents == nil {
+		return nil
+	}
+	wsID, wsName, ok := matchWorkspaceInPrompt(h.Sources.Workspaces, prompt)
+	if !ok {
+		return nil
+	}
+	agentName, ok := matchAgentInPrompt(h.Sources.Agents, prompt)
+	if !ok {
+		return nil
+	}
+	return &HomeActionConfirmation{
+		ActionID:   "assign-agent",
+		ActionType: HomeActionAssignAgent,
+		Summary:    fmt.Sprintf("Add agent %q to workspace %q?", agentName, wsName),
+		Arguments:  map[string]any{"workspace_id": wsID, "agent_name": agentName},
+	}
+}
+
+// matchAgentInPrompt returns the name of a roster agent that appears in the
+// prompt (longest match wins), so assignment resolves to a real agent.
+func matchAgentInPrompt(reader homeAgentsReader, prompt string) (string, bool) {
+	if reader == nil {
+		return "", false
+	}
+	roster, ok := reader.AgentRoster()
+	if !ok {
+		return "", false
+	}
+	p := strings.ToLower(prompt)
+	best := ""
+	bestLen := 0
+	for _, a := range roster {
+		name := strings.ToLower(strings.TrimSpace(a.Name))
+		if len(name) >= 2 && strings.Contains(p, name) && len(name) > bestLen {
+			best, bestLen = a.Name, len(name)
+		}
+	}
+	return best, bestLen > 0
 }
 
 // detectWorkspaceCreationRequest matches "create/new/make/add a workspace

--- a/internal/agenthttp/home_assistant_task_mutation.go
+++ b/internal/agenthttp/home_assistant_task_mutation.go
@@ -150,7 +150,9 @@ func matchAgentInPrompt(reader homeAgentsReader, prompt string) (string, bool) {
 	bestLen := 0
 	for _, a := range roster {
 		name := strings.ToLower(strings.TrimSpace(a.Name))
-		if len(name) >= 2 && strings.Contains(p, name) && len(name) > bestLen {
+		// Require >= 3 chars (matching matchWorkspaceInPrompt) so very short agent
+		// names don't substring-match unrelated words; longest match wins.
+		if len(name) >= 3 && strings.Contains(p, name) && len(name) > bestLen {
 			best, bestLen = a.Name, len(name)
 		}
 	}

--- a/internal/agenthttp/home_assistant_task_mutation_test.go
+++ b/internal/agenthttp/home_assistant_task_mutation_test.go
@@ -235,6 +235,8 @@ type recordingMutator struct {
 	startedTask    string
 	createdTaskWS  string
 	createdTaskDsc string
+	assignedWS     string
+	assignedAgent  string
 }
 
 func (m *recordingMutator) CreateWorkspace(_ context.Context, name, _ string) (string, string, error) {
@@ -250,5 +252,11 @@ func (m *recordingMutator) CreateTask(_ context.Context, wsID, description strin
 func (m *recordingMutator) StartTask(_ context.Context, wsID, taskID string) (string, error) {
 	m.startedWS = wsID
 	m.startedTask = taskID
+	return "/workspaces/" + wsID, nil
+}
+
+func (m *recordingMutator) AssignAgent(_ context.Context, wsID, agentName string) (string, error) {
+	m.assignedWS = wsID
+	m.assignedAgent = agentName
 	return "/workspaces/" + wsID, nil
 }

--- a/internal/agenthttp/home_assistant_task_mutation_test.go
+++ b/internal/agenthttp/home_assistant_task_mutation_test.go
@@ -231,12 +231,16 @@ func TestAsk_ConfirmAndExecuteStartTask(t *testing.T) {
 
 // recordingMutator captures the arguments passed to each mutator method.
 type recordingMutator struct {
-	startedWS      string
-	startedTask    string
-	createdTaskWS  string
-	createdTaskDsc string
-	assignedWS     string
-	assignedAgent  string
+	startedWS       string
+	startedTask     string
+	createdTaskWS   string
+	createdTaskDsc  string
+	assignedWS      string
+	assignedAgent   string
+	createdAgent    string
+	createdAgentDsc string
+	removedWS       string
+	removedAgent    string
 }
 
 func (m *recordingMutator) CreateWorkspace(_ context.Context, name, _ string) (string, string, error) {
@@ -258,5 +262,17 @@ func (m *recordingMutator) StartTask(_ context.Context, wsID, taskID string) (st
 func (m *recordingMutator) AssignAgent(_ context.Context, wsID, agentName string) (string, error) {
 	m.assignedWS = wsID
 	m.assignedAgent = agentName
+	return "/workspaces/" + wsID, nil
+}
+
+func (m *recordingMutator) CreateAgent(_ context.Context, name, description string) (string, error) {
+	m.createdAgent = name
+	m.createdAgentDsc = description
+	return "/agents", nil
+}
+
+func (m *recordingMutator) RemoveAgent(_ context.Context, wsID, agentName string) (string, error) {
+	m.removedWS = wsID
+	m.removedAgent = agentName
 	return "/workspaces/" + wsID, nil
 }

--- a/internal/agenthttp/home_snapshot.go
+++ b/internal/agenthttp/home_snapshot.go
@@ -3,6 +3,7 @@ package agenthttp
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ const (
 	homeSnapshotMaxTasks         = 40
 	homeSnapshotMaxSessions      = 20
 	homeSnapshotMaxOpportunities = 20
+	homeSnapshotMaxAgents        = 30
 	homeSnapshotPreviewLimit     = 180
 	homeSnapshotTextLimit        = 120
 )
@@ -66,6 +68,15 @@ type homeUsageReader interface {
 	UsageSummary() (HomeUsageSummary, bool)
 }
 
+// homeAgentsReader returns the app-wide agent roster. The server wires an
+// agent-store adapter so agenthttp stays decoupled from the agent/store
+// packages. A false ok degrades the agents section rather than failing the
+// answer. Workspace usage is cross-referenced from the workspace list, not the
+// reader, so the roster carries only per-agent profile fields.
+type homeAgentsReader interface {
+	AgentRoster() ([]HomeAgentSummary, bool)
+}
+
 // HomeSnapshotSources bundles the data sources the snapshot aggregates. Any may
 // be nil; a nil source degrades its section instead of failing the snapshot.
 type HomeSnapshotSources struct {
@@ -73,6 +84,7 @@ type HomeSnapshotSources struct {
 	Opportunities workspace.OpportunityStore
 	Sessions      homeRecentSessionsReader
 	Usage         homeUsageReader
+	Agents        homeAgentsReader
 	// Now allows tests to pin the clock; defaults to time.Now.
 	Now func() time.Time
 }
@@ -99,6 +111,23 @@ type HomeTaskSummary struct {
 	UpdatedAt     time.Time
 }
 
+// HomeAgentSummary is a single agent profile in the app-wide roster, plus the
+// count and names of workspaces that use it (cross-referenced from the workspace
+// list, so the home assistant can answer "which agents do I have and where are
+// they used").
+type HomeAgentSummary struct {
+	Name           string
+	Type           string
+	Role           string
+	Model          string
+	Provider       string
+	Description    string
+	Capabilities   []string
+	Status         string
+	WorkspaceCount int
+	Workspaces     []string
+}
+
 // HomeOpportunitySummary is a single open Action Center opportunity.
 type HomeOpportunitySummary struct {
 	ID            string
@@ -120,6 +149,7 @@ type HomeSnapshotMeta struct {
 	TaskCount        int            `json:"task_count"`
 	SessionCount     int            `json:"session_count"`
 	OpportunityCount int            `json:"opportunity_count"`
+	AgentCount       int            `json:"agent_count"`
 	Truncated        []string       `json:"truncated,omitempty"`
 	Degraded         []string       `json:"degraded,omitempty"`
 }
@@ -132,6 +162,7 @@ type HomeSnapshot struct {
 	Tasks         []HomeTaskSummary
 	Sessions      []HomeSessionSummary
 	Opportunities []HomeOpportunitySummary
+	Agents        []HomeAgentSummary
 	Usage         *HomeUsageSummary
 }
 
@@ -234,7 +265,8 @@ func BuildHomeSnapshot(ctx context.Context, sources HomeSnapshotSources, window 
 		TaskCounts: map[string]int{},
 	}
 
-	wsByID := map[string]string{} // id -> name, for cross-section labeling
+	wsByID := map[string]string{}            // id -> name, for cross-section labeling
+	agentWorkspaces := map[string][]string{} // agent name -> workspace names that use it
 
 	// Workspaces + tasks.
 	if sources.Workspaces == nil {
@@ -265,6 +297,9 @@ func BuildHomeSnapshot(ctx context.Context, sources HomeSnapshotSources, window 
 			var windowedTasks []HomeTaskSummary
 			for _, ws := range workspaces {
 				wsByID[ws.ID] = ws.Name
+				for _, agentName := range workspaceAgentNames(ws) {
+					agentWorkspaces[agentName] = append(agentWorkspaces[agentName], ws.Name)
+				}
 				stats := ws.GetTaskStats()
 				for k, v := range stats {
 					snap.TaskCounts[k] += v
@@ -334,7 +369,91 @@ func BuildHomeSnapshot(ctx context.Context, sources HomeSnapshotSources, window 
 		snap.Meta.Degraded = append(snap.Meta.Degraded, "usage")
 	}
 
+	// Agents (roster + workspace usage cross-referenced from the workspace loop).
+	snap.Agents, snap.Meta.AgentCount = collectHomeAgents(sources.Agents, agentWorkspaces, &snap.Meta)
+
 	return snap
+}
+
+// collectHomeAgents reads the agent roster, fills in each agent's workspace usage
+// from the cross-reference map, and applies the snapshot cap. A nil/failed reader
+// degrades the agents section.
+func collectHomeAgents(reader homeAgentsReader, agentWorkspaces map[string][]string, meta *HomeSnapshotMeta) ([]HomeAgentSummary, int) {
+	if reader == nil {
+		meta.Degraded = append(meta.Degraded, "agents")
+		return nil, 0
+	}
+	roster, ok := reader.AgentRoster()
+	if !ok {
+		meta.Degraded = append(meta.Degraded, "agents")
+		return nil, 0
+	}
+	for i := range roster {
+		names := dedupeSortedStrings(agentWorkspaces[roster[i].Name])
+		roster[i].Workspaces = names
+		roster[i].WorkspaceCount = len(names)
+	}
+	// Most-used agents first, then alphabetical for stability.
+	sort.Slice(roster, func(i, j int) bool {
+		if roster[i].WorkspaceCount != roster[j].WorkspaceCount {
+			return roster[i].WorkspaceCount > roster[j].WorkspaceCount
+		}
+		return roster[i].Name < roster[j].Name
+	})
+	total := len(roster)
+	if len(roster) > homeSnapshotMaxAgents {
+		roster = roster[:homeSnapshotMaxAgents]
+		meta.Truncated = append(meta.Truncated, "agents")
+	}
+	return roster, total
+}
+
+// workspaceAgentNames returns the distinct agent profile names a workspace uses,
+// preferring stable AgentInstances and falling back to the deprecated Agents
+// slice. Field access mirrors the lock-free reads elsewhere in this snapshot.
+func workspaceAgentNames(ws *workspace.Workspace) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	add := func(raw string) {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for _, inst := range ws.AgentInstances {
+		add(inst.Name)
+	}
+	for _, name := range ws.Agents {
+		add(name)
+	}
+	return names
+}
+
+// dedupeSortedStrings returns the unique, sorted set of non-empty strings.
+func dedupeSortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func collectHomeOpportunities(store workspace.OpportunityStore, workspaces []*workspace.Workspace, meta *HomeSnapshotMeta) ([]HomeOpportunitySummary, int) {
@@ -433,6 +552,21 @@ func (s HomeSnapshot) PromptText() string {
 			homeSnapshotDate(ws.UpdatedAt), ws.ID)
 	}
 
+	fmt.Fprintf(&b, "\n### Agents (%d)\n\n", s.Meta.AgentCount)
+	if len(s.Agents) == 0 {
+		if slices.Contains(s.Meta.Degraded, "agents") {
+			b.WriteString("- unavailable\n")
+		} else {
+			b.WriteString("- none\n")
+		}
+	}
+	for _, a := range s.Agents {
+		fmt.Fprintf(&b, "- %q type=%s role=%s model=%s/%s used_in=%d workspace(s)%s%s\n",
+			homeSnapshotClip(a.Name, homeSnapshotTextLimit), emptyTo(a.Type, "n/a"), emptyTo(a.Role, "n/a"),
+			emptyTo(a.Provider, "n/a"), emptyTo(a.Model, "n/a"), a.WorkspaceCount,
+			homeAgentWorkspacesText(a.Workspaces), homeAgentDescriptionText(a.Description))
+	}
+
 	b.WriteString("\n### Task activity\n\n")
 	b.WriteString("- Counts (all-time): " + homeTaskCountsLine(s.TaskCounts) + "\n")
 	fmt.Fprintf(&b, "- Tasks active in window: %d\n", s.Meta.TaskCount)
@@ -475,6 +609,32 @@ func (s HomeSnapshot) PromptText() string {
 
 	b.WriteString("\nUse this snapshot as the source of truth for app-data questions. Call the home_* tools to read full state when a section is truncated or you need detail. Do not fabricate activity; if a section is empty or degraded, say so.\n")
 	return b.String()
+}
+
+func homeAgentWorkspacesText(workspaces []string) string {
+	if len(workspaces) == 0 {
+		return ""
+	}
+	const maxNamed = 5
+	named := workspaces
+	suffix := ""
+	if len(named) > maxNamed {
+		named = named[:maxNamed]
+		suffix = ", …"
+	}
+	clipped := make([]string, 0, len(named))
+	for _, name := range named {
+		clipped = append(clipped, homeSnapshotClip(name, homeSnapshotTextLimit))
+	}
+	return " [" + strings.Join(clipped, ", ") + suffix + "]"
+}
+
+func homeAgentDescriptionText(description string) string {
+	clipped := homeSnapshotClip(description, homeSnapshotPreviewLimit)
+	if clipped == "" {
+		return ""
+	}
+	return " — " + clipped
 }
 
 func homeTaskCountsLine(stats map[string]int) string {

--- a/internal/agenthttp/home_snapshot_test.go
+++ b/internal/agenthttp/home_snapshot_test.go
@@ -34,6 +34,13 @@ type stubUsageReader struct {
 
 func (u stubUsageReader) UsageSummary() (HomeUsageSummary, bool) { return u.summary, u.ok }
 
+type stubAgentsReader struct {
+	roster []HomeAgentSummary
+	ok     bool
+}
+
+func (a stubAgentsReader) AgentRoster() ([]HomeAgentSummary, bool) { return a.roster, a.ok }
+
 func fixedNow() time.Time {
 	// A Wednesday so "this week" (Mon-based) has prior days inside the window.
 	return time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
@@ -87,11 +94,15 @@ func TestBuildHomeSnapshot_WithData(t *testing.T) {
 		Opportunities: workspace.NewOpportunityStore(store),
 		Sessions:      stubSessionsReader{sessions: []HomeSessionSummary{{ID: "s1", Title: "Chat", AgentName: "Ori", MessageCount: 4, UpdatedAt: now}}},
 		Usage:         stubUsageReader{summary: HomeUsageSummary{TodayCost: 0.12, TodayTokens: 1000, MonthCost: 3.4, MonthTokens: 50000, Currency: "USD"}, ok: true},
+		Agents:        stubAgentsReader{roster: []HomeAgentSummary{{Name: "Ori", Type: "tool-calling", Role: "orchestrator", Model: "gpt-5", Provider: "openai"}}, ok: true},
 		Now:           fixedNow,
 	}, HomeWindowThisWeek)
 
 	if snap.Meta.WorkspaceCount != 2 {
 		t.Errorf("WorkspaceCount = %d, want 2", snap.Meta.WorkspaceCount)
+	}
+	if snap.Meta.AgentCount != 1 || len(snap.Agents) != 1 || snap.Agents[0].Name != "Ori" {
+		t.Errorf("expected 1 agent 'Ori', got count=%d agents=%+v", snap.Meta.AgentCount, snap.Agents)
 	}
 	// Only the in-window task should appear; the 3-month-old completed task is out.
 	if snap.Meta.TaskCount != 1 || len(snap.Tasks) != 1 || snap.Tasks[0].Description != "recent task" {

--- a/internal/agenthttp/home_tools.go
+++ b/internal/agenthttp/home_tools.go
@@ -90,13 +90,25 @@ func (r *homeToolRegistry) Definitions() []llm.Tool {
 				"properties": map[string]any{},
 			},
 		},
+		{
+			Name:        "home_agents",
+			Description: "List the user's agents (the roster the OS manages), with type, role, model, capabilities, and which workspaces use each. Read-only.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":         map[string]any{"type": "string", "description": "Optional case-insensitive substring filter on agent name."},
+					"workspace_id": map[string]any{"type": "string", "description": "Optional: only agents used by this workspace."},
+					"limit":        map[string]any{"type": "integer", "description": "Max results (default 50, max 100)."},
+				},
+			},
+		},
 	}
 }
 
 // Has reports whether a tool name belongs to this registry.
 func (r *homeToolRegistry) Has(name string) bool {
 	switch name {
-	case "home_workspaces", "home_tasks", "home_sessions", "home_opportunities", "home_usage":
+	case "home_workspaces", "home_tasks", "home_sessions", "home_opportunities", "home_usage", "home_agents":
 		return true
 	}
 	return false
@@ -119,6 +131,8 @@ func (r *homeToolRegistry) Execute(ctx context.Context, name, argsJSON string) (
 		return r.opportunities(args)
 	case "home_usage":
 		return r.usage()
+	case "home_agents":
+		return r.agents(args)
 	default:
 		return "", fmt.Errorf("unknown home tool %q", name)
 	}
@@ -363,6 +377,85 @@ func (r *homeToolRegistry) opportunities(args map[string]any) (string, error) {
 		rows = rows[:limit]
 	}
 	return homeToolJSON(map[string]any{"opportunities": rows, "total": total})
+}
+
+func (r *homeToolRegistry) agents(args map[string]any) (string, error) {
+	if r.sources.Agents == nil {
+		return homeToolJSON(map[string]any{"agents": []any{}, "note": "agent roster unavailable"})
+	}
+	roster, ok := r.sources.Agents.AgentRoster()
+	if !ok {
+		return homeToolJSON(map[string]any{"agents": []any{}, "note": "agent roster unavailable"})
+	}
+	nameFilter := strings.ToLower(homeToolString(args, "name"))
+	wsFilter := homeToolString(args, "workspace_id")
+	limit := homeToolLimit(args)
+
+	// Cross-reference workspace usage from the workspace list (read-only).
+	agentWorkspaces := map[string][]string{}
+	if r.sources.Workspaces != nil {
+		if ids, err := r.sources.Workspaces.List(); err == nil {
+			for _, id := range ids {
+				ws, getErr := r.sources.Workspaces.Get(id)
+				if getErr != nil || ws == nil || isGroupWorkspace(ws) {
+					continue
+				}
+				if wsFilter != "" && ws.ID != wsFilter {
+					continue
+				}
+				for _, agentName := range workspaceAgentNames(ws) {
+					agentWorkspaces[agentName] = append(agentWorkspaces[agentName], ws.Name)
+				}
+			}
+		}
+	}
+
+	type row struct {
+		Name           string   `json:"name"`
+		Type           string   `json:"type"`
+		Role           string   `json:"role"`
+		Model          string   `json:"model"`
+		Provider       string   `json:"provider"`
+		Description    string   `json:"description,omitempty"`
+		Capabilities   []string `json:"capabilities,omitempty"`
+		Status         string   `json:"status,omitempty"`
+		WorkspaceCount int      `json:"workspace_count"`
+		Workspaces     []string `json:"workspaces,omitempty"`
+	}
+	var rows []row
+	for _, a := range roster {
+		if nameFilter != "" && !strings.Contains(strings.ToLower(a.Name), nameFilter) {
+			continue
+		}
+		used := dedupeSortedStrings(agentWorkspaces[a.Name])
+		// When filtering by workspace, drop agents not used by it.
+		if wsFilter != "" && len(used) == 0 {
+			continue
+		}
+		rows = append(rows, row{
+			Name:           a.Name,
+			Type:           a.Type,
+			Role:           a.Role,
+			Model:          a.Model,
+			Provider:       a.Provider,
+			Description:    homeSnapshotClip(a.Description, homeSnapshotPreviewLimit),
+			Capabilities:   a.Capabilities,
+			Status:         a.Status,
+			WorkspaceCount: len(used),
+			Workspaces:     used,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].WorkspaceCount != rows[j].WorkspaceCount {
+			return rows[i].WorkspaceCount > rows[j].WorkspaceCount
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return homeToolJSON(map[string]any{"agents": rows, "total": total})
 }
 
 func (r *homeToolRegistry) usage() (string, error) {

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -266,13 +266,17 @@ func (m homeActionMutator) CreateAgent(ctx context.Context, name, description st
 		return href, err
 	}
 	if description = strings.TrimSpace(description); description != "" {
-		_ = m.agents.UpdateAgent(name, func(ag *agent.Agent) error {
+		// The agent already exists at this point; a failed description write is
+		// non-fatal (creation succeeded) but worth a warning for debugging.
+		if updErr := m.agents.UpdateAgent(name, func(ag *agent.Agent) error {
 			if ag.Metadata == nil {
 				ag.Metadata = &types.AgentMetadata{}
 			}
 			ag.Metadata.Description = description
 			return nil
-		})
+		}); updErr != nil {
+			logger.Warn("home assistant: failed to set new agent description", logger.Fields{"agent": name, "err": updErr})
+		}
 	}
 	return href, nil
 }

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/johnjallday/ori-agent/internal/agenthttp"
 	"github.com/johnjallday/ori-agent/internal/llm"
@@ -220,6 +221,30 @@ func (m homeActionMutator) StartTask(ctx context.Context, workspaceID, taskID st
 		}
 	}()
 
+	return href, nil
+}
+
+func (m homeActionMutator) AssignAgent(ctx context.Context, workspaceID, agentName string) (string, error) {
+	href := "/workspaces/" + workspaceID
+	if m.workspaces == nil {
+		return href, fmt.Errorf("workspace store unavailable")
+	}
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		return href, fmt.Errorf("agent name is required")
+	}
+	// Defense in depth: never add a phantom agent even if the client supplies one.
+	if m.agents != nil {
+		if _, ok := m.agents.GetAgent(agentName); !ok {
+			return href, fmt.Errorf("agent %q does not exist", agentName)
+		}
+	}
+	err := m.workspaces.Update(workspaceID, func(ws *workspace.Workspace) error {
+		return ws.AddAgent(agentName)
+	})
+	if err != nil {
+		return href, err
+	}
 	return href, nil
 }
 

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -67,6 +67,42 @@ func (a homeUsageAdapter) UsageSummary() (agenthttp.HomeUsageSummary, bool) {
 	}, true
 }
 
+// homeAgentsAdapter bridges the agent store to the home harness's agent-roster
+// reader, keeping agenthttp decoupled from the agent/store packages. Workspace
+// usage is cross-referenced in the snapshot/tool, so the roster carries only
+// per-agent profile fields.
+type homeAgentsAdapter struct {
+	agents store.Store
+}
+
+func (a homeAgentsAdapter) AgentRoster() ([]agenthttp.HomeAgentSummary, bool) {
+	if a.agents == nil {
+		return nil, false
+	}
+	names := a.agents.ListAgents()
+	out := make([]agenthttp.HomeAgentSummary, 0, len(names))
+	for _, name := range names {
+		ag, ok := a.agents.GetAgent(name)
+		if !ok || ag == nil {
+			continue
+		}
+		summary := agenthttp.HomeAgentSummary{
+			Name:         name,
+			Type:         ag.Type,
+			Role:         string(ag.Role),
+			Model:        ag.Settings.Model,
+			Provider:     ag.Settings.Provider,
+			Capabilities: ag.Capabilities,
+			Status:       string(ag.Status),
+		}
+		if ag.Metadata != nil {
+			summary.Description = ag.Metadata.Description
+		}
+		out = append(out, summary)
+	}
+	return out, true
+}
+
 // homeActionMutator executes confirmed home actions (PRD 4.6). CreateWorkspace,
 // CreateTask, and StartTask are wired; StartTask runs the task through the same
 // orchestrator path the workspace UI uses, so coordinator-driven assignment and
@@ -201,6 +237,9 @@ func (s *Server) newHomeAssistantAskHandler() *agenthttp.HomeAssistantAskHandler
 			sources.Opportunities = workspace.NewOpportunityStore(s.Storage.WorkspaceStore)
 		}
 		sources.Sessions = homeRecentSessionsAdapter{store: s.Storage.SessionStore}
+		if s.Storage.AgentStore != nil {
+			sources.Agents = homeAgentsAdapter{agents: s.Storage.AgentStore}
+		}
 	}
 	if s.Core != nil {
 		sources.Usage = homeUsageAdapter{tracker: s.Core.CostTracker}

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/agenthttp"
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
@@ -241,6 +243,51 @@ func (m homeActionMutator) AssignAgent(ctx context.Context, workspaceID, agentNa
 	}
 	err := m.workspaces.Update(workspaceID, func(ws *workspace.Workspace) error {
 		return ws.AddAgent(agentName)
+	})
+	if err != nil {
+		return href, err
+	}
+	return href, nil
+}
+
+func (m homeActionMutator) CreateAgent(ctx context.Context, name, description string) (string, error) {
+	const href = "/agents"
+	if m.agents == nil {
+		return href, fmt.Errorf("agent store unavailable")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return href, fmt.Errorf("agent name is required")
+	}
+	if _, exists := m.agents.GetAgent(name); exists {
+		return href, fmt.Errorf("an agent named %q already exists", name)
+	}
+	if err := m.agents.CreateAgent(name, &store.CreateAgentConfig{}); err != nil {
+		return href, err
+	}
+	if description = strings.TrimSpace(description); description != "" {
+		_ = m.agents.UpdateAgent(name, func(ag *agent.Agent) error {
+			if ag.Metadata == nil {
+				ag.Metadata = &types.AgentMetadata{}
+			}
+			ag.Metadata.Description = description
+			return nil
+		})
+	}
+	return href, nil
+}
+
+func (m homeActionMutator) RemoveAgent(ctx context.Context, workspaceID, agentName string) (string, error) {
+	href := "/workspaces/" + workspaceID
+	if m.workspaces == nil {
+		return href, fmt.Errorf("workspace store unavailable")
+	}
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		return href, fmt.Errorf("agent name is required")
+	}
+	err := m.workspaces.Update(workspaceID, func(ws *workspace.Workspace) error {
+		return ws.RemoveAgent(agentName)
 	})
 	if err != nil {
 		return href, err

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -8635,7 +8635,8 @@
   }
 
   function isMutatingHomeActionType(type) {
-    return type === 'create_workspace' || type === 'create_task' || type === 'start_task' || type === 'assign_agent';
+    return type === 'create_workspace' || type === 'create_task' || type === 'start_task' ||
+      type === 'assign_agent' || type === 'create_agent' || type === 'remove_agent';
   }
 
   // buildHomeActionButtons maps the backend action schema to renderHomeAssistant-

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -8635,7 +8635,7 @@
   }
 
   function isMutatingHomeActionType(type) {
-    return type === 'create_workspace' || type === 'create_task' || type === 'start_task';
+    return type === 'create_workspace' || type === 'create_task' || type === 'start_task' || type === 'assign_agent';
   }
 
   // buildHomeActionButtons maps the backend action schema to renderHomeAssistant-


### PR DESCRIPTION
> ⚠️ **Stacked on #74 — merge #74 first.** Branched off `feature/home-assistant-task-actions` (#74), so until #74 merges to `dev` this PR's diff also shows #74's commits. Once #74 merges, this diff collapses to just the agent-management changes below. Targets `dev` so CI runs (CI skips feature-branch bases).

## Summary

Gives the home **"Ask Ori"** assistant the **full agent-management lifecycle** — see, create, deploy, and remove the agents an AI OS coordinates. Until now the home snapshot didn't even include agents; now the assistant can read the roster and manage it end to end, every mutation behind explicit confirmation.

### Read — roster awareness
- **Snapshot** (`home_snapshot.go`): `HomeAgentSummary` (type, role, model, provider, capabilities, status) + each agent's **workspace usage**, cross-referenced from the workspace list. Bounded, degrades like other sections, rendered most-used-first.
- **Read tool** (`home_tools.go`): `home_agents` with `name` / `workspace_id` filters.
- **Server**: `homeAgentsAdapter` bridges the agent store to the roster reader.

Answers *"what agents do I have / what can X do / which agents are unused"*.

### Write — lifecycle (all confirm-gated)
| Mutation | Example prompt | Server behavior |
| --- | --- | --- |
| `create_agent` | "create an agent called Atlas" | `store.CreateAgent` w/ default settings; rejects duplicate name; sets description if given |
| `assign_agent` | "add agent Scout to Ops" / "assign Scout to Ops" | `Workspace.AddAgent`; re-validates the agent exists |
| `remove_agent` | "remove agent Scout from Ops" | `Workspace.RemoveAgent`; guards the required entry agent |

Detection resolves agents against the roster and workspaces against real state, and is ordered so `create_agent`≠`create_workspace` and `remove_agent`/`assign_agent` don't collide with task phrasings. The model is never handed write tools — it only ever proposes; execution happens on a confirmed follow-up.

### Docs / frontend
`agent_count`, `home_agents`, and the `create_agent` / `assign_agent` / `remove_agent` action + confirmation entries added to the `/api/home-assistant/ask` reference. Frontend treats all three as confirmed mutations (`agent_name` flows through existing confirmation arguments).

## Why this advances the AI-OS goal

"A personal assistant that manages other agents and workspaces" needs to see *and* manage its agents across their lifecycle. This PR delivers the full surface: report the roster with capabilities/placement, create new agents, and add/remove them from workspaces — alongside the task actions in #74 (create/start tasks).

## Tests

Roster: cross-reference (usage counts, most-used-first, unused agents), degrade-when-no-reader, `home_agents` filters, unavailable reader. Lifecycle: detection happy-paths + declines for each of create/assign/remove (incl. "add a task"/"remove a task" not misread as agent ops, create_agent vs create_workspace), and confirm→execute for create/assign/remove. `go build`, `go vet`, full `go test ./...`, `golangci-lint` (0 issues), `gofmt`, eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)