### PR TITLE
feat: workspace UI/UX update — drag grouping + unified tag system

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -20,6 +20,7 @@ http://localhost:8765/api
 - [Vault API](#vault-api)
 - [Chat API](#chat-api)
 - [Updates API](#updates-api)
+- [Tags API](#tags-api)
 - [Workspace Groups](#workspace-groups)
 - [Scheduler Nodes API](#scheduler-nodes-api)
 - [Custom Workflows API](#custom-workflows-api)
@@ -870,6 +871,69 @@ POST   /api/project-templates/reveal          { "id": "..." }   // empty id open
 Import copies the folder **verbatim** (no token substitution — `{{name}}` in file names is preserved for instantiation time; symlinks skipped). Delete prefers the system Trash; deleted starter templates are re-materialized on the next server start. Metadata updates preserve unknown `template.json` fields.
 
 **Settings:** `GET`/`POST /api/settings/templates-root` mirrors the workspace/vault root endpoints (`templates_root`, `effective_templates_root`, `default_templates_root`, `source`). Changing the root materializes the library (including absent starters) in the new location.
+
+## Tags API
+
+Tags form one normalized vocabulary (trimmed, lowercased, ≤64 chars, ≤20 per entity) shared by **workspaces**, **chat sessions**, **notes**, **tasks**, and **project template manifests**. Workspaces, notes, and tasks accept a `tags` array on their create/update endpoints; sessions keep their dedicated `PUT /api/sessions/:id/tags`. Workspace tags live canonically in `workspace.json`, note tags are mirrored into the note file's YAML frontmatter (`tags:` list, Obsidian-compatible), and task tags appear in the task markdown metadata (`tags=` key).
+
+**List tags:**
+
+```http
+GET /api/tags                  // sessions-only (legacy shape, unchanged)
+GET /api/tags?scope=all        // unified pool across all sources
+```
+
+```json
+{
+  "tags": [
+    {
+      "name": "music",
+      "counts": { "workspaces": 2, "sessions": 1, "notes": 3, "tasks": 1, "templates": 1 },
+      "total": 8
+    }
+  ]
+}
+```
+
+The unified pool is computed on request (no caches to refresh), counts each entity once per tag, and is sorted by `total` descending, then name. It powers the shared tag-input suggestions and the Settings → Tags management table.
+
+**Usage preview** (for confirmation dialogs):
+
+```http
+GET /api/tags/usage?tag=music
+```
+
+```json
+{ "tag": "music", "counts": { "...": 0 }, "total": 8, "templates": ["Reaper Song"] }
+```
+
+`templates` lists the display names of library templates whose manifest declares the tag.
+
+**Rename a tag globally:**
+
+```http
+POST /api/tags/rename
+{ "from": "musci", "to": "music" }
+```
+
+```json
+{ "success": true, "from": "musci", "to": "music", "renamed": { "workspaces": 1, "sessions": 2, "notes": 1, "tasks": 0 } }
+```
+
+Renaming applies to workspaces, sessions, notes, and tasks — including their synced files (`workspace.json`, note frontmatter, task markdown). Renaming onto an existing tag **merges** (per-entity dedupe). Template manifests are **read-only**: they are never modified, so new workspaces created from a declaring template reintroduce the original tag.
+
+**Delete a tag globally:**
+
+```http
+POST /api/tags/delete
+{ "tag": "obsolete" }
+```
+
+```json
+{ "success": true, "tag": "obsolete", "removed": { "workspaces": 1, "sessions": 0, "notes": 2, "tasks": 1 } }
+```
+
+Both mutations return per-source affected counts; an unknown tag is a no-op `200` with zero counts. `400` for missing fields, an over-long `to`, or `from == to`.
 
 ## Workspace Groups
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -155,6 +155,9 @@ export default defineConfig([
       'internal/web/static/js/modules/relative-time.js',
       'internal/web/static/js/modules/workspace-run.js',
       'internal/web/static/js/modules/task-result-artifacts.js',
+      'internal/web/static/js/modules/tag-input.js',
+      'internal/web/static/js/modules/tag-filter-bar.js',
+      'internal/web/static/js/modules/workspace-tags-card.js',
     ],
     languageOptions: {
       sourceType: 'module'

--- a/internal/chathttp/workspace_tools.go
+++ b/internal/chathttp/workspace_tools.go
@@ -522,6 +522,7 @@ func (p *WorkspaceToolProvider) saveNoteTool() toolapi.Tool {
 				workspace.SyncNoteFile(p.fileStore, workspace.NoteFileParams{
 					ID: existing.ID, WorkspaceID: existing.WorkspaceID,
 					Name: existing.Name, Content: existing.Content,
+					Tags:      existing.Tags,
 					CreatedAt: existing.CreatedAt, UpdatedAt: existing.UpdatedAt,
 				})
 				return marshalToolResponse(map[string]any{
@@ -551,6 +552,7 @@ func (p *WorkspaceToolProvider) saveNoteTool() toolapi.Tool {
 			workspace.SyncNoteFile(p.fileStore, workspace.NoteFileParams{
 				ID: note.ID, WorkspaceID: note.WorkspaceID,
 				Name: note.Name, Content: note.Content,
+				Tags:      note.Tags,
 				CreatedAt: note.CreatedAt, UpdatedAt: note.UpdatedAt,
 			})
 			logger.Info("Workspace tool created note", logger.Fields{

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -10,7 +10,7 @@ import (
 
 // schemaVersion is the current database schema version.
 // Increment this when adding new migrations.
-const schemaVersion = 26
+const schemaVersion = 27
 
 // migrate runs all pending migrations to bring the database up to the current schema.
 func (db *DB) migrate(ctx context.Context) error {
@@ -117,6 +117,8 @@ func (db *DB) runMigration(ctx context.Context, version int) error {
 		return db.migration025WorkspaceOpportunities(ctx)
 	case 26:
 		return db.migration026WorkspaceTags(ctx)
+	case 27:
+		return db.migration027NoteTags(ctx)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -1168,6 +1170,35 @@ func (db *DB) migration026WorkspaceTags(ctx context.Context) error {
 		ALTER TABLE workspaces ADD COLUMN tags TEXT DEFAULT '[]'
 	`); err != nil && !isDuplicateColumnError(err) {
 		return fmt.Errorf("failed to add workspace tags column: %w", err)
+	}
+	return nil
+}
+
+// migration027NoteTags stores workspace note tags, mirroring the session_tags
+// layout so per-tag usage counting stays a cheap GROUP BY.
+func (db *DB) migration027NoteTags(ctx context.Context) error {
+	exists, err := db.tableExists(ctx, "workspace_notes")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS note_tags (
+			note_id TEXT NOT NULL,
+			tag TEXT NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (note_id, tag),
+			FOREIGN KEY (note_id) REFERENCES workspace_notes(id) ON DELETE CASCADE
+		)
+	`); err != nil {
+		return fmt.Errorf("failed to create note_tags table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_note_tags_tag ON note_tags(tag)
+	`); err != nil {
+		return fmt.Errorf("failed to create note_tags index: %w", err)
 	}
 	return nil
 }

--- a/internal/orchestrationhttp/task_handler.go
+++ b/internal/orchestrationhttp/task_handler.go
@@ -343,6 +343,7 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 		Description            string                         `json:"description"`
 		Details                string                         `json:"details"`
 		ReferenceURL           string                         `json:"reference_url"`
+		Tags                   []string                       `json:"tags"`
 		Priority               int                            `json:"priority"`
 		InputTaskIDs           []string                       `json:"input_task_ids"`
 		ParentTaskID           string                         `json:"parent_task_id"`
@@ -390,6 +391,11 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 		orihttp.BadRequest(w, err.Error())
 		return
 	}
+	tags, err := workspace.ValidateWorkspaceTags(req.Tags)
+	if err != nil {
+		orihttp.BadRequest(w, err.Error())
+		return
+	}
 
 	ws, err := th.workspaceStore.Get(req.WorkspaceID)
 	if err != nil {
@@ -417,6 +423,7 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 		Description:            req.Description,
 		Details:                req.Details,
 		ReferenceURL:           referenceURL,
+		Tags:                   tags,
 		Priority:               normalizeTaskPriority(req.Priority),
 		InputTaskIDs:           req.InputTaskIDs,
 		ParentTaskID:           req.ParentTaskID,
@@ -551,6 +558,7 @@ type taskUpdateRequest struct {
 	Description            *string                        `json:"description"`
 	Details                *string                        `json:"details"`
 	ReferenceURL           *string                        `json:"reference_url"`
+	Tags                   *[]string                      `json:"tags"`
 	Priority               *int                           `json:"priority"`
 	Context                map[string]any                 `json:"context"`
 	To                     *string                        `json:"to"`
@@ -581,7 +589,7 @@ type taskUpdateRequest struct {
 
 // hasFieldUpdates returns true if the request contains any field updates
 func (r *taskUpdateRequest) hasFieldUpdates() bool {
-	return r.Description != nil || r.Details != nil || r.ReferenceURL != nil || r.Priority != nil || r.Context != nil || r.InputTaskIDs != nil ||
+	return r.Description != nil || r.Details != nil || r.ReferenceURL != nil || r.Tags != nil || r.Priority != nil || r.Context != nil || r.InputTaskIDs != nil ||
 		r.To != nil || r.ParentTaskID != nil || r.SubtaskIndex != nil || r.OrchestrationMode != nil ||
 		r.ResultCombinationMode != nil || r.CombinationInstruction != nil || r.OutputSchema != nil ||
 		r.OutputContract != nil || r.OutputSpec != nil || r.DraftOutputSpec != nil ||
@@ -608,6 +616,13 @@ func (th *TaskHandler) applyBasicFieldUpdates(task *workspace.Task, req *taskUpd
 	if req.ReferenceURL != nil {
 		task.ReferenceURL = *req.ReferenceURL
 		logger.Debug("Updated task reference URL", logger.Fields{"task_id": req.TaskID, "has_reference_url": task.ReferenceURL != ""})
+	}
+	if req.Tags != nil {
+		// Lenient normalization (dedupe, lowercase, cap) — the strict
+		// validation path lives on the workspace task endpoints; the shared
+		// tag widget already enforces limits client-side.
+		task.Tags = workspace.NormalizeWorkspaceTags(*req.Tags)
+		logger.Debug("Updated task tags", logger.Fields{"task_id": req.TaskID, "tag_count": len(task.Tags)})
 	}
 	if req.Priority != nil {
 		task.Priority = normalizeTaskPriority(*req.Priority)

--- a/internal/orchestrationhttp/workflow_create_handler.go
+++ b/internal/orchestrationhttp/workflow_create_handler.go
@@ -35,6 +35,7 @@ type workflowParentInput struct {
 	Description    string                         `json:"description"`
 	Details        string                         `json:"details"`
 	ReferenceURL   string                         `json:"reference_url"`
+	Tags           []string                       `json:"tags"`
 	From           string                         `json:"from"`
 	To             string                         `json:"to"`
 	AssignedNodeID string                         `json:"assigned_node_id"`
@@ -156,6 +157,11 @@ func (th *TaskHandler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Reque
 			orihttp.BadRequest(w, err.Error())
 			return
 		}
+		parentTags, err := workspace.ValidateWorkspaceTags(req.Parent.Tags)
+		if err != nil {
+			orihttp.BadRequest(w, err.Error())
+			return
+		}
 		tasks = append(tasks, workspace.Task{
 			ID:             parentTaskID,
 			WorkspaceID:    req.WorkspaceID,
@@ -165,6 +171,7 @@ func (th *TaskHandler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Reque
 			Description:    req.Parent.Description,
 			Details:        req.Parent.Details,
 			ReferenceURL:   referenceURL,
+			Tags:           parentTags,
 			Priority:       normalizeTaskPriority(req.Parent.Priority),
 			InputTaskIDs:   req.Parent.InputTaskIDs,
 			ParentTaskID:   strings.TrimSpace(req.Parent.ParentTaskID),

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -593,6 +593,9 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}", s.handleProjectTemplateDelete)
 
 		mux.HandleFunc("/api/tags", s.Handlers.Session.HandleTags)
+		mux.HandleFunc("/api/tags/usage", s.Handlers.Session.HandleTagUsage)
+		mux.HandleFunc("/api/tags/rename", s.Handlers.Session.HandleTagRename)
+		mux.HandleFunc("/api/tags/delete", s.Handlers.Session.HandleTagDelete)
 		mux.HandleFunc("/api/session-cache/stats", s.Handlers.Session.HandleCacheStats)
 	}
 

--- a/internal/session/hybrid_store.go
+++ b/internal/session/hybrid_store.go
@@ -263,6 +263,61 @@ func (h *hybridStore) GetAllTags(ctx context.Context) ([]Tag, error) {
 	return h.sqlite.GetAllTags(ctx)
 }
 
+// RenameSessionTag renames a tag across all sessions.
+func (h *hybridStore) RenameSessionTag(ctx context.Context, from, to string) (int, error) {
+	affected, err := h.sqlite.RenameSessionTag(ctx, from, to)
+	if err != nil {
+		return 0, err
+	}
+	h.mutateCachedSessionTags(from, to)
+	return affected, nil
+}
+
+// RemoveSessionTag removes a tag from all sessions.
+func (h *hybridStore) RemoveSessionTag(ctx context.Context, tag string) (int, error) {
+	affected, err := h.sqlite.RemoveSessionTag(ctx, tag)
+	if err != nil {
+		return 0, err
+	}
+	h.mutateCachedSessionTags(tag, "")
+	return affected, nil
+}
+
+// mutateCachedSessionTags applies a tag rename (or removal when to == "")
+// to every cached session, so reads don't serve stale tags after a bulk
+// SQL mutation that bypassed the per-session update path.
+func (h *hybridStore) mutateCachedSessionTags(from, to string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, session := range h.cache.GetAll() {
+		if session == nil {
+			continue
+		}
+		next := make([]string, 0, len(session.Tags))
+		seen := make(map[string]struct{}, len(session.Tags))
+		changed := false
+		for _, tag := range session.Tags {
+			value := tag
+			if value == from {
+				changed = true
+				if to == "" {
+					continue
+				}
+				value = to
+			}
+			if _, ok := seen[value]; ok {
+				changed = true
+				continue
+			}
+			seen[value] = struct{}{}
+			next = append(next, value)
+		}
+		if changed {
+			session.Tags = next
+		}
+	}
+}
+
 // CreateWorkspace creates a new workspace.
 func (h *hybridStore) CreateWorkspace(ctx context.Context, workspace *Workspace) error {
 	if workspace.ID == "" {
@@ -754,6 +809,21 @@ func (h *hybridStore) DeleteNote(ctx context.Context, id string) error {
 // ListNotesByWorkspace returns all notes in a workspace.
 func (h *hybridStore) ListNotesByWorkspace(ctx context.Context, workspaceID string) ([]WorkspaceNoteListItem, error) {
 	return h.sqlite.ListNotesByWorkspace(ctx, workspaceID)
+}
+
+// GetAllNoteTags returns all unique note tags with usage counts.
+func (h *hybridStore) GetAllNoteTags(ctx context.Context) ([]Tag, error) {
+	return h.sqlite.GetAllNoteTags(ctx)
+}
+
+// RenameNoteTag renames a tag across all notes.
+func (h *hybridStore) RenameNoteTag(ctx context.Context, from, to string) ([]string, error) {
+	return h.sqlite.RenameNoteTag(ctx, from, to)
+}
+
+// RemoveNoteTag removes a tag from all notes.
+func (h *hybridStore) RemoveNoteTag(ctx context.Context, tag string) ([]string, error) {
+	return h.sqlite.RemoveNoteTag(ctx, tag)
 }
 
 // SearchNotes performs full-text search across note names and content.

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -379,6 +379,9 @@ type WorkspaceNote struct {
 	// Content is the markdown content of the note.
 	Content string `json:"content"`
 
+	// Tags are normalized labels used for note organization and filtering.
+	Tags []string `json:"tags,omitempty"`
+
 	// VaultRef records the private vault source when this note was imported.
 	VaultRef *vaultref.Reference `json:"vault_reference,omitempty"`
 
@@ -396,6 +399,7 @@ type WorkspaceNoteListItem struct {
 	WorkspaceID string              `json:"workspace_id"`
 	Name        string              `json:"name"`
 	Preview     string              `json:"preview,omitempty"`
+	Tags        []string            `json:"tags,omitempty"`
 	VaultRef    *vaultref.Reference `json:"vault_reference,omitempty"`
 	CreatedAt   time.Time           `json:"created_at"`
 	UpdatedAt   time.Time           `json:"updated_at"`

--- a/internal/session/note_tags_test.go
+++ b/internal/session/note_tags_test.go
@@ -1,0 +1,190 @@
+package session
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func createNoteTagsTestWorkspace(t *testing.T, store HybridStore) *Workspace {
+	t.Helper()
+	workspace := &Workspace{ID: "note-tags-ws", Name: "Note Tags"}
+	if err := store.CreateWorkspace(context.Background(), workspace); err != nil {
+		t.Fatalf("Failed to create workspace: %v", err)
+	}
+	return workspace
+}
+
+func TestNoteTags_CreateGetRoundTrip(t *testing.T) {
+	store, cleanup := setupHybridStore(t, 10)
+	defer cleanup()
+	ctx := context.Background()
+	ws := createNoteTagsTestWorkspace(t, store)
+
+	now := time.Now()
+	note := &WorkspaceNote{
+		ID:          "note-1",
+		WorkspaceID: ws.ID,
+		Name:        "Tagged Note",
+		Content:     "body",
+		Tags:        []string{" Music ", "mixing", "music"},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := store.CreateNote(ctx, note); err != nil {
+		t.Fatalf("Failed to create note: %v", err)
+	}
+
+	got, err := store.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("Failed to get note: %v", err)
+	}
+	want := []string{"music", "mixing"}
+	if !noteTagSetsEqual(got.Tags, want) {
+		t.Fatalf("Tags mismatch: got %v, want %v", got.Tags, want)
+	}
+}
+
+func TestNoteTags_UpdateReplacesTags(t *testing.T) {
+	store, cleanup := setupHybridStore(t, 10)
+	defer cleanup()
+	ctx := context.Background()
+	ws := createNoteTagsTestWorkspace(t, store)
+
+	now := time.Now()
+	note := &WorkspaceNote{
+		ID: "note-2", WorkspaceID: ws.ID, Name: "N", Content: "c",
+		Tags: []string{"old", "stale"}, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := store.CreateNote(ctx, note); err != nil {
+		t.Fatalf("Failed to create note: %v", err)
+	}
+
+	note.Tags = []string{"fresh"}
+	note.UpdatedAt = time.Now()
+	if err := store.UpdateNote(ctx, note); err != nil {
+		t.Fatalf("Failed to update note: %v", err)
+	}
+
+	got, err := store.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("Failed to get note: %v", err)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"fresh"}) {
+		t.Fatalf("Tags mismatch after update: got %v", got.Tags)
+	}
+
+	// Clearing tags persists too.
+	note.Tags = nil
+	if err := store.UpdateNote(ctx, note); err != nil {
+		t.Fatalf("Failed to clear tags: %v", err)
+	}
+	got, err = store.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("Failed to get note: %v", err)
+	}
+	if len(got.Tags) != 0 {
+		t.Fatalf("Expected no tags after clearing, got %v", got.Tags)
+	}
+}
+
+func TestNoteTags_ListHydratesTags(t *testing.T) {
+	store, cleanup := setupHybridStore(t, 10)
+	defer cleanup()
+	ctx := context.Background()
+	ws := createNoteTagsTestWorkspace(t, store)
+
+	now := time.Now()
+	tagged := &WorkspaceNote{
+		ID: "note-3", WorkspaceID: ws.ID, Name: "Tagged", Content: "c",
+		Tags: []string{"alpha", "beta"}, CreatedAt: now, UpdatedAt: now,
+	}
+	plain := &WorkspaceNote{
+		ID: "note-4", WorkspaceID: ws.ID, Name: "Plain", Content: "c",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	for _, n := range []*WorkspaceNote{tagged, plain} {
+		if err := store.CreateNote(ctx, n); err != nil {
+			t.Fatalf("Failed to create note %s: %v", n.ID, err)
+		}
+	}
+
+	items, err := store.ListNotesByWorkspace(ctx, ws.ID)
+	if err != nil {
+		t.Fatalf("Failed to list notes: %v", err)
+	}
+	byID := map[string][]string{}
+	for _, item := range items {
+		byID[item.ID] = item.Tags
+	}
+	if !noteTagSetsEqual(byID["note-3"], []string{"alpha", "beta"}) {
+		t.Errorf("Tagged note list tags mismatch: got %v", byID["note-3"])
+	}
+	if len(byID["note-4"]) != 0 {
+		t.Errorf("Plain note should have no tags, got %v", byID["note-4"])
+	}
+}
+
+func TestNoteTags_GetAllNoteTagsCountsAndDeleteCascade(t *testing.T) {
+	store, cleanup := setupHybridStore(t, 10)
+	defer cleanup()
+	ctx := context.Background()
+	ws := createNoteTagsTestWorkspace(t, store)
+
+	now := time.Now()
+	notes := []*WorkspaceNote{
+		{ID: "note-5", WorkspaceID: ws.ID, Name: "A", Content: "c", Tags: []string{"shared", "solo"}, CreatedAt: now, UpdatedAt: now},
+		{ID: "note-6", WorkspaceID: ws.ID, Name: "B", Content: "c", Tags: []string{"shared"}, CreatedAt: now, UpdatedAt: now},
+	}
+	for _, n := range notes {
+		if err := store.CreateNote(ctx, n); err != nil {
+			t.Fatalf("Failed to create note %s: %v", n.ID, err)
+		}
+	}
+
+	tags, err := store.GetAllNoteTags(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get all note tags: %v", err)
+	}
+	counts := map[string]int{}
+	for _, tag := range tags {
+		counts[tag.Name] = tag.UsageCount
+	}
+	if counts["shared"] != 2 || counts["solo"] != 1 {
+		t.Fatalf("Unexpected note tag counts: %v", counts)
+	}
+
+	// Deleting a note removes its tag rows via ON DELETE CASCADE.
+	if err := store.DeleteNote(ctx, "note-5"); err != nil {
+		t.Fatalf("Failed to delete note: %v", err)
+	}
+	tags, err = store.GetAllNoteTags(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get all note tags: %v", err)
+	}
+	counts = map[string]int{}
+	for _, tag := range tags {
+		counts[tag.Name] = tag.UsageCount
+	}
+	if counts["shared"] != 1 || counts["solo"] != 0 {
+		t.Fatalf("Unexpected note tag counts after delete: %v", counts)
+	}
+}
+
+func noteTagSetsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, tag := range a {
+		seen[tag]++
+	}
+	for _, tag := range b {
+		if seen[tag] == 0 {
+			return false
+		}
+		seen[tag]--
+	}
+	return true
+}

--- a/internal/session/sqlite_note_store.go
+++ b/internal/session/sqlite_note_store.go
@@ -49,6 +49,9 @@ func (s *SQLiteStore) CreateNote(ctx context.Context, note *WorkspaceNote) error
 		return fmt.Errorf("failed to create note: %w", err)
 	}
 
+	if err := s.replaceNoteTags(ctx, note.ID, note.Tags); err != nil {
+		return fmt.Errorf("failed to save note tags: %w", err)
+	}
 	if err := s.indexNoteHeadings(ctx, note.ID, note.Content); err != nil {
 		return fmt.Errorf("failed to index note headings: %w", err)
 	}
@@ -88,6 +91,9 @@ func (s *SQLiteStore) GetNote(ctx context.Context, id string) (*WorkspaceNote, e
 	if note.VaultRef, err = decodeNoteVaultReference(vaultReferenceJSON.String); err != nil {
 		return nil, fmt.Errorf("failed to decode note vault reference: %w", err)
 	}
+	if note.Tags, err = s.getNoteTags(ctx, note.ID); err != nil {
+		return nil, fmt.Errorf("failed to load note tags: %w", err)
+	}
 
 	return note, nil
 }
@@ -108,6 +114,9 @@ func (s *SQLiteStore) UpdateNote(ctx context.Context, note *WorkspaceNote) error
 		return err
 	}
 
+	if err := s.replaceNoteTags(ctx, note.ID, note.Tags); err != nil {
+		return fmt.Errorf("failed to save note tags: %w", err)
+	}
 	if err := s.indexNoteHeadings(ctx, note.ID, note.Content); err != nil {
 		return fmt.Errorf("failed to index note headings: %w", err)
 	}
@@ -174,7 +183,172 @@ func (s *SQLiteStore) ListNotesByWorkspace(ctx context.Context, workspaceID stri
 		notes = append(notes, note)
 	}
 
+	if err := s.attachNoteListTags(ctx, workspaceID, notes); err != nil {
+		return nil, fmt.Errorf("failed to load note tags: %w", err)
+	}
+
 	return notes, nil
+}
+
+// replaceNoteTags replaces all tags for a note (normalized lowercase/trimmed),
+// mirroring the session updateTagsInternal pattern.
+func (s *SQLiteStore) replaceNoteTags(ctx context.Context, noteID string, tags []string) error {
+	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "DELETE FROM note_tags WHERE note_id = ?", noteID); err != nil {
+			return err
+		}
+		seen := make(map[string]struct{}, len(tags))
+		for _, tag := range tags {
+			normalized := strings.ToLower(strings.TrimSpace(tag))
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			if _, err := tx.ExecContext(ctx,
+				"INSERT INTO note_tags (note_id, tag) VALUES (?, ?)",
+				noteID, normalized); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// getNoteTags returns the tags for a single note.
+func (s *SQLiteStore) getNoteTags(ctx context.Context, noteID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT tag FROM note_tags WHERE note_id = ?", noteID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tags []string
+	for rows.Next() {
+		var tag string
+		if err := rows.Scan(&tag); err != nil {
+			return nil, err
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
+}
+
+// attachNoteListTags hydrates Tags onto note list items with one query for the
+// whole workspace instead of one query per note.
+func (s *SQLiteStore) attachNoteListTags(ctx context.Context, workspaceID string, notes []WorkspaceNoteListItem) error {
+	if len(notes) == 0 {
+		return nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT nt.note_id, nt.tag
+		FROM note_tags nt
+		JOIN workspace_notes wn ON wn.id = nt.note_id
+		WHERE wn.workspace_id = ?
+	`, workspaceID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	tagsByNote := map[string][]string{}
+	for rows.Next() {
+		var noteID, tag string
+		if err := rows.Scan(&noteID, &tag); err != nil {
+			return err
+		}
+		tagsByNote[noteID] = append(tagsByNote[noteID], tag)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for i := range notes {
+		notes[i].Tags = tagsByNote[notes[i].ID]
+	}
+	return nil
+}
+
+// noteIDsWithTag returns the IDs of notes carrying the tag.
+func (s *SQLiteStore) noteIDsWithTag(ctx context.Context, tag string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT note_id FROM note_tags WHERE tag = ?", tag)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// RenameNoteTag renames a tag across all notes, merging when the new name
+// already exists on a note. Returns the IDs of affected notes so callers can
+// re-sync their markdown files.
+func (s *SQLiteStore) RenameNoteTag(ctx context.Context, from, to string) ([]string, error) {
+	ids, err := s.noteIDsWithTag(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("failed to rename note tag: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	err = s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT OR IGNORE INTO note_tags (note_id, tag) SELECT note_id, ? FROM note_tags WHERE tag = ?",
+			to, from,
+		); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, "DELETE FROM note_tags WHERE tag = ?", from)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to rename note tag: %w", err)
+	}
+	return ids, nil
+}
+
+// RemoveNoteTag removes a tag from all notes. Returns the IDs of affected
+// notes so callers can re-sync their markdown files.
+func (s *SQLiteStore) RemoveNoteTag(ctx context.Context, tag string) ([]string, error) {
+	ids, err := s.noteIDsWithTag(ctx, tag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove note tag: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if _, err := s.db.ExecContext(ctx, "DELETE FROM note_tags WHERE tag = ?", tag); err != nil {
+		return nil, fmt.Errorf("failed to remove note tag: %w", err)
+	}
+	return ids, nil
+}
+
+// GetAllNoteTags returns all unique note tags with usage counts.
+func (s *SQLiteStore) GetAllNoteTags(ctx context.Context) ([]Tag, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT tag, COUNT(*) FROM note_tags GROUP BY tag ORDER BY COUNT(*) DESC")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get note tags: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	tags := make([]Tag, 0)
+	for rows.Next() {
+		var tag Tag
+		if err := rows.Scan(&tag.Name, &tag.UsageCount); err != nil {
+			return nil, fmt.Errorf("failed to scan note tag: %w", err)
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
 }
 
 func encodeNoteVaultReference(ref *vaultref.Reference) string {

--- a/internal/session/sqlite_store.go
+++ b/internal/session/sqlite_store.go
@@ -440,6 +440,45 @@ func (s *SQLiteStore) getSessionPreview(ctx context.Context, sessionID string) s
 	return content
 }
 
+// RenameSessionTag renames a tag across all sessions, merging when the new
+// name already exists on a session. Returns the number of affected sessions.
+func (s *SQLiteStore) RenameSessionTag(ctx context.Context, from, to string) (int, error) {
+	affected := 0
+	err := s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx,
+			"SELECT COUNT(DISTINCT session_id) FROM session_tags WHERE tag = ?", from,
+		).Scan(&affected); err != nil {
+			return err
+		}
+		if affected == 0 {
+			return nil
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT OR IGNORE INTO session_tags (session_id, tag) SELECT session_id, ? FROM session_tags WHERE tag = ?",
+			to, from,
+		); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, "DELETE FROM session_tags WHERE tag = ?", from)
+		return err
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to rename session tag: %w", err)
+	}
+	return affected, nil
+}
+
+// RemoveSessionTag removes a tag from all sessions. Returns the number of
+// affected sessions.
+func (s *SQLiteStore) RemoveSessionTag(ctx context.Context, tag string) (int, error) {
+	result, err := s.db.ExecContext(ctx, "DELETE FROM session_tags WHERE tag = ?", tag)
+	if err != nil {
+		return 0, fmt.Errorf("failed to remove session tag: %w", err)
+	}
+	affected, _ := result.RowsAffected()
+	return int(affected), nil
+}
+
 func (s *SQLiteStore) updateTagsInternal(ctx context.Context, sessionID string, tags []string) error {
 	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
 		// Delete existing tags

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -67,6 +67,14 @@ type SessionStore interface {
 	// Tags are normalized (lowercase, trimmed) before storage.
 	UpdateTags(ctx context.Context, sessionID string, tags []string) error
 
+	// RenameSessionTag renames a tag across all sessions (merging when the
+	// target already exists). Returns the number of affected sessions.
+	RenameSessionTag(ctx context.Context, from, to string) (int, error)
+
+	// RemoveSessionTag removes a tag from all sessions. Returns the number
+	// of affected sessions.
+	RemoveSessionTag(ctx context.Context, tag string) (int, error)
+
 	// GetAllTags returns all unique tags with usage counts.
 	// Useful for tag autocomplete and management.
 	GetAllTags(ctx context.Context) ([]Tag, error)
@@ -131,6 +139,17 @@ type NoteStore interface {
 	// ListNotesByWorkspace returns all notes in a workspace.
 	// Notes are returned without full content for efficiency.
 	ListNotesByWorkspace(ctx context.Context, workspaceID string) ([]WorkspaceNoteListItem, error)
+
+	// GetAllNoteTags returns all unique note tags with usage counts.
+	GetAllNoteTags(ctx context.Context) ([]Tag, error)
+
+	// RenameNoteTag renames a tag across all notes (merging when the target
+	// already exists). Returns the IDs of affected notes.
+	RenameNoteTag(ctx context.Context, from, to string) ([]string, error)
+
+	// RemoveNoteTag removes a tag from all notes. Returns the IDs of
+	// affected notes.
+	RemoveNoteTag(ctx context.Context, tag string) ([]string, error)
 
 	// SearchNotes performs full-text search across note names and content.
 	// Returns results with matching text snippets for display.

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -436,9 +436,28 @@ func (h *Handler) addMessage(w http.ResponseWriter, r *http.Request, sessionID s
 }
 
 // HandleTags handles GET /api/tags for tag listing.
+//
+// The default response lists session tags only (the original behavior, kept
+// byte-compatible for existing consumers). With ?scope=all it returns the
+// unified app-wide pool with per-source usage counts.
 func (h *Handler) HandleTags(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+
+	if r.URL.Query().Get("scope") == "all" {
+		tags, err := h.collectUnifiedTags(r.Context())
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				logger.Error("Failed to get unified tags", logger.Fields{"error": err})
+			}
+			_ = orihttp.RespondInternalError(w, "Failed to get tags")
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{
+			"tags": tags,
+		})
 		return
 	}
 

--- a/internal/sessionhttp/note_file_sync.go
+++ b/internal/sessionhttp/note_file_sync.go
@@ -12,6 +12,7 @@ func (h *Handler) syncNoteToFile(note *session.WorkspaceNote) {
 		WorkspaceID: note.WorkspaceID,
 		Name:        note.Name,
 		Content:     note.Content,
+		Tags:        note.Tags,
 		CreatedAt:   note.CreatedAt,
 		UpdatedAt:   note.UpdatedAt,
 	})

--- a/internal/sessionhttp/note_file_sync_test.go
+++ b/internal/sessionhttp/note_file_sync_test.go
@@ -212,6 +212,84 @@ func TestDeleteNoteFile(t *testing.T) {
 	}
 }
 
+func TestSyncNoteToFile_TagsFrontmatterRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := workspace.NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now()
+	ws := &workspace.Workspace{
+		ID:         "ws-tags-test",
+		Name:       "Tags Test",
+		Status:     workspace.StatusActive,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		SharedData: make(map[string]any),
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &Handler{workspaceStore: store}
+
+	note := &session.WorkspaceNote{
+		ID:          "note-tags-1234",
+		WorkspaceID: "ws-tags-test",
+		Name:        "Tagged Note",
+		Content:     "body",
+		Tags:        []string{"music", "deep work"},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	h.syncNoteToFile(note)
+
+	folderPath, err := store.GetFolderPath("ws-tags-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	noteFile := filepath.Join(folderPath, workspace.NotesDir, workspace.NoteFilename("Tagged Note", note.ID))
+	data, err := os.ReadFile(noteFile)
+	if err != nil {
+		t.Fatalf("Expected note file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "tags:\n  - \"music\"\n  - \"deep work\"\n") {
+		t.Fatalf("Expected tags list in frontmatter, got:\n%s", content)
+	}
+
+	// The workspace-folder importer parses the tags back out.
+	parsed, err := parseImportedWorkspaceNoteFile("ws-tags-test", noteFile, filepath.Base(noteFile))
+	if err != nil {
+		t.Fatalf("parseImportedWorkspaceNoteFile: %v", err)
+	}
+	if len(parsed.Tags) != 2 || parsed.Tags[0] != "music" || parsed.Tags[1] != "deep work" {
+		t.Fatalf("Expected tags to round-trip through the importer, got %#v", parsed.Tags)
+	}
+
+	// A note without tags writes no tags key (legacy format unchanged).
+	plain := &session.WorkspaceNote{
+		ID:          "note-plain-1234",
+		WorkspaceID: "ws-tags-test",
+		Name:        "Plain Note",
+		Content:     "body",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	h.syncNoteToFile(plain)
+	plainFile := filepath.Join(folderPath, workspace.NotesDir, workspace.NoteFilename("Plain Note", plain.ID))
+	plainData, err := os.ReadFile(plainFile)
+	if err != nil {
+		t.Fatalf("Expected plain note file: %v", err)
+	}
+	if strings.Contains(string(plainData), "tags:") {
+		t.Fatalf("Plain note should have no tags key, got:\n%s", string(plainData))
+	}
+}
+
 func TestSyncNoteToFile_NilWorkspaceStore(t *testing.T) {
 	// Handler without workspace store should not panic
 	h := &Handler{}

--- a/internal/sessionhttp/notes_handler.go
+++ b/internal/sessionhttp/notes_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/vaultref"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 // HandleNotes routes requests to /api/notes.
@@ -103,9 +104,10 @@ func (h *Handler) handleNote(w http.ResponseWriter, r *http.Request, id string) 
 // createNote handles POST /api/notes.
 func (h *Handler) createNote(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		WorkspaceID string `json:"workspace_id"`
-		Name        string `json:"name"`
-		Content     string `json:"content"`
+		WorkspaceID string   `json:"workspace_id"`
+		Name        string   `json:"name"`
+		Content     string   `json:"content"`
+		Tags        []string `json:"tags,omitempty"`
 	}
 
 	if !orihttp.ParseJSONBody(w, r, &req) {
@@ -114,6 +116,11 @@ func (h *Handler) createNote(w http.ResponseWriter, r *http.Request) {
 
 	if req.WorkspaceID == "" {
 		_ = orihttp.RespondBadRequest(w, "workspace_id is required")
+		return
+	}
+	tags, err := agentworkspace.ValidateWorkspaceTags(req.Tags)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
 		return
 	}
 	if _, err := h.requireWorkspace(r.Context(), req.WorkspaceID); err != nil {
@@ -136,6 +143,7 @@ func (h *Handler) createNote(w http.ResponseWriter, r *http.Request) {
 		WorkspaceID: req.WorkspaceID,
 		Name:        req.Name,
 		Content:     req.Content,
+		Tags:        tags,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -166,6 +174,7 @@ func (h *Handler) createNoteInWorkspace(w http.ResponseWriter, r *http.Request, 
 	var req struct {
 		Name     string              `json:"name"`
 		Content  string              `json:"content"`
+		Tags     []string            `json:"tags,omitempty"`
 		VaultRef *vaultref.Reference `json:"vault_reference,omitempty"`
 	}
 
@@ -175,6 +184,11 @@ func (h *Handler) createNoteInWorkspace(w http.ResponseWriter, r *http.Request, 
 
 	if req.Name == "" {
 		req.Name = "Untitled Note"
+	}
+	tags, err := agentworkspace.ValidateWorkspaceTags(req.Tags)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
+		return
 	}
 	if _, err := h.requireWorkspace(r.Context(), workspaceID); err != nil {
 		switch {
@@ -192,6 +206,7 @@ func (h *Handler) createNoteInWorkspace(w http.ResponseWriter, r *http.Request, 
 		WorkspaceID: workspaceID,
 		Name:        req.Name,
 		Content:     req.Content,
+		Tags:        tags,
 		VaultRef:    vaultref.Normalize(req.VaultRef),
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -253,6 +268,7 @@ func (h *Handler) updateNote(w http.ResponseWriter, r *http.Request, id string) 
 		Name        *string             `json:"name,omitempty"`
 		Content     *string             `json:"content,omitempty"`
 		WorkspaceID *string             `json:"workspace_id,omitempty"`
+		Tags        *[]string           `json:"tags,omitempty"`
 		VaultRef    *vaultref.Reference `json:"vault_reference,omitempty"`
 	}
 
@@ -272,6 +288,14 @@ func (h *Handler) updateNote(w http.ResponseWriter, r *http.Request, id string) 
 	}
 	if req.WorkspaceID != nil {
 		note.WorkspaceID = *req.WorkspaceID
+	}
+	if req.Tags != nil {
+		tags, err := agentworkspace.ValidateWorkspaceTags(*req.Tags)
+		if err != nil {
+			_ = orihttp.RespondBadRequest(w, err.Error())
+			return
+		}
+		note.Tags = tags
 	}
 	if req.VaultRef != nil {
 		note.VaultRef = vaultref.Normalize(req.VaultRef)

--- a/internal/sessionhttp/tags_admin_handler.go
+++ b/internal/sessionhttp/tags_admin_handler.go
@@ -1,0 +1,337 @@
+package sessionhttp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// Global tag management: usage preview, rename (with merge), and delete
+// across every entity type that stores tags — workspaces, sessions, notes,
+// and tasks. Project template manifests are read-only by design: they are
+// source files (built-ins ship embedded in the binary), so renames and
+// deletes never touch them; the usage endpoint reports which templates
+// declare a tag so the UI can mark it as reintroducible.
+
+// tagMutationCounts reports how many entities a rename/delete touched.
+type tagMutationCounts struct {
+	Workspaces int `json:"workspaces"`
+	Sessions   int `json:"sessions"`
+	Notes      int `json:"notes"`
+	Tasks      int `json:"tasks"`
+}
+
+// HandleTagUsage handles GET /api/tags/usage?tag=… — per-source usage counts
+// plus the templates that declare the tag, for confirmation dialogs.
+func (h *Handler) HandleTagUsage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+	tag := normalizeAdminTag(r.URL.Query().Get("tag"))
+	if tag == "" {
+		_ = orihttp.RespondBadRequest(w, "tag is required")
+		return
+	}
+
+	pool, err := h.collectUnifiedTags(r.Context())
+	if err != nil {
+		logger.Error("Failed to collect tag usage", logger.Fields{"tag": tag, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to collect tag usage")
+		return
+	}
+
+	entry := UnifiedTag{Name: tag}
+	for _, candidate := range pool {
+		if candidate.Name == tag {
+			entry = candidate
+			break
+		}
+	}
+
+	orihttp.WriteJSON(w, map[string]any{
+		"tag":       entry.Name,
+		"counts":    entry.Counts,
+		"total":     entry.Total,
+		"templates": h.templatesDeclaringTag(tag),
+	})
+}
+
+// HandleTagRename handles POST /api/tags/rename {"from","to"} — renames a tag
+// across workspaces, sessions, notes, and tasks. Renaming onto an existing
+// tag merges the two (per-entity dedupe).
+func (h *Handler) HandleTagRename(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+	var req struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	from := normalizeAdminTag(req.From)
+	to := normalizeAdminTag(req.To)
+	if from == "" || to == "" {
+		_ = orihttp.RespondBadRequest(w, "from and to are required")
+		return
+	}
+	if utf8.RuneCountInString(to) > agentworkspace.MaxWorkspaceTagLength {
+		_ = orihttp.RespondBadRequest(w, "new tag exceeds the length limit")
+		return
+	}
+	if from == to {
+		_ = orihttp.RespondBadRequest(w, "from and to are the same tag")
+		return
+	}
+
+	counts, err := h.applyTagMutation(r.Context(), from, to)
+	if err != nil {
+		logger.Error("Failed to rename tag", logger.Fields{"from": from, "to": to, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to rename tag")
+		return
+	}
+
+	logger.Info("Tag renamed", logger.Fields{
+		"from": from, "to": to,
+		"workspaces": counts.Workspaces, "sessions": counts.Sessions,
+		"notes": counts.Notes, "tasks": counts.Tasks,
+	})
+	orihttp.WriteJSON(w, map[string]any{
+		"success": true,
+		"from":    from,
+		"to":      to,
+		"renamed": counts,
+	})
+}
+
+// HandleTagDelete handles POST /api/tags/delete {"tag"} — removes a tag from
+// all workspaces, sessions, notes, and tasks.
+func (h *Handler) HandleTagDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+	var req struct {
+		Tag string `json:"tag"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	tag := normalizeAdminTag(req.Tag)
+	if tag == "" {
+		_ = orihttp.RespondBadRequest(w, "tag is required")
+		return
+	}
+
+	counts, err := h.applyTagMutation(r.Context(), tag, "")
+	if err != nil {
+		logger.Error("Failed to delete tag", logger.Fields{"tag": tag, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to delete tag")
+		return
+	}
+
+	logger.Info("Tag deleted", logger.Fields{
+		"tag":        tag,
+		"workspaces": counts.Workspaces, "sessions": counts.Sessions,
+		"notes": counts.Notes, "tasks": counts.Tasks,
+	})
+	orihttp.WriteJSON(w, map[string]any{
+		"success": true,
+		"tag":     tag,
+		"removed": counts,
+	})
+}
+
+// applyTagMutation renames `from` to `to` everywhere, or removes `from`
+// everywhere when `to` is empty. Sources are mutated independently and
+// best-effort per entity: a failure in one source aborts with an error, but
+// already-applied sources stay applied (each is individually idempotent, so
+// retrying the same mutation converges).
+func (h *Handler) applyTagMutation(ctx context.Context, from, to string) (tagMutationCounts, error) {
+	var counts tagMutationCounts
+
+	workspaces, err := h.mutateWorkspaceTags(ctx, from, to)
+	if err != nil {
+		return counts, err
+	}
+	counts.Workspaces = workspaces
+
+	sessions, err := h.mutateSessionTags(ctx, from, to)
+	if err != nil {
+		return counts, err
+	}
+	counts.Sessions = sessions
+
+	notes, err := h.mutateNoteTags(ctx, from, to)
+	if err != nil {
+		return counts, err
+	}
+	counts.Notes = notes
+
+	counts.Tasks = h.mutateTaskTags(from, to)
+	return counts, nil
+}
+
+func (h *Handler) mutateSessionTags(ctx context.Context, from, to string) (int, error) {
+	if to == "" {
+		return h.store.RemoveSessionTag(ctx, from)
+	}
+	return h.store.RenameSessionTag(ctx, from, to)
+}
+
+// mutateNoteTags renames/removes the tag in SQLite, then re-syncs the
+// affected notes' markdown files so the frontmatter on disk stays truthful.
+func (h *Handler) mutateNoteTags(ctx context.Context, from, to string) (int, error) {
+	var (
+		noteIDs []string
+		err     error
+	)
+	if to == "" {
+		noteIDs, err = h.store.RemoveNoteTag(ctx, from)
+	} else {
+		noteIDs, err = h.store.RenameNoteTag(ctx, from, to)
+	}
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range noteIDs {
+		note, err := h.store.GetNote(ctx, id)
+		if err != nil {
+			logger.Warn("Tag mutation: failed to reload note for file sync", logger.Fields{"note_id": id, "error": err})
+			continue
+		}
+		h.syncNoteToFile(note)
+	}
+	return len(noteIDs), nil
+}
+
+// mutateWorkspaceTags rewrites tags on every workspace carrying the tag.
+// workspace.json is the read-canonical store whenever the SQLite row has no
+// tags, so the folder store is written first; the session row mirror is
+// best-effort.
+func (h *Handler) mutateWorkspaceTags(ctx context.Context, from, to string) (int, error) {
+	workspaces, err := h.store.ListWorkspaces(ctx)
+	if err != nil {
+		return 0, err
+	}
+	workspaces = pruneTrashedWorkspaces(workspaces)
+
+	affected := 0
+	for i := range workspaces {
+		ws := &workspaces[i]
+		h.hydrateWorkspaceMetadataInto(ws)
+		next, changed := replaceTagInList(ws.Tags, from, to)
+		if !changed {
+			continue
+		}
+		ws.Tags = next
+		ws.UpdatedAt = time.Now()
+		if err := h.syncWorkspaceTagsToFileStore(ws); err != nil {
+			logger.Warn("Tag mutation: failed to sync workspace tags to file store", logger.Fields{"id": ws.ID, "error": err})
+		}
+		if err := h.store.UpdateWorkspace(ctx, ws); err != nil {
+			logger.Warn("Tag mutation: failed to update workspace row", logger.Fields{"id": ws.ID, "error": err})
+		}
+		affected++
+	}
+	return affected, nil
+}
+
+// mutateTaskTags rewrites tags on every task carrying the tag. Tasks live
+// in the folder store; Save also refreshes the task markdown files.
+func (h *Handler) mutateTaskTags(from, to string) int {
+	if h.workspaceStore == nil {
+		return 0
+	}
+	ids, err := h.workspaceStore.List()
+	if err != nil {
+		logger.Warn("Tag mutation: failed to list folder workspaces", logger.Fields{"error": err})
+		return 0
+	}
+
+	affected := 0
+	for _, id := range ids {
+		ws, err := h.workspaceStore.Get(id)
+		if err != nil || ws == nil {
+			continue
+		}
+		changed := false
+		for i := range ws.Tasks {
+			next, taskChanged := replaceTagInList(ws.Tasks[i].Tags, from, to)
+			if !taskChanged {
+				continue
+			}
+			ws.Tasks[i].Tags = next
+			affected++
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+		ws.UpdatedAt = time.Now()
+		if err := h.workspaceStore.Save(ws); err != nil {
+			logger.Warn("Tag mutation: failed to save workspace tasks", logger.Fields{"id": id, "error": err})
+		}
+	}
+	return affected
+}
+
+// replaceTagInList maps `from` to `to` (or drops it when `to` is empty) and
+// re-normalizes, which also merges duplicates introduced by the rename.
+// Returns the new list and whether the input carried `from`.
+func replaceTagInList(tags []string, from, to string) ([]string, bool) {
+	normalized := agentworkspace.NormalizeWorkspaceTags(tags)
+	carried := false
+	next := make([]string, 0, len(normalized))
+	for _, tag := range normalized {
+		if tag == from {
+			carried = true
+			if to != "" {
+				next = append(next, to)
+			}
+			continue
+		}
+		next = append(next, tag)
+	}
+	if !carried {
+		return normalized, false
+	}
+	return agentworkspace.NormalizeWorkspaceTags(next), true
+}
+
+// templatesDeclaringTag returns the display names of library templates whose
+// manifest declares the tag.
+func (h *Handler) templatesDeclaringTag(tag string) []string {
+	names := []string{}
+	if h.templatesRootResolver == nil {
+		return names
+	}
+	templates, err := projecttemplates.ListLibrary(h.templatesRootResolver())
+	if err != nil {
+		logger.Warn("Failed to list templates for tag usage", logger.Fields{"error": err})
+		return names
+	}
+	for _, tpl := range templates {
+		for _, declared := range tpl.Tags {
+			if declared == tag {
+				names = append(names, tpl.Name)
+				break
+			}
+		}
+	}
+	return names
+}
+
+func normalizeAdminTag(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/sessionhttp/tags_admin_handler_test.go
+++ b/internal/sessionhttp/tags_admin_handler_test.go
@@ -1,0 +1,273 @@
+package sessionhttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+func postTagAdmin(t *testing.T, handlerFunc http.HandlerFunc, url, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handlerFunc(w, req)
+	return w
+}
+
+func unifiedPoolByName(t *testing.T, handler *Handler) map[string]UnifiedTag {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/tags?scope=all", nil)
+	w := httptest.NewRecorder()
+	handler.HandleTags(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pool fetch failed: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Tags []UnifiedTag `json:"tags"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal pool: %v", err)
+	}
+	byName := map[string]UnifiedTag{}
+	for _, tag := range resp.Tags {
+		byName[tag.Name] = tag
+	}
+	return byName
+}
+
+func tagsTestNoteFile(t *testing.T, handler *Handler) string {
+	t.Helper()
+	folderPath, err := handler.workspaceStore.GetFolderPath("ws-tags")
+	if err != nil {
+		t.Fatalf("GetFolderPath: %v", err)
+	}
+	return filepath.Join(folderPath, agentworkspace.NotesDir, agentworkspace.NoteFilename("N", "note-1"))
+}
+
+func TestHandleTagRename_PropagatesEverywhere(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	// Materialize the note's markdown file so the rename has a file to fix.
+	note, err := handler.store.GetNote(ctx, "note-1")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	handler.syncNoteToFile(note)
+
+	w := postTagAdmin(t, handler.HandleTagRename, "/api/tags/rename", `{"from":" Music ","to":"Audio"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rename failed: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Renamed tagMutationCounts `json:"renamed"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := tagMutationCounts{Workspaces: 1, Sessions: 1, Notes: 1, Tasks: 1}
+	if resp.Renamed != want {
+		t.Fatalf("renamed counts mismatch: got %+v want %+v", resp.Renamed, want)
+	}
+
+	// Pool: music is gone from every entity source (the template still
+	// declares it — manifests are read-only), audio carries the counts.
+	pool := unifiedPoolByName(t, handler)
+	if music, ok := pool["music"]; ok {
+		entityTotal := music.Counts.Workspaces + music.Counts.Sessions + music.Counts.Notes + music.Counts.Tasks
+		if entityTotal != 0 {
+			t.Fatalf("music should be gone from entities, got %+v", music.Counts)
+		}
+		if music.Counts.Templates == 0 {
+			t.Fatalf("music should still be declared by the template, got %+v", music.Counts)
+		}
+	}
+	audio, ok := pool["audio"]
+	if !ok {
+		t.Fatalf("audio missing from pool: %v", pool)
+	}
+	if audio.Counts.Workspaces != 1 || audio.Counts.Sessions != 1 || audio.Counts.Notes != 1 || audio.Counts.Tasks != 1 {
+		t.Fatalf("audio counts mismatch: %+v", audio.Counts)
+	}
+
+	// Folder store: workspace.json tags and the task both renamed.
+	folderWS, err := handler.workspaceStore.Get("ws-tags")
+	if err != nil {
+		t.Fatalf("folder Get: %v", err)
+	}
+	if strings.Join(folderWS.Tags, ",") != "audio,disk-only" {
+		t.Fatalf("workspace.json tags mismatch: %v", folderWS.Tags)
+	}
+	if strings.Join(folderWS.Tasks[0].Tags, ",") != "audio,task-only" {
+		t.Fatalf("task tags mismatch: %v", folderWS.Tasks[0].Tags)
+	}
+
+	// Note markdown frontmatter rewritten on disk.
+	data, err := os.ReadFile(tagsTestNoteFile(t, handler))
+	if err != nil {
+		t.Fatalf("read note file: %v", err)
+	}
+	if !strings.Contains(string(data), `- "audio"`) || strings.Contains(string(data), `- "music"`) {
+		t.Fatalf("note frontmatter not renamed:\n%s", string(data))
+	}
+
+	// Template manifest untouched.
+	manifest, err := os.ReadFile(filepath.Join(handler.templatesRootResolver(), "demo-template", "template.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if !strings.Contains(string(manifest), "Music") {
+		t.Fatalf("template manifest must not be modified: %s", string(manifest))
+	}
+}
+
+func TestHandleTagRename_MergesWithExistingTag(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	// This session already carries both the old and the new name.
+	sess := &session.Session{Title: "Merge", AgentName: "a", Tags: []string{"music", "audio"}}
+	if err := handler.store.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	w := postTagAdmin(t, handler.HandleTagRename, "/api/tags/rename", `{"from":"music","to":"audio"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rename failed: %d %s", w.Code, w.Body.String())
+	}
+
+	got, err := handler.store.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "audio" {
+		t.Fatalf("expected merged tags [audio], got %v", got.Tags)
+	}
+}
+
+func TestHandleTagDelete_RemovesEverywhere(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	note, err := handler.store.GetNote(ctx, "note-1")
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	handler.syncNoteToFile(note)
+
+	w := postTagAdmin(t, handler.HandleTagDelete, "/api/tags/delete", `{"tag":"music"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete failed: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Removed tagMutationCounts `json:"removed"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := tagMutationCounts{Workspaces: 1, Sessions: 1, Notes: 1, Tasks: 1}
+	if resp.Removed != want {
+		t.Fatalf("removed counts mismatch: got %+v want %+v", resp.Removed, want)
+	}
+
+	pool := unifiedPoolByName(t, handler)
+	if music, ok := pool["music"]; ok {
+		entityTotal := music.Counts.Workspaces + music.Counts.Sessions + music.Counts.Notes + music.Counts.Tasks
+		if entityTotal != 0 {
+			t.Fatalf("music should be removed from entities, got %+v", music.Counts)
+		}
+	}
+
+	folderWS, err := handler.workspaceStore.Get("ws-tags")
+	if err != nil {
+		t.Fatalf("folder Get: %v", err)
+	}
+	if strings.Join(folderWS.Tags, ",") != "disk-only" {
+		t.Fatalf("workspace.json tags mismatch after delete: %v", folderWS.Tags)
+	}
+	if strings.Join(folderWS.Tasks[0].Tags, ",") != "task-only" {
+		t.Fatalf("task tags mismatch after delete: %v", folderWS.Tasks[0].Tags)
+	}
+
+	data, err := os.ReadFile(tagsTestNoteFile(t, handler))
+	if err != nil {
+		t.Fatalf("read note file: %v", err)
+	}
+	if strings.Contains(string(data), `- "music"`) {
+		t.Fatalf("note frontmatter should drop music:\n%s", string(data))
+	}
+}
+
+func TestHandleTagUsage_ReportsCountsAndTemplates(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tags/usage?tag=Music", nil)
+	w := httptest.NewRecorder()
+	handler.HandleTagUsage(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("usage failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Tag       string           `json:"tag"`
+		Counts    UnifiedTagCounts `json:"counts"`
+		Total     int              `json:"total"`
+		Templates []string         `json:"templates"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Tag != "music" || resp.Total != 5 {
+		t.Fatalf("unexpected usage payload: %+v", resp)
+	}
+	if len(resp.Templates) != 1 || resp.Templates[0] != "Demo" {
+		t.Fatalf("expected template name Demo, got %v", resp.Templates)
+	}
+}
+
+func TestHandleTagRename_Validation(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+
+	for name, body := range map[string]string{
+		"missing to":   `{"from":"music"}`,
+		"missing from": `{"to":"music"}`,
+		"same tag":     `{"from":"Music","to":" music "}`,
+	} {
+		w := postTagAdmin(t, handler.HandleTagRename, "/api/tags/rename", body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d (%s)", name, w.Code, w.Body.String())
+		}
+	}
+
+	w := postTagAdmin(t, handler.HandleTagDelete, "/api/tags/delete", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("delete without tag: expected 400, got %d", w.Code)
+	}
+
+	// Unknown tag is a no-op success with zero counts.
+	w = postTagAdmin(t, handler.HandleTagDelete, "/api/tags/delete", `{"tag":"does-not-exist"}`)
+	if w.Code != http.StatusOK {
+		t.Errorf("unknown tag delete: expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		Removed tagMutationCounts `json:"removed"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Removed != (tagMutationCounts{}) {
+		t.Errorf("unknown tag delete should touch nothing, got %+v", resp.Removed)
+	}
+}

--- a/internal/sessionhttp/tags_aggregator.go
+++ b/internal/sessionhttp/tags_aggregator.go
@@ -1,0 +1,131 @@
+package sessionhttp
+
+import (
+	"context"
+	"sort"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/session"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// UnifiedTagCounts breaks a tag's usage down by source.
+type UnifiedTagCounts struct {
+	Workspaces int `json:"workspaces"`
+	Sessions   int `json:"sessions"`
+	Notes      int `json:"notes"`
+	Tasks      int `json:"tasks"`
+	Templates  int `json:"templates"`
+}
+
+// UnifiedTag is one entry of the app-wide tag pool exposed by
+// GET /api/tags?scope=all.
+type UnifiedTag struct {
+	Name   string           `json:"name"`
+	Counts UnifiedTagCounts `json:"counts"`
+	Total  int              `json:"total"`
+}
+
+// collectUnifiedTags aggregates the app-wide tag pool: workspace tags (SQLite
+// rows hydrated from workspace.json so disk-only tags count too), session
+// tags, note tags, task tags (folder store), and project template tags.
+// Counts are per-entity — a workspace carrying a tag counts once — keyed by
+// the normalized tag value. Optional sources (folder store, templates
+// library) degrade to zero counts instead of failing the whole pool.
+func (h *Handler) collectUnifiedTags(ctx context.Context) ([]UnifiedTag, error) {
+	pool := map[string]*UnifiedTag{}
+	entry := func(name string) *UnifiedTag {
+		if e, ok := pool[name]; ok {
+			return e
+		}
+		e := &UnifiedTag{Name: name}
+		pool[name] = e
+		return e
+	}
+
+	// Session and note tags are stored normalized with usage counts.
+	sessionTags, err := h.store.GetAllTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range sessionTags {
+		entry(tag.Name).Counts.Sessions += tag.UsageCount
+	}
+
+	noteTags, err := h.store.GetAllNoteTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range noteTags {
+		entry(tag.Name).Counts.Notes += tag.UsageCount
+	}
+
+	// Workspace tags use the same source as the workspace listing, so the
+	// pool matches what the UI shows (trashed workspaces excluded).
+	workspaces, err := h.store.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workspaces = pruneTrashedWorkspaces(workspaces)
+	workspaces = h.hydrateWorkspaceListFromFileStore(workspaces)
+	var countWorkspace func(ws *session.Workspace)
+	countWorkspace = func(ws *session.Workspace) {
+		for _, tag := range agentworkspace.NormalizeWorkspaceTags(ws.Tags) {
+			entry(tag).Counts.Workspaces++
+		}
+		for i := range ws.Children {
+			countWorkspace(&ws.Children[i])
+		}
+	}
+	for i := range workspaces {
+		countWorkspace(&workspaces[i])
+	}
+
+	// Task tags live only in the folder store.
+	if h.workspaceStore != nil {
+		ids, err := h.workspaceStore.List()
+		if err != nil {
+			logger.Warn("Unified tags: failed to list folder workspaces for task tags", logger.Fields{"error": err})
+		} else {
+			for _, id := range ids {
+				ws, err := h.workspaceStore.Get(id)
+				if err != nil || ws == nil {
+					continue
+				}
+				for _, task := range ws.Tasks {
+					for _, tag := range agentworkspace.NormalizeWorkspaceTags(task.Tags) {
+						entry(tag).Counts.Tasks++
+					}
+				}
+			}
+		}
+	}
+
+	// Template tags are normalized when manifests load.
+	if h.templatesRootResolver != nil {
+		templates, err := projecttemplates.ListLibrary(h.templatesRootResolver())
+		if err != nil {
+			logger.Warn("Unified tags: failed to list templates library", logger.Fields{"error": err})
+		} else {
+			for _, tpl := range templates {
+				for _, tag := range tpl.Tags {
+					entry(tag).Counts.Templates++
+				}
+			}
+		}
+	}
+
+	result := make([]UnifiedTag, 0, len(pool))
+	for _, e := range pool {
+		e.Total = e.Counts.Workspaces + e.Counts.Sessions + e.Counts.Notes + e.Counts.Tasks + e.Counts.Templates
+		result = append(result, *e)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Total != result[j].Total {
+			return result[i].Total > result[j].Total
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result, nil
+}

--- a/internal/sessionhttp/tags_aggregator_test.go
+++ b/internal/sessionhttp/tags_aggregator_test.go
@@ -1,0 +1,189 @@
+package sessionhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// setupUnifiedTagsHandler seeds every tag source: a session, a workspace
+// (SQLite row + folder store with a disk-only tag), a note, a folder-store
+// task, and a templates library manifest.
+func setupUnifiedTagsHandler(t *testing.T) (*Handler, func()) {
+	t.Helper()
+
+	handler, cleanup := createTestHandler(t)
+	ctx := t.Context()
+
+	// Folder-based workspace store.
+	fileStore, err := agentworkspace.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	handler.SetWorkspaceStore(fileStore)
+
+	// Templates library with one manifest.
+	templatesRoot := t.TempDir()
+	tplDir := filepath.Join(templatesRoot, "demo-template")
+	if err := os.MkdirAll(tplDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := `{"name": "Demo", "tags": ["Music", "template-only"]}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	handler.SetTemplatesRootResolver(func() string { return templatesRoot })
+
+	// Workspace: SQLite row without tags; folder store carries a disk-only
+	// tag plus a tagged task. The aggregator must hydrate tags from disk.
+	now := time.Now()
+	ws := &session.Workspace{ID: "ws-tags", Name: "Tagged WS"}
+	if err := handler.store.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	folderWS := &agentworkspace.Workspace{
+		ID:         "ws-tags",
+		Name:       "Tagged WS",
+		Status:     agentworkspace.StatusActive,
+		Tags:       []string{"music", "disk-only"},
+		SharedData: make(map[string]any),
+		Tasks: []agentworkspace.Task{
+			{
+				ID:          "task-1",
+				WorkspaceID: "ws-tags",
+				Description: "Tagged task",
+				Tags:        []string{"music", "task-only"},
+				Status:      agentworkspace.TaskStatusPending,
+				CreatedAt:   now,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := fileStore.Save(folderWS); err != nil {
+		t.Fatalf("fileStore.Save: %v", err)
+	}
+
+	// Session tags.
+	sess := &session.Session{Title: "S", AgentName: "a", Tags: []string{"music", "session-only"}}
+	if err := handler.store.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Note tags.
+	note := &session.WorkspaceNote{
+		ID: "note-1", WorkspaceID: "ws-tags", Name: "N", Content: "c",
+		Tags: []string{"music", "note-only"}, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := handler.store.CreateNote(ctx, note); err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	return handler, func() {
+		_ = fileStore.Close()
+		cleanup()
+	}
+}
+
+func TestHandleTags_ScopeAllAggregatesAllSources(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tags?scope=all", nil)
+	w := httptest.NewRecorder()
+	handler.HandleTags(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Tags []UnifiedTag `json:"tags"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	byName := map[string]UnifiedTag{}
+	for _, tag := range resp.Tags {
+		byName[tag.Name] = tag
+	}
+
+	music, ok := byName["music"]
+	if !ok {
+		t.Fatalf("expected music tag in pool, got %#v", byName)
+	}
+	want := UnifiedTagCounts{Workspaces: 1, Sessions: 1, Notes: 1, Tasks: 1, Templates: 1}
+	if music.Counts != want {
+		t.Fatalf("music counts mismatch: got %+v want %+v", music.Counts, want)
+	}
+	if music.Total != 5 {
+		t.Fatalf("music total mismatch: got %d", music.Total)
+	}
+	if resp.Tags[0].Name != "music" {
+		t.Fatalf("expected music first (highest total), got %q", resp.Tags[0].Name)
+	}
+
+	// One representative per single-source tag, including the disk-only
+	// workspace tag that exists in workspace.json but not in SQLite, and the
+	// template manifest tag (normalized to lowercase).
+	for name, want := range map[string]UnifiedTagCounts{
+		"disk-only":     {Workspaces: 1},
+		"session-only":  {Sessions: 1},
+		"note-only":     {Notes: 1},
+		"task-only":     {Tasks: 1},
+		"template-only": {Templates: 1},
+	} {
+		got, ok := byName[name]
+		if !ok {
+			t.Errorf("expected %s in pool", name)
+			continue
+		}
+		if got.Counts != want {
+			t.Errorf("%s counts mismatch: got %+v want %+v", name, got.Counts, want)
+		}
+		if got.Total != 1 {
+			t.Errorf("%s total mismatch: got %d", name, got.Total)
+		}
+	}
+}
+
+func TestHandleTags_DefaultScopeStaysSessionsOnly(t *testing.T) {
+	handler, cleanup := setupUnifiedTagsHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tags", nil)
+	w := httptest.NewRecorder()
+	handler.HandleTags(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The legacy shape: {"tags": [{"name", "usage_count"}]} with session tags
+	// only — no workspace/note/task/template tags, no counts object.
+	var resp struct {
+		Tags []session.Tag `json:"tags"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	names := map[string]int{}
+	for _, tag := range resp.Tags {
+		names[tag.Name] = tag.UsageCount
+	}
+	if len(names) != 2 || names["music"] != 1 || names["session-only"] != 1 {
+		t.Fatalf("expected sessions-only tags, got %#v", names)
+	}
+	if strings.Contains(w.Body.String(), "counts") {
+		t.Fatalf("default response must not contain unified counts: %s", w.Body.String())
+	}
+}

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -209,6 +209,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		TemplateID         string                     `json:"template_id,omitempty"`   // Optional project template from the library
 		TemplatePath       string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
 		ProjectName        string                     `json:"project_name,omitempty"`  // Project name for template instantiation (defaults to the workspace name)
+		Tags               []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
 	}
 
 	if !orihttp.ParseJSONBody(w, r, &req) {
@@ -217,6 +218,12 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 
 	if req.Name == "" {
 		_ = orihttp.RespondBadRequest(w, "name is required")
+		return
+	}
+
+	requestedTags, err := agentworkspace.ValidateWorkspaceTags(req.Tags)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
 		return
 	}
 
@@ -248,6 +255,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		Color:       req.Color,
 		FolderSlug:  agentworkspace.Slugify(req.Name),
 		ProjectPath: req.ProjectPath,
+		Tags:        requestedTags,
 	}
 	if wantsProject {
 		if tpl, tplErr := h.resolveProjectTemplate(req.TemplateID, req.TemplatePath); tplErr == nil {

--- a/internal/sessionhttp/workspace_note_import.go
+++ b/internal/sessionhttp/workspace_note_import.go
@@ -17,10 +17,11 @@ import (
 )
 
 type importedNoteFrontmatter struct {
-	ID        string `yaml:"id"`
-	Name      string `yaml:"name"`
-	CreatedAt string `yaml:"created_at"`
-	UpdatedAt string `yaml:"updated_at"`
+	ID        string   `yaml:"id"`
+	Name      string   `yaml:"name"`
+	Tags      []string `yaml:"tags"`
+	CreatedAt string   `yaml:"created_at"`
+	UpdatedAt string   `yaml:"updated_at"`
 }
 
 func (h *Handler) importWorkspaceNoteFilesForWorkspace(ctx context.Context, workspaceID string) (int, error) {
@@ -133,6 +134,7 @@ func (h *Handler) syncImportedNoteIfChanged(ctx context.Context, existing, parse
 
 	existing.Name = parsed.Name
 	existing.Content = parsed.Content
+	existing.Tags = parsed.Tags
 	existing.UpdatedAt = noteFileModTime(path, time.Now())
 
 	if err := h.store.UpdateNote(ctx, existing); err != nil {
@@ -155,7 +157,30 @@ func importedNoteDiffers(existing, parsed *session.WorkspaceNote) bool {
 	if existing.Name != parsed.Name {
 		return true
 	}
+	if !importedNoteTagsEqual(existing.Tags, parsed.Tags) {
+		return true
+	}
 	return normalizeImportedNoteContent(existing.Content) != normalizeImportedNoteContent(parsed.Content)
+}
+
+// importedNoteTagsEqual compares tag lists order-insensitively: the DB returns
+// tags in insertion order while frontmatter preserves authoring order, and a
+// reordering is not an edit worth syncing.
+func importedNoteTagsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, tag := range a {
+		seen[tag]++
+	}
+	for _, tag := range b {
+		if seen[tag] == 0 {
+			return false
+		}
+		seen[tag]--
+	}
+	return true
 }
 
 func normalizeImportedNoteContent(content string) string {
@@ -208,6 +233,7 @@ func parseImportedWorkspaceNoteFile(workspaceID, path, filename string) (*sessio
 		if fmName := strings.TrimSpace(fm.Name); fmName != "" {
 			note.Name = fmName
 		}
+		note.Tags = agentworkspace.NormalizeWorkspaceTags(fm.Tags)
 		note.CreatedAt = parseImportedNoteTime(fm.CreatedAt, now)
 		note.UpdatedAt = parseImportedNoteTime(fm.UpdatedAt, note.CreatedAt)
 	}

--- a/internal/web/static/css/tag-input.css
+++ b/internal/web/static/css/tag-input.css
@@ -1,0 +1,232 @@
+/* Shared tag input component (js/modules/tag-input.js).
+   Chip styling matches the existing workspace tag pills; colors come from
+   theme variables so light and dark mode both work. */
+
+.tag-input {
+  position: relative;
+  min-width: 0;
+}
+
+.tag-input-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.35rem 0.45rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-primary);
+  cursor: text;
+}
+
+.tag-input-chips:focus-within {
+  border-color: rgba(31, 107, 78, 0.55);
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 12rem;
+  min-height: 1.55rem;
+  padding: 0.15rem 0.3rem 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 107, 78, 0.24);
+  background: rgba(31, 107, 78, 0.12);
+  color: var(--text-primary);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.tag-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.tag-chip-remove:hover {
+  background: rgba(31, 107, 78, 0.18);
+  color: var(--text-primary);
+}
+
+.tag-input-field {
+  flex: 1 1 7rem;
+  min-width: 7rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  padding: 0.15rem 0.1rem;
+}
+
+.tag-input-field::placeholder {
+  color: var(--text-secondary);
+}
+
+.tag-input-dropdown {
+  position: absolute;
+  z-index: 1080;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  max-height: 14rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.tag-input-option {
+  display: block;
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-input-option:hover,
+.tag-input-option.is-highlighted {
+  background: rgba(31, 107, 78, 0.14);
+}
+
+.tag-input-suggested {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.45rem;
+}
+
+.tag-input-suggested-label {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tag-input-suggested-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 10rem;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(31, 107, 78, 0.4);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.74rem;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-input-suggested-chip:hover {
+  background: rgba(31, 107, 78, 0.12);
+  border-style: solid;
+}
+
+.tag-input-hint {
+  margin-top: 0.35rem;
+  color: var(--danger-color, #c0392b);
+  font-size: 0.76rem;
+}
+
+/* Shared tag filter bar (js/modules/tag-filter-bar.js) */
+
+.tag-filter-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.tag-filter-bar-label {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tag-filter-bar-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.tag-filter-bar-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 11rem;
+  padding: 0.14rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-filter-bar-chip:hover {
+  border-color: rgba(31, 107, 78, 0.45);
+  background: rgba(31, 107, 78, 0.08);
+}
+
+.tag-filter-bar-chip.is-active {
+  border-color: rgba(31, 107, 78, 0.5);
+  background: rgba(31, 107, 78, 0.16);
+}
+
+.tag-filter-bar-clear {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+}
+
+.tag-filter-bar-clear:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+}

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -4605,6 +4605,16 @@ body.chat-panel-open .chat-panel-backdrop {
   background-color: rgba(31, 107, 78, 0.15);
 }
 
+.launcher-card-item.is-drop-into {
+  border-color: var(--accent-primary, #1F6B4E) !important;
+  background: rgba(31, 107, 78, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(31, 107, 78, 0.28), 0 0 0 2px rgba(31, 107, 78, 0.2);
+}
+
+.launcher-group-header.is-drop-into {
+  background: rgba(31, 107, 78, 0.18);
+}
+
 /* ============================================================
    Floating Support Chat Widget
    ============================================================ */

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -2943,6 +2943,7 @@ button.hub-stat[hidden] {
   border-radius: 6px;
   color: var(--text-primary);
   cursor: pointer;
+  user-select: none;
   transition: background 0.14s ease, border-color 0.14s ease, box-shadow 0.14s ease;
 }
 
@@ -3113,6 +3114,31 @@ button.hub-stat[hidden] {
   border-radius: 6px;
   background: rgba(31, 107, 78, 0.06);
   box-shadow: inset 0 0 0 1px rgba(31, 107, 78, 0.18);
+}
+
+.launcher-tree-root-drop {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  margin: 0.25rem 0 0;
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(31, 107, 78, 0.04);
+}
+
+.launcher-grid.is-tree-view.is-dragging-workspace .launcher-tree-root-drop {
+  display: flex;
+}
+
+.launcher-tree-root-drop.is-drag-over {
+  border-color: rgba(31, 107, 78, 0.55);
+  color: var(--text-primary);
+  background: rgba(31, 107, 78, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(31, 107, 78, 0.22);
 }
 
 @media (max-width: 640px) {
@@ -3299,6 +3325,19 @@ button.hub-stat[hidden] {
   transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   position: relative;
   cursor: pointer;
+  user-select: none;
+}
+
+.launcher-card-item[draggable="true"],
+.launcher-tree-row[draggable="true"] {
+  cursor: grab;
+}
+
+.launcher-card-item[draggable="true"]:active,
+.launcher-tree-row[draggable="true"]:active,
+.launcher-card-item.is-dragging,
+.launcher-tree-row.is-dragging {
+  cursor: grabbing;
 }
 
 .launcher-card-item:focus-visible {

--- a/internal/web/static/js/modules/note-page.js
+++ b/internal/web/static/js/modules/note-page.js
@@ -346,6 +346,56 @@ async function savePageNote() {
   } catch (_) { return false; }
 }
 
+// =============================================================================
+// Note tags (shared tag input widget; saved independently of content autosave)
+// =============================================================================
+
+let noteTagsWidget = null;
+
+async function saveNoteTags(tags) {
+  if (!currentNote?.id) return;
+  const noteId = currentNote.id;
+  try {
+    const resp = await fetch(`/api/notes/${encodeURIComponent(noteId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tags }),
+    });
+    if (!resp.ok) {
+      showToast('Failed to save tags', 'error');
+      return;
+    }
+    const data = await resp.json();
+    if (currentNote?.id === noteId) {
+      currentNote = { ...currentNote, tags: data?.note?.tags || tags };
+    }
+    // New tags should show up in suggestions everywhere right away.
+    window.OriTagInput?.clearTagPoolCache?.();
+  } catch (_) {
+    showToast('Failed to save tags', 'error');
+  }
+}
+
+function syncNoteTagsWidget() {
+  const row = document.getElementById('notePageTagsRow');
+  const mount = document.getElementById('notePageTagsMount');
+  if (!row || !mount) return;
+  if (!currentNote?.id) {
+    row.hidden = true;
+    return;
+  }
+  if (!noteTagsWidget && window.OriTagInput?.createTagInput) {
+    noteTagsWidget = window.OriTagInput.createTagInput({
+      container: mount,
+      initialTags: currentNote.tags || [],
+      onChange: (tags) => { void saveNoteTags(tags); },
+    });
+  } else if (noteTagsWidget) {
+    noteTagsWidget.setTags(currentNote.tags || []);
+  }
+  row.hidden = !noteTagsWidget;
+}
+
 function primaryNoteIsDirty() {
   return Boolean(currentNote?.id && bundle?.autosave?.isDirty?.() && !switching);
 }
@@ -889,6 +939,7 @@ async function loadNoteIntoActivePane(noteId) {
 
   currentNote = next;
   resetPageAIAssistForCurrentNote(null);
+  syncNoteTagsWidget();
   fetchWorkspaceName(stateWorkspaceId).then((name) => populateBreadcrumb(currentNote, name, stateWorkspaceId));
 
   // 4. Reset history so undo doesn't cross note boundaries.
@@ -1442,6 +1493,7 @@ async function bootstrap() {
     showWorkspaceEmptyState();
     document.title = 'Workspace Notes - Ori Agent';
   }
+  syncNoteTagsWidget();
 
   // 4. Breadcrumb workspace name (best effort).
   fetchWorkspaceName(stateWorkspaceId).then((name) => populateBreadcrumb(currentNote, name, stateWorkspaceId));

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -280,9 +280,6 @@ const sessionManager = {
       delete addFolderModal.dataset.pendingEntryPoint;
     });
 
-    // Save tags button
-    document.getElementById('saveTagsBtn')?.addEventListener('click', () => this.saveTags());
-
     // Close dropdowns when clicking outside
     document.addEventListener('click', () => this.closeDropdowns());
 
@@ -539,14 +536,17 @@ const sessionManager = {
     }
   },
 
-  // Load all tags from API
+  // Load all tags from API. The session filter list stays sessions-only;
+  // the API returns {name, usage_count} objects, which we flatten to names.
   async loadTags() {
     try {
       const response = await fetch('/api/tags');
       if (!response.ok) throw new Error('Failed to load tags');
 
       const data = await response.json();
-      this.tags = data.tags || [];
+      this.tags = (data.tags || [])
+        .map((tag) => (typeof tag === 'string' ? tag : tag?.name))
+        .filter(Boolean);
       this.renderTagFilters();
     } catch (error) {
       console.error('Failed to load tags:', error);
@@ -3184,6 +3184,7 @@ const sessionManager = {
     if (window.WorkspaceBootstrapReview && typeof window.WorkspaceBootstrapReview.reset === 'function') {
       window.WorkspaceBootstrapReview.reset();
     }
+    if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
   },
 
   async createWorkspaceSeedTask(workspaceId, taskConfig) {
@@ -3319,10 +3320,15 @@ const sessionManager = {
         payload.path = importPath;
         payload.allow_duplicate = Boolean(this.importAllowDuplicate);
         payload.entry_point = this.importEntryPoint || 'workspace_hub_create';
-      } else if (window.ProjectTemplateCard) {
-        // Optional project scaffolding from the "Project (optional)" card
-        // (template_id/template_path + project_name).
-        Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+      } else {
+        if (window.ProjectTemplateCard) {
+          // Optional project scaffolding from the "Project (optional)" card
+          // (template_id/template_path + project_name).
+          Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+        }
+        if (window.WorkspaceTagsCard) {
+          Object.assign(payload, window.WorkspaceTagsCard.getPayloadFields());
+        }
       }
 
       const requestPayload = { ...payload };
@@ -3379,6 +3385,8 @@ const sessionManager = {
         this.showToast(result.project_warning, 'warning');
       }
       if (window.ProjectTemplateCard) window.ProjectTemplateCard.reset();
+      if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
+      window.OriTagInput?.clearTagPoolCache?.();
 
       const createdWorkspaceId = result && result.folder && result.folder.id
         ? String(result.folder.id)
@@ -4119,78 +4127,32 @@ const sessionManager = {
     modal.show();
   },
 
-  // Show edit tags modal
+  // Show edit tags modal (shared tag input widget with unified-pool suggestions)
   showEditTagsModal(sessionId) {
     const session = this.sessions.find(s => s.id === sessionId);
     if (!session) return;
 
     const currentTags = session.tags || [];
-    const tagInput = document.getElementById('tagInput');
-    const currentTagsContainer = document.getElementById('currentTags');
-    const suggestedTagsContainer = document.getElementById('suggestedTags');
-
-    // Clear input
-    if (tagInput) tagInput.value = '';
-
-    // Render current tags
-    if (currentTagsContainer) {
-      currentTagsContainer.innerHTML = currentTags.map(tag => `
-        <span class="session-tag-edit" data-color="${this.getTagColor(tag)}">
-          ${this.escapeHtml(tag)}
-          <button class="tag-remove" data-tag="${this.escapeHtml(tag)}">
-            <svg width="8" height="8" viewBox="0 0 24 24" fill="white">
-              <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/>
-            </svg>
-          </button>
-        </span>
-      `).join('');
-
-      // Bind remove handlers
-      currentTagsContainer.querySelectorAll('.tag-remove').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const tagToRemove = e.currentTarget.dataset.tag;
-          const newTags = currentTags.filter(t => t !== tagToRemove);
-          this.updateSessionTags(sessionId, newTags);
-
-          // Update UI
-          e.currentTarget.parentElement.remove();
+    const mount = document.getElementById('sessionTagsMount');
+    if (mount && window.OriTagInput?.createTagInput) {
+      if (!this.sessionTagsWidget) {
+        this.sessionTagsWidget = window.OriTagInput.createTagInput({
+          container: mount,
+          initialTags: currentTags
         });
-      });
+      } else {
+        this.sessionTagsWidget.setTags(currentTags);
+      }
+      void this.sessionTagsWidget.refreshPool?.();
     }
 
-    // Render suggested tags (tags not already on this session)
-    if (suggestedTagsContainer) {
-      const suggestedTags = this.tags.filter(t => !currentTags.includes(t));
-      suggestedTagsContainer.innerHTML = suggestedTags.length > 0
-        ? suggestedTags.map(tag => `
-            <button class="session-tag-suggest" data-tag="${this.escapeHtml(tag)}">+ ${this.escapeHtml(tag)}</button>
-          `).join('')
-        : '<span class="text-muted small">No suggestions</span>';
-
-      // Bind add handlers
-      suggestedTagsContainer.querySelectorAll('.session-tag-suggest').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          const tagToAdd = e.currentTarget.dataset.tag;
-          const newTags = [...currentTags, tagToAdd];
-          this.updateSessionTags(sessionId, newTags);
-
-          // Remove from suggestions, add to current
-          e.currentTarget.remove();
-        });
-      });
-    }
-
-    // Setup save button
+    // Setup save button (Save commits, Cancel discards)
     const saveBtn = document.getElementById('saveTagsBtn');
     if (saveBtn) {
-      saveBtn.onclick = () => {
-        const input = document.getElementById('tagInput');
-        if (input?.value.trim()) {
-          const newTags = input.value.split(',').map(t => t.trim()).filter(t => t);
-          const allTags = [...new Set([...currentTags, ...newTags])];
-          this.updateSessionTags(sessionId, allTags);
-        }
+      saveBtn.onclick = async () => {
+        const tags = this.sessionTagsWidget ? this.sessionTagsWidget.getTags() : currentTags;
+        await this.updateSessionTags(sessionId, tags);
+        window.OriTagInput?.clearTagPoolCache?.();
 
         const modal = bootstrap.Modal.getInstance(document.getElementById('editTagsModal'));
         modal?.hide();

--- a/internal/web/static/js/modules/settings-page.js
+++ b/internal/web/static/js/modules/settings-page.js
@@ -3136,3 +3136,163 @@ document.getElementById('systemDiagnosticsBtn')?.addEventListener('click', async
     if (VALID.has(v)) select(v, false);
   }).catch(() => {});
 })();
+
+// =============================================================================
+// Tag Management (Settings → Tags)
+// =============================================================================
+// Lists the unified tag pool (GET /api/tags?scope=all) with per-source usage
+// counts, and offers global rename/delete. Both actions confirm with live
+// usage counts from /api/tags/usage. Template-declared tags can still be
+// renamed/deleted on entities, but the dialogs warn that template manifests
+// are read-only and will reintroduce the tag on new workspaces.
+(function initTagManagement() {
+  const tableBody = document.getElementById('tagManagementTableBody');
+  if (!tableBody) return;
+
+  const refreshBtn = document.getElementById('tagManagementRefreshBtn');
+  const esc = (value) => (typeof escapeHtml === 'function'
+    ? escapeHtml(String(value ?? ''))
+    : String(value ?? '').replace(/[&<>"']/g, (ch) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    })[ch]));
+
+  async function fetchPool() {
+    const response = await fetch('/api/tags?scope=all');
+    if (!response.ok) throw new Error('Failed to load tags');
+    const data = await response.json();
+    return Array.isArray(data?.tags) ? data.tags : [];
+  }
+
+  async function fetchUsage(tag) {
+    const response = await fetch(`/api/tags/usage?tag=${encodeURIComponent(tag)}`);
+    if (!response.ok) throw new Error('Failed to load tag usage');
+    return response.json();
+  }
+
+  function usageSummary(usage) {
+    const counts = usage?.counts || {};
+    const parts = [
+      `${counts.workspaces || 0} workspace(s)`,
+      `${counts.sessions || 0} session(s)`,
+      `${counts.notes || 0} note(s)`,
+      `${counts.tasks || 0} task(s)`
+    ];
+    let summary = parts.join(', ');
+    const templates = Array.isArray(usage?.templates) ? usage.templates : [];
+    if (templates.length > 0) {
+      summary += `\n\nNote: declared by template${templates.length === 1 ? '' : 's'} ${templates.join(', ')}. ` +
+        'Template manifests are read-only, so new workspaces created from them will reintroduce this tag.';
+    }
+    return summary;
+  }
+
+  function renderRows(pool) {
+    if (!Array.isArray(pool) || pool.length === 0) {
+      tableBody.innerHTML = '<tr><td colspan="7" class="text-muted">No tags yet. Tags you add to workspaces, sessions, notes, or tasks show up here.</td></tr>';
+      return;
+    }
+
+    tableBody.innerHTML = pool.map((tag) => {
+      const counts = tag.counts || {};
+      const templateOnly = (tag.total || 0) > 0 && tag.total === (counts.templates || 0);
+      const lockHint = (counts.templates || 0) > 0
+        ? ' <span class="text-muted" title="Declared by a project template (read-only in the manifest)">●</span>'
+        : '';
+      const actions = templateOnly
+        ? '<span class="text-muted" title="Only declared by templates — nothing to rename or delete on entities">template-only</span>'
+        : `
+          <button type="button" class="modern-btn modern-btn-secondary modern-btn-sm" data-tag-rename="${esc(tag.name)}">Rename</button>
+          <button type="button" class="modern-btn modern-btn-secondary modern-btn-sm" data-tag-delete="${esc(tag.name)}">Delete</button>
+        `;
+      return `
+        <tr>
+          <td><span class="workspace-detail-tag-chip" style="max-width: 16rem;">${esc(tag.name)}</span>${lockHint}</td>
+          <td class="text-end">${counts.workspaces || 0}</td>
+          <td class="text-end">${counts.sessions || 0}</td>
+          <td class="text-end">${counts.notes || 0}</td>
+          <td class="text-end">${counts.tasks || 0}</td>
+          <td class="text-end">${counts.templates || 0}</td>
+          <td class="text-end" style="white-space: nowrap;">${actions}</td>
+        </tr>
+      `;
+    }).join('');
+
+    tableBody.querySelectorAll('[data-tag-rename]').forEach((button) => {
+      button.addEventListener('click', () => renameTag(button.getAttribute('data-tag-rename')));
+    });
+    tableBody.querySelectorAll('[data-tag-delete]').forEach((button) => {
+      button.addEventListener('click', () => deleteTag(button.getAttribute('data-tag-delete')));
+    });
+  }
+
+  async function loadTable() {
+    try {
+      renderRows(await fetchPool());
+    } catch (error) {
+      console.error('Failed to load tag management table:', error);
+      tableBody.innerHTML = '<tr><td colspan="7" class="text-danger">Failed to load tags.</td></tr>';
+    }
+  }
+
+  async function renameTag(tag) {
+    const raw = window.prompt(`Rename tag "${tag}" to:`, tag);
+    if (raw === null) return;
+    const to = String(raw).trim().toLowerCase();
+    if (!to) return;
+    if (to === tag) {
+      notify('That is already the tag name', 'info');
+      return;
+    }
+
+    try {
+      const usage = await fetchUsage(tag);
+      const confirmed = window.confirm(
+        `Rename "${tag}" to "${to}"?\n\nThis updates ${usageSummary(usage)}`
+      );
+      if (!confirmed) return;
+
+      const response = await fetch('/api/tags/rename', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ from: tag, to })
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(result.error || 'Failed to rename tag');
+
+      window.OriTagInput?.clearTagPoolCache?.();
+      notify(`Renamed "${tag}" to "${to}"`, 'success');
+      await loadTable();
+    } catch (error) {
+      console.error('Failed to rename tag:', error);
+      notify(error.message || 'Failed to rename tag', 'error');
+    }
+  }
+
+  async function deleteTag(tag) {
+    try {
+      const usage = await fetchUsage(tag);
+      const confirmed = window.confirm(
+        `Delete tag "${tag}" everywhere?\n\nThis removes it from ${usageSummary(usage)}`
+      );
+      if (!confirmed) return;
+
+      const response = await fetch('/api/tags/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag })
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(result.error || 'Failed to delete tag');
+
+      window.OriTagInput?.clearTagPoolCache?.();
+      notify(`Deleted "${tag}"`, 'success');
+      await loadTable();
+    } catch (error) {
+      console.error('Failed to delete tag:', error);
+      notify(error.message || 'Failed to delete tag', 'error');
+    }
+  }
+
+  refreshBtn?.addEventListener('click', () => loadTable());
+  loadTable();
+})();

--- a/internal/web/static/js/modules/tag-filter-bar.js
+++ b/internal/web/static/js/modules/tag-filter-bar.js
@@ -1,0 +1,159 @@
+/**
+ * Shared multi-select tag filter bar.
+ *
+ * Modeled on the workspace hub launcher's tag filter: chips for every
+ * available tag, AND-matching multi-select, a Clear button, and the whole
+ * bar hides when there is nothing to filter by. Selection is plain UI
+ * state — it intentionally does not persist across reloads.
+ *
+ * Pure helpers are exported for node:test; plain (non-module) scripts use
+ * window.OriTagFilterBar.
+ */
+
+/** Normalized tag list for one item (workspace, note, task…). */
+export function itemTags(item) {
+  if (!item || !Array.isArray(item.tags)) return [];
+  return item.tags.map((tag) => String(tag || '').trim()).filter((tag) => tag.length > 0);
+}
+
+/** Sorted unique tags across all items. */
+export function collectTags(items, getTags = itemTags) {
+  const tags = new Set();
+  (Array.isArray(items) ? items : []).forEach((item) => {
+    getTags(item).forEach((tag) => tags.add(tag));
+  });
+  return Array.from(tags).sort((a, b) => a.localeCompare(b));
+}
+
+/** AND-matching: the item must carry every active tag. */
+export function matchesActiveTags(tags, activeTags) {
+  const active = Array.from(activeTags || []);
+  if (active.length === 0) return true;
+  const tagSet = new Set(tags || []);
+  return active.every((tag) => tagSet.has(tag));
+}
+
+/** Items that carry every active tag. */
+export function filterItems(items, activeTags, getTags = itemTags) {
+  const active = Array.from(activeTags || []);
+  if (active.length === 0) return Array.isArray(items) ? items : [];
+  return (Array.isArray(items) ? items : []).filter((item) =>
+    matchesActiveTags(getTags(item), active)
+  );
+}
+
+/**
+ * Create the filter bar inside `container`.
+ *
+ * Options: label (default "Tags"), onChange(activeTagsArray).
+ * Returns { setAvailableTags, getActiveTags, clear, element, destroy }.
+ */
+export function createTagFilterBar(options = {}) {
+  const container = options.container;
+  if (!container) throw new Error('createTagFilterBar requires a container element');
+
+  const active = new Set();
+  let available = [];
+
+  const root = document.createElement('div');
+  root.className = 'tag-filter-bar';
+  root.hidden = true;
+
+  const label = document.createElement('span');
+  label.className = 'tag-filter-bar-label';
+  label.textContent = options.label ?? 'Tags';
+
+  const chips = document.createElement('div');
+  chips.className = 'tag-filter-bar-chips';
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'tag-filter-bar-clear';
+  clearBtn.textContent = 'Clear';
+  clearBtn.hidden = true;
+
+  root.appendChild(label);
+  root.appendChild(chips);
+  root.appendChild(clearBtn);
+  container.appendChild(root);
+
+  function emitChange() {
+    if (typeof options.onChange === 'function') {
+      options.onChange(Array.from(active));
+    }
+  }
+
+  function render() {
+    chips.innerHTML = '';
+    if (available.length === 0) {
+      root.hidden = true;
+      clearBtn.hidden = true;
+      return;
+    }
+    root.hidden = false;
+    available.forEach((tag) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'tag-filter-bar-chip';
+      if (active.has(tag)) chip.classList.add('is-active');
+      chip.setAttribute('aria-pressed', active.has(tag) ? 'true' : 'false');
+      chip.textContent = tag;
+      chip.title = tag;
+      chip.addEventListener('click', () => {
+        if (active.has(tag)) {
+          active.delete(tag);
+        } else {
+          active.add(tag);
+        }
+        render();
+        emitChange();
+      });
+      chips.appendChild(chip);
+    });
+    clearBtn.hidden = active.size === 0;
+  }
+
+  clearBtn.addEventListener('click', () => {
+    if (active.size === 0) return;
+    active.clear();
+    render();
+    emitChange();
+  });
+
+  return {
+    element: root,
+    setAvailableTags(tags) {
+      available = Array.from(new Set(tags || [])).sort((a, b) => a.localeCompare(b));
+      // Prune selections that no longer exist among the available tags.
+      let pruned = false;
+      Array.from(active).forEach((tag) => {
+        if (!available.includes(tag)) {
+          active.delete(tag);
+          pruned = true;
+        }
+      });
+      render();
+      if (pruned) emitChange();
+    },
+    getActiveTags: () => Array.from(active),
+    clear() {
+      if (active.size === 0) return;
+      active.clear();
+      render();
+      emitChange();
+    },
+    destroy() {
+      root.remove();
+    }
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.OriTagFilterBar = {
+    createTagFilterBar,
+    collectTags,
+    filterItems,
+    matchesActiveTags,
+    itemTags
+  };
+}

--- a/internal/web/static/js/modules/tag-filter-bar.test.js
+++ b/internal/web/static/js/modules/tag-filter-bar.test.js
@@ -1,0 +1,53 @@
+// Tests for tag-filter-bar.js pure helpers.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { itemTags, collectTags, matchesActiveTags, filterItems } = await import('./tag-filter-bar.js');
+
+const items = [
+  { id: 'a', tags: ['music', 'client'] },
+  { id: 'b', tags: ['music'] },
+  { id: 'c', tags: [] },
+  { id: 'd' },
+  { id: 'e', tags: [' archive '] },
+];
+
+test('itemTags trims and drops empty entries', () => {
+  assert.deepEqual(itemTags({ tags: [' music ', '', null] }), ['music']);
+  assert.deepEqual(itemTags(null), []);
+  assert.deepEqual(itemTags({}), []);
+});
+
+test('collectTags returns sorted unique tags across items', () => {
+  assert.deepEqual(collectTags(items), ['archive', 'client', 'music']);
+});
+
+test('matchesActiveTags uses AND logic', () => {
+  assert.equal(matchesActiveTags(['music', 'client'], ['music']), true);
+  assert.equal(matchesActiveTags(['music', 'client'], ['music', 'client']), true);
+  assert.equal(matchesActiveTags(['music'], ['music', 'client']), false);
+  assert.equal(matchesActiveTags([], []), true);
+});
+
+test('filterItems with no active tags returns all items', () => {
+  assert.equal(filterItems(items, []).length, items.length);
+  assert.equal(filterItems(items, new Set()).length, items.length);
+});
+
+test('filterItems narrows to items carrying every active tag', () => {
+  const one = filterItems(items, ['music']);
+  assert.deepEqual(one.map((item) => item.id), ['a', 'b']);
+
+  const both = filterItems(items, new Set(['music', 'client']));
+  assert.deepEqual(both.map((item) => item.id), ['a']);
+});
+
+test('filterItems supports a custom tag getter', () => {
+  const rows = [
+    { name: 'x', labels: ['alpha'] },
+    { name: 'y', labels: ['beta'] },
+  ];
+  const filtered = filterItems(rows, ['beta'], (row) => row.labels || []);
+  assert.deepEqual(filtered.map((row) => row.name), ['y']);
+});

--- a/internal/web/static/js/modules/tag-input.js
+++ b/internal/web/static/js/modules/tag-input.js
@@ -1,0 +1,404 @@
+/**
+ * Shared tag input component.
+ *
+ * One canonical editor for tags everywhere they are entered (workspace
+ * detail, create-workspace modal, sessions, notes, tasks): chips with
+ * remove buttons, a text field with typeahead suggestions from the unified
+ * tag pool (GET /api/tags?scope=all), and a clickable row of the most-used
+ * pool tags not yet applied.
+ *
+ * Pure helpers are exported for node:test; the DOM widget is created with
+ * createTagInput(). Plain (non-module) scripts use window.OriTagInput.
+ */
+
+const TAG_POOL_URL = '/api/tags?scope=all';
+const TAG_POOL_CACHE_MS = 30000;
+
+export const DEFAULT_MAX_TAGS = 20;
+export const DEFAULT_MAX_TAG_LENGTH = 64;
+
+/** Normalize a single tag the same way the backend does: trim + lowercase. */
+export function normalizeTagValue(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Normalize a tag list: trim/lowercase, drop empties, dedupe, enforce caps.
+ * Returns { tags, error } where error is '' when the list is valid.
+ */
+export function normalizeTagList(tags, options = {}) {
+  const maxTags = options.maxTags ?? DEFAULT_MAX_TAGS;
+  const maxTagLength = options.maxTagLength ?? DEFAULT_MAX_TAG_LENGTH;
+
+  const normalized = [];
+  const seen = new Set();
+  (Array.isArray(tags) ? tags : []).forEach(tag => {
+    const value = normalizeTagValue(tag);
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    normalized.push(value);
+  });
+
+  const overlong = normalized.find(tag => Array.from(tag).length > maxTagLength);
+  if (overlong) {
+    return { tags: normalized, error: `"${overlong}" exceeds the ${maxTagLength} character limit.` };
+  }
+  if (normalized.length > maxTags) {
+    return { tags: normalized, error: `At most ${maxTags} tags are allowed.` };
+  }
+  return { tags: normalized, error: '' };
+}
+
+/**
+ * Typeahead matches for the dropdown: pool tags containing the query,
+ * prefix matches first, then by usage. Already-selected tags are excluded.
+ */
+export function filterSuggestions(pool, options = {}) {
+  const query = normalizeTagValue(options.query);
+  const limit = options.limit ?? 8;
+  const exclude = new Set((options.exclude || []).map(normalizeTagValue));
+
+  const candidates = (Array.isArray(pool) ? pool : [])
+    .filter(entry => entry && entry.name && !exclude.has(entry.name))
+    .filter(entry => query === '' || entry.name.includes(query));
+
+  candidates.sort((a, b) => {
+    if (query !== '') {
+      const aPrefix = a.name.startsWith(query) ? 0 : 1;
+      const bPrefix = b.name.startsWith(query) ? 0 : 1;
+      if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+    }
+    if ((b.total ?? 0) !== (a.total ?? 0)) return (b.total ?? 0) - (a.total ?? 0);
+    return a.name.localeCompare(b.name);
+  });
+
+  return candidates.slice(0, limit).map(entry => entry.name);
+}
+
+/** Most-used pool tags not yet applied, for the "Suggested" chip row. */
+export function topSuggestions(pool, options = {}) {
+  return filterSuggestions(pool, {
+    query: '',
+    exclude: options.exclude || [],
+    limit: options.limit ?? 10
+  });
+}
+
+let tagPoolCache = { at: 0, data: null };
+
+/** Clear the shared pool cache (used after tag mutations and in tests). */
+export function clearTagPoolCache() {
+  tagPoolCache = { at: 0, data: null };
+}
+
+/**
+ * Fetch the unified tag pool with a short-lived shared cache so several
+ * editors on one page don't refetch. Returns [] when the request fails —
+ * tag entry must keep working without suggestions.
+ */
+export async function fetchTagPool(options = {}) {
+  const now = Date.now();
+  if (!options.force && tagPoolCache.data && now - tagPoolCache.at < TAG_POOL_CACHE_MS) {
+    return tagPoolCache.data;
+  }
+  const fetcher = options.fetcher || (typeof fetch !== 'undefined' ? fetch : null);
+  if (!fetcher) return [];
+  try {
+    const response = await fetcher(TAG_POOL_URL);
+    if (!response || !response.ok) return [];
+    const payload = await response.json();
+    const pool = Array.isArray(payload?.tags) ? payload.tags : [];
+    tagPoolCache = { at: now, data: pool };
+    return pool;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Create the tag input widget inside `container`.
+ *
+ * Options: initialTags, maxTags, maxTagLength, placeholder, suggestedLimit,
+ * dropdownLimit, fetchPool (override), onChange(tags).
+ * Returns { getTags, setTags, focus, refreshPool, destroy, element }.
+ */
+export function createTagInput(options = {}) {
+  const container = options.container;
+  if (!container) throw new Error('createTagInput requires a container element');
+
+  const maxTags = options.maxTags ?? DEFAULT_MAX_TAGS;
+  const maxTagLength = options.maxTagLength ?? DEFAULT_MAX_TAG_LENGTH;
+  const suggestedLimit = options.suggestedLimit ?? 10;
+  const dropdownLimit = options.dropdownLimit ?? 8;
+  const loadPool = options.fetchPool || fetchTagPool;
+
+  let tags = normalizeTagList(options.initialTags, { maxTags, maxTagLength }).tags;
+  let pool = [];
+  let poolLoaded = false;
+  let highlightIndex = -1;
+  let dropdownItems = [];
+
+  const root = document.createElement('div');
+  root.className = 'tag-input';
+
+  const chips = document.createElement('div');
+  chips.className = 'tag-input-chips';
+
+  const field = document.createElement('input');
+  field.type = 'text';
+  field.className = 'tag-input-field';
+  field.placeholder = options.placeholder ?? 'Add tag…';
+  field.maxLength = maxTagLength;
+  field.autocomplete = 'off';
+  field.spellcheck = false;
+  field.setAttribute('aria-label', 'Add tag');
+
+  const dropdown = document.createElement('div');
+  dropdown.className = 'tag-input-dropdown';
+  dropdown.hidden = true;
+  dropdown.setAttribute('role', 'listbox');
+
+  const suggested = document.createElement('div');
+  suggested.className = 'tag-input-suggested';
+  suggested.hidden = true;
+
+  const hint = document.createElement('div');
+  hint.className = 'tag-input-hint';
+  hint.hidden = true;
+  hint.setAttribute('role', 'alert');
+
+  chips.appendChild(field);
+  root.appendChild(chips);
+  root.appendChild(dropdown);
+  root.appendChild(suggested);
+  root.appendChild(hint);
+  container.appendChild(root);
+
+  function setHint(message) {
+    const text = String(message || '').trim();
+    hint.textContent = text;
+    hint.hidden = text === '';
+  }
+
+  function emitChange() {
+    if (typeof options.onChange === 'function') {
+      options.onChange([...tags]);
+    }
+  }
+
+  function renderChips() {
+    chips.querySelectorAll('.tag-chip').forEach(chip => chip.remove());
+    tags.forEach(tag => {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+
+      const label = document.createElement('span');
+      label.className = 'tag-chip-label';
+      label.textContent = tag;
+      label.title = tag;
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'tag-chip-remove';
+      remove.textContent = '×';
+      remove.setAttribute('aria-label', `Remove ${tag}`);
+      remove.addEventListener('click', () => removeTag(tag));
+
+      chip.appendChild(label);
+      chip.appendChild(remove);
+      chips.insertBefore(chip, field);
+    });
+  }
+
+  function closeDropdown() {
+    dropdown.hidden = true;
+    dropdown.innerHTML = '';
+    dropdownItems = [];
+    highlightIndex = -1;
+  }
+
+  function renderDropdown() {
+    const query = field.value;
+    if (normalizeTagValue(query) === '') {
+      closeDropdown();
+      return;
+    }
+    dropdownItems = filterSuggestions(pool, {
+      query,
+      exclude: tags,
+      limit: dropdownLimit
+    });
+    dropdown.innerHTML = '';
+    if (dropdownItems.length === 0) {
+      closeDropdown();
+      return;
+    }
+    highlightIndex = Math.min(highlightIndex, dropdownItems.length - 1);
+    dropdownItems.forEach((name, index) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'tag-input-option';
+      option.setAttribute('role', 'option');
+      option.textContent = name;
+      if (index === highlightIndex) option.classList.add('is-highlighted');
+      // mousedown beats the field blur so the click still lands.
+      option.addEventListener('mousedown', event => {
+        event.preventDefault();
+        addTag(name);
+      });
+      dropdown.appendChild(option);
+    });
+    dropdown.hidden = false;
+  }
+
+  function renderSuggested() {
+    const names = topSuggestions(pool, { exclude: tags, limit: suggestedLimit });
+    suggested.innerHTML = '';
+    if (names.length === 0) {
+      suggested.hidden = true;
+      return;
+    }
+    const label = document.createElement('span');
+    label.className = 'tag-input-suggested-label';
+    label.textContent = 'Suggested:';
+    suggested.appendChild(label);
+    names.forEach(name => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'tag-input-suggested-chip';
+      chip.textContent = name;
+      chip.title = `Add ${name}`;
+      chip.addEventListener('click', () => addTag(name));
+      suggested.appendChild(chip);
+    });
+    suggested.hidden = false;
+  }
+
+  function renderAll() {
+    renderChips();
+    renderSuggested();
+  }
+
+  function addTag(rawValue) {
+    const value = normalizeTagValue(rawValue);
+    if (!value) return false;
+    const result = normalizeTagList([...tags, value], { maxTags, maxTagLength });
+    if (result.error) {
+      setHint(result.error);
+      return false;
+    }
+    const changed = result.tags.length !== tags.length;
+    tags = result.tags;
+    setHint('');
+    field.value = '';
+    closeDropdown();
+    renderAll();
+    if (changed) emitChange();
+    field.focus();
+    return changed;
+  }
+
+  function removeTag(tag) {
+    const next = tags.filter(existing => existing !== tag);
+    if (next.length === tags.length) return;
+    tags = next;
+    setHint('');
+    renderAll();
+    emitChange();
+  }
+
+  async function ensurePool(force = false) {
+    if (poolLoaded && !force) return;
+    poolLoaded = true;
+    pool = await loadPool(force ? { force: true } : {});
+    renderSuggested();
+    if (!dropdown.hidden) renderDropdown();
+  }
+
+  function onKeydown(event) {
+    if (event.key === 'ArrowDown' && !dropdown.hidden) {
+      event.preventDefault();
+      highlightIndex = Math.min(highlightIndex + 1, dropdownItems.length - 1);
+      renderDropdown();
+    } else if (event.key === 'ArrowUp' && !dropdown.hidden) {
+      event.preventDefault();
+      highlightIndex = Math.max(highlightIndex - 1, -1);
+      renderDropdown();
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      if (highlightIndex >= 0 && highlightIndex < dropdownItems.length) {
+        addTag(dropdownItems[highlightIndex]);
+      } else if (normalizeTagValue(field.value)) {
+        addTag(field.value);
+      }
+    } else if (event.key === ',') {
+      event.preventDefault();
+      if (normalizeTagValue(field.value)) addTag(field.value);
+    } else if (event.key === 'Escape') {
+      if (!dropdown.hidden) {
+        // Swallow Esc when it only closes the dropdown, so a surrounding
+        // editor (e.g. the workspace tags editor) doesn't also close.
+        event.stopPropagation();
+        closeDropdown();
+      }
+    } else if (event.key === 'Backspace' && field.value === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  }
+
+  function onInput() {
+    setHint('');
+    highlightIndex = -1;
+    renderDropdown();
+  }
+
+  function onFocus() {
+    void ensurePool();
+  }
+
+  function onBlur() {
+    // Delay so option mousedown handlers run first.
+    setTimeout(() => closeDropdown(), 120);
+  }
+
+  field.addEventListener('keydown', onKeydown);
+  field.addEventListener('input', onInput);
+  field.addEventListener('focus', onFocus);
+  field.addEventListener('blur', onBlur);
+  chips.addEventListener('click', event => {
+    if (event.target === chips) field.focus();
+  });
+
+  renderAll();
+
+  return {
+    element: root,
+    getTags: () => [...tags],
+    setTags: nextTags => {
+      tags = normalizeTagList(nextTags, { maxTags, maxTagLength }).tags;
+      setHint('');
+      field.value = '';
+      closeDropdown();
+      renderAll();
+    },
+    focus: () => field.focus(),
+    refreshPool: () => ensurePool(true),
+    destroy: () => {
+      root.remove();
+    }
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.OriTagInput = {
+    createTagInput,
+    fetchTagPool,
+    clearTagPoolCache,
+    normalizeTagValue,
+    normalizeTagList,
+    filterSuggestions,
+    topSuggestions
+  };
+}

--- a/internal/web/static/js/modules/tag-input.test.js
+++ b/internal/web/static/js/modules/tag-input.test.js
@@ -1,0 +1,100 @@
+// Tests for tag-input.js pure helpers.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  normalizeTagValue,
+  normalizeTagList,
+  filterSuggestions,
+  topSuggestions,
+  fetchTagPool,
+  clearTagPoolCache,
+} = await import('./tag-input.js');
+
+const pool = [
+  { name: 'music', total: 9, counts: { workspaces: 3 } },
+  { name: 'mixing', total: 5, counts: { workspaces: 1 } },
+  { name: 'mastering', total: 5, counts: { notes: 5 } },
+  { name: 'client', total: 2, counts: { sessions: 2 } },
+  { name: 'archive', total: 1, counts: { templates: 1 } },
+];
+
+test('normalizeTagValue trims and lowercases', () => {
+  assert.equal(normalizeTagValue('  Deep Work '), 'deep work');
+  assert.equal(normalizeTagValue(null), '');
+});
+
+test('normalizeTagList dedupes after normalization and drops empties', () => {
+  const result = normalizeTagList([' Music ', 'music', '', 'Client:Acme']);
+  assert.deepEqual(result, { tags: ['music', 'client:acme'], error: '' });
+});
+
+test('normalizeTagList reports overlong tags', () => {
+  const result = normalizeTagList(['x'.repeat(65)]);
+  assert.match(result.error, /64 character limit/);
+});
+
+test('normalizeTagList enforces the tag cap', () => {
+  const result = normalizeTagList(Array.from({ length: 21 }, (_, i) => `tag-${i}`));
+  assert.match(result.error, /At most 20 tags/);
+});
+
+test('filterSuggestions matches substrings and ranks prefix matches first', () => {
+  const names = filterSuggestions(pool, { query: 'm' });
+  // Prefix matches (music, mixing, mastering) before substring-only ones.
+  assert.deepEqual(names, ['music', 'mastering', 'mixing']);
+});
+
+test('filterSuggestions excludes already-selected tags', () => {
+  const names = filterSuggestions(pool, { query: 'm', exclude: ['Music'] });
+  assert.ok(!names.includes('music'));
+});
+
+test('filterSuggestions respects the limit', () => {
+  const names = filterSuggestions(pool, { query: 'm', limit: 1 });
+  assert.deepEqual(names, ['music']);
+});
+
+test('filterSuggestions with empty query returns nothing-filtered list by usage', () => {
+  const names = filterSuggestions(pool, { query: '', limit: 3 });
+  assert.deepEqual(names, ['music', 'mastering', 'mixing']);
+});
+
+test('topSuggestions returns most-used tags excluding applied, capped at 10', () => {
+  const bigPool = Array.from({ length: 15 }, (_, i) => ({ name: `tag-${String(i).padStart(2, '0')}`, total: 100 - i }));
+  const names = topSuggestions(bigPool, { exclude: ['tag-00'] });
+  assert.equal(names.length, 10);
+  assert.equal(names[0], 'tag-01');
+});
+
+test('fetchTagPool returns pool tags and caches them', async () => {
+  clearTagPoolCache();
+  let calls = 0;
+  const fetcher = async () => {
+    calls++;
+    return { ok: true, json: async () => ({ tags: pool }) };
+  };
+  const first = await fetchTagPool({ fetcher });
+  const second = await fetchTagPool({ fetcher });
+  assert.equal(first.length, pool.length);
+  assert.equal(second.length, pool.length);
+  assert.equal(calls, 1, 'second call should hit the cache');
+
+  const forced = await fetchTagPool({ fetcher, force: true });
+  assert.equal(forced.length, pool.length);
+  assert.equal(calls, 2, 'force bypasses the cache');
+  clearTagPoolCache();
+});
+
+test('fetchTagPool degrades to an empty pool on failure', async () => {
+  clearTagPoolCache();
+  const failing = async () => {
+    throw new Error('network down');
+  };
+  assert.deepEqual(await fetchTagPool({ fetcher: failing }), []);
+
+  const notOK = async () => ({ ok: false, json: async () => ({}) });
+  assert.deepEqual(await fetchTagPool({ fetcher: notOK }), []);
+  clearTagPoolCache();
+});

--- a/internal/web/static/js/modules/task-modal-controller.js
+++ b/internal/web/static/js/modules/task-modal-controller.js
@@ -462,6 +462,22 @@ class TaskModalController {
     mirror(autoReferenceURLInput, manualReferenceURLInput);
   }
 
+  // Mounts the shared tag input widget into the modal (lazily, the markup
+  // ships on several pages) and seeds it with the given tags.
+  syncTaskModalTags(tags) {
+    const mount = document.getElementById('taskModalTagsMount');
+    if (!mount) return;
+    if (!this.taskTagsWidget && window.OriTagInput?.createTagInput) {
+      this.taskTagsWidget = window.OriTagInput.createTagInput({
+        container: mount,
+        initialTags: tags || []
+      });
+    } else if (this.taskTagsWidget) {
+      this.taskTagsWidget.setTags(tags || []);
+    }
+    void this.taskTagsWidget?.refreshPool?.();
+  }
+
   getReferenceURLValue() {
     const activeId = this.autoMode && !this.editingTaskId
       ? 'taskAutoReferenceURL'
@@ -841,6 +857,7 @@ class TaskModalController {
     if (referenceURLInput) referenceURLInput.value = referenceURL;
     if (autoReferenceURLInput) autoReferenceURLInput.value = referenceURL;
     if (priorityInput) priorityInput.value = String(createOptions.draftPriority || '3');
+    this.syncTaskModalTags(createOptions.prefillTags || []);
 
     // Populate agent assignment dropdown
     await this.populateAgentDropdown(workspaceId);
@@ -959,6 +976,7 @@ class TaskModalController {
     if (detailsInput) detailsInput.value = task.details || '';
     if (referenceURLInput) referenceURLInput.value = task.reference_url || '';
     if (autoReferenceURLInput) autoReferenceURLInput.value = task.reference_url || '';
+    this.syncTaskModalTags(task.tags || []);
 
     let loadedSubtasks = [];
     if (!isSubtask) {
@@ -2149,6 +2167,7 @@ class TaskModalController {
     const referenceURL = this.getReferenceURLValue();
     const priority = parseInt(priorityInput?.value || '3', 10);
     const assignment = assignmentInput?.value || '';
+    const tags = this.taskTagsWidget ? this.taskTagsWidget.getTags() : [];
 
     if (!description) {
       this.showToast('Task title is required', 'error');
@@ -2295,6 +2314,7 @@ class TaskModalController {
             description,
             details,
             reference_url: referenceURL,
+            tags,
             to: to || undefined,
             assigned_node_id: assignedNodeId || undefined,
             input_task_ids: mainInputIds,
@@ -2310,6 +2330,7 @@ class TaskModalController {
             description,
             details,
             reference_url: referenceURL,
+            tags,
             to: to || undefined,
             assigned_node_id: assignedNodeId || undefined,
             input_task_ids: [],
@@ -2375,6 +2396,7 @@ class TaskModalController {
             description,
             details,
             reference_url: referenceURL,
+            tags,
             to: to || undefined,
             assigned_node_id: assignedNodeId || undefined,
             input_task_ids: mainInputIds,
@@ -2420,6 +2442,7 @@ class TaskModalController {
             description,
             details,
             reference_url: referenceURL,
+            tags,
             priority,
             to: to || '',
             assigned_node_id: assignedNodeId || ''
@@ -2449,6 +2472,7 @@ class TaskModalController {
           description,
           details,
           reference_url: referenceURL,
+          tags,
           priority,
           to: to || undefined,
           assigned_node_id: assignedNodeId || undefined,

--- a/internal/web/static/js/modules/workspace-create.js
+++ b/internal/web/static/js/modules/workspace-create.js
@@ -504,8 +504,13 @@ async function createWorkspace() {
       payload.path = importPath;
       payload.allow_duplicate = workspaceCreateState.allowDuplicateImport;
       payload.entry_point = workspaceCreateState.entryPoint || 'create_modal';
-    } else if (window.ProjectTemplateCard) {
-      Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+    } else {
+      if (window.ProjectTemplateCard) {
+        Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+      }
+      if (window.WorkspaceTagsCard) {
+        Object.assign(payload, window.WorkspaceTagsCard.getPayloadFields());
+      }
     }
 
     const requestPayload = { ...payload };
@@ -601,6 +606,8 @@ async function createWorkspace() {
     setImportMode(false);
     clearDuplicateWarning();
     if (window.ProjectTemplateCard) window.ProjectTemplateCard.reset();
+    if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
+    window.OriTagInput?.clearTagPoolCache?.();
     window.selectedAgents.clear();
     resetImportState();
 

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -961,9 +961,7 @@ export class WorkspaceDetailPage {
       workspaceTagsList: document.getElementById('workspace-tags-list'),
       workspaceTagsEditBtn: document.getElementById('workspace-tags-edit-btn'),
       workspaceTagsEditor: document.getElementById('workspace-tags-editor'),
-      workspaceTagsEditorList: document.getElementById('workspace-tags-editor-list'),
-      workspaceTagsInput: document.getElementById('workspace-tags-input'),
-      workspaceTagsAddBtn: document.getElementById('workspace-tags-add-btn'),
+      workspaceTagsEditorMount: document.getElementById('workspace-tags-editor-mount'),
       workspaceTagsSaveBtn: document.getElementById('workspace-tags-save-btn'),
       workspaceTagsCancelBtn: document.getElementById('workspace-tags-cancel-btn'),
       workspaceTagsError: document.getElementById('workspace-tags-error'),
@@ -1679,18 +1677,14 @@ export class WorkspaceDetailPage {
     this.elements.workspaceTagsEditBtn?.addEventListener('click', () =>
       this.openWorkspaceTagsEditor()
     );
-    this.elements.workspaceTagsAddBtn?.addEventListener('click', () =>
-      this.addWorkspaceTagFromInput()
-    );
     this.elements.workspaceTagsSaveBtn?.addEventListener('click', () => this.saveWorkspaceTags());
     this.elements.workspaceTagsCancelBtn?.addEventListener('click', () =>
       this.closeWorkspaceTagsEditor()
     );
-    this.elements.workspaceTagsInput?.addEventListener('keydown', event => {
-      if (event.key === 'Enter') {
-        event.preventDefault();
-        this.addWorkspaceTagFromInput();
-      } else if (event.key === 'Escape') {
+    // Esc anywhere inside the editor closes it (the tag widget swallows Esc
+    // itself when it is only dismissing its suggestion dropdown).
+    this.elements.workspaceTagsEditor?.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
         event.preventDefault();
         this.closeWorkspaceTagsEditor();
       }
@@ -2010,27 +2004,39 @@ export class WorkspaceDetailPage {
       : '<span class="workspace-detail-tag-empty">No tags</span>';
 
     container.hidden = false;
-    if (this.elements.workspaceTagsEditor && !this.elements.workspaceTagsEditor.hidden) {
-      this.renderWorkspaceTagEditor();
-    }
   }
 
   openWorkspaceTagsEditor() {
     this.workspaceTagDraft = this.getWorkspaceTags();
     this.setWorkspaceTagsError('');
+    this.ensureWorkspaceTagInput();
+    this.workspaceTagInput?.setTags(this.workspaceTagDraft);
     if (this.elements.workspaceTagsEditor) {
       this.elements.workspaceTagsEditor.hidden = false;
     }
-    this.renderWorkspaceTagEditor();
-    this.elements.workspaceTagsInput?.focus();
+    this.workspaceTagInput?.focus();
+  }
+
+  // Lazily mount the shared tag input widget (suggestions from the unified
+  // tag pool) into the editor. Falls back to a no-op when the module failed
+  // to load — Save then just submits the unchanged draft.
+  ensureWorkspaceTagInput() {
+    if (this.workspaceTagInput || !this.elements.workspaceTagsEditorMount) return;
+    if (!window.OriTagInput?.createTagInput) return;
+    this.workspaceTagInput = window.OriTagInput.createTagInput({
+      container: this.elements.workspaceTagsEditorMount,
+      initialTags: this.workspaceTagDraft,
+      onChange: tags => {
+        this.workspaceTagDraft = tags;
+        this.setWorkspaceTagsError('');
+      }
+    });
   }
 
   closeWorkspaceTagsEditor() {
     this.workspaceTagDraft = this.getWorkspaceTags();
     this.setWorkspaceTagsError('');
-    if (this.elements.workspaceTagsInput) {
-      this.elements.workspaceTagsInput.value = '';
-    }
+    this.workspaceTagInput?.setTags(this.workspaceTagDraft);
     if (this.elements.workspaceTagsEditor) {
       this.elements.workspaceTagsEditor.hidden = true;
     }
@@ -2044,82 +2050,11 @@ export class WorkspaceDetailPage {
     errorEl.hidden = text === '';
   }
 
-  addWorkspaceTagFromInput() {
-    const input = this.elements.workspaceTagsInput;
-    const raw = input?.value || '';
-    if (!this.normalizeWorkspaceTagValue(raw)) return;
-
-    const result = this.normalizeWorkspaceTagList([...this.workspaceTagDraft, raw]);
-    if (result.error) {
-      this.setWorkspaceTagsError(result.error);
-      return;
-    }
-
-    this.workspaceTagDraft = result.tags;
-    this.setWorkspaceTagsError('');
-    if (input) {
-      input.value = '';
-      input.focus();
-    }
-    this.renderWorkspaceTagEditor();
-  }
-
-  removeWorkspaceTagDraft(index) {
-    if (index < 0 || index >= this.workspaceTagDraft.length) return;
-    this.workspaceTagDraft = this.workspaceTagDraft.filter((_, tagIndex) => tagIndex !== index);
-    this.setWorkspaceTagsError('');
-    this.renderWorkspaceTagEditor();
-  }
-
-  moveWorkspaceTagDraft(index, direction) {
-    const nextIndex = index + direction;
-    if (index < 0 || nextIndex < 0 || index >= this.workspaceTagDraft.length || nextIndex >= this.workspaceTagDraft.length) {
-      return;
-    }
-    const tags = [...this.workspaceTagDraft];
-    [tags[index], tags[nextIndex]] = [tags[nextIndex], tags[index]];
-    this.workspaceTagDraft = tags;
-    this.renderWorkspaceTagEditor();
-  }
-
-  renderWorkspaceTagEditor() {
-    const list = this.elements.workspaceTagsEditorList;
-    if (!list) return;
-
-    const tags = Array.isArray(this.workspaceTagDraft) ? this.workspaceTagDraft : [];
-    list.innerHTML = tags.length
-      ? tags
-          .map((tag, index) => {
-            const safe = this.escapeHtml(tag);
-            const attr = this.escapeAttribute(tag);
-            return `
-              <span class="workspace-detail-tag-edit-chip">
-                <span class="workspace-detail-tag-edit-label" title="${attr}">${safe}</span>
-                <button type="button" class="workspace-detail-tag-action" data-workspace-tag-move="-1" data-index="${index}" title="Move left" aria-label="Move ${attr} left"${index === 0 ? ' disabled' : ''}>&lt;</button>
-                <button type="button" class="workspace-detail-tag-action" data-workspace-tag-move="1" data-index="${index}" title="Move right" aria-label="Move ${attr} right"${index === tags.length - 1 ? ' disabled' : ''}>&gt;</button>
-                <button type="button" class="workspace-detail-tag-action" data-workspace-tag-remove data-index="${index}" title="Remove" aria-label="Remove ${attr}">x</button>
-              </span>
-            `;
-          })
-          .join('')
-      : '<span class="workspace-detail-tag-empty">No tags</span>';
-
-    list.querySelectorAll('[data-workspace-tag-remove]').forEach(button => {
-      button.addEventListener('click', () => {
-        this.removeWorkspaceTagDraft(Number(button.dataset.index));
-      });
-    });
-    list.querySelectorAll('[data-workspace-tag-move]').forEach(button => {
-      button.addEventListener('click', () => {
-        this.moveWorkspaceTagDraft(Number(button.dataset.index), Number(button.dataset.workspaceTagMove));
-      });
-    });
-  }
-
   async saveWorkspaceTags() {
     if (this.workspaceTagsSaving) return;
 
-    const result = this.normalizeWorkspaceTagList(this.workspaceTagDraft);
+    const draft = this.workspaceTagInput ? this.workspaceTagInput.getTags() : this.workspaceTagDraft;
+    const result = this.normalizeWorkspaceTagList(draft);
     if (result.error) {
       this.setWorkspaceTagsError(result.error);
       return;
@@ -2141,6 +2076,8 @@ export class WorkspaceDetailPage {
       };
       this.closeWorkspaceTagsEditor();
       this.renderWorkspaceTags();
+      // New tags should show up in suggestions everywhere right away.
+      window.OriTagInput?.clearTagPoolCache?.();
       if (window.Toast) window.Toast.success('Tags updated');
     } catch (error) {
       console.error('Failed to update workspace tags:', error);
@@ -3423,8 +3360,23 @@ export class WorkspaceDetailPage {
    * Render tasks grouped by agent
    */
   renderTasks() {
+    this.syncTasksTagFilter();
     this.renderAgentGroups();
     this.refreshTaskActivityBadges();
+  }
+
+  // Mounts the shared tag filter bar above the task/agent groups and keeps
+  // its available tags in sync. The bar hides itself while no task has tags.
+  syncTasksTagFilter() {
+    const mount = document.getElementById('workspace-detail-tasks-tag-filter');
+    if (!mount || !window.OriTagFilterBar?.createTagFilterBar) return;
+    if (!this.tasksTagFilterBar) {
+      this.tasksTagFilterBar = window.OriTagFilterBar.createTagFilterBar({
+        container: mount,
+        onChange: () => this.renderTasks()
+      });
+    }
+    this.tasksTagFilterBar.setAvailableTags(window.OriTagFilterBar.collectTags(this.tasks || []));
   }
 
   // refreshTaskActivityBadges is called after renderTasks() (which rebuilds
@@ -4157,9 +4109,26 @@ export class WorkspaceDetailPage {
       });
     }
 
-    const topLevelTasks = Array.isArray(this.tasks)
+    let topLevelTasks = Array.isArray(this.tasks)
       ? this.tasks.filter(task => !task.parent_task_id)
       : [];
+
+    // Tag filter: keep a parent visible when it or any of its subtasks
+    // carries every selected tag.
+    const activeTaskTags = this.tasksTagFilterBar ? this.tasksTagFilterBar.getActiveTags() : [];
+    if (activeTaskTags.length > 0 && window.OriTagFilterBar) {
+      const matchesTags = task =>
+        window.OriTagFilterBar.matchesActiveTags(
+          Array.isArray(task?.tags) ? task.tags : [],
+          activeTaskTags
+        );
+      topLevelTasks = topLevelTasks.filter(task => {
+        if (matchesTags(task)) return true;
+        return this.tasks.some(
+          subtask => subtask.parent_task_id === task.id && matchesTags(subtask)
+        );
+      });
+    }
 
     topLevelTasks.forEach(task => {
       const assigned = String(task?.to || '').trim();
@@ -4409,10 +4378,23 @@ export class WorkspaceDetailPage {
       statusInfo.reason || 'Agent needs your guidance before this task can continue.';
     const scheduleIndicator = this.renderTaskScheduleIndicator(task);
     const referenceIndicator = this.renderTaskReferenceURLIndicator(task);
+    const taskTags = Array.isArray(task.tags)
+      ? task.tags.map(tag => String(tag || '').trim()).filter(Boolean)
+      : [];
     const taskMetaParts = [];
     if (isParent) {
       const stepsLabel = `${parentSubtaskCount} step${parentSubtaskCount === 1 ? '' : 's'}`;
       taskMetaParts.push(`<span class="workspace-detail-workflow-steps">${stepsLabel}</span>`);
+    }
+    if (taskTags.length > 0) {
+      taskMetaParts.push(
+        `<span class="workspace-detail-item-tags">${taskTags
+          .map(
+            tag =>
+              `<span class="workspace-detail-tag-chip" title="${this.escapeAttribute(tag)}">${this.escapeHtml(tag)}</span>`
+          )
+          .join('')}</span>`
+      );
     }
     if (assignedAgent) {
       taskMetaParts.push(
@@ -13403,15 +13385,40 @@ export class WorkspaceDetailPage {
     });
 
     if (this.notes.length === 0) {
+      this.syncNotesTagFilter();
       this.elements.notesList.innerHTML = '<div class="workspace-detail-empty">No notes yet.</div>';
       this.updateCopyNotesButtonState(false);
       return;
     }
 
-    this.elements.notesList.innerHTML = this.notes
+    this.syncNotesTagFilter();
+    const activeNoteTags = this.notesTagFilterBar ? this.notesTagFilterBar.getActiveTags() : [];
+    const visibleNotes = window.OriTagFilterBar
+      ? window.OriTagFilterBar.filterItems(this.notes, activeNoteTags)
+      : this.notes;
+
+    if (visibleNotes.length === 0) {
+      this.elements.notesList.innerHTML =
+        '<div class="workspace-detail-empty">No notes match the selected tags.</div>';
+      this.updateCopyNotesButtonState(false);
+      return;
+    }
+
+    this.elements.notesList.innerHTML = visibleNotes
       .map(note => {
         const title = note.name || note.title || 'Untitled Note';
         const preview = note.preview || note.content || '';
+        const noteTags = Array.isArray(note.tags)
+          ? note.tags.map(tag => String(tag || '').trim()).filter(Boolean)
+          : [];
+        const tagChips = noteTags.length
+          ? `<div class="workspace-detail-item-tags">${noteTags
+              .map(
+                tag =>
+                  `<span class="workspace-detail-tag-chip" title="${this.escapeAttribute(tag)}">${this.escapeHtml(tag)}</span>`
+              )
+              .join('')}</div>`
+          : '';
         const noteUrl = `/notes/${encodeURIComponent(note.id)}`;
         const vaultReference = this.normalizeVaultReference(note.vault_reference);
         const isSelected = this.selectedNoteIds.has(String(note.id));
@@ -13444,6 +13451,7 @@ export class WorkspaceDetailPage {
              aria-label="Open note ${this.escapeHtml(title)}"
              onclick="event.stopPropagation()">
 	          <div class="workspace-detail-item-title">${this.escapeHtml(title)}</div>
+	          ${tagChips}
 	          <div class="workspace-detail-item-meta">
 	            ${preview ? this.escapeHtml(preview.substring(0, 50)) + (preview.length > 50 ? '…' : '') : 'Empty note'}
 	            ${vaultReference ? this.renderVaultReferenceBadge(vaultReference) : ''}
@@ -13454,6 +13462,20 @@ export class WorkspaceDetailPage {
       })
       .join('');
     this.updateCopyNotesButtonState(false);
+  }
+
+  // Mounts the shared tag filter bar above the notes list and keeps its
+  // available tags in sync. The bar hides itself while no note has tags.
+  syncNotesTagFilter() {
+    const mount = document.getElementById('workspace-detail-notes-tag-filter');
+    if (!mount || !window.OriTagFilterBar?.createTagFilterBar) return;
+    if (!this.notesTagFilterBar) {
+      this.notesTagFilterBar = window.OriTagFilterBar.createTagFilterBar({
+        container: mount,
+        onChange: () => this.renderNotes()
+      });
+    }
+    this.notesTagFilterBar.setAvailableTags(window.OriTagFilterBar.collectTags(this.notes));
   }
 
   /**

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -246,6 +246,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   let launcherActiveView = LAUNCHER_VIEW_CARDS;
   let launcherWorkspaceRootState = null;
   let launcherWorkspaceRootEditorOpen = false;
+  let launcherSuppressClickUntil = 0;
 
   /**
    * Schedule a workspace tasks refresh (debounced)
@@ -1753,6 +1754,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     elements.launcherGrid.innerHTML = `
       <div class="launcher-tree" role="tree" aria-label="Workspaces" aria-multiselectable="true">
         ${tree.map((workspace, index) => renderLauncherTreeNode(workspace, 0, tree, index, ctx)).join('')}
+        <div class="launcher-tree-root-drop" data-tree-root-drop aria-label="Drop here to move workspace to top level">Top level</div>
       </div>
     `;
     bindLauncherInteractions();
@@ -1866,7 +1868,12 @@ console.log('[workspace-hub.js] FILE LOADED');
       // /workspaces/{id}; the server branches on kind). The caret
       // (data-group-toggle), checkboxes, and delete button each stopPropagation
       // so they keep their own behavior and never trigger navigation.
-      card.addEventListener('click', () => {
+      card.addEventListener('click', (e) => {
+        if (Date.now() < launcherSuppressClickUntil) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
         navigateToWorkspace(card.dataset.workspaceId);
       });
 
@@ -1941,6 +1948,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     elements.launcherGrid.querySelectorAll('[data-group-children]').forEach((grid) => {
       grid.addEventListener('dragover', (e) => {
+        if (e.target && typeof e.target.closest === 'function' && e.target.closest('[data-workspace-id]')) return;
         e.preventDefault();
         e.stopPropagation();
         grid.classList.add('is-drag-over');
@@ -1950,6 +1958,7 @@ console.log('[workspace-hub.js] FILE LOADED');
         grid.classList.remove('is-drag-over');
       });
       grid.addEventListener('drop', (e) => {
+        if (e.target && typeof e.target.closest === 'function' && e.target.closest('[data-workspace-id]')) return;
         e.preventDefault();
         e.stopPropagation();
         grid.classList.remove('is-drag-over');
@@ -1957,6 +1966,27 @@ console.log('[workspace-hub.js] FILE LOADED');
         const targetId = grid.getAttribute('data-group-children');
         if (draggedId && targetId && draggedId !== targetId) {
           reorderWorkspace(draggedId, targetId, '');
+        }
+      });
+    });
+
+    elements.launcherGrid.querySelectorAll('[data-tree-root-drop]').forEach((dropTarget) => {
+      dropTarget.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        dropTarget.classList.add('is-drag-over');
+        e.dataTransfer.dropEffect = 'move';
+      });
+      dropTarget.addEventListener('dragleave', () => {
+        dropTarget.classList.remove('is-drag-over');
+      });
+      dropTarget.addEventListener('drop', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        dropTarget.classList.remove('is-drag-over');
+        const draggedId = e.dataTransfer.getData('text/plain');
+        if (draggedId) {
+          reorderWorkspace(draggedId, '', '');
         }
       });
     });
@@ -2097,7 +2127,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   function clearLauncherTreeDropIndicators() {
     if (!elements.launcherGrid) return;
-    elements.launcherGrid.querySelectorAll('.launcher-tree-row, .launcher-card-item').forEach((row) => {
+    elements.launcherGrid.querySelectorAll('.launcher-tree-row, .launcher-card-item, .launcher-tree-root-drop').forEach((row) => {
       row.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into');
     });
   }
@@ -2186,6 +2216,173 @@ console.log('[workspace-hub.js] FILE LOADED');
     item.classList.add('is-drag-over');
   }
 
+  function shouldIgnoreLauncherPointerDragTarget(target) {
+    if (!target || typeof target.closest !== 'function') return false;
+    return !!target.closest([
+      'input',
+      'textarea',
+      'select',
+      'button',
+      'a',
+      '[contenteditable="true"]',
+      '[role="textbox"]',
+      '[data-workspace-checkbox]',
+      '[data-workspace-delete]',
+      '[data-group-toggle]',
+      '[data-launcher-tag-filter]',
+      '[data-workspace-tag-remove]',
+      '.launcher-card-checkbox',
+      '.launcher-tree-checkbox',
+      '.workspace-tag-chip-remove'
+    ].join(', '));
+  }
+
+  function startLauncherDragVisuals(item, rootDrop, rootGrid) {
+    if (item) item.classList.add('is-dragging');
+    if (rootDrop) {
+      rootDrop.hidden = false;
+      rootDrop.classList.add('is-active');
+    }
+    if (rootGrid) {
+      rootGrid.classList.add('is-dragging-workspace');
+    }
+  }
+
+  function stopLauncherDragVisuals(item, rootDrop, rootGrid, items = []) {
+    if (item) item.classList.remove('is-dragging');
+    items.forEach(i => i.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into'));
+    clearLauncherTreeDropIndicators();
+    if (rootDrop) {
+      rootDrop.classList.remove('is-drag-over');
+      rootDrop.classList.remove('is-active');
+      rootDrop.hidden = true;
+    }
+    if (rootGrid) {
+      rootGrid.classList.remove('is-dragging-workspace');
+      rootGrid.classList.remove('is-drag-over-root');
+    }
+  }
+
+  function getLauncherPointerDropIntent(sourceItem, event) {
+    if (!sourceItem || !event || !document.elementFromPoint) return null;
+    const target = document.elementFromPoint(event.clientX, event.clientY);
+    if (!target || typeof target.closest !== 'function') return null;
+
+    const workspaceTarget = target.closest('[data-workspace-id][draggable="true"]');
+    if (workspaceTarget && workspaceTarget !== sourceItem) {
+      const treeIntent = getLauncherTreeDropIntent(workspaceTarget, event);
+      if (treeIntent) {
+        return { element: workspaceTarget, intent: treeIntent, kind: 'workspace' };
+      }
+      const cardIntent = getLauncherCardDropIntent(workspaceTarget);
+      if (cardIntent) {
+        return { element: workspaceTarget, intent: cardIntent, kind: 'workspace' };
+      }
+    }
+
+    const rootDrop = target.closest('[data-tree-root-drop]');
+    if (rootDrop) {
+      return {
+        element: rootDrop,
+        intent: { type: 'root', targetParentId: '', insertBeforeId: '' },
+        kind: 'root'
+      };
+    }
+
+    const groupChildren = target.closest('[data-group-children]');
+    if (groupChildren && !target.closest('[data-workspace-id]')) {
+      const targetId = groupChildren.getAttribute('data-group-children');
+      if (targetId && targetId !== sourceItem.dataset.workspaceId) {
+        return {
+          element: groupChildren,
+          intent: { type: 'into', targetParentId: targetId, insertBeforeId: '' },
+          kind: 'group-children'
+        };
+      }
+    }
+
+    return null;
+  }
+
+  function applyLauncherPointerDropIndicator(drop) {
+    clearLauncherTreeDropIndicators();
+    if (!drop || !drop.element || !drop.intent) return;
+    if (drop.kind === 'root' || drop.kind === 'group-children') {
+      drop.element.classList.add('is-drag-over');
+      return;
+    }
+    if (drop.element.classList.contains('launcher-tree-row')) {
+      applyLauncherTreeDropIndicator(drop.element, drop.intent);
+      return;
+    }
+    if (drop.element.classList.contains('launcher-card-item')) {
+      applyLauncherCardDropIndicator(drop.element, drop.intent);
+    }
+  }
+
+  function bindLauncherPointerDrag(item, items, rootDrop, rootGrid) {
+    item.addEventListener('pointerdown', (e) => {
+      if (e.button !== undefined && e.button !== 0) return;
+      if (shouldIgnoreLauncherPointerDragTarget(e.target)) return;
+      if (!item.dataset.workspaceId) return;
+
+      const pointerId = e.pointerId;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const threshold = 4;
+      let active = false;
+      let latestDrop = null;
+
+      const cleanup = () => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        document.removeEventListener('pointercancel', onCancel);
+      };
+
+      const activate = () => {
+        active = true;
+        startLauncherDragVisuals(item, rootDrop, rootGrid);
+      };
+
+      const onMove = (moveEvent) => {
+        if (pointerId !== undefined && moveEvent.pointerId !== pointerId) return;
+        const dx = Math.abs(moveEvent.clientX - startX);
+        const dy = Math.abs(moveEvent.clientY - startY);
+        if (!active && dx < threshold && dy < threshold) return;
+        if (!active) activate();
+        moveEvent.preventDefault();
+        latestDrop = getLauncherPointerDropIntent(item, moveEvent);
+        applyLauncherPointerDropIndicator(latestDrop);
+      };
+
+      const finish = (upEvent) => {
+        if (pointerId !== undefined && upEvent.pointerId !== pointerId) return;
+        cleanup();
+        if (!active) return;
+        upEvent.preventDefault();
+        upEvent.stopPropagation();
+        launcherSuppressClickUntil = Date.now() + 400;
+        stopLauncherDragVisuals(item, rootDrop, rootGrid, Array.from(items || []));
+        if (latestDrop && latestDrop.intent && latestDrop.intent.targetParentId !== item.dataset.workspaceId) {
+          reorderWorkspace(item.dataset.workspaceId, latestDrop.intent.targetParentId, latestDrop.intent.insertBeforeId || '');
+        }
+      };
+
+      const onUp = (upEvent) => finish(upEvent);
+      const onCancel = () => {
+        cleanup();
+        if (active) {
+          launcherSuppressClickUntil = Date.now() + 400;
+          stopLauncherDragVisuals(item, rootDrop, rootGrid, Array.from(items || []));
+        }
+      };
+
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+      document.addEventListener('pointercancel', onCancel);
+    });
+  }
+
   function animateLauncherGroupReveal() {
     const state = window.WorkspaceHubState.getState();
     const revealIds = state.launcherJustExpandedGroups;
@@ -2265,34 +2462,16 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
 
     items.forEach(item => {
+      bindLauncherPointerDrag(item, items, rootDrop, rootGrid);
+
       item.addEventListener('dragstart', (e) => {
-        // Keep checkbox selection and drag reordering as separate interactions.
-        if (hasLauncherSelection()) {
-          e.preventDefault();
-          return;
-        }
         e.dataTransfer.setData('text/plain', e.currentTarget.dataset.workspaceId);
-        e.currentTarget.classList.add('is-dragging');
         e.dataTransfer.effectAllowed = 'move';
-        if (rootDrop) {
-          rootDrop.hidden = false;
-          rootDrop.classList.add('is-active');
-        }
+        startLauncherDragVisuals(e.currentTarget, rootDrop, rootGrid);
       });
 
       item.addEventListener('dragend', (e) => {
-        e.currentTarget.classList.remove('is-dragging');
-        // Clean up any remaining drag-over classes
-        items.forEach(i => i.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into'));
-        clearLauncherTreeDropIndicators();
-        if (rootDrop) {
-          rootDrop.classList.remove('is-drag-over');
-          rootDrop.classList.remove('is-active');
-          rootDrop.hidden = true;
-        }
-        if (rootGrid) {
-          rootGrid.classList.remove('is-drag-over-root');
-        }
+        stopLauncherDragVisuals(e.currentTarget, rootDrop, rootGrid, Array.from(items || []));
       });
 
       item.addEventListener('dragover', (e) => {

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -2097,8 +2097,8 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   function clearLauncherTreeDropIndicators() {
     if (!elements.launcherGrid) return;
-    elements.launcherGrid.querySelectorAll('.launcher-tree-row').forEach((row) => {
-      row.classList.remove('is-drop-before', 'is-drop-after', 'is-drop-into');
+    elements.launcherGrid.querySelectorAll('.launcher-tree-row, .launcher-card-item').forEach((row) => {
+      row.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into');
     });
   }
 
@@ -2152,6 +2152,38 @@ console.log('[workspace-hub.js] FILE LOADED');
     } else if (intent.type === 'into') {
       row.classList.add('is-drop-into');
     }
+  }
+
+  function getLauncherCardDropIntent(item) {
+    if (!item || !item.classList || !item.classList.contains('launcher-card-item')) return null;
+
+    const targetId = item.dataset?.workspaceId || '';
+    if (!targetId) return null;
+
+    const workspaceKind = normalizeWorkspaceKind(item.dataset?.workspaceKind);
+    if (workspaceKind === 'group') {
+      return {
+        type: 'into',
+        targetParentId: targetId,
+        insertBeforeId: ''
+      };
+    }
+
+    return {
+      type: 'before',
+      targetParentId: getWorkspaceParentId(targetId),
+      insertBeforeId: targetId
+    };
+  }
+
+  function applyLauncherCardDropIndicator(item, intent) {
+    if (!item || !intent) return;
+    clearLauncherTreeDropIndicators();
+    if (intent.type === 'into') {
+      item.classList.add('is-drop-into');
+      return;
+    }
+    item.classList.add('is-drag-over');
   }
 
   function animateLauncherGroupReveal() {
@@ -2251,7 +2283,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       item.addEventListener('dragend', (e) => {
         e.currentTarget.classList.remove('is-dragging');
         // Clean up any remaining drag-over classes
-        items.forEach(i => i.classList.remove('is-drag-over'));
+        items.forEach(i => i.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into'));
         clearLauncherTreeDropIndicators();
         if (rootDrop) {
           rootDrop.classList.remove('is-drag-over');
@@ -2277,14 +2309,18 @@ console.log('[workspace-hub.js] FILE LOADED');
           applyLauncherTreeDropIndicator(e.currentTarget, treeIntent);
           return;
         }
+
+        const cardIntent = getLauncherCardDropIntent(e.currentTarget);
+        if (cardIntent) {
+          applyLauncherCardDropIndicator(e.currentTarget, cardIntent);
+          return;
+        }
+
         e.currentTarget.classList.add('is-drag-over');
       });
 
       item.addEventListener('dragleave', (e) => {
-        e.currentTarget.classList.remove('is-drag-over');
-        if (e.currentTarget.classList.contains('launcher-tree-row')) {
-          e.currentTarget.classList.remove('is-drop-before', 'is-drop-after', 'is-drop-into');
-        }
+        e.currentTarget.classList.remove('is-drag-over', 'is-drop-before', 'is-drop-after', 'is-drop-into');
       });
 
       item.addEventListener('drop', (e) => {
@@ -2301,6 +2337,12 @@ console.log('[workspace-hub.js] FILE LOADED');
         const treeIntent = getLauncherTreeDropIntent(e.currentTarget, e);
         if (treeIntent) {
           reorderWorkspace(draggedId, treeIntent.targetParentId, treeIntent.insertBeforeId);
+          return;
+        }
+
+        const cardIntent = getLauncherCardDropIntent(e.currentTarget);
+        if (cardIntent) {
+          reorderWorkspace(draggedId, cardIntent.targetParentId, cardIntent.insertBeforeId);
           return;
         }
 
@@ -4200,6 +4242,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   window.WorkspaceHub = window.WorkspaceHub || {};
   window.WorkspaceHub.loadWorkspaces = loadWorkspaces;
   window.WorkspaceHub.__test = {
+    getLauncherCardDropIntent,
     getLauncherTreeDropIntent,
     getLauncherViewPreference,
     bindLauncherTreeKeyboardEvents,

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -248,9 +248,14 @@ function loadWorkspaceHub(overrides = {}) {
     setTimeout
   };
 
+  const documentListeners = new Map();
   const document = {
     activeElement: null,
-    addEventListener: () => {},
+    addEventListener: (type, handler) => documentListeners.set(type, handler),
+    removeEventListener: (type, handler) => {
+      if (documentListeners.get(type) === handler) documentListeners.delete(type);
+    },
+    elementFromPoint: overrides.elementFromPoint || (() => null),
     getElementById: (id) => elements.get(id) || null,
     querySelector: (selector) => selector === '.workspace-hub-header .hub-title-text' ? createElement('headerTitle') : null,
     querySelectorAll: () => []
@@ -287,6 +292,7 @@ function loadWorkspaceHub(overrides = {}) {
     launcherTagFilterClear,
     launcherViewCards,
     launcherViewTree,
+    documentListeners,
     state,
     storage,
     window,
@@ -340,6 +346,7 @@ test('launcher tree renders minimal hierarchy with always-available workspace ch
   assert.doesNotMatch(launcherGrid.innerHTML, /launcher-tree-checkbox-placeholder/);
   assert.doesNotMatch(launcherGrid.innerHTML, /data-select-mode/);
   assert.match(launcherGrid.innerHTML, /Drop workspaces here/);
+  assert.match(launcherGrid.innerHTML, /data-tree-root-drop/);
   assert.doesNotMatch(launcherGrid.innerHTML, /No description yet/);
   assert.equal(state.workspaces, workspaces);
 });
@@ -780,4 +787,175 @@ test('launcher card drop intent moves into group cards and before workspace card
     JSON.stringify(helpers.getLauncherCardDropIntent(workspaceCard)),
     JSON.stringify({ type: 'before', targetParentId: 'group-1', insertBeforeId: 'workspace-1' })
   );
+});
+
+test('launcher dragstart is not blocked by checkbox selection', () => {
+  const listeners = new Map();
+  const workspaceRow = {
+    classList: createClassList(),
+    dataset: { workspaceId: 'workspace-1', workspaceKind: 'workspace' },
+    addEventListener: (type, handler) => listeners.set(type, handler),
+    closest: () => null
+  };
+  const { helpers, launcherGrid, state } = loadWorkspaceHub({
+    state: {
+      selectedWorkspaces: new Set(['workspace-2'])
+    }
+  });
+  launcherGrid.querySelector = () => null;
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '[data-workspace-id]') return [workspaceRow];
+    if (selector === '[data-workspace-id][draggable="true"]') return [workspaceRow];
+    return [];
+  };
+
+  helpers.bindLauncherInteractions();
+
+  const dragData = new Map();
+  const event = {
+    currentTarget: workspaceRow,
+    dataTransfer: {
+      effectAllowed: '',
+      setData: (key, value) => dragData.set(key, value)
+    },
+    prevented: false,
+    preventDefault() {
+      this.prevented = true;
+    }
+  };
+  listeners.get('dragstart')(event);
+
+  assert.equal(state.selectedWorkspaces.has('workspace-2'), true);
+  assert.equal(event.prevented, false);
+  assert.equal(dragData.get('text/plain'), 'workspace-1');
+  assert.equal(workspaceRow.classList.contains('is-dragging'), true);
+});
+
+test('pointer dragging a tree row can move it to top level', async () => {
+  const workspaces = [
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Clients',
+      children: [
+        { id: 'workspace-1', kind: 'workspace', name: 'Campaign', parent_id: 'group-1' },
+        { id: 'workspace-2', kind: 'workspace', name: 'Planning', parent_id: 'group-1' }
+      ]
+    }
+  ];
+  const listeners = new Map();
+  const workspaceRow = {
+    classList: createClassList(),
+    dataset: { workspaceId: 'workspace-1', workspaceKind: 'workspace' },
+    addEventListener: (type, handler) => listeners.set(type, handler),
+    closest: () => null
+  };
+  const rootDrop = {
+    classList: createClassList(),
+    addEventListener: () => {},
+    closest: (selector) => selector === '[data-tree-root-drop]' ? rootDrop : null
+  };
+  const patches = [];
+  const { helpers, launcherGrid, documentListeners } = loadWorkspaceHub({
+    state: {
+      workspaces,
+      workspaceMap: buildWorkspaceMap(workspaces)
+    },
+    elementFromPoint: () => rootDrop,
+    fetch: async (url, options = {}) => {
+      if (String(url).includes('/api/workspaces?tree=true')) {
+        return { ok: true, json: async () => ({ folders: workspaces }), text: async () => '' };
+      }
+      if (options.method === 'PATCH') {
+        patches.push({ url: String(url), body: JSON.parse(options.body) });
+      }
+      return { ok: true, json: async () => ({ path: '/tmp/workspaces' }), text: async () => '' };
+    }
+  });
+  launcherGrid.querySelector = () => null;
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '[data-workspace-id]') return [workspaceRow];
+    if (selector === '[data-workspace-id][draggable="true"]') return [workspaceRow];
+    if (selector === '[data-tree-root-drop]') return [rootDrop];
+    return [];
+  };
+
+  helpers.bindLauncherInteractions();
+
+  listeners.get('pointerdown')({
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    pointerId: 7,
+    target: workspaceRow
+  });
+  documentListeners.get('pointermove')({
+    clientX: 12,
+    clientY: 0,
+    pointerId: 7,
+    preventDefault() {}
+  });
+  documentListeners.get('pointerup')({
+    pointerId: 7,
+    preventDefault() {},
+    stopPropagation() {}
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  const movedWorkspace = patches.find((patch) => patch.url.endsWith('/api/workspaces/workspace-1'));
+  assert.equal(movedWorkspace.body.parent_id, '');
+});
+
+test('launcher tree root drop target moves workspace to top level', async () => {
+  const workspaces = [
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Clients',
+      children: [
+        { id: 'workspace-1', kind: 'workspace', name: 'Campaign', parent_id: 'group-1' },
+        { id: 'workspace-2', kind: 'workspace', name: 'Planning', parent_id: 'group-1' }
+      ]
+    }
+  ];
+  const listeners = new Map();
+  const rootDrop = {
+    classList: createClassList(),
+    addEventListener: (type, handler) => listeners.set(type, handler)
+  };
+  const patches = [];
+  const { helpers, launcherGrid } = loadWorkspaceHub({
+    state: {
+      workspaces,
+      workspaceMap: buildWorkspaceMap(workspaces)
+    },
+    fetch: async (url, options = {}) => {
+      if (String(url).includes('/api/workspaces?tree=true')) {
+        return { ok: true, json: async () => ({ folders: workspaces }), text: async () => '' };
+      }
+      if (options.method === 'PATCH') {
+        patches.push({ url: String(url), body: JSON.parse(options.body) });
+      }
+      return { ok: true, json: async () => ({ path: '/tmp/workspaces' }), text: async () => '' };
+    }
+  });
+
+  launcherGrid.querySelector = () => null;
+  launcherGrid.querySelectorAll = (selector) => {
+    if (selector === '[data-tree-root-drop]') return [rootDrop];
+    return [];
+  };
+
+  helpers.bindLauncherInteractions();
+  listeners.get('drop')({
+    dataTransfer: { getData: () => 'workspace-1' },
+    preventDefault() {},
+    stopPropagation() {}
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  const movedWorkspace = patches.find((patch) => patch.url.endsWith('/api/workspaces/workspace-1'));
+  assert.equal(movedWorkspace.body.parent_id, '');
 });

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -744,3 +744,40 @@ test('launcher tree drop intent maps edge and middle regions', () => {
     JSON.stringify({ type: 'after', targetParentId: 'group-parent', insertBeforeId: '' })
   );
 });
+
+test('launcher card drop intent moves into group cards and before workspace cards', () => {
+  const workspaces = [
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Clients',
+      children: [
+        { id: 'workspace-1', kind: 'workspace', name: 'Campaign', parent_id: 'group-1' }
+      ]
+    }
+  ];
+  const { helpers } = loadWorkspaceHub({
+    state: {
+      workspaces,
+      workspaceMap: buildWorkspaceMap(workspaces)
+    }
+  });
+
+  const groupCard = {
+    classList: { contains: (className) => className === 'launcher-card-item' },
+    dataset: { workspaceId: 'group-1', workspaceKind: 'group' }
+  };
+  const workspaceCard = {
+    classList: { contains: (className) => className === 'launcher-card-item' },
+    dataset: { workspaceId: 'workspace-1', workspaceKind: 'workspace' }
+  };
+
+  assert.equal(
+    JSON.stringify(helpers.getLauncherCardDropIntent(groupCard)),
+    JSON.stringify({ type: 'into', targetParentId: 'group-1', insertBeforeId: '' })
+  );
+  assert.equal(
+    JSON.stringify(helpers.getLauncherCardDropIntent(workspaceCard)),
+    JSON.stringify({ type: 'before', targetParentId: 'group-1', insertBeforeId: 'workspace-1' })
+  );
+});

--- a/internal/web/static/js/modules/workspace-listing.js
+++ b/internal/web/static/js/modules/workspace-listing.js
@@ -20,6 +20,11 @@ let serverOfflineNotification = null;
 // Workspace-specific state for agent management
 // Note: Using let instead of const so workspace-agent-modals.js can reassign this array
 let workspaceSystemAgents = [];
+
+// Last successfully loaded workspace list + the shared tag filter bar over it.
+// The filter is plain UI state and intentionally resets on reload.
+let loadedWorkspaces = [];
+let workspaceTagFilterBar = null;
 // workspaceAvailableProviders is declared in workspace-agent-modals.js
 
 /**
@@ -252,7 +257,8 @@ async function loadWorkspaces(options = {}) {
     // Connection successful
     handleConnectionSuccess();
     // Flat workspace list includes groups (kind === 'group').
-    renderWorkspaces(data.folders || []);
+    loadedWorkspaces = data.folders || [];
+    renderFilteredWorkspaces();
     hasLoadedWorkspaces = true;
 
   } catch (error) {
@@ -452,6 +458,32 @@ function renderWorkspaces(workspaces) {
   }
 
   grid.innerHTML = workspaces.map(renderWorkspaceCard).join('');
+}
+
+/**
+ * Render the loaded workspaces through the shared tag filter bar. The bar
+ * only offers tags that appear on the listed workspaces and AND-matches
+ * the selected ones (same behavior as the hub launcher filter).
+ */
+function renderFilteredWorkspaces() {
+  const filterBar = ensureWorkspaceTagFilterBar();
+  if (!filterBar) {
+    renderWorkspaces(loadedWorkspaces);
+    return;
+  }
+  filterBar.setAvailableTags(window.OriTagFilterBar.collectTags(loadedWorkspaces));
+  renderWorkspaces(window.OriTagFilterBar.filterItems(loadedWorkspaces, filterBar.getActiveTags()));
+}
+
+function ensureWorkspaceTagFilterBar() {
+  if (workspaceTagFilterBar) return workspaceTagFilterBar;
+  const mount = document.getElementById('workspaces-tag-filter');
+  if (!mount || !window.OriTagFilterBar?.createTagFilterBar) return null;
+  workspaceTagFilterBar = window.OriTagFilterBar.createTagFilterBar({
+    container: mount,
+    onChange: () => renderFilteredWorkspaces()
+  });
+  return workspaceTagFilterBar;
 }
 
 function renderWorkspaceCard(workspace) {

--- a/internal/web/static/js/modules/workspace-tags-card.js
+++ b/internal/web/static/js/modules/workspace-tags-card.js
@@ -1,0 +1,110 @@
+/**
+ * Tags field for the create-workspace modal (create-workspace-modal.tmpl).
+ *
+ * Like ProjectTemplateCard, the markup ships on several pages driven by
+ * different host modules (sessions.js on the live hub/home,
+ * workspace-create.js on the legacy hub), so the card binds its own
+ * behavior here and host modules only merge getPayloadFields() into their
+ * create payload and call reset() when the modal form resets.
+ *
+ * The actual editor is the shared tag input widget (tag-input.js); this
+ * module additionally shows which tags the selected project template will
+ * contribute automatically.
+ */
+
+let wtcWidget = null;
+
+function wtcElements() {
+  return {
+    mount: document.getElementById('folderTagsMount'),
+    templateHint: document.getElementById('folderTemplateTagsHint'),
+    templateSelect: document.getElementById('projectTemplateSelect'),
+    templatePathInput: document.getElementById('projectTemplatePathInput'),
+    modal: document.getElementById('addFolderModal')
+  };
+}
+
+function wtcEnsureWidget() {
+  if (wtcWidget) return wtcWidget;
+  const els = wtcElements();
+  if (!els.mount || !window.OriTagInput?.createTagInput) return null;
+  wtcWidget = window.OriTagInput.createTagInput({
+    container: els.mount,
+    placeholder: 'Add tag…'
+  });
+  return wtcWidget;
+}
+
+export function wtcGetPayloadFields() {
+  const tags = wtcWidget?.getTags() || [];
+  return tags.length > 0 ? { tags } : {};
+}
+
+export function wtcReset() {
+  wtcWidget?.setTags([]);
+  wtcRenderTemplateTagsHint([]);
+}
+
+function wtcRenderTemplateTagsHint(tags) {
+  const els = wtcElements();
+  if (!els.templateHint) return;
+  if (!Array.isArray(tags) || tags.length === 0) {
+    els.templateHint.hidden = true;
+    els.templateHint.textContent = '';
+    return;
+  }
+  els.templateHint.textContent = `From template: ${tags.join(', ')} (added automatically)`;
+  els.templateHint.hidden = false;
+}
+
+async function wtcUpdateTemplateTagsHint() {
+  const els = wtcElements();
+  const templateId = els.templateSelect?.value?.trim() || '';
+  if (!templateId) {
+    wtcRenderTemplateTagsHint([]);
+    return;
+  }
+  try {
+    const response = await fetch('/api/project-templates');
+    if (!response.ok) {
+      wtcRenderTemplateTagsHint([]);
+      return;
+    }
+    const payload = await response.json().catch(() => ({}));
+    const templates = Array.isArray(payload?.templates) ? payload.templates : [];
+    const selected = templates.find(tpl => tpl?.id === templateId);
+    wtcRenderTemplateTagsHint(selected?.tags || []);
+  } catch {
+    wtcRenderTemplateTagsHint([]);
+  }
+}
+
+function wtcInit() {
+  const els = wtcElements();
+  if (!els.mount) return;
+  wtcEnsureWidget();
+  els.templateSelect?.addEventListener('change', () => {
+    void wtcUpdateTemplateTagsHint();
+  });
+  // Re-create the widget lazily after late module load and refresh the
+  // suggestion pool every time the modal opens.
+  els.modal?.addEventListener('show.bs.modal', () => {
+    const widget = wtcEnsureWidget();
+    void widget?.refreshPool?.();
+    void wtcUpdateTemplateTagsHint();
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.WorkspaceTagsCard = {
+    getPayloadFields: wtcGetPayloadFields,
+    reset: wtcReset
+  };
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', wtcInit);
+    } else {
+      wtcInit();
+    }
+  }
+}

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -2715,7 +2715,49 @@ export class WorkspaceTaskPage {
       // last phase from the previous run.
       this._latestActivity = null;
     }
+    this.syncTaskTagsWidget();
     this.renderLiveBadge();
+  }
+
+  // Mounts the shared tag input widget into the hero and keeps it in sync
+  // with the task without clobbering an edit mid-flight: renders happen on
+  // every poll, so the widget is only reset when the lists actually differ.
+  syncTaskTagsWidget() {
+    const row = document.getElementById('workspace-task-tags-row');
+    const mount = document.getElementById('workspace-task-tags-mount');
+    if (!row || !mount) return;
+    if (!this.task?.id) {
+      row.hidden = true;
+      return;
+    }
+    const tags = Array.isArray(this.task.tags) ? this.task.tags : [];
+    if (!this.taskTagsWidget && window.OriTagInput?.createTagInput) {
+      this.taskTagsWidget = window.OriTagInput.createTagInput({
+        container: mount,
+        initialTags: tags,
+        onChange: (next) => { void this.saveTaskTags(next); }
+      });
+    } else if (this.taskTagsWidget) {
+      const current = this.taskTagsWidget.getTags();
+      const same = current.length === tags.length && current.every((tag, index) => tag === tags[index]);
+      if (!same && !this._taskTagsSaving) this.taskTagsWidget.setTags(tags);
+    }
+    row.hidden = !this.taskTagsWidget;
+  }
+
+  async saveTaskTags(tags) {
+    this._taskTagsSaving = true;
+    try {
+      await this.updateTaskFields({ tags }, { deferRender: true });
+      // New tags should show up in suggestions everywhere right away.
+      window.OriTagInput?.clearTagPoolCache?.();
+    } catch (error) {
+      if (window.Toast && typeof window.Toast.error === 'function') {
+        window.Toast.error(error.message || 'Failed to update tags');
+      }
+    } finally {
+      this._taskTagsSaving = false;
+    }
   }
 
   renderHeroActions(statusInfo) {

--- a/internal/web/templates/components/session-modals.tmpl
+++ b/internal/web/templates/components/session-modals.tmpl
@@ -151,13 +151,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <input type="text" id="tagInput" class="modern-input w-100 mb-2" placeholder="Add tags (comma separated)">
-        <div id="currentTags" class="session-tags-edit">
-          <!-- Current tags will be shown here -->
-        </div>
-        <div id="suggestedTags" class="session-tags-suggested mt-2">
-          <!-- Suggested tags will be shown here -->
-        </div>
+        <div id="sessionTagsMount"></div>
       </div>
       <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
         <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/internal/web/templates/components/task-modal.tmpl
+++ b/internal/web/templates/components/task-modal.tmpl
@@ -234,6 +234,10 @@
         <label for="taskModalReferenceURL" class="task-modal-label">Reference URL <span class="task-modal-optional">(optional)</span></label>
         <input type="url" id="taskModalReferenceURL" class="task-modal-input" placeholder="https://example.com/spec" autocomplete="off">
       </div>
+      <div class="task-modal-field">
+        <label class="task-modal-label">Tags <span class="task-modal-optional">(optional)</span></label>
+        <div id="taskModalTagsMount"></div>
+      </div>
       <div style="display: flex; gap: 12px;">
         <div class="task-modal-field" style="flex: 1;">
           <label for="taskModalPriority" class="task-modal-label">Priority</label>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -83,6 +83,10 @@
               Optional. Choose a group for this workspace.
             </div>
 
+            <label style="font-size: 12px; color: var(--text-secondary);">Tags <span style="opacity: 0.8;">(optional)</span></label>
+            <div id="folderTagsMount" class="mb-1"></div>
+            <div id="folderTemplateTagsHint" style="margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
+
             <div class="workspace-setup-card mb-2" id="projectTemplateCard">
               <div class="workspace-setup-header" style="align-items: flex-start; justify-content: space-between;">
                 <div>

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -59,6 +59,13 @@
   <link href="/css/workspace-hub.css" rel="stylesheet">
   <link href="/css/settings.css" rel="stylesheet">
   <link href="/css/ui-refresh.css" rel="stylesheet">
+  <link href="/css/tag-input.css" rel="stylesheet">
   <link href="/css/keyboard-navigation.css" rel="stylesheet">
   {{if eq .CurrentPage "vault"}}<link href="/css/vault-page.css" rel="stylesheet">{{end}}
+  <!-- Shared tag input widget (deferred ES module; exposes window.OriTagInput) -->
+  <script type="module" src="/js/modules/tag-input.js"></script>
+  <!-- Shared tag filter bar (deferred ES module; exposes window.OriTagFilterBar) -->
+  <script type="module" src="/js/modules/tag-filter-bar.js"></script>
+  <!-- Create-workspace modal tags card (no-op on pages without the modal) -->
+  <script type="module" src="/js/modules/workspace-tags-card.js"></script>
 </head>

--- a/internal/web/templates/pages/note.tmpl
+++ b/internal/web/templates/pages/note.tmpl
@@ -41,6 +41,10 @@
         </div>
       </div>
 
+      <div class="note-page-tags-row" id="notePageTagsRow" style="margin: 2px 0 8px;" hidden>
+        <div id="notePageTagsMount"></div>
+      </div>
+
       <!-- Toolbar (reused IDs match the modal so NoteEditor wires them automatically) -->
       <div class="note-editor-toolbar">
         <button type="button" id="noteTocToggle" class="note-toolbar-btn" title="Toggle Notes &amp; Outline sidebar" aria-pressed="false">

--- a/internal/web/templates/pages/settings.tmpl
+++ b/internal/web/templates/pages/settings.tmpl
@@ -153,6 +153,14 @@
               </span>
               <span class="settings-nav-item-text">Project Templates</span>
             </a>
+            <a href="#tag-management" class="settings-nav-item" data-section="tag-management">
+              <span class="settings-nav-item-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M5.5,7A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 8.5,7A1.5,1.5 0 0,1 7,8.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z"/>
+                </svg>
+              </span>
+              <span class="settings-nav-item-text">Tags</span>
+            </a>
             <a href="#session-management" class="settings-nav-item" data-section="session-management">
               <span class="settings-nav-item-icon">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -1113,6 +1121,45 @@
               <button id="manageTemplatesBtn" class="modern-btn modern-btn-secondary">
                 Manage Templates
               </button>
+            </div>
+          </section>
+
+          <!-- Tag Management Section -->
+          <section id="tag-management" class="settings-section modern-card p-4">
+            <div class="settings-section-header">
+              <span class="settings-section-icon">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M5.5,7A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 8.5,7A1.5,1.5 0 0,1 7,8.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z"/>
+                </svg>
+              </span>
+              <h2 class="settings-section-title">Tags</h2>
+            </div>
+
+            <p class="settings-section-description">
+              One tag vocabulary across workspaces, sessions, notes, and tasks. Rename or delete a tag here and it updates everywhere it is used. Tags declared by project templates are read-only — template manifests are never modified, and new workspaces created from those templates reintroduce their tags.
+            </p>
+
+            <div class="table-responsive">
+              <table class="table align-middle" id="tagManagementTable">
+                <thead>
+                  <tr>
+                    <th scope="col">Tag</th>
+                    <th scope="col" class="text-end">Workspaces</th>
+                    <th scope="col" class="text-end">Sessions</th>
+                    <th scope="col" class="text-end">Notes</th>
+                    <th scope="col" class="text-end">Tasks</th>
+                    <th scope="col" class="text-end">Templates</th>
+                    <th scope="col" class="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="tagManagementTableBody">
+                  <tr><td colspan="7" class="text-muted">Loading tags…</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="settings-actions">
+              <button id="tagManagementRefreshBtn" class="modern-btn modern-btn-secondary" type="button">Refresh</button>
             </div>
           </section>
 

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -147,10 +147,8 @@
                   </button>
                 </div>
                 <div class="workspace-detail-tags-editor" id="workspace-tags-editor" hidden>
-                  <div id="workspace-tags-editor-list" class="workspace-detail-tags-editor-list" aria-live="polite"></div>
+                  <div id="workspace-tags-editor-mount" aria-live="polite"></div>
                   <div class="workspace-detail-tags-editor-row">
-                    <input id="workspace-tags-input" class="workspace-detail-tags-input" type="text" maxlength="64" autocomplete="off" spellcheck="false" aria-label="Tag">
-                    <button id="workspace-tags-add-btn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button">Add</button>
                     <button id="workspace-tags-save-btn" class="modern-btn modern-btn-primary modern-btn-sm" type="button">Save</button>
                     <button id="workspace-tags-cancel-btn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button">Cancel</button>
                   </div>
@@ -929,6 +927,7 @@
                 </div>
               </div>
               <div class="workspace-detail-panel-body" role="region" tabindex="0" aria-label="Agents panel content">
+                <div id="workspace-detail-tasks-tag-filter" class="workspace-detail-list-tag-filter"></div>
                 <div id="workspace-detail-agents-list" class="workspace-detail-agent-grid">
                   <div class="workspace-detail-loading">Loading agents...</div>
                 </div>
@@ -1026,6 +1025,7 @@
                     </svg>
                   </button>
                 </div>
+                <div id="workspace-detail-notes-tag-filter" class="workspace-detail-list-tag-filter"></div>
                 <div id="workspace-detail-notes-list" class="workspace-detail-list">
                   <div class="workspace-detail-empty">No notes yet.</div>
                 </div>
@@ -8389,6 +8389,18 @@
       flex-wrap: wrap;
       gap: 0.4rem;
       min-width: 0;
+    }
+
+    .workspace-detail-list-tag-filter:not(:empty) {
+      margin-bottom: 0.5rem;
+    }
+
+    .workspace-detail-item-tags {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      margin: 0.15rem 0;
     }
 
     .workspace-detail-tag-chip,

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -79,6 +79,9 @@
                 </svg>
               </button>
             </div>
+            <div id="workspace-task-tags-row" style="margin-top: 6px; max-width: 30rem;" hidden>
+              <div id="workspace-task-tags-mount"></div>
+            </div>
           </div>
           <div class="workspace-task-page-hero-meta">
             <span id="workspace-task-status" class="workspace-task-page-status" data-state="pending" aria-live="polite">Pending</span>

--- a/internal/web/templates/pages/workspaces-hub.tmpl
+++ b/internal/web/templates/pages/workspaces-hub.tmpl
@@ -38,6 +38,7 @@
 
         <!-- Grid View -->
         <div id="grid-view">
+          <div id="workspaces-tag-filter" class="mb-3"></div>
           <div id="workspaces-grid" class="row g-4">
             <div class="col-12 text-center py-5">
               <div class="spinner-border text-primary" role="status">

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -22,6 +22,7 @@ type CreateTaskRequest struct {
 	ReferenceURL           string               `json:"reference_url"`
 	From                   string               `json:"from"`
 	To                     string               `json:"to"`
+	Tags                   []string             `json:"tags,omitempty"`
 	Priority               int                  `json:"priority"`
 	ParentTaskID           string               `json:"parent_task_id"`
 	SubtaskIndex           int                  `json:"subtask_index"`
@@ -69,6 +70,11 @@ func (h *HTTPHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 		orihttp.BadRequest(w, err.Error())
 		return
 	}
+	tags, err := ValidateWorkspaceTags(req.Tags)
+	if err != nil {
+		orihttp.BadRequest(w, err.Error())
+		return
+	}
 
 	// Get workspace
 	workspace, err := h.store.Get(workspaceID)
@@ -98,6 +104,7 @@ func (h *HTTPHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 		From:                   req.From,
 		Description:            req.Description,
 		ReferenceURL:           referenceURL,
+		Tags:                   tags,
 		Priority:               req.Priority,
 		Context:                make(map[string]any),
 		ParentTaskID:           req.ParentTaskID,
@@ -187,6 +194,7 @@ func (h *HTTPHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 		Description            *string              `json:"description,omitempty"`
 		Details                *string              `json:"details,omitempty"`
 		ReferenceURL           *string              `json:"reference_url,omitempty"`
+		Tags                   *[]string            `json:"tags,omitempty"`
 		To                     *string              `json:"to,omitempty"`
 		From                   *string              `json:"from,omitempty"`
 		InputTaskIDs           *[]string            `json:"input_task_ids,omitempty"`
@@ -233,6 +241,14 @@ func (h *HTTPHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				workspace.Tasks[i].ReferenceURL = referenceURL
+			}
+			if req.Tags != nil {
+				tags, err := ValidateWorkspaceTags(*req.Tags)
+				if err != nil {
+					orihttp.BadRequest(w, err.Error())
+					return
+				}
+				workspace.Tasks[i].Tags = tags
 			}
 			if req.From != nil {
 				workspace.Tasks[i].From = *req.From

--- a/internal/workspace/note_file_sync.go
+++ b/internal/workspace/note_file_sync.go
@@ -16,6 +16,7 @@ type NoteFileParams struct {
 	WorkspaceID string
 	Name        string
 	Content     string
+	Tags        []string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -61,6 +62,13 @@ func SyncNoteFile(fs *FileStore, note NoteFileParams) {
 	sb.WriteString("---\n")
 	fmt.Fprintf(&sb, "id: %q\n", note.ID)
 	fmt.Fprintf(&sb, "name: %q\n", note.Name)
+	if tags := NormalizeWorkspaceTags(note.Tags); len(tags) > 0 {
+		// Obsidian-compatible tag list so tags survive in the folder.
+		sb.WriteString("tags:\n")
+		for _, tag := range tags {
+			fmt.Fprintf(&sb, "  - %q\n", tag)
+		}
+	}
 	fmt.Fprintf(&sb, "created_at: %q\n", note.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Fprintf(&sb, "updated_at: %q\n", note.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
 	sb.WriteString("---\n\n")

--- a/internal/workspace/task_markdown_sync.go
+++ b/internal/workspace/task_markdown_sync.go
@@ -56,6 +56,7 @@ type taskMarkdownItem struct {
 	To             string
 	AssignedNodeID string
 	InputTaskIDs   []string
+	Tags           []string
 	Mode           string
 }
 
@@ -288,6 +289,7 @@ func ParseWorkspaceTasksMarkdown(content, workspaceID string) ([]taskMarkdownIte
 		item.Mode = meta["mode"]
 		item.To = resolveTaskMarkdownAssignee(meta["to"], parseTaskMarkdownAgent(rawText))
 		item.InputTaskIDs = splitTaskMarkdownIDs(meta["depends"])
+		item.Tags = splitTaskMarkdownIDs(meta["tags"])
 		if item.SubtaskIndex == 0 {
 			item.SubtaskIndex = intFromString(meta["index"])
 		}
@@ -438,6 +440,9 @@ func buildTaskMarkdownMetadata(workspaceID string, task Task) string {
 	if len(task.InputTaskIDs) > 0 {
 		parts = append(parts, "depends="+escapeTaskMarkdownValue(strings.Join(task.InputTaskIDs, ",")))
 	}
+	if len(task.Tags) > 0 {
+		parts = append(parts, "tags="+escapeTaskMarkdownValue(strings.Join(task.Tags, ",")))
+	}
 	if mode := strings.TrimSpace(string(task.OrchestrationMode)); mode != "" {
 		parts = append(parts, "mode="+escapeTaskMarkdownValue(mode))
 	}
@@ -539,6 +544,11 @@ func applyMarkdownItemsToWorkspace(ws *Workspace, items []taskMarkdownItem, warn
 			}
 			if item.InputTaskIDs != nil && !stringSlicesEqual(item.InputTaskIDs, t.InputTaskIDs) {
 				t.InputTaskIDs = item.InputTaskIDs
+			}
+			if item.Tags != nil {
+				if tags := NormalizeWorkspaceTags(item.Tags); !stringSlicesEqual(tags, t.Tags) {
+					t.Tags = tags
+				}
 			}
 			if item.Checked && t.Status != TaskStatusCompleted {
 				// User edited the markdown checkbox to checked. This is a manual
@@ -851,7 +861,8 @@ func tasksEqualForMarkdownUpdate(a, b Task) bool {
 		a.Status == b.Status &&
 		((a.CompletedAt == nil && b.CompletedAt == nil) ||
 			(a.CompletedAt != nil && b.CompletedAt != nil && a.CompletedAt.Equal(*b.CompletedAt))) &&
-		stringSlicesEqual(a.InputTaskIDs, b.InputTaskIDs)
+		stringSlicesEqual(a.InputTaskIDs, b.InputTaskIDs) &&
+		stringSlicesEqual(a.Tags, b.Tags)
 }
 
 func LogTaskMarkdownWarnings(workspaceID string, warnings []string) {

--- a/internal/workspace/task_markdown_sync_test.go
+++ b/internal/workspace/task_markdown_sync_test.go
@@ -133,6 +133,66 @@ workspace_id: workspace-1
 	}
 }
 
+func TestTaskMarkdown_TagsRoundTrip(t *testing.T) {
+	ws := &Workspace{
+		ID:   "workspace-1",
+		Name: "Tagged Tasks",
+		Tasks: []Task{
+			{
+				ID:          "task-1",
+				WorkspaceID: "workspace-1",
+				Description: "Mix the track",
+				Tags:        []string{"music", "deep work"},
+				Status:      TaskStatusPending,
+				CreatedAt:   time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	rendered := RenderWorkspaceTasksMarkdown(ws)
+	if !strings.Contains(rendered, "tags=music%2Cdeep+work") {
+		t.Fatalf("expected rendered markdown to contain escaped tags metadata:\n%s", rendered)
+	}
+
+	items, warnings, err := ParseWorkspaceTasksMarkdown(rendered, "workspace-1")
+	if err != nil {
+		t.Fatalf("ParseWorkspaceTasksMarkdown: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %#v", items)
+	}
+	if len(items[0].Tags) != 2 || items[0].Tags[0] != "music" || items[0].Tags[1] != "deep work" {
+		t.Fatalf("expected tags to round-trip, got %#v", items[0].Tags)
+	}
+
+	// A no-op re-import must not report changes.
+	var importWarnings []string
+	if changed := applyMarkdownItemsToWorkspace(ws, items, &importWarnings); changed {
+		t.Fatalf("expected unchanged workspace on re-import, warnings=%v", importWarnings)
+	}
+
+	// An external tag edit in the markdown is pulled back into the task,
+	// normalized (lowercased, deduped).
+	edited := strings.Replace(rendered, "tags=music%2Cdeep+work", "tags=Music%2Cmastering", 1)
+	items, _, err = ParseWorkspaceTasksMarkdown(edited, "workspace-1")
+	if err != nil {
+		t.Fatalf("ParseWorkspaceTasksMarkdown (edited): %v", err)
+	}
+	if changed := applyMarkdownItemsToWorkspace(ws, items, &importWarnings); !changed {
+		t.Fatal("expected tag edit to mark workspace changed")
+	}
+	task, err := ws.GetTask("task-1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if len(task.Tags) != 2 || task.Tags[0] != "music" || task.Tags[1] != "mastering" {
+		t.Fatalf("expected normalized edited tags, got %#v", task.Tags)
+	}
+}
+
 func TestImportTaskMarkdownFromStore_UpdatesStatusAndPreservesRuntimeFields(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewFileStore(dir)

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -236,6 +236,7 @@ type Task struct {
 	Description      string               `json:"description"`
 	Details          string               `json:"details,omitempty"`
 	ReferenceURL     string               `json:"reference_url,omitempty"`
+	Tags             []string             `json:"tags,omitempty"` // Normalized labels used for organization and filtering
 	Priority         int                  `json:"priority"`
 	Context          map[string]any       `json:"context"`
 	Timeout          time.Duration        `json:"timeout"`


### PR DESCRIPTION
## Summary

Workspace UI/UX update in two parts:

**Drag grouping** (first two commits)
- Drag a workspace card onto another to group them; reliability fixes for the drag interactions.

**Unified tag system** (third commit) — one normalized tag vocabulary across workspaces, sessions, notes, and tasks:
- **Notes & tasks are now taggable** — migration 27 adds `note_tags`; note tags sync into YAML frontmatter (Obsidian-compatible) and round-trip through the workspace-folder importer; task tags ride in the task markdown metadata (`tags=`) and round-trip on import.
- **Unified pool** — `GET /api/tags?scope=all` aggregates all five sources with per-source usage counts (including disk-only `workspace.json` tags); the default `/api/tags` response is unchanged for existing consumers.
- **Suggestions everywhere tags are entered** — shared `tag-input.js` widget (chips, typeahead, top-10 suggested row, keyboard support) on the workspace detail editor, create-workspace modal (new optional Tags field + "From template" hint), session tags modal (also fixes a pre-existing `[object Object]` suggestions bug), note page, and task modal/detail.
- **Filtering** — shared `tag-filter-bar.js` on the Workspaces page and per-workspace notes/task lists; tag chips on note and task items.
- **Global management** — Settings → Tags table with per-source counts; rename (merges on collision) and delete confirm with live usage (`GET /api/tags/usage`) and propagate to every entity *and its synced files*; template manifests stay read-only (reintroduction warning in the UI); the hybrid session cache updates in place on bulk mutations.
- Tags API documented in `docs/api/API_REFERENCE.md`; PRD + task list under `tasks/`.

## Test plan

- [x] `go vet ./...` clean; full `go test ./...` green except the documented pre-existing `TestSettingsEndpoint` e2e false positive
- [x] `npm run lint` clean; `npm run test:modules` 411/411 (17 new widget tests; new Go tests for store layer, aggregator, admin endpoints, markdown/frontmatter round-trips)
- [x] Live-server smoke: created tagged workspace/note/task over HTTP, pool updated immediately; global rename propagated to `workspace.json`, note frontmatter, and task tags on disk while the built-in template manifest stayed untouched
- [ ] Browser click-through of the five tag entry surfaces (widget logic is unit-tested; recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)