### PR TITLE
docs: fix drift found by Friday maintenance check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,19 @@ Each domain has dedicated handler modules in `internal/*http/`:
 - `mcphttp` - MCP (Model Context Protocol) integration
 - `skillshttp` - Skills management and marketplace
 - `sessionhttp` - Session and workspace data management
+- `actioncenterhttp` - Cross-workspace triage for workspace mission findings (Action Center)
+- `notehttp` - Workspace notes
+- `fileshttp` - Session file management
+- `filehttp` - File serving and preview
+- `vaulthttp` - Vault (secrets) management
+- `workflowhttp` - Custom workflow management
+- `reviewhttp` - Conversation review system
+- `speechhttp` - Speech/voice endpoints
+- `locationhttp` - Location detection
+- `evolutionhttp` - Agent evolution features
+- `externalagentshttp` - External agent integrations
+- `modelcategoryhttp` - Model category configuration and auto-categorization
+- `cliagenthttp` - CLI agent execution
 
 **3. LLM Provider Abstraction** (`internal/llm/`)
 - Factory pattern supports multiple providers: `factory.go`
@@ -129,7 +142,7 @@ Each domain has dedicated handler modules in `internal/*http/`:
 - See `internal/llm/README.md` for detailed usage patterns
 
 **4. Agent Isolation & Workspaces**
-- Agent configs stored in `agents/<agent-name>/config.json`
+- Agent list in `agents.json`; per-agent settings in `agents/<agent-name>/agent_settings.json` (workspace-scoped agents use `config.json` inside the workspace folder)
 - **Workspace System** (`internal/workspace/`): Multi-agent collaboration
   - Workspace-scoped MCP bindings and skill bindings
   - Workspace-scoped tools for notes, tasks, sessions, files
@@ -177,7 +190,6 @@ Tool Execution → Result → UI Rendering
 - `settings.json` - Global settings, API keys, LLM provider config
 - `agents.json` - Agent configurations
 - `app_state.json` - Onboarding and application state
-- `agents/<agent-name>/config.json` - Per-agent settings
 - `agents/<agent-name>/agent_settings.json` - Per-agent settings
 
 ### Build Outputs
@@ -262,7 +274,7 @@ There is a `go.work` file in the parent directory. Edit it and remove non-existe
 ### Port already in use
 ```bash
 # Kill process on port 8765
-./kill-8080.sh  # Script name unchanged for backward compatibility
+lsof -ti :8765 | xargs kill
 
 # Or use custom port
 PORT=9000 go run ./cmd/server
@@ -310,7 +322,6 @@ This project follows a feature branch workflow with squash merging.
 
 ### Documentation
 - `README.md` - Main project documentation
-- `TESTING.md` - Complete testing guide
 - `docs/` - Organized documentation directory
   - `docs/api/API_REFERENCE.md` - HTTP API endpoint reference
   - `docs/testing/TEST_CHEATSHEET.md` - Quick testing commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ This directory contains detailed documentation for Ori Agent.
 
 ### Getting Started
 - [Main README](../README.md) - Project overview and quick start
+- [macOS Installation](./INSTALLATION_MACOS.md) - Installing on macOS
+- [Linux Installation](./INSTALLATION_LINUX.md) - Installing on Linux
+- [Windows Installation](./INSTALLATION_WINDOWS.md) - Installing on Windows
 
 ### API & Development
 - [API Reference](./api/API_REFERENCE.md) - HTTP API endpoint documentation
@@ -13,6 +16,14 @@ This directory contains detailed documentation for Ori Agent.
 
 ### Feature Guides
 - [Scheduler Nodes Guide](./SCHEDULER_NODES_GUIDE.md) - Complete guide to using scheduler nodes for task automation
+- [Multi-Agent Support](./features/multi-agent-support.md) - Running multiple agents
+- [Home Assistant Task Routing](./features/home-assistant-task-routing.md) - "Ask Ori" task routing
+- [Project Templates](./features/project-templates.md) - Folder-skeleton workspace templates
+- [Session File Management](./features/session-file-management.md) - Managing files in sessions
+- [Task Input Templating](./features/task-input-templating.md) - Templated task inputs
+- [Task Output Contracts](./features/task-output-contracts.md) - Structured task outputs
+- [Workspace Runs Harness Model](./features/workspace-runs-harness-model.md) - Workspace run execution model
+- [Premium Features](./premium_features.md) - Premium feature overview
 
 ### Testing & Quality
 - [Smoke Tests Guide](./testing/SMOKE_TESTS.md) - Automated installer smoke testing (CI/CD)
@@ -20,18 +31,23 @@ This directory contains detailed documentation for Ori Agent.
 - [Test Cheat Sheet](./testing/TEST_CHEATSHEET.md) - Quick command reference
 - [Testing Setup Summary](./testing/TESTING_SETUP_SUMMARY.md) - Overview of testing infrastructure
 - [Direct Tool Testing](./testing/DIRECT_TOOL_TESTING.md) - Direct tool launch feature testing guide
+- [Ollama Testing](./testing/OLLAMA_TESTING.md) - Testing with local Ollama models
+- [User Test Guide](./testing/USER_TEST_GUIDE.md) - Interactive user testing system
 
 ### Release & Deployment
 - [Release Checklist](./RELEASE_CHECKLIST.md) - Pre-release validation checklist
 - [Dependency Management](./DEPENDENCY_MANAGEMENT.md) - Managing Go dependencies
+- [Building the MSI Installer](./BUILD_MSI.md) - Windows MSI build guide
 
 ### Project Policies
 - [Ori Services](../ORI_SERVICES.md) - Private services access and scope
 - [Trademarks](../TRADEMARKS.md) - Branding and trademark usage
 
 ### Feature Planning
+- [AI Features Roadmap](./features/AI_FEATURES_ROADMAP.md) - Planned AI feature work
 - [Agent Output Viewing Plan](./features/AGENT_OUTPUT_VIEWING_PLAN.md) - Implementation plan for viewing agent outputs
 - [Progress Tracking Plan](./features/PROGRESS_TRACKING_PLAN.md) - Implementation plan for progress tracking
+- [System Home Context Routing Plan](./features/system-home-context-routing-plan.md) - Home context routing plan
 - [Open-Core Boundaries](./architecture/open-core-boundaries.md) - Separation of OSS core and private services
 
 ### UI Documentation
@@ -46,10 +62,15 @@ This directory contains detailed documentation for Ori Agent.
 docs/
 ├── README.md                           # This file
 │
+├── INSTALLATION_MACOS.md               # macOS installation guide
+├── INSTALLATION_LINUX.md               # Linux installation guide
+├── INSTALLATION_WINDOWS.md             # Windows installation guide
+├── BUILD_MSI.md                        # Windows MSI build guide
 ├── TESTING_INSTALLERS.md               # Manual installer testing guide
 ├── RELEASE_CHECKLIST.md                # Pre-release validation checklist
 ├── DEPENDENCY_MANAGEMENT.md            # Go dependency management guide
 ├── SCHEDULER_NODES_GUIDE.md            # Scheduler nodes usage guide
+├── premium_features.md                 # Premium feature overview
 │
 ├── api/
 │   └── API_REFERENCE.md                # HTTP API documentation
@@ -58,11 +79,22 @@ docs/
 │   ├── SMOKE_TESTS.md                  # Automated installer smoke testing
 │   ├── TEST_CHEATSHEET.md              # Quick testing commands
 │   ├── TESTING_SETUP_SUMMARY.md        # Testing infrastructure overview
-│   └── DIRECT_TOOL_TESTING.md          # Direct tool launch feature testing guide
+│   ├── DIRECT_TOOL_TESTING.md          # Direct tool launch feature testing guide
+│   ├── OLLAMA_TESTING.md               # Ollama-based local model testing
+│   └── USER_TEST_GUIDE.md              # Interactive user testing system
 │
-├── features/
-│   ├── AGENT_OUTPUT_VIEWING_PLAN.md    # Agent output viewing implementation plan
-│   └── PROGRESS_TRACKING_PLAN.md       # Progress tracking implementation plan
+├── features/                           # Feature guides and implementation plans
+│   ├── AI_FEATURES_ROADMAP.md
+│   ├── AGENT_OUTPUT_VIEWING_PLAN.md
+│   ├── PROGRESS_TRACKING_PLAN.md
+│   ├── home-assistant-task-routing.md
+│   ├── multi-agent-support.md
+│   ├── project-templates.md
+│   ├── session-file-management.md
+│   ├── system-home-context-routing-plan.md
+│   ├── task-input-templating.md
+│   ├── task-output-contracts.md
+│   └── workspace-runs-harness-model.md
 │
 ├── architecture/
 │   └── open-core-boundaries.md         # Open-core vs private service boundaries

--- a/tests/user/README.md
+++ b/tests/user/README.md
@@ -308,6 +308,5 @@ make test-scenarios
 - [TEST_CHEATSHEET.md](TEST_CHEATSHEET.md) - Quick command reference
 - [SHARED_PLUGINS_TESTING.md](SHARED_PLUGINS_TESTING.md) - Testing ../plugins directory
 - [IMPLEMENTATION_SUMMARY.md](IMPLEMENTATION_SUMMARY.md) - What was built
-- [TESTING.md](../../TESTING.md) - Complete testing guide
-- [PROJECT_GUIDELINES.md](../../PROJECT_GUIDELINES.md) - Architecture overview
-- [Plugin Development](../../CLAUDE.md#plugin-development) - Plugin creation guide
+- [Testing docs](../../docs/testing/) - Test cheat sheet, setup summary, and guides
+- [CLAUDE.md](../../CLAUDE.md) - Architecture overview and development guide


### PR DESCRIPTION
## Summary

Acting on today's daily maintenance run (**Check #5: Docs Drift**, Friday 2026-06-12). Every finding was verified against the live codebase before fixing; false positives were discarded.

### Verified drift, fixed
- **CLAUDE.md**
  - `TESTING.md` referenced but deleted → now points at `docs/` testing docs
  - `./kill-8080.sh` referenced but deleted → replaced with `lsof -ti :8765 | xargs kill`
  - Claimed per-agent config lives in `agents/<name>/config.json` — the code (`internal/store/file_store.go`) uses `agents/<name>/agent_settings.json`; `config.json` is the *workspace-scoped* agent config (`internal/workspace/slugify.go:31`)
  - HTTP handler list named 11 of the 24 `internal/*http` packages tracked in git → list refreshed
- **docs/README.md** — index omitted many existing docs (3 installation guides, BUILD_MSI, premium_features, 9 `features/` docs, OLLAMA_TESTING, USER_TEST_GUIDE); Quick Links + structure tree now match disk
- **tests/user/README.md** — dead links to `TESTING.md`, `PROJECT_GUIDELINES.md`, and the removed plugin-development CLAUDE.md section

### Verified clean (no action)
- **AGENTS.md** — `make test-e2e` exists (Makefile:147), `tests/{integration,e2e}` exist, all named make targets present
- `internal/pluginhttp/` is untracked runtime data, not a resurrected plugin package — the "plugin system removed" claim in CLAUDE.md stands

All relative links in the touched files were checked to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)