### PR TITLE
fix(workspace): reconcile externally deleted workspace folders

### DIFF
--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -144,6 +144,12 @@ const (
 	// WorkspaceStatusTrashed marks a workspace whose folder has been moved to the
 	// system trash. It is hidden from listings but can be restored.
 	WorkspaceStatusTrashed WorkspaceStatus = "trashed"
+	// WorkspaceStatusMissing marks a workspace whose folder disappeared from disk
+	// outside this app (deleted in Finder, removed by another instance, or
+	// superseded by a recreated folder with a different ID). It is hidden from
+	// listings; the status clears automatically if the folder reappears, or the
+	// row can be cleaned up via the workspace sync flow.
+	WorkspaceStatusMissing WorkspaceStatus = "missing"
 )
 
 // WorkspaceKind describes whether a record is a concrete workspace or a

--- a/internal/sessionhttp/group_backfill.go
+++ b/internal/sessionhttp/group_backfill.go
@@ -32,7 +32,9 @@ func (h *Handler) BackfillGroupScaffolding(ctx context.Context) error {
 	parents := make(map[string]string, len(workspaces))
 	for _, ws := range workspaces {
 		parents[ws.ID] = ws.ParentID
-		if ws.IsGroup() && ws.Status != session.WorkspaceStatusTrashed {
+		// Skip trashed groups (owned by the trash/undo flow) and missing ones
+		// (folder deleted externally — backfill must not resurrect it).
+		if ws.IsGroup() && ws.Status != session.WorkspaceStatusTrashed && ws.Status != session.WorkspaceStatusMissing {
 			groups = append(groups, ws)
 		}
 	}

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
@@ -25,6 +26,12 @@ type Handler struct {
 	agentStore            store.Store
 	workspaceAllowlist    *workspace.Allowlist
 	eventBus              *workspace.EventBus // optional, for project.created events
+
+	// rescanMu serializes disk reconciles so concurrent rescan requests
+	// (e.g. several hub tabs loading at once) don't run overlapping filesystem
+	// walks; lastRescanAt backs the cooldown for background-initiated rescans.
+	rescanMu     sync.Mutex
+	lastRescanAt time.Time
 }
 
 // New creates a new session handler.

--- a/internal/sessionhttp/tags_admin_handler.go
+++ b/internal/sessionhttp/tags_admin_handler.go
@@ -224,7 +224,7 @@ func (h *Handler) mutateWorkspaceTags(ctx context.Context, from, to string) (int
 	if err != nil {
 		return 0, err
 	}
-	workspaces = pruneTrashedWorkspaces(workspaces)
+	workspaces = pruneHiddenWorkspaces(workspaces)
 
 	affected := 0
 	for i := range workspaces {

--- a/internal/sessionhttp/tags_aggregator.go
+++ b/internal/sessionhttp/tags_aggregator.go
@@ -67,7 +67,7 @@ func (h *Handler) collectUnifiedTags(ctx context.Context) ([]UnifiedTag, error) 
 	if err != nil {
 		return nil, err
 	}
-	workspaces = pruneTrashedWorkspaces(workspaces)
+	workspaces = pruneHiddenWorkspaces(workspaces)
 	workspaces = h.hydrateWorkspaceListFromFileStore(workspaces)
 	var countWorkspace func(ws *session.Workspace)
 	countWorkspace = func(ws *session.Workspace) {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -595,10 +595,10 @@ func rewriteWorkspaceProjectPath(ws *session.Workspace, oldPath, newPath string)
 	return true
 }
 
-// pruneTrashedWorkspaces removes workspaces that have been moved to the trash
+// pruneHiddenWorkspaces removes workspaces that have been moved to the trash
 // or whose folder is missing from disk, recursing into children so hidden
 // sub-workspaces don't leak into the tree.
-func pruneTrashedWorkspaces(workspaces []session.Workspace) []session.Workspace {
+func pruneHiddenWorkspaces(workspaces []session.Workspace) []session.Workspace {
 	if len(workspaces) == 0 {
 		return workspaces
 	}
@@ -608,7 +608,7 @@ func pruneTrashedWorkspaces(workspaces []session.Workspace) []session.Workspace 
 		if ws.Status == session.WorkspaceStatusTrashed || ws.Status == session.WorkspaceStatusMissing {
 			continue
 		}
-		ws.Children = pruneTrashedWorkspaces(ws.Children)
+		ws.Children = pruneHiddenWorkspaces(ws.Children)
 		filtered = append(filtered, ws)
 	}
 	return filtered
@@ -1339,7 +1339,7 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 			_ = orihttp.RespondInternalError(w, "Failed to get workspaces")
 			return
 		}
-		workspaces = pruneTrashedWorkspaces(workspaces)
+		workspaces = pruneHiddenWorkspaces(workspaces)
 		workspaces = h.hydrateWorkspaceListFromFileStore(workspaces)
 
 		orihttp.WriteJSON(w, map[string]any{
@@ -1360,7 +1360,7 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaces = pruneTrashedWorkspaces(workspaces)
+	workspaces = pruneHiddenWorkspaces(workspaces)
 	workspaces = h.hydrateWorkspaceListFromFileStore(workspaces)
 
 	orihttp.WriteJSON(w, map[string]any{
@@ -3264,7 +3264,7 @@ func (h *Handler) handleWorkspaceSync(w http.ResponseWriter, r *http.Request) {
 
 			// Refuse to overwrite a folder that was recreated externally as a
 			// different workspace; cleanup is the right action for this row.
-			if diskID := workspaceIDOnDisk(targetPath); diskID != "" && diskID != sessionWS.ID {
+			if diskID := h.workspaceIDOnDisk(targetPath); diskID != "" && diskID != sessionWS.ID {
 				warnings = append(warnings, fmt.Sprintf("Folder for %s now belongs to a different workspace; remove this entry instead", sessionWS.Name))
 				continue
 			}
@@ -3378,6 +3378,27 @@ func (h *Handler) handleWorkspaceRescan(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Background rescans (fired on every hub page load) honor a cooldown so
+	// several tabs opening at once don't each trigger a full filesystem walk.
+	// Explicit user-initiated rescans always run.
+	if r.URL.Query().Get("background") == "1" {
+		h.rescanMu.Lock()
+		recent := time.Since(h.lastRescanAt) < workspaceRescanCooldown
+		h.rescanMu.Unlock()
+		if recent {
+			orihttp.WriteJSON(w, map[string]any{
+				"success":    true,
+				"skipped":    true,
+				"imported":   0,
+				"reparented": 0,
+				"orphaned":   0,
+				"restored":   0,
+				"warnings":   []string{},
+			})
+			return
+		}
+	}
+
 	stats, warnings, err := h.reconcileWorkspacesFromDisk(r.Context())
 	if err != nil {
 		logger.Error("Rescan: failed to reconcile workspaces from disk", logger.Fields{"error": err})
@@ -3414,13 +3435,26 @@ type workspaceReconcileStats struct {
 	Restored int
 }
 
+// workspaceRescanCooldown is the minimum interval between background-initiated
+// disk reconciles (page loads); explicit rescans are exempt.
+const workspaceRescanCooldown = 30 * time.Second
+
 // reconcileWorkspacesFromDisk reloads the folder store from disk and updates the
 // session store so its structure matches the on-disk layout. Returns reconcile
-// stats plus any non-fatal warnings. Safe to call on startup and on demand.
+// stats plus any non-fatal warnings. Safe to call on startup and on demand;
+// concurrent calls are serialized.
 func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (stats workspaceReconcileStats, warnings []string, err error) {
 	if h.workspaceStore == nil {
 		return stats, nil, nil
 	}
+
+	h.rescanMu.Lock()
+	defer func() {
+		if err == nil {
+			h.lastRescanAt = time.Now()
+		}
+		h.rescanMu.Unlock()
+	}()
 
 	// Refresh the file-store cache + index from disk; physical layout wins.
 	if err := h.workspaceStore.Reload(); err != nil {
@@ -3532,7 +3566,7 @@ func (h *Handler) sweepMissingWorkspaces(ctx context.Context, diskWorkspaces map
 			// either the folder now belongs to a different workspace (deleted
 			// and recreated externally — mark the stale row missing), or it
 			// lives outside the workspaces root (located/imported — leave it).
-			diskID := workspaceIDOnDisk(path)
+			diskID := h.workspaceIDOnDisk(path)
 			if diskID == "" || diskID == sessionWS.ID {
 				continue
 			}
@@ -3557,11 +3591,21 @@ func (h *Handler) sweepMissingWorkspaces(ctx context.Context, diskWorkspaces map
 
 // workspaceIDOnDisk reads the workspace ID recorded in workspace.json at dir.
 // Managed paths may point at the folder root or at a scoped content directory
-// inside it (groups), so the parent directory is checked as a fallback. Returns
-// "" when no workspace.json is readable.
-func workspaceIDOnDisk(dir string) string {
+// inside it (groups), so the parent directory is checked as a fallback. The
+// workspaces root itself is never probed, bounding the fallback so it cannot
+// walk above workspace folders. Returns "" when no workspace.json is readable.
+func (h *Handler) workspaceIDOnDisk(dir string) string {
+	root := ""
+	if h.workspaceStore != nil {
+		root = cleanWorkspaceSyncPath(h.workspaceStore.BasePath())
+	}
+
 	for _, candidate := range []string{dir, filepath.Dir(dir)} {
-		data, err := os.ReadFile(filepath.Join(candidate, agentworkspace.WorkspaceConfigFile))
+		cleaned := cleanWorkspaceSyncPath(candidate)
+		if cleaned == "" || (root != "" && cleaned == root) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(cleaned, agentworkspace.WorkspaceConfigFile)) // #nosec G304 -- cleaned is a stored workspace directory reference bounded above, not raw user input; filename is the fixed WorkspaceConfigFile constant
 		if err != nil {
 			continue
 		}

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -595,8 +595,9 @@ func rewriteWorkspaceProjectPath(ws *session.Workspace, oldPath, newPath string)
 	return true
 }
 
-// pruneTrashedWorkspaces removes workspaces that have been moved to the trash,
-// recursing into children so trashed sub-workspaces don't leak into the tree.
+// pruneTrashedWorkspaces removes workspaces that have been moved to the trash
+// or whose folder is missing from disk, recursing into children so hidden
+// sub-workspaces don't leak into the tree.
 func pruneTrashedWorkspaces(workspaces []session.Workspace) []session.Workspace {
 	if len(workspaces) == 0 {
 		return workspaces
@@ -604,7 +605,7 @@ func pruneTrashedWorkspaces(workspaces []session.Workspace) []session.Workspace 
 
 	filtered := make([]session.Workspace, 0, len(workspaces))
 	for _, ws := range workspaces {
-		if ws.Status == session.WorkspaceStatusTrashed {
+		if ws.Status == session.WorkspaceStatusTrashed || ws.Status == session.WorkspaceStatusMissing {
 			continue
 		}
 		ws.Children = pruneTrashedWorkspaces(ws.Children)
@@ -3078,16 +3079,33 @@ func (h *Handler) handleWorkspaceSyncStatus(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	// Store → Disk: in SQLite but not on disk.
+	// Store → Disk: in SQLite but not on disk. Rows already marked missing are
+	// always listed — their folder may have been recreated as a different
+	// workspace, in which case the path exists but no longer belongs to them.
 	for id, ws := range sqliteIDs {
-		path, managed := h.syncManagedWorkspacePath(ws)
-		if !managed {
+		isMissing := ws.Status == session.WorkspaceStatusMissing
+		resolved := ws
+		if isMissing {
+			// The flat listing omits the JSON columns that hold directory
+			// references; hydrate the full row so the last-known path resolves.
+			if full, err := h.store.GetWorkspace(ctx, id); err == nil && full != nil {
+				resolved = *full
+			}
+		}
+
+		path, managed := h.syncManagedWorkspacePath(resolved)
+		if managed {
+			existsOnDisk, err := workspaceFolderExists(path)
+			if err != nil {
+				continue
+			}
+			if existsOnDisk && !isMissing {
+				continue
+			}
+		} else if !isMissing {
 			continue
 		}
-		existsOnDisk, err := workspaceFolderExists(path)
-		if err != nil || existsOnDisk {
-			continue
-		}
+
 		orphaned = append(orphaned, agentworkspace.SyncWorkspaceInfo{
 			ID:   id,
 			Name: ws.Name,
@@ -3196,6 +3214,10 @@ func (h *Handler) handleWorkspaceSync(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
+			// Locating a folder recovers a workspace hidden as missing.
+			if sessionWS.Status == session.WorkspaceStatusMissing {
+				sessionWS.Status = session.WorkspaceStatusActive
+			}
 			sessionWS.UpdatedAt = time.Now()
 			folderWS, err := buildFileStoreWorkspace(sessionWS)
 			if err != nil {
@@ -3240,12 +3262,23 @@ func (h *Handler) handleWorkspaceSync(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
+			// Refuse to overwrite a folder that was recreated externally as a
+			// different workspace; cleanup is the right action for this row.
+			if diskID := workspaceIDOnDisk(targetPath); diskID != "" && diskID != sessionWS.ID {
+				warnings = append(warnings, fmt.Sprintf("Folder for %s now belongs to a different workspace; remove this entry instead", sessionWS.Name))
+				continue
+			}
+
 			if err := updateManagedWorkspaceReferences(sessionWS, targetPath, targetPath); err != nil {
 				logger.Warn("Sync recreate: failed to update workspace folder references", logger.Fields{"id": id, "error": err})
 				warnings = append(warnings, fmt.Sprintf("Failed to update workspace references for %s", sessionWS.Name))
 				continue
 			}
 
+			// Recreating the folder recovers a workspace hidden as missing.
+			if sessionWS.Status == session.WorkspaceStatusMissing {
+				sessionWS.Status = session.WorkspaceStatusActive
+			}
 			sessionWS.UpdatedAt = time.Now()
 			folderWS, err := buildFileStoreWorkspace(sessionWS)
 			if err != nil {
@@ -3329,10 +3362,12 @@ func (h *Handler) handleWorkspaceSync(w http.ResponseWriter, r *http.Request) {
 // handleWorkspaceRescan re-reads the workspace folder tree from disk and
 // reconciles the session store's structure (existence, kind, derived parent,
 // order) to match — disk is the source of truth for grouping. It imports
-// workspaces newly present on disk and re-parents existing ones whose folder
-// moved (e.g. via git pull or a cloud-sync client). It never deletes
-// session-only data such as chat history; workspaces missing from disk are left
-// for the existing orphaned-workspace flow (sync-status / cleanup).
+// workspaces newly present on disk, re-parents existing ones whose folder
+// moved (e.g. via git pull or a cloud-sync client), marks folder-managed
+// workspaces whose folder disappeared as missing (hidden from listings), and
+// restores previously-missing ones whose folder reappeared. It never deletes
+// session-only data such as chat history; missing workspaces remain available
+// through the sync-status / cleanup flow.
 func (h *Handler) handleWorkspaceRescan(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		_ = orihttp.RespondMethodNotAllowed(w)
@@ -3343,38 +3378,58 @@ func (h *Handler) handleWorkspaceRescan(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	imported, reparented, warnings, err := h.reconcileWorkspacesFromDisk(r.Context())
+	stats, warnings, err := h.reconcileWorkspacesFromDisk(r.Context())
 	if err != nil {
 		logger.Error("Rescan: failed to reconcile workspaces from disk", logger.Fields{"error": err})
 		_ = orihttp.RespondInternalError(w, "Failed to rescan workspaces")
 		return
 	}
 
-	logger.Info("Workspaces rescanned from disk", logger.Fields{"imported": imported, "reparented": reparented})
+	logger.Info("Workspaces rescanned from disk", logger.Fields{
+		"imported":   stats.Imported,
+		"reparented": stats.Reparented,
+		"orphaned":   stats.Orphaned,
+		"restored":   stats.Restored,
+	})
 	orihttp.WriteJSON(w, map[string]any{
 		"success":    true,
-		"imported":   imported,
-		"reparented": reparented,
+		"imported":   stats.Imported,
+		"reparented": stats.Reparented,
+		"orphaned":   stats.Orphaned,
+		"restored":   stats.Restored,
 		"warnings":   warnings,
 	})
 }
 
+// workspaceReconcileStats summarizes the outcome of a disk reconcile pass.
+type workspaceReconcileStats struct {
+	// Imported counts disk workspaces newly created in the session store.
+	Imported int
+	// Reparented counts session workspaces whose parent changed to match disk.
+	Reparented int
+	// Orphaned counts session workspaces marked missing because their folder
+	// is gone from disk (or was recreated as a different workspace).
+	Orphaned int
+	// Restored counts previously-missing workspaces whose folder reappeared.
+	Restored int
+}
+
 // reconcileWorkspacesFromDisk reloads the folder store from disk and updates the
-// session store so its structure matches the on-disk layout. Returns counts of
-// newly-imported and re-parented workspaces plus any non-fatal warnings. Safe to
-// call on startup and on demand.
-func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (imported int, reparented int, warnings []string, err error) {
+// session store so its structure matches the on-disk layout. Returns reconcile
+// stats plus any non-fatal warnings. Safe to call on startup and on demand.
+func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (stats workspaceReconcileStats, warnings []string, err error) {
 	if h.workspaceStore == nil {
-		return 0, 0, nil, nil
+		return stats, nil, nil
 	}
 
 	// Refresh the file-store cache + index from disk; physical layout wins.
 	if err := h.workspaceStore.Reload(); err != nil {
-		return 0, 0, nil, err
+		return stats, nil, err
 	}
 
 	warnings = make([]string, 0)
-	for id, diskWS := range h.workspaceStore.CachedWorkspaces() {
+	diskWorkspaces := h.workspaceStore.CachedWorkspaces()
+	for id, diskWS := range diskWorkspaces {
 		sessionWS, getErr := h.store.GetWorkspace(ctx, id)
 		if getErr == session.ErrWorkspaceNotFound {
 			converted := session.ConvertAgentWorkspace(diskWS)
@@ -3386,7 +3441,7 @@ func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (imported int
 				warnings = append(warnings, fmt.Sprintf("Failed to import %s", diskWS.Name))
 				continue
 			}
-			imported++
+			stats.Imported++
 			continue
 		}
 		if getErr != nil {
@@ -3406,18 +3461,118 @@ func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (imported int
 			sessionWS.OrderIndex = diskWS.OrderIndex
 			changed = true
 		}
+		// Disk reappearance heals a workspace previously marked missing.
+		if sessionWS.Status == session.WorkspaceStatusMissing {
+			sessionWS.Status = session.WorkspaceStatusActive
+			changed = true
+			stats.Restored++
+		}
 		if changed {
 			if updateErr := h.store.UpdateWorkspace(ctx, sessionWS); updateErr != nil {
 				warnings = append(warnings, fmt.Sprintf("Failed to update %s", sessionWS.Name))
 				continue
 			}
 			if parentChanged {
-				reparented++
+				stats.Reparented++
 			}
 		}
 	}
 
-	return imported, reparented, warnings, nil
+	// Disk is the source of truth for existence too: folder-managed session
+	// workspaces whose folder is no longer on disk are marked missing so they
+	// drop out of listings. Chat history is preserved on the hidden row and the
+	// sync-status / cleanup flow can recover or remove it.
+	orphaned, sweepWarnings := h.sweepMissingWorkspaces(ctx, diskWorkspaces)
+	stats.Orphaned = orphaned
+	warnings = append(warnings, sweepWarnings...)
+
+	return stats, warnings, nil
+}
+
+// sweepMissingWorkspaces marks folder-managed session workspaces as missing when
+// their backing folder is gone from disk or has been recreated as a different
+// workspace (same path, different ID). Returns the number of workspaces marked.
+func (h *Handler) sweepMissingWorkspaces(ctx context.Context, diskWorkspaces map[string]*agentworkspace.Workspace) (int, []string) {
+	sessionWorkspaces, listErr := h.store.ListWorkspaces(ctx)
+	if listErr != nil {
+		return 0, []string{"Failed to list workspaces for missing-folder sweep"}
+	}
+
+	orphaned := 0
+	warnings := make([]string, 0)
+	for _, listed := range sessionWorkspaces {
+		if _, onDisk := diskWorkspaces[listed.ID]; onDisk {
+			continue
+		}
+		// Trashed rows are owned by the trash/undo flow; missing rows are
+		// already hidden.
+		if listed.Status == session.WorkspaceStatusTrashed || listed.Status == session.WorkspaceStatusMissing {
+			continue
+		}
+
+		// The flat listing omits JSON columns; load the full row so the
+		// managed-path resolution can inspect directory references.
+		sessionWS, getErr := h.store.GetWorkspace(ctx, listed.ID)
+		if getErr != nil {
+			warnings = append(warnings, fmt.Sprintf("Failed to load %s", listed.ID))
+			continue
+		}
+
+		path, managed := h.syncManagedWorkspacePath(*sessionWS)
+		if !managed {
+			continue // legacy DB-only workspace; nothing on disk to compare
+		}
+
+		exists, statErr := workspaceFolderExists(path)
+		if statErr != nil {
+			continue // unreadable path: leave the workspace alone
+		}
+		if exists {
+			// The folder is still there but this ID is not in the disk cache:
+			// either the folder now belongs to a different workspace (deleted
+			// and recreated externally — mark the stale row missing), or it
+			// lives outside the workspaces root (located/imported — leave it).
+			diskID := workspaceIDOnDisk(path)
+			if diskID == "" || diskID == sessionWS.ID {
+				continue
+			}
+		}
+
+		sessionWS.Status = session.WorkspaceStatusMissing
+		sessionWS.UpdatedAt = time.Now()
+		if updateErr := h.store.UpdateWorkspace(ctx, sessionWS); updateErr != nil {
+			warnings = append(warnings, fmt.Sprintf("Failed to mark %s as missing", sessionWS.Name))
+			continue
+		}
+		logger.Info("Workspace folder missing from disk; hiding workspace", logger.Fields{
+			"workspace_id": sessionWS.ID,
+			"name":         sessionWS.Name,
+			"path":         path,
+		})
+		orphaned++
+	}
+
+	return orphaned, warnings
+}
+
+// workspaceIDOnDisk reads the workspace ID recorded in workspace.json at dir.
+// Managed paths may point at the folder root or at a scoped content directory
+// inside it (groups), so the parent directory is checked as a fallback. Returns
+// "" when no workspace.json is readable.
+func workspaceIDOnDisk(dir string) string {
+	for _, candidate := range []string{dir, filepath.Dir(dir)} {
+		data, err := os.ReadFile(filepath.Join(candidate, agentworkspace.WorkspaceConfigFile))
+		if err != nil {
+			continue
+		}
+		var meta struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(data, &meta) == nil && meta.ID != "" {
+			return meta.ID
+		}
+	}
+	return ""
 }
 
 // ReconcileWorkspacesFromDisk reconciles the session store's workspace structure
@@ -3428,12 +3583,17 @@ func (h *Handler) ReconcileWorkspacesFromDisk(ctx context.Context) error {
 	if h == nil || h.workspaceStore == nil {
 		return nil
 	}
-	imported, reparented, _, err := h.reconcileWorkspacesFromDisk(ctx)
+	stats, _, err := h.reconcileWorkspacesFromDisk(ctx)
 	if err != nil {
 		return err
 	}
-	if imported > 0 || reparented > 0 {
-		logger.Info("Startup workspace reconcile from disk", logger.Fields{"imported": imported, "reparented": reparented})
+	if stats.Imported > 0 || stats.Reparented > 0 || stats.Orphaned > 0 || stats.Restored > 0 {
+		logger.Info("Startup workspace reconcile from disk", logger.Fields{
+			"imported":   stats.Imported,
+			"reparented": stats.Reparented,
+			"orphaned":   stats.Orphaned,
+			"restored":   stats.Restored,
+		})
 	}
 	return nil
 }
@@ -3505,6 +3665,20 @@ func (h *Handler) syncManagedWorkspacePath(ws session.Workspace) (string, bool) 
 	refs, err := decodeDirectoryReferences(ws.DirectoryReferencesJSON)
 	if err != nil {
 		return "", false
+	}
+
+	// Prefer the primary linked-folder reference recorded at scaffolding time.
+	// FolderSlug has no SQLite column (it is hydrated from disk, which may be
+	// gone), so the primary directory ID in shared_data is the reliable link
+	// between a DB row and its last-known folder path.
+	if primaryID := workspacePrimaryDirectoryID(&ws); primaryID != "" {
+		for _, ref := range refs {
+			if ref.ID == primaryID {
+				if cleaned := cleanWorkspaceSyncPath(ref.Path); cleaned != "" {
+					return cleaned, true
+				}
+			}
+		}
 	}
 
 	folderSlug := strings.TrimSpace(ws.FolderSlug)

--- a/internal/sessionhttp/workspace_rescan_missing_test.go
+++ b/internal/sessionhttp/workspace_rescan_missing_test.go
@@ -62,6 +62,50 @@ func rescanCount(t *testing.T, resp map[string]any, key string) int {
 	return int(value)
 }
 
+// TestRescanBackgroundCooldownSkips verifies that background rescans (hub page
+// loads) honor the server-side cooldown while explicit rescans always run.
+func TestRescanBackgroundCooldownSkips(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	rescan := func(background bool) map[string]any {
+		t.Helper()
+		url := "/api/workspaces/rescan"
+		if background {
+			url += "?background=1"
+		}
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		handler.HandleWorkspaces(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for rescan, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode rescan response: %v", err)
+		}
+		return resp
+	}
+
+	if resp := rescan(true); resp["skipped"] == true {
+		t.Fatalf("first background rescan should run, got %#v", resp)
+	}
+	if resp := rescan(true); resp["skipped"] != true {
+		t.Fatalf("second background rescan within cooldown should be skipped, got %#v", resp)
+	}
+	if resp := rescan(false); resp["skipped"] == true {
+		t.Fatalf("explicit rescan must ignore the cooldown, got %#v", resp)
+	}
+}
+
 // TestRescanMarksMissingWorkspaceAndRecreateRestores covers the externally
 // deleted folder flow: the rescan hides the stale row instead of leaving it in
 // listings, and the sync recreate action recovers it.

--- a/internal/sessionhttp/workspace_rescan_missing_test.go
+++ b/internal/sessionhttp/workspace_rescan_missing_test.go
@@ -1,0 +1,316 @@
+package sessionhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// postWorkspaceRescan runs POST /api/workspaces/rescan and decodes the response.
+func postWorkspaceRescan(t *testing.T, handler *Handler) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/rescan", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for rescan, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode rescan response: %v", err)
+	}
+	return resp
+}
+
+// listWorkspaceIDs returns the IDs in the GET /api/workspaces response.
+func listWorkspaceIDs(t *testing.T, handler *Handler) map[string]int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for workspace list, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Workspaces []session.Workspace `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode workspace list: %v", err)
+	}
+	ids := make(map[string]int, len(resp.Workspaces))
+	for _, ws := range resp.Workspaces {
+		ids[ws.ID]++
+	}
+	return ids
+}
+
+func rescanCount(t *testing.T, resp map[string]any, key string) int {
+	t.Helper()
+	value, ok := resp[key].(float64)
+	if !ok {
+		t.Fatalf("expected numeric %q in rescan response, got %#v", key, resp[key])
+	}
+	return int(value)
+}
+
+// TestRescanMarksMissingWorkspaceAndRecreateRestores covers the externally
+// deleted folder flow: the rescan hides the stale row instead of leaving it in
+// listings, and the sync recreate action recovers it.
+func TestRescanMarksMissingWorkspaceAndRecreateRestores(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	workspaceID := createTestWorkspace(t, handler, "Vanishing")
+
+	folderPath, err := fileStore.GetFolderPath(workspaceID)
+	if err != nil {
+		t.Fatalf("GetFolderPath: %v", err)
+	}
+
+	// Delete the folder out from under the app, as Finder or another instance
+	// sharing the workspaces root would.
+	if err := os.RemoveAll(folderPath); err != nil {
+		t.Fatalf("RemoveAll workspace folder: %v", err)
+	}
+
+	resp := postWorkspaceRescan(t, handler)
+	if got := rescanCount(t, resp, "orphaned"); got != 1 {
+		t.Fatalf("expected orphaned=1, got %d (%#v)", got, resp)
+	}
+
+	ws, err := handler.store.GetWorkspace(context.Background(), workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if ws.Status != session.WorkspaceStatusMissing {
+		t.Fatalf("expected status missing, got %q", ws.Status)
+	}
+
+	if ids := listWorkspaceIDs(t, handler); ids[workspaceID] != 0 {
+		t.Fatalf("expected missing workspace to be hidden from listings, got %#v", ids)
+	}
+
+	// The sync-status panel must still surface it for recovery.
+	statusReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/sync-status", nil)
+	statusW := httptest.NewRecorder()
+	handler.HandleWorkspaces(statusW, statusReq)
+	if statusW.Code != http.StatusOK {
+		t.Fatalf("expected 200 for sync status, got %d: %s", statusW.Code, statusW.Body.String())
+	}
+	var status agentworkspace.SyncStatus
+	if err := json.Unmarshal(statusW.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode sync status: %v", err)
+	}
+	foundOrphan := false
+	for _, info := range status.Orphaned {
+		if info.ID == workspaceID {
+			foundOrphan = true
+			break
+		}
+	}
+	if !foundOrphan {
+		t.Fatalf("expected missing workspace in sync-status orphaned list, got %#v", status.Orphaned)
+	}
+
+	// Recreating the folder through the sync flow restores the workspace.
+	payload, _ := json.Marshal(map[string]any{"recreate": []string{workspaceID}})
+	syncReq := httptest.NewRequest(http.MethodPost, "/api/workspaces/sync", bytes.NewBuffer(payload))
+	syncReq.Header.Set("Content-Type", "application/json")
+	syncW := httptest.NewRecorder()
+	handler.HandleWorkspaces(syncW, syncReq)
+	if syncW.Code != http.StatusOK {
+		t.Fatalf("expected 200 for sync recreate, got %d: %s", syncW.Code, syncW.Body.String())
+	}
+	var syncResp map[string]any
+	if err := json.Unmarshal(syncW.Body.Bytes(), &syncResp); err != nil {
+		t.Fatalf("decode sync response: %v", err)
+	}
+	if got := int(syncResp["recreated"].(float64)); got != 1 {
+		t.Fatalf("expected recreated=1, got %d (%#v)", got, syncResp)
+	}
+
+	ws, err = handler.store.GetWorkspace(context.Background(), workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace after recreate: %v", err)
+	}
+	if ws.Status == session.WorkspaceStatusMissing {
+		t.Fatalf("expected recreate to clear missing status, got %q", ws.Status)
+	}
+	if ids := listWorkspaceIDs(t, handler); ids[workspaceID] != 1 {
+		t.Fatalf("expected recreated workspace back in listings, got %#v", ids)
+	}
+}
+
+// TestRescanRestoresReappearedWorkspaceFolder covers the self-heal direction:
+// a folder that comes back (cloud sync restore, drive remount) clears the
+// missing status without user action.
+func TestRescanRestoresReappearedWorkspaceFolder(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	workspaceID := createTestWorkspace(t, handler, "Roundtrip")
+
+	folderPath, err := fileStore.GetFolderPath(workspaceID)
+	if err != nil {
+		t.Fatalf("GetFolderPath: %v", err)
+	}
+
+	stash := filepath.Join(t.TempDir(), filepath.Base(folderPath))
+	if err := os.Rename(folderPath, stash); err != nil {
+		t.Fatalf("move folder away: %v", err)
+	}
+
+	resp := postWorkspaceRescan(t, handler)
+	if got := rescanCount(t, resp, "orphaned"); got != 1 {
+		t.Fatalf("expected orphaned=1 after folder removal, got %d", got)
+	}
+
+	if err := os.Rename(stash, folderPath); err != nil {
+		t.Fatalf("move folder back: %v", err)
+	}
+
+	resp = postWorkspaceRescan(t, handler)
+	if got := rescanCount(t, resp, "restored"); got != 1 {
+		t.Fatalf("expected restored=1 after folder reappeared, got %d (%#v)", got, resp)
+	}
+
+	ws, err := handler.store.GetWorkspace(context.Background(), workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if ws.Status == session.WorkspaceStatusMissing {
+		t.Fatalf("expected reappeared workspace to be active, got %q", ws.Status)
+	}
+	if ids := listWorkspaceIDs(t, handler); ids[workspaceID] != 1 {
+		t.Fatalf("expected reappeared workspace in listings, got %#v", ids)
+	}
+}
+
+// TestRescanHidesWorkspaceSupersededByRecreatedFolder covers the duplicate-name
+// case: the folder was deleted and recreated externally with a new workspace
+// ID. The rescan imports the new workspace and hides the stale row instead of
+// showing two entries with the same name.
+func TestRescanHidesWorkspaceSupersededByRecreatedFolder(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	staleID := createTestWorkspace(t, handler, "Grouptest")
+
+	folderPath, err := fileStore.GetFolderPath(staleID)
+	if err != nil {
+		t.Fatalf("GetFolderPath: %v", err)
+	}
+	slug := filepath.Base(folderPath)
+
+	if err := os.RemoveAll(folderPath); err != nil {
+		t.Fatalf("RemoveAll workspace folder: %v", err)
+	}
+
+	// Recreate the folder at the same path as a different app instance would:
+	// same name and slug, brand-new workspace ID.
+	recreated := &agentworkspace.Workspace{
+		ID:         "ws-recreated-elsewhere",
+		Name:       "Grouptest",
+		FolderSlug: slug,
+		Status:     agentworkspace.StatusActive,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	data, err := recreated.ToJSON()
+	if err != nil {
+		t.Fatalf("serialize recreated workspace: %v", err)
+	}
+	if err := os.MkdirAll(folderPath, 0o755); err != nil {
+		t.Fatalf("recreate folder: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(folderPath, agentworkspace.WorkspaceConfigFile), data, 0o644); err != nil {
+		t.Fatalf("write recreated workspace.json: %v", err)
+	}
+
+	resp := postWorkspaceRescan(t, handler)
+	if got := rescanCount(t, resp, "imported"); got != 1 {
+		t.Fatalf("expected imported=1 for recreated folder, got %d (%#v)", got, resp)
+	}
+	if got := rescanCount(t, resp, "orphaned"); got != 1 {
+		t.Fatalf("expected orphaned=1 for superseded row, got %d (%#v)", got, resp)
+	}
+
+	staleWS, err := handler.store.GetWorkspace(context.Background(), staleID)
+	if err != nil {
+		t.Fatalf("GetWorkspace stale: %v", err)
+	}
+	if staleWS.Status != session.WorkspaceStatusMissing {
+		t.Fatalf("expected superseded row to be missing, got %q", staleWS.Status)
+	}
+
+	ids := listWorkspaceIDs(t, handler)
+	if ids[staleID] != 0 {
+		t.Fatalf("expected stale workspace hidden from listings, got %#v", ids)
+	}
+	if ids[recreated.ID] != 1 {
+		t.Fatalf("expected recreated workspace in listings exactly once, got %#v", ids)
+	}
+
+	// Recreate must refuse to clobber the folder that now belongs to the new
+	// workspace; cleanup is the supported action for the stale row.
+	payload, _ := json.Marshal(map[string]any{"recreate": []string{staleID}})
+	syncReq := httptest.NewRequest(http.MethodPost, "/api/workspaces/sync", bytes.NewBuffer(payload))
+	syncReq.Header.Set("Content-Type", "application/json")
+	syncW := httptest.NewRecorder()
+	handler.HandleWorkspaces(syncW, syncReq)
+	if syncW.Code != http.StatusOK {
+		t.Fatalf("expected 200 for sync recreate, got %d: %s", syncW.Code, syncW.Body.String())
+	}
+	var syncResp map[string]any
+	if err := json.Unmarshal(syncW.Body.Bytes(), &syncResp); err != nil {
+		t.Fatalf("decode sync response: %v", err)
+	}
+	if got := int(syncResp["recreated"].(float64)); got != 0 {
+		t.Fatalf("expected recreate to be refused for superseded row, got recreated=%d", got)
+	}
+
+	rawOnDisk, err := os.ReadFile(filepath.Join(folderPath, agentworkspace.WorkspaceConfigFile))
+	if err != nil {
+		t.Fatalf("read workspace.json after refused recreate: %v", err)
+	}
+	onDisk, err := agentworkspace.FromJSON(rawOnDisk)
+	if err != nil {
+		t.Fatalf("parse workspace.json after refused recreate: %v", err)
+	}
+	if onDisk.ID != recreated.ID {
+		t.Fatalf("expected recreated folder to keep its identity, got %q", onDisk.ID)
+	}
+}

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -2899,14 +2899,18 @@ console.log('[workspace-hub.js] FILE LOADED');
       const result = await res.json().catch(() => ({}));
       const imported = Number(result?.imported || 0);
       const reparented = Number(result?.reparented || 0);
+      const orphaned = Number(result?.orphaned || 0);
+      const restored = Number(result?.restored || 0);
       await loadWorkspaces();
       if (window.Toast) {
-        if (imported === 0 && reparented === 0) {
+        if (imported === 0 && reparented === 0 && orphaned === 0 && restored === 0) {
           window.Toast.success('Workspaces are up to date with disk');
         } else {
           const parts = [];
           if (imported > 0) parts.push(`${imported} imported`);
           if (reparented > 0) parts.push(`${reparented} re-grouped`);
+          if (orphaned > 0) parts.push(`${orphaned} hidden (folder missing on disk)`);
+          if (restored > 0) parts.push(`${restored} restored`);
           window.Toast.success(`Rescanned from disk: ${parts.join(', ')}`);
         }
       }
@@ -2915,6 +2919,28 @@ console.log('[workspace-hub.js] FILE LOADED');
       if (window.Toast) window.Toast.error('Failed to rescan workspaces');
     } finally {
       if (btn) btn.disabled = false;
+    }
+  }
+
+  // Silently reconcile the session store with the workspaces root once when the
+  // hub loads, so folders deleted/created outside this app (Finder, another
+  // instance) are reflected without a manual rescan. Refreshes the list only
+  // when the reconcile actually changed something; errors are non-fatal.
+  async function reconcileWorkspacesOnLoad() {
+    try {
+      const res = await fetch('/api/workspaces/rescan', { method: 'POST' });
+      if (!res.ok) return;
+      const result = await res.json().catch(() => ({}));
+      const changed =
+        Number(result?.imported || 0) +
+        Number(result?.reparented || 0) +
+        Number(result?.orphaned || 0) +
+        Number(result?.restored || 0);
+      if (changed > 0) {
+        await loadWorkspaces();
+      }
+    } catch (err) {
+      console.warn('Background workspace reconcile failed:', err);
     }
   }
 
@@ -4450,5 +4476,5 @@ console.log('[workspace-hub.js] FILE LOADED');
     areAllLauncherWorkspacesSelected
   };
 
-  loadWorkspaces();
+  loadWorkspaces().then(() => reconcileWorkspacesOnLoad());
 })();

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -2924,11 +2924,13 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   // Silently reconcile the session store with the workspaces root once when the
   // hub loads, so folders deleted/created outside this app (Finder, another
-  // instance) are reflected without a manual rescan. Refreshes the list only
-  // when the reconcile actually changed something; errors are non-fatal.
+  // instance) are reflected without a manual rescan. The background flag lets
+  // the server apply a cooldown so several tabs opening at once don't each
+  // trigger a filesystem walk. Refreshes the list only when the reconcile
+  // actually changed something; errors are non-fatal.
   async function reconcileWorkspacesOnLoad() {
     try {
-      const res = await fetch('/api/workspaces/rescan', { method: 'POST' });
+      const res = await fetch('/api/workspaces/rescan?background=1', { method: 'POST' });
       if (!res.ok) return;
       const result = await res.json().catch(() => ({}));
       const changed =

--- a/internal/workspace/sync_store.go
+++ b/internal/workspace/sync_store.go
@@ -35,7 +35,7 @@ func (s *SyncStore) FileStore() *FileStore {
 // we still persist to the primary so the authoritative record is updated;
 // the disk sync is best-effort.
 func (s *SyncStore) Save(ws *Workspace) error {
-	if s.fileSync != nil && ws != nil && ws.Status != StatusTrashed {
+	if s.fileSync != nil && ws != nil && ws.Status != StatusTrashed && ws.Status != StatusMissing {
 		if err := s.fileSync.Save(ws); err != nil {
 			logger.Warn("Failed to sync workspace to disk", logger.Fields{
 				"workspace_id": ws.ID,
@@ -124,7 +124,7 @@ func (s *SyncStore) Update(wsID string, fn func(*Workspace) error) error {
 
 // SaveWorkspaceAgent writes the snapshot to the primary store and to disk.
 func (s *SyncStore) SaveWorkspaceAgent(workspaceID, agentName string, ag *agent.Agent) error {
-	if ws, err := s.primary.Get(workspaceID); err == nil && ws != nil && ws.Status == StatusTrashed {
+	if ws, err := s.primary.Get(workspaceID); err == nil && ws != nil && (ws.Status == StatusTrashed || ws.Status == StatusMissing) {
 		return nil
 	}
 	if err := s.primary.SaveWorkspaceAgent(workspaceID, agentName, ag); err != nil {

--- a/internal/workspace/sync_store_test.go
+++ b/internal/workspace/sync_store_test.go
@@ -158,6 +158,46 @@ func TestSyncStore_SaveSkipsDiskForTrashedWorkspace(t *testing.T) {
 	}
 }
 
+// TestSyncStore_SaveSkipsDiskForMissingWorkspace guards against resurrection:
+// a workspace whose folder was deleted externally (status missing) must not
+// have its folder silently recreated by a write-through save.
+func TestSyncStore_SaveSkipsDiskForMissingWorkspace(t *testing.T) {
+	primary := NewInMemoryStore()
+	dir := t.TempDir()
+	fileSync, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = fileSync.Close() }()
+
+	store := NewSyncStore(primary, fileSync)
+
+	now := time.Now()
+	ws := &Workspace{
+		ID:         "ws-missing-test",
+		Name:       "Missing Test",
+		FolderSlug: "missing-test",
+		Status:     StatusMissing,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := primary.Get(ws.ID)
+	if err != nil {
+		t.Fatalf("Primary store should have missing workspace: %v", err)
+	}
+	if got.Status != StatusMissing {
+		t.Fatalf("Primary status = %q, want %q", got.Status, StatusMissing)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "missing-test")); !os.IsNotExist(err) {
+		t.Fatalf("missing workspace folder should not be recreated, stat err = %v", err)
+	}
+}
+
 func TestSyncStore_SaveWorkspaceAgentSkipsTrashedWorkspace(t *testing.T) {
 	primary := NewInMemoryStore()
 	dir := t.TempDir()

--- a/internal/workspace/sync_store_test.go
+++ b/internal/workspace/sync_store_test.go
@@ -232,6 +232,41 @@ func TestSyncStore_SaveWorkspaceAgentSkipsTrashedWorkspace(t *testing.T) {
 	}
 }
 
+func TestSyncStore_SaveWorkspaceAgentSkipsMissingWorkspace(t *testing.T) {
+	primary := NewInMemoryStore()
+	dir := t.TempDir()
+	fileSync, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = fileSync.Close() }()
+
+	store := NewSyncStore(primary, fileSync)
+
+	now := time.Now()
+	ws := &Workspace{
+		ID:         "ws-missing-agent",
+		Name:       "Missing Agent",
+		FolderSlug: "missing-agent",
+		Status:     StatusMissing,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := primary.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SaveWorkspaceAgent(ws.ID, "Manager", &agent.Agent{Type: agent.TypeToolCalling}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := primary.GetWorkspaceAgent(ws.ID, "Manager"); err != nil || ok {
+		t.Fatalf("primary agent snapshot should not be written for missing workspace, ok=%v err=%v", ok, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "missing-agent")); !os.IsNotExist(err) {
+		t.Fatalf("missing workspace folder should not be recreated by agent snapshot, stat err = %v", err)
+	}
+}
+
 func TestSyncStore_DeleteRemovesFromBoth(t *testing.T) {
 	primary := NewInMemoryStore()
 	dir := t.TempDir()

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -17,6 +17,10 @@ const (
 	StatusFailed    WorkspaceStatus = "failed"
 	StatusCancelled WorkspaceStatus = "cancelled"
 	StatusTrashed   WorkspaceStatus = "trashed"
+	// StatusMissing marks a workspace whose folder disappeared from disk outside
+	// this app. Hidden from listings and excluded from disk write-through so a
+	// stale record cannot resurrect a deleted folder.
+	StatusMissing WorkspaceStatus = "missing"
 )
 
 // MessageType represents the type of inter-agent message


### PR DESCRIPTION
## Problem

The Workspaces page is served from each app instance's private SQLite session store, while the shared workspaces root (`~/Ori Workspaces`) is only a write-through sync target. The disk reconcile (startup + Rescan) was additive-only — it imported and re-parented what it found on disk but never flagged rows whose folder was gone. So deleting a workspace folder in Finder or from another app instance left a stale row in the UI forever, and deleting + recreating a folder produced duplicate entries with the same name (new ID imported alongside the stale row). Stale rows could even silently re-create deleted folders via write-through saves.

## Solution

Disk is the source of truth for existence, with soft deletion so chat history is never destroyed:

- **New `missing` workspace status + orphan sweep**: the reconcile now marks folder-managed session rows as `missing` when their folder is gone from disk, or when the folder was recreated as a different workspace (same path, different `workspace.json` ID — the duplicate case). Missing rows are hidden from listings, like trashed ones.
- **Self-healing in both directions**: a reappearing folder (cloud sync restore, drive remount) automatically clears the missing status on the next reconcile; the sync panel's locate/recreate actions also recover it.
- **Resurrection guards**: `SyncStore` write-through, workspace agent snapshots, and the group scaffolding backfill all skip missing rows, so a stale DB row can no longer re-create a folder that was deleted elsewhere.
- **Recovery stays discoverable**: missing rows are always listed in sync-status for cleanup/locate/recreate; recreate refuses to clobber a folder that now belongs to a different workspace.
- **Reliable path resolution**: a row's last-known folder is now resolved via the `primary_directory_id` recorded in `shared_data` at scaffolding time — `FolderSlug` has no SQLite column, so the existing slug-name fallback never fired on DB-hydrated rows.
- **Freshness**: the workspace hub runs a silent rescan on page load (refreshing only when something changed), and the Rescan toast reports hidden/restored counts.

## Testing

- New handler tests: external delete → hidden + recoverable via recreate; folder reappears → auto-restored; folder recreated with new ID → new workspace imported, stale row hidden, recreate refused without clobbering the new folder's identity
- New `SyncStore` test: saving a missing workspace does not re-create its folder
- `go build ./...`, `go vet`, full `sessionhttp`/`workspace`/`session` suites, eslint, and the 18 workspace-hub module tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)