### PR TITLE
feat(workspace-assistant): floating panel UX overhaul — idle state, layout, input model

### DIFF
--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -5054,11 +5054,40 @@ body.modal-open .hub-support-chat {
   width: auto;
   min-width: 148px;
   height: 46px;
-  align-self: flex-end;
   border-radius: 12px;
   gap: 8px;
   padding: 0 18px;
   font-weight: 700;
+}
+
+.hub-workspace-assistant-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.hub-workspace-assistant-actions .hub-support-chat-configure {
+  width: 46px;
+  height: 46px;
+  padding: 0;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.hub-workspace-assistant-actions .hub-support-chat-configure[hidden] {
+  display: none;
+}
+
+/* The workspaces hub has no single workspace context: the manager identity,
+   Task/Ask/Note modes, and workspace quick actions don't apply there. */
+.hub-support-chat[data-surface="workspace_hub"] .hub-workspace-assistant-meta,
+.hub-support-chat[data-surface="workspace_hub"] .hub-workspace-mode-switch,
+.hub-support-chat[data-surface="workspace_hub"] .hub-workspace-assistant-quick {
+  display: none;
 }
 
 .hub-workspace-assistant-quick {
@@ -5236,8 +5265,8 @@ body.modal-open .hub-support-chat {
   }
 
   .hub-support-chat-workspace .hub-support-chat-send {
-    width: 100%;
-    align-self: stretch;
+    flex: 1 1 auto;
+    width: auto;
   }
 
   .hub-support-chat-launcher {

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -4964,10 +4964,19 @@ body.modal-open .hub-support-chat {
 /* Floating Workspace Assistant consolidation */
 .hub-support-chat-workspace .hub-support-chat-panel {
   width: min(600px, calc(100vw - 56px));
-  height: min(780px, calc(100vh - 112px));
+  /* Hug content while idle; grow with activity up to the viewport cap. */
+  height: auto;
   max-height: calc(100vh - 112px);
   background: var(--bg-primary, #fff);
   border-radius: 14px;
+}
+
+/* The assistant panel is conversational; sentence-case its controls instead
+   of the app-wide uppercase button treatment from ui-refresh.css. */
+.hub-support-chat-workspace .modern-btn,
+.hub-support-chat-workspace .home-assistant-workspace-mode-btn {
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .hub-support-chat-workspace .hub-support-chat-header {
@@ -4981,7 +4990,6 @@ body.modal-open .hub-support-chat {
 }
 
 .hub-workspace-assistant {
-  border-bottom: 1px solid var(--border-color, #e2e2e2);
   background: var(--bg-primary, #fff);
   padding: 18px 24px 20px;
   flex-shrink: 0;
@@ -5081,7 +5089,14 @@ body.modal-open .hub-support-chat {
   min-height: 0;
   overflow-y: auto;
   padding: 18px 24px 24px;
+  border-top: 1px solid var(--border-color, #e2e2e2);
   background: var(--bg-secondary, #f7f7f7);
+}
+
+/* Hidden while idle (no run, no conversation); dashboard.js toggles is-idle
+   in syncHomeAssistantActivityIdle(). */
+.hub-support-chat-activity.is-idle {
+  display: none;
 }
 
 .hub-support-chat-status-row {
@@ -5125,7 +5140,7 @@ body.modal-open .hub-support-chat {
 }
 
 .hub-support-chat-conversation.home-assistant-conversation {
-  max-height: 260px;
+  max-height: min(44vh, 400px);
   overflow-y: auto;
 }
 
@@ -5170,8 +5185,8 @@ body.modal-open .hub-support-chat {
   background: #11141b;
 }
 
-[data-bs-theme="dark"] .hub-workspace-assistant {
-  border-bottom-color: rgba(255, 255, 255, 0.12);
+[data-bs-theme="dark"] .hub-support-chat-activity {
+  border-top-color: rgba(255, 255, 255, 0.12);
 }
 
 [data-bs-theme="dark"] .hub-support-chat-workspace .hub-support-chat-input {
@@ -5199,7 +5214,7 @@ body.modal-open .hub-support-chat {
   .hub-support-chat-workspace .hub-support-chat-panel {
     width: 100%;
     max-width: none;
-    height: min(82vh, 720px);
+    height: auto;
     max-height: calc(100vh - 92px);
     transform-origin: bottom center;
   }

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -5118,6 +5118,12 @@ body.modal-open .hub-support-chat {
   border-radius: 12px;
 }
 
+/* Hidden until the first message lands; dashboard.js toggles is-empty
+   in syncHomeAssistantConversationSection(). */
+.hub-support-chat-conversation-section.home-assistant-conversation-section.is-empty {
+  display: none;
+}
+
 .hub-support-chat-conversation.home-assistant-conversation {
   max-height: 260px;
   overflow-y: auto;

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -337,7 +337,7 @@
   function truncateText(value, maxLength) {
     var text = String(value || '').trim();
     if (text.length <= maxLength) return text;
-    return text.slice(0, Math.max(0, maxLength - 3)) + '...';
+    return text.slice(0, Math.max(0, maxLength - 1)) + '…';
   }
 
   function formatRelativeTime(timestamp) {
@@ -1126,7 +1126,7 @@
       els.thinkingModalLabel.textContent = label + ' has an update ready';
       return;
     }
-    els.thinkingModalLabel.textContent = label + ' is working';
+    els.thinkingModalLabel.textContent = label + (homeAssistantState.busy ? ' is working' : ' is ready');
   }
 
   function setHomeAssistantConversationCollapsed(collapsed) {
@@ -1224,7 +1224,7 @@
     } else if (homeAssistantState.routingSummary && homeAssistantState.routingSummary.text) {
       statusText = homeAssistantState.routingSummary.text;
     } else if (homeAssistantState.busy) {
-      statusText = 'Working...';
+      statusText = 'Working…';
     } else if (hasVisibleHomeAssistantPlanning()) {
       statusText = 'Complete the active planning step below.';
     } else if (hasVisibleHomeAssistantInlineReply()) {
@@ -1604,7 +1604,7 @@
       els.input.disabled = homeAssistantState.busy;
       setHomeAssistantSendButtonLabel(
         els.sendBtn,
-        homeAssistantState.busy ? (busyLabel || 'Working...') : els.sendBtn.dataset.defaultLabel
+        homeAssistantState.busy ? (busyLabel || 'Working…') : els.sendBtn.dataset.defaultLabel
       );
     }
     for (var i = 0; i < els.quickButtons.length; i++) {
@@ -2546,12 +2546,12 @@
 
     if (planningState && planningState.specialistBusy === specialistKey) {
       if (status && status.taskId) {
-        return 'Opening ' + config.label + ' Task...';
+        return 'Opening ' + config.label + ' Task…';
       }
       if (status && status.agentName) {
-        return 'Handing Off To ' + status.agentName + '...';
+        return 'Handing Off To ' + status.agentName + '…';
       }
-      return 'Creating ' + config.label + '...';
+      return 'Creating ' + config.label + '…';
     }
 
     if (status && status.taskId) {
@@ -2809,7 +2809,7 @@
       if (!planningState.mainTask || !planningState.mainTask.id) {
         planningState.mainTaskCreating = true;
         renderHomeAssistantPlanning();
-        setHomeAssistantBusy(true, 'Adding Main Task...');
+        setHomeAssistantBusy(true, 'Adding Main Task…');
         setHomeAssistantRoutingSummary(
           'Planning Review',
           'Adding the main task to this workspace before the planning subtasks continue.'
@@ -2823,7 +2823,7 @@
 
       planningState.mainTaskCreating = false;
       renderHomeAssistantPlanning();
-      setHomeAssistantBusy(true, 'Starting Task...');
+      setHomeAssistantBusy(true, 'Starting Task…');
       setHomeAssistantRoutingSummary(
         planningState.agentLabel,
         isTravelPlanningReviewState(planningState)
@@ -2872,7 +2872,7 @@
     if (intent && intent.key === 'travel_planning') {
       return 'Example: 1A, 2C, 3B, 4B, and I care about food and museums.';
     }
-    return 'Reply to ' + (agentLabel || getWorkspaceHomeAssistantDisplayName()) + '...';
+    return 'Reply to ' + (agentLabel || getWorkspaceHomeAssistantDisplayName()) + '…';
   }
 
   function getInlineReplyWorkspaceName(routeContext) {
@@ -3181,7 +3181,7 @@
       saveNoteButton.className = 'modern-btn modern-btn-secondary';
       saveNoteButton.disabled = isReviewBusy || Boolean(planningState.noteSaved);
       saveNoteButton.textContent = planningState.noteSaving
-        ? 'Saving Note...'
+        ? 'Saving Note…'
         : (planningState.noteSaved && planningState.noteSaved.name
             ? 'Saved To "' + planningState.noteSaved.name + '"'
             : 'Save Summary To Note');
@@ -3197,9 +3197,9 @@
         : 'modern-btn modern-btn-primary';
       continueButton.disabled = isReviewBusy;
       continueButton.textContent = planningState.mainTaskCreating
-        ? 'Adding Main Task...'
+        ? 'Adding Main Task…'
         : planningState.continuing
-        ? 'Continuing...'
+        ? 'Continuing…'
         : specialistFirstReview
         ? ('Keep Task With ' + planningState.agentLabel)
         : ('Start Task With ' + planningState.agentLabel);
@@ -3459,7 +3459,7 @@
     submitButton.type = 'submit';
     submitButton.className = 'modern-btn modern-btn-primary';
     submitButton.textContent = isSubmitting
-      ? 'Sending...'
+      ? 'Sending…'
       : (planningState.schema.submit_label || ('Continue With ' + planningState.agentLabel));
     submitButton.disabled = isSubmitting;
     actions.appendChild(submitButton);
@@ -3715,7 +3715,7 @@
     sendButton.className = 'modern-btn modern-btn-primary';
     sendButton.disabled = isSubmitting || (choiceStep ? !replyState.selectedChoiceId : false);
     sendButton.textContent = isSubmitting
-      ? 'Sending...'
+      ? 'Sending…'
       : choiceStep
       ? 'Complete Subtask'
       : 'Submit Subtask';
@@ -3780,7 +3780,7 @@
     replyState.submitting = true;
     renderHomeAssistantInlineReply();
     appendHomeAssistantMessage('user', submittedText);
-    setHomeAssistantBusy(true, 'Sending Reply...');
+    setHomeAssistantBusy(true, 'Sending Reply…');
     setHomeAssistantRoutingSummary(replyState.agentLabel, 'Continuing inline with the workspace manager.');
 
     try {
@@ -3859,7 +3859,7 @@
     var manager = window.sessionManager;
     var deleted = false;
 
-    setHomeAssistantBusy(true, 'Deleting...');
+    setHomeAssistantBusy(true, 'Deleting…');
     renderHomeAssistantActions([]);
     try {
       if (manager && typeof manager.deleteSession === 'function') {
@@ -5125,7 +5125,7 @@
       + '      <p class="small mb-3" style="color: var(--text-secondary);">' + String(modalOptions.description || 'Select an MCP connector and apply it with explicit approval.') + '</p>'
       + '      <div class="input-group mb-2">'
       + '        <span class="input-group-text" style="background: var(--bg-tertiary); border-color: var(--border-color); color: var(--text-secondary);">Search</span>'
-      + '        <input id="' + searchId + '" type="text" class="form-control" placeholder="' + String(modalOptions.searchPlaceholder || 'Search connectors...') + '" style="background: var(--bg-tertiary); border-color: var(--border-color); color: var(--text-primary);">'
+      + '        <input id="' + searchId + '" type="text" class="form-control" placeholder="' + String(modalOptions.searchPlaceholder || 'Search connectors…') + '" style="background: var(--bg-tertiary); border-color: var(--border-color); color: var(--text-primary);">'
       + '      </div>'
       + '      <div id="' + countId + '" class="small mb-2" style="color: var(--text-secondary);"></div>'
       + '      <div id="' + listId + '" class="list-group" style="max-height: 360px; overflow-y: auto;"></div>'
@@ -5354,8 +5354,8 @@
           if (switchButton) switchButton.disabled = true;
           var originalLabel = confirmButton.textContent;
           confirmButton.textContent = agentName
-            ? String(modalOptions.progressWithAgentLabel || 'Applying...')
-            : String(modalOptions.progressWithoutAgentLabel || 'Installing...');
+            ? String(modalOptions.progressWithAgentLabel || 'Applying…')
+            : String(modalOptions.progressWithoutAgentLabel || 'Installing…');
 
           try {
             var outcome = await applyEmailMCPCandidate(agentName, selectedCandidate, routeContext);
@@ -5390,7 +5390,7 @@
       modalPrefix: 'homeEmailMCPBrowseModal',
       title: 'Browse Email MCP Connectors',
       description: 'Select an email connector for Gmail, Outlook, or IMAP. Installed connectors are bound from the active workspace when one is available.',
-      searchPlaceholder: 'gmail, outlook, imap...',
+      searchPlaceholder: 'gmail, outlook, imap…',
       emptyStateText: 'No matching email MCP connectors found.',
       pendingInstallText: 'Will be installed and then bound in the active workspace.',
       switchLabel: 'Use Browser Control',
@@ -5404,7 +5404,7 @@
       modalPrefix: 'homeBrowserMCPBrowseModal',
       title: 'Browse Browser Control MCP',
       description: 'Select a browser-control connector (Playwright, Browserbase, or Puppeteer). Installed connectors are bound from the active workspace when one is available.',
-      searchPlaceholder: 'playwright, browserbase, puppeteer...',
+      searchPlaceholder: 'playwright, browserbase, puppeteer…',
       emptyStateText: 'No matching browser-control MCP connectors found.',
       pendingInstallText: 'Will be installed and then bound in the active workspace.',
       switchLabel: 'Use Email Connector',
@@ -6102,7 +6102,7 @@
   async function executeCapabilityPlan(plan, prompt, routeContext, appLaunchRequest) {
     if (!plan) return;
 
-    setHomeAssistantBusy(true, 'Applying Plan...');
+    setHomeAssistantBusy(true, 'Applying Plan…');
     renderHomeAssistantActions([]);
     appendHomeAssistantMessage('assistant', 'Applying the capability plan now.');
 
@@ -7617,7 +7617,7 @@
 
         submitting = true;
         createButton.disabled = true;
-        createButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Creating...';
+        createButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Creating…';
 
         try {
           var requestBody = {
@@ -7734,10 +7734,10 @@
       return;
     }
 
-    setHomeAssistantBusy(true, 'Creating...');
+    setHomeAssistantBusy(true, 'Creating…');
     renderHomeAssistantActions([]);
-    appendHomeAssistantMessage('assistant', 'Creating a new agent for this task...');
-    setHomeAssistantRoutingSummary('Agent Creation', 'Creating a new agent for this task...');
+    appendHomeAssistantMessage('assistant', 'Creating a new agent for this task…');
+    setHomeAssistantRoutingSummary('Agent Creation', 'Creating a new agent for this task…');
 
     try {
       var listData = await API.get('/api/agents');
@@ -7802,7 +7802,7 @@
           return;
         }
         agentName = semiAutoConfirmation.agentName;
-        setHomeAssistantBusy(true, 'Finalizing...');
+        setHomeAssistantBusy(true, 'Finalizing…');
       } else if (!payload.model) {
         appendHomeAssistantMessage('assistant',
           'I could not auto-select a model. Please review and confirm in the Create Agent modal.');
@@ -7832,7 +7832,7 @@
           return;
         }
         agentName = confirmation.agentName;
-        setHomeAssistantBusy(true, 'Finalizing...');
+        setHomeAssistantBusy(true, 'Finalizing…');
       } else {
         appendHomeAssistantMessage('assistant', 'Auto-selected model "' + payload.model + '" for "' + agentName + '".');
         await API.post('/api/agents', payload);
@@ -8318,7 +8318,7 @@
     var appLaunchRequest = options && options.appLaunchRequest ? options.appLaunchRequest : null;
     var dispatchMessage = buildAskOriDispatchMessage(prompt, appLaunchRequest, dispatchIntent, routeContext);
 
-    setHomeAssistantBusy(true, 'Running Capability...');
+    setHomeAssistantBusy(true, 'Running Capability…');
     renderHomeAssistantActions([]);
     appendHomeAssistantMessage('assistant', 'Using the current capability setup to answer this directly.');
     setHomeAssistantRoutingSummary('Capability Direct', 'Running the request inline with the selected agent.');
@@ -8413,7 +8413,7 @@
       return;
     }
 
-    setHomeAssistantBusy(true, 'Checking Workspace Schedule...');
+    setHomeAssistantBusy(true, 'Checking Workspace Schedule…');
     renderHomeAssistantActions([]);
     appendHomeAssistantMessage('assistant', 'Checking scheduled tasks in the current workspace.');
     setHomeAssistantRoutingSummary('Workspace Schedule', 'Loading scheduled tasks for this workspace.');
@@ -8526,7 +8526,7 @@
       routeContext: buildHomeRouteContext(),
       finalHandoffTarget: 'tool'
     });
-    setHomeAssistantBusy(true, 'Running Utility...');
+    setHomeAssistantBusy(true, 'Running Utility…');
     renderHomeAssistantActions([]);
     appendHomeAssistantMessage('assistant', 'Running this as a direct utility request in the current assistant session.');
     setHomeAssistantRoutingSummary('Utility Direct', 'Executing directly without creating or handing off to another agent.');
@@ -8589,11 +8589,11 @@
     var confirmedAction = options.confirmedAction || null;
     var summaryLabel = intent === 'app_navigation' ? 'Navigation' : 'Activity';
 
-    setHomeAssistantBusy(true, confirmedAction ? 'Applying...' : 'Thinking...');
+    setHomeAssistantBusy(true, confirmedAction ? 'Applying…' : 'Thinking…');
     renderHomeAssistantActions([]);
     setHomeAssistantRoutingSummary(
       summaryLabel,
-      confirmedAction ? 'Applying your confirmed action...' : 'Reviewing your workspaces, tasks, and activity...'
+      confirmedAction ? 'Applying your confirmed action…' : 'Reviewing your workspaces, tasks, and activity…'
     );
 
     try {
@@ -9564,7 +9564,7 @@
     var allowCreate = options && options.allowCreate === true;
     var managerLabel = getWorkspaceHomeAssistantDisplayName();
 
-    setHomeAssistantBusy(true, allowCreate ? 'Creating Specialist...' : 'Routing Task...');
+    setHomeAssistantBusy(true, allowCreate ? 'Creating Specialist…' : 'Routing Task…');
     renderHomeAssistantActions([]);
     appendHomeAssistantMessage(
       'assistant',
@@ -9943,10 +9943,10 @@
       var chosenAgent = String(agentName || '').trim();
       if (!chosenAgent) return;
 
-      setHomeAssistantBusy(true, 'Creating Scheduled Task...');
+      setHomeAssistantBusy(true, 'Creating Scheduled Task…');
       renderHomeAssistantActions([]);
-      appendHomeAssistantMessage('assistant', 'Creating a scheduled task and assigning it to "' + chosenAgent + '"...');
-      setHomeAssistantRoutingSummary('Scheduled Task', 'Creating and assigning scheduled task...');
+      appendHomeAssistantMessage('assistant', 'Creating a scheduled task and assigning it to "' + chosenAgent + '"…');
+      setHomeAssistantRoutingSummary('Scheduled Task', 'Creating and assigning scheduled task…');
 
       try {
         await createScheduledWorkspaceTask(workspaceId, prompt, chosenAgent, scheduleConfig, scheduleName);
@@ -10123,7 +10123,7 @@
       commandSummaryText = 'Saving a note in this workspace.';
     }
 
-    setHomeAssistantBusy(true, command === 'task' ? 'Creating Task...' : command === 'note' ? 'Saving Note...' : 'Running Command...');
+    setHomeAssistantBusy(true, command === 'task' ? 'Creating Task…' : command === 'note' ? 'Saving Note…' : 'Running Command…');
     renderHomeAssistantActions([]);
     setHomeAssistantRoutingSummary(commandSummaryTitle, commandSummaryText);
 
@@ -10544,9 +10544,9 @@
       workspaceBootstrap: buildWorkspaceBootstrapFromPrompt(sourcePrompt || ('Create workspace: ' + name))
     };
 
-    setHomeAssistantBusy(true, 'Preparing Workspace...');
+    setHomeAssistantBusy(true, 'Preparing Workspace…');
     renderHomeAssistantActions([]);
-    appendHomeAssistantMessage('assistant', 'Opening the Create Workspace modal for "' + name + '"...');
+    appendHomeAssistantMessage('assistant', 'Opening the Create Workspace modal for "' + name + '"…');
     setHomeAssistantRoutingSummary('Workspace', 'Preparing Create Workspace modal.');
 
     try {
@@ -10612,9 +10612,9 @@
       finalHandoffTarget: 'workspace_create'
     });
 
-    setHomeAssistantBusy(true, 'Preparing Workspace...');
+    setHomeAssistantBusy(true, 'Preparing Workspace…');
     renderHomeAssistantActions([]);
-    appendHomeAssistantMessage('assistant', 'Opening Create Workspace so you can review details first...');
+    appendHomeAssistantMessage('assistant', 'Opening Create Workspace so you can review details first…');
     setHomeAssistantRoutingSummary('Workspace', 'Preparing Create Workspace modal.');
 
     try {
@@ -10677,10 +10677,10 @@
       finalHandoffTarget: 'chat_agent'
     });
 
-    setHomeAssistantBusy(true, 'Opening Chat...');
+    setHomeAssistantBusy(true, 'Opening Chat…');
     renderHomeAssistantActions([]);
-    appendHomeAssistantMessage('assistant', 'Opening a chat session with "' + agentName + '"...');
-    setHomeAssistantRoutingSummary('Handoff', 'Routing task to "' + agentName + '"...');
+    appendHomeAssistantMessage('assistant', 'Opening a chat session with "' + agentName + '"…');
+    setHomeAssistantRoutingSummary('Handoff', 'Routing task to "' + agentName + '"…');
     if (appLaunchRequest && appLaunchRequest.appName) {
       appendHomeAssistantMessage('assistant',
         'Routing steps: 1) Start a new session. 2) Execute /openapp ' + appLaunchRequest.appName + ' to launch the app.');
@@ -10798,7 +10798,7 @@
 
     if (homeAssistantState.awaitingCreateConfirmation && isAffirmativeConfirmation(text)) {
       appendHomeAssistantMessage('user', text);
-      setHomeAssistantRoutingSummary('Agent Creation', 'Confirmed. Creating a new agent...');
+      setHomeAssistantRoutingSummary('Agent Creation', 'Confirmed. Creating a new agent…');
       await createAgentForPendingTask();
       return;
     }
@@ -10857,11 +10857,11 @@
       }
 
       var workspaceManagerLabel = getWorkspaceHomeAssistantDisplayName();
-      setHomeAssistantBusy(true, 'Asking...');
+      setHomeAssistantBusy(true, 'Asking…');
       renderHomeAssistantActions([]);
       setHomeAssistantRoutingSummary(
         workspaceManagerLabel,
-        'Sending your request to the workspace manager...'
+        'Sending your request to the workspace manager…'
       );
 
       try {
@@ -10914,9 +10914,9 @@
       return;
     }
 
-    setHomeAssistantBusy(true, 'Routing...');
+    setHomeAssistantBusy(true, 'Routing…');
     renderHomeAssistantActions([]);
-    setHomeAssistantRoutingSummary('Routing', 'Analyzing task and selecting the best agent...');
+    setHomeAssistantRoutingSummary('Routing', 'Analyzing task and selecting the best agent…');
 
     try {
       var routeData = await routePromptWithBackend(text, routeContext);

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -712,11 +712,11 @@
     var raw = String(prompt || '').trim();
     if (!raw || raw.charAt(0) !== '/') return null;
 
-    var match = raw.match(/^\/(task|chat|c|note|directory|dir|file|upload)(?:\s+([\s\S]*))?$/i);
+    var match = raw.match(/^\/(task|chat|c|ask|note|directory|dir|file|upload)(?:\s+([\s\S]*))?$/i);
     if (!match) return null;
 
     var command = normalizeToken(match[1]);
-    if (command === 'c') command = 'chat';
+    if (command === 'c' || command === 'ask') command = 'chat';
     if (command === 'dir') command = 'directory';
     if (command === 'upload') command = 'file';
 
@@ -1457,8 +1457,8 @@
     }
     if (hasWorkspaceRouteContext(routeContext)) {
       if (workspaceMode === 'ask') return 'Ask ' + displayName + ' about this workspace… (/task creates a task)';
-      if (workspaceMode === 'note') return 'Save a workspace note… (/task creates a task, /chat asks)';
-      return 'Create a task for ' + displayName + '… (/chat asks, /note saves a note)';
+      if (workspaceMode === 'note') return 'Save a workspace note… (/task creates a task, /ask asks)';
+      return 'Create a task for ' + displayName + '… (/ask asks, /note saves a note)';
     }
     return document.querySelector('#homeAssistantCard[data-first-run="true"]') ? 'Plan a product launch…' : 'Ask Ori to do something…';
   }
@@ -11266,8 +11266,17 @@
         if (homeAssistantState.busy) return;
         var prompt = event.currentTarget && event.currentTarget.getAttribute('data-home-prompt');
         if (!prompt) return;
+        // Prefill instead of auto-send so the prompt can be reviewed and
+        // edited before anything is created.
         els.input.value = prompt;
-        handleHomeAssistantSubmit();
+        if (window.hubSupportChat && typeof window.hubSupportChat.resize === 'function') {
+          window.hubSupportChat.resize();
+        }
+        els.input.focus();
+        if (typeof els.input.setSelectionRange === 'function') {
+          var caret = els.input.value.length;
+          els.input.setSelectionRange(caret, caret);
+        }
       });
     }
 

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -1007,12 +1007,14 @@
       return {
         show: function () {
           els.thinkingModal.classList.add('show');
+          els.thinkingModal.classList.remove('is-idle');
           if (window.hubSupportChat && typeof window.hubSupportChat.open === 'function') {
             window.hubSupportChat.open({ focus: 'input' });
           }
         },
         hide: function () {
           els.thinkingModal.classList.remove('show');
+          syncHomeAssistantActivityIdle();
         }
       };
     }
@@ -1134,6 +1136,17 @@
     syncHomeAssistantConversationSection();
   }
 
+  // Embedded-panel surface only: hide the activity area entirely until the
+  // assistant has something to show (busy, summary, structured step, actions,
+  // or conversation), so the idle panel is just compose + quick actions.
+  function syncHomeAssistantActivityIdle() {
+    var els = getHomeAssistantElements();
+    if (!els.thinkingModal) return;
+    if (els.thinkingModal.getAttribute('data-home-assistant-surface') !== 'panel') return;
+    var hasActivity = shouldKeepHomeAssistantThinkingModalOpen() || hasHomeAssistantConversation();
+    els.thinkingModal.classList.toggle('is-idle', !hasActivity);
+  }
+
   function syncHomeAssistantConversationSection() {
     var els = getHomeAssistantElements();
     var section = els.conversationSection;
@@ -1242,6 +1255,7 @@
     }
 
     syncHomeAssistantModalHeading();
+    syncHomeAssistantActivityIdle();
     syncHomeAssistantLauncher();
   }
 

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -2154,6 +2154,7 @@ export class WorkspaceDetailPage {
     if (this.elements.workspaceName) {
       this.elements.workspaceName.textContent = this.workspace.name || 'Unnamed Workspace';
     }
+    window.hubSupportChat?.setSubtitle?.(this.workspace.name || '');
     if (this.elements.workspaceDescription) {
       if (this.workspace.description) {
         this.elements.workspaceDescription.textContent = this.workspace.description;

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -408,7 +408,7 @@ export class WorkspaceDetailPage {
       this.setHomeAssistantQuickPrompt(
         homeAssistantQuickNotesBtn,
         'Summarize Notes',
-        `/chat Summarize notes in ${workspaceName} and produce a prioritized execution checklist.`
+        `/ask Summarize notes in ${workspaceName} and produce a prioritized execution checklist.`
       );
     }
 
@@ -14672,8 +14672,8 @@ export class WorkspaceDetailPage {
         requireConfirmation: true,
         source: 'assistant'
       });
-    } else if (input.startsWith('/chat ') || input.startsWith('/c ')) {
-      const message = input.replace(/^\/(chat|c)\s+/, '').trim();
+    } else if (input.startsWith('/chat ') || input.startsWith('/c ') || input.startsWith('/ask ')) {
+      const message = input.replace(/^\/(chat|c|ask)\s+/, '').trim();
       handled = await this.createSessionWithMessage(message);
     } else if (input.startsWith('/note ')) {
       const noteContent = input.substring(6).trim();

--- a/internal/web/static/js/modules/workspace-hub-support-chat.js
+++ b/internal/web/static/js/modules/workspace-hub-support-chat.js
@@ -16,7 +16,7 @@
     },
     workspace_detail: {
       title: 'Workspace Assistant',
-      subtitle: 'Ask about this workspace',
+      subtitle: 'Tasks, questions, and notes for this workspace',
       inputLabel: 'Workspace manager prompt'
     },
     workspace_task: {
@@ -68,6 +68,15 @@
     if (titleEl) titleEl.textContent = config.title;
     if (subtitleEl) subtitleEl.textContent = config.subtitle;
     if (inputEl) inputEl.setAttribute('aria-label', config.inputLabel);
+  }
+
+  // Page modules call this once they know the concrete context (e.g. the
+  // workspace name) so the header names what the assistant is acting on.
+  function setSubtitle(text) {
+    const subtitleEl = $('hubSupportChatSubtitle');
+    if (!subtitleEl) return;
+    const value = String(text || '').trim();
+    subtitleEl.textContent = value || (surface ? surface.subtitle : '');
   }
 
   function setPanelState(open) {
@@ -195,7 +204,8 @@
       close: closePanel,
       toggle: togglePanel,
       surface: () => surface.key,
-      resize: autoResizeInput
+      resize: autoResizeInput,
+      setSubtitle: setSubtitle
     };
   }
 

--- a/internal/web/static/js/modules/workspace-hub-support-chat.js
+++ b/internal/web/static/js/modules/workspace-hub-support-chat.js
@@ -63,11 +63,18 @@
     const titleEl = $('hubSupportChatTitle');
     const subtitleEl = $('hubSupportChatSubtitle');
     const inputEl = $('homeAssistantInput');
+    const configureBtn = $('homeAssistantConfigureTaskBtn');
     const config = surface || SURFACES.workspace_detail;
 
     if (titleEl) titleEl.textContent = config.title;
     if (subtitleEl) subtitleEl.textContent = config.subtitle;
     if (inputEl) inputEl.setAttribute('aria-label', config.inputLabel);
+    if (elements && elements.root) {
+      elements.root.setAttribute('data-surface', surface ? surface.key : 'workspace_detail');
+    }
+    // The task editor is bound by the workspace detail page module; the
+    // button is dead weight on other surfaces.
+    if (configureBtn) configureBtn.hidden = !surface || surface.key !== 'workspace_detail';
   }
 
   // Page modules call this once they know the concrete context (e.g. the

--- a/internal/web/templates/components/support-chat.tmpl
+++ b/internal/web/templates/components/support-chat.tmpl
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <section id="homeAssistantThinkingModal" class="hub-support-chat-activity" data-home-assistant-surface="panel" aria-labelledby="homeAssistantThinkingModalLabel">
+    <section id="homeAssistantThinkingModal" class="hub-support-chat-activity is-idle" data-home-assistant-surface="panel" aria-labelledby="homeAssistantThinkingModalLabel">
       <div class="hub-support-chat-status-row">
         <div>
           <div id="homeAssistantThinkingModalLabel" class="hub-support-chat-activity-title">Workspace Manager is ready</div>

--- a/internal/web/templates/components/support-chat.tmpl
+++ b/internal/web/templates/components/support-chat.tmpl
@@ -1,6 +1,6 @@
 {{define "support-chat.tmpl"}}
 <!-- Floating Workspace Assistant -->
-<div id="hubSupportChat" class="hub-support-chat hub-support-chat-workspace" data-state="closed" aria-live="polite">
+<div id="hubSupportChat" class="hub-support-chat hub-support-chat-workspace" data-state="closed">
   <div id="hubSupportChatPanel" class="hub-support-chat-panel" role="dialog" aria-labelledby="hubSupportChatTitle" aria-modal="false" aria-hidden="true" tabindex="-1">
     <header class="hub-support-chat-header">
       <div class="hub-support-chat-header-text">
@@ -28,7 +28,7 @@
         </div>
         <div class="hub-workspace-assistant-compose">
           <textarea id="homeAssistantInput" class="hub-support-chat-input modern-input" rows="1" maxlength="800"
-                    placeholder="Create a task for Workspace Manager..."
+                    placeholder="Create a task for Workspace Manager…"
                     aria-label="Workspace manager prompt"></textarea>
           <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn hub-support-chat-send" aria-label="Send workspace assistant prompt">
             <span class="hub-support-chat-send-label">Create Task</span>
@@ -77,7 +77,7 @@
       <div id="homeAssistantInlineReply" class="home-assistant-inline-reply d-none mt-3"></div>
       <div id="homeAssistantActions" class="hub-support-chat-actions d-flex flex-wrap gap-2 mt-3 d-none"></div>
 
-      <section id="homeAssistantConversationSection" class="home-assistant-conversation-section hub-support-chat-conversation-section mt-3">
+      <section id="homeAssistantConversationSection" class="home-assistant-conversation-section hub-support-chat-conversation-section mt-3 is-empty">
         <div class="home-assistant-conversation-section-header">
           <div>
             <div class="home-assistant-conversation-section-eyebrow">Conversation History</div>

--- a/internal/web/templates/components/support-chat.tmpl
+++ b/internal/web/templates/components/support-chat.tmpl
@@ -30,13 +30,22 @@
           <textarea id="homeAssistantInput" class="hub-support-chat-input modern-input" rows="1" maxlength="800"
                     placeholder="Create a task for Workspace Manager…"
                     aria-label="Workspace manager prompt"></textarea>
-          <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn hub-support-chat-send" aria-label="Send workspace assistant prompt">
-            <span class="hub-support-chat-send-label">Create Task</span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <line x1="22" y1="2" x2="11" y2="13"></line>
-              <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-            </svg>
-          </button>
+          <div class="hub-workspace-assistant-actions">
+            <button id="homeAssistantConfigureTaskBtn" type="button" class="modern-btn modern-btn-secondary hub-support-chat-configure"
+                    title="Open task editor (review details, agent, schedule before saving)"
+                    aria-label="Open task editor" hidden>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M3 17v2h6v-2H3M3 5v2h10V5H3M13 21v-2h8v-2h-8v-2h-2v6h2M7 9v2H3v2h4v2h2V9H7M21 13v-2H11v2h10M15 9h2V7h4V5h-4V3h-2v6Z"/>
+              </svg>
+            </button>
+            <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn hub-support-chat-send" aria-label="Send workspace assistant prompt">
+              <span class="hub-support-chat-send-label">Create Task</span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="22" y1="2" x2="11" y2="13"></line>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+              </svg>
+            </button>
+          </div>
         </div>
       </form>
 

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -80,7 +80,7 @@
                 <button type="button" class="home-assistant-workspace-mode-btn" data-home-workspace-mode="note" aria-pressed="false">Note</button>
               </div>
               <input id="homeAssistantInput" type="text" class="modern-input flex-grow-1" maxlength="800"
-                     placeholder="Create a task for Workspace Manager... (/chat asks, /note saves a note)"
+                     placeholder="Create a task for Workspace Manager… (/chat asks, /note saves a note)"
                      aria-label="Workspace manager prompt"
                      style="min-height: 42px;">
               <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn">Create Task</button>
@@ -1275,7 +1275,7 @@
             <h5 id="homeAssistantThinkingModalLabel" class="modal-title">Workspace Manager is working</h5>
             <div id="homeAssistantThinkingStatus" class="home-thinking-modal-status" role="status" aria-live="polite">
               <span id="homeAssistantThinkingSpinner" class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
-              <span>Analyzing your request...</span>
+              <span>Analyzing your request…</span>
             </div>
           </div>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -80,7 +80,7 @@
                 <button type="button" class="home-assistant-workspace-mode-btn" data-home-workspace-mode="note" aria-pressed="false">Note</button>
               </div>
               <input id="homeAssistantInput" type="text" class="modern-input flex-grow-1" maxlength="800"
-                     placeholder="Create a task for Workspace Manager… (/chat asks, /note saves a note)"
+                     placeholder="Create a task for Workspace Manager… (/ask asks, /note saves a note)"
                      aria-label="Workspace manager prompt"
                      style="min-height: 42px;">
               <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn">Create Task</button>


### PR DESCRIPTION
## Summary

UX review of the floating Workspace Assistant panel turned up an idle state that was ~80% empty chrome, a self-contradicting status card, and three overlapping input affordances. Three batches of fixes:

**Quick wins (`9543274b`)**
- Idle heading now says "<agent> is ready" instead of always "is working" (it contradicted the "Ready for your next task." status line below it)
- Empty Conversation History section (with its doubled placeholder text) is hidden until the first message lands
- Removed `aria-live="polite"` from the panel root — screen readers were announcing every DOM change; the inner `role="status"`/`role="log"` regions remain
- `…` instead of `...` across assistant strings; `truncateText` math fixed for the single-char ellipsis
- Panel subtitle now names the workspace (`hubSupportChat.setSubtitle` fed from `renderWorkspaceInfo`), replacing the mode-biased "Ask about this workspace"

**Layout (`c5fbc624`)**
- Panel is content-sized (`height: auto` + viewport cap) instead of a fixed 600×780 frame
- Activity area hidden entirely until the assistant has something to show (busy/summary/step/actions/conversation) via new `syncHomeAssistantActivityIdle()` — idle panel is just compose + quick actions
- Conversation log cap raised 260px → `min(44vh, 400px)`; separator moved to the activity block
- Panel controls opt out of the app-wide uppercase `.modern-btn` treatment (sentence case)

**Input model (`aaa89bc3`)**
- Quick actions prefill the prompt (focused, caret at end) instead of auto-sending — canned prompts are reviewable before they create anything; the multiline `/note` → note-modal intercept keeps its behavior
- `/ask` is the advertised ask command, matching the Ask mode (`/chat`, `/c` remain as aliases)
- "Open task editor" button restored in the panel compose row (was lost vs the legacy bar); hidden on surfaces that don't bind it
- Workspaces-hub surface drops the manager identity row, inert Task/Ask/Note switch, and "this workspace" quick actions

## Test plan

- `go build ./...`, `go test ./internal/web/...`, ESLint + `node --check` on changed modules — all green
- Smoke-verified each batch against an isolated server (temp `HOME`/`ORI_DATA_DIR`): rendered markup, served JS/CSS, flag-on/off paths
- Worth a visual pass on the workspace detail page + workspaces hub (idle panel, first task send, quick-action prefill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)