### PR TITLE
chore(wt): npm install in new worktrees

### DIFF
--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -193,6 +193,13 @@ function wt {
       echo "Building folder picker in new worktree..."
       (cd "$WORKTREE_DIR$name" && bash scripts/build-folder-picker.sh)
     fi
+    # Install npm dependencies. node_modules is gitignored and not shared
+    # between worktrees, so a fresh worktree starts without it and tooling
+    # like eslint/prettier/playwright won't run until this completes.
+    if [[ -f "$WORKTREE_DIR$name/package.json" ]] && command -v npm >/dev/null 2>&1; then
+      echo "Installing npm dependencies in new worktree..."
+      (cd "$WORKTREE_DIR$name" && npm install)
+    fi
     ;;
   rm)
     local name="$2"


### PR DESCRIPTION
## Summary

`wt new` now runs `npm install` in the freshly created worktree (guarded on `package.json` existing and `npm` being on PATH), right after the existing folder-picker build step.

## Why

`node_modules/` is gitignored (`.gitignore:110`) and not shared between git worktrees — each worktree has its own working directory, so a fresh `wt new <name>` starts with no `node_modules`. Until you remembered to `npm install` by hand, the project's JS tooling (eslint, prettier, playwright) couldn't run in that worktree. This bit a recent feature branch: `npx eslint` fell back to fetching a mismatched eslint and failed with `Cannot find package '@eslint/js'`.

## Notes

- Non-fatal and quiet-ish: skipped entirely when there's no `package.json` or no `npm`.
- Mirrors the existing folder-picker `(cd … && …)` pattern.
- zsh `-n` syntax check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)