### PR TITLE
feat(workspace): persistent workspace memory (MEMORY.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Each domain has dedicated handler modules in `internal/*http/`:
 - `sessionhttp` - Session and workspace data management
 - `actioncenterhttp` - Cross-workspace triage for workspace mission findings (Action Center)
 - `notehttp` - Workspace notes
+- `memoryhttp` - Workspace memory (MEMORY.md) CRUD for the Memory tab
 - `fileshttp` - Session file management
 - `filehttp` - File serving and preview
 - `vaulthttp` - Vault (secrets) management

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ A mission's reach is bounded by the policy you choose for the workspace:
 
 | Policy | What it can do |
 |--------|----------------|
-| **Watch** | Read-only tools. No writes anywhere. |
+| **Watch** | Read-only tools. No writes anywhere — except workspace memory. |
 | **Propose** | Reads plus workspace-internal writes (draft notes/artifacts, recommended-task drafts). External-effect tools stay denied. |
 
-Each MCP/skill binding is classified by side effect (read / write / external), and the autonomy gate enforces the policy **per tool call** — so a mission can't take an action you haven't authorized for that workspace.
+Each MCP/skill binding is classified by side effect (read / write / external), and the autonomy gate enforces the policy **per tool call** — so a mission can't take an action you haven't authorized for that workspace. The one exception is **workspace memory**: agents may record durable knowledge there under every policy (including Watch), so even a read-only mission can remember what it found and avoid re-reporting it next run.
 
 ## ✨ What you can do
 
@@ -41,6 +41,7 @@ Each MCP/skill binding is classified by side effect (read / write / external), a
 - **Multiple agents** — create named agents, each with its own provider/model, system prompt, skills, and MCP servers.
 - **Multi-agent orchestration** — chain agents into workflows and combine their results.
 - **MCP servers & Skills** — extend agents with external tools (MCP) and reusable prompt-based capabilities (Skills), bound per workspace.
+- **Workspace memory** — each workspace keeps a curated `MEMORY.md` of durable knowledge (facts, decisions, dead ends, watch-state) that agents read at the start of every run and chat and update as they learn, so missions compound instead of restarting cold. Editable from a Memory tab; travels with the workspace folder.
 - **Sessions** — persistent, searchable chat history with folders and tagging.
 - **Private Vault** — local encrypted storage for secrets and sensitive records, backed by the OS keychain.
 - **Usage & cost tracking** — monitor token usage and spend across providers.

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -999,6 +999,53 @@ DELETE /api/workspaces/:id?confirm=true&delete_mode=contents
 
 Both modes hard-block with `409 Conflict` while any workspace in the group has active task work.
 
+## Workspace Memory API
+
+Each workspace keeps a curated `MEMORY.md` of durable operational knowledge (facts, decisions, dead ends, watch-state) at the root of its folder. The file on disk is canonical — there is no database copy. Memory is injected into every mission run and workspace chat (capped at ~2,000 tokens) and can be written by agents via the `memory_write` / `memory_forget` tools under every autonomy policy, including Watch.
+
+Each entry is one line: `- [<type>, <YYYY-MM-DD>, <provenance>] <text>`, where `<type>` is one of `fact`, `feedback`, `decision`, `dead-end`, `watch`, `thread`. Entries are capped at 500 characters and obvious secrets are refused (store credentials in the Vault).
+
+### Get Workspace Memory
+
+**Endpoint:** `GET /api/workspaces/{workspaceID}/memory`
+
+```json
+{
+  "entries": [
+    { "index": 0, "type": "watch", "date": "2026-06-13", "provenance": "run:abc (Scout)", "text": "build baseline ~7 min; flag if >10" }
+  ],
+  "unstructured": ["# Workspace Memory"],
+  "raw_size": 149,
+  "char_budget": 8000,
+  "token_budget": 2000,
+  "over_budget": false
+}
+```
+
+`entries` are the structured lines (with their file-order `index`); `unstructured` holds non-entry lines (the header, hand-written prose) for display. `404` if the workspace doesn't exist; `503` if folder storage is unavailable.
+
+### Add Memory Entry
+
+**Endpoint:** `POST /api/workspaces/{workspaceID}/memory/entries`
+
+```json
+{ "text": "releases are human-triggered from main", "type": "fact" }
+```
+
+`type` defaults to `fact`. The server fills in today's date and provenance `user`. Returns the full updated memory document (same shape as GET). `400` on empty/over-length/secret-looking text.
+
+### Update Memory Entry
+
+**Endpoint:** `PUT /api/workspaces/{workspaceID}/memory/entries/{index}`
+
+Body identical to add. `index` is the structured-entry index from GET. Returns the updated document. `400` for a non-numeric index or invalid text; `404` when the index is out of range.
+
+### Delete Memory Entry
+
+**Endpoint:** `DELETE /api/workspaces/{workspaceID}/memory/entries/{index}`
+
+Removes one entry by index and returns the updated document. `404` when the index is out of range.
+
 ## Scheduler Nodes API
 
 Scheduler nodes enable automatic execution of tasks at scheduled times on the workspace canvas. They support various schedule types including cron expressions, intervals, daily/weekly schedules, and relative delays.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -148,6 +148,7 @@ export default defineConfig([
       'internal/web/static/js/modules/workspace-detail-file-modal.js',
       'internal/web/static/js/modules/workspace-detail-mcp.js',
       'internal/web/static/js/modules/workspace-detail-skills.js',
+      'internal/web/static/js/modules/workspace-detail-memory.js',
       'internal/web/static/js/modules/workspace-task.js',
       'internal/web/static/js/modules/workspace-task-execution-views.js',
       'internal/web/static/js/modules/workspace-task-result-actions.js',

--- a/internal/chathttp/workspace_context_prompt.go
+++ b/internal/chathttp/workspace_context_prompt.go
@@ -39,7 +39,36 @@ func (h *Handler) buildRuntimeSystemPrompt(ctx context.Context, routeCtx normali
 }
 
 func (h *Handler) buildRuntimeSystemPromptForToolCapability(ctx context.Context, routeCtx normalizedChatRouteContext, toolCallable bool) string {
-	return buildWorkspaceRuntimeSystemPromptForToolCapability(ctx, routeCtx, h.workspaceStore, h.sessionStore, toolCallable)
+	base := buildWorkspaceRuntimeSystemPromptForToolCapability(ctx, routeCtx, h.workspaceStore, h.sessionStore, toolCallable)
+	memory := h.buildWorkspaceMemoryPrompt(routeCtx, toolCallable)
+
+	parts := make([]string, 0, 2)
+	if strings.TrimSpace(base) != "" {
+		parts = append(parts, base)
+	}
+	if strings.TrimSpace(memory) != "" {
+		parts = append(parts, memory)
+	}
+	return strings.Join(parts, "\n\n---\n")
+}
+
+// buildWorkspaceMemoryPrompt renders the workspace's persistent memory for the
+// chat runtime prompt. Scoped to workspace surfaces (same gate as the snapshot)
+// and requires the folder-backed file store to read MEMORY.md. Tool guidance is
+// included only when workspace tools are callable on this route.
+func (h *Handler) buildWorkspaceMemoryPrompt(routeCtx normalizedChatRouteContext, toolCallable bool) string {
+	if !shouldAttachWorkspaceSnapshot(routeCtx) || h.fileStore == nil {
+		return ""
+	}
+	doc, err := workspace.NewMemoryStore(h.fileStore).Read(routeCtx.WorkspaceID)
+	if err != nil {
+		logger.Debug("Skipping workspace memory for chat runtime prompt", logger.Fields{
+			"workspace_id": routeCtx.WorkspaceID,
+			"error":        err,
+		})
+		return ""
+	}
+	return workspace.RenderMemoryPromptSection(doc, toolCallable)
 }
 
 func buildWorkspaceRuntimeSystemPrompt(

--- a/internal/chathttp/workspace_memory_tools.go
+++ b/internal/chathttp/workspace_memory_tools.go
@@ -1,0 +1,132 @@
+package chathttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/toolapi"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// memoryProvenance attributes a memory mutation to its execution context:
+// task-scoped executions record the task ID, everything else the agent name.
+func (p *WorkspaceToolProvider) memoryProvenance() string {
+	agentName := strings.TrimSpace(p.executingAgent)
+	if taskID := strings.TrimSpace(p.taskID); taskID != "" {
+		if agentName != "" {
+			return fmt.Sprintf("task:%s (%s)", taskID, agentName)
+		}
+		return "task:" + taskID
+	}
+	if agentName != "" {
+		return "agent:" + agentName
+	}
+	return "agent:unknown"
+}
+
+func (p *WorkspaceToolProvider) workspaceMemoryStore() (*workspace.MemoryStore, error) {
+	if p.fileStore == nil {
+		return nil, fmt.Errorf("workspace folder storage is unavailable, so workspace memory cannot be accessed")
+	}
+	return workspace.NewMemoryStore(p.fileStore), nil
+}
+
+// --- memory_write (workspace-internal write; allowed under every autonomy policy) ---
+
+func (p *WorkspaceToolProvider) memoryWriteTool() toolapi.Tool {
+	return &nativeUtilityTool{
+		definition: toolapi.ToolDefinition{
+			Name:        workspace.MemoryWriteToolName,
+			Description: "Save one short operational fact to this workspace's persistent memory (MEMORY.md), so every future run and chat in this workspace starts knowing it. Use it for stable facts, learned constraints, decisions with rationale, dead ends (failed approaches), watch-state/baselines, and open threads. Do NOT use it for deliverables (write a note), work items (create a task), anything cheaply re-derivable from workspace files, or secrets (Vault only — secret-looking text is refused). One line, max 500 characters.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"text": map[string]any{
+						"type":        "string",
+						"description": "The fact to remember, as one self-contained line.",
+					},
+					"type": map[string]any{
+						"type":        "string",
+						"enum":        []string{"fact", "feedback", "decision", "dead-end", "watch", "thread"},
+						"description": "Kind of knowledge: fact (stable workspace fact), feedback (user guidance), decision (choice + rationale), dead-end (failed approach), watch (cursor/baseline state), thread (open investigation). Defaults to fact.",
+					},
+				},
+				"required": []string{"text"},
+			},
+		},
+		call: func(ctx context.Context, args string) (string, error) {
+			var req struct {
+				Text string `json:"text"`
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal([]byte(args), &req); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			text, err := workspace.ValidateMemoryText(req.Text)
+			if err != nil {
+				return "", err
+			}
+			store, err := p.workspaceMemoryStore()
+			if err != nil {
+				return "", err
+			}
+			entry := workspace.MemoryEntry{
+				Type:       workspace.NormalizeMemoryEntryType(req.Type),
+				Date:       time.Now().Format("2006-01-02"),
+				Provenance: p.memoryProvenance(),
+				Text:       text,
+			}
+			if err := store.Append(p.workspaceID, entry); err != nil {
+				return "", fmt.Errorf("failed to save memory entry: %w", err)
+			}
+			return marshalToolResponse(map[string]any{
+				"entry":   entry,
+				"message": "Saved to workspace memory. Future runs and chats in this workspace will start with this in context.",
+			})
+		},
+	}
+}
+
+// --- memory_forget (workspace-internal write; allowed under every autonomy policy) ---
+
+func (p *WorkspaceToolProvider) memoryForgetTool() toolapi.Tool {
+	return &nativeUtilityTool{
+		definition: toolapi.ToolDefinition{
+			Name:        workspace.MemoryForgetToolName,
+			Description: "Remove exactly one entry from this workspace's persistent memory (MEMORY.md), identified by its exact text or a unique substring. Use it when a remembered fact is wrong or obsolete; to revise an entry, forget it and then memory_write the corrected version. If several entries match you'll get the candidate list back — retry with a more specific match.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"match": map[string]any{
+						"type":        "string",
+						"description": "Exact entry text, or a substring that matches exactly one entry.",
+					},
+				},
+				"required": []string{"match"},
+			},
+		},
+		call: func(ctx context.Context, args string) (string, error) {
+			var req struct {
+				Match string `json:"match"`
+			}
+			if err := json.Unmarshal([]byte(args), &req); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			store, err := p.workspaceMemoryStore()
+			if err != nil {
+				return "", err
+			}
+			removed, err := store.Forget(p.workspaceID, req.Match)
+			if err != nil {
+				return "", err
+			}
+			return marshalToolResponse(map[string]any{
+				"removed": removed,
+				"message": fmt.Sprintf("Removed from workspace memory: %q", removed.Text),
+			})
+		},
+	}
+}

--- a/internal/chathttp/workspace_memory_tools_test.go
+++ b/internal/chathttp/workspace_memory_tools_test.go
@@ -1,0 +1,154 @@
+package chathttp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+func newMemoryToolProvider(t *testing.T) (*WorkspaceToolProvider, *workspace.FileStore) {
+	t.Helper()
+	fs, err := workspace.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	ws := &workspace.Workspace{ID: "ws-mem-1", Name: "Mem Test"}
+	if err := fs.Save(ws); err != nil {
+		t.Fatalf("Save workspace: %v", err)
+	}
+	p := NewWorkspaceToolProvider(nil, nil, ws.ID)
+	p.SetFileStore(fs)
+	p.SetExecutingAgent("Scout")
+	return p, fs
+}
+
+func readMemoryFile(t *testing.T, fs *workspace.FileStore) string {
+	t.Helper()
+	folder, err := fs.GetFolderPath("ws-mem-1")
+	if err != nil {
+		t.Fatalf("GetFolderPath: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(folder, workspace.MemoryFileName))
+	if err != nil {
+		t.Fatalf("read MEMORY.md: %v", err)
+	}
+	return string(data)
+}
+
+func TestMemoryWriteTool_AppendsEntry(t *testing.T) {
+	p, fs := newMemoryToolProvider(t)
+
+	out, err := p.memoryWriteTool().Call(context.Background(), `{"text":"build baseline is ~7 min","type":"watch"}`)
+	if err != nil {
+		t.Fatalf("memory_write: %v", err)
+	}
+	if !strings.Contains(out, "workspace memory") {
+		t.Errorf("response should confirm the save, got: %s", out)
+	}
+
+	content := readMemoryFile(t, fs)
+	want := "- [watch, " + time.Now().Format("2006-01-02") + ", agent:Scout] build baseline is ~7 min"
+	if !strings.Contains(content, want) {
+		t.Errorf("MEMORY.md missing entry %q, got:\n%s", want, content)
+	}
+}
+
+func TestMemoryWriteTool_CollapsesWhitespaceAndDefaultsType(t *testing.T) {
+	p, fs := newMemoryToolProvider(t)
+
+	if _, err := p.memoryWriteTool().Call(context.Background(), `{"text":"line one\nline   two"}`); err != nil {
+		t.Fatalf("memory_write: %v", err)
+	}
+	content := readMemoryFile(t, fs)
+	if !strings.Contains(content, "- [fact, ") || !strings.Contains(content, "] line one line two") {
+		t.Errorf("expected single-line fact entry, got:\n%s", content)
+	}
+}
+
+func TestMemoryWriteTool_Validation(t *testing.T) {
+	p, _ := newMemoryToolProvider(t)
+	tool := p.memoryWriteTool()
+
+	if _, err := tool.Call(context.Background(), `{"text":"   "}`); err == nil {
+		t.Error("empty text should be rejected")
+	}
+
+	long := strings.Repeat("x", workspace.MemoryEntryMaxLen+1)
+	if _, err := tool.Call(context.Background(), `{"text":"`+long+`"}`); err == nil || !strings.Contains(err.Error(), "note") {
+		t.Errorf("over-length text should point the agent to notes, got: %v", err)
+	}
+
+	if _, err := tool.Call(context.Background(), `{"text":"the api key is sk-abc1234567890def"}`); err == nil || !strings.Contains(err.Error(), "Vault") {
+		t.Errorf("secret-looking text should point the agent to the Vault, got: %v", err)
+	}
+	if _, err := tool.Call(context.Background(), `{"text":"-----BEGIN RSA PRIVATE KEY----- stuff"}`); err == nil {
+		t.Error("PEM header should be refused")
+	}
+}
+
+func TestMemoryWriteTool_TaskProvenance(t *testing.T) {
+	p, fs := newMemoryToolProvider(t)
+	p.SetTaskID("task-7")
+
+	if _, err := p.memoryWriteTool().Call(context.Background(), `{"text":"checked through commit abc123"}`); err != nil {
+		t.Fatalf("memory_write: %v", err)
+	}
+	if content := readMemoryFile(t, fs); !strings.Contains(content, "task:task-7 (Scout)") {
+		t.Errorf("task-scoped writes should carry task provenance, got:\n%s", content)
+	}
+}
+
+func TestMemoryForgetTool(t *testing.T) {
+	p, fs := newMemoryToolProvider(t)
+	write := p.memoryWriteTool()
+	for _, text := range []string{"alpha beta", "beta gamma"} {
+		if _, err := write.Call(context.Background(), `{"text":"`+text+`"}`); err != nil {
+			t.Fatalf("seed write: %v", err)
+		}
+	}
+	forget := p.memoryForgetTool()
+
+	if _, err := forget.Call(context.Background(), `{"match":"beta"}`); err == nil || !strings.Contains(err.Error(), "alpha beta") {
+		t.Errorf("ambiguous match should list candidates, got: %v", err)
+	}
+	out, err := forget.Call(context.Background(), `{"match":"gamma"}`)
+	if err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+	if !strings.Contains(out, "beta gamma") {
+		t.Errorf("response should name the removed entry, got: %s", out)
+	}
+	if content := readMemoryFile(t, fs); strings.Contains(content, "beta gamma") {
+		t.Errorf("entry should be gone from MEMORY.md:\n%s", content)
+	}
+}
+
+func TestMemoryTools_RequireFileStore(t *testing.T) {
+	p := NewWorkspaceToolProvider(nil, nil, "ws-x")
+	p.SetExecutingAgent("Scout")
+
+	if _, err := p.memoryWriteTool().Call(context.Background(), `{"text":"hi"}`); err == nil || !strings.Contains(err.Error(), "unavailable") {
+		t.Errorf("missing file store should be an instructive error, got: %v", err)
+	}
+
+	names := func(p *WorkspaceToolProvider) map[string]bool {
+		out := map[string]bool{}
+		for _, tool := range p.Tools() {
+			out[tool.Definition().Name] = true
+		}
+		return out
+	}
+	if got := names(p); got[workspace.MemoryWriteToolName] || got[workspace.MemoryForgetToolName] {
+		t.Error("memory tools should not register without a file store")
+	}
+
+	withFS, _ := newMemoryToolProvider(t)
+	if got := names(withFS); !got[workspace.MemoryWriteToolName] || !got[workspace.MemoryForgetToolName] {
+		t.Error("memory tools should register when the file store is wired")
+	}
+}

--- a/internal/chathttp/workspace_tools.go
+++ b/internal/chathttp/workspace_tools.go
@@ -101,6 +101,11 @@ func (p *WorkspaceToolProvider) Tools() []toolapi.Tool {
 		p.readDirectoriesTool(),
 	}
 
+	// Workspace memory tools (need folder storage for MEMORY.md)
+	if p.fileStore != nil {
+		tools = append(tools, p.memoryWriteTool(), p.memoryForgetTool())
+	}
+
 	// Task-scoped tools (only when the chat is bound to a specific task)
 	if p.taskID != "" {
 		tools = append(tools, p.currentTaskTool(), p.taskRunsTool())

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -1,0 +1,224 @@
+// Package memoryhttp serves the workspace memory API: read, add, edit, and
+// delete the curated MEMORY.md entries surfaced in the workspace Memory tab.
+// The file on disk is canonical; this handler is a thin CRUD layer over
+// workspace.MemoryStore.
+package memoryhttp
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// workspaceLookup resolves a workspace for existence checks. *workspace.FileStore
+// satisfies it (and also satisfies workspace.WorkspaceFolderResolver).
+type workspaceLookup interface {
+	Get(id string) (*workspace.Workspace, error)
+}
+
+// Handler serves the workspace memory endpoints.
+type Handler struct {
+	lookup workspaceLookup
+	memory *workspace.MemoryStore
+}
+
+// NewHandler builds the memory handler over a folder-backed store. Both
+// arguments are typically the same *workspace.FileStore. Returns a handler
+// whose endpoints 503 when the store is unavailable.
+func NewHandler(lookup workspaceLookup, resolver workspace.WorkspaceFolderResolver) *Handler {
+	h := &Handler{lookup: lookup}
+	if resolver != nil {
+		h.memory = workspace.NewMemoryStore(resolver)
+	}
+	return h
+}
+
+type entryDTO struct {
+	Index      int    `json:"index"`
+	Type       string `json:"type"`
+	Date       string `json:"date"`
+	Provenance string `json:"provenance"`
+	Text       string `json:"text"`
+}
+
+type memoryResponse struct {
+	Entries      []entryDTO `json:"entries"`
+	Unstructured []string   `json:"unstructured"`
+	RawSize      int        `json:"raw_size"`
+	CharBudget   int        `json:"char_budget"`
+	TokenBudget  int        `json:"token_budget"`
+	OverBudget   bool       `json:"over_budget"`
+}
+
+type writeRequest struct {
+	Text string `json:"text"`
+	Type string `json:"type"`
+}
+
+// GetMemory handles GET /api/workspaces/{workspaceID}/memory.
+func (h *Handler) GetMemory(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.resolveWorkspace(w, r)
+	if !ok {
+		return
+	}
+	h.writeMemoryResponse(w, workspaceID)
+}
+
+// AddEntry handles POST /api/workspaces/{workspaceID}/memory/entries.
+func (h *Handler) AddEntry(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.resolveWorkspace(w, r)
+	if !ok {
+		return
+	}
+	var req writeRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	text, err := workspace.ValidateMemoryText(req.Text)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
+		return
+	}
+	entry := workspace.MemoryEntry{
+		Type:       workspace.NormalizeMemoryEntryType(req.Type),
+		Date:       time.Now().Format("2006-01-02"),
+		Provenance: "user",
+		Text:       text,
+	}
+	if err := h.memory.Append(workspaceID, entry); err != nil {
+		_ = orihttp.RespondInternalError(w, "Failed to save memory entry: "+err.Error())
+		return
+	}
+	h.writeMemoryResponse(w, workspaceID)
+}
+
+// UpdateEntry handles PUT /api/workspaces/{workspaceID}/memory/entries/{index}.
+func (h *Handler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.resolveWorkspace(w, r)
+	if !ok {
+		return
+	}
+	index, ok := h.parseIndex(w, r)
+	if !ok {
+		return
+	}
+	var req writeRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	text, err := workspace.ValidateMemoryText(req.Text)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
+		return
+	}
+	entry := workspace.MemoryEntry{
+		Type:       workspace.NormalizeMemoryEntryType(req.Type),
+		Date:       time.Now().Format("2006-01-02"),
+		Provenance: "user",
+		Text:       text,
+	}
+	if err := h.memory.EditAt(workspaceID, index, entry); err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	h.writeMemoryResponse(w, workspaceID)
+}
+
+// DeleteEntry handles DELETE /api/workspaces/{workspaceID}/memory/entries/{index}.
+func (h *Handler) DeleteEntry(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.resolveWorkspace(w, r)
+	if !ok {
+		return
+	}
+	index, ok := h.parseIndex(w, r)
+	if !ok {
+		return
+	}
+	if err := h.memory.DeleteAt(workspaceID, index); err != nil {
+		h.writeMutationError(w, err)
+		return
+	}
+	h.writeMemoryResponse(w, workspaceID)
+}
+
+// resolveWorkspace validates the store is wired and the workspace exists,
+// returning the workspace ID. It writes the appropriate error response and
+// returns ok=false otherwise.
+func (h *Handler) resolveWorkspace(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if h == nil || h.memory == nil {
+		_ = orihttp.RespondAPIError(w, http.StatusServiceUnavailable,
+			orihttp.NewAPIError("unavailable", "Workspace memory storage is not available."))
+		return "", false
+	}
+	workspaceID := strings.TrimSpace(r.PathValue("workspaceID"))
+	if workspaceID == "" {
+		_ = orihttp.RespondBadRequest(w, "workspace id is required")
+		return "", false
+	}
+	if h.lookup != nil {
+		if ws, err := h.lookup.Get(workspaceID); err != nil || ws == nil {
+			_ = orihttp.RespondNotFound(w, "workspace not found")
+			return "", false
+		}
+	}
+	return workspaceID, true
+}
+
+func (h *Handler) parseIndex(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := strings.TrimSpace(r.PathValue("index"))
+	index, err := strconv.Atoi(raw)
+	if err != nil || index < 0 {
+		_ = orihttp.RespondBadRequest(w, "entry index must be a non-negative integer")
+		return 0, false
+	}
+	return index, true
+}
+
+func (h *Handler) writeMutationError(w http.ResponseWriter, err error) {
+	if errors.Is(err, workspace.ErrMemoryIndexOutOfRange) {
+		_ = orihttp.RespondNotFound(w, err.Error())
+		return
+	}
+	_ = orihttp.RespondInternalError(w, "Failed to update memory: "+err.Error())
+}
+
+func (h *Handler) writeMemoryResponse(w http.ResponseWriter, workspaceID string) {
+	raw, err := h.memory.ReadRaw(workspaceID)
+	if err != nil {
+		_ = orihttp.RespondInternalError(w, "Failed to read memory: "+err.Error())
+		return
+	}
+	doc := workspace.ParseMemoryDocument(raw)
+	entries := doc.Entries()
+	dtos := make([]entryDTO, len(entries))
+	for i, e := range entries {
+		dtos[i] = entryDTO{
+			Index:      i,
+			Type:       string(e.Type),
+			Date:       e.Date,
+			Provenance: e.Provenance,
+			Text:       e.Text,
+		}
+	}
+	unstructured := doc.UnstructuredLines()
+	if unstructured == nil {
+		unstructured = []string{}
+	}
+	resp := memoryResponse{
+		Entries:      dtos,
+		Unstructured: unstructured,
+		RawSize:      len(raw),
+		CharBudget:   workspace.MemoryPromptTokenBudget * 4,
+		TokenBudget:  workspace.MemoryPromptTokenBudget,
+		OverBudget:   len(raw) > workspace.MemoryPromptTokenBudget*4,
+	}
+	if err := orihttp.RespondJSON(w, http.StatusOK, resp); err != nil {
+		logger.Debug("Failed to write memory response", logger.Fields{"workspace_id": workspaceID, "error": err})
+	}
+}

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -1,0 +1,174 @@
+package memoryhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+func newTestHandler(t *testing.T) (*Handler, *workspace.FileStore) {
+	t.Helper()
+	fs, err := workspace.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := fs.Save(&workspace.Workspace{ID: "ws1", Name: "Mem"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return NewHandler(fs, fs), fs
+}
+
+// serve dispatches a request through a mux so r.PathValue works.
+func serve(h *Handler, method, target string, body string) *httptest.ResponseRecorder {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/workspaces/{workspaceID}/memory", h.GetMemory)
+	mux.HandleFunc("POST /api/workspaces/{workspaceID}/memory/entries", h.AddEntry)
+	mux.HandleFunc("PUT /api/workspaces/{workspaceID}/memory/entries/{index}", h.UpdateEntry)
+	mux.HandleFunc("DELETE /api/workspaces/{workspaceID}/memory/entries/{index}", h.DeleteEntry)
+
+	var rdr *strings.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	} else {
+		rdr = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, target, rdr)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeMemory(t *testing.T, rec *httptest.ResponseRecorder) memoryResponse {
+	t.Helper()
+	var resp memoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+func TestGetMemory_EmptyAndLazyCreate(t *testing.T) {
+	h, fs := newTestHandler(t)
+
+	rec := serve(h, http.MethodGet, "/api/workspaces/ws1/memory", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET empty memory: status %d body %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeMemory(t, rec)
+	if len(resp.Entries) != 0 || resp.RawSize != 0 {
+		t.Errorf("empty memory should have no entries and zero size, got %+v", resp)
+	}
+	if resp.TokenBudget != workspace.MemoryPromptTokenBudget {
+		t.Errorf("token budget = %d, want %d", resp.TokenBudget, workspace.MemoryPromptTokenBudget)
+	}
+
+	// File should not exist until first write.
+	folder, _ := fs.GetFolderPath("ws1")
+	if _, err := os.Stat(filepath.Join(folder, workspace.MemoryFileName)); !os.IsNotExist(err) {
+		t.Errorf("MEMORY.md should not exist before any write")
+	}
+
+	rec = serve(h, http.MethodPost, "/api/workspaces/ws1/memory/entries", `{"text":"staging is at stage.example.com","type":"fact"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST entry: status %d body %s", rec.Code, rec.Body.String())
+	}
+	resp = decodeMemory(t, rec)
+	if len(resp.Entries) != 1 {
+		t.Fatalf("expected 1 entry after POST, got %d", len(resp.Entries))
+	}
+	if resp.Entries[0].Provenance != "user" || resp.Entries[0].Type != "fact" {
+		t.Errorf("user entry should be provenance=user type=fact, got %+v", resp.Entries[0])
+	}
+	if _, err := os.Stat(filepath.Join(folder, workspace.MemoryFileName)); err != nil {
+		t.Errorf("MEMORY.md should exist after first POST: %v", err)
+	}
+}
+
+func TestAddEntry_Validation(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	rec := serve(h, http.MethodPost, "/api/workspaces/ws1/memory/entries", `{"text":"  "}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty text should be 400, got %d", rec.Code)
+	}
+
+	rec = serve(h, http.MethodPost, "/api/workspaces/ws1/memory/entries", `{"text":"key is sk-abcdefgh12345678"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("secret-looking text should be 400, got %d", rec.Code)
+	}
+}
+
+func TestUpdateAndDeleteEntry(t *testing.T) {
+	h, _ := newTestHandler(t)
+	serve(h, http.MethodPost, "/api/workspaces/ws1/memory/entries", `{"text":"first"}`)
+	serve(h, http.MethodPost, "/api/workspaces/ws1/memory/entries", `{"text":"second"}`)
+
+	rec := serve(h, http.MethodPut, "/api/workspaces/ws1/memory/entries/0", `{"text":"first revised","type":"decision"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: status %d body %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeMemory(t, rec)
+	if resp.Entries[0].Text != "first revised" || resp.Entries[0].Type != "decision" {
+		t.Errorf("edit not applied: %+v", resp.Entries[0])
+	}
+
+	// Out-of-range index => 404.
+	rec = serve(h, http.MethodPut, "/api/workspaces/ws1/memory/entries/9", `{"text":"x"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("out-of-range edit should be 404, got %d", rec.Code)
+	}
+	// Non-numeric index => 400.
+	rec = serve(h, http.MethodDelete, "/api/workspaces/ws1/memory/entries/abc", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-numeric index should be 400, got %d", rec.Code)
+	}
+
+	rec = serve(h, http.MethodDelete, "/api/workspaces/ws1/memory/entries/0", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE: status %d body %s", rec.Code, rec.Body.String())
+	}
+	resp = decodeMemory(t, rec)
+	if len(resp.Entries) != 1 || resp.Entries[0].Text != "second" {
+		t.Errorf("delete removed wrong entry: %+v", resp.Entries)
+	}
+}
+
+func TestGetMemory_UnknownWorkspace(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := serve(h, http.MethodGet, "/api/workspaces/nope/memory", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown workspace should be 404, got %d", rec.Code)
+	}
+}
+
+func TestHandler_Unavailable(t *testing.T) {
+	h := NewHandler(nil, nil) // no resolver => memory store nil
+	rec := serve(h, http.MethodGet, "/api/workspaces/ws1/memory", "")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("nil store should be 503, got %d", rec.Code)
+	}
+}
+
+func TestGetMemory_ExposesUnstructured(t *testing.T) {
+	h, fs := newTestHandler(t)
+	folder, _ := fs.GetFolderPath("ws1")
+	content := "# Workspace Memory\n\nHand-written note line.\n- [fact, 2026-06-01, user] alpha\n"
+	if err := os.WriteFile(filepath.Join(folder, workspace.MemoryFileName), []byte(content), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rec := serve(h, http.MethodGet, "/api/workspaces/ws1/memory", "")
+	resp := decodeMemory(t, rec)
+	if len(resp.Entries) != 1 {
+		t.Errorf("expected 1 structured entry, got %d", len(resp.Entries))
+	}
+	joined := strings.Join(resp.Unstructured, "\n")
+	if !strings.Contains(joined, "Hand-written note line.") {
+		t.Errorf("unstructured lines should be exposed, got %q", resp.Unstructured)
+	}
+}

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/macwake"
 	"github.com/johnjallday/ori-agent/internal/mcp"
 	"github.com/johnjallday/ori-agent/internal/mcphttp"
+	"github.com/johnjallday/ori-agent/internal/memoryhttp"
 	"github.com/johnjallday/ori-agent/internal/modelcategoryhttp"
 	"github.com/johnjallday/ori-agent/internal/notehttp"
 	"github.com/johnjallday/ori-agent/internal/onboarding"
@@ -380,6 +381,9 @@ func (b *ServerBuilder) createDomainFacades() {
 	// initializeMissionBridge (which builds the trigger handler) runs before
 	// this facade is rebuilt, so re-attach here — same pattern as ActionCenter.
 	b.server.Handlers.Triggers = b.triggerHandler
+	if b.workspaceFileStore != nil {
+		b.server.Handlers.WorkspaceMemory = memoryhttp.NewHandler(b.workspaceFileStore, b.workspaceFileStore)
+	}
 }
 
 // WithLLMFactory injects a custom LLM factory (for testing).

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -265,7 +265,12 @@ func (b *ServerBuilder) initializeHandlers() {
 
 	runProfiles := workspacerun.NewProfileRegistry()
 	b.workspaceRunExecutors = workspacerun.NewExecutorRegistry()
-	b.workspaceRunExecutors.Register(workspacerun.ExecutorKindNativeCLI, workspacerun.NewNativeCLIExecutor(b.cliAgentRegistry))
+	nativeCLIExecutor := workspacerun.NewNativeCLIExecutor(b.cliAgentRegistry)
+	if b.workspaceFileStore != nil {
+		// Inject workspace memory into native-CLI run prompts (read-only context).
+		nativeCLIExecutor.SetWorkspaceFolderResolver(b.workspaceFileStore)
+	}
+	b.workspaceRunExecutors.Register(workspacerun.ExecutorKindNativeCLI, nativeCLIExecutor)
 	b.workspaceRunExecutors.Register(workspacerun.ExecutorKindOriAgent, workspacerun.NewOriAgentExecutor())
 	runEnv := workspacerun.NewLocalEnvironmentManager("")
 	runValidator := workspacerun.NewValidator()

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -264,7 +264,12 @@ func (b *ServerBuilder) initializeTaskExecution() {
 
 	taskExecutionHandler := workspace.TaskHandler(b.taskHandler)
 	if b.workspaceRunExecutors != nil && b.workspaceRunStore != nil && b.workspaceRunService != nil {
-		b.workspaceRunExecutors.Register(workspacerun.ExecutorKindOriAgent, workspacerun.NewOriAgentExecutor(b.taskHandler))
+		oriExecutor := workspacerun.NewOriAgentExecutor(b.taskHandler)
+		if b.workspaceFileStore != nil {
+			// Snapshot workspace memory before/after each run to record what it learned.
+			oriExecutor.SetWorkspaceFolderResolver(b.workspaceFileStore)
+		}
+		b.workspaceRunExecutors.Register(workspacerun.ExecutorKindOriAgent, oriExecutor)
 		b.runBackedTaskHandler = workspacerun.NewTaskRunBridge(b.workspaceRunStore, b.workspaceRunService, b.workspaceStore)
 		taskExecutionHandler = b.runBackedTaskHandler
 	}

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -19,6 +19,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/locationhttp"
 	"github.com/johnjallday/ori-agent/internal/mcp"
 	"github.com/johnjallday/ori-agent/internal/mcphttp"
+	"github.com/johnjallday/ori-agent/internal/memoryhttp"
 	"github.com/johnjallday/ori-agent/internal/modelcategoryhttp"
 	"github.com/johnjallday/ori-agent/internal/notehttp"
 	"github.com/johnjallday/ori-agent/internal/onboarding"
@@ -124,6 +125,7 @@ type HandlerFacade struct {
 	WorkspaceRuns    *workspacerun.Handler
 	ActionCenter     *actioncenterhttp.Handler
 	Triggers         *triggerhttp.Handler
+	WorkspaceMemory  *memoryhttp.Handler
 }
 
 // NewCoreSystemFacade creates a new core system facade

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -654,6 +654,16 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	}
 
 	// =============================================================================
+	// Workspace Memory (MEMORY.md) Endpoints
+	// =============================================================================
+	if s.Handlers.WorkspaceMemory != nil {
+		mux.HandleFunc("GET /api/workspaces/{workspaceID}/memory", s.Handlers.WorkspaceMemory.GetMemory)
+		mux.HandleFunc("POST /api/workspaces/{workspaceID}/memory/entries", s.Handlers.WorkspaceMemory.AddEntry)
+		mux.HandleFunc("PUT /api/workspaces/{workspaceID}/memory/entries/{index}", s.Handlers.WorkspaceMemory.UpdateEntry)
+		mux.HandleFunc("DELETE /api/workspaces/{workspaceID}/memory/entries/{index}", s.Handlers.WorkspaceMemory.DeleteEntry)
+	}
+
+	// =============================================================================
 	// External Agents (Claude Code, Codex) Endpoints
 	// =============================================================================
 	if s.Handlers.ExternalAgents != nil {

--- a/internal/web/static/js/modules/workspace-detail-memory.js
+++ b/internal/web/static/js/modules/workspace-detail-memory.js
@@ -1,0 +1,249 @@
+/**
+ * Workspace Memory tab manager.
+ *
+ * Owns the Memory tab on the workspace detail page: loads MEMORY.md entries
+ * from the memory API, renders them with provenance, and handles add / inline
+ * edit / delete. MEMORY.md on disk is canonical; this is a thin CRUD surface
+ * over /api/workspaces/{id}/memory.
+ *
+ * Instantiated by WorkspaceDetailPage, which provides workspaceId and
+ * escapeHtml through the host. Lazy-loads the first time its tab is shown.
+ *
+ * @module workspace-detail-memory
+ */
+
+const MEMORY_TYPES = ['fact', 'feedback', 'decision', 'dead-end', 'watch', 'thread'];
+
+export class WorkspaceMemoryManager {
+  constructor(host) {
+    this.host = host;
+    this.loaded = false;
+    this.entries = [];
+    this.unstructured = [];
+    this.editingIndex = -1;
+    this.elements = {};
+  }
+
+  get workspaceId() {
+    return this.host?.workspaceId || '';
+  }
+
+  esc(text) {
+    return this.host?.escapeHtml ? this.host.escapeHtml(text) : String(text ?? '');
+  }
+
+  bindEvents() {
+    this.elements = {
+      tab: document.getElementById('workspace-detail-config-memory-tab'),
+      meta: document.getElementById('workspace-detail-memory-meta'),
+      list: document.getElementById('workspace-detail-memory-list'),
+      addForm: document.getElementById('workspace-detail-memory-add-form'),
+      addType: document.getElementById('workspace-detail-memory-add-type'),
+      addText: document.getElementById('workspace-detail-memory-add-text')
+    };
+
+    // Lazy-load the first time the tab is shown (Bootstrap fires shown.bs.tab).
+    this.elements.tab?.addEventListener('shown.bs.tab', () => {
+      if (!this.loaded) this.load();
+    });
+
+    this.elements.addForm?.addEventListener('submit', event => {
+      event.preventDefault();
+      this.addEntry();
+    });
+
+    // Event delegation for edit/delete/save/cancel on the list.
+    this.elements.list?.addEventListener('click', event => this.handleListClick(event));
+  }
+
+  async load() {
+    if (!this.workspaceId || !this.elements.list) return;
+    try {
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}/memory`);
+      if (!response.ok) throw new Error('Failed to load workspace memory');
+      const payload = await response.json();
+      this.entries = Array.isArray(payload?.entries) ? payload.entries : [];
+      this.unstructured = Array.isArray(payload?.unstructured) ? payload.unstructured : [];
+      this.meta = {
+        rawSize: Number(payload?.raw_size) || 0,
+        charBudget: Number(payload?.char_budget) || 0,
+        overBudget: Boolean(payload?.over_budget)
+      };
+      this.loaded = true;
+      this.editingIndex = -1;
+      this.render();
+    } catch (error) {
+      if (window.Toast) window.Toast.error(error.message || 'Failed to load workspace memory');
+    }
+  }
+
+  render() {
+    this.renderMeta();
+    this.renderList();
+  }
+
+  renderMeta() {
+    if (!this.elements.meta) return;
+    const { rawSize = 0, charBudget = 0, overBudget = false } = this.meta || {};
+    if (!charBudget) {
+      this.elements.meta.innerHTML = '';
+      return;
+    }
+    const cls = overBudget ? 'is-over-budget' : '';
+    const warn = overBudget
+      ? ' — over the injection budget; oldest non-watch/thread entries are dropped from prompts. Consider pruning.'
+      : '';
+    this.elements.meta.innerHTML =
+      `<span class="workspace-detail-memory-size ${cls}">${rawSize} / ${charBudget} chars${this.esc(warn)}</span>`;
+  }
+
+  renderList() {
+    const list = this.elements.list;
+    if (!list) return;
+
+    if (!this.entries.length && !this.unstructured.length) {
+      list.innerHTML = `
+        <div class="workspace-detail-memory-empty">
+          <p>No memory yet. As missions and chats run in this workspace, agents record durable facts here — or add one yourself.</p>
+          <p class="workspace-detail-memory-empty-example">Example: <code>[watch] build baseline is ~7 min; flag if &gt;10</code></p>
+        </div>`;
+      return;
+    }
+
+    const entriesHtml = this.entries
+      .map((entry, index) => (index === this.editingIndex ? this.editRowHtml(entry, index) : this.entryRowHtml(entry, index)))
+      .join('');
+
+    let unstructuredHtml = '';
+    if (this.unstructured.length) {
+      const items = this.unstructured
+        .map(line => `<li class="workspace-detail-memory-unstructured-line">${this.esc(line)}</li>`)
+        .join('');
+      unstructuredHtml = `
+        <div class="workspace-detail-memory-unstructured">
+          <div class="workspace-detail-memory-unstructured-label">Unstructured lines (not injected as entries)</div>
+          <ul class="workspace-detail-memory-unstructured-list">${items}</ul>
+        </div>`;
+    }
+
+    list.innerHTML = entriesHtml + unstructuredHtml;
+  }
+
+  entryRowHtml(entry, index) {
+    const type = this.esc(entry?.type || 'fact');
+    const meta = [entry?.provenance, entry?.date].filter(Boolean).map(v => this.esc(v)).join(' · ');
+    return `
+      <article class="workspace-detail-memory-entry" data-index="${index}">
+        <div class="workspace-detail-memory-entry-main">
+          <span class="workspace-detail-memory-badge workspace-detail-memory-badge-${type}">${type}</span>
+          <span class="workspace-detail-memory-text">${this.esc(entry?.text || '')}</span>
+        </div>
+        <div class="workspace-detail-memory-entry-foot">
+          <span class="workspace-detail-memory-prov">${meta}</span>
+          <span class="workspace-detail-memory-actions">
+            <button type="button" class="workspace-detail-memory-action" data-action="edit" data-index="${index}">Edit</button>
+            <button type="button" class="workspace-detail-memory-action is-danger" data-action="delete" data-index="${index}">Delete</button>
+          </span>
+        </div>
+      </article>`;
+  }
+
+  editRowHtml(entry, index) {
+    const options = MEMORY_TYPES
+      .map(t => `<option value="${t}"${t === (entry?.type || 'fact') ? ' selected' : ''}>${t}</option>`)
+      .join('');
+    return `
+      <article class="workspace-detail-memory-entry is-editing" data-index="${index}">
+        <div class="workspace-detail-memory-edit">
+          <select class="form-select workspace-detail-memory-type" data-edit-type="${index}" aria-label="Entry type">${options}</select>
+          <input type="text" class="form-control workspace-detail-memory-input" data-edit-text="${index}" maxlength="500" value="${this.esc(entry?.text || '')}" aria-label="Entry text">
+        </div>
+        <div class="workspace-detail-memory-entry-foot">
+          <span class="workspace-detail-memory-prov">${this.esc(entry?.provenance || '')}</span>
+          <span class="workspace-detail-memory-actions">
+            <button type="button" class="workspace-detail-memory-action" data-action="save" data-index="${index}">Save</button>
+            <button type="button" class="workspace-detail-memory-action" data-action="cancel" data-index="${index}">Cancel</button>
+          </span>
+        </div>
+      </article>`;
+  }
+
+  handleListClick(event) {
+    const button = event.target.closest('[data-action]');
+    if (!button) return;
+    const index = Number(button.dataset.index);
+    if (!Number.isInteger(index)) return;
+    switch (button.dataset.action) {
+      case 'edit':
+        this.editingIndex = index;
+        this.renderList();
+        break;
+      case 'cancel':
+        this.editingIndex = -1;
+        this.renderList();
+        break;
+      case 'save':
+        this.saveEdit(index);
+        break;
+      case 'delete':
+        this.deleteEntry(index);
+        break;
+      default:
+        break;
+    }
+  }
+
+  async addEntry() {
+    const text = (this.elements.addText?.value || '').trim();
+    const type = this.elements.addType?.value || 'fact';
+    if (!text) return;
+    await this.mutate('POST', `/api/workspaces/${encodeURIComponent(this.workspaceId)}/memory/entries`, { text, type }, () => {
+      if (this.elements.addText) this.elements.addText.value = '';
+      if (window.Toast) window.Toast.success('Saved to workspace memory');
+    });
+  }
+
+  async saveEdit(index) {
+    const typeEl = this.elements.list.querySelector(`[data-edit-type="${index}"]`);
+    const textEl = this.elements.list.querySelector(`[data-edit-text="${index}"]`);
+    const text = (textEl?.value || '').trim();
+    const type = typeEl?.value || 'fact';
+    if (!text) return;
+    await this.mutate('PUT', `/api/workspaces/${encodeURIComponent(this.workspaceId)}/memory/entries/${index}`, { text, type }, () => {
+      this.editingIndex = -1;
+      if (window.Toast) window.Toast.success('Memory entry updated');
+    });
+  }
+
+  async deleteEntry(index) {
+    await this.mutate('DELETE', `/api/workspaces/${encodeURIComponent(this.workspaceId)}/memory/entries/${index}`, null, () => {
+      if (window.Toast) window.Toast.info('Memory entry removed');
+    });
+  }
+
+  // mutate performs a memory mutation, refreshes from the authoritative
+  // response, and re-renders. onSuccess runs before re-render.
+  async mutate(method, url, body, onSuccess) {
+    try {
+      const options = { method, headers: { 'Content-Type': 'application/json' } };
+      if (body) options.body = JSON.stringify(body);
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload?.error?.message || payload?.message || `Request failed (${response.status})`);
+      }
+      const payload = await response.json();
+      this.entries = Array.isArray(payload?.entries) ? payload.entries : [];
+      this.unstructured = Array.isArray(payload?.unstructured) ? payload.unstructured : [];
+      this.meta = {
+        rawSize: Number(payload?.raw_size) || 0,
+        charBudget: Number(payload?.char_budget) || 0,
+        overBudget: Boolean(payload?.over_budget)
+      };
+      if (typeof onSuccess === 'function') onSuccess();
+      this.render();
+    } catch (error) {
+      if (window.Toast) window.Toast.error(error.message || 'Memory update failed');
+    }
+  }
+}

--- a/internal/web/static/js/modules/workspace-detail-memory.test.js
+++ b/internal/web/static/js/modules/workspace-detail-memory.test.js
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceMemoryManager } from './workspace-detail-memory.js';
+
+// Minimal host: escapeHtml mirrors the page helper closely enough for assertions.
+function makeManager() {
+  const host = {
+    workspaceId: 'ws1',
+    escapeHtml: text => String(text ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  };
+  return new WorkspaceMemoryManager(host);
+}
+
+test('entryRowHtml renders type badge, text, and provenance', () => {
+  const m = makeManager();
+  const html = m.entryRowHtml({ type: 'watch', date: '2026-06-11', provenance: 'run:abc', text: 'baseline ~7 min' }, 0);
+  assert.match(html, /workspace-detail-memory-badge-watch/);
+  assert.match(html, /baseline ~7 min/);
+  assert.match(html, /run:abc · 2026-06-11/);
+  assert.match(html, /data-action="edit" data-index="0"/);
+  assert.match(html, /data-action="delete" data-index="0"/);
+});
+
+test('entryRowHtml escapes hostile text', () => {
+  const m = makeManager();
+  const html = m.entryRowHtml({ type: 'fact', text: '<img src=x onerror=alert(1)>' }, 0);
+  assert.ok(!html.includes('<img src=x'), 'raw HTML must be escaped');
+  assert.match(html, /&lt;img/);
+});
+
+test('editRowHtml preselects the current type', () => {
+  const m = makeManager();
+  const html = m.editRowHtml({ type: 'decision', text: 'keep sqlite as cache' }, 2);
+  assert.match(html, /<option value="decision" selected>decision<\/option>/);
+  assert.match(html, /data-edit-text="2"/);
+  assert.match(html, /value="keep sqlite as cache"/);
+});
+
+test('renderList shows the teaching empty state when there is nothing', () => {
+  const m = makeManager();
+  m.elements = { list: { innerHTML: '' } };
+  m.entries = [];
+  m.unstructured = [];
+  m.renderList();
+  assert.match(m.elements.list.innerHTML, /workspace-detail-memory-empty/);
+  assert.match(m.elements.list.innerHTML, /No memory yet/);
+});
+
+test('renderList renders entries and an unstructured group', () => {
+  const m = makeManager();
+  m.elements = { list: { innerHTML: '' } };
+  m.entries = [{ type: 'fact', date: '2026-06-01', provenance: 'user', text: 'alpha' }];
+  m.unstructured = ['# Workspace Memory', 'hand note'];
+  m.editingIndex = -1;
+  m.renderList();
+  assert.match(m.elements.list.innerHTML, /alpha/);
+  assert.match(m.elements.list.innerHTML, /workspace-detail-memory-unstructured/);
+  assert.match(m.elements.list.innerHTML, /hand note/);
+});
+
+test('renderList switches the editing row into an edit form', () => {
+  const m = makeManager();
+  m.elements = { list: { innerHTML: '' } };
+  m.entries = [
+    { type: 'fact', text: 'first' },
+    { type: 'fact', text: 'second' }
+  ];
+  m.editingIndex = 1;
+  m.renderList();
+  // Row 0 stays read-only, row 1 is an edit form.
+  assert.match(m.elements.list.innerHTML, /data-action="edit" data-index="0"/);
+  assert.match(m.elements.list.innerHTML, /data-edit-text="1"/);
+});

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -9,6 +9,7 @@
 import { WorkspaceDirectoryExplorer } from './workspace-detail-directory-explorer.js';
 import { WorkspaceMCPManager } from './workspace-detail-mcp.js';
 import { WorkspaceSkillsManager } from './workspace-detail-skills.js';
+import { WorkspaceMemoryManager } from './workspace-detail-memory.js';
 import { WorkspaceFileModalManager } from './workspace-detail-file-modal.js';
 import { WorkspaceMembersPanel } from './workspace-detail-members.js';
 
@@ -225,6 +226,7 @@ export class WorkspaceDetailPage {
     this.agentSkillsPromises = new Map();
     this.mcpManager = new WorkspaceMCPManager(this);
     this.skillsManager = new WorkspaceSkillsManager(this);
+    this.memoryManager = new WorkspaceMemoryManager(this);
     this.workspaceSettings = null;
     this.workspaceSettingsEffectiveBehavior = null;
     this.workspaceTaskMarkdownStatus = null;
@@ -1579,6 +1581,7 @@ export class WorkspaceDetailPage {
       await this.loadWorkspace();
     });
     this.skillsManager.bindEvents();
+    this.memoryManager.bindEvents();
     this.elements.skillsModal?.addEventListener('shown.bs.modal', () => {
       this.applyTopBackdropLayer('workspace-detail-backdrop-skills');
     });

--- a/internal/web/static/js/modules/workspace-run.js
+++ b/internal/web/static/js/modules/workspace-run.js
@@ -105,6 +105,8 @@ export class WorkspaceRunPage {
       report: document.getElementById('workspace-run-report'),
       validationCard: document.getElementById('workspace-run-validation-card'),
       validation: document.getElementById('workspace-run-validation'),
+      memoryCard: document.getElementById('workspace-run-memory-card'),
+      memory: document.getElementById('workspace-run-memory'),
       artifactsCard: document.getElementById('workspace-run-artifacts-card'),
       artifacts: document.getElementById('workspace-run-artifacts'),
       trace: document.getElementById('workspace-run-trace'),
@@ -277,9 +279,45 @@ export class WorkspaceRunPage {
     this.renderContext();
     this.renderReport();
     this.renderValidation();
+    this.renderMemoryLearned();
     this.renderArtifacts();
     this.renderTrace();
     this.renderActions();
+  }
+
+  // renderMemoryLearned surfaces the run's memory diff (the memory_diff trace
+  // artifact) as a human-readable "what this run learned" card. Hidden when the
+  // run wrote nothing to workspace memory.
+  renderMemoryLearned() {
+    if (!this.elements.memoryCard || !this.elements.memory) return;
+    const artifacts = Array.isArray(this.artifacts) ? this.artifacts : [];
+    const diff = artifacts.find((a) => a?.metadata && a.metadata.role === 'memory_diff');
+    const added = Array.isArray(diff?.metadata?.added) ? diff.metadata.added : [];
+    const removed = Array.isArray(diff?.metadata?.removed) ? diff.metadata.removed : [];
+
+    if (!added.length && !removed.length) {
+      this.elements.memoryCard.hidden = true;
+      this.elements.memory.innerHTML = '';
+      return;
+    }
+
+    const renderGroup = (label, entries, cls) => {
+      if (!entries.length) return '';
+      const items = entries
+        .map((line) => `<li class="workspace-run-memory-entry ${cls}">${escapeHtml(String(line))}</li>`)
+        .join('');
+      return `
+        <div class="workspace-run-memory-group">
+          <div class="workspace-run-memory-group-label">${escapeHtml(label)}</div>
+          <ul class="workspace-run-memory-entries">${items}</ul>
+        </div>
+      `;
+    };
+
+    this.elements.memoryCard.hidden = false;
+    this.elements.memory.innerHTML =
+      renderGroup(`Remembered (${added.length})`, added, 'is-added') +
+      renderGroup(`Forgotten (${removed.length})`, removed, 'is-removed');
   }
 
   renderHero() {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -400,6 +400,17 @@
                   aria-selected="false">
                   Triggers
                 </button>
+                <button
+                  class="nav-link workspace-detail-config-tab"
+                  id="workspace-detail-config-memory-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#workspace-detail-config-memory-pane"
+                  type="button"
+                  role="tab"
+                  aria-controls="workspace-detail-config-memory-pane"
+                  aria-selected="false">
+                  Memory
+                </button>
               </div>
               <div class="tab-content workspace-detail-config-body">
                 <div
@@ -832,7 +843,7 @@
                             <label class="workspace-detail-settings-summary-card" style="cursor: pointer; display: block; margin: 0; padding: 0.75rem;">
                               <input type="radio" name="workspace-detail-mission-autonomy" value="watch" style="margin-right: 0.5rem;">
                               <strong>Watch</strong>
-                              <div class="workspace-detail-settings-field-hint" style="margin: 0.25rem 0 0 1.5rem;">Analyze and report findings. Make no changes to anything.</div>
+                              <div class="workspace-detail-settings-field-hint" style="margin: 0.25rem 0 0 1.5rem;">Analyze and report findings. Makes no changes — except recording what it learns to workspace memory.</div>
                             </label>
                           </div>
                           <div class="col-md-6">
@@ -940,6 +951,32 @@
                     <button type="button" class="btn btn-outline-primary btn-sm" data-trigger-add="webhook">Add webhook</button>
                     <button type="button" class="btn btn-outline-primary btn-sm" data-trigger-add="file_watch">Watch a folder</button>
                   </div>
+                </div>
+                <div
+                  class="tab-pane fade workspace-detail-config-pane"
+                  id="workspace-detail-config-memory-pane"
+                  role="tabpanel"
+                  aria-labelledby="workspace-detail-config-memory-tab">
+                  <div class="workspace-detail-config-pane-head">
+                    <div class="workspace-detail-config-pane-title">Workspace Memory</div>
+                    <div class="workspace-detail-config-pane-subtitle">
+                      Durable knowledge agents accumulate across runs and chats in this workspace — facts, decisions, dead ends, and watch-state. It's injected into every mission run and workspace chat. Edit or remove anything that's wrong; never store secrets here (use the Vault).
+                    </div>
+                  </div>
+                  <div id="workspace-detail-memory-meta" class="workspace-detail-memory-meta" aria-live="polite"></div>
+                  <form id="workspace-detail-memory-add-form" class="workspace-detail-memory-add" autocomplete="off">
+                    <select id="workspace-detail-memory-add-type" class="form-select workspace-detail-memory-type" aria-label="Memory entry type">
+                      <option value="fact">fact</option>
+                      <option value="feedback">feedback</option>
+                      <option value="decision">decision</option>
+                      <option value="dead-end">dead-end</option>
+                      <option value="watch">watch</option>
+                      <option value="thread">thread</option>
+                    </select>
+                    <input type="text" id="workspace-detail-memory-add-text" class="form-control workspace-detail-memory-input" maxlength="500" placeholder="Add a memory entry (one line)…" aria-label="New memory entry text">
+                    <button type="submit" class="btn btn-primary" id="workspace-detail-memory-add-btn">Add</button>
+                  </form>
+                  <div id="workspace-detail-memory-list" class="workspace-detail-memory-list"></div>
                 </div>
               </div>
             </div>
@@ -3294,6 +3331,169 @@
       font-size: 0.82rem;
       line-height: 1.5;
       color: var(--text-secondary);
+    }
+
+    .workspace-detail-config-pane-subtitle {
+      max-width: 72ch;
+      font-size: 0.82rem;
+      line-height: 1.5;
+      color: var(--text-secondary);
+      margin-top: 0.25rem;
+    }
+
+    .workspace-detail-memory-meta {
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+      margin: 0.6rem 0;
+    }
+
+    .workspace-detail-memory-size.is-over-budget {
+      color: var(--warning-color, #f5a623);
+      font-weight: 600;
+    }
+
+    .workspace-detail-memory-add {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 0.85rem;
+      flex-wrap: wrap;
+    }
+
+    .workspace-detail-memory-type {
+      max-width: 9rem;
+      flex: 0 0 auto;
+    }
+
+    .workspace-detail-memory-input {
+      flex: 1 1 18rem;
+    }
+
+    .workspace-detail-memory-list {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .workspace-detail-memory-entry {
+      display: grid;
+      gap: 0.4rem;
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+      background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+    }
+
+    .workspace-detail-memory-entry-main {
+      display: flex;
+      gap: 0.5rem;
+      align-items: baseline;
+    }
+
+    .workspace-detail-memory-text {
+      font-size: 0.85rem;
+      color: var(--text-primary);
+      word-break: break-word;
+    }
+
+    .workspace-detail-memory-badge {
+      flex: 0 0 auto;
+      font-size: 0.68rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 0.1rem 0.4rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--accent-color, #4a7dff) 16%, transparent);
+      color: var(--accent-color, #4a7dff);
+    }
+
+    .workspace-detail-memory-badge-watch,
+    .workspace-detail-memory-badge-thread {
+      background: color-mix(in srgb, var(--warning-color, #f5a623) 18%, transparent);
+      color: var(--warning-color, #c77f12);
+    }
+
+    .workspace-detail-memory-badge-dead-end {
+      background: color-mix(in srgb, var(--danger, #c62828) 16%, transparent);
+      color: var(--danger, #c62828);
+    }
+
+    .workspace-detail-memory-entry-foot {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .workspace-detail-memory-prov {
+      font-size: 0.72rem;
+      color: var(--text-secondary);
+      font-family: var(--font-mono, monospace);
+    }
+
+    .workspace-detail-memory-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .workspace-detail-memory-action {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 0.75rem;
+      color: var(--accent-color, #4a7dff);
+      cursor: pointer;
+    }
+
+    .workspace-detail-memory-action.is-danger {
+      color: var(--danger, #c62828);
+    }
+
+    .workspace-detail-memory-edit {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .workspace-detail-memory-empty {
+      padding: 1rem;
+      border: 1px dashed color-mix(in srgb, var(--border-color) 80%, transparent);
+      border-radius: 12px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .workspace-detail-memory-empty-example {
+      margin-top: 0.4rem;
+      font-size: 0.8rem;
+      opacity: 0.85;
+    }
+
+    .workspace-detail-memory-unstructured {
+      margin-top: 0.85rem;
+      padding-top: 0.6rem;
+      border-top: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+    }
+
+    .workspace-detail-memory-unstructured-label {
+      font-size: 0.74rem;
+      color: var(--text-secondary);
+      margin-bottom: 0.35rem;
+    }
+
+    .workspace-detail-memory-unstructured-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .workspace-detail-memory-unstructured-line {
+      font-family: var(--font-mono, monospace);
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+      opacity: 0.8;
+      word-break: break-word;
     }
 
     .workspace-detail-config-pane-actions {

--- a/internal/web/templates/pages/workspace-run.tmpl
+++ b/internal/web/templates/pages/workspace-run.tmpl
@@ -94,6 +94,16 @@
             <div id="workspace-run-validation" class="workspace-run-validation-list"></div>
           </section>
 
+          <section id="workspace-run-memory-card" class="workspace-run-card" hidden>
+            <div class="workspace-run-card-header">
+              <div>
+                <div class="workspace-run-card-kicker">Memory</div>
+                <h2>What this run learned</h2>
+              </div>
+            </div>
+            <div id="workspace-run-memory" class="workspace-run-memory-list"></div>
+          </section>
+
           <section id="workspace-run-artifacts-card" class="workspace-run-card" hidden>
             <div class="workspace-run-card-header">
               <div>
@@ -438,9 +448,45 @@
     .workspace-run-validation-list,
     .workspace-run-context-list,
     .workspace-run-artifact-list,
-    .workspace-run-trace-list {
+    .workspace-run-trace-list,
+    .workspace-run-memory-list {
       display: grid;
       gap: 0.65rem;
+    }
+
+    .workspace-run-memory-group-label {
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      margin-bottom: 0.35rem;
+    }
+
+    .workspace-run-memory-entries {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+
+    .workspace-run-memory-entry {
+      padding: 0.5rem 0.65rem;
+      border-radius: 12px;
+      border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
+      background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+      font-family: var(--font-mono, monospace);
+      font-size: 0.82rem;
+      word-break: break-word;
+    }
+
+    .workspace-run-memory-entry.is-added {
+      border-left: 3px solid color-mix(in srgb, var(--success, #2e7d32) 70%, transparent);
+    }
+
+    .workspace-run-memory-entry.is-removed {
+      border-left: 3px solid color-mix(in srgb, var(--danger, #c62828) 60%, transparent);
+      opacity: 0.75;
+      text-decoration: line-through;
     }
 
     .workspace-run-validation-item,

--- a/internal/workspace/memory.go
+++ b/internal/workspace/memory.go
@@ -1,0 +1,510 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// MemoryFileName is the canonical memory file at the workspace folder root.
+// The file on disk is the source of truth; memory is never cached in SQLite.
+const MemoryFileName = "MEMORY.md"
+
+// MemoryEntryMaxLen bounds a single entry's text. Longer knowledge belongs in
+// a note with a one-line pointer stored here instead.
+const MemoryEntryMaxLen = 500
+
+// Memory prompt-injection budget. Memory is injected into every mission run
+// and workspace chat, so it is capped to protect the context window. The cap
+// is expressed in tokens and converted with a tokenizer-free heuristic
+// (~4 chars/token) so there is no model-tokenizer dependency in this package.
+const (
+	MemoryPromptTokenBudget   = 2000
+	memoryPromptCharsPerToken = 4
+	memoryPromptCharBudget    = MemoryPromptTokenBudget * memoryPromptCharsPerToken
+)
+
+// MemoryEntryType classifies what kind of knowledge an entry carries.
+type MemoryEntryType string
+
+const (
+	MemoryTypeFact     MemoryEntryType = "fact"
+	MemoryTypeFeedback MemoryEntryType = "feedback"
+	MemoryTypeDecision MemoryEntryType = "decision"
+	MemoryTypeDeadEnd  MemoryEntryType = "dead-end"
+	MemoryTypeWatch    MemoryEntryType = "watch"
+	MemoryTypeThread   MemoryEntryType = "thread"
+)
+
+// MemoryEntryTypes lists the recognized types in display order.
+var MemoryEntryTypes = []MemoryEntryType{
+	MemoryTypeFact,
+	MemoryTypeFeedback,
+	MemoryTypeDecision,
+	MemoryTypeDeadEnd,
+	MemoryTypeWatch,
+	MemoryTypeThread,
+}
+
+// memorySecretPatterns are obvious credential shapes that ValidateMemoryText
+// refuses: MEMORY.md is plaintext on disk, injected into every prompt, and
+// travels with the workspace folder, so secrets must go to the Vault instead.
+// The list is deliberately conservative — a false positive blocks a legitimate
+// entry, while a miss is still covered by the prompt-contract prohibition.
+var memorySecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}`),            // OpenAI/Anthropic-style keys
+	regexp.MustCompile(`\bgh[poasur]_[A-Za-z0-9]{8,}`),      // GitHub tokens (ghp_, gho_, ...)
+	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{8,}`),     // GitHub fine-grained PAT
+	regexp.MustCompile(`\bAKIA[0-9A-Z]{8,}`),                // AWS access key ID
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{8,}`),     // Slack tokens
+	regexp.MustCompile(`-----BEGIN[A-Z ]*PRIVATE KEY-----`), // PEM private keys
+}
+
+// ValidateMemoryText enforces the entry-text contract shared by the memory
+// tools and the HTTP API: collapse to one line, reject empty, cap length, and
+// refuse obvious secrets. Returns the cleaned single-line text. Errors are
+// worded for whoever reads them (the agent or the API client).
+func ValidateMemoryText(raw string) (string, error) {
+	text := strings.Join(strings.Fields(raw), " ")
+	if text == "" {
+		return "", errors.New("memory text must not be empty")
+	}
+	if len(text) > MemoryEntryMaxLen {
+		return "", fmt.Errorf("memory entries are capped at %d characters (got %d) — memory holds one curated line per fact; put long content in a workspace note and store a one-line pointer here instead", MemoryEntryMaxLen, len(text))
+	}
+	for _, re := range memorySecretPatterns {
+		if re.MatchString(text) {
+			return "", errors.New("this text looks like a credential or secret; workspace memory is plaintext on disk and injected into prompts, so secrets are refused — store it in the Vault instead")
+		}
+	}
+	return text, nil
+}
+
+// NormalizeMemoryEntryType maps arbitrary input to a recognized type. The
+// file is hand-editable, so unrecognized types degrade to "fact" rather than
+// failing.
+func NormalizeMemoryEntryType(raw string) MemoryEntryType {
+	candidate := MemoryEntryType(strings.ToLower(strings.TrimSpace(raw)))
+	for _, t := range MemoryEntryTypes {
+		if candidate == t {
+			return t
+		}
+	}
+	return MemoryTypeFact
+}
+
+// MemoryEntry is one structured line of workspace memory.
+type MemoryEntry struct {
+	Type       MemoryEntryType `json:"type"`
+	Date       string          `json:"date"` // YYYY-MM-DD
+	Provenance string          `json:"provenance"`
+	Text       string          `json:"text"`
+}
+
+// Render formats the entry as its canonical markdown list line.
+func (e MemoryEntry) Render() string {
+	return fmt.Sprintf("- [%s, %s, %s] %s", e.Type, e.Date, e.Provenance, e.Text)
+}
+
+// memoryLine is one physical line of the file. Entry is nil for unstructured
+// lines (headers, hand-written prose), which must survive every rewrite
+// byte-identically via Raw.
+type memoryLine struct {
+	raw   string
+	entry *MemoryEntry
+}
+
+// MemoryDocument is the parsed form of a MEMORY.md file.
+type MemoryDocument struct {
+	lines []memoryLine
+}
+
+// memoryEntryPattern matches `- [<type>, <YYYY-MM-DD>, <provenance>] <text>`.
+// Type and provenance are free-form within their slots; the date shape is the
+// structural anchor that separates entries from ordinary markdown bullets.
+var memoryEntryPattern = regexp.MustCompile(`^-\s+\[\s*([^,\]]+?)\s*,\s*(\d{4}-\d{2}-\d{2})\s*,\s*([^\]]+?)\s*\]\s+(\S.*)$`)
+
+// ParseMemoryDocument parses file content leniently: lines matching the entry
+// pattern become entries (unknown types degrade to "fact"), everything else
+// is preserved verbatim as unstructured.
+func ParseMemoryDocument(content string) MemoryDocument {
+	if content == "" {
+		return MemoryDocument{}
+	}
+	rawLines := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	doc := MemoryDocument{lines: make([]memoryLine, 0, len(rawLines))}
+	for _, raw := range rawLines {
+		line := memoryLine{raw: raw}
+		if m := memoryEntryPattern.FindStringSubmatch(raw); m != nil {
+			line.entry = &MemoryEntry{
+				Type:       NormalizeMemoryEntryType(m[1]),
+				Date:       m[2],
+				Provenance: strings.TrimSpace(m[3]),
+				Text:       strings.TrimSpace(m[4]),
+			}
+		}
+		doc.lines = append(doc.lines, line)
+	}
+	return doc
+}
+
+// Render reassembles the file. Untouched lines come back byte-identical.
+func (d MemoryDocument) Render() string {
+	if len(d.lines) == 0 {
+		return ""
+	}
+	raws := make([]string, len(d.lines))
+	for i, l := range d.lines {
+		raws[i] = l.raw
+	}
+	return strings.Join(raws, "\n") + "\n"
+}
+
+// Entries returns the structured entries in file order.
+func (d MemoryDocument) Entries() []MemoryEntry {
+	var entries []MemoryEntry
+	for _, l := range d.lines {
+		if l.entry != nil {
+			entries = append(entries, *l.entry)
+		}
+	}
+	return entries
+}
+
+// UnstructuredLines returns non-entry, non-blank lines (headers, hand-written
+// prose) for UI display.
+func (d MemoryDocument) UnstructuredLines() []string {
+	var out []string
+	for _, l := range d.lines {
+		if l.entry == nil && strings.TrimSpace(l.raw) != "" {
+			out = append(out, l.raw)
+		}
+	}
+	return out
+}
+
+// entryLineIndexes maps entry index -> physical line index.
+func (d MemoryDocument) entryLineIndexes() []int {
+	var idx []int
+	for i, l := range d.lines {
+		if l.entry != nil {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
+// memoryPromptGuidance is the standing instruction about how to use workspace
+// memory. Injected wherever the memory_write / memory_forget tools are
+// available (mission runs, workspace chat) so the agent knows what the store
+// is for and what must never go in it.
+const memoryPromptGuidance = "Persistent knowledge accumulated for this workspace across runs and from the user. " +
+	"Treat it as context you already established; verify load-bearing facts before relying on them. " +
+	"Use memory_write to record durable operational knowledge (stable facts, decisions and their rationale, dead ends, watch-state/baselines, open threads) and memory_forget to remove what's wrong or stale. " +
+	"Do not store deliverables (write a note), work items (create a task), or secrets/credentials (use the Vault) here."
+
+// RenderMemoryPromptSection renders workspace memory as a `## Workspace Memory`
+// markdown section for prompt injection. Returns "" when there is nothing to
+// say (no entries and no tool guidance requested).
+//
+// Selection under the char budget keeps the most operationally valuable
+// entries: all watch and thread entries first (they carry cross-run cursors
+// and open investigations), then the remaining entries newest-first by date.
+// Kept entries are rendered in their original file order for stable reading,
+// and a single notice line reports how many were dropped. Unstructured lines
+// (the file header, hand-written prose) are not injected — the agent consumes
+// structured entries, humans read the raw file.
+//
+// includeToolGuidance adds the standing memory_write/forget guidance; callers
+// pass true where those tools are available (mission/chat) and false for the
+// native-CLI path, which only reads memory as context.
+func RenderMemoryPromptSection(doc MemoryDocument, includeToolGuidance bool) string {
+	entries := doc.Entries()
+	if len(entries) == 0 && !includeToolGuidance {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Workspace Memory\n\n")
+	if includeToolGuidance {
+		b.WriteString(memoryPromptGuidance)
+		b.WriteString("\n\n")
+	}
+	if len(entries) == 0 {
+		b.WriteString("_(empty — nothing recorded yet)_\n")
+		return b.String()
+	}
+
+	kept, dropped := selectMemoryEntriesForBudget(entries, memoryPromptCharBudget)
+	for _, e := range kept {
+		b.WriteString(e.Render())
+		b.WriteString("\n")
+	}
+	if dropped > 0 {
+		fmt.Fprintf(&b, "\n(memory truncated — %d entr%s not shown; consider pruning)\n", dropped, plural(dropped, "y", "ies"))
+	}
+	return b.String()
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// selectMemoryEntriesForBudget chooses which entries survive the char budget,
+// then returns them in original file order along with the dropped count.
+// Priority: watch/thread entries first, then others newest-first by date.
+func selectMemoryEntriesForBudget(entries []MemoryEntry, charBudget int) (kept []MemoryEntry, dropped int) {
+	type indexed struct {
+		entry MemoryEntry
+		order int
+	}
+	priority := make([]indexed, 0, len(entries))
+	rest := make([]indexed, 0, len(entries))
+	for i, e := range entries {
+		if e.Type == MemoryTypeWatch || e.Type == MemoryTypeThread {
+			priority = append(priority, indexed{e, i})
+		} else {
+			rest = append(rest, indexed{e, i})
+		}
+	}
+	// Newest first within the non-priority bucket (YYYY-MM-DD sorts
+	// lexicographically == chronologically). Stable so equal dates keep file order.
+	sort.SliceStable(rest, func(i, j int) bool {
+		return rest[i].entry.Date > rest[j].entry.Date
+	})
+
+	used := 0
+	selected := make([]indexed, 0, len(entries))
+	take := func(buckets ...[]indexed) {
+		for _, bucket := range buckets {
+			for _, it := range bucket {
+				cost := len(it.entry.Render()) + 1 // newline
+				if used+cost > charBudget && len(selected) > 0 {
+					dropped++
+					continue
+				}
+				selected = append(selected, it)
+				used += cost
+			}
+		}
+	}
+	take(priority, rest)
+
+	// Restore original file order for readable output.
+	sort.Slice(selected, func(i, j int) bool { return selected[i].order < selected[j].order })
+	kept = make([]MemoryEntry, len(selected))
+	for i, it := range selected {
+		kept[i] = it.entry
+	}
+	return kept, dropped
+}
+
+var (
+	// ErrMemoryEntryNotFound is returned when a forget/edit target matches no entry.
+	ErrMemoryEntryNotFound = errors.New("memory entry not found")
+	// ErrMemoryAmbiguousMatch is returned when a forget match hits multiple entries.
+	ErrMemoryAmbiguousMatch = errors.New("memory match is ambiguous")
+	// ErrMemoryIndexOutOfRange is returned for an invalid entry index.
+	ErrMemoryIndexOutOfRange = errors.New("memory entry index out of range")
+)
+
+// WorkspaceFolderResolver resolves a workspace ID to its folder path.
+// *FileStore satisfies this via GetFolderPath.
+type WorkspaceFolderResolver interface {
+	GetFolderPath(workspaceID string) (string, error)
+}
+
+// memoryMu serializes all MEMORY.md mutations process-wide. MemoryStore
+// instances are constructed per tool provider and per HTTP handler, so a
+// struct-level mutex would not actually serialize concurrent writers; the
+// lock must be shared across instances. Memory writes are tiny and rare, so
+// one global lock is sufficient (per-workspace sharding is a future
+// optimization if contention ever shows up).
+var memoryMu sync.Mutex
+
+// MemoryStore reads and mutates a workspace's MEMORY.md. All mutations are
+// serialized process-wide (memoryMu) and re-read the file from disk first, so
+// concurrent hand edits are honored on a last-write-wins basis.
+type MemoryStore struct {
+	resolver WorkspaceFolderResolver
+}
+
+// NewMemoryStore creates a memory store backed by the given folder resolver.
+func NewMemoryStore(resolver WorkspaceFolderResolver) *MemoryStore {
+	return &MemoryStore{resolver: resolver}
+}
+
+func (s *MemoryStore) filePath(workspaceID string) (string, error) {
+	folder, err := s.resolver.GetFolderPath(workspaceID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(folder, MemoryFileName), nil
+}
+
+// ReadRaw returns the raw file content. A missing file is empty memory, not
+// an error.
+func (s *MemoryStore) ReadRaw(workspaceID string) (string, error) {
+	path, err := s.filePath(workspaceID)
+	if err != nil {
+		return "", err
+	}
+	// Path is filepath.Join(store-resolved folder, constant MemoryFileName);
+	// workspaceID is only a lookup key in GetFolderPath, never a path segment,
+	// so there is no user-controlled path component to traverse.
+	data, err := os.ReadFile(path) // #nosec G304 G703
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read workspace memory: %w", err)
+	}
+	return string(data), nil
+}
+
+// Read returns the parsed memory document.
+func (s *MemoryStore) Read(workspaceID string) (MemoryDocument, error) {
+	raw, err := s.ReadRaw(workspaceID)
+	if err != nil {
+		return MemoryDocument{}, err
+	}
+	return ParseMemoryDocument(raw), nil
+}
+
+// Append adds an entry, lazily creating MEMORY.md (with a title header) on
+// first write.
+func (s *MemoryStore) Append(workspaceID string, entry MemoryEntry) error {
+	if strings.TrimSpace(entry.Text) == "" {
+		return errors.New("memory entry text must not be empty")
+	}
+	entry.Type = NormalizeMemoryEntryType(string(entry.Type))
+
+	memoryMu.Lock()
+	defer memoryMu.Unlock()
+
+	doc, err := s.Read(workspaceID)
+	if err != nil {
+		return err
+	}
+	if len(doc.lines) == 0 {
+		doc.lines = append(doc.lines,
+			memoryLine{raw: "# Workspace Memory"},
+			memoryLine{raw: ""},
+		)
+	}
+	line := memoryLine{raw: entry.Render(), entry: &entry}
+	doc.lines = append(doc.lines, line)
+	return s.write(workspaceID, doc)
+}
+
+// Forget removes exactly one entry. An exact text match wins; otherwise a
+// case-insensitive substring match must identify a single entry, or the call
+// fails with ErrMemoryAmbiguousMatch listing the candidates.
+func (s *MemoryStore) Forget(workspaceID string, match string) (MemoryEntry, error) {
+	match = strings.TrimSpace(match)
+	if match == "" {
+		return MemoryEntry{}, errors.New("memory forget match must not be empty")
+	}
+
+	memoryMu.Lock()
+	defer memoryMu.Unlock()
+
+	doc, err := s.Read(workspaceID)
+	if err != nil {
+		return MemoryEntry{}, err
+	}
+
+	entryLines := doc.entryLineIndexes()
+	var exact, partial []int
+	for _, li := range entryLines {
+		text := doc.lines[li].entry.Text
+		if text == match {
+			exact = append(exact, li)
+		} else if strings.Contains(strings.ToLower(text), strings.ToLower(match)) {
+			partial = append(partial, li)
+		}
+	}
+
+	candidates := exact
+	if len(exact) == 0 {
+		candidates = partial
+	}
+	switch len(candidates) {
+	case 0:
+		return MemoryEntry{}, fmt.Errorf("%w: no entry matches %q", ErrMemoryEntryNotFound, match)
+	case 1:
+		removed := *doc.lines[candidates[0]].entry
+		doc.lines = append(doc.lines[:candidates[0]], doc.lines[candidates[0]+1:]...)
+		if err := s.write(workspaceID, doc); err != nil {
+			return MemoryEntry{}, err
+		}
+		return removed, nil
+	default:
+		texts := make([]string, len(candidates))
+		for i, li := range candidates {
+			texts[i] = fmt.Sprintf("%q", doc.lines[li].entry.Text)
+		}
+		return MemoryEntry{}, fmt.Errorf("%w: %q matches %d entries: %s",
+			ErrMemoryAmbiguousMatch, match, len(candidates), strings.Join(texts, ", "))
+	}
+}
+
+// EditAt replaces the entry at the given entry index (file order, 0-based)
+// with the provided entry, rendered canonically.
+func (s *MemoryStore) EditAt(workspaceID string, index int, entry MemoryEntry) error {
+	if strings.TrimSpace(entry.Text) == "" {
+		return errors.New("memory entry text must not be empty")
+	}
+	entry.Type = NormalizeMemoryEntryType(string(entry.Type))
+
+	memoryMu.Lock()
+	defer memoryMu.Unlock()
+
+	doc, err := s.Read(workspaceID)
+	if err != nil {
+		return err
+	}
+	entryLines := doc.entryLineIndexes()
+	if index < 0 || index >= len(entryLines) {
+		return fmt.Errorf("%w: index %d, have %d entries", ErrMemoryIndexOutOfRange, index, len(entryLines))
+	}
+	doc.lines[entryLines[index]] = memoryLine{raw: entry.Render(), entry: &entry}
+	return s.write(workspaceID, doc)
+}
+
+// DeleteAt removes the entry at the given entry index (file order, 0-based).
+func (s *MemoryStore) DeleteAt(workspaceID string, index int) error {
+	memoryMu.Lock()
+	defer memoryMu.Unlock()
+
+	doc, err := s.Read(workspaceID)
+	if err != nil {
+		return err
+	}
+	entryLines := doc.entryLineIndexes()
+	if index < 0 || index >= len(entryLines) {
+		return fmt.Errorf("%w: index %d, have %d entries", ErrMemoryIndexOutOfRange, index, len(entryLines))
+	}
+	li := entryLines[index]
+	doc.lines = append(doc.lines[:li], doc.lines[li+1:]...)
+	return s.write(workspaceID, doc)
+}
+
+func (s *MemoryStore) write(workspaceID string, doc MemoryDocument) error {
+	path, err := s.filePath(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := atomicWriteFile(path, []byte(doc.Render())); err != nil {
+		return fmt.Errorf("failed to write workspace memory: %w", err)
+	}
+	return nil
+}

--- a/internal/workspace/memory_test.go
+++ b/internal/workspace/memory_test.go
@@ -1,0 +1,394 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type staticFolderResolver struct {
+	folders map[string]string
+}
+
+func (r staticFolderResolver) GetFolderPath(workspaceID string) (string, error) {
+	p, ok := r.folders[workspaceID]
+	if !ok {
+		return "", fmt.Errorf("workspace %s not found", workspaceID)
+	}
+	return p, nil
+}
+
+func newTestMemoryStore(t *testing.T) (*MemoryStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store := NewMemoryStore(staticFolderResolver{folders: map[string]string{"ws1": dir}})
+	return store, dir
+}
+
+func writeTestMemoryFile(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, MemoryFileName), []byte(content), 0644); err != nil {
+		t.Fatalf("write memory file: %v", err)
+	}
+}
+
+const handEditedMemory = `# Workspace Memory
+
+Some hand-written context the user added.
+
+- [fact, 2026-06-01, user] Releases are human-triggered from main.
+- [mystery, 2026-06-02, run:a1b2] Unknown type degrades to fact.
+- [watch, 2026-06-11, run:g8h9 (Scout)] Checked through commit 95c10b3.
+- a plain bullet without the entry shape
+- [fact, not-a-date, user] bad date means unstructured
+`
+
+func TestParseMemoryDocument_RoundTripPreservesContent(t *testing.T) {
+	doc := ParseMemoryDocument(handEditedMemory)
+	if got := doc.Render(); got != handEditedMemory {
+		t.Fatalf("round-trip changed content:\n--- got ---\n%s\n--- want ---\n%s", got, handEditedMemory)
+	}
+}
+
+func TestParseMemoryDocument_EntriesAndUnstructured(t *testing.T) {
+	doc := ParseMemoryDocument(handEditedMemory)
+
+	entries := doc.Entries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].Type != MemoryTypeFact || entries[0].Provenance != "user" {
+		t.Errorf("entry 0 parsed wrong: %+v", entries[0])
+	}
+	if entries[1].Type != MemoryTypeFact {
+		t.Errorf("unknown type should degrade to fact, got %q", entries[1].Type)
+	}
+	if entries[2].Type != MemoryTypeWatch || entries[2].Provenance != "run:g8h9 (Scout)" {
+		t.Errorf("entry 2 parsed wrong: %+v", entries[2])
+	}
+
+	unstructured := doc.UnstructuredLines()
+	wantUnstructured := []string{
+		"# Workspace Memory",
+		"Some hand-written context the user added.",
+		"- a plain bullet without the entry shape",
+		"- [fact, not-a-date, user] bad date means unstructured",
+	}
+	if len(unstructured) != len(wantUnstructured) {
+		t.Fatalf("expected %d unstructured lines, got %d: %q", len(wantUnstructured), len(unstructured), unstructured)
+	}
+	for i, want := range wantUnstructured {
+		if unstructured[i] != want {
+			t.Errorf("unstructured[%d] = %q, want %q", i, unstructured[i], want)
+		}
+	}
+}
+
+func TestParseMemoryDocument_Empty(t *testing.T) {
+	doc := ParseMemoryDocument("")
+	if doc.Render() != "" {
+		t.Errorf("empty content should render empty, got %q", doc.Render())
+	}
+	if len(doc.Entries()) != 0 {
+		t.Errorf("empty content should have no entries")
+	}
+}
+
+func TestMemoryStore_ReadMissingFile(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+	doc, err := store.Read("ws1")
+	if err != nil {
+		t.Fatalf("missing file must not error: %v", err)
+	}
+	if len(doc.Entries()) != 0 {
+		t.Errorf("missing file should parse as empty memory")
+	}
+}
+
+func TestMemoryStore_ReadUnknownWorkspace(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+	if _, err := store.Read("nope"); err == nil {
+		t.Fatal("unknown workspace should error")
+	}
+}
+
+func TestMemoryStore_AppendLazyCreatesWithHeader(t *testing.T) {
+	store, dir := newTestMemoryStore(t)
+	entry := MemoryEntry{Type: MemoryTypeFact, Date: "2026-06-12", Provenance: "user", Text: "staging is at https://stage.example.com"}
+	if err := store.Append("ws1", entry); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, MemoryFileName))
+	if err != nil {
+		t.Fatalf("memory file should exist after first append: %v", err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, "# Workspace Memory\n") {
+		t.Errorf("lazy-created file should start with title header, got:\n%s", content)
+	}
+	if !strings.Contains(content, "- [fact, 2026-06-12, user] staging is at https://stage.example.com") {
+		t.Errorf("entry line missing, got:\n%s", content)
+	}
+
+	doc, err := store.Read("ws1")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(doc.Entries()) != 1 {
+		t.Fatalf("expected 1 entry after append, got %d", len(doc.Entries()))
+	}
+}
+
+func TestMemoryStore_AppendValidation(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+	if err := store.Append("ws1", MemoryEntry{Text: "   "}); err == nil {
+		t.Error("empty text should be rejected")
+	}
+	if err := store.Append("ws1", MemoryEntry{Type: "bogus", Date: "2026-06-12", Provenance: "user", Text: "x"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	doc, _ := store.Read("ws1")
+	if doc.Entries()[0].Type != MemoryTypeFact {
+		t.Errorf("bogus type should normalize to fact, got %q", doc.Entries()[0].Type)
+	}
+}
+
+func TestMemoryStore_AppendPreservesHandEdits(t *testing.T) {
+	store, dir := newTestMemoryStore(t)
+	writeTestMemoryFile(t, dir, handEditedMemory)
+
+	if err := store.Append("ws1", MemoryEntry{Type: MemoryTypeThread, Date: "2026-06-12", Provenance: "run:z9", Text: "new thread"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, MemoryFileName))
+	content := string(data)
+	if !strings.HasPrefix(content, handEditedMemory) {
+		t.Errorf("append must preserve existing content byte-identically:\n%s", content)
+	}
+	if !strings.HasSuffix(content, "- [thread, 2026-06-12, run:z9] new thread\n") {
+		t.Errorf("appended entry should be the last line:\n%s", content)
+	}
+}
+
+func TestMemoryStore_Forget(t *testing.T) {
+	store, dir := newTestMemoryStore(t)
+	writeTestMemoryFile(t, dir, `# Workspace Memory
+
+- [fact, 2026-06-01, user] alpha beta
+- [fact, 2026-06-02, user] beta gamma
+`)
+
+	// Ambiguous substring across both entries.
+	_, err := store.Forget("ws1", "beta")
+	if !errors.Is(err, ErrMemoryAmbiguousMatch) {
+		t.Fatalf("expected ambiguous-match error, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "alpha beta") {
+		t.Errorf("ambiguity error should list candidates, got: %v", err)
+	}
+
+	// Exact match wins even when it is also a substring of nothing else.
+	removed, err := store.Forget("ws1", "alpha beta")
+	if err != nil {
+		t.Fatalf("exact forget: %v", err)
+	}
+	if removed.Text != "alpha beta" {
+		t.Errorf("removed wrong entry: %+v", removed)
+	}
+
+	// Unambiguous substring.
+	if _, err := store.Forget("ws1", "gamma"); err != nil {
+		t.Fatalf("substring forget: %v", err)
+	}
+
+	// Nothing left to match.
+	_, err = store.Forget("ws1", "beta")
+	if !errors.Is(err, ErrMemoryEntryNotFound) {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+
+	// Header survives all mutations.
+	data, _ := os.ReadFile(filepath.Join(dir, MemoryFileName))
+	if !strings.HasPrefix(string(data), "# Workspace Memory\n") {
+		t.Errorf("unstructured header must survive forgets:\n%s", string(data))
+	}
+}
+
+func TestMemoryStore_EditAtAndDeleteAt(t *testing.T) {
+	store, dir := newTestMemoryStore(t)
+	writeTestMemoryFile(t, dir, `- [fact, 2026-06-01, user] first
+- [fact, 2026-06-02, user] second
+`)
+
+	if err := store.EditAt("ws1", 1, MemoryEntry{Type: MemoryTypeDecision, Date: "2026-06-12", Provenance: "user", Text: "second, revised"}); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	doc, _ := store.Read("ws1")
+	if got := doc.Entries()[1]; got.Text != "second, revised" || got.Type != MemoryTypeDecision {
+		t.Errorf("edit did not apply: %+v", got)
+	}
+
+	if err := store.DeleteAt("ws1", 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	doc, _ = store.Read("ws1")
+	if len(doc.Entries()) != 1 || doc.Entries()[0].Text != "second, revised" {
+		t.Errorf("delete removed wrong entry: %+v", doc.Entries())
+	}
+
+	for _, idx := range []int{-1, 5} {
+		if err := store.EditAt("ws1", idx, MemoryEntry{Text: "x"}); !errors.Is(err, ErrMemoryIndexOutOfRange) {
+			t.Errorf("EditAt(%d) expected out-of-range, got %v", idx, err)
+		}
+		if err := store.DeleteAt("ws1", idx); !errors.Is(err, ErrMemoryIndexOutOfRange) {
+			t.Errorf("DeleteAt(%d) expected out-of-range, got %v", idx, err)
+		}
+	}
+}
+
+func TestWorkspaceMemoryToolsGate(t *testing.T) {
+	hostileOverrides := map[string]SideEffect{
+		MemoryWriteToolName:  SideEffectExternal,
+		MemoryForgetToolName: SideEffectExternal,
+	}
+	for _, policy := range []AutonomyPolicy{AutonomyWatch, AutonomyPropose} {
+		for _, tool := range []string{MemoryWriteToolName, MemoryForgetToolName} {
+			dec := EvaluateMissionToolCall(policy, SideEffectExternal, hostileOverrides, tool)
+			if !dec.Allowed {
+				t.Errorf("%s must be allowed under %s, got blocked: %s", tool, policy, dec.Reason)
+			}
+			if dec.Classification != SideEffectWrite {
+				t.Errorf("%s should classify as write, got %q", tool, dec.Classification)
+			}
+
+			// Handler-side wrapper must agree even when the caller passes a
+			// hostile pre-resolved classification.
+			if dec := EvaluateMissionToolCallDecision(policy, SideEffectExternal, tool); !dec.Allowed {
+				t.Errorf("decision wrapper blocked %s under %s: %s", tool, policy, dec.Reason)
+			}
+		}
+	}
+
+	// Control: ordinary write tools are still denied under Watch.
+	if dec := EvaluateMissionToolCall(AutonomyWatch, SideEffectWrite, nil, "save_note"); dec.Allowed {
+		t.Error("save_note must stay blocked under Watch")
+	}
+
+	if !IsWorkspaceMemoryTool(MemoryWriteToolName) || !IsWorkspaceMemoryTool(MemoryForgetToolName) {
+		t.Error("memory tool names should be recognized")
+	}
+	if IsWorkspaceMemoryTool("save_note") {
+		t.Error("save_note is not a memory tool")
+	}
+}
+
+func TestRenderMemoryPromptSection_EmptyAndGuidance(t *testing.T) {
+	empty := ParseMemoryDocument("")
+
+	// Empty + no guidance => nothing to inject (native-CLI path).
+	if got := RenderMemoryPromptSection(empty, false); got != "" {
+		t.Errorf("empty memory without guidance should render nothing, got: %q", got)
+	}
+
+	// Empty + guidance => header + guidance + empty marker (mission/chat path).
+	withGuidance := RenderMemoryPromptSection(empty, true)
+	if !strings.Contains(withGuidance, "## Workspace Memory") {
+		t.Error("guidance render should include the section header")
+	}
+	if !strings.Contains(withGuidance, "memory_write") || !strings.Contains(withGuidance, "Vault") {
+		t.Errorf("guidance should mention the tools and the secrets prohibition, got:\n%s", withGuidance)
+	}
+	if !strings.Contains(withGuidance, "empty") {
+		t.Errorf("empty memory should be marked as such, got:\n%s", withGuidance)
+	}
+}
+
+func TestRenderMemoryPromptSection_NoToolGuidanceForCLI(t *testing.T) {
+	doc := ParseMemoryDocument("- [fact, 2026-06-01, user] alpha\n")
+	section := RenderMemoryPromptSection(doc, false)
+	if strings.Contains(section, "memory_write") {
+		t.Errorf("native-CLI render must omit tool guidance, got:\n%s", section)
+	}
+	if !strings.Contains(section, "alpha") {
+		t.Errorf("entry should still be rendered, got:\n%s", section)
+	}
+}
+
+func TestRenderMemoryPromptSection_TruncationPrefersWatchAndThread(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("# Workspace Memory\n\n")
+	// Many old facts that will overflow the budget.
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&b, "- [fact, 2026-01-%02d, user] old padding fact number %03d with enough text to consume budget quickly\n", (i%28)+1, i)
+	}
+	// Critical cross-run state, oldest dates so pure-recency would drop them.
+	b.WriteString("- [watch, 2020-01-01, run:x] CRITICAL checked through commit deadbeef\n")
+	b.WriteString("- [thread, 2020-01-02, run:y] CRITICAL open investigation into flaky test\n")
+
+	doc := ParseMemoryDocument(b.String())
+	// Render without tool guidance so the assertion isolates the entry budget
+	// from the fixed guidance/header overhead.
+	section := RenderMemoryPromptSection(doc, false)
+
+	if !strings.Contains(section, "CRITICAL checked through commit deadbeef") {
+		t.Error("watch entry must survive truncation despite being oldest")
+	}
+	if !strings.Contains(section, "CRITICAL open investigation") {
+		t.Error("thread entry must survive truncation despite being oldest")
+	}
+	if !strings.Contains(section, "memory truncated") {
+		t.Error("over-budget memory should carry a truncation notice")
+	}
+	// Entry content is bounded by the budget; header + notice are small fixed overhead.
+	if len(section) > memoryPromptCharBudget+256 {
+		t.Errorf("rendered entries should respect the budget (got %d chars, budget %d)", len(section), memoryPromptCharBudget)
+	}
+}
+
+func TestRenderMemoryPromptSection_KeepsFileOrder(t *testing.T) {
+	doc := ParseMemoryDocument(strings.Join([]string{
+		"- [fact, 2026-06-01, user] first",
+		"- [watch, 2026-06-11, run:z] second is watch",
+		"- [decision, 2026-06-05, user] third",
+		"",
+	}, "\n"))
+	section := RenderMemoryPromptSection(doc, false)
+	iFirst := strings.Index(section, "first")
+	iSecond := strings.Index(section, "second is watch")
+	iThird := strings.Index(section, "third")
+	if !(iFirst < iSecond && iSecond < iThird) {
+		t.Errorf("kept entries should render in original file order, got offsets %d/%d/%d in:\n%s", iFirst, iSecond, iThird, section)
+	}
+}
+
+func TestMemoryStore_ConcurrentAppends(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+	const n = 20
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := MemoryEntry{Type: MemoryTypeFact, Date: "2026-06-12", Provenance: "user", Text: fmt.Sprintf("entry %02d", i)}
+			if err := store.Append("ws1", entry); err != nil {
+				t.Errorf("append %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	doc, err := store.Read("ws1")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(doc.Entries()) != n {
+		t.Fatalf("expected %d entries after concurrent appends, got %d", n, len(doc.Entries()))
+	}
+}

--- a/internal/workspace/mission.go
+++ b/internal/workspace/mission.go
@@ -362,6 +362,13 @@ type GateDecision struct {
 // and the same function works in tests, the executor, and the readiness
 // preview UI.
 func EvaluateMissionToolCall(policy AutonomyPolicy, defaultSE SideEffect, overrides map[string]SideEffect, toolName string) GateDecision {
+	// Native workspace-memory tools bypass binding classification entirely:
+	// they are always workspace-internal writes and are allowed under every
+	// policy, including Watch (see IsWorkspaceMemoryTool for the rationale).
+	// Checked first so binding overrides cannot re-classify or block them.
+	if IsWorkspaceMemoryTool(toolName) {
+		return GateDecision{Allowed: true, Classification: SideEffectWrite, Policy: policy, ToolName: toolName}
+	}
 	resolved := ResolveSideEffect(defaultSE, overrides, toolName)
 	dec := GateDecision{
 		Classification: resolved,

--- a/internal/workspace/task_handler_mission_gate.go
+++ b/internal/workspace/task_handler_mission_gate.go
@@ -88,6 +88,11 @@ func (h *LLMTaskHandler) evaluateExecutionAutonomyGate(task Task, toolName strin
 // allows) and is deliberately checked BEFORE the name heuristic so an external
 // binding's read-prefixed tool (e.g. "fetch_url") isn't mis-allowed as a read.
 func (h *LLMTaskHandler) resolveMissionToolSideEffect(workspaceID, toolName string) SideEffect {
+	// Native workspace-memory tools have a fixed classification; binding
+	// overrides and defaults must not be able to re-classify them.
+	if IsWorkspaceMemoryTool(toolName) {
+		return SideEffectWrite
+	}
 	if h.workspaceStore == nil {
 		return SuggestSideEffect(toolName)
 	}
@@ -173,6 +178,11 @@ func missionDefaultSideEffect(ws *Workspace) SideEffect {
 // classification (avoiding re-resolving). Kept here rather than in mission.go
 // because the resolution step lives on the handler.
 func EvaluateMissionToolCallDecision(policy AutonomyPolicy, classification SideEffect, toolName string) GateDecision {
+	// Memory tools are allowed under every policy regardless of the resolved
+	// classification (see IsWorkspaceMemoryTool); mirror EvaluateMissionToolCall.
+	if IsWorkspaceMemoryTool(toolName) {
+		return GateDecision{Allowed: true, Classification: SideEffectWrite, Policy: policy, ToolName: toolName}
+	}
 	dec := GateDecision{
 		Classification: classification,
 		Policy:         policy,

--- a/internal/workspace/task_prompt_context.go
+++ b/internal/workspace/task_prompt_context.go
@@ -79,6 +79,29 @@ func (h *LLMTaskHandler) buildTaskSystemPrompt() string {
 	return prompt.String()
 }
 
+// buildTaskMemorySection renders the workspace's persistent memory for the task
+// prompt. Memory tools are available during task execution, so tool guidance is
+// included. Returns "" when the store can't resolve a folder path (e.g. a
+// non-folder store) or memory is empty and there's nothing to guide.
+func (h *LLMTaskHandler) buildTaskMemorySection(task Task) string {
+	if h.workspaceStore == nil || strings.TrimSpace(task.WorkspaceID) == "" {
+		return ""
+	}
+	resolver, ok := h.workspaceStore.(workspaceFolderStore)
+	if !ok {
+		return ""
+	}
+	doc, err := NewMemoryStore(resolver).Read(task.WorkspaceID)
+	if err != nil {
+		logger.Debug("Skipping workspace memory for task prompt", logger.Fields{
+			"workspace_id": task.WorkspaceID,
+			"error":        err,
+		})
+		return ""
+	}
+	return RenderMemoryPromptSection(doc, true)
+}
+
 func (h *LLMTaskHandler) buildTaskWorkspaceSnapshot(ctx context.Context, task Task) string {
 	if h.workspaceStore == nil || strings.TrimSpace(task.WorkspaceID) == "" {
 		return ""
@@ -638,6 +661,11 @@ func (h *LLMTaskHandler) buildTaskPrompt(ctx context.Context, task Task) string 
 		prompt.WriteString(referenceURL)
 		prompt.WriteString("\n\n")
 		prompt.WriteString("Treat this URL as authoritative source material for this task. Inspect it with available fetch, browser, or web tools before making claims about its contents. If you cannot inspect it, state that limitation in your final response.\n\n")
+	}
+
+	if workspaceMemory := h.buildTaskMemorySection(task); workspaceMemory != "" {
+		prompt.WriteString(workspaceMemory)
+		prompt.WriteString("\n\n")
 	}
 
 	if workspaceSnapshot := h.buildTaskWorkspaceSnapshot(ctx, task); workspaceSnapshot != "" {

--- a/internal/workspace/tool_classification.go
+++ b/internal/workspace/tool_classification.go
@@ -103,10 +103,31 @@ func MissionBindingsReady(ws *Workspace) bool {
 	return len(mcp) == 0 && len(sk) == 0
 }
 
+// Workspace memory tool names. Defined here rather than in chathttp so the
+// autonomy gate, which works by tool name, has a single source of truth.
+const (
+	MemoryWriteToolName  = "memory_write"
+	MemoryForgetToolName = "memory_forget"
+)
+
+// IsWorkspaceMemoryTool reports whether toolName is a native workspace-memory
+// tool. Memory tools are workspace-internal writes permitted under every
+// autonomy policy, including Watch: memory is the agent's own operational
+// state, and a Watch mission that cannot remember what it watched can never
+// deduplicate findings or track trends across runs. The user-facing Watch
+// guarantee is correspondingly worded "no writes anywhere — except workspace
+// memory".
+func IsWorkspaceMemoryTool(toolName string) bool {
+	return toolName == MemoryWriteToolName || toolName == MemoryForgetToolName
+}
+
 // IsAllowedUnderPolicy reports whether a tool call classified with `se` is
 // permitted under the given autonomy policy. The empty SideEffect (unclassified)
 // is always denied. Watch allows only read; Propose allows read and write.
 // Higher policies (Act-with-approval, Autopilot) land in v1.5+.
+// Workspace memory tools are exempted upstream (see IsWorkspaceMemoryTool and
+// the EvaluateMissionToolCall* entry points) — this function stays
+// classification-pure.
 func IsAllowedUnderPolicy(policy AutonomyPolicy, se SideEffect) bool {
 	if se == "" {
 		return false

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -38,7 +38,9 @@ const (
 type AutonomyPolicy string
 
 const (
-	// AutonomyWatch limits the run to read-classified tools only. No writes anywhere.
+	// AutonomyWatch limits the run to read-classified tools only. No writes
+	// anywhere — except workspace memory (see IsWorkspaceMemoryTool), so even
+	// watch-only missions can learn across runs.
 	AutonomyWatch AutonomyPolicy = "watch"
 	// AutonomyPropose allows read + workspace-internal writes (draft artifacts, notes,
 	// recommended-task drafts). External-effect tools remain denied.

--- a/internal/workspacerun/memory_diff.go
+++ b/internal/workspacerun/memory_diff.go
@@ -1,0 +1,72 @@
+package workspacerun
+
+import (
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// memoryDiffRole tags the trace artifact that records what a run learned —
+// the entries added to or removed from workspace memory during the run.
+const memoryDiffRole = "memory_diff"
+
+// snapshotMemoryLines returns the workspace's memory entries rendered as their
+// canonical lines, for before/after diffing. Returns nil when memory can't be
+// read (no resolver, non-folder store, missing workspace) — callers treat a nil
+// snapshot as "memory unobservable", which yields an empty diff.
+func snapshotMemoryLines(resolver workspaceFolderResolver, workspaceID string) []string {
+	if resolver == nil || workspaceID == "" {
+		return nil
+	}
+	doc, err := workspace.NewMemoryStore(resolver).Read(workspaceID)
+	if err != nil {
+		return nil
+	}
+	entries := doc.Entries()
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.Render())
+	}
+	return lines
+}
+
+// diffMemoryLines reports which entry lines were added (in after, not before)
+// and removed (in before, not after). Order follows the slice the line came
+// from. An edit surfaces as one removal plus one addition, which is the
+// intended representation for "what changed".
+func diffMemoryLines(before, after []string) (added, removed []string) {
+	beforeSet := make(map[string]int, len(before))
+	for _, l := range before {
+		beforeSet[l]++
+	}
+	afterSet := make(map[string]int, len(after))
+	for _, l := range after {
+		afterSet[l]++
+	}
+	for _, l := range after {
+		if afterSet[l] > beforeSet[l] {
+			added = append(added, l)
+			afterSet[l]-- // count each surplus occurrence once
+		}
+	}
+	for _, l := range before {
+		if beforeSet[l] > afterSet[l] {
+			removed = append(removed, l)
+			beforeSet[l]--
+		}
+	}
+	return added, removed
+}
+
+// memoryDiffArtifact builds the run's "what it learned" trace artifact, or nil
+// when nothing changed (so empty diffs add no noise to the run record).
+func memoryDiffArtifact(runID string, before, after []string) *Artifact {
+	added, removed := diffMemoryLines(before, after)
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+	artifact := NewArtifact(runID, ArtifactTrace, ArtifactMetadata(map[string]any{
+		"role":    memoryDiffRole,
+		"added":   added,
+		"removed": removed,
+	}))
+	return &artifact
+}

--- a/internal/workspacerun/memory_diff_test.go
+++ b/internal/workspacerun/memory_diff_test.go
@@ -1,0 +1,62 @@
+package workspacerun
+
+import (
+	"testing"
+)
+
+func TestDiffMemoryLines(t *testing.T) {
+	before := []string{
+		"- [fact, 2026-06-01, user] alpha",
+		"- [watch, 2026-06-10, run:x] cursor at v1",
+	}
+	after := []string{
+		"- [fact, 2026-06-01, user] alpha",          // unchanged
+		"- [watch, 2026-06-11, run:y] cursor at v2", // edit => remove old + add new
+		"- [decision, 2026-06-12, user] new call",   // pure addition
+	}
+
+	added, removed := diffMemoryLines(before, after)
+
+	wantAdded := map[string]bool{
+		"- [watch, 2026-06-11, run:y] cursor at v2": true,
+		"- [decision, 2026-06-12, user] new call":   true,
+	}
+	if len(added) != len(wantAdded) {
+		t.Fatalf("added = %v, want %d entries", added, len(wantAdded))
+	}
+	for _, l := range added {
+		if !wantAdded[l] {
+			t.Errorf("unexpected added line: %q", l)
+		}
+	}
+	if len(removed) != 1 || removed[0] != "- [watch, 2026-06-10, run:x] cursor at v1" {
+		t.Errorf("removed = %v, want the old watch cursor", removed)
+	}
+}
+
+func TestDiffMemoryLines_NoChange(t *testing.T) {
+	lines := []string{"- [fact, 2026-06-01, user] alpha"}
+	added, removed := diffMemoryLines(lines, lines)
+	if len(added) != 0 || len(removed) != 0 {
+		t.Errorf("identical snapshots should produce no diff, got added=%v removed=%v", added, removed)
+	}
+}
+
+func TestMemoryDiffArtifact(t *testing.T) {
+	// No change => no artifact (keeps empty runs quiet).
+	if a := memoryDiffArtifact("run-1", []string{"x"}, []string{"x"}); a != nil {
+		t.Error("unchanged memory should produce no artifact")
+	}
+
+	a := memoryDiffArtifact("run-1", nil, []string{"- [fact, 2026-06-12, run:run-1] learned a thing"})
+	if a == nil {
+		t.Fatal("a change should produce an artifact")
+	}
+	if a.Metadata["role"] != memoryDiffRole {
+		t.Errorf("artifact role = %v, want %q", a.Metadata["role"], memoryDiffRole)
+	}
+	added, ok := a.Metadata["added"].([]string)
+	if !ok || len(added) != 1 {
+		t.Errorf("artifact should record one added entry, got %v", a.Metadata["added"])
+	}
+}

--- a/internal/workspacerun/nativecli.go
+++ b/internal/workspacerun/nativecli.go
@@ -7,11 +7,19 @@ import (
 	"sync"
 
 	"github.com/johnjallday/ori-agent/internal/cliagent"
+	"github.com/johnjallday/ori-agent/internal/workspace"
 )
+
+// workspaceFolderResolver resolves a workspace ID to its folder path so the
+// executor can read MEMORY.md. *workspace.FileStore satisfies it.
+type workspaceFolderResolver interface {
+	GetFolderPath(workspaceID string) (string, error)
+}
 
 type NativeCLIExecutor struct {
 	registry *cliagent.CLIAgentRegistry
 	diff     *cliagent.DiffDetector
+	folders  workspaceFolderResolver
 
 	mu        sync.Mutex
 	artifacts map[string][]Artifact
@@ -29,6 +37,27 @@ func NewNativeCLIExecutor(registry *cliagent.CLIAgentRegistry) *NativeCLIExecuto
 		artifacts: make(map[string][]Artifact),
 		traces:    make(map[string][]TraceEvent),
 	}
+}
+
+// SetWorkspaceFolderResolver wires folder-path resolution so native-CLI runs
+// can inject the workspace's persistent memory. Without it, runs proceed
+// without a memory section.
+func (e *NativeCLIExecutor) SetWorkspaceFolderResolver(resolver workspaceFolderResolver) {
+	e.folders = resolver
+}
+
+// renderMemorySection loads and renders the workspace's memory for the run
+// prompt, or "" when unavailable. Tool guidance is omitted: CLI backends can't
+// call Ori's memory tools, so memory is read-only context here.
+func (e *NativeCLIExecutor) renderMemorySection(run *Run) string {
+	if e.folders == nil || strings.TrimSpace(run.WorkspaceID) == "" {
+		return ""
+	}
+	doc, err := workspace.NewMemoryStore(e.folders).Read(run.WorkspaceID)
+	if err != nil {
+		return ""
+	}
+	return workspace.RenderMemoryPromptSection(doc, false)
 }
 
 func (e *NativeCLIExecutor) Execute(ctx context.Context, run *Run) error {
@@ -67,16 +96,20 @@ func (e *NativeCLIExecutor) Execute(ctx context.Context, run *Run) error {
 	}
 
 	snapshot, _ := e.diff.Snapshot(workingDir)
+	memoryBefore := snapshotMemoryLines(e.folders, run.WorkspaceID)
 	result, err := adapter.ExecuteStep(ctx, cliagent.StepRequest{
 		TaskID:     run.ID,
 		StepNumber: 1,
-		Prompt:     BuildRunExecutionPrompt(run),
+		Prompt:     BuildRunExecutionPrompt(run, e.renderMemorySection(run)),
 		WorkingDir: workingDir,
 		Model:      cfg.Model,
 		Budget: cliagent.StepBudget{
 			Timeout: cliagent.DefaultStepTimeout,
 		},
 	})
+	if diff := memoryDiffArtifact(run.ID, memoryBefore, snapshotMemoryLines(e.folders, run.WorkspaceID)); diff != nil {
+		e.addArtifact(run.ID, *diff)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/workspacerun/oriagent.go
+++ b/internal/workspacerun/oriagent.go
@@ -24,7 +24,8 @@ type OriAgentTaskContextPreparer interface {
 }
 
 type OriAgentExecutor struct {
-	runner OriAgentTaskRunner
+	runner  OriAgentTaskRunner
+	folders workspaceFolderResolver
 
 	mu        sync.Mutex
 	artifacts map[string][]Artifact
@@ -39,6 +40,12 @@ func NewOriAgentExecutor(runners ...OriAgentTaskRunner) *OriAgentExecutor {
 		runner:    runner,
 		artifacts: make(map[string][]Artifact),
 	}
+}
+
+// SetWorkspaceFolderResolver wires folder-path resolution so the executor can
+// snapshot workspace memory before and after the run and record what changed.
+func (e *OriAgentExecutor) SetWorkspaceFolderResolver(resolver workspaceFolderResolver) {
+	e.folders = resolver
 }
 
 func (e *OriAgentExecutor) Execute(ctx context.Context, run *Run) error {
@@ -58,9 +65,13 @@ func (e *OriAgentExecutor) Execute(ctx context.Context, run *Run) error {
 	if strings.TrimSpace(task.ReferenceURL) == "" {
 		task.ReferenceURL = strings.TrimSpace(run.ReferenceURL)
 	}
+	memoryBefore := snapshotMemoryLines(e.folders, task.WorkspaceID)
 	result, err := e.runner.ExecuteTask(ctx, run.Executor.Ref, task)
 	if err != nil {
 		return err
+	}
+	if diff := memoryDiffArtifact(run.ID, memoryBefore, snapshotMemoryLines(e.folders, task.WorkspaceID)); diff != nil {
+		e.addArtifact(run.ID, *diff)
 	}
 	e.addArtifact(run.ID, NewArtifact(
 		run.ID,

--- a/internal/workspacerun/prompt_contract.go
+++ b/internal/workspacerun/prompt_contract.go
@@ -7,7 +7,12 @@ import (
 
 const referenceURLInspectionRole = "reference_url_inspection"
 
-func BuildRunExecutionPrompt(run *Run) string {
+// BuildRunExecutionPrompt assembles the execution contract for a native-CLI
+// run. memorySection, when non-empty, is a pre-rendered `## Workspace Memory`
+// block (see workspace.RenderMemoryPromptSection) injected as read-only context
+// before the user prompt — CLI backends don't have Ori's memory tools, so it
+// carries no tool guidance.
+func BuildRunExecutionPrompt(run *Run, memorySection string) string {
 	if run == nil {
 		return ""
 	}
@@ -41,6 +46,12 @@ func BuildRunExecutionPrompt(run *Run) string {
 		prompt.WriteString("Do not claim facts about the URL from memory or assumptions. ")
 		prompt.WriteString("If URL access tools are unavailable, the host is not reachable, authentication is required, or access is blocked, state that limitation in the final response.\n\n")
 		prompt.WriteString("In your final response, include `Reference URL inspection: inspected`, `Reference URL inspection: blocked`, or `Reference URL inspection: unknown` with a short reason.\n")
+	}
+
+	if section := strings.TrimSpace(memorySection); section != "" {
+		prompt.WriteString("\n")
+		prompt.WriteString(section)
+		prompt.WriteString("\n")
 	}
 
 	prompt.WriteString("\n## User Prompt\n\n")

--- a/internal/workspacerun/prompt_contract_memory_test.go
+++ b/internal/workspacerun/prompt_contract_memory_test.go
@@ -1,0 +1,29 @@
+package workspacerun
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRunExecutionPrompt_MemorySection(t *testing.T) {
+	run := &Run{ID: "run-1", Prompt: "do the thing"}
+
+	// No memory section => no Workspace Memory block, user prompt still present.
+	bare := BuildRunExecutionPrompt(run, "")
+	if strings.Contains(bare, "Workspace Memory") {
+		t.Errorf("empty memory section should not appear, got:\n%s", bare)
+	}
+	if !strings.Contains(bare, "do the thing") {
+		t.Errorf("user prompt must always be present, got:\n%s", bare)
+	}
+
+	// Provided section is injected before the user prompt.
+	section := "## Workspace Memory\n\n- [fact, 2026-06-01, user] staging is at stage.example.com\n"
+	withMem := BuildRunExecutionPrompt(run, section)
+	if !strings.Contains(withMem, "staging is at stage.example.com") {
+		t.Errorf("memory section should be injected, got:\n%s", withMem)
+	}
+	if idxMem, idxPrompt := strings.Index(withMem, "Workspace Memory"), strings.Index(withMem, "## User Prompt"); idxMem == -1 || idxMem > idxPrompt {
+		t.Errorf("memory section must precede the user prompt (mem=%d, prompt=%d)", idxMem, idxPrompt)
+	}
+}


### PR DESCRIPTION
## Summary

Gives every workspace a curated `MEMORY.md` of durable operational knowledge — facts, decisions, dead ends, watch-state — that agents read at the start of every mission run and workspace chat and update as they learn. Mission runs **compound** what they discover instead of restarting cold, which turns the mechanical title-match dedup into cognitive dedup and makes cross-run trend detection possible.

Implements `tasks/prd-workspace-memory.md` (v1). Top-priority gap from the AI-OS direction analysis.

## What's included

- **Store core** (`internal/workspace/memory.go`) — `MEMORY.md` parser/serializer that preserves hand edits byte-for-byte, a mutex-serialized `MemoryStore` (lazy create, **disk is canonical** via `GetFolderPath`, no SQLite column), shared `ValidateMemoryText` (500-char cap + secret-pattern guard), and `RenderMemoryPromptSection` (watch/thread-priority truncation under a ~2k-token budget).
- **Agent tools** `memory_write` / `memory_forget` (`chathttp`), exempted from the autonomy gate by name (`IsWorkspaceMemoryTool`) so they work under **Watch** too — a watch-only mission can still record what it found.
- **Prompt injection** across all three paths: mission/oriagent runs (`buildTaskPrompt`), workspace chat (`buildRuntimeSystemPromptForToolCapability`), and native-CLI runs (`BuildRunExecutionPrompt`).
- **Per-run memory diff** (`workspacerun/memory_diff.go`) — both executors snapshot before/after and emit a `memory_diff` artifact; the run record shows a **"What this run learned"** card.
- **HTTP API** (`internal/memoryhttp`) — GET/POST/PUT/DELETE on `/api/workspaces/{id}/memory`.
- **Memory tab** on the workspace detail page — view/add/edit/delete with provenance, type badges, and a budget meter.
- **Docs/copy** — README Watch row + memory bullet, in-app Watch hint, API_REFERENCE section, CLAUDE.md handler list.

## Policy change

Watch is reworded to *"Read-only tools. No writes anywhere — except workspace memory."* Memory is the agent's own operational state, not an external effect; a Watch mission that can't remember what it watched is permanently amnesiac. The autonomy gate enforces this by name, checked **before** binding classification, so a hostile binding override can't re-classify or block memory tools.

## Out of scope (designated fast-follows)

- Action Center **triage writeback** (dismiss-with-reason → `feedback` entry).
- Memory **compaction/aging**.
- Per-agent private memory; group-inherited memory; Ask Ori reading memories.

## Testing

- Go unit/integration tests for the store, tools, gate exemption, prompt rendering/truncation, run diff, and the HTTP handler.
- JS module tests for the Memory tab (8/8).
- `go vet` clean; `eslint` exit 0. `go test ./...` passes except the **pre-existing** `TestSettingsEndpoint` e2e false positive (404 "agent not found", needs a seeded agent — unrelated to this change).
- **End-to-end API smoke** on an isolated server: lazy-create, `user` provenance, secret→400, edit, delete, out-of-range→404, and the on-disk file all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)