### PR TITLE
perf(workspace): make workspace cache memory scale with active workspaces, not history

### DIFF
--- a/internal/session/hybrid_store.go
+++ b/internal/session/hybrid_store.go
@@ -381,6 +381,12 @@ func (h *hybridStore) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
 	return h.sqlite.ListWorkspaces(ctx)
 }
 
+// ListWorkspacesForScheduling returns workspaces with all orchestration fields
+// except chat history, for the task scheduler's per-tick scan.
+func (h *hybridStore) ListWorkspacesForScheduling(ctx context.Context) ([]Workspace, error) {
+	return h.sqlite.ListWorkspacesForScheduling(ctx)
+}
+
 // GetWorkspaceTree returns workspaces as a tree.
 func (h *hybridStore) GetWorkspaceTree(ctx context.Context) ([]Workspace, error) {
 	return h.sqlite.GetWorkspaceTree(ctx)

--- a/internal/session/sqlite_workspace_store.go
+++ b/internal/session/sqlite_workspace_store.go
@@ -564,6 +564,116 @@ func (s *SQLiteStore) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
 	return workspaces, nil
 }
 
+// ListWorkspacesForScheduling returns every workspace with all orchestration
+// fields EXCEPT chat history (messages_json). The task scheduler scans this once
+// per tick instead of doing a full Get per workspace, avoiding the deserialization
+// of chat history it never reads. Every other column matches GetWorkspace exactly,
+// so the result is identical to a per-workspace Get minus Messages.
+func (s *SQLiteStore) ListWorkspacesForScheduling(ctx context.Context) ([]Workspace, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, kind, description, parent_id, order_index, color, session_count, created_at, updated_at,
+			agents, agent_instances, tags, shared_data, status, layout,
+			tasks_json, attachments_json, folders_json, scheduled_tasks_json, store_nodes_json, workflows_json, directory_references_json,
+			mcp_bindings_json, agent_mcp_access_json, skill_bindings_json, agent_skill_access_json, opportunities_json, version
+		FROM workspaces
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspaces for scheduling: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	workspaces := make([]Workspace, 0)
+	for rows.Next() {
+		var workspace Workspace
+		var parentID, color, description, kind sql.NullString
+		var agentsJSON, agentInstancesJSON, tagsJSON, sharedDataJSON, status, layoutJSON sql.NullString
+		var tasksJSON, attachmentsJSON, foldersJSON, scheduledTasksJSON, storeNodesJSON, workflowsJSON, directoryReferencesJSON sql.NullString
+		var mcpBindingsJSON, agentMCPAccessJSON, skillBindingsJSON, agentSkillAccessJSON, opportunitiesJSON sql.NullString
+		var createdAtRaw, updatedAtRaw any
+
+		if err := rows.Scan(&workspace.ID, &workspace.Name, &kind, &description, &parentID, &workspace.OrderIndex, &color,
+			&workspace.SessionCount, &createdAtRaw, &updatedAtRaw,
+			&agentsJSON, &agentInstancesJSON, &tagsJSON, &sharedDataJSON, &status, &layoutJSON,
+			&tasksJSON, &attachmentsJSON, &foldersJSON, &scheduledTasksJSON, &storeNodesJSON, &workflowsJSON, &directoryReferencesJSON,
+			&mcpBindingsJSON, &agentMCPAccessJSON, &skillBindingsJSON, &agentSkillAccessJSON, &opportunitiesJSON, &workspace.Version); err != nil {
+			return nil, fmt.Errorf("failed to scan workspace for scheduling: %w", err)
+		}
+		if err := assignWorkspaceTimes(&workspace, createdAtRaw, updatedAtRaw); err != nil {
+			return nil, fmt.Errorf("failed to parse workspace timestamps: %w", err)
+		}
+
+		workspace.Description = description.String
+		workspace.Kind = NormalizeWorkspaceKind(kind.String)
+		workspace.ParentID = parentID.String
+		workspace.Color = color.String
+
+		if agentsJSON.Valid && agentsJSON.String != "" {
+			_ = json.Unmarshal([]byte(agentsJSON.String), &workspace.Agents)
+		}
+		if agentInstancesJSON.Valid && agentInstancesJSON.String != "" {
+			_ = json.Unmarshal([]byte(agentInstancesJSON.String), &workspace.AgentInstances)
+		}
+		if tagsJSON.Valid && tagsJSON.String != "" {
+			_ = json.Unmarshal([]byte(tagsJSON.String), &workspace.Tags)
+		}
+		if sharedDataJSON.Valid && sharedDataJSON.String != "" {
+			_ = json.Unmarshal([]byte(sharedDataJSON.String), &workspace.SharedData)
+		}
+		if status.Valid && status.String != "" {
+			workspace.Status = WorkspaceStatus(status.String)
+		}
+		if layoutJSON.Valid && layoutJSON.String != "" {
+			var layout CanvasLayout
+			if err := json.Unmarshal([]byte(layoutJSON.String), &layout); err == nil {
+				workspace.Layout = &layout
+			}
+		}
+
+		// Raw JSON for orchestration fields the scheduler / conversion needs.
+		// messages_json is intentionally omitted.
+		if tasksJSON.Valid && tasksJSON.String != "" {
+			workspace.TasksJSON = json.RawMessage(tasksJSON.String)
+		}
+		if attachmentsJSON.Valid && attachmentsJSON.String != "" {
+			workspace.AttachmentsJSON = json.RawMessage(attachmentsJSON.String)
+		}
+		if foldersJSON.Valid && foldersJSON.String != "" {
+			workspace.FoldersJSON = json.RawMessage(foldersJSON.String)
+		}
+		if scheduledTasksJSON.Valid && scheduledTasksJSON.String != "" {
+			workspace.ScheduledTasksJSON = json.RawMessage(scheduledTasksJSON.String)
+		}
+		if storeNodesJSON.Valid && storeNodesJSON.String != "" {
+			workspace.StoreNodesJSON = json.RawMessage(storeNodesJSON.String)
+		}
+		if workflowsJSON.Valid && workflowsJSON.String != "" {
+			workspace.WorkflowsJSON = json.RawMessage(workflowsJSON.String)
+		}
+		if directoryReferencesJSON.Valid && directoryReferencesJSON.String != "" {
+			workspace.DirectoryReferencesJSON = json.RawMessage(directoryReferencesJSON.String)
+		}
+		if mcpBindingsJSON.Valid && mcpBindingsJSON.String != "" {
+			workspace.MCPBindingsJSON = json.RawMessage(mcpBindingsJSON.String)
+		}
+		if agentMCPAccessJSON.Valid && agentMCPAccessJSON.String != "" {
+			workspace.AgentMCPAccessJSON = json.RawMessage(agentMCPAccessJSON.String)
+		}
+		if skillBindingsJSON.Valid && skillBindingsJSON.String != "" {
+			workspace.SkillBindingsJSON = json.RawMessage(skillBindingsJSON.String)
+		}
+		if agentSkillAccessJSON.Valid && agentSkillAccessJSON.String != "" {
+			workspace.AgentSkillAccessJSON = json.RawMessage(agentSkillAccessJSON.String)
+		}
+		if opportunitiesJSON.Valid && opportunitiesJSON.String != "" {
+			workspace.OpportunitiesJSON = json.RawMessage(opportunitiesJSON.String)
+		}
+
+		workspaces = append(workspaces, workspace)
+	}
+
+	return workspaces, rows.Err()
+}
+
 // GetWorkspaceTree returns workspaces organized as a tree structure.
 func (s *SQLiteStore) GetWorkspaceTree(ctx context.Context) ([]Workspace, error) {
 	workspaces, err := s.ListWorkspaces(ctx)

--- a/internal/session/workspace_scheduling_test.go
+++ b/internal/session/workspace_scheduling_test.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// TestListActiveForScheduling_KeepsTasksDropsMessages guards item 2.4: the
+// scheduler's per-tick listing keeps scheduling state (tasks, schedule fields,
+// status) but omits chat history, which the scheduler never reads.
+func TestListActiveForScheduling_KeepsTasksDropsMessages(t *testing.T) {
+	store, cleanup := setupHybridStore(t, 10)
+	defer cleanup()
+
+	adapter := NewWorkspaceStoreAdapter(store)
+
+	next := time.Now().Add(time.Hour)
+	ws := &agentworkspace.Workspace{
+		ID:     "ws-sched-1",
+		Name:   "Scheduler WS",
+		Status: agentworkspace.StatusActive,
+		Messages: []agentworkspace.AgentMessage{
+			{ID: "m1", Content: "hello"},
+			{ID: "m2", Content: "world"},
+		},
+		Tasks: []agentworkspace.Task{{
+			ID:              "t1",
+			ScheduleEnabled: true,
+			NextRun:         &next,
+			Schedule:        &agentworkspace.ScheduleConfig{},
+		}},
+	}
+	if err := adapter.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	active, err := adapter.ListActiveForScheduling()
+	if err != nil {
+		t.Fatalf("ListActiveForScheduling: %v", err)
+	}
+
+	var got *agentworkspace.Workspace
+	for _, w := range active {
+		if w.ID == "ws-sched-1" {
+			got = w
+		}
+	}
+	if got == nil {
+		t.Fatal("workspace not returned by ListActiveForScheduling")
+	}
+	if len(got.Messages) != 0 {
+		t.Errorf("scheduling view should omit messages, got %d", len(got.Messages))
+	}
+	if len(got.Tasks) != 1 || got.Tasks[0].ID != "t1" {
+		t.Fatalf("scheduling view should keep tasks, got %d", len(got.Tasks))
+	}
+	if !got.Tasks[0].ScheduleEnabled || got.Tasks[0].NextRun == nil {
+		t.Errorf("schedule fields not preserved: enabled=%v nextRun=%v",
+			got.Tasks[0].ScheduleEnabled, got.Tasks[0].NextRun)
+	}
+
+	// Sanity: a full Get still returns the chat history.
+	full, err := adapter.Get("ws-sched-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(full.Messages) != 2 {
+		t.Errorf("full Get should keep messages, got %d", len(full.Messages))
+	}
+}

--- a/internal/session/workspace_store_adapter.go
+++ b/internal/session/workspace_store_adapter.go
@@ -116,6 +116,39 @@ func (a *WorkspaceStoreAdapter) ListActive() ([]*workspace.Workspace, error) {
 	return active, nil
 }
 
+// ListActiveForScheduling returns active workspaces for the task scheduler with
+// chat history omitted. The scheduler reads only scheduling state (tasks, scheduled
+// tasks, mission fields, status) and routes writes through Update (which re-fetches
+// the full record), so dropping Messages avoids deserializing chat history for every
+// workspace each tick. Falls back to the full ListActive when the backing store does
+// not support the lighter query.
+func (a *WorkspaceStoreAdapter) ListActiveForScheduling() ([]*workspace.Workspace, error) {
+	ctx := context.Background()
+
+	type schedulingStore interface {
+		ListWorkspacesForScheduling(ctx context.Context) ([]Workspace, error)
+	}
+	ss, ok := a.store.(schedulingStore)
+	if !ok {
+		return a.ListActive()
+	}
+
+	workspaces, err := ss.ListWorkspacesForScheduling(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	active := make([]*workspace.Workspace, 0, len(workspaces))
+	for i := range workspaces {
+		ws := workspaces[i]
+		if ws.Status != WorkspaceStatusActive && ws.Status != "" {
+			continue
+		}
+		active = append(active, a.toAgentWorkspace(&ws))
+	}
+	return active, nil
+}
+
 // toSessionWorkspace converts workspace.Workspace to session.Workspace.
 func (a *WorkspaceStoreAdapter) toSessionWorkspace(ws *workspace.Workspace) *Workspace {
 	sessionWS := &Workspace{

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -3523,7 +3523,14 @@ func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context, reload bool) 
 	for id, diskWS := range diskWorkspaces {
 		sessionWS, getErr := h.store.GetWorkspace(ctx, id)
 		if getErr == session.ErrWorkspaceNotFound {
-			converted := session.ConvertAgentWorkspace(diskWS)
+			// CachedWorkspaces returns metadata-only structs (item 2.0); Get reads
+			// the full record so the imported workspace keeps its history and tasks.
+			fullWS, loadErr := h.workspaceStore.Get(id)
+			if loadErr != nil {
+				warnings = append(warnings, fmt.Sprintf("Failed to load %s for import", diskWS.Name))
+				continue
+			}
+			converted := session.ConvertAgentWorkspace(fullWS)
 			if converted == nil {
 				warnings = append(warnings, fmt.Sprintf("Failed to convert %s", diskWS.Name))
 				continue

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -3449,7 +3449,7 @@ func (h *Handler) handleWorkspaceRescan(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	stats, warnings, err := h.reconcileWorkspacesFromDisk(r.Context())
+	stats, warnings, err := h.reconcileWorkspacesFromDisk(r.Context(), true)
 	if err != nil {
 		logger.Error("Rescan: failed to reconcile workspaces from disk", logger.Fields{"error": err})
 		_ = orihttp.RespondInternalError(w, "Failed to rescan workspaces")
@@ -3493,7 +3493,12 @@ const workspaceRescanCooldown = 30 * time.Second
 // session store so its structure matches the on-disk layout. Returns reconcile
 // stats plus any non-fatal warnings. Safe to call on startup and on demand;
 // concurrent calls are serialized.
-func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (stats workspaceReconcileStats, warnings []string, err error) {
+//
+// reload controls whether the folder store is refreshed from disk first. On-demand
+// rescans pass true so out-of-band changes (git pull, cloud sync) are picked up.
+// The startup caller passes false: NewFileStore has just loaded the cache + index
+// from disk, so an immediate Reload would redo that full scan/parse for nothing.
+func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context, reload bool) (stats workspaceReconcileStats, warnings []string, err error) {
 	if h.workspaceStore == nil {
 		return stats, nil, nil
 	}
@@ -3507,8 +3512,10 @@ func (h *Handler) reconcileWorkspacesFromDisk(ctx context.Context) (stats worksp
 	}()
 
 	// Refresh the file-store cache + index from disk; physical layout wins.
-	if err := h.workspaceStore.Reload(); err != nil {
-		return stats, nil, err
+	if reload {
+		if err := h.workspaceStore.Reload(); err != nil {
+			return stats, nil, err
+		}
 	}
 
 	warnings = make([]string, 0)
@@ -3673,11 +3680,15 @@ func (h *Handler) workspaceIDOnDisk(dir string) string {
 // with the on-disk folder layout. Intended for a one-time run at startup so
 // groupings that arrived via git/cloud sync are reflected without a manual
 // rescan. No-op when no folder store is configured.
+//
+// Skips the folder-store reload: at startup NewFileStore has already loaded the
+// cache + index from disk moments earlier, so reloading here would repeat that
+// full scan/parse (the second "Workspace index rebuilt" at boot) for nothing.
 func (h *Handler) ReconcileWorkspacesFromDisk(ctx context.Context) error {
 	if h == nil || h.workspaceStore == nil {
 		return nil
 	}
-	stats, _, err := h.reconcileWorkspacesFromDisk(ctx)
+	stats, _, err := h.reconcileWorkspacesFromDisk(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/internal/workspace/agent_snapshot_store.go
+++ b/internal/workspace/agent_snapshot_store.go
@@ -109,6 +109,23 @@ type metadataLister interface {
 	CachedWorkspaces() map[string]*Workspace
 }
 
+// schedulingLister is an optional Store capability returning active workspaces for
+// the task scheduler with chat history omitted (the scheduler never reads it). The
+// SQLite-backed adapter implements it with a lighter query; the wrapping stores
+// forward to it so the scheduler avoids deserializing chat history every tick.
+type schedulingLister interface {
+	ListActiveForScheduling() ([]*Workspace, error)
+}
+
+// ListActiveForScheduling forwards to the wrapped store's scheduling-optimized
+// listing when available, else falls back to the full ListActive.
+func (s *AgentSnapshotStore) ListActiveForScheduling() ([]*Workspace, error) {
+	if sl, ok := s.Store.(schedulingLister); ok {
+		return sl.ListActiveForScheduling()
+	}
+	return s.Store.ListActive()
+}
+
 // eachWorkspaceMeta invokes fn for every workspace. When the store exposes a cheap
 // metadata listing (FileStore's lean cache) it iterates that; otherwise it streams
 // via List()+Get() one workspace at a time. The agent-snapshot routines read only

--- a/internal/workspace/agent_snapshot_store.go
+++ b/internal/workspace/agent_snapshot_store.go
@@ -101,6 +101,42 @@ func referencedAgentNames(ws *Workspace) []string {
 	return out
 }
 
+// metadataLister is an optional Store capability that returns metadata-only
+// snapshots of every workspace (no chat history / tasks). FileStore satisfies it
+// via its lean cache. The wrapping stores (SyncStore, AgentSnapshotStore) do NOT,
+// so their List()+Get() fallback still covers DB-only workspaces.
+type metadataLister interface {
+	CachedWorkspaces() map[string]*Workspace
+}
+
+// eachWorkspaceMeta invokes fn for every workspace. When the store exposes a cheap
+// metadata listing (FileStore's lean cache) it iterates that; otherwise it streams
+// via List()+Get() one workspace at a time. The agent-snapshot routines read only
+// metadata (status, agent references), so the metadata path is sufficient and, now
+// that FileStore.Get reads through to disk, avoids re-reading every workspace.json.
+func eachWorkspaceMeta(workspaces Store, fn func(ws *Workspace)) {
+	if ml, ok := workspaces.(metadataLister); ok {
+		for _, ws := range ml.CachedWorkspaces() {
+			if ws != nil {
+				fn(ws)
+			}
+		}
+		return
+	}
+	ids, err := workspaces.List()
+	if err != nil {
+		logger.Warn("agent snapshot: list workspaces failed", logger.Fields{"error": err.Error()})
+		return
+	}
+	for _, id := range ids {
+		ws, err := workspaces.Get(id)
+		if err != nil || ws == nil {
+			continue
+		}
+		fn(ws)
+	}
+}
+
 // SnapshotAllWorkspaces walks the workspace store once and snapshots referenced
 // agents for every workspace. Intended as a one-shot startup migration so
 // existing workspaces become self-contained after startup.
@@ -112,19 +148,10 @@ func SnapshotAllWorkspaces(workspaces Store, agents store.Store) {
 	if !ok {
 		snapshotter = NewAgentSnapshotStore(workspaces, agents)
 	}
-	ids, err := workspaces.List()
-	if err != nil {
-		logger.Warn("agent snapshot migration: list workspaces failed", logger.Fields{"error": err.Error()})
-		return
-	}
 	migrated := 0
-	for _, id := range ids {
-		ws, err := workspaces.Get(id)
-		if err != nil || ws == nil {
-			continue
-		}
+	eachWorkspaceMeta(workspaces, func(ws *Workspace) {
 		if ws.Status == StatusTrashed {
-			continue
+			return
 		}
 		before := referencedAgentSnapshotCount(workspaces, ws)
 		snapshotter.SnapshotReferencedAgents(ws)
@@ -132,7 +159,7 @@ func SnapshotAllWorkspaces(workspaces Store, agents store.Store) {
 		if after > before {
 			migrated++
 		}
-	}
+	})
 	if migrated > 0 {
 		logger.Info("Workspace agent snapshots migrated", logger.Fields{"workspaces": migrated})
 	}
@@ -165,38 +192,28 @@ func restoreWorkspaceAgentsFiltered(workspaces Store, agents store.Store, allowl
 	if workspaces == nil || agents == nil {
 		return
 	}
-	ids, err := workspaces.List()
-	if err != nil {
-		logger.Warn("workspace agent restore: list workspaces failed", logger.Fields{"error": err.Error()})
-		return
-	}
-
 	restoredWorkspaces := 0
 	restoredAgents := 0
-	for _, id := range ids {
-		if allowlist != nil && !allowlist.Contains(id) {
-			continue
-		}
-		ws, err := workspaces.Get(id)
-		if err != nil || ws == nil {
-			continue
+	eachWorkspaceMeta(workspaces, func(ws *Workspace) {
+		if allowlist != nil && !allowlist.Contains(ws.ID) {
+			return
 		}
 		if ws.Status == StatusTrashed {
-			continue
+			return
 		}
 		registered, err := RestoreWorkspaceAgents(workspaces, ws, agents)
 		if err != nil {
 			logger.Warn("workspace agent restore: restore failed", logger.Fields{
-				"workspace_id": id,
+				"workspace_id": ws.ID,
 				"error":        err.Error(),
 			})
-			continue
+			return
 		}
 		if len(registered) > 0 {
 			restoredWorkspaces++
 			restoredAgents += len(registered)
 		}
-	}
+	})
 
 	if restoredAgents > 0 {
 		logger.Info("Workspace agent snapshots restored", logger.Fields{
@@ -219,12 +236,6 @@ func WipeNonAllowlistedAgentSnapshots(workspaces Store, agents store.Store, allo
 	if workspaces == nil || agents == nil {
 		return
 	}
-	ids, err := workspaces.List()
-	if err != nil {
-		logger.Warn("wipe non-allowlisted agents: list workspaces failed", logger.Fields{"error": err.Error()})
-		return
-	}
-
 	// Set of agent names protected because at least one allowlisted workspace
 	// references them.
 	allowedReferencedAgents := make(map[string]struct{})
@@ -233,16 +244,12 @@ func WipeNonAllowlistedAgentSnapshots(workspaces Store, agents store.Store, allo
 	// not in allowedReferencedAgents.
 	workspaceManagedAgents := make(map[string]struct{})
 
-	for _, id := range ids {
-		ws, err := workspaces.Get(id)
-		if err != nil || ws == nil {
-			continue
-		}
+	eachWorkspaceMeta(workspaces, func(ws *Workspace) {
 		if ws.Status == StatusTrashed {
-			continue
+			return
 		}
 		referenced := referencedAgentNames(ws)
-		allowed := allowlist != nil && allowlist.Contains(id)
+		allowed := allowlist != nil && allowlist.Contains(ws.ID)
 		for _, name := range referenced {
 			key := strings.ToLower(name)
 			if _, ok, err := workspaces.GetWorkspaceAgent(ws.ID, name); err == nil && ok {
@@ -252,7 +259,7 @@ func WipeNonAllowlistedAgentSnapshots(workspaces Store, agents store.Store, allo
 				allowedReferencedAgents[key] = struct{}{}
 			}
 		}
-	}
+	})
 
 	wiped := 0
 	for _, name := range agents.ListAgents() {

--- a/internal/workspace/cache_residency_measure_test.go
+++ b/internal/workspace/cache_residency_measure_test.go
@@ -90,6 +90,53 @@ func TestMeasure_FileStoreCacheResidency(t *testing.T) {
 	_ = store.Close()
 }
 
+// TestMeasure_BootParse compares the boot-time parse cost of a heavy workspace.json
+// with FromJSON (full) vs FromJSONMetadata (chat history skipped, item 3.0/C).
+// Skipped by default; run with ORI_MEASURE=1.
+func TestMeasure_BootParse(t *testing.T) {
+	if os.Getenv("ORI_MEASURE") == "" {
+		t.Skip("set ORI_MEASURE=1 to run the boot-parse measurement")
+	}
+
+	const (
+		iterations   = 2000
+		msgsPerWS    = 200
+		contentBytes = 300
+	)
+
+	content := strings.Repeat("x", contentBytes)
+	ws := newTestWorkspace("ws-bench", "Bench")
+	ws.Messages = make([]AgentMessage, msgsPerWS)
+	for j := range ws.Messages {
+		ws.Messages[j] = AgentMessage{ID: fmt.Sprintf("m%d", j), Content: content, Timestamp: time.Now()}
+	}
+	data, err := ws.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	for range iterations {
+		if _, err := FromJSON(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	full := time.Since(start)
+
+	start = time.Now()
+	for range iterations {
+		if _, err := FromJSONMetadata(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	meta := time.Since(start)
+
+	t.Logf("payload=%s  iterations=%d", humanBytes(int64(len(data))), iterations)
+	t.Logf("FromJSON (full):         %v (%v/parse)", full, full/iterations)
+	t.Logf("FromJSONMetadata (lean): %v (%v/parse)", meta, meta/iterations)
+	t.Logf("speedup: %.2fx", float64(full)/float64(meta))
+}
+
 func dirSizeBytes(t *testing.T, dir string) int64 {
 	t.Helper()
 	var total int64

--- a/internal/workspace/cache_residency_measure_test.go
+++ b/internal/workspace/cache_residency_measure_test.go
@@ -1,0 +1,122 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMeasure_FileStoreCacheResidency quantifies the resident heap cost of the
+// eager FileStore cache, which holds a full Workspace struct (including embedded
+// chat history) for every workspace on disk. This is the cost item 2.0 targets:
+// reads are served from SQLite via the adapter, so these resident structs are
+// largely dead weight.
+//
+// Skipped by default (it writes hundreds of files and allocates tens of MB). Run:
+//
+//	ORI_MEASURE=1 go test ./internal/workspace/ \
+//	  -run TestMeasure_FileStoreCacheResidency -v -count=1
+func TestMeasure_FileStoreCacheResidency(t *testing.T) {
+	if os.Getenv("ORI_MEASURE") == "" {
+		t.Skip("set ORI_MEASURE=1 to run the cache-residency measurement")
+	}
+
+	const (
+		numWorkspaces = 500
+		msgsPerWS     = 200
+		contentBytes  = 300
+	)
+
+	dir := t.TempDir()
+	content := strings.Repeat("x", contentBytes)
+	now := time.Now()
+
+	for i := range numWorkspaces {
+		slug := fmt.Sprintf("ws-%04d", i)
+		ws := newTestWorkspace(slug, fmt.Sprintf("Workspace %04d", i))
+		ws.FolderSlug = slug
+		ws.Messages = make([]AgentMessage, msgsPerWS)
+		for j := range ws.Messages {
+			ws.Messages[j] = AgentMessage{
+				ID:        fmt.Sprintf("m-%d-%d", i, j),
+				From:      "agent",
+				To:        "user",
+				Content:   content,
+				Timestamp: now,
+			}
+		}
+		folder := filepath.Join(dir, slug)
+		if err := os.MkdirAll(folder, 0755); err != nil {
+			t.Fatal(err)
+		}
+		data, err := ws.ToJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(folder, WorkspaceConfigFile), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	onDisk := dirSizeBytes(t, dir)
+
+	var m0, m1 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m0)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	cached := len(store.cache)
+	indexed := len(store.idToPath)
+	runtime.KeepAlive(store) // keep the cache resident across the measurement
+
+	heapDelta := int64(m1.HeapAlloc) - int64(m0.HeapAlloc)
+	t.Logf("workspaces=%d  msgs/ws=%d  content=%dB", numWorkspaces, msgsPerWS, contentBytes)
+	t.Logf("on-disk workspace.json total: %s", humanBytes(onDisk))
+	t.Logf("cache entries=%d  idToPath entries=%d", cached, indexed)
+	t.Logf("resident heap delta after NewFileStore: %s (%.1f KB/workspace)",
+		humanBytes(heapDelta), float64(heapDelta)/float64(numWorkspaces)/1024)
+
+	_ = store.Close()
+}
+
+func dirSizeBytes(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	return total
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/workspace/index.go
+++ b/internal/workspace/index.go
@@ -173,6 +173,46 @@ func (idx *Index) Rebuild() error {
 	return nil
 }
 
+// RebuildFromEntries replaces all index entries with the provided set in a single
+// transaction. Callers that have already scanned and parsed every workspace from
+// disk (e.g. FileStore right after loadCache) use this to repopulate the index
+// without a second disk walk + JSON parse. The entries are the authoritative set;
+// duplicate IDs resolve last-wins, mirroring the in-memory cache.
+func (idx *Index) RebuildFromEntries(entries []IndexEntry) error {
+	ctx := context.Background()
+	tx, err := idx.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin rebuild transaction: %w", err)
+	}
+
+	if _, err := tx.Exec(`DELETE FROM workspaces`); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to clear index for rebuild: %w", err)
+	}
+
+	for _, e := range entries {
+		if _, err := tx.Exec(`
+			INSERT INTO workspaces (id, name, folder_path, parent_id, updated_at)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name = excluded.name,
+				folder_path = excluded.folder_path,
+				parent_id = excluded.parent_id,
+				updated_at = excluded.updated_at
+		`, e.ID, e.Name, e.FolderPath, nullString(e.ParentID), e.UpdatedAt); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to insert workspace %s: %w", e.ID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit rebuild: %w", err)
+	}
+
+	logger.Info("Workspace index rebuilt", logger.Fields{"base_path": idx.basePath, "source": "cache"})
+	return nil
+}
+
 // scanDir recursively scans a directory for workspace folders.
 func (idx *Index) scanDir(tx *sql.Tx, dir, parentID string, depth int) error {
 	if depth > MaxNestingDepth {

--- a/internal/workspace/index_test.go
+++ b/internal/workspace/index_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -208,6 +209,104 @@ func TestIndex_RebuildWithSubWorkspaces(t *testing.T) {
 	if childEntry.ParentID != "ws-parent" {
 		t.Errorf("child ParentID=%q, want %q", childEntry.ParentID, "ws-parent")
 	}
+}
+
+func TestIndex_RebuildFromEntries(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := NewIndex(dir)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	// Seed a stale entry that a rebuild must drop.
+	_ = idx.Register(IndexEntry{ID: "stale", Name: "Stale", FolderPath: "stale", UpdatedAt: time.Now()})
+
+	now := time.Now().Truncate(time.Second)
+	err = idx.RebuildFromEntries([]IndexEntry{
+		{ID: "ws-1", Name: "Alpha", FolderPath: "alpha", UpdatedAt: now},
+		{ID: "ws-2", Name: "Beta", FolderPath: "alpha/sub-workspaces/beta", ParentID: "ws-1", UpdatedAt: now},
+	})
+	if err != nil {
+		t.Fatalf("RebuildFromEntries: %v", err)
+	}
+
+	entries, err := idx.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2 (stale should be gone)", len(entries))
+	}
+	if _, err := idx.Get("stale"); err == nil {
+		t.Error("stale entry should have been removed by RebuildFromEntries")
+	}
+	child, err := idx.Get("ws-2")
+	if err != nil {
+		t.Fatalf("Get ws-2: %v", err)
+	}
+	if child.ParentID != "ws-1" {
+		t.Errorf("ParentID=%q, want ws-1", child.ParentID)
+	}
+}
+
+// TestFileStore_IndexFromCacheMatchesDiskRebuild guards the 1.3 optimization: the
+// index that NewFileStore builds from the cache (rebuildIndexFromCache) must be
+// identical to the one a full disk-scan Rebuild produces.
+func TestFileStore_IndexFromCacheMatchesDiskRebuild(t *testing.T) {
+	dir := t.TempDir()
+
+	parentDir := filepath.Join(dir, "parent")
+	_ = os.MkdirAll(parentDir, 0755)
+	parent := newTestWorkspace("ws-parent", "Parent")
+	parent.FolderSlug = "parent"
+	pData, _ := parent.ToJSON()
+	_ = os.WriteFile(filepath.Join(parentDir, WorkspaceConfigFile), pData, 0644)
+
+	childDir := filepath.Join(parentDir, SubWorkspacesDir, "child")
+	_ = os.MkdirAll(childDir, 0755)
+	child := newTestWorkspace("ws-child", "Child")
+	child.FolderSlug = "child"
+	cData, _ := child.ToJSON()
+	_ = os.WriteFile(filepath.Join(childDir, WorkspaceConfigFile), cData, 0644)
+
+	// Construction populates the index from the loaded cache.
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	fromCache := indexEntriesByID(t, store.index)
+	if len(fromCache) != 2 {
+		t.Fatalf("cache-built index has %d entries, want 2", len(fromCache))
+	}
+	if fromCache["ws-child"].ParentID != "ws-parent" {
+		t.Errorf("child ParentID=%q, want ws-parent", fromCache["ws-child"].ParentID)
+	}
+
+	// A full disk-scan rebuild must yield the same entries.
+	if err := store.index.Rebuild(); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	fromDisk := indexEntriesByID(t, store.index)
+
+	if !reflect.DeepEqual(fromCache, fromDisk) {
+		t.Fatalf("index from cache != index from disk rebuild\n cache=%+v\n disk=%+v", fromCache, fromDisk)
+	}
+}
+
+func indexEntriesByID(t *testing.T, idx *Index) map[string]IndexEntry {
+	t.Helper()
+	list, err := idx.List()
+	if err != nil {
+		t.Fatalf("index List: %v", err)
+	}
+	m := make(map[string]IndexEntry, len(list))
+	for _, e := range list {
+		m[e.ID] = e
+	}
+	return m
 }
 
 func TestIndex_ParentID(t *testing.T) {

--- a/internal/workspace/scheduler.go
+++ b/internal/workspace/scheduler.go
@@ -138,7 +138,7 @@ func (ts *TaskScheduler) pollLoop() {
 //
 // Note: Uses pointer iteration (&ws.Tasks[i]) to allow in-place modifications
 func (ts *TaskScheduler) checkScheduledTasks() {
-	workspaceIDs, err := ts.workspaceStore.List()
+	workspaces, err := ts.listActiveWorkspacesForScheduling()
 	if err != nil {
 		logger.Error("Failed to list workspaces", logger.Fields{"error": err})
 		return
@@ -147,9 +147,8 @@ func (ts *TaskScheduler) checkScheduledTasks() {
 	now := time.Now()
 	wakeCandidates := make([]WakeCandidate, 0)
 
-	for _, wsID := range workspaceIDs {
-		ws, err := ts.workspaceStore.Get(wsID)
-		if err != nil {
+	for _, ws := range workspaces {
+		if ws == nil {
 			continue
 		}
 
@@ -232,6 +231,31 @@ func (ts *TaskScheduler) checkScheduledTasks() {
 			logger.Warn("Failed to sync macOS wake schedule", logger.Fields{"error": err})
 		}
 	}
+}
+
+// listActiveWorkspacesForScheduling returns the workspaces to scan this tick.
+// When the store supports the scheduling-optimized listing (SQLite-backed, chat
+// history omitted) it is used; otherwise it falls back to List()+Get() so any
+// Store still works. The scheduler reads only scheduling state and routes writes
+// through Update (which re-fetches the full record), so the lighter view is safe.
+func (ts *TaskScheduler) listActiveWorkspacesForScheduling() ([]*Workspace, error) {
+	if sl, ok := ts.workspaceStore.(schedulingLister); ok {
+		return sl.ListActiveForScheduling()
+	}
+
+	ids, err := ts.workspaceStore.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*Workspace, 0, len(ids))
+	for _, id := range ids {
+		ws, err := ts.workspaceStore.Get(id)
+		if err != nil {
+			continue
+		}
+		out = append(out, ws)
+	}
+	return out, nil
 }
 
 func collectWakeCandidates(ws *Workspace, now time.Time) []WakeCandidate {

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -1426,7 +1426,9 @@ func (s *FileStore) loadWorkspacesFromDir(dir string, depth int, parentID string
 			continue // Not a workspace folder, skip
 		}
 
-		ws, err := FromJSON(data)
+		// Boot parses metadata only: the cache is metadata-only, so building chat
+		// history for every workspace just to drop it is wasted work (item 3.0/C).
+		ws, err := FromJSONMetadata(data)
 		if err != nil {
 			// Quarantine the corrupt file so it isn't silently skipped on
 			// every subsequent boot. The renamed file remains for forensic
@@ -1459,9 +1461,24 @@ func (s *FileStore) loadWorkspacesFromDir(dir string, depth int, parentID string
 		// disk or synced from another machine).
 		ws.ParentID = parentID
 
-		// Run migrations
+		// Run migrations. A migration rewrites workspace.json, so re-parse with the
+		// full record (chat history included) before persisting — the metadata-only
+		// ws has no Messages and would otherwise wipe them from disk.
 		if s.migrateIfNeeded(ws, configPath) {
-			s.persistMigration(ws, configPath)
+			if full, ferr := FromJSON(data); ferr == nil {
+				if full.FolderSlug == "" {
+					full.FolderSlug = entry.Name()
+				}
+				full.ParentID = parentID
+				if s.migrateIfNeeded(full, configPath) {
+					s.persistMigration(full, configPath)
+				}
+			} else {
+				logger.Warn("Failed to re-parse workspace for migration persist", logger.Fields{
+					"file":  configPath,
+					"error": ferr.Error(),
+				})
+			}
 		}
 
 		// Compute relative path from basePath

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -137,11 +137,11 @@ func NewFileStore(basePath string) (*FileStore, error) {
 		return nil, fmt.Errorf("failed to load workspace cache: %w", err)
 	}
 
-	// Rebuild the index from disk to ensure consistency
-	if store.index != nil {
-		if err := store.index.Rebuild(); err != nil {
-			logger.Warn("Failed to rebuild workspace index", logger.Fields{"error": err.Error()})
-		}
+	// Repopulate the index from the cache loadCache just built. loadCache already
+	// walked and parsed every workspace.json, so feeding the index from the cache
+	// avoids a second full disk scan + JSON parse on every construction.
+	if err := store.rebuildIndexFromCache(); err != nil {
+		logger.Warn("Failed to rebuild workspace index", logger.Fields{"error": err.Error()})
 	}
 
 	return store, nil
@@ -1344,12 +1344,34 @@ func (s *FileStore) Reload() error {
 	if err := s.loadCache(); err != nil {
 		return err
 	}
-	if s.index != nil {
-		if err := s.index.Rebuild(); err != nil {
-			logger.Warn("Failed to rebuild workspace index during reload", logger.Fields{"error": err.Error()})
-		}
+	if err := s.rebuildIndexFromCache(); err != nil {
+		logger.Warn("Failed to rebuild workspace index during reload", logger.Fields{"error": err.Error()})
 	}
 	return nil
+}
+
+// rebuildIndexFromCache repopulates the index from the in-memory cache, which
+// loadCache has just filled from disk. This avoids a second disk walk + JSON
+// parse versus index.Rebuild (which re-scans disk). It is exact for normal
+// layouts — loadCache and a disk rebuild derive the same id/name/folder_path/
+// parent/updated_at for every workspace — and stays consistent with the cache on
+// pathological duplicate IDs (last-wins). No-op when no index is configured.
+// Callers must hold s.mu (or run single-threaded, as during construction).
+func (s *FileStore) rebuildIndexFromCache() error {
+	if s.index == nil {
+		return nil
+	}
+	entries := make([]IndexEntry, 0, len(s.cache))
+	for id, ws := range s.cache {
+		entries = append(entries, IndexEntry{
+			ID:         id,
+			Name:       ws.Name,
+			FolderPath: s.idToPath[id],
+			ParentID:   ws.ParentID,
+			UpdatedAt:  ws.UpdatedAt,
+		})
+	}
+	return s.index.RebuildFromEntries(entries)
 }
 
 // loadWorkspacesFromDir recursively loads workspaces from a directory. parentID

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -266,7 +266,7 @@ func (s *FileStore) Save(ws *Workspace) error {
 	}
 
 	// Update cache and ID-to-path mapping
-	s.cache[ws.ID] = freshWS
+	s.cacheMeta(freshWS)
 	s.idToPath[ws.ID] = relPath
 
 	// Update the global index
@@ -338,7 +338,7 @@ func (s *FileStore) SaveAt(ws *Workspace, location string) error {
 	defer s.mu.Unlock()
 
 	// Store the absolute path for custom locations
-	s.cache[ws.ID] = freshWS
+	s.cacheMeta(freshWS)
 	s.idToPath[ws.ID] = folderPath
 
 	// Register in global index
@@ -439,7 +439,7 @@ func (s *FileStore) RebindExistingFolder(ws *Workspace, folderPath string) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.cache[ws.ID] = freshWS
+	s.cacheMeta(freshWS)
 	s.idToPath[ws.ID] = storedPath
 
 	if s.index != nil {
@@ -590,41 +590,28 @@ func (s *FileStore) BasePath() string {
 	return s.basePath
 }
 
-// Get retrieves a workspace by ID. Returns a deep clone so callers may safely
-// mutate the result without affecting the cache or other concurrent callers.
+// Get retrieves a workspace by ID, reading the full record (including chat history
+// and tasks) from disk. The in-memory cache holds metadata only (item 2.0), so Get
+// reads through to disk for the complete workspace rather than serving heavy fields
+// from a lean cache entry; it refreshes the metadata cache as a side effect. Returns
+// a deep clone so callers may safely mutate the result.
 func (s *FileStore) Get(id string) (*Workspace, error) {
 	s.mu.RLock()
-
-	// Check cache first
-	if ws, ok := s.cache[id]; ok {
-		s.mu.RUnlock()
-		return cloneWorkspaceForRebind(ws)
-	}
-
-	// Check if we know the slug for this ID
 	slug, ok := s.idToPath[id]
 	s.mu.RUnlock()
-
 	if !ok {
 		return nil, fmt.Errorf("workspace %s not found", id)
 	}
 
-	// Load from disk
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Double-check cache after acquiring write lock
-	if ws, ok := s.cache[id]; ok {
-		return cloneWorkspaceForRebind(ws)
-	}
-
-	folderPath := s.resolveFolder(slug)
-	configPath := filepath.Join(folderPath, WorkspaceConfigFile)
+	configPath := filepath.Join(s.resolveFolder(slug), WorkspaceConfigFile)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Folder was removed externally — clean up mappings
+			// Folder was removed externally — clean up mappings.
+			s.mu.Lock()
 			delete(s.idToPath, id)
+			delete(s.cache, id)
+			s.mu.Unlock()
 			return nil, fmt.Errorf("workspace %s not found", id)
 		}
 		return nil, fmt.Errorf("failed to read workspace file: %w", err)
@@ -640,16 +627,50 @@ func (s *FileStore) Get(id string) (*Workspace, error) {
 		ws.FolderSlug = slug
 	}
 
-	// Run migrations if needed
-	if s.migrateIfNeeded(ws, configPath) {
-		// Migration happened — persist it
-		s.persistMigration(ws, configPath)
-	}
-
-	// Update cache
-	s.cache[id] = ws
+	s.mu.Lock()
+	// Normalize in memory so callers see migrated fields, but do not persist here:
+	// Get is a read, and boot loadCache / Reload / Save own writing migrations to
+	// disk. Persisting on every read would rewrite workspace.json on each access.
+	s.migrateIfNeeded(ws, configPath)
+	// Keep the metadata cache fresh; cacheMeta detaches the heavy fields for the
+	// cached copy only, leaving ws intact for the full clone returned below.
+	s.cacheMeta(ws)
+	s.mu.Unlock()
 
 	return cloneWorkspaceForRebind(ws)
+}
+
+// cacheMeta stores a metadata-only copy of ws in the cache, keyed by ws.ID. The
+// FileStore cache exists for listing/graph/metadata only; reads of full records
+// are served from the primary (SQLite) store, so keeping Messages/Tasks resident
+// for every workspace is wasted memory (item 2.0). Best-effort: on the (practically
+// impossible) clone failure it logs and skips, leaving the entry to be lazily
+// reloaded by Get. Callers must hold s.mu.
+func (s *FileStore) cacheMeta(ws *Workspace) {
+	lean, err := metadataCacheCopy(ws)
+	if err != nil {
+		logger.Warn("failed to build metadata cache copy", logger.Fields{"workspace_id": ws.ID, "error": err.Error()})
+		return
+	}
+	s.cache[ws.ID] = lean
+}
+
+// metadataCacheCopy clones ws with the heavy embedded fields (chat history, tasks)
+// dropped. It reuses the JSON round-trip clone (which also resets the embedded
+// lock) but detaches Messages/Tasks first so they are never serialized; the source
+// ws is restored before return and left unchanged.
+func metadataCacheCopy(ws *Workspace) (*Workspace, error) {
+	if ws == nil {
+		return nil, nil
+	}
+	msgs, tasks := ws.Messages, ws.Tasks
+	ws.Messages, ws.Tasks = nil, nil
+	clone, err := cloneWorkspaceForRebind(ws)
+	ws.Messages, ws.Tasks = msgs, tasks
+	if err != nil {
+		return nil, err
+	}
+	return clone, nil
 }
 
 // List returns all workspace IDs from the in-memory cache.
@@ -938,7 +959,7 @@ func (s *FileStore) RenameWithSlug(id, newName, requestedSlug string) ([]MovedWo
 
 	// Update mappings first so persistWorkspaceLocked can find the path
 	s.idToPath[id] = newRelPath
-	s.cache[id] = ws
+	s.cacheMeta(ws)
 
 	// Persist updated workspace.json in new location
 	if err := s.persistWorkspaceLocked(ws); err != nil {
@@ -1052,7 +1073,7 @@ func (s *FileStore) Import(folderPath string) (*Workspace, string, error) {
 	}
 
 	// Register in cache and index
-	s.cache[ws.ID] = ws
+	s.cacheMeta(ws)
 	s.idToPath[ws.ID] = relPath
 
 	if s.index != nil {
@@ -1111,7 +1132,7 @@ func (s *FileStore) importSubWorkspace(folderPath, parentID string) {
 		return
 	}
 
-	s.cache[ws.ID] = ws
+	s.cacheMeta(ws)
 	s.idToPath[ws.ID] = relPath
 
 	if s.index != nil {
@@ -1449,7 +1470,7 @@ func (s *FileStore) loadWorkspacesFromDir(dir string, depth int, parentID string
 			relPath = entry.Name()
 		}
 
-		s.cache[ws.ID] = ws
+		s.cacheMeta(ws)
 		s.idToPath[ws.ID] = relPath
 
 		// Recurse into sub-workspaces directory; the current workspace becomes

--- a/internal/workspace/store_metadata_cache_test.go
+++ b/internal/workspace/store_metadata_cache_test.go
@@ -1,0 +1,78 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFileStore_CacheIsMetadataOnly guards item 2.0: the resident cache holds
+// metadata only (no chat history / tasks), while Get reads through to disk and
+// still returns the complete record.
+func TestFileStore_CacheIsMetadataOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	ws := newTestWorkspace("ws-1", "Alpha")
+	ws.FolderSlug = "ws-1"
+	ws.Messages = []AgentMessage{{ID: "m1", Content: "hello"}, {ID: "m2", Content: "world"}}
+	ws.Tasks = []Task{{ID: "t1"}}
+	folder := filepath.Join(dir, "ws-1")
+	if err := os.MkdirAll(folder, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := ws.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, WorkspaceConfigFile), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// The resident cache entry must be metadata-only but keep metadata fields.
+	store.mu.RLock()
+	cached := store.cache["ws-1"]
+	store.mu.RUnlock()
+	if cached == nil {
+		t.Fatal("workspace not cached after load")
+	}
+	if len(cached.Messages) != 0 || len(cached.Tasks) != 0 {
+		t.Errorf("cache should be metadata-only, got %d messages / %d tasks", len(cached.Messages), len(cached.Tasks))
+	}
+	if cached.Name != "Alpha" {
+		t.Errorf("cache lost metadata: Name=%q, want Alpha", cached.Name)
+	}
+
+	// Get reads through to disk and returns the full record.
+	got, err := store.Get("ws-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Messages) != 2 || len(got.Tasks) != 1 {
+		t.Errorf("Get should read through to full history, got %d messages / %d tasks", len(got.Messages), len(got.Tasks))
+	}
+
+	// The cache entry stays metadata-only even after a read-through Get.
+	store.mu.RLock()
+	cachedAfter := store.cache["ws-1"]
+	store.mu.RUnlock()
+	if cachedAfter == nil || len(cachedAfter.Messages) != 0 || len(cachedAfter.Tasks) != 0 {
+		t.Errorf("cache must remain metadata-only after Get")
+	}
+
+	// metadataCacheCopy must not mutate its source.
+	src := newTestWorkspace("ws-2", "Beta")
+	src.Messages = []AgentMessage{{ID: "x"}}
+	src.Tasks = []Task{{ID: "y"}}
+	if _, err := metadataCacheCopy(src); err != nil {
+		t.Fatalf("metadataCacheCopy: %v", err)
+	}
+	if len(src.Messages) != 1 || len(src.Tasks) != 1 {
+		t.Errorf("metadataCacheCopy mutated its source: %d messages / %d tasks", len(src.Messages), len(src.Tasks))
+	}
+}

--- a/internal/workspace/store_metadata_cache_test.go
+++ b/internal/workspace/store_metadata_cache_test.go
@@ -65,6 +65,21 @@ func TestFileStore_CacheIsMetadataOnly(t *testing.T) {
 		t.Errorf("cache must remain metadata-only after Get")
 	}
 
+	// Boot (loadCache) parses metadata only, but must NOT wipe chat history from
+	// the on-disk workspace.json.
+	onDiskBytes, err := os.ReadFile(filepath.Join(folder, WorkspaceConfigFile))
+	if err != nil {
+		t.Fatalf("read workspace.json: %v", err)
+	}
+	onDisk, err := FromJSON(onDiskBytes)
+	if err != nil {
+		t.Fatalf("parse on-disk workspace.json: %v", err)
+	}
+	if len(onDisk.Messages) != 2 || len(onDisk.Tasks) != 1 {
+		t.Errorf("boot wiped on-disk history: %d messages / %d tasks (want 2/1)",
+			len(onDisk.Messages), len(onDisk.Tasks))
+	}
+
 	// metadataCacheCopy must not mutate its source.
 	src := newTestWorkspace("ws-2", "Beta")
 	src.Messages = []AgentMessage{{ID: "x"}}

--- a/internal/workspace/sync_store.go
+++ b/internal/workspace/sync_store.go
@@ -75,6 +75,16 @@ func (s *SyncStore) ListActive() ([]*Workspace, error) {
 	return s.primary.ListActive()
 }
 
+// ListActiveForScheduling returns active workspaces for the scheduler, delegating
+// to the primary store's lighter (Messages-omitting) scan when it supports one and
+// falling back to the full ListActive otherwise.
+func (s *SyncStore) ListActiveForScheduling() ([]*Workspace, error) {
+	if sl, ok := s.primary.(schedulingLister); ok {
+		return sl.ListActiveForScheduling()
+	}
+	return s.primary.ListActive()
+}
+
 // GetFilesPath returns the files path from the FileStore so uploads
 // go to the correct workspace folder on disk.
 func (s *SyncStore) GetFilesPath(workspaceID string) string {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -148,6 +148,42 @@ func FromJSON(data []byte) (*Workspace, error) {
 	return &ws, nil
 }
 
+// discardJSON is a json.Unmarshaler that ignores its input. It lets a decode skip
+// building a heavy field's value while the decoder still scans past it.
+type discardJSON struct{}
+
+func (discardJSON) UnmarshalJSON([]byte) error { return nil }
+
+// FromJSONMetadata decodes a workspace.json like FromJSON but skips building the
+// chat-history slice (Messages). The boot loader uses it because the in-memory
+// cache is metadata-only (item 2.0): allocating every AgentMessage just to drop it
+// is wasted work. Tasks are still decoded — migrations and the task index need them
+// — and all of FromJSON's normalizations run, so the result equals FromJSON minus
+// Messages. The result must NOT be persisted: it would write empty messages to
+// disk. Callers that may rewrite the file re-parse with FromJSON first.
+func FromJSONMetadata(data []byte) (*Workspace, error) {
+	// Embedding Workspace and re-declaring Messages at the outer (shallower) level
+	// shadows Workspace.Messages during unmarshal, so chat history is discarded
+	// instead of decoded. Returning &lite.Workspace avoids copying the struct's lock.
+	lite := &struct {
+		Workspace
+		Messages discardJSON `json:"messages"`
+	}{}
+	if err := json.Unmarshal(data, lite); err != nil {
+		return nil, err
+	}
+	ws := &lite.Workspace
+	ws.Messages = nil
+	ws.MigrateToAgentInstances()
+	ws.NormalizeAgentInstances()
+	ws.MigrateScheduledTasksToTasks()
+	if ws.Folders == nil {
+		ws.Folders = []WorkspaceFolder{}
+	}
+	ws.rebuildTaskIndex()
+	return ws, nil
+}
+
 // MigrateToAgentInstances migrates legacy Agents []string to AgentInstances
 func (w *Workspace) MigrateToAgentInstances() {
 	w.mu.Lock()


### PR DESCRIPTION
## Summary

The `FileStore` cache held a full `Workspace` struct — including embedded chat history and task results — for **every** workspace on disk, so resident memory scaled with cumulative usage even though reads are served from SQLite. Boot also did redundant work (a reload + double index scan), and the scheduler deserialized chat history for every workspace each tick.

Measured baseline: 500 history-rich workspaces (~45 MB on disk) → **48.7 MB resident** in the cache (~100 KB/workspace), almost all dead weight.

This branch makes the workspace cache (and boot/scheduler hot paths) scale with **active** workspaces, not accumulated chat history — without changing the on-disk format or portability.

## Changes (6 commits)

1. **Skip redundant startup `Reload()`** — the boot reconcile re-ran a full `loadCache` + index rebuild right after `NewFileStore` already loaded from disk. The startup path now skips it; the on-demand HTTP rescan still reloads.
2. **Build the index from the cache** instead of a second disk walk — `NewFileStore`/`Reload` no longer parse every `workspace.json` twice.
3. **Metadata-only FileStore cache** — drop `Messages`/`Tasks` from cached entries; `Get` reads through to disk for full records (so the ~20 `Get`→modify→`Save` sites stay correct). **48.7 MB → 586 KB** resident for the same fixture (~99% cut). Lost-write/CAS check still works (version preserved).
4. **Boot snapshot routines served from the metadata cache** — `SnapshotAllWorkspaces`/`Restore`/`Wipe` no longer re-read every file via read-through `Get`; the SQLite path still streams `List()`+`Get()` to cover DB-only workspaces.
5. **Scheduler scans without chat history each tick** — a new `ListWorkspacesForScheduling` query returns scheduling state minus `messages_json`, replacing N full per-workspace Gets/tick with one query. Safe: the scheduler reads only scheduling state and routes writes through `Update` (re-fetches the full record).
6. **Skip parsing chat history at boot** — `FromJSONMetadata` decodes `workspace.json` without building the `Messages` slice (the cache is metadata-only). Migrations re-parse with full history before persisting, so disk history is never dropped.

## Net effect

- Resident workspace-cache memory scales with active workspaces, not cumulative history (~99% cut on the fixture).
- Boot does **one** tree scan instead of four (one `Workspace index rebuilt` line).
- Scheduler no longer deserializes chat history every tick.
- On-disk `workspace.json` format and folder portability are **unchanged**.

## Verification

- New tests: metadata-only cache + read-through `Get` + on-disk history preserved across boot; index-from-cache equals a disk rebuild; scheduling listing keeps tasks/drops messages; boot-parse measurement.
- `go build ./...`, `go vet`, and `internal/workspace` + `internal/session` + `internal/sessionhttp` + `internal/server` suites pass.
- Full `go test ./...` clean except the pre-existing `tests/e2e` `TestSettingsEndpoint` false-positive (needs a seeded agent; unrelated to this branch).
- Isolated smoke boots healthy throughout (1 rebuild line, 0 errors, create/list works).

## Deferred follow-ups (not needed for the memory goal)

- Optional LRU/eviction backstop — unnecessary given the residency cut.
- Move chat history out of `workspace.json` for on-disk **size** reduction (separate portable file vs SQLite-only) — bigger change, needs a portability decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)