### PR TITLE
feat: plugin support (Claude Code- & Codex-compatible plugins)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,6 @@ workspace_allowlist.json
 agents/*/agent_settings.json
 agents/*/workspace/
 internal/server/agents/
-internal/pluginhttp/
 
 # Session data
 .claude-sessions/

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,86 @@
+# Plugins
+
+Ori can install **Claude Code-** and **Codex-compatible plugins** — bundles that
+package MCP servers and skills (and, in those ecosystems, commands/agents/hooks).
+A plugin is a **packaging layer over Ori's existing MCP + skills primitives**, not a
+return of the old gRPC plugin system: installing one registers its MCP servers in
+Ori's MCP registry and drops its skills into a scanned skills directory.
+
+## Installing a plugin
+
+**From the UI** — open **Plugins** in the sidebar:
+- Paste a **local path** or **git URL** under *Install a plugin*, click **Preview**,
+  review what it will register, then **Confirm install**.
+- Or **add a marketplace** (git URL / local folder) and install a listed plugin by name.
+
+**From the API:**
+```
+# Preview (no changes) — returns the trust disclosure
+POST /api/plugins/install     {"source": "<path|git>", "confirm": false}
+# Install
+POST /api/plugins/install     {"source": "<path|git>", "confirm": true}
+GET  /api/plugins                                  # list installed
+POST /api/plugins/{name}/enable | /disable         # per-workspace binding state
+DELETE /api/plugins/{name}                         # uninstall (removes all components)
+
+# Marketplaces
+GET  /api/plugins/marketplaces
+POST /api/plugins/marketplaces            {"source": "<path|git>"}
+POST /api/plugins/marketplaces/install    {"marketplace": "...", "plugin": "...", "confirm": true}
+```
+
+## Trust
+
+Before anything is registered, install shows a **disclosure**: the exact commands each
+MCP server will run, the skills it adds, any unsupported components, and warnings (e.g. a
+missing binary). Nothing is registered until you confirm; declining makes **no changes**.
+
+## Supported components
+
+| Component | Status |
+|-----------|--------|
+| MCP servers (`.mcp.json`) | ✅ registered |
+| Skills (`skills/<name>/SKILL.md`) | ✅ installed (discovered by Ori) |
+| Slash commands (`commands/`) | ⏸ recognized, **skipped + reported** (not yet registered) |
+| Agents (`agents/`) | ⏸ recognized, skipped + reported |
+| Hooks (`hooks/`) | ⏸ recognized, skipped + reported |
+| Codex app connectors (`.app.json`) | ⏸ metadata only |
+
+Unsupported components never fail an install — they're listed in the trust disclosure and
+on the plugin's entry.
+
+## Plugin layout
+
+**Claude Code:**
+```
+my-plugin/
+├── .claude-plugin/plugin.json     # name (required), version, description, …
+├── .mcp.json                      # { "<server>": { "command": "${CLAUDE_PLUGIN_ROOT}/bin/x", "args": [] } }
+└── skills/<name>/SKILL.md
+```
+
+**Codex** (also supports a versioned `<plugin>/<version>/` layout):
+```
+my-plugin/
+├── .codex-plugin/plugin.json      # name, version, "mcpServers": "./.mcp.json", "skills": "./skills/", "interface": {…}
+├── .mcp.json                      # { "mcpServers": { "<server>": { "command": "./bin/x", "cwd": "." } } }
+└── skills/<name>/SKILL.md
+```
+
+Ori normalizes both formats into one internal descriptor. Notable differences it handles:
+the `.mcp.json` shape (Codex wraps servers under `mcpServers`; Claude uses a bare keyed
+map), and the plugin-root model (Claude's `${CLAUDE_PLUGIN_ROOT}` vs. Codex relative
+command + `cwd`, which Ori resolves to an absolute command).
+
+## Binary delivery
+
+Ori runs whatever command a plugin's `.mcp.json` specifies; it does **not** build the
+binary. If the resolved command is missing or not executable, the plugin still installs but
+the server is marked **"unavailable — binary missing"** until you provide the binary
+(prebuilt, `go build`, or a downloaded release) and re-enable it.
+
+## Component ownership & uninstall
+
+Plugin-registered MCP servers and skills are **owned by the plugin** (managed via
+install/uninstall, not edited directly). Uninstall removes every component the plugin
+registered, recorded at install time, leaving no orphans.

--- a/internal/plugin/adapter.go
+++ b/internal/plugin/adapter.go
@@ -1,0 +1,172 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Normalize converts a located manifest into a PluginDescriptor, reading the
+// plugin's .mcp.json and skills/ directory and recording unsupported components.
+func Normalize(m locatedManifest, sourceLocation string) (PluginDescriptor, error) {
+	d := PluginDescriptor{
+		Name:           m.raw.Name,
+		Version:        m.raw.Version,
+		Description:    m.raw.Description,
+		Author:         authorName(m.raw.Author),
+		Homepage:       m.raw.Homepage,
+		Repository:     m.raw.Repository,
+		Keywords:       m.raw.Keywords,
+		SourceFormat:   m.format,
+		SourceLocation: sourceLocation,
+		InstallDir:     m.root,
+	}
+
+	servers, err := loadMCPServers(m)
+	if err != nil {
+		return PluginDescriptor{}, err
+	}
+	d.MCPServers = servers
+	d.Skills = loadSkills(m)
+
+	if m.raw.Interface != nil {
+		d.Interface = &InterfaceMetadata{
+			DisplayName:      m.raw.Interface.DisplayName,
+			ShortDescription: m.raw.Interface.ShortDescription,
+			LongDescription:  m.raw.Interface.LongDescription,
+			Category:         m.raw.Interface.Category,
+			Logo:             m.raw.Interface.Logo,
+			DefaultPrompt:    m.raw.Interface.DefaultPrompt,
+		}
+	}
+
+	d.Unsupported = collectUnsupported(m)
+	return d, nil
+}
+
+// loadMCPServers resolves the manifest's mcpServers declaration, which may be:
+//   - a path string ("./.mcp.json"), Codex-style;
+//   - an inline object, Claude inline-style; or
+//   - absent, in which case a root .mcp.json is auto-discovered.
+//
+// The .mcp.json file itself may be a bare keyed map (Claude) or wrapped under a
+// "mcpServers" key (Codex).
+func loadMCPServers(m locatedManifest) ([]MCPServerSpec, error) {
+	if raw := m.raw.MCPServers; len(raw) > 0 {
+		if path, ok := jsonString(raw); ok {
+			return readMCPFile(filepath.Join(m.root, filepath.Clean(path)))
+		}
+		return parseMCPMap(raw)
+	}
+	def := filepath.Join(m.root, ".mcp.json")
+	if fileExists(def) {
+		return readMCPFile(def)
+	}
+	return nil, nil
+}
+
+func readMCPFile(path string) ([]MCPServerSpec, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path within a user-provided plugin directory
+	if err != nil {
+		return nil, fmt.Errorf("plugin: read mcp config %s: %w", path, err)
+	}
+	// Codex-style wrapper: {"mcpServers": {...}}.
+	var wrapped struct {
+		MCPServers json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.MCPServers) > 0 {
+		return parseMCPMap(wrapped.MCPServers)
+	}
+	// Claude-style bare keyed map.
+	return parseMCPMap(data)
+}
+
+type rawMCPServer struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env"`
+	Cwd     string            `json:"cwd"`
+}
+
+func parseMCPMap(raw json.RawMessage) ([]MCPServerSpec, error) {
+	var mm map[string]rawMCPServer
+	if err := json.Unmarshal(raw, &mm); err != nil {
+		return nil, fmt.Errorf("plugin: parse mcp servers: %w", err)
+	}
+	out := make([]MCPServerSpec, 0, len(mm))
+	for name, s := range mm {
+		out = append(out, MCPServerSpec{
+			Name:    name,
+			Command: s.Command,
+			Args:    s.Args,
+			Env:     s.Env,
+			Cwd:     s.Cwd,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func loadSkills(m locatedManifest) []SkillSpec {
+	skillsDir := filepath.Join(m.root, "skills")
+	if path, ok := jsonString(m.raw.Skills); ok && strings.TrimSpace(path) != "" {
+		skillsDir = filepath.Join(m.root, filepath.Clean(path))
+	}
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+	var out []SkillSpec
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(skillsDir, e.Name())
+		if fileExists(filepath.Join(dir, "SKILL.md")) {
+			out = append(out, SkillSpec{Name: e.Name(), Path: dir})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func collectUnsupported(m locatedManifest) []UnsupportedComponent {
+	var out []UnsupportedComponent
+	if hasComponent(m.raw.Commands) || dirHasFiles(filepath.Join(m.root, "commands")) {
+		out = append(out, UnsupportedComponent{Kind: "command", Detail: "slash commands are not yet registered (P2)"})
+	}
+	if hasComponent(m.raw.Agents) || dirHasFiles(filepath.Join(m.root, "agents")) {
+		out = append(out, UnsupportedComponent{Kind: "agent", Detail: "agents are not yet registered (P2)"})
+	}
+	if hasComponent(m.raw.Hooks) || fileExists(filepath.Join(m.root, "hooks", "hooks.json")) {
+		out = append(out, UnsupportedComponent{Kind: "hook", Detail: "hooks are not yet executed (P3)"})
+	}
+	if fileExists(filepath.Join(m.root, ".app.json")) {
+		out = append(out, UnsupportedComponent{Kind: "app-connector", Detail: "Codex app connectors are metadata-only"})
+	}
+	return out
+}
+
+func jsonString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	return "", false
+}
+
+func hasComponent(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s != "" && s != "null"
+}
+
+func dirHasFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
+}

--- a/internal/plugin/descriptor.go
+++ b/internal/plugin/descriptor.go
@@ -1,0 +1,77 @@
+// Package plugin installs Claude Code- and Codex-compatible plugins into Ori.
+//
+// A plugin is a packaging layer over Ori's existing MCP + skills primitives:
+// installing one resolves an external bundle, normalizes its manifest into a
+// PluginDescriptor, and (elsewhere) registers the supported components through
+// mechanisms Ori already has. It is NOT a runtime-extension protocol — the old
+// gRPC plugin system is not revived here.
+package plugin
+
+// SourceFormat identifies which external plugin packaging format a bundle uses.
+type SourceFormat string
+
+const (
+	// FormatClaude is the Claude Code packaging format (.claude-plugin/plugin.json).
+	FormatClaude SourceFormat = "claude"
+	// FormatCodex is the Codex packaging format (.codex-plugin/plugin.json).
+	FormatCodex SourceFormat = "codex"
+)
+
+// PluginDescriptor is Ori's normalized, format-agnostic view of a plugin,
+// produced from a Claude Code or Codex manifest before component registration.
+type PluginDescriptor struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	Homepage    string   `json:"homepage,omitempty"`
+	Repository  string   `json:"repository,omitempty"`
+	Keywords    []string `json:"keywords,omitempty"`
+
+	SourceFormat   SourceFormat `json:"source_format"`
+	SourceLocation string       `json:"source_location,omitempty"`
+	InstallDir     string       `json:"install_dir"`
+
+	MCPServers  []MCPServerSpec        `json:"mcp_servers,omitempty"`
+	Skills      []SkillSpec            `json:"skills,omitempty"`
+	Interface   *InterfaceMetadata     `json:"interface,omitempty"`
+	Unsupported []UnsupportedComponent `json:"unsupported,omitempty"`
+}
+
+// MCPServerSpec is one MCP server declared by a plugin, before resolution to a
+// runtime mcp.ServerConfig. Cwd is the raw working directory from the manifest
+// (Codex uses relative Command + Cwd); the installer resolves Cwd + a relative
+// Command into an absolute command, since mcp.ServerConfig has no cwd field.
+type MCPServerSpec struct {
+	Name    string            `json:"name"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Cwd     string            `json:"cwd,omitempty"`
+}
+
+// SkillSpec points at a skill directory (containing SKILL.md) bundled by a plugin.
+type SkillSpec struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// InterfaceMetadata holds Codex presentation metadata (the manifest "interface"
+// block). It is display-only; the capability itself is delivered via the
+// plugin's MCP server.
+type InterfaceMetadata struct {
+	DisplayName      string   `json:"display_name,omitempty"`
+	ShortDescription string   `json:"short_description,omitempty"`
+	LongDescription  string   `json:"long_description,omitempty"`
+	Category         string   `json:"category,omitempty"`
+	Logo             string   `json:"logo,omitempty"`
+	DefaultPrompt    []string `json:"default_prompt,omitempty"`
+}
+
+// UnsupportedComponent records a component Ori does not yet register (commands,
+// agents, hooks, Codex app connectors) so install can skip-and-report it rather
+// than fail.
+type UnsupportedComponent struct {
+	Kind   string `json:"kind"`
+	Detail string `json:"detail,omitempty"`
+}

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -1,0 +1,12 @@
+package plugin
+
+import "errors"
+
+var (
+	// ErrNoManifest means neither a Claude nor a Codex plugin manifest was found.
+	ErrNoManifest = errors.New("plugin: no .claude-plugin/plugin.json or .codex-plugin/plugin.json found")
+	// ErrNoName means the manifest is missing the required name field.
+	ErrNoName = errors.New(`plugin: manifest missing required "name" field`)
+	// ErrEmptySource means no plugin source was provided.
+	ErrEmptySource = errors.New("plugin: empty source")
+)

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -1,0 +1,74 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+)
+
+// MCPRegistrar registers and removes MCP servers. It is satisfied by an adapter
+// over Ori's MCP config manager + runtime registry, wired during server setup
+// (task 4.x). Keeping it an interface lets the installer be unit-tested without
+// a live server.
+type MCPRegistrar interface {
+	AddServer(cfg mcp.ServerConfig) error
+	RemoveServer(name string) error
+}
+
+// SkillInstaller makes a plugin's skill directory discoverable by Ori and
+// removes it on uninstall. Satisfied by an adapter over the skills manager
+// (task 4.x).
+type SkillInstaller interface {
+	InstallSkill(pluginName, skillName, srcDir string) error
+	RemoveSkill(pluginName, skillName string) error
+}
+
+// RegisterResult reports what an install registered, plus non-fatal warnings.
+type RegisterResult struct {
+	MCPServers     []string               // namespaced server names registered
+	Skills         []string               // skill names registered
+	BinaryWarnings []string               // servers whose command is missing/not executable
+	Unsupported    []UnsupportedComponent // components skipped-and-reported
+}
+
+// Register registers a descriptor's Phase-1 components (MCP servers + skills)
+// through the injected registrar/installer. Components are registered disabled;
+// the trust gate and per-workspace binding (task 3.x) enable them. On any
+// failure the partial registration is rolled back so install is transactional.
+func Register(d PluginDescriptor, reg MCPRegistrar, skills SkillInstaller) (RegisterResult, error) {
+	var res RegisterResult
+	res.Unsupported = d.Unsupported
+
+	for _, spec := range d.MCPServers {
+		cfg := ToServerConfig(d.Name, spec, d.InstallDir)
+		if !CommandAvailable(cfg.Command) {
+			res.BinaryWarnings = append(res.BinaryWarnings,
+				fmt.Sprintf("%s: command %q not found or not executable — install the binary, then re-enable", cfg.Name, cfg.Command))
+		}
+		if err := reg.AddServer(cfg); err != nil {
+			rollback(reg, skills, d.Name, res)
+			return RegisterResult{}, fmt.Errorf("plugin %q: register MCP server %q: %w", d.Name, cfg.Name, err)
+		}
+		res.MCPServers = append(res.MCPServers, cfg.Name)
+	}
+
+	for _, s := range d.Skills {
+		if err := skills.InstallSkill(d.Name, s.Name, s.Path); err != nil {
+			rollback(reg, skills, d.Name, res)
+			return RegisterResult{}, fmt.Errorf("plugin %q: install skill %q: %w", d.Name, s.Name, err)
+		}
+		res.Skills = append(res.Skills, s.Name)
+	}
+
+	return res, nil
+}
+
+// rollback removes whatever was registered so far (best effort).
+func rollback(reg MCPRegistrar, skills SkillInstaller, pluginName string, res RegisterResult) {
+	for _, name := range res.MCPServers {
+		_ = reg.RemoveServer(name)
+	}
+	for _, name := range res.Skills {
+		_ = skills.RemoveSkill(pluginName, name)
+	}
+}

--- a/internal/plugin/lifecycle.go
+++ b/internal/plugin/lifecycle.go
@@ -1,0 +1,98 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrInstallDeclined is returned when the trust prompt is declined.
+var ErrInstallDeclined = errors.New("plugin: installation declined at trust prompt")
+
+// Manager performs plugin install/uninstall against injected component
+// registrars and the installed-plugins store. The concrete registrar/installer
+// adapters over Ori's live MCP and skills managers are wired during server
+// setup (task 4.x).
+type Manager struct {
+	reg      MCPRegistrar
+	skills   SkillInstaller
+	store    *Store
+	cloneDir string
+}
+
+// NewManager builds a plugin manager. cloneDir is where git sources are cloned.
+func NewManager(reg MCPRegistrar, skills SkillInstaller, store *Store, cloneDir string) *Manager {
+	return &Manager{reg: reg, skills: skills, store: store, cloneDir: cloneDir}
+}
+
+// Install resolves, discloses, confirms, and registers a plugin. Declining the
+// trust prompt makes no changes. On success the plugin is recorded in the store,
+// disabled — enabling happens per workspace (task 4.x).
+func (m *Manager) Install(source string, prefer SourceFormat, confirm ConfirmFunc) (InstalledPlugin, error) {
+	d, err := Load(source, m.cloneDir, prefer)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+
+	if confirm != nil && !confirm(BuildTrustReport(d)) {
+		return InstalledPlugin{}, ErrInstallDeclined
+	}
+
+	res, err := Register(d, m.reg, m.skills)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+
+	p := InstalledPlugin{
+		Name:        d.Name,
+		Version:     d.Version,
+		Description: d.Description,
+		Source:      source,
+		Format:      d.SourceFormat,
+		InstallDir:  d.InstallDir,
+		MCPServers:  res.MCPServers,
+		Skills:      res.Skills,
+		Enabled:     false,
+		InstalledAt: time.Now().UTC(),
+	}
+	if err := m.store.Put(p); err != nil {
+		// Couldn't record the install — undo the registration so we don't leave
+		// orphaned components the store doesn't know about.
+		rollback(m.reg, m.skills, d.Name, RegisterResult{MCPServers: res.MCPServers, Skills: res.Skills})
+		return InstalledPlugin{}, fmt.Errorf("plugin: record install: %w", err)
+	}
+	return p, nil
+}
+
+// SetEnabled toggles a plugin's enabled state in the store.
+func (m *Manager) SetEnabled(name string, enabled bool) error {
+	return m.store.SetEnabled(name, enabled)
+}
+
+// List returns installed plugins.
+func (m *Manager) List() ([]InstalledPlugin, error) {
+	return m.store.List()
+}
+
+// Uninstall removes a plugin's registered components and its store entry,
+// reversing the install exactly via the recorded component IDs.
+func (m *Manager) Uninstall(name string) error {
+	p, ok, err := m.store.Get(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("plugin: %q not installed", name)
+	}
+	for _, srv := range p.MCPServers {
+		if err := m.reg.RemoveServer(srv); err != nil {
+			return fmt.Errorf("plugin %q: remove server %q: %w", name, srv, err)
+		}
+	}
+	for _, sk := range p.Skills {
+		if err := m.skills.RemoveSkill(name, sk); err != nil {
+			return fmt.Errorf("plugin %q: remove skill %q: %w", name, sk, err)
+		}
+	}
+	return m.store.Delete(name)
+}

--- a/internal/plugin/lifecycle.go
+++ b/internal/plugin/lifecycle.go
@@ -14,15 +14,24 @@ var ErrInstallDeclined = errors.New("plugin: installation declined at trust prom
 // adapters over Ori's live MCP and skills managers are wired during server
 // setup (task 4.x).
 type Manager struct {
-	reg      MCPRegistrar
-	skills   SkillInstaller
-	store    *Store
-	cloneDir string
+	reg          MCPRegistrar
+	skills       SkillInstaller
+	store        *Store
+	marketplaces *MarketplaceStore
+	cloneDir     string
 }
 
-// NewManager builds a plugin manager. cloneDir is where git sources are cloned.
-func NewManager(reg MCPRegistrar, skills SkillInstaller, store *Store, cloneDir string) *Manager {
-	return &Manager{reg: reg, skills: skills, store: store, cloneDir: cloneDir}
+// NewManager builds a plugin manager backed by the managed pluginsDir (which
+// holds the installed-plugins registry and marketplace records). cloneDir is
+// where git sources are cloned.
+func NewManager(reg MCPRegistrar, skills SkillInstaller, pluginsDir, cloneDir string) *Manager {
+	return &Manager{
+		reg:          reg,
+		skills:       skills,
+		store:        NewStore(pluginsDir),
+		marketplaces: NewMarketplaceStore(pluginsDir),
+		cloneDir:     cloneDir,
+	}
 }
 
 // Install resolves, discloses, confirms, and registers a plugin. Declining the

--- a/internal/plugin/lifecycle.go
+++ b/internal/plugin/lifecycle.go
@@ -64,6 +64,16 @@ func (m *Manager) Install(source string, prefer SourceFormat, confirm ConfirmFun
 	return p, nil
 }
 
+// Preview resolves a source and returns its trust report without installing or
+// registering anything — used to render the disclosure before confirmation.
+func (m *Manager) Preview(source string, prefer SourceFormat) (TrustReport, error) {
+	d, err := Load(source, m.cloneDir, prefer)
+	if err != nil {
+		return TrustReport{}, err
+	}
+	return BuildTrustReport(d), nil
+}
+
 // SetEnabled toggles a plugin's enabled state in the store.
 func (m *Manager) SetEnabled(name string, enabled bool) error {
 	return m.store.SetEnabled(name, enabled)

--- a/internal/plugin/lifecycle.go
+++ b/internal/plugin/lifecycle.go
@@ -115,3 +115,113 @@ func (m *Manager) Uninstall(name string) error {
 	}
 	return m.store.Delete(name)
 }
+
+// UpdatePreview re-resolves an installed plugin from its source and returns the
+// trust report plus whether the set of registered components changed.
+func (m *Manager) UpdatePreview(name string) (TrustReport, bool, error) {
+	existing, ok, err := m.store.Get(name)
+	if err != nil {
+		return TrustReport{}, false, err
+	}
+	if !ok {
+		return TrustReport{}, false, fmt.Errorf("plugin: %q not installed", name)
+	}
+	d, err := m.reload(existing)
+	if err != nil {
+		return TrustReport{}, false, err
+	}
+	return BuildTrustReport(d), componentsChanged(existing, d), nil
+}
+
+// Update reinstalls a plugin from its recorded source (re-pulling git sources),
+// re-running the trust prompt when the registered component set changed.
+func (m *Manager) Update(name string, confirm ConfirmFunc) (InstalledPlugin, error) {
+	existing, ok, err := m.store.Get(name)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+	if !ok {
+		return InstalledPlugin{}, fmt.Errorf("plugin: %q not installed", name)
+	}
+	d, err := m.reload(existing)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+	if componentsChanged(existing, d) && confirm != nil && !confirm(BuildTrustReport(d)) {
+		return InstalledPlugin{}, ErrInstallDeclined
+	}
+
+	// Reinstall: remove the previously-registered components, then register the
+	// refreshed set.
+	for _, srv := range existing.MCPServers {
+		_ = m.reg.RemoveServer(srv)
+	}
+	for _, sk := range existing.Skills {
+		_ = m.skills.RemoveSkill(name, sk)
+	}
+	res, err := Register(d, m.reg, m.skills)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+
+	updated := InstalledPlugin{
+		Name:        d.Name,
+		Version:     d.Version,
+		Description: d.Description,
+		Source:      existing.Source,
+		Format:      d.SourceFormat,
+		InstallDir:  d.InstallDir,
+		MCPServers:  res.MCPServers,
+		Skills:      res.Skills,
+		Enabled:     existing.Enabled,
+		InstalledAt: existing.InstalledAt,
+	}
+	if err := m.store.Put(updated); err != nil {
+		return InstalledPlugin{}, fmt.Errorf("plugin: record update: %w", err)
+	}
+	return updated, nil
+}
+
+// reload re-resolves a descriptor for an installed plugin, refreshing git clones.
+func (m *Manager) reload(existing InstalledPlugin) (PluginDescriptor, error) {
+	if isGitURL(existing.Source) {
+		if err := pullGit(existing.InstallDir); err != nil {
+			return PluginDescriptor{}, err
+		}
+	}
+	mfst, err := DetectManifest(existing.InstallDir, existing.Format)
+	if err != nil {
+		return PluginDescriptor{}, err
+	}
+	return Normalize(mfst, existing.Source)
+}
+
+// componentsChanged reports whether the descriptor's registered component set
+// differs from what the plugin previously registered.
+func componentsChanged(existing InstalledPlugin, d PluginDescriptor) bool {
+	servers := make([]string, 0, len(d.MCPServers))
+	for _, s := range d.MCPServers {
+		servers = append(servers, NamespacedServerName(d.Name, s.Name))
+	}
+	skills := make([]string, 0, len(d.Skills))
+	for _, s := range d.Skills {
+		skills = append(skills, s.Name)
+	}
+	return !sameStringSet(existing.MCPServers, servers) || !sameStringSet(existing.Skills, skills)
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]bool, len(a))
+	for _, x := range a {
+		set[x] = true
+	}
+	for _, x := range b {
+		if !set[x] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plugin/lifecycle_test.go
+++ b/internal/plugin/lifecycle_test.go
@@ -54,8 +54,7 @@ func TestManagerInstallAndUninstall(t *testing.T) {
 	root := makeClaudeBundle(t)
 	reg := &fakeRegistrar{}
 	sk := &fakeSkills{}
-	store := NewStore(t.TempDir())
-	m := NewManager(reg, sk, store, "")
+	m := NewManager(reg, sk, t.TempDir(), "")
 
 	confirmed := false
 	p, err := m.Install(root, "", func(TrustReport) bool { confirmed = true; return true })
@@ -71,7 +70,7 @@ func TestManagerInstallAndUninstall(t *testing.T) {
 	if _, ok := reg.added["reaper/ori-reaper"]; !ok {
 		t.Errorf("server not registered: %v", reg.added)
 	}
-	if list, _ := store.List(); len(list) != 1 {
+	if list, _ := m.List(); len(list) != 1 {
 		t.Errorf("store should have 1 entry, got %d", len(list))
 	}
 
@@ -81,7 +80,7 @@ func TestManagerInstallAndUninstall(t *testing.T) {
 	if len(reg.added) != 0 {
 		t.Errorf("server not removed on uninstall: %v", reg.added)
 	}
-	if list, _ := store.List(); len(list) != 0 {
+	if list, _ := m.List(); len(list) != 0 {
 		t.Errorf("store entry not removed, got %d", len(list))
 	}
 }
@@ -90,8 +89,7 @@ func TestManagerInstallDeclinedMakesNoChanges(t *testing.T) {
 	root := makeClaudeBundle(t)
 	reg := &fakeRegistrar{}
 	sk := &fakeSkills{}
-	store := NewStore(t.TempDir())
-	m := NewManager(reg, sk, store, "")
+	m := NewManager(reg, sk, t.TempDir(), "")
 
 	_, err := m.Install(root, "", func(TrustReport) bool { return false })
 	if !errors.Is(err, ErrInstallDeclined) {
@@ -100,7 +98,7 @@ func TestManagerInstallDeclinedMakesNoChanges(t *testing.T) {
 	if len(reg.added) != 0 {
 		t.Error("declined install must register nothing")
 	}
-	if list, _ := store.List(); len(list) != 0 {
+	if list, _ := m.List(); len(list) != 0 {
 		t.Error("declined install must record nothing")
 	}
 }

--- a/internal/plugin/lifecycle_test.go
+++ b/internal/plugin/lifecycle_test.go
@@ -127,3 +127,37 @@ func TestBuildTrustReport(t *testing.T) {
 		t.Error("disclosure string should not be empty")
 	}
 }
+
+func TestManagerUpdate(t *testing.T) {
+	root := makeClaudeBundle(t)
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+	m := NewManager(reg, sk, t.TempDir(), "")
+	if _, err := m.Install(root, "", func(TrustReport) bool { return true }); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// A no-change update keeps the server registered and reports no change.
+	if _, changed, err := m.UpdatePreview("reaper"); err != nil || changed {
+		t.Errorf("no-op update preview: changed=%v err=%v", changed, err)
+	}
+	if _, err := m.Update("reaper", func(TrustReport) bool { return true }); err != nil {
+		t.Fatalf("update (no change): %v", err)
+	}
+	if _, ok := reg.added["reaper/ori-reaper"]; !ok {
+		t.Error("server missing after no-op update")
+	}
+
+	// Add a skill to the bundle; update detects the change and records it.
+	writeFile(t, filepath.Join(root, "skills", "extra", "SKILL.md"), "---\nname: extra\n---\n")
+	if _, changed, err := m.UpdatePreview("reaper"); err != nil || !changed {
+		t.Fatalf("expected changed=true after adding a skill: changed=%v err=%v", changed, err)
+	}
+	if _, err := m.Update("reaper", func(TrustReport) bool { return true }); err != nil {
+		t.Fatalf("update (changed): %v", err)
+	}
+	list, _ := m.List()
+	if len(list) != 1 || len(list[0].Skills) != 2 {
+		t.Errorf("expected 2 skills after update, got %+v", list)
+	}
+}

--- a/internal/plugin/lifecycle_test.go
+++ b/internal/plugin/lifecycle_test.go
@@ -1,0 +1,131 @@
+package plugin
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func makeClaudeBundle(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"reaper","version":"0.1.0"}`)
+	writeFile(t, filepath.Join(root, ".mcp.json"), `{"ori-reaper":{"command":"/usr/bin/true"}}`)
+	writeFile(t, filepath.Join(root, "skills", "reaper-session-setup", "SKILL.md"), "---\nname: x\n---\n")
+	return root
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if list, _ := s.List(); len(list) != 0 {
+		t.Fatalf("new store should be empty, got %d", len(list))
+	}
+	p := InstalledPlugin{
+		Name:       "reaper",
+		Format:     FormatClaude,
+		MCPServers: []string{"reaper/ori-reaper"},
+		Skills:     []string{"reaper-session-setup"},
+	}
+	if err := s.Put(p); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Get("reaper")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if len(got.MCPServers) != 1 {
+		t.Errorf("servers = %v", got.MCPServers)
+	}
+	if err := s.SetEnabled("reaper", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, _, _ = s.Get("reaper"); !got.Enabled {
+		t.Error("expected enabled after SetEnabled")
+	}
+	if err := s.Delete("reaper"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.Get("reaper"); ok {
+		t.Error("expected plugin gone after Delete")
+	}
+}
+
+func TestManagerInstallAndUninstall(t *testing.T) {
+	root := makeClaudeBundle(t)
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+	store := NewStore(t.TempDir())
+	m := NewManager(reg, sk, store, "")
+
+	confirmed := false
+	p, err := m.Install(root, "", func(TrustReport) bool { confirmed = true; return true })
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !confirmed {
+		t.Error("confirm callback not invoked")
+	}
+	if p.Enabled {
+		t.Error("installed plugin should start disabled")
+	}
+	if _, ok := reg.added["reaper/ori-reaper"]; !ok {
+		t.Errorf("server not registered: %v", reg.added)
+	}
+	if list, _ := store.List(); len(list) != 1 {
+		t.Errorf("store should have 1 entry, got %d", len(list))
+	}
+
+	if err := m.Uninstall("reaper"); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if len(reg.added) != 0 {
+		t.Errorf("server not removed on uninstall: %v", reg.added)
+	}
+	if list, _ := store.List(); len(list) != 0 {
+		t.Errorf("store entry not removed, got %d", len(list))
+	}
+}
+
+func TestManagerInstallDeclinedMakesNoChanges(t *testing.T) {
+	root := makeClaudeBundle(t)
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+	store := NewStore(t.TempDir())
+	m := NewManager(reg, sk, store, "")
+
+	_, err := m.Install(root, "", func(TrustReport) bool { return false })
+	if !errors.Is(err, ErrInstallDeclined) {
+		t.Fatalf("err = %v, want ErrInstallDeclined", err)
+	}
+	if len(reg.added) != 0 {
+		t.Error("declined install must register nothing")
+	}
+	if list, _ := store.List(); len(list) != 0 {
+		t.Error("declined install must record nothing")
+	}
+}
+
+func TestBuildTrustReport(t *testing.T) {
+	d := PluginDescriptor{
+		Name: "p", SourceFormat: FormatCodex, InstallDir: "/p",
+		MCPServers:  []MCPServerSpec{{Name: "srv", Command: "/nope/missing"}},
+		Skills:      []SkillSpec{{Name: "s1"}},
+		Unsupported: []UnsupportedComponent{{Kind: "hook", Detail: "deferred"}},
+	}
+	r := BuildTrustReport(d)
+	if len(r.MCPCommands) != 1 {
+		t.Errorf("mcp commands = %v", r.MCPCommands)
+	}
+	if len(r.Skills) != 1 {
+		t.Errorf("skills = %v", r.Skills)
+	}
+	if len(r.Warnings) != 1 {
+		t.Errorf("expected binary-missing warning, got %v", r.Warnings)
+	}
+	if len(r.Unsupported) != 1 {
+		t.Errorf("unsupported = %v", r.Unsupported)
+	}
+	if r.String() == "" {
+		t.Error("disclosure string should not be empty")
+	}
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -1,0 +1,144 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	claudeManifestDir = ".claude-plugin"
+	codexManifestDir  = ".codex-plugin"
+	manifestFile      = "plugin.json"
+)
+
+// rawManifest mirrors the on-disk plugin.json. Fields that vary by format
+// (author may be a string or an object; mcpServers may be a path string or an
+// inline map) are captured as json.RawMessage and decoded separately.
+type rawManifest struct {
+	Name        string          `json:"name"`
+	Version     string          `json:"version"`
+	Description string          `json:"description"`
+	Author      json.RawMessage `json:"author"`
+	Homepage    string          `json:"homepage"`
+	Repository  string          `json:"repository"`
+	Keywords    []string        `json:"keywords"`
+	MCPServers  json.RawMessage `json:"mcpServers"`
+	Skills      json.RawMessage `json:"skills"`
+	Commands    json.RawMessage `json:"commands"`
+	Agents      json.RawMessage `json:"agents"`
+	Hooks       json.RawMessage `json:"hooks"`
+	Interface   *rawInterface   `json:"interface"`
+}
+
+type rawInterface struct {
+	DisplayName      string   `json:"displayName"`
+	ShortDescription string   `json:"shortDescription"`
+	LongDescription  string   `json:"longDescription"`
+	Category         string   `json:"category"`
+	Logo             string   `json:"logo"`
+	DefaultPrompt    []string `json:"defaultPrompt"`
+}
+
+// locatedManifest is a parsed manifest with its format and the plugin root
+// directory (the directory that contains the manifest dir and component dirs).
+type locatedManifest struct {
+	format SourceFormat
+	root   string
+	raw    rawManifest
+}
+
+// DetectManifest locates and parses a plugin manifest under root. When both a
+// Claude and a Codex manifest are present, Claude wins by default; pass prefer
+// to override. Codex's versioned layout (<root>/<version>/.codex-plugin/) is
+// handled transparently.
+func DetectManifest(root string, prefer SourceFormat) (locatedManifest, error) {
+	claudePath := filepath.Join(root, claudeManifestDir, manifestFile)
+	codexRoot, codexPath := findCodexManifest(root)
+
+	hasClaude := fileExists(claudePath)
+	hasCodex := codexPath != ""
+
+	switch {
+	case hasClaude && hasCodex:
+		if prefer == FormatCodex {
+			return loadManifest(FormatCodex, codexRoot, codexPath)
+		}
+		return loadManifest(FormatClaude, root, claudePath) // default precedence: Claude > Codex
+	case hasClaude:
+		return loadManifest(FormatClaude, root, claudePath)
+	case hasCodex:
+		return loadManifest(FormatCodex, codexRoot, codexPath)
+	default:
+		return locatedManifest{}, ErrNoManifest
+	}
+}
+
+// findCodexManifest looks for .codex-plugin/plugin.json at root, then under one
+// level of version subdirectories (Codex's installed layout), choosing the
+// highest-sorted version.
+func findCodexManifest(root string) (manifestRoot, manifestPath string) {
+	direct := filepath.Join(root, codexManifestDir, manifestFile)
+	if fileExists(direct) {
+		return root, direct
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", ""
+	}
+	var versions []string
+	for _, e := range entries {
+		if e.IsDir() && fileExists(filepath.Join(root, e.Name(), codexManifestDir, manifestFile)) {
+			versions = append(versions, e.Name())
+		}
+	}
+	if len(versions) == 0 {
+		return "", ""
+	}
+	sort.Strings(versions) // lexical; good enough for v1 version selection
+	latest := versions[len(versions)-1]
+	vroot := filepath.Join(root, latest)
+	return vroot, filepath.Join(vroot, codexManifestDir, manifestFile)
+}
+
+func loadManifest(format SourceFormat, root, path string) (locatedManifest, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path derived from a user-provided plugin directory
+	if err != nil {
+		return locatedManifest{}, fmt.Errorf("plugin: read manifest %s: %w", path, err)
+	}
+	var raw rawManifest
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return locatedManifest{}, fmt.Errorf("plugin: parse manifest %s: %w", path, err)
+	}
+	if strings.TrimSpace(raw.Name) == "" {
+		return locatedManifest{}, ErrNoName
+	}
+	return locatedManifest{format: format, root: root, raw: raw}, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// authorName extracts a display name from the author field, which may be a bare
+// string or an object with a "name" key.
+func authorName(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj.Name
+	}
+	return ""
+}

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -18,12 +18,63 @@ type Marketplace struct {
 	Plugins []MarketplaceEntry `json:"plugins"`
 }
 
-// MarketplaceEntry is one plugin listed in a marketplace. Source may be a path
-// relative to the catalog, an absolute path, or a git URL.
+// MarketplaceEntry is one plugin listed in a marketplace. In real catalogs the
+// "source" is often an object (e.g. {"source":"local","path":"./..."} or
+// {"source":"github","repo":"owner/name"}) rather than a string; UnmarshalJSON
+// normalizes both to a single installable Source (a path relative to the
+// catalog, an absolute path, or a git URL).
 type MarketplaceEntry struct {
 	Name        string `json:"name"`
 	Source      string `json:"source"`
 	Description string `json:"description,omitempty"`
+}
+
+// UnmarshalJSON accepts both the string and object forms of "source".
+func (e *MarketplaceEntry) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Source      json.RawMessage `json:"source"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	e.Name = raw.Name
+	e.Description = raw.Description
+	e.Source = normalizeEntrySource(raw.Source)
+	return nil
+}
+
+// normalizeEntrySource reduces a marketplace entry's "source" (a string or an
+// object) to one installable source string, or "" if it can't be resolved.
+func normalizeEntrySource(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		Source string `json:"source"`
+		Type   string `json:"type"`
+		Path   string `json:"path"`
+		Repo   string `json:"repo"`
+		URL    string `json:"url"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	switch {
+	case obj.Path != "":
+		return obj.Path
+	case obj.URL != "":
+		return obj.URL
+	case obj.Repo != "":
+		return "https://github.com/" + obj.Repo + ".git"
+	default:
+		return ""
+	}
 }
 
 // marketplaceManifestPaths are the catalog file locations checked, in order —

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -1,0 +1,233 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Marketplace is a catalog of installable plugins (a marketplace.json),
+// compatible with Claude Code and Codex marketplace layouts.
+type Marketplace struct {
+	Name    string             `json:"name"`
+	Source  string             `json:"source,omitempty"` // where the catalog was added from
+	Dir     string             `json:"dir,omitempty"`    // resolved local catalog directory
+	Plugins []MarketplaceEntry `json:"plugins"`
+}
+
+// MarketplaceEntry is one plugin listed in a marketplace. Source may be a path
+// relative to the catalog, an absolute path, or a git URL.
+type MarketplaceEntry struct {
+	Name        string `json:"name"`
+	Source      string `json:"source"`
+	Description string `json:"description,omitempty"`
+}
+
+// marketplaceManifestPaths are the catalog file locations checked, in order —
+// covering Claude Code (.claude-plugin/, repo root) and Codex (.agents/plugins/).
+var marketplaceManifestPaths = []string{
+	"marketplace.json",
+	filepath.Join(".claude-plugin", "marketplace.json"),
+	filepath.Join(".codex-plugin", "marketplace.json"),
+	filepath.Join(".agents", "plugins", "marketplace.json"),
+}
+
+// ParseMarketplace finds and parses a marketplace.json under dir.
+func ParseMarketplace(dir string) (Marketplace, error) {
+	for _, rel := range marketplaceManifestPaths {
+		data, err := os.ReadFile(filepath.Join(dir, rel)) // #nosec G304 -- path under a user-provided catalog dir
+		if err != nil {
+			continue
+		}
+		var m Marketplace
+		if err := json.Unmarshal(data, &m); err != nil {
+			return Marketplace{}, fmt.Errorf("plugin: parse marketplace %s: %w", rel, err)
+		}
+		m.Dir = dir
+		return m, nil
+	}
+	return Marketplace{}, fmt.Errorf("plugin: no marketplace.json found under %s", dir)
+}
+
+// resolveEntrySource resolves a marketplace entry's source: a relative path is
+// joined to the catalog dir; git URLs and absolute paths are returned as-is.
+func resolveEntrySource(catalogDir, source string) string {
+	if isGitURL(source) || filepath.IsAbs(source) {
+		return source
+	}
+	return filepath.Join(catalogDir, filepath.Clean(source))
+}
+
+// marketplaceRecord is a persisted reference to an added marketplace.
+type marketplaceRecord struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Dir    string `json:"dir"`
+}
+
+// MarketplaceStore persists the set of added marketplaces.
+type MarketplaceStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewMarketplaceStore returns a store backed by marketplaces.json under dir.
+func NewMarketplaceStore(dir string) *MarketplaceStore {
+	return &MarketplaceStore{path: filepath.Join(dir, "marketplaces.json")}
+}
+
+func (s *MarketplaceStore) load() ([]marketplaceRecord, error) {
+	data, err := os.ReadFile(s.path) // #nosec G304 -- managed plugins directory
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []marketplaceRecord{}, nil
+		}
+		return nil, fmt.Errorf("plugin: read marketplaces: %w", err)
+	}
+	var recs []marketplaceRecord
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return nil, fmt.Errorf("plugin: parse marketplaces: %w", err)
+	}
+	return recs, nil
+}
+
+func (s *MarketplaceStore) save(recs []marketplaceRecord) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o750); err != nil {
+		return fmt.Errorf("plugin: create marketplaces dir: %w", err)
+	}
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("plugin: marshal marketplaces: %w", err)
+	}
+	if err := os.WriteFile(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("plugin: write marketplaces: %w", err)
+	}
+	return nil
+}
+
+// Put inserts or replaces a marketplace record (keyed by name).
+func (s *MarketplaceStore) Put(rec marketplaceRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	recs, err := s.load()
+	if err != nil {
+		return err
+	}
+	for i := range recs {
+		if recs[i].Name == rec.Name {
+			recs[i] = rec
+			return s.save(recs)
+		}
+	}
+	return s.save(append(recs, rec))
+}
+
+// Get returns the named marketplace record.
+func (s *MarketplaceStore) Get(name string) (marketplaceRecord, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	recs, err := s.load()
+	if err != nil {
+		return marketplaceRecord{}, false, err
+	}
+	for _, r := range recs {
+		if r.Name == name {
+			return r, true, nil
+		}
+	}
+	return marketplaceRecord{}, false, nil
+}
+
+// List returns all added marketplace records, sorted by name.
+func (s *MarketplaceStore) List() ([]marketplaceRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	recs, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Name < recs[j].Name })
+	return recs, nil
+}
+
+// AddMarketplace resolves a marketplace source, parses its catalog, and records
+// it so plugins can later be installed from it by name.
+func (m *Manager) AddMarketplace(source string) (Marketplace, error) {
+	dir, err := ResolveSource(source, m.cloneDir)
+	if err != nil {
+		return Marketplace{}, err
+	}
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		return Marketplace{}, err
+	}
+	mp.Source = source
+	if err := m.marketplaces.Put(marketplaceRecord{Name: mp.Name, Source: source, Dir: dir}); err != nil {
+		return Marketplace{}, err
+	}
+	return mp, nil
+}
+
+// Marketplaces returns the added marketplaces with their current catalog entries.
+func (m *Manager) Marketplaces() ([]Marketplace, error) {
+	recs, err := m.marketplaces.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Marketplace, 0, len(recs))
+	for _, r := range recs {
+		mp, err := ParseMarketplace(r.Dir)
+		if err != nil {
+			mp = Marketplace{} // catalog unreadable; report the record without entries
+		}
+		mp.Name = r.Name
+		mp.Source = r.Source
+		mp.Dir = r.Dir
+		out = append(out, mp)
+	}
+	return out, nil
+}
+
+// marketplaceEntrySource resolves a marketplace entry to an installable source
+// (relative entry paths are joined to the catalog dir).
+func (m *Manager) marketplaceEntrySource(marketplaceName, pluginName string) (string, error) {
+	rec, ok, err := m.marketplaces.Get(marketplaceName)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("plugin: marketplace %q not added", marketplaceName)
+	}
+	mp, err := ParseMarketplace(rec.Dir)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range mp.Plugins {
+		if e.Name == pluginName {
+			return resolveEntrySource(rec.Dir, e.Source), nil
+		}
+	}
+	return "", fmt.Errorf("plugin: %q not found in marketplace %q", pluginName, marketplaceName)
+}
+
+// PreviewFromMarketplace returns the trust report for a marketplace plugin
+// without installing anything.
+func (m *Manager) PreviewFromMarketplace(marketplaceName, pluginName string, prefer SourceFormat) (TrustReport, error) {
+	src, err := m.marketplaceEntrySource(marketplaceName, pluginName)
+	if err != nil {
+		return TrustReport{}, err
+	}
+	return m.Preview(src, prefer)
+}
+
+// InstallFromMarketplace installs a named plugin listed in an added marketplace.
+func (m *Manager) InstallFromMarketplace(marketplaceName, pluginName string, prefer SourceFormat, confirm ConfirmFunc) (InstalledPlugin, error) {
+	src, err := m.marketplaceEntrySource(marketplaceName, pluginName)
+	if err != nil {
+		return InstalledPlugin{}, err
+	}
+	return m.Install(src, prefer, confirm)
+}

--- a/internal/plugin/marketplace_test.go
+++ b/internal/plugin/marketplace_test.go
@@ -80,3 +80,31 @@ func TestMarketplaceAddAndInstall(t *testing.T) {
 		t.Error("expected error for missing marketplace entry")
 	}
 }
+
+func TestParseMarketplaceObjectSource(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "marketplace.json"), `{
+	  "name": "real",
+	  "plugins": [
+	    {"name": "local-one", "description": "d", "source": {"source": "local", "path": "./plugins/local-one"}},
+	    {"name": "gh-one", "source": {"source": "github", "repo": "acme/gh-one"}}
+	  ]
+	}`)
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(mp.Plugins) != 2 {
+		t.Fatalf("plugins = %+v", mp.Plugins)
+	}
+	byName := map[string]string{}
+	for _, p := range mp.Plugins {
+		byName[p.Name] = p.Source
+	}
+	if byName["local-one"] != "./plugins/local-one" {
+		t.Errorf("local object source = %q, want ./plugins/local-one", byName["local-one"])
+	}
+	if byName["gh-one"] != "https://github.com/acme/gh-one.git" {
+		t.Errorf("github object source = %q", byName["gh-one"])
+	}
+}

--- a/internal/plugin/marketplace_test.go
+++ b/internal/plugin/marketplace_test.go
@@ -1,0 +1,82 @@
+package plugin
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseMarketplace(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "marketplace.json"),
+		`{"name":"acme","plugins":[{"name":"reaper","source":"./reaper","description":"d"}]}`)
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if mp.Name != "acme" {
+		t.Errorf("name = %q", mp.Name)
+	}
+	if len(mp.Plugins) != 1 || mp.Plugins[0].Name != "reaper" {
+		t.Fatalf("plugins = %+v", mp.Plugins)
+	}
+	if mp.Dir != dir {
+		t.Errorf("dir = %q, want %q", mp.Dir, dir)
+	}
+}
+
+func TestParseMarketplaceClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude-plugin", "marketplace.json"), `{"name":"acme","plugins":[]}`)
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if mp.Name != "acme" {
+		t.Errorf("name = %q", mp.Name)
+	}
+}
+
+func TestMarketplaceAddAndInstall(t *testing.T) {
+	// A catalog dir with a marketplace.json + a bundled Claude plugin under ./reaper.
+	catalog := t.TempDir()
+	writeFile(t, filepath.Join(catalog, "marketplace.json"),
+		`{"name":"acme","plugins":[{"name":"reaper","source":"./reaper"}]}`)
+	writeFile(t, filepath.Join(catalog, "reaper", ".claude-plugin", "plugin.json"), `{"name":"reaper","version":"0.1.0"}`)
+	writeFile(t, filepath.Join(catalog, "reaper", ".mcp.json"), `{"ori-reaper":{"command":"/usr/bin/true"}}`)
+	writeFile(t, filepath.Join(catalog, "reaper", "skills", "s1", "SKILL.md"), "---\nname: s1\n---\n")
+
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+	m := NewManager(reg, sk, t.TempDir(), "")
+
+	mp, err := m.AddMarketplace(catalog)
+	if err != nil {
+		t.Fatalf("add marketplace: %v", err)
+	}
+	if mp.Name != "acme" || len(mp.Plugins) != 1 {
+		t.Fatalf("marketplace = %+v", mp)
+	}
+
+	list, err := m.Marketplaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Name != "acme" {
+		t.Fatalf("marketplaces = %+v", list)
+	}
+
+	p, err := m.InstallFromMarketplace("acme", "reaper", "", func(TrustReport) bool { return true })
+	if err != nil {
+		t.Fatalf("install from marketplace: %v", err)
+	}
+	if p.Name != "reaper" {
+		t.Errorf("installed = %q", p.Name)
+	}
+	if _, ok := reg.added["reaper/ori-reaper"]; !ok {
+		t.Errorf("server not registered: %v", reg.added)
+	}
+
+	if _, err := m.InstallFromMarketplace("acme", "nope", "", nil); err == nil {
+		t.Error("expected error for missing marketplace entry")
+	}
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,158 @@
+package plugin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectClaude(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"demo","version":"1.0.0"}`)
+	m, err := DetectManifest(root, "")
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if m.format != FormatClaude {
+		t.Errorf("format = %s, want claude", m.format)
+	}
+	if m.raw.Name != "demo" {
+		t.Errorf("name = %q", m.raw.Name)
+	}
+}
+
+func TestDetectCodexVersioned(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "1.0.809", ".codex-plugin", "plugin.json"), `{"name":"cu"}`)
+	m, err := DetectManifest(root, "")
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if m.format != FormatCodex {
+		t.Errorf("format = %s, want codex", m.format)
+	}
+	if filepath.Base(m.root) != "1.0.809" {
+		t.Errorf("root = %s, want version subdir", m.root)
+	}
+}
+
+func TestDetectDualPrecedence(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"c"}`)
+	writeFile(t, filepath.Join(root, ".codex-plugin", "plugin.json"), `{"name":"x"}`)
+
+	m, err := DetectManifest(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.format != FormatClaude {
+		t.Errorf("default precedence = %s, want claude", m.format)
+	}
+
+	m2, err := DetectManifest(root, FormatCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m2.format != FormatCodex {
+		t.Errorf("override = %s, want codex", m2.format)
+	}
+}
+
+func TestDetectNone(t *testing.T) {
+	if _, err := DetectManifest(t.TempDir(), ""); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("err = %v, want ErrNoManifest", err)
+	}
+}
+
+func TestNormalizeClaudeBareMCP(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"reaper","version":"0.1.0","description":"d","author":"jj"}`)
+	writeFile(t, filepath.Join(root, ".mcp.json"), `{"ori-reaper":{"command":"/abs/reaper-mcp","args":[]}}`)
+	writeFile(t, filepath.Join(root, "skills", "reaper-session-setup", "SKILL.md"), "---\nname: x\n---\n")
+
+	d, err := Load(root, "", "")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if d.SourceFormat != FormatClaude {
+		t.Errorf("format = %s", d.SourceFormat)
+	}
+	if d.Author != "jj" {
+		t.Errorf("author = %q", d.Author)
+	}
+	if len(d.MCPServers) != 1 || d.MCPServers[0].Name != "ori-reaper" {
+		t.Fatalf("mcp servers = %+v", d.MCPServers)
+	}
+	if d.MCPServers[0].Command != "/abs/reaper-mcp" {
+		t.Errorf("command = %q", d.MCPServers[0].Command)
+	}
+	if len(d.Skills) != 1 || d.Skills[0].Name != "reaper-session-setup" {
+		t.Errorf("skills = %+v", d.Skills)
+	}
+	if len(d.Unsupported) != 0 {
+		t.Errorf("unexpected unsupported = %+v", d.Unsupported)
+	}
+}
+
+func TestNormalizeCodexWrappedMCP(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".codex-plugin", "plugin.json"),
+		`{"name":"cu","version":"1.0.809","mcpServers":"./.mcp.json","skills":"./skills/","interface":{"displayName":"Computer Use","category":"Productivity"},"hooks":{"x":1}}`)
+	writeFile(t, filepath.Join(root, ".mcp.json"),
+		`{"mcpServers":{"computer-use":{"command":"./app/bin","args":["mcp"],"cwd":"."}}}`)
+	writeFile(t, filepath.Join(root, "skills", "computer-use", "SKILL.md"), "---\nname: cu\n---\n")
+
+	d, err := Load(root, "", "")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if d.SourceFormat != FormatCodex {
+		t.Errorf("format = %s", d.SourceFormat)
+	}
+	if len(d.MCPServers) != 1 || d.MCPServers[0].Name != "computer-use" {
+		t.Fatalf("mcp servers = %+v", d.MCPServers)
+	}
+	if d.MCPServers[0].Cwd != "." {
+		t.Errorf("cwd = %q, want .", d.MCPServers[0].Cwd)
+	}
+	if d.Interface == nil || d.Interface.DisplayName != "Computer Use" {
+		t.Fatalf("interface = %+v", d.Interface)
+	}
+	if len(d.Skills) != 1 || d.Skills[0].Name != "computer-use" {
+		t.Errorf("skills = %+v", d.Skills)
+	}
+	hook := false
+	for _, u := range d.Unsupported {
+		if u.Kind == "hook" {
+			hook = true
+		}
+	}
+	if !hook {
+		t.Errorf("expected hook in unsupported = %+v", d.Unsupported)
+	}
+}
+
+func TestResolveSourceLocalDir(t *testing.T) {
+	root := t.TempDir()
+	got, err := ResolveSource(root, "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != root {
+		t.Errorf("got %q, want %q", got, root)
+	}
+	if _, err := ResolveSource("", ""); !errors.Is(err, ErrEmptySource) {
+		t.Errorf("empty source err = %v", err)
+	}
+}

--- a/internal/plugin/register.go
+++ b/internal/plugin/register.go
@@ -1,0 +1,83 @@
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+)
+
+// claudePluginRootVar is Claude's plugin-root placeholder, expanded to the
+// plugin's install directory at registration time.
+const claudePluginRootVar = "${CLAUDE_PLUGIN_ROOT}"
+
+// NamespacedServerName returns the plugin-scoped MCP server name used in Ori's
+// registry so a plugin's server cannot collide with a user's global server
+// (PRD reqs #11/#14). Format: "<plugin>/<server>".
+func NamespacedServerName(plugin, server string) string {
+	return plugin + "/" + server
+}
+
+// ToServerConfig maps a plugin MCP server spec to a runtime mcp.ServerConfig
+// with a namespaced name and an absolute command. It is left disabled; the
+// trust gate / per-workspace binding (task 3.x) enables it.
+func ToServerConfig(pluginName string, spec MCPServerSpec, installDir string) mcp.ServerConfig {
+	cmd, args := resolveCommand(spec, installDir)
+	return mcp.ServerConfig{
+		Name:      NamespacedServerName(pluginName, spec.Name),
+		Command:   cmd,
+		Args:      args,
+		Env:       spec.Env,
+		Transport: "stdio",
+		Enabled:   false,
+	}
+}
+
+// resolveCommand returns the absolute command + args for an MCP server spec.
+// It expands Claude's ${CLAUDE_PLUGIN_ROOT} and resolves Codex's relative
+// command (plus its cwd) against installDir, because mcp.ServerConfig has no
+// cwd field. Bare PATH commands (e.g. "npx", "uvx") are left untouched.
+func resolveCommand(spec MCPServerSpec, installDir string) (string, []string) {
+	cmd := strings.ReplaceAll(spec.Command, claudePluginRootVar, installDir)
+
+	args := make([]string, len(spec.Args))
+	for i, a := range spec.Args {
+		args[i] = strings.ReplaceAll(a, claudePluginRootVar, installDir)
+	}
+
+	if !filepath.IsAbs(cmd) && !looksLikePATHCommand(cmd) {
+		base := installDir
+		if strings.TrimSpace(spec.Cwd) != "" {
+			base = filepath.Join(installDir, spec.Cwd)
+		}
+		cmd = filepath.Join(base, cmd)
+	}
+	return cmd, args
+}
+
+// looksLikePATHCommand reports whether cmd is a bare command name to be found on
+// PATH rather than a path relative to (or inside) the plugin directory.
+func looksLikePATHCommand(cmd string) bool {
+	return !strings.ContainsAny(cmd, `/\`) && !strings.HasPrefix(cmd, ".")
+}
+
+// CommandAvailable reports whether an MCP server's command is present and
+// runnable on this host (closes the binary-delivery gap — a clear status beats
+// a cryptic runtime "connection refused"). PATH commands are looked up; path
+// commands are stat'd and checked for an executable bit.
+func CommandAvailable(cmd string) bool {
+	if strings.TrimSpace(cmd) == "" {
+		return false
+	}
+	if looksLikePATHCommand(cmd) {
+		_, err := exec.LookPath(cmd)
+		return err == nil
+	}
+	info, err := os.Stat(cmd)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}

--- a/internal/plugin/register_test.go
+++ b/internal/plugin/register_test.go
@@ -1,0 +1,194 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+)
+
+func TestResolveCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		spec     MCPServerSpec
+		dir      string
+		wantCmd  string
+		wantArgs []string
+	}{
+		{
+			name:    "claude plugin-root var",
+			spec:    MCPServerSpec{Command: "${CLAUDE_PLUGIN_ROOT}/bin/reaper-mcp", Args: []string{"--x"}},
+			dir:     "/p",
+			wantCmd: "/p/bin/reaper-mcp", wantArgs: []string{"--x"},
+		},
+		{
+			name:    "codex relative command with cwd",
+			spec:    MCPServerSpec{Command: "./app/bin", Cwd: "."},
+			dir:     "/p",
+			wantCmd: "/p/app/bin", wantArgs: []string{},
+		},
+		{
+			name:    "bare PATH command untouched",
+			spec:    MCPServerSpec{Command: "npx", Args: []string{"-y", "srv"}},
+			dir:     "/p",
+			wantCmd: "npx", wantArgs: []string{"-y", "srv"},
+		},
+		{
+			name:    "absolute command untouched",
+			spec:    MCPServerSpec{Command: "/usr/local/bin/srv"},
+			dir:     "/p",
+			wantCmd: "/usr/local/bin/srv", wantArgs: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, args := resolveCommand(tc.spec, tc.dir)
+			if cmd != tc.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tc.wantCmd)
+			}
+			if len(args) != len(tc.wantArgs) {
+				t.Fatalf("args = %v, want %v", args, tc.wantArgs)
+			}
+			for i := range args {
+				if args[i] != tc.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, args[i], tc.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestToServerConfig(t *testing.T) {
+	cfg := ToServerConfig("reaper", MCPServerSpec{Name: "ori-reaper", Command: "${CLAUDE_PLUGIN_ROOT}/bin/x"}, "/p")
+	if cfg.Name != "reaper/ori-reaper" {
+		t.Errorf("name = %q, want reaper/ori-reaper", cfg.Name)
+	}
+	if cfg.Command != "/p/bin/x" {
+		t.Errorf("command = %q", cfg.Command)
+	}
+	if cfg.Transport != "stdio" {
+		t.Errorf("transport = %q", cfg.Transport)
+	}
+	if cfg.Enabled {
+		t.Errorf("server should be registered disabled")
+	}
+}
+
+func TestCommandAvailable(t *testing.T) {
+	// PATH command that exists everywhere.
+	if !CommandAvailable("sh") {
+		t.Errorf("sh should be available on PATH")
+	}
+	// Executable file.
+	exe := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !CommandAvailable(exe) {
+		t.Errorf("executable file should be available: %s", exe)
+	}
+	// Non-executable file.
+	noexe := filepath.Join(t.TempDir(), "data")
+	if err := os.WriteFile(noexe, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if CommandAvailable(noexe) {
+		t.Errorf("non-executable file should be unavailable")
+	}
+	// Missing path.
+	if CommandAvailable("/nope/missing-binary") {
+		t.Errorf("missing path should be unavailable")
+	}
+}
+
+// --- fakes for Register ---
+
+type fakeRegistrar struct {
+	added   map[string]mcp.ServerConfig
+	removed []string
+	failOn  string
+}
+
+func (f *fakeRegistrar) AddServer(cfg mcp.ServerConfig) error {
+	if cfg.Name == f.failOn {
+		return fmt.Errorf("add failed for %s", cfg.Name)
+	}
+	if f.added == nil {
+		f.added = map[string]mcp.ServerConfig{}
+	}
+	f.added[cfg.Name] = cfg
+	return nil
+}
+
+func (f *fakeRegistrar) RemoveServer(name string) error {
+	f.removed = append(f.removed, name)
+	delete(f.added, name)
+	return nil
+}
+
+type fakeSkills struct {
+	installed []string
+	removed   []string
+	failOn    string
+}
+
+func (f *fakeSkills) InstallSkill(_, name, _ string) error {
+	if name == f.failOn {
+		return fmt.Errorf("install failed for %s", name)
+	}
+	f.installed = append(f.installed, name)
+	return nil
+}
+
+func (f *fakeSkills) RemoveSkill(_, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+func TestRegisterSuccessWithBinaryWarning(t *testing.T) {
+	d := PluginDescriptor{
+		Name:       "reaper",
+		InstallDir: "/p",
+		MCPServers: []MCPServerSpec{{Name: "ori-reaper", Command: "/nope/missing"}},
+		Skills:     []SkillSpec{{Name: "reaper-session-setup", Path: "/p/skills/reaper-session-setup"}},
+	}
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+
+	res, err := Register(d, reg, sk)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if len(res.MCPServers) != 1 || res.MCPServers[0] != "reaper/ori-reaper" {
+		t.Errorf("mcp = %v", res.MCPServers)
+	}
+	if len(res.Skills) != 1 {
+		t.Errorf("skills = %v", res.Skills)
+	}
+	if len(res.BinaryWarnings) != 1 {
+		t.Errorf("expected a binary-missing warning, got %v", res.BinaryWarnings)
+	}
+}
+
+func TestRegisterRollbackOnSkillFailure(t *testing.T) {
+	d := PluginDescriptor{
+		Name:       "p",
+		InstallDir: "/p",
+		MCPServers: []MCPServerSpec{{Name: "srv", Command: "/usr/bin/true"}},
+		Skills:     []SkillSpec{{Name: "bad", Path: "/p/skills/bad"}},
+	}
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{failOn: "bad"}
+
+	if _, err := Register(d, reg, sk); err == nil {
+		t.Fatal("expected error from skill install")
+	}
+	if len(reg.removed) != 1 || reg.removed[0] != "p/srv" {
+		t.Errorf("expected MCP server rollback, removed = %v", reg.removed)
+	}
+	if len(reg.added) != 0 {
+		t.Errorf("server should have been rolled back, added = %v", reg.added)
+	}
+}

--- a/internal/plugin/source.go
+++ b/internal/plugin/source.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Load resolves a plugin source, detects and parses its manifest, and returns a
+// normalized descriptor. cloneDir is used only when source is a git URL.
+func Load(source, cloneDir string, prefer SourceFormat) (PluginDescriptor, error) {
+	root, err := ResolveSource(source, cloneDir)
+	if err != nil {
+		return PluginDescriptor{}, err
+	}
+	m, err := DetectManifest(root, prefer)
+	if err != nil {
+		return PluginDescriptor{}, err
+	}
+	return Normalize(m, source)
+}
+
+// ResolveSource returns a local directory containing the plugin bundle. A local
+// path is returned as-is; a git URL is cloned into cloneDir/<repo>. The caller
+// owns cloneDir (e.g. a managed plugins directory).
+func ResolveSource(source, cloneDir string) (string, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", ErrEmptySource
+	}
+	if isGitURL(source) {
+		return cloneGit(source, cloneDir)
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("plugin: source %q not found: %w", source, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("plugin: source %q is not a directory", source)
+	}
+	return source, nil
+}
+
+func isGitURL(s string) bool {
+	switch {
+	case strings.HasPrefix(s, "git@"):
+		return true
+	case strings.HasSuffix(s, ".git"):
+		return true
+	case strings.HasPrefix(s, "https://"), strings.HasPrefix(s, "http://"):
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneGit(url, cloneDir string) (string, error) {
+	if strings.TrimSpace(cloneDir) == "" {
+		return "", fmt.Errorf("plugin: git source requires a clone directory")
+	}
+	if err := os.MkdirAll(cloneDir, 0o750); err != nil {
+		return "", fmt.Errorf("plugin: create clone dir: %w", err)
+	}
+	dest := filepath.Join(cloneDir, repoName(url))
+	if _, err := os.Stat(dest); err == nil {
+		return dest, nil // already cloned; update flow handles refresh
+	}
+	cmd := exec.Command("git", "clone", "--depth", "1", url, dest) // #nosec G204 -- url supplied by the user installing the plugin
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("plugin: git clone failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return dest, nil
+}
+
+func repoName(url string) string {
+	url = strings.TrimSuffix(strings.TrimSpace(url), ".git")
+	url = strings.TrimSuffix(url, "/")
+	if i := strings.LastIndexAny(url, "/:"); i >= 0 {
+		return url[i+1:]
+	}
+	return url
+}

--- a/internal/plugin/source.go
+++ b/internal/plugin/source.go
@@ -82,3 +82,13 @@ func repoName(url string) string {
 	}
 	return url
 }
+
+// pullGit fast-forwards an existing git clone in place (used when updating a
+// plugin installed from a git source).
+func pullGit(dir string) error {
+	cmd := exec.Command("git", "-C", dir, "pull", "--ff-only") // #nosec G204 -- dir is a managed clone path
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("plugin: git pull failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/plugin/store.go
+++ b/internal/plugin/store.go
@@ -1,0 +1,148 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// InstalledPlugin records an installed plugin and exactly what it registered, so
+// uninstall is exact and reversible (PRD req #14).
+type InstalledPlugin struct {
+	Name        string       `json:"name"`
+	Version     string       `json:"version,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Source      string       `json:"source"`
+	Format      SourceFormat `json:"format"`
+	InstallDir  string       `json:"install_dir"`
+	MCPServers  []string     `json:"mcp_servers,omitempty"` // namespaced names
+	Skills      []string     `json:"skills,omitempty"`
+	Enabled     bool         `json:"enabled"`
+	InstalledAt time.Time    `json:"installed_at"`
+}
+
+// Store is the JSON-backed installed-plugins registry. Components owned by a
+// plugin are recorded here so they can be listed and cleanly removed; plugin
+// components are read-only/plugin-owned (PRD decision #8) and managed only
+// through install/uninstall.
+type Store struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewStore returns a store backed by installed.json under the managed plugins dir.
+func NewStore(dir string) *Store {
+	return &Store{path: filepath.Join(dir, "installed.json")}
+}
+
+func (s *Store) load() ([]InstalledPlugin, error) {
+	data, err := os.ReadFile(s.path) // #nosec G304 -- path is the managed plugins directory
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []InstalledPlugin{}, nil
+		}
+		return nil, fmt.Errorf("plugin: read store: %w", err)
+	}
+	var list []InstalledPlugin
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("plugin: parse store: %w", err)
+	}
+	return list, nil
+}
+
+func (s *Store) save(list []InstalledPlugin) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o750); err != nil {
+		return fmt.Errorf("plugin: create store dir: %w", err)
+	}
+	data, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return fmt.Errorf("plugin: marshal store: %w", err)
+	}
+	if err := os.WriteFile(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("plugin: write store: %w", err)
+	}
+	return nil
+}
+
+// List returns installed plugins sorted by name.
+func (s *Store) List() ([]InstalledPlugin, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+	return list, nil
+}
+
+// Get returns the named plugin, if installed.
+func (s *Store) Get(name string) (InstalledPlugin, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list, err := s.load()
+	if err != nil {
+		return InstalledPlugin{}, false, err
+	}
+	for _, p := range list {
+		if p.Name == name {
+			return p, true, nil
+		}
+	}
+	return InstalledPlugin{}, false, nil
+}
+
+// Put inserts or replaces a plugin entry.
+func (s *Store) Put(p InstalledPlugin) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list, err := s.load()
+	if err != nil {
+		return err
+	}
+	for i := range list {
+		if list[i].Name == p.Name {
+			list[i] = p
+			return s.save(list)
+		}
+	}
+	return s.save(append(list, p))
+}
+
+// Delete removes a plugin entry (no-op if absent).
+func (s *Store) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list, err := s.load()
+	if err != nil {
+		return err
+	}
+	out := make([]InstalledPlugin, 0, len(list))
+	for _, p := range list {
+		if p.Name != name {
+			out = append(out, p)
+		}
+	}
+	return s.save(out)
+}
+
+// SetEnabled updates a plugin's enabled flag.
+func (s *Store) SetEnabled(name string, enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list, err := s.load()
+	if err != nil {
+		return err
+	}
+	for i := range list {
+		if list[i].Name == name {
+			list[i].Enabled = enabled
+			return s.save(list)
+		}
+	}
+	return fmt.Errorf("plugin: %q not installed", name)
+}

--- a/internal/plugin/trust.go
+++ b/internal/plugin/trust.go
@@ -1,0 +1,69 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TrustReport enumerates everything a plugin will register or expose, shown to
+// the user before install (PRD req #15). Install proceeds only on explicit
+// confirmation; declining makes no changes.
+type TrustReport struct {
+	Name        string
+	Format      SourceFormat
+	MCPCommands []string // "<namespaced server> → <resolved command>"
+	Skills      []string
+	Unsupported []UnsupportedComponent
+	Warnings    []string // e.g. binary-missing
+}
+
+// ConfirmFunc returns true to proceed with installation. It receives the report
+// so a CLI/UI can render the disclosure (supplied by the HTTP/UI layer).
+type ConfirmFunc func(TrustReport) bool
+
+// BuildTrustReport produces the install disclosure for a descriptor, resolving
+// the exact commands each MCP server will run and flagging missing binaries.
+func BuildTrustReport(d PluginDescriptor) TrustReport {
+	r := TrustReport{Name: d.Name, Format: d.SourceFormat, Unsupported: d.Unsupported}
+	for _, spec := range d.MCPServers {
+		cmd, args := resolveCommand(spec, d.InstallDir)
+		full := cmd
+		if len(args) > 0 {
+			full = cmd + " " + strings.Join(args, " ")
+		}
+		name := NamespacedServerName(d.Name, spec.Name)
+		r.MCPCommands = append(r.MCPCommands, fmt.Sprintf("%s → %s", name, full))
+		if !CommandAvailable(cmd) {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("%s: command not found — install the binary, then enable", name))
+		}
+	}
+	for _, s := range d.Skills {
+		r.Skills = append(r.Skills, s.Name)
+	}
+	return r
+}
+
+// String renders a human-readable disclosure (used by CLIs and tests).
+func (r TrustReport) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Plugin %q (%s) will register:\n", r.Name, r.Format)
+	if len(r.MCPCommands) > 0 {
+		b.WriteString("  MCP servers (run as local commands):\n")
+		for _, c := range r.MCPCommands {
+			fmt.Fprintf(&b, "    - %s\n", c)
+		}
+	}
+	if len(r.Skills) > 0 {
+		fmt.Fprintf(&b, "  Skills: %s\n", strings.Join(r.Skills, ", "))
+	}
+	if len(r.Unsupported) > 0 {
+		b.WriteString("  Skipped (not yet supported):\n")
+		for _, u := range r.Unsupported {
+			fmt.Fprintf(&b, "    - %s: %s\n", u.Kind, u.Detail)
+		}
+	}
+	for _, w := range r.Warnings {
+		fmt.Fprintf(&b, "  ! %s\n", w)
+	}
+	return b.String()
+}

--- a/internal/pluginhttp/adapters.go
+++ b/internal/pluginhttp/adapters.go
@@ -1,0 +1,114 @@
+// Package pluginhttp wires the plugin installer (internal/plugin) to Ori's live
+// MCP and skills managers and exposes plugin operations over HTTP.
+package pluginhttp
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+)
+
+// mcpRegistrar adapts Ori's MCP config manager (persistence) + runtime registry
+// to plugin.MCPRegistrar, registering to both — the same pair the MCP import
+// path uses (configManager.AddServer + registry.AddServer).
+type mcpRegistrar struct {
+	config   *mcp.ConfigManager
+	registry *mcp.Registry
+}
+
+func newMCPRegistrar(config *mcp.ConfigManager, registry *mcp.Registry) *mcpRegistrar {
+	return &mcpRegistrar{config: config, registry: registry}
+}
+
+func (a *mcpRegistrar) AddServer(cfg mcp.ServerConfig) error {
+	if err := a.config.AddServer(cfg); err != nil {
+		return err
+	}
+	if err := a.registry.AddServer(cfg); err != nil {
+		_ = a.config.RemoveServer(cfg.Name) // keep persisted + runtime in sync
+		return err
+	}
+	return nil
+}
+
+func (a *mcpRegistrar) RemoveServer(name string) error {
+	rerr := a.registry.RemoveServer(name)
+	if cerr := a.config.RemoveServer(name); cerr != nil {
+		return cerr
+	}
+	return rerr
+}
+
+var _ plugin.MCPRegistrar = (*mcpRegistrar)(nil)
+
+// skillDirInstaller adapts a skills directory that Ori already scans (e.g.
+// ~/.agents/skills) to plugin.SkillInstaller by copying a plugin's skill folder
+// into it; the skills manager discovers it on its next scan.
+type skillDirInstaller struct {
+	skillsDir string
+}
+
+func newSkillDirInstaller(skillsDir string) *skillDirInstaller {
+	return &skillDirInstaller{skillsDir: skillsDir}
+}
+
+func (s *skillDirInstaller) InstallSkill(_, skillName, srcDir string) error {
+	if s.skillsDir == "" {
+		return fmt.Errorf("pluginhttp: no skills directory configured")
+	}
+	if err := copyDir(srcDir, filepath.Join(s.skillsDir, skillName)); err != nil {
+		return fmt.Errorf("pluginhttp: install skill %q: %w", skillName, err)
+	}
+	return nil
+}
+
+func (s *skillDirInstaller) RemoveSkill(_, skillName string) error {
+	if s.skillsDir == "" {
+		return nil
+	}
+	return os.RemoveAll(filepath.Join(s.skillsDir, skillName))
+}
+
+var _ plugin.SkillInstaller = (*skillDirInstaller)(nil)
+
+// copyDir recursively copies src into dst.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o750)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return err
+	}
+	in, err := os.Open(src) // #nosec G304 -- copying a user-installed plugin's own files
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst) // #nosec G304 -- destination within the managed skills dir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/pluginhttp/adapters_test.go
+++ b/internal/pluginhttp/adapters_test.go
@@ -1,0 +1,41 @@
+package pluginhttp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillDirInstaller(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// nested supporting file (scripts/) should be copied too
+	if err := os.MkdirAll(filepath.Join(src, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "scripts", "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	inst := newSkillDirInstaller(dest)
+
+	if err := inst.InstallSkill("plug", "myskill", src); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "myskill", "SKILL.md")); err != nil {
+		t.Fatalf("installed SKILL.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "myskill", "scripts", "run.sh")); err != nil {
+		t.Errorf("nested supporting file not copied: %v", err)
+	}
+
+	if err := inst.RemoveSkill("plug", "myskill"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "myskill")); !os.IsNotExist(err) {
+		t.Errorf("skill dir should be gone after RemoveSkill")
+	}
+}

--- a/internal/pluginhttp/handlers.go
+++ b/internal/pluginhttp/handlers.go
@@ -23,7 +23,7 @@ func NewHandler(config *mcp.ConfigManager, registry *mcp.Registry, skillsDir, pl
 	mgr := plugin.NewManager(
 		newMCPRegistrar(config, registry),
 		newSkillDirInstaller(skillsDir),
-		plugin.NewStore(pluginsDir),
+		pluginsDir,
 		filepath.Join(pluginsDir, "src"),
 	)
 	return newHandlerWithManager(mgr)
@@ -125,4 +125,76 @@ func (h *Handler) SetEnabledHandler(enabled bool) http.HandlerFunc {
 		}
 		orihttp.WriteJSON(w, map[string]any{"name": name, "enabled": enabled})
 	}
+}
+
+// MarketplacesHandler lists (GET) or adds (POST) marketplaces at
+// /api/plugins/marketplaces.
+func (h *Handler) MarketplacesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		list, err := h.mgr.Marketplaces()
+		if err != nil {
+			orihttp.InternalError(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"marketplaces": list})
+	case http.MethodPost:
+		var req struct {
+			Source string `json:"source"`
+		}
+		if !orihttp.ParseJSONBody(w, r, &req) {
+			return
+		}
+		if req.Source == "" {
+			orihttp.BadRequest(w, "source is required")
+			return
+		}
+		mp, err := h.mgr.AddMarketplace(req.Source)
+		if err != nil {
+			orihttp.BadRequest(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"marketplace": mp})
+	default:
+		orihttp.MethodNotAllowed(w)
+	}
+}
+
+// MarketplaceInstallHandler installs a plugin from an added marketplace at
+// POST /api/plugins/marketplaces/install. confirm=false returns the trust
+// disclosure; confirm=true installs.
+func (h *Handler) MarketplaceInstallHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	var req struct {
+		Marketplace string `json:"marketplace"`
+		Plugin      string `json:"plugin"`
+		Format      string `json:"format"`
+		Confirm     bool   `json:"confirm"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.Marketplace == "" || req.Plugin == "" {
+		orihttp.BadRequest(w, "marketplace and plugin are required")
+		return
+	}
+	prefer := plugin.SourceFormat(req.Format)
+	if !req.Confirm {
+		report, err := h.mgr.PreviewFromMarketplace(req.Marketplace, req.Plugin, prefer)
+		if err != nil {
+			orihttp.BadRequest(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"installed": false, "trust": report})
+		return
+	}
+	installed, err := h.mgr.InstallFromMarketplace(req.Marketplace, req.Plugin, prefer, func(plugin.TrustReport) bool { return true })
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{"installed": true, "plugin": installed})
 }

--- a/internal/pluginhttp/handlers.go
+++ b/internal/pluginhttp/handlers.go
@@ -1,0 +1,128 @@
+package pluginhttp
+
+import (
+	"net/http"
+	"path/filepath"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/mcp"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+)
+
+// Handler serves plugin operations and owns the plugin Manager wired to Ori's
+// live MCP config/registry and skills directory.
+type Handler struct {
+	mgr *plugin.Manager
+}
+
+// NewHandler builds the plugin manager over Ori's MCP config manager + runtime
+// registry and the given skills directory, and returns an HTTP handler for it.
+// pluginsDir is the managed directory for the installed-plugins registry and
+// git clones.
+func NewHandler(config *mcp.ConfigManager, registry *mcp.Registry, skillsDir, pluginsDir string) *Handler {
+	mgr := plugin.NewManager(
+		newMCPRegistrar(config, registry),
+		newSkillDirInstaller(skillsDir),
+		plugin.NewStore(pluginsDir),
+		filepath.Join(pluginsDir, "src"),
+	)
+	return newHandlerWithManager(mgr)
+}
+
+// newHandlerWithManager wraps an existing manager (used by tests).
+func newHandlerWithManager(mgr *plugin.Manager) *Handler {
+	return &Handler{mgr: mgr}
+}
+
+// ListHandler handles GET /api/plugins.
+func (h *Handler) ListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	list, err := h.mgr.List()
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{"plugins": list})
+}
+
+// InstallHandler handles POST /api/plugins/install. With confirm=false it
+// returns the trust report (a no-op disclosure preview); with confirm=true it
+// performs the install.
+func (h *Handler) InstallHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	var req struct {
+		Source  string `json:"source"`
+		Format  string `json:"format"`
+		Confirm bool   `json:"confirm"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.Source == "" {
+		orihttp.BadRequest(w, "source is required")
+		return
+	}
+	prefer := plugin.SourceFormat(req.Format)
+
+	if !req.Confirm {
+		report, err := h.mgr.Preview(req.Source, prefer)
+		if err != nil {
+			orihttp.BadRequest(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"installed": false, "trust": report})
+		return
+	}
+
+	installed, err := h.mgr.Install(req.Source, prefer, func(plugin.TrustReport) bool { return true })
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{"installed": true, "plugin": installed})
+}
+
+// UninstallHandler handles DELETE /api/plugins/{name}.
+func (h *Handler) UninstallHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		orihttp.BadRequest(w, "plugin name is required")
+		return
+	}
+	if err := h.mgr.Uninstall(name); err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{"uninstalled": name})
+}
+
+// SetEnabledHandler returns a handler that enables or disables a plugin
+// (POST /api/plugins/{name}/enable and .../disable).
+func (h *Handler) SetEnabledHandler(enabled bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			orihttp.MethodNotAllowed(w)
+			return
+		}
+		name := r.PathValue("name")
+		if name == "" {
+			orihttp.BadRequest(w, "plugin name is required")
+			return
+		}
+		if err := h.mgr.SetEnabled(name, enabled); err != nil {
+			orihttp.InternalError(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"name": name, "enabled": enabled})
+	}
+}

--- a/internal/pluginhttp/handlers.go
+++ b/internal/pluginhttp/handlers.go
@@ -198,3 +198,39 @@ func (h *Handler) MarketplaceInstallHandler(w http.ResponseWriter, r *http.Reque
 	}
 	orihttp.WriteJSON(w, map[string]any{"installed": true, "plugin": installed})
 }
+
+// UpdateHandler updates a plugin from its recorded source at
+// POST /api/plugins/{name}/update. confirm=false returns the trust disclosure
+// plus whether the registered component set changed; confirm=true updates.
+func (h *Handler) UpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		orihttp.BadRequest(w, "plugin name is required")
+		return
+	}
+	var req struct {
+		Confirm bool `json:"confirm"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if !req.Confirm {
+		report, changed, err := h.mgr.UpdatePreview(name)
+		if err != nil {
+			orihttp.BadRequest(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, map[string]any{"updated": false, "changed": changed, "trust": report})
+		return
+	}
+	updated, err := h.mgr.Update(name, func(plugin.TrustReport) bool { return true })
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{"updated": true, "plugin": updated})
+}

--- a/internal/pluginhttp/handlers_test.go
+++ b/internal/pluginhttp/handlers_test.go
@@ -30,7 +30,7 @@ func (stubSkills) RemoveSkill(_, _ string) error     { return nil }
 
 func testHandler(t *testing.T) *Handler {
 	t.Helper()
-	mgr := plugin.NewManager(&stubReg{}, stubSkills{}, plugin.NewStore(t.TempDir()), "")
+	mgr := plugin.NewManager(&stubReg{}, stubSkills{}, t.TempDir(), "")
 	return newHandlerWithManager(mgr)
 }
 

--- a/internal/pluginhttp/handlers_test.go
+++ b/internal/pluginhttp/handlers_test.go
@@ -1,0 +1,114 @@
+package pluginhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+)
+
+type stubReg struct{ added map[string]mcp.ServerConfig }
+
+func (s *stubReg) AddServer(c mcp.ServerConfig) error {
+	if s.added == nil {
+		s.added = map[string]mcp.ServerConfig{}
+	}
+	s.added[c.Name] = c
+	return nil
+}
+func (s *stubReg) RemoveServer(name string) error { delete(s.added, name); return nil }
+
+type stubSkills struct{}
+
+func (stubSkills) InstallSkill(_, _, _ string) error { return nil }
+func (stubSkills) RemoveSkill(_, _ string) error     { return nil }
+
+func testHandler(t *testing.T) *Handler {
+	t.Helper()
+	mgr := plugin.NewManager(&stubReg{}, stubSkills{}, plugin.NewStore(t.TempDir()), "")
+	return newHandlerWithManager(mgr)
+}
+
+func claudeBundle(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"reaper","version":"0.1.0"}`)
+	mustWrite(t, filepath.Join(root, ".mcp.json"), `{"ori-reaper":{"command":"/usr/bin/true"}}`)
+	mustWrite(t, filepath.Join(root, "skills", "s1", "SKILL.md"), "---\nname: s1\n---\n")
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func postInstall(t *testing.T, h *Handler, source string, confirm bool) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"source":"` + source + `","confirm":` + map[bool]string{true: "true", false: "false"}[confirm] + `}`
+	rr := httptest.NewRecorder()
+	h.InstallHandler(rr, httptest.NewRequest(http.MethodPost, "/api/plugins/install", strings.NewReader(body)))
+	return rr
+}
+
+func listBody(t *testing.T, h *Handler) string {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	h.ListHandler(rr, httptest.NewRequest(http.MethodGet, "/api/plugins", nil))
+	return rr.Body.String()
+}
+
+func TestInstallPreviewMakesNoChanges(t *testing.T) {
+	h := testHandler(t)
+	rr := postInstall(t, h, claudeBundle(t), false)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preview status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"installed":false`) {
+		t.Errorf("expected installed:false, got %s", rr.Body.String())
+	}
+	if strings.Contains(listBody(t, h), "reaper") {
+		t.Error("preview must not record a plugin")
+	}
+}
+
+func TestInstallConfirmThenList(t *testing.T) {
+	h := testHandler(t)
+	rr := postInstall(t, h, claudeBundle(t), true)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("install status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"installed":true`) {
+		t.Errorf("expected installed:true, got %s", rr.Body.String())
+	}
+	if !strings.Contains(listBody(t, h), "reaper") {
+		t.Errorf("expected reaper in list, got %s", listBody(t, h))
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	h := testHandler(t)
+	if rr := postInstall(t, h, claudeBundle(t), true); rr.Code != http.StatusOK {
+		t.Fatalf("install: %d %s", rr.Code, rr.Body.String())
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/plugins/reaper", nil)
+	req.SetPathValue("name", "reaper")
+	rr := httptest.NewRecorder()
+	h.UninstallHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("uninstall: %d %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(listBody(t, h), "reaper") {
+		t.Error("reaper should be gone after uninstall")
+	}
+}

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/orchestrationhttp"
+	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
 	"github.com/johnjallday/ori-agent/internal/reviewhttp"
 	"github.com/johnjallday/ori-agent/internal/session"
@@ -150,6 +151,7 @@ type ServerBuilder struct {
 	workspaceHandler       *workspace.HTTPHandler
 	usageHandler           *usagehttp.Handler
 	mcpHandler             *mcphttp.Handler
+	pluginHandler          *pluginhttp.Handler
 	locationHandler        *locationhttp.Handler
 	workflowHandler        *workflowhttp.Handler
 	modelCategoryStore     store.ModelCategoryStore
@@ -388,6 +390,7 @@ func (b *ServerBuilder) createDomainFacades() {
 	b.server.Handlers.CLIAgentRegistry = b.cliAgentRegistry
 	b.server.Handlers.WorkspaceRuns = b.workspaceRunHandler
 	b.server.Handlers.ActionCenter = b.actionCenterHandler
+	b.server.Handlers.Plugin = b.pluginHandler
 	// initializeMissionBridge (which builds the trigger handler) runs before
 	// this facade is rebuilt, so re-attach here — same pattern as ActionCenter.
 	b.server.Handlers.Triggers = b.triggerHandler

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/modelcategoryhttp"
 	"github.com/johnjallday/ori-agent/internal/notehttp"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
+	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/review"
 	"github.com/johnjallday/ori-agent/internal/reviewhttp"
 	"github.com/johnjallday/ori-agent/internal/session"
@@ -325,6 +326,12 @@ func (b *ServerBuilder) initializeHandlers() {
 	})
 	b.skillsHandler = skillshttp.New(b.skillsManager, b.st, b.llmFactory, b.configManager)
 	b.chatHandler.SetSkillsManager(b.skillsManager)
+
+	// Plugin installer (Claude Code- and Codex-compatible bundles): wired over the
+	// MCP registry + the personal skills dir; installed plugins live under ./plugins.
+	if b.mcpConfigManager != nil && b.mcpRegistry != nil {
+		b.pluginHandler = pluginhttp.NewHandler(b.mcpConfigManager, b.mcpRegistry, personalSkillsDir, "plugins")
+	}
 }
 
 func (b *ServerBuilder) registerWorkspaceRunTaskValidationMirror() {

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -25,6 +25,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/orchestrationhttp"
+	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
 	"github.com/johnjallday/ori-agent/internal/reviewhttp"
 	"github.com/johnjallday/ori-agent/internal/session"
@@ -106,6 +107,7 @@ type HandlerFacade struct {
 	Workspace        *workspace.HTTPHandler
 	Usage            *usagehttp.Handler
 	MCP              *mcphttp.Handler
+	Plugin           *pluginhttp.Handler
 	Location         *locationhttp.Handler
 	Workflow         *workflowhttp.Handler
 	ModelCategory    *modelcategoryhttp.Handler

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -44,6 +44,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("/skills", s.serveSkills)
 	mux.HandleFunc("/workflows", s.serveWorkflows)
 	mux.HandleFunc("/mcp", s.serveMCP)
+	mux.HandleFunc("/plugins", s.servePlugins)
 	mux.HandleFunc("/models", s.serveModels)
 	mux.HandleFunc("/agents", s.serveAgents)      // Clean URL
 	mux.HandleFunc("/agents.html", s.serveAgents) // Legacy support

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -688,6 +688,17 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	}
 
 	// =============================================================================
+	// Plugin Endpoints (Claude Code / Codex-compatible bundles)
+	// =============================================================================
+	if s.Handlers.Plugin != nil {
+		mux.HandleFunc("GET /api/plugins", s.Handlers.Plugin.ListHandler)
+		mux.HandleFunc("POST /api/plugins/install", s.Handlers.Plugin.InstallHandler)
+		mux.HandleFunc("DELETE /api/plugins/{name}", s.Handlers.Plugin.UninstallHandler)
+		mux.HandleFunc("POST /api/plugins/{name}/enable", s.Handlers.Plugin.SetEnabledHandler(true))
+		mux.HandleFunc("POST /api/plugins/{name}/disable", s.Handlers.Plugin.SetEnabledHandler(false))
+	}
+
+	// =============================================================================
 	// Folder Picker Launcher
 	// =============================================================================
 	mux.HandleFunc("/api/launch-folder-picker", s.Handlers.Workspace.LaunchFolderPicker)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -700,6 +700,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("DELETE /api/plugins/{name}", s.Handlers.Plugin.UninstallHandler)
 		mux.HandleFunc("POST /api/plugins/{name}/enable", s.Handlers.Plugin.SetEnabledHandler(true))
 		mux.HandleFunc("POST /api/plugins/{name}/disable", s.Handlers.Plugin.SetEnabledHandler(false))
+		mux.HandleFunc("POST /api/plugins/{name}/update", s.Handlers.Plugin.UpdateHandler)
 	}
 
 	// =============================================================================

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -694,6 +694,9 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	if s.Handlers.Plugin != nil {
 		mux.HandleFunc("GET /api/plugins", s.Handlers.Plugin.ListHandler)
 		mux.HandleFunc("POST /api/plugins/install", s.Handlers.Plugin.InstallHandler)
+		mux.HandleFunc("GET /api/plugins/marketplaces", s.Handlers.Plugin.MarketplacesHandler)
+		mux.HandleFunc("POST /api/plugins/marketplaces", s.Handlers.Plugin.MarketplacesHandler)
+		mux.HandleFunc("POST /api/plugins/marketplaces/install", s.Handlers.Plugin.MarketplaceInstallHandler)
 		mux.HandleFunc("DELETE /api/plugins/{name}", s.Handlers.Plugin.UninstallHandler)
 		mux.HandleFunc("POST /api/plugins/{name}/enable", s.Handlers.Plugin.SetEnabledHandler(true))
 		mux.HandleFunc("POST /api/plugins/{name}/disable", s.Handlers.Plugin.SetEnabledHandler(false))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -301,6 +301,11 @@ func (s *Server) serveMCP(w http.ResponseWriter, r *http.Request) {
 	s.renderAndWritePage(w, "mcp", data)
 }
 
+func (s *Server) servePlugins(w http.ResponseWriter, r *http.Request) {
+	data := s.prepareBasePageData("plugins")
+	s.renderAndWritePage(w, "plugins", data)
+}
+
 func (s *Server) serveSkills(w http.ResponseWriter, r *http.Request) {
 	data := s.prepareBasePageData("skills")
 	data.Title = "Skills - Ori Agent"

--- a/internal/web/static/js/mcp.js
+++ b/internal/web/static/js/mcp.js
@@ -319,6 +319,10 @@ function createServerCard(server) {
     : '<span class="badge bg-secondary ms-2">Disabled globally</span>';
   const toggleLabel = server.enabled ? 'Disable' : 'Enable';
   const toggleClass = server.enabled ? 'modern-btn-secondary' : 'modern-btn-primary';
+  // Plugin-owned servers are namespaced "<plugin>/<server>"; they're read-only
+  // here (manage via the Plugins page), though enable/disable is still allowed.
+  const isPlugin = server.name.includes('/');
+  const pluginBadge = isPlugin ? '<span class="badge bg-info ms-2">Plugin (read-only)</span>' : '';
 
   div.innerHTML = `
     <div class="d-flex justify-content-between align-items-start">
@@ -329,6 +333,7 @@ function createServerCard(server) {
           ${statusBadge}
           ${toolCountBadge}
           ${enabledBadge}
+          ${pluginBadge}
         </div>
       </div>
       <div class="d-flex gap-2">
@@ -343,9 +348,9 @@ function createServerCard(server) {
             Retry
           </button>
         ` : ''}
-        <button class="modern-btn modern-btn-danger modern-btn-sm" onclick="confirmRemoveServer('${server.name}')">
-          Remove
-        </button>
+        ${isPlugin
+          ? '<span class="modern-btn modern-btn-secondary modern-btn-sm disabled" title="Managed by its plugin; uninstall from the Plugins page">Managed by plugin</span>'
+          : `<button class="modern-btn modern-btn-danger modern-btn-sm" onclick="confirmRemoveServer('${server.name}')">Remove</button>`}
       </div>
     </div>
   `;

--- a/internal/web/static/js/plugins.js
+++ b/internal/web/static/js/plugins.js
@@ -1,0 +1,130 @@
+// Plugins page: install, list, enable/disable, and uninstall Claude Code- and
+// Codex-compatible plugins via the /api/plugins endpoints.
+(function () {
+  'use strict';
+
+  const byId = (id) => document.getElementById(id);
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])
+    );
+  }
+
+  async function api(method, url, body) {
+    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body !== undefined) opts.body = JSON.stringify(body);
+    const res = await fetch(url, opts);
+    const text = await res.text();
+    let data = {};
+    try { data = text ? JSON.parse(text) : {}; } catch (_) { data = { message: text }; }
+    if (!res.ok) throw new Error(data.message || ('HTTP ' + res.status));
+    return data;
+  }
+
+  window.loadPlugins = async function () {
+    const list = byId('pluginList');
+    try {
+      const data = await api('GET', '/api/plugins');
+      const plugins = (data && data.plugins) || [];
+      if (!plugins.length) {
+        list.innerHTML = '<p class="text-muted mb-0">No plugins installed yet.</p>';
+        return;
+      }
+      list.innerHTML = plugins.map(renderPlugin).join('');
+    } catch (e) {
+      list.innerHTML = '<p class="text-danger mb-0">Failed to load plugins: ' + esc(e.message) + '</p>';
+    }
+  };
+
+  function renderPlugin(p) {
+    const servers = (p.mcp_servers || []).map(esc).join(', ') || '&mdash;';
+    const skills = (p.skills || []).map(esc).join(', ') || '&mdash;';
+    const badge = '<span class="badge bg-secondary">' + esc(p.format) + '</span>';
+    const name = esc(p.name);
+    return (
+      '<div class="d-flex align-items-start justify-content-between border-bottom py-3">' +
+      '<div>' +
+      '<div class="fw-semibold">' + name + ' <span class="text-muted small">' + esc(p.version || '') + '</span> ' + badge + '</div>' +
+      (p.description ? '<div class="small text-muted">' + esc(p.description) + '</div>' : '') +
+      '<div class="small mt-1">MCP: ' + servers + ' &middot; Skills: ' + skills + '</div>' +
+      '</div>' +
+      '<div class="d-flex gap-2">' +
+      '<button class="modern-btn modern-btn-secondary" onclick="pluginToggle(\'' + name + '\', ' + (p.enabled ? 'false' : 'true') + ')">' +
+      (p.enabled ? 'Disable' : 'Enable') + '</button>' +
+      '<button class="modern-btn modern-btn-secondary" onclick="pluginUninstall(\'' + name + '\')">Uninstall</button>' +
+      '</div>' +
+      '</div>'
+    );
+  }
+
+  function installArgs() {
+    return {
+      source: byId('pluginSource').value.trim(),
+      format: byId('pluginFormat').value,
+    };
+  }
+
+  window.pluginPreview = async function () {
+    const { source, format } = installArgs();
+    if (!source) { alert('Enter a plugin source.'); return; }
+    try {
+      const data = await api('POST', '/api/plugins/install', { source, format, confirm: false });
+      renderTrust(data.trust || {});
+      byId('pluginTrust').style.display = 'block';
+    } catch (e) {
+      alert('Preview failed: ' + e.message);
+    }
+  };
+
+  function renderTrust(t) {
+    const mcp = (t.MCPCommands || []).map((c) => '<li><code>' + esc(c) + '</code></li>').join('');
+    const skills = (t.Skills || []).map(esc).join(', ');
+    const unsupported = (t.Unsupported || []).map((u) => '<li>' + esc(u.kind) + ': ' + esc(u.detail) + '</li>').join('');
+    const warnings = (t.Warnings || []).map((w) => '<li class="text-warning">' + esc(w) + '</li>').join('');
+    let html = '';
+    if (mcp) html += '<div class="small fw-semibold">MCP servers (run as local commands):</div><ul class="small">' + mcp + '</ul>';
+    if (skills) html += '<div class="small">Skills: ' + esc(skills) + '</div>';
+    if (unsupported) html += '<div class="small fw-semibold mt-2">Skipped (not yet supported):</div><ul class="small">' + unsupported + '</ul>';
+    if (warnings) html += '<ul class="small mb-0">' + warnings + '</ul>';
+    byId('pluginTrustBody').innerHTML = html || '<div class="small text-muted">Nothing to register.</div>';
+  }
+
+  window.pluginConfirmInstall = async function () {
+    const { source, format } = installArgs();
+    try {
+      await api('POST', '/api/plugins/install', { source, format, confirm: true });
+      pluginCancelInstall();
+      byId('pluginSource').value = '';
+      loadPlugins();
+    } catch (e) {
+      alert('Install failed: ' + e.message);
+    }
+  };
+
+  window.pluginCancelInstall = function () {
+    byId('pluginTrust').style.display = 'none';
+    byId('pluginTrustBody').innerHTML = '';
+  };
+
+  window.pluginToggle = async function (name, enable) {
+    try {
+      await api('POST', '/api/plugins/' + encodeURIComponent(name) + (enable ? '/enable' : '/disable'));
+      loadPlugins();
+    } catch (e) {
+      alert('Failed: ' + e.message);
+    }
+  };
+
+  window.pluginUninstall = async function (name) {
+    if (!confirm('Uninstall ' + name + '? This removes its MCP servers and skills.')) return;
+    try {
+      await api('DELETE', '/api/plugins/' + encodeURIComponent(name));
+      loadPlugins();
+    } catch (e) {
+      alert('Uninstall failed: ' + e.message);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', loadPlugins);
+})();

--- a/internal/web/static/js/plugins.js
+++ b/internal/web/static/js/plugins.js
@@ -103,7 +103,7 @@
       const data = await api('POST', '/api/plugins/install', { source, format, confirm: false });
       showTrust(data.trust, async () => {
         await api('POST', '/api/plugins/install', { source, format, confirm: true });
-        pluginCancelInstall();
+        window.pluginCancelInstall();
         byId('pluginSource').value = '';
         loadPlugins();
       });
@@ -133,7 +133,7 @@
       const data = await api('POST', url, { confirm: false });
       const doUpdate = async () => {
         await api('POST', url, { confirm: true });
-        pluginCancelInstall();
+        window.pluginCancelInstall();
         loadPlugins();
       };
       if (data.changed) {
@@ -182,7 +182,7 @@
     try {
       await api('POST', '/api/plugins/marketplaces', { source });
       byId('marketplaceSource').value = '';
-      loadMarketplaces();
+      window.loadMarketplaces();
     } catch (e) {
       alert('Add marketplace failed: ' + e.message);
     }
@@ -193,7 +193,7 @@
       const data = await api('POST', '/api/plugins/marketplaces/install', { marketplace, plugin: pluginName, confirm: false });
       showTrust(data.trust, async () => {
         await api('POST', '/api/plugins/marketplaces/install', { marketplace, plugin: pluginName, confirm: true });
-        pluginCancelInstall();
+        window.pluginCancelInstall();
         loadPlugins();
       });
     } catch (e) {
@@ -203,6 +203,6 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     loadPlugins();
-    loadMarketplaces();
+    window.loadMarketplaces();
   });
 })();

--- a/internal/web/static/js/plugins.js
+++ b/internal/web/static/js/plugins.js
@@ -1,13 +1,13 @@
-// Plugins page: install, list, enable/disable, and uninstall Claude Code- and
-// Codex-compatible plugins via the /api/plugins endpoints.
+// Plugins page: install (by source or from a marketplace), list, enable/disable,
+// and uninstall Claude Code- and Codex-compatible plugins via /api/plugins.
 (function () {
   'use strict';
 
   const byId = (id) => document.getElementById(id);
 
   function esc(s) {
-    return String(s == null ? '' : s).replace(/[&<>"]/g, (c) =>
-      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
     );
   }
 
@@ -22,16 +22,50 @@
     return data;
   }
 
+  // ---- shared trust disclosure (used by source-install and marketplace-install) ----
+
+  let pendingConfirm = null;
+
+  function showTrust(report, onConfirm) {
+    renderTrustBody(report || {});
+    pendingConfirm = onConfirm;
+    byId('pluginTrust').style.display = 'block';
+  }
+
+  window.pluginConfirmInstall = async function () {
+    if (!pendingConfirm) return;
+    const fn = pendingConfirm;
+    pendingConfirm = null;
+    try { await fn(); } catch (e) { alert('Install failed: ' + e.message); }
+  };
+
+  window.pluginCancelInstall = function () {
+    pendingConfirm = null;
+    byId('pluginTrust').style.display = 'none';
+    byId('pluginTrustBody').innerHTML = '';
+  };
+
+  function renderTrustBody(t) {
+    const mcp = (t.MCPCommands || []).map((c) => '<li><code>' + esc(c) + '</code></li>').join('');
+    const skills = (t.Skills || []).map(esc).join(', ');
+    const unsupported = (t.Unsupported || []).map((u) => '<li>' + esc(u.kind) + ': ' + esc(u.detail) + '</li>').join('');
+    const warnings = (t.Warnings || []).map((w) => '<li class="text-warning">' + esc(w) + '</li>').join('');
+    let html = '';
+    if (mcp) html += '<div class="small fw-semibold">MCP servers (run as local commands):</div><ul class="small">' + mcp + '</ul>';
+    if (skills) html += '<div class="small">Skills: ' + esc(skills) + '</div>';
+    if (unsupported) html += '<div class="small fw-semibold mt-2">Skipped (not yet supported):</div><ul class="small">' + unsupported + '</ul>';
+    if (warnings) html += '<ul class="small mb-0">' + warnings + '</ul>';
+    byId('pluginTrustBody').innerHTML = html || '<div class="small text-muted">Nothing to register.</div>';
+  }
+
+  // ---- installed plugins ----
+
   window.loadPlugins = async function () {
     const list = byId('pluginList');
     try {
       const data = await api('GET', '/api/plugins');
       const plugins = (data && data.plugins) || [];
-      if (!plugins.length) {
-        list.innerHTML = '<p class="text-muted mb-0">No plugins installed yet.</p>';
-        return;
-      }
-      list.innerHTML = plugins.map(renderPlugin).join('');
+      list.innerHTML = plugins.length ? plugins.map(renderPlugin).join('') : '<p class="text-muted mb-0">No plugins installed yet.</p>';
     } catch (e) {
       list.innerHTML = '<p class="text-danger mb-0">Failed to load plugins: ' + esc(e.message) + '</p>';
     }
@@ -58,62 +92,30 @@
     );
   }
 
-  function installArgs() {
-    return {
-      source: byId('pluginSource').value.trim(),
-      format: byId('pluginFormat').value,
-    };
-  }
+  // ---- install by source ----
 
   window.pluginPreview = async function () {
-    const { source, format } = installArgs();
+    const source = byId('pluginSource').value.trim();
+    const format = byId('pluginFormat').value;
     if (!source) { alert('Enter a plugin source.'); return; }
     try {
       const data = await api('POST', '/api/plugins/install', { source, format, confirm: false });
-      renderTrust(data.trust || {});
-      byId('pluginTrust').style.display = 'block';
+      showTrust(data.trust, async () => {
+        await api('POST', '/api/plugins/install', { source, format, confirm: true });
+        pluginCancelInstall();
+        byId('pluginSource').value = '';
+        loadPlugins();
+      });
     } catch (e) {
       alert('Preview failed: ' + e.message);
     }
-  };
-
-  function renderTrust(t) {
-    const mcp = (t.MCPCommands || []).map((c) => '<li><code>' + esc(c) + '</code></li>').join('');
-    const skills = (t.Skills || []).map(esc).join(', ');
-    const unsupported = (t.Unsupported || []).map((u) => '<li>' + esc(u.kind) + ': ' + esc(u.detail) + '</li>').join('');
-    const warnings = (t.Warnings || []).map((w) => '<li class="text-warning">' + esc(w) + '</li>').join('');
-    let html = '';
-    if (mcp) html += '<div class="small fw-semibold">MCP servers (run as local commands):</div><ul class="small">' + mcp + '</ul>';
-    if (skills) html += '<div class="small">Skills: ' + esc(skills) + '</div>';
-    if (unsupported) html += '<div class="small fw-semibold mt-2">Skipped (not yet supported):</div><ul class="small">' + unsupported + '</ul>';
-    if (warnings) html += '<ul class="small mb-0">' + warnings + '</ul>';
-    byId('pluginTrustBody').innerHTML = html || '<div class="small text-muted">Nothing to register.</div>';
-  }
-
-  window.pluginConfirmInstall = async function () {
-    const { source, format } = installArgs();
-    try {
-      await api('POST', '/api/plugins/install', { source, format, confirm: true });
-      pluginCancelInstall();
-      byId('pluginSource').value = '';
-      loadPlugins();
-    } catch (e) {
-      alert('Install failed: ' + e.message);
-    }
-  };
-
-  window.pluginCancelInstall = function () {
-    byId('pluginTrust').style.display = 'none';
-    byId('pluginTrustBody').innerHTML = '';
   };
 
   window.pluginToggle = async function (name, enable) {
     try {
       await api('POST', '/api/plugins/' + encodeURIComponent(name) + (enable ? '/enable' : '/disable'));
       loadPlugins();
-    } catch (e) {
-      alert('Failed: ' + e.message);
-    }
+    } catch (e) { alert('Failed: ' + e.message); }
   };
 
   window.pluginUninstall = async function (name) {
@@ -121,10 +123,66 @@
     try {
       await api('DELETE', '/api/plugins/' + encodeURIComponent(name));
       loadPlugins();
+    } catch (e) { alert('Uninstall failed: ' + e.message); }
+  };
+
+  // ---- marketplaces ----
+
+  window.loadMarketplaces = async function () {
+    const el = byId('marketplaceList');
+    if (!el) return;
+    try {
+      const data = await api('GET', '/api/plugins/marketplaces');
+      const mps = (data && data.marketplaces) || [];
+      el.innerHTML = mps.length ? mps.map(renderMarketplace).join('') : '<p class="text-muted mb-0">No marketplaces added.</p>';
     } catch (e) {
-      alert('Uninstall failed: ' + e.message);
+      el.innerHTML = '<p class="text-danger mb-0">Failed to load marketplaces: ' + esc(e.message) + '</p>';
     }
   };
 
-  document.addEventListener('DOMContentLoaded', loadPlugins);
+  function renderMarketplace(mp) {
+    const name = esc(mp.name);
+    const entries = (mp.plugins || []).map((e) =>
+      '<li class="d-flex justify-content-between align-items-center py-1">' +
+      '<span>' + esc(e.name) + (e.description ? ' <span class="text-muted small">' + esc(e.description) + '</span>' : '') + '</span>' +
+      '<button class="modern-btn modern-btn-secondary" onclick="marketplaceInstall(\'' + name + '\', \'' + esc(e.name) + '\')">Install</button>' +
+      '</li>'
+    ).join('');
+    return (
+      '<div class="border-bottom py-2">' +
+      '<div class="fw-semibold">' + name + ' <span class="text-muted small">' + esc(mp.source || '') + '</span></div>' +
+      '<ul class="list-unstyled mb-0">' + (entries || '<li class="text-muted small">No plugins listed.</li>') + '</ul>' +
+      '</div>'
+    );
+  }
+
+  window.addMarketplace = async function () {
+    const source = byId('marketplaceSource').value.trim();
+    if (!source) { alert('Enter a marketplace source.'); return; }
+    try {
+      await api('POST', '/api/plugins/marketplaces', { source });
+      byId('marketplaceSource').value = '';
+      loadMarketplaces();
+    } catch (e) {
+      alert('Add marketplace failed: ' + e.message);
+    }
+  };
+
+  window.marketplaceInstall = async function (marketplace, pluginName) {
+    try {
+      const data = await api('POST', '/api/plugins/marketplaces/install', { marketplace, plugin: pluginName, confirm: false });
+      showTrust(data.trust, async () => {
+        await api('POST', '/api/plugins/marketplaces/install', { marketplace, plugin: pluginName, confirm: true });
+        pluginCancelInstall();
+        loadPlugins();
+      });
+    } catch (e) {
+      alert('Preview failed: ' + e.message);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', function () {
+    loadPlugins();
+    loadMarketplaces();
+  });
 })();

--- a/internal/web/static/js/plugins.js
+++ b/internal/web/static/js/plugins.js
@@ -86,6 +86,7 @@
       '<div class="d-flex gap-2">' +
       '<button class="modern-btn modern-btn-secondary" onclick="pluginToggle(\'' + name + '\', ' + (p.enabled ? 'false' : 'true') + ')">' +
       (p.enabled ? 'Disable' : 'Enable') + '</button>' +
+      '<button class="modern-btn modern-btn-secondary" onclick="pluginUpdate(\'' + name + '\')">Update</button>' +
       '<button class="modern-btn modern-btn-secondary" onclick="pluginUninstall(\'' + name + '\')">Uninstall</button>' +
       '</div>' +
       '</div>'
@@ -124,6 +125,25 @@
       await api('DELETE', '/api/plugins/' + encodeURIComponent(name));
       loadPlugins();
     } catch (e) { alert('Uninstall failed: ' + e.message); }
+  };
+
+  window.pluginUpdate = async function (name) {
+    const url = '/api/plugins/' + encodeURIComponent(name) + '/update';
+    try {
+      const data = await api('POST', url, { confirm: false });
+      const doUpdate = async () => {
+        await api('POST', url, { confirm: true });
+        pluginCancelInstall();
+        loadPlugins();
+      };
+      if (data.changed) {
+        showTrust(data.trust, doUpdate); // re-prompt: the registered components changed
+      } else {
+        await doUpdate();
+      }
+    } catch (e) {
+      alert('Update failed: ' + e.message);
+    }
   };
 
   // ---- marketplaces ----

--- a/internal/web/static/js/skills.js
+++ b/internal/web/static/js/skills.js
@@ -228,6 +228,23 @@ function renderSourceFilters() {
   });
 }
 
+let pluginSkillNames = null; // null until first fetched
+let lastRenderedSkills = null;
+
+// ensurePluginSkillNames lazily fetches which skills are plugin-owned (read-only)
+// so they can be badged, then re-renders once. Cached; safe if /api/plugins is absent.
+function ensurePluginSkillNames() {
+  if (pluginSkillNames !== null) return;
+  pluginSkillNames = new Set();
+  fetch('/api/plugins')
+    .then(r => (r.ok ? r.json() : { plugins: [] }))
+    .then(d => {
+      (d.plugins || []).forEach(p => (p.skills || []).forEach(s => pluginSkillNames.add(s)));
+      if (lastRenderedSkills) renderSkills(lastRenderedSkills);
+    })
+    .catch(() => {});
+}
+
 function renderSkills(skills) {
   const container = document.getElementById('skillsList');
   if (!container) return;
@@ -238,12 +255,16 @@ function renderSkills(skills) {
     return;
   }
 
+  lastRenderedSkills = skills;
+  ensurePluginSkillNames();
+  const pNames = pluginSkillNames || new Set();
   container.innerHTML = '';
   skills.forEach(skill => {
     const name = skill?.name || '(unnamed skill)';
     const description = skill?.description || 'No description';
     const source = getSourceLabel(skill?.source);
-    const isEditable = source === 'agent' || source === '.agents' || source === 'personal';
+    const isPlugin = pNames.has(name);
+    const isEditable = !isPlugin && (source === 'agent' || source === '.agents' || source === 'personal');
     const canDelete = source === 'agent';
     const validationErrors = Array.isArray(skill?.validation_errors) ? skill.validation_errors : [];
     const hasErrors = validationErrors.length > 0;
@@ -262,6 +283,9 @@ function renderSkills(skills) {
     const sourceTheme = getSourceTheme(source);
     const badges = [];
     badges.push(`<span class="badge" style="background: ${sourceTheme.bg}; color: ${sourceTheme.color}; font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;">${safeText(source)}</span>`);
+    if (isPlugin) {
+      badges.push('<span class="badge bg-info" style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;">plugin</span>');
+    }
     if (hasErrors) {
       badges.push('<span class="badge bg-danger" style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;">invalid</span>');
     }

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -106,6 +106,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/workspace-run.tmpl",
 		"templates/pages/usage.tmpl",
 		"templates/pages/mcp.tmpl",
+		"templates/pages/plugins.tmpl",
 		"templates/pages/models.tmpl",
 		"templates/pages/review.tmpl",
 		"templates/pages/skills.tmpl",
@@ -149,6 +150,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["workspace-run"] = tmpl
 	tr.templates["usage"] = tmpl
 	tr.templates["mcp"] = tmpl
+	tr.templates["plugins"] = tmpl
 	tr.templates["models"] = tmpl
 	tr.templates["review"] = tmpl
 	tr.templates["skills"] = tmpl
@@ -177,7 +179,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "models", "review", "agents-detail", "agents-edit", "agents-create", "skills", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-edit", "agents-create", "skills", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/components/sidebar.tmpl
+++ b/internal/web/templates/components/sidebar.tmpl
@@ -97,6 +97,13 @@
         </svg>
         <span>MCP Servers</span>
       </a>
+
+      <a href="/plugins" class="sidebar-nav-link {{if eq .CurrentPage "plugins"}}active{{end}}" data-title="Plugins">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M10,2V4H8A2,2 0 0,0 6,6V8H4V10H6V14H4V16H6V18A2,2 0 0,0 8,20H10V22H12V20H16V22H18V20A2,2 0 0,0 20,18V6A2,2 0 0,0 18,4H16V2H14V4H12V2H10M8,6H18V18H8V6Z"/>
+        </svg>
+        <span>Plugins</span>
+      </a>
     </div>
 
     <!-- Group 3: System (Bottom-pinned) -->

--- a/internal/web/templates/pages/plugins.tmpl
+++ b/internal/web/templates/pages/plugins.tmpl
@@ -58,6 +58,21 @@
           </div>
         </div>
 
+        <!-- Marketplaces -->
+        <div class="modern-card p-4 mb-4">
+          <h2 class="h6 mb-3">Marketplaces</h2>
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-10">
+              <label class="form-label" for="marketplaceSource">Add a marketplace (git URL or local folder)</label>
+              <input type="text" class="form-control" id="marketplaceSource" placeholder="https://github.com/user/marketplace.git or /path/to/catalog">
+            </div>
+            <div class="col-md-2">
+              <button class="modern-btn modern-btn-secondary w-100" onclick="addMarketplace()">Add</button>
+            </div>
+          </div>
+          <div id="marketplaceList"><p class="text-muted mb-0">Loading&hellip;</p></div>
+        </div>
+
         <!-- Installed -->
         <div class="modern-card p-4">
           <div class="d-flex align-items-center justify-content-between mb-3">

--- a/internal/web/templates/pages/plugins.tmpl
+++ b/internal/web/templates/pages/plugins.tmpl
@@ -1,0 +1,93 @@
+{{define "plugins"}}
+<!DOCTYPE html>
+<html data-bs-theme="light">
+{{template "head.tmpl" .}}
+
+<body class="bg-light">
+  <!-- Navigation -->
+  {{template "navbar.tmpl" .}}
+
+  <div class="main-content-wrapper">
+    {{template "sidebar.tmpl" .}}
+
+    <!-- Main Content -->
+    <div class="main-content">
+      <div class="container-fluid py-4">
+
+        <!-- Page Header -->
+        <div class="modern-card p-4 mb-4">
+          <div class="d-flex align-items-center justify-content-between">
+            <div>
+              <h1 class="h4 mb-1">Plugins</h1>
+              <p class="text-muted mb-0">Install Claude Code- and Codex-compatible plugins (MCP servers + skills) from a local path or a git repo.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Install -->
+        <div class="modern-card p-4 mb-4">
+          <h2 class="h6 mb-3">Install a plugin</h2>
+          <div class="row g-2 align-items-end">
+            <div class="col-md-7">
+              <label class="form-label" for="pluginSource">Source (local path or git URL)</label>
+              <input type="text" class="form-control" id="pluginSource" placeholder="/path/to/plugin or https://github.com/user/repo.git">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label" for="pluginFormat">Format</label>
+              <select class="form-select" id="pluginFormat">
+                <option value="">Auto-detect</option>
+                <option value="claude">Claude Code</option>
+                <option value="codex">Codex</option>
+              </select>
+            </div>
+            <div class="col-md-2">
+              <button class="modern-btn modern-btn-primary w-100" onclick="pluginPreview()">Preview</button>
+            </div>
+          </div>
+
+          <!-- Trust disclosure (shown after preview) -->
+          <div id="pluginTrust" class="mt-3" style="display:none;">
+            <div class="modern-card p-3" style="border:1px solid var(--border-color);">
+              <h3 class="h6 mb-2">This plugin will register:</h3>
+              <div id="pluginTrustBody"></div>
+              <div class="mt-3 d-flex gap-2">
+                <button class="modern-btn modern-btn-primary" onclick="pluginConfirmInstall()">Confirm install</button>
+                <button class="modern-btn modern-btn-secondary" onclick="pluginCancelInstall()">Cancel</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Installed -->
+        <div class="modern-card p-4">
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h6 mb-0">Installed plugins</h2>
+            <button class="modern-btn modern-btn-secondary" onclick="loadPlugins()">Refresh</button>
+          </div>
+          <div id="pluginList"><p class="text-muted mb-0">Loading&hellip;</p></div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  {{template "modals.tmpl" .}}
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- DX Utilities -->
+  <script src="/js/utils/logger.js"></script>
+  <script src="/js/utils/event-bus.js"></script>
+  <script src="/js/utils/api-client.js"></script>
+  <script src="/js/utils/dom-utils.js"></script>
+  <script src="/js/app.js"></script>
+  <script src="/js/modules/sidebar.js"></script>
+  <script src="/js/modules/themeManager.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      themeManager.initialize();
+    });
+  </script>
+  <script src="/js/plugins.js"></script>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary

Adds **plugin support** to Ori — install **Claude Code-** and **Codex-compatible plugins** (MCP servers + skills) as cohesive, shareable bundles. A plugin is a *packaging layer over Ori's existing MCP + skills primitives*, not a revival of the gRPC plugin system.

Users can install a plugin from a local path, a git URL, or a marketplace catalog; review a trust disclosure of exactly what it will register; enable/disable, update, and uninstall it; and browse/install from Claude- and Codex-compatible `marketplace.json` catalogs.

## What's included

- **Engine** (`internal/plugin`): dual-format manifest parsing (`.claude-plugin` / `.codex-plugin`, incl. Codex versioned layout), normalization to one descriptor, MCP + skill registration (`${CLAUDE_PLUGIN_ROOT}` / Codex relative-path + `cwd` → absolute resolution, namespacing, binary-presence checks), trust gate, install/uninstall/update lifecycle, and a JSON-backed installed-plugins + marketplace registry.
- **Integration** (`internal/pluginhttp` + server wiring): adapters over the live MCP config/registry + skills dir; `/api/plugins…` endpoints; routes + handler-facade wiring.
- **UI**: a Plugins page (install with trust preview, enable/disable, update, uninstall, marketplace add/browse/install) + plugin-owned MCP servers/skills shown read-only on the existing MCP/Skills pages.
- **Docs**: `docs/plugins.md`.

## Testing

- Unit-tested across `internal/plugin` and `internal/pluginhttp`.
- End-to-end (isolated server): a Claude `reaper` plugin and a Codex `.codex-plugin` both install (trust preview → confirm) → register MCP server + skill → uninstall → **zero orphans**.
- Marketplace verified against the real `awesome-codex-plugins` catalog (**113 plugins** parse + list).
- `go vet/build/test ./...` green except the pre-existing `tests/e2e TestSettingsEndpoint` false positive (unrelated — needs a seeded agent).

## Deferred (cosmetic)

- Codex `interface` logo/displayName on the plugin card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
