### PR TITLE
feat(workspace): plugin integration across creation, details, and agent skills

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -148,6 +148,7 @@ export default defineConfig([
       'internal/web/static/js/modules/workspace-detail-file-modal.js',
       'internal/web/static/js/modules/workspace-detail-mcp.js',
       'internal/web/static/js/modules/workspace-detail-skills.js',
+      'internal/web/static/js/modules/workspace-detail-plugins.js',
       'internal/web/static/js/modules/workspace-detail-memory.js',
       'internal/web/static/js/modules/workspace-task.js',
       'internal/web/static/js/modules/workspace-task-execution-views.js',

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3419,6 +3419,7 @@ const sessionManager = {
         invitedAgents: 0,
         boundMCPs: 0,
         attachedSkills: 0,
+        addedPlugins: 0,
         failures: []
       };
 
@@ -3457,6 +3458,7 @@ const sessionManager = {
         bootstrapApplyResult.invitedAgents > 0 ||
         bootstrapApplyResult.boundMCPs > 0 ||
         bootstrapApplyResult.attachedSkills > 0 ||
+        bootstrapApplyResult.addedPlugins > 0 ||
         askOriSeedResult.tasksCreated > 0 ||
         askOriSeedResult.notesCreated > 0
       ) {
@@ -3464,6 +3466,7 @@ const sessionManager = {
         if (bootstrapApplyResult.invitedAgents > 0) summaryParts.push(`${bootstrapApplyResult.invitedAgents} agent${bootstrapApplyResult.invitedAgents === 1 ? '' : 's'} invited`);
         if (bootstrapApplyResult.boundMCPs > 0) summaryParts.push(`${bootstrapApplyResult.boundMCPs} MCP${bootstrapApplyResult.boundMCPs === 1 ? '' : 's'} bound`);
         if (bootstrapApplyResult.attachedSkills > 0) summaryParts.push(`${bootstrapApplyResult.attachedSkills} skill${bootstrapApplyResult.attachedSkills === 1 ? '' : 's'} attached`);
+        if (bootstrapApplyResult.addedPlugins > 0) summaryParts.push(`${bootstrapApplyResult.addedPlugins} plugin${bootstrapApplyResult.addedPlugins === 1 ? '' : 's'} added`);
         if (askOriSeedResult.tasksCreated > 0) summaryParts.push(`${askOriSeedResult.tasksCreated} Assistant task`);
         if (askOriSeedResult.notesCreated > 0) summaryParts.push(`${askOriSeedResult.notesCreated} Assistant note`);
         const summaryText = summaryParts.join(', ');

--- a/internal/web/static/js/modules/workspace-bootstrap-review.js
+++ b/internal/web/static/js/modules/workspace-bootstrap-review.js
@@ -352,6 +352,24 @@
     }
   }
 
+  async function fetchInstalledPlugins() {
+    try {
+      const data = await apiRequest('/api/plugins');
+      return Array.isArray(data?.plugins) ? data.plugins : [];
+    } catch (_error) {
+      return [];
+    }
+  }
+
+  async function fetchPluginMarketplaces() {
+    try {
+      const data = await apiRequest('/api/plugins/marketplaces');
+      return Array.isArray(data?.marketplaces) ? data.marketplaces : [];
+    } catch (_error) {
+      return [];
+    }
+  }
+
   async function searchMarketplaceSkills(query) {
     try {
       const data = await apiRequest('/api/skills/marketplace/search', {
@@ -734,13 +752,79 @@
       .slice(0, 4);
   }
 
+  function normalizePluginCandidates(installedPlugins, marketplaces, queries) {
+    const candidates = [];
+    const seen = new Set();
+
+    (Array.isArray(installedPlugins) ? installedPlugins : []).forEach((plugin) => {
+      const name = String(plugin?.name || '').trim();
+      if (!name) return;
+      const key = name.toLowerCase();
+      if (seen.has(key)) return;
+      const description = String(plugin?.description || '').trim();
+      const mcpServers = (Array.isArray(plugin?.mcp_servers) ? plugin.mcp_servers : []).filter(Boolean);
+      const skills = (Array.isArray(plugin?.skills) ? plugin.skills : []).filter(Boolean);
+      const score = scoreTextAgainstQueries(
+        `${name} ${description} ${mcpServers.join(' ')} ${skills.join(' ')}`,
+        queries
+      );
+      if (score <= 0) return;
+      seen.add(key);
+      candidates.push({
+        id: `plugin-${key.replace(/[^a-z0-9]+/g, '-')}`,
+        name,
+        description,
+        source: 'installed',
+        action: 'attach',
+        selected: false,
+        enabled: plugin?.enabled !== false,
+        mcpServers,
+        skills,
+        score
+      });
+    });
+
+    (Array.isArray(marketplaces) ? marketplaces : []).forEach((marketplace) => {
+      const marketplaceName = String(marketplace?.name || '').trim();
+      (Array.isArray(marketplace?.plugins) ? marketplace.plugins : []).forEach((entry) => {
+        const name = String(entry?.name || '').trim();
+        if (!name) return;
+        const key = name.toLowerCase();
+        if (seen.has(key)) return;
+        const description = String(entry?.description || '').trim();
+        const score = scoreTextAgainstQueries(`${name} ${description}`, queries);
+        if (score <= 0) return;
+        seen.add(key);
+        candidates.push({
+          id: `plugin-market-${key.replace(/[^a-z0-9]+/g, '-')}`,
+          name,
+          description: description || `Suggested from the ${marketplaceName || 'plugin'} marketplace.`,
+          source: 'marketplace',
+          action: 'install_attach',
+          selected: false,
+          marketplace: marketplaceName,
+          pluginName: name,
+          mcpServers: [],
+          skills: [],
+          score
+        });
+      });
+    });
+
+    return candidates
+      .sort((left, right) => right.score - left.score)
+      .slice(0, 4);
+  }
+
   async function buildPlan(input) {
     const normalizedInput = normalizeReviewInput(input);
     const queries = deriveSearchQueries(normalizedInput);
-    const [agents, installedSkills, configuredMCPs] = await Promise.all([
+    const [agents, installedSkills, configuredMCPs, installedPlugins, pluginMarketplaces] = await Promise.all([
       fetchAgents(),
       fetchInstalledSkills(),
-      fetchConfiguredMCPServers()
+      fetchConfiguredMCPServers(),
+      fetchInstalledPlugins(),
+      fetchPluginMarketplaces()
     ]);
 
     const marketplaceSkillResults = [];
@@ -763,13 +847,15 @@
     ]).slice(0, 5);
     const planSkills = normalizeSkillCandidates(installedSkills, marketplaceSkillResults, goalQueries);
     const planMCPs = normalizeMCPCandidates(configuredMCPs, registryMCPResults, goalQueries);
+    const planPlugins = normalizePluginCandidates(installedPlugins, pluginMarketplaces, goalQueries);
 
     return {
       summary: buildPlanSummary(planAgents, planMCPs, planSkills),
       agents: planAgents,
       mcps: planMCPs,
       skills: planSkills,
-      notes: buildPlanNotes(planAgents, planMCPs, planSkills),
+      plugins: planPlugins,
+      notes: buildPlanNotes(planAgents, planMCPs, planSkills, planPlugins),
       queries
     };
   }
@@ -794,7 +880,8 @@
     return `Ori reviewed the description and prepared a starter setup with ${parts.join(', ')}${suggestionParts.length > 0 ? `. ${suggestionParts.join(', ')} available below` : ''}.`;
   }
 
-  function buildPlanNotes(agents, mcps, skills) {
+  function buildPlanNotes(agents, mcps, skills, plugins) {
+    const pluginList = Array.isArray(plugins) ? plugins : [];
     const notes = [];
     if (agents.some((agent) => agent.action === 'create')) {
       notes.push('New agents will be auto-configured from this workspace description after the workspace is created.');
@@ -808,7 +895,13 @@
     if (skills.length > 0) {
       notes.push('Skill suggestions are optional and will only be attached if selected.');
     }
-    notes.push('Selected MCPs and skills will be shared with every agent Ori adds through this setup.');
+    if (pluginList.some((item) => item.action === 'install_attach')) {
+      notes.push('Marketplace plugin suggestions are installed globally (running their local commands) before their components are added to the workspace.');
+    }
+    if (pluginList.length > 0) {
+      notes.push("Selecting a plugin binds all of its MCP servers and skills to the workspace.");
+    }
+    notes.push('Selected MCPs, skills, and plugin components will be shared with every agent Ori adds through this setup.');
     return notes;
   }
 
@@ -827,11 +920,13 @@
     const extraAgentCount = countSelections('input[data-workspace-bootstrap-agent]');
     const mcpCount = countSelections('input[data-workspace-bootstrap-mcp]');
     const skillCount = countSelections('input[data-workspace-bootstrap-skill]');
+    const pluginCount = countSelections('input[data-workspace-bootstrap-plugin]');
     const agentTotal = leadCount + extraAgentCount;
 
     const parts = [`${agentTotal} agent${agentTotal === 1 ? '' : 's'}`];
     if (mcpCount > 0) parts.push(`${mcpCount} MCP${mcpCount === 1 ? '' : 's'}`);
     if (skillCount > 0) parts.push(`${skillCount} skill${skillCount === 1 ? '' : 's'}`);
+    if (pluginCount > 0) parts.push(`${pluginCount} plugin${pluginCount === 1 ? '' : 's'}`);
     const unselectedSkillCount = Array.isArray(state.plan.skills)
       ? Math.max(0, state.plan.skills.length - skillCount)
       : 0;
@@ -932,9 +1027,58 @@
     `).join('');
   }
 
+  function renderPluginCards(items) {
+    if (!Array.isArray(items) || items.length === 0) {
+      return `
+        <div class="workspace-detail-empty">
+          No plugin suggestions yet.
+        </div>
+      `;
+    }
+
+    return items.map((item) => {
+      const isMarketplace = item.action === 'install_attach';
+      const bundleBits = [];
+      if (Array.isArray(item.mcpServers) && item.mcpServers.length > 0) {
+        bundleBits.push(`${item.mcpServers.length} MCP server${item.mcpServers.length === 1 ? '' : 's'}`);
+      }
+      if (Array.isArray(item.skills) && item.skills.length > 0) {
+        bundleBits.push(`${item.skills.length} skill${item.skills.length === 1 ? '' : 's'}`);
+      }
+      const bundleNote = isMarketplace
+        ? 'Installs globally, then adds its MCP servers and skills to this workspace.'
+        : (bundleBits.length > 0
+          ? `Bundles ${bundleBits.join(' and ')} — all added to this workspace.`
+          : "Adds this plugin's components to the workspace.");
+
+      return `
+        <div class="modern-card p-3 d-flex align-items-start gap-2 mb-2" style="border: 1px solid var(--border-color);">
+          <input type="checkbox"
+                 id="${escapeHtml(`workspace-bootstrap-plugin-${item.id}`)}"
+                 data-workspace-bootstrap-plugin="true"
+                 value="${escapeHtml(item.id)}"
+                 ${item.selected ? 'checked' : ''}>
+          <div style="display: block; flex: 1; min-width: 0;">
+            <label for="${escapeHtml(`workspace-bootstrap-plugin-${item.id}`)}" style="display: block; cursor: pointer;">
+              <span style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                <span style="font-weight: 600; color: var(--text-primary);">${escapeHtml(item.name)}</span>
+                <span class="workspace-detail-mcp-chip ${isMarketplace ? 'source' : 'status'}">
+                  ${isMarketplace ? 'Install Globally + Add' : 'Add to Workspace'}
+                </span>
+                ${isMarketplace ? '' : '<span class="workspace-detail-mcp-chip local">Local</span>'}
+              </span>
+              <span style="display: block; margin-top: 4px; font-size: 12px; color: var(--text-secondary);">${escapeHtml(item.description || 'Suggested plugin.')}</span>
+              <span style="display: block; margin-top: 4px; font-size: 11px; color: var(--text-secondary); opacity: 0.85;">${escapeHtml(bundleNote)}</span>
+            </label>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
   function bindRenderedSelectionListeners() {
     document.querySelectorAll(
-      'input[data-workspace-bootstrap-agent], input[data-workspace-bootstrap-mcp], input[data-workspace-bootstrap-skill]'
+      'input[data-workspace-bootstrap-agent], input[data-workspace-bootstrap-mcp], input[data-workspace-bootstrap-skill], input[data-workspace-bootstrap-plugin]'
     ).forEach((input) => {
       input.addEventListener('change', updateRenderedSummary);
     });
@@ -957,6 +1101,10 @@
           <div class="workspace-setup-section">
             <div class="workspace-setup-label">Workspace Skills</div>
             ${renderCapabilityCards(plan.skills, 'skill')}
+          </div>
+          <div class="workspace-setup-section">
+            <div class="workspace-setup-label">Workspace Plugins</div>
+            ${renderPluginCards(plan.plugins)}
           </div>
         </div>
         <div class="workspace-setup-preview">
@@ -1003,10 +1151,18 @@
       if (match) selectedSkills.push(match);
     });
 
+    const selectedPlugins = [];
+    document.querySelectorAll('input[data-workspace-bootstrap-plugin]').forEach((input) => {
+      if (!input.checked) return;
+      const match = (state.plan.plugins || []).find((item) => item.id === input.value);
+      if (match) selectedPlugins.push(match);
+    });
+
     return {
       agents: selectedAgents,
       mcps: selectedMCPs,
       skills: selectedSkills,
+      plugins: selectedPlugins,
       queries: state.plan.queries || []
     };
   }
@@ -1411,6 +1567,87 @@
     }
   }
 
+  function findInstalledPlugin(plugins, candidate) {
+    const candidateName = normalizeText(candidate?.name);
+    return (Array.isArray(plugins) ? plugins : []).find(
+      (plugin) => normalizeText(plugin?.name) === candidateName
+    ) || null;
+  }
+
+  // ensurePluginInstalled returns the installed plugin record (with its
+  // registered mcp_servers + skills), installing it globally from a marketplace
+  // first when the suggestion is not yet installed.
+  async function ensurePluginInstalled(candidate) {
+    if (!candidate) {
+      throw new Error('Plugin candidate missing');
+    }
+
+    const existing = findInstalledPlugin(await fetchInstalledPlugins(), candidate);
+    if (existing) {
+      return existing;
+    }
+
+    if (candidate.action !== 'install_attach') {
+      throw new Error(`Plugin ${candidate.name} is not installed`);
+    }
+    if (!candidate.marketplace || !candidate.pluginName) {
+      throw new Error(`Plugin ${candidate.name} is missing install details`);
+    }
+
+    await apiRequest('/api/plugins/marketplaces/install', {
+      method: 'POST',
+      body: { marketplace: candidate.marketplace, plugin: candidate.pluginName, confirm: true }
+    });
+
+    const installed = findInstalledPlugin(await fetchInstalledPlugins(), candidate);
+    if (!installed) {
+      throw new Error(`Plugin ${candidate.name} was not installed globally`);
+    }
+    return installed;
+  }
+
+  // applyPluginToWorkspace installs/enables a plugin globally, then binds each of
+  // its MCP servers and skills to the workspace (granting access to the same
+  // agents the rest of the setup uses). A plugin's MCP servers and skills are
+  // already registered globally once installed, so they bind through the same
+  // workspace endpoints as standalone MCPs and skills.
+  async function applyPluginToWorkspace(workspaceId, workspaceState, candidate, agentInstanceIds) {
+    const plugin = await ensurePluginInstalled(candidate);
+    const pluginName = String(plugin?.name || candidate.name || '').trim();
+
+    if (plugin.enabled === false && pluginName) {
+      try {
+        await apiRequest(`/api/plugins/${encodeURIComponent(pluginName)}/enable`, { method: 'POST' });
+      } catch (_error) {
+        // Enabling the plugin record is best-effort; binding its components below
+        // enables the underlying MCP servers regardless.
+      }
+    }
+
+    const mcpServers = (Array.isArray(plugin?.mcp_servers) ? plugin.mcp_servers : []).filter(Boolean);
+    for (const serverName of mcpServers) {
+      const bindingId = await ensureWorkspaceMCPBinding(workspaceId, workspaceState, {
+        name: serverName,
+        action: 'bind'
+      });
+      if (bindingId && agentInstanceIds.length > 0) {
+        await grantMCPAccess(workspaceId, workspaceState, bindingId, agentInstanceIds);
+      }
+    }
+
+    const skills = (Array.isArray(plugin?.skills) ? plugin.skills : []).filter(Boolean);
+    for (const skillName of skills) {
+      const bindingId = await ensureWorkspaceSkillBinding(workspaceId, workspaceState, {
+        name: skillName,
+        action: 'attach',
+        trusted: true
+      });
+      if (bindingId && agentInstanceIds.length > 0) {
+        await grantSkillAccess(workspaceId, workspaceState, bindingId, agentInstanceIds);
+      }
+    }
+  }
+
   async function applyPlan(workspaceId) {
     const selectedPlan = getSelectedPlan();
     return applySelectedPlan(workspaceId, selectedPlan, {
@@ -1425,6 +1662,7 @@
         invitedAgents: 0,
         boundMCPs: 0,
         attachedSkills: 0,
+        addedPlugins: 0,
         failures: []
       };
     }
@@ -1442,6 +1680,7 @@
       invitedAgents: 0,
       boundMCPs: 0,
       attachedSkills: 0,
+      addedPlugins: 0,
       failures: []
     };
 
@@ -1503,6 +1742,15 @@
           summary.attachedSkills += 1;
         } catch (error) {
           summary.failures.push(`Skill ${skillCandidate.name}: ${error.message || 'failed to attach'}`);
+        }
+      }
+
+      for (const pluginCandidate of (Array.isArray(selectedPlan.plugins) ? selectedPlan.plugins : [])) {
+        try {
+          await applyPluginToWorkspace(workspaceId, workspaceState, pluginCandidate, agentInstanceIds);
+          summary.addedPlugins += 1;
+        } catch (error) {
+          summary.failures.push(`Plugin ${pluginCandidate.name}: ${error.message || 'failed to add'}`);
         }
       }
 

--- a/internal/web/static/js/modules/workspace-create.js
+++ b/internal/web/static/js/modules/workspace-create.js
@@ -564,6 +564,7 @@ async function createWorkspace() {
       invitedAgents: 0,
       boundMCPs: 0,
       attachedSkills: 0,
+      addedPlugins: 0,
       failures: []
     };
     if (
@@ -631,6 +632,7 @@ async function createWorkspace() {
       if (bootstrapApplyResult.invitedAgents > 0) successMessageParts.push(`${bootstrapApplyResult.invitedAgents} agent${bootstrapApplyResult.invitedAgents === 1 ? '' : 's'} invited`);
       if (bootstrapApplyResult.boundMCPs > 0) successMessageParts.push(`${bootstrapApplyResult.boundMCPs} MCP${bootstrapApplyResult.boundMCPs === 1 ? '' : 's'} bound`);
       if (bootstrapApplyResult.attachedSkills > 0) successMessageParts.push(`${bootstrapApplyResult.attachedSkills} skill${bootstrapApplyResult.attachedSkills === 1 ? '' : 's'} attached`);
+      if (bootstrapApplyResult.addedPlugins > 0) successMessageParts.push(`${bootstrapApplyResult.addedPlugins} plugin${bootstrapApplyResult.addedPlugins === 1 ? '' : 's'} added`);
       if (seededTaskCount > 0) successMessageParts.push(`${seededTaskCount} starter task${seededTaskCount === 1 ? '' : 's'} added`);
       if (typeof window.showToast === 'function') {
         if (bootstrapApplyResult.failures.length > 0) {

--- a/internal/web/static/js/modules/workspace-detail-plugins.js
+++ b/internal/web/static/js/modules/workspace-detail-plugins.js
@@ -1,0 +1,403 @@
+/**
+ * Workspace Plugins Manager
+ *
+ * Owns the workspace detail page's "Plugins" tab. Plugins are installed
+ * globally (see the Plugins page); a plugin is "in" a workspace when its
+ * MCP servers and skills are bound to that workspace. This manager lists the
+ * globally installed plugins, shows whether each is attached to the current
+ * workspace, and lets the user add or remove a plugin's components.
+ *
+ * - Add reuses WorkspaceBootstrapReview.applySelectedPlan, the same code path
+ *   the workspace-creation modal uses to install/enable a plugin and bind its
+ *   components.
+ * - Remove deletes the workspace MCP/skill bindings that match the plugin's
+ *   components (the global plugin install is left untouched).
+ *
+ * Extracted to mirror WorkspaceMCPManager / WorkspaceSkillsManager. The host
+ * (WorkspaceDetailPage) provides workspace, workspaceId, escapeHtml,
+ * loadWorkspace, and DOM element refs.
+ *
+ * @module workspace-detail-plugins
+ */
+
+export class WorkspacePluginsManager {
+  constructor(host) {
+    this.host = host;
+    this.installedPlugins = [];
+    this.loaded = false;
+    this.loadPromise = null;
+    this.busyPlugins = new Set();
+  }
+
+  bindEvents() {
+    const elements = this.host.elements;
+    elements.refreshPluginsBtn?.addEventListener('click', () => this.reload());
+    elements.pluginsList?.addEventListener('click', event => this.handleListClick(event));
+  }
+
+  normalize(value) {
+    return String(value || '')
+      .trim()
+      .toLowerCase();
+  }
+
+  async loadInstalledPlugins(force = false) {
+    if (!force && this.loaded) {
+      return this.installedPlugins;
+    }
+    if (!force && this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    this.loadPromise = (async () => {
+      const response = await fetch('/api/plugins');
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'Failed to load plugins');
+      }
+      const data = await response.json();
+      this.installedPlugins = Array.isArray(data?.plugins) ? data.plugins : [];
+      this.loaded = true;
+      return this.installedPlugins;
+    })();
+
+    try {
+      return await this.loadPromise;
+    } finally {
+      this.loadPromise = null;
+    }
+  }
+
+  async reload() {
+    try {
+      await this.loadInstalledPlugins(true);
+    } catch (error) {
+      console.error('Failed to refresh plugins:', error);
+      if (window.Toast) window.Toast.error(error.message || 'Failed to refresh plugins');
+    }
+    this.render();
+  }
+
+  /**
+   * Render the plugins list. Uses the cached installed-plugins list (loading it
+   * once on first render) and the current workspace bindings, so add/remove and
+   * workspace reloads re-render attachment status without refetching the list.
+   */
+  render() {
+    if (!this.host.elements.pluginsList) return;
+
+    if (!this.loaded) {
+      if (!this.loadPromise) {
+        this.loadInstalledPlugins()
+          .then(() => this.render())
+          .catch(error => {
+            console.error('Failed to load plugins:', error);
+            this.renderError(error);
+          });
+      }
+      this.host.elements.pluginsList.innerHTML = `
+        <div class="workspace-detail-empty">Loading installed plugins...</div>
+      `;
+      return;
+    }
+
+    const plugins = Array.isArray(this.installedPlugins) ? this.installedPlugins : [];
+    if (plugins.length === 0) {
+      this.host.elements.pluginsList.innerHTML = `
+        <div class="workspace-detail-empty">
+          No plugins installed yet.
+          <div class="workspace-detail-mcp-empty-note">Install Claude Code- or Codex-compatible plugins on the <a href="/plugins">Plugins page</a>, then add them to this workspace here.</div>
+        </div>
+      `;
+      return;
+    }
+
+    this.host.elements.pluginsList.innerHTML = plugins
+      .map(plugin => this.renderPluginCard(plugin))
+      .join('');
+  }
+
+  renderError(error) {
+    if (!this.host.elements.pluginsList) return;
+    this.host.elements.pluginsList.innerHTML = `
+      <div class="workspace-detail-empty">Failed to load plugins: ${this.host.escapeHtml(
+        error?.message || 'unknown error'
+      )}</div>
+    `;
+  }
+
+  getBoundComponentNames(bindings, ...keys) {
+    const names = new Set();
+    (Array.isArray(bindings) ? bindings : []).forEach(binding => {
+      for (const key of keys) {
+        const value = this.normalize(binding?.[key]);
+        if (value) {
+          names.add(value);
+          break;
+        }
+      }
+    });
+    return names;
+  }
+
+  describePluginAttachment(plugin) {
+    const mcpServers = (Array.isArray(plugin?.mcp_servers) ? plugin.mcp_servers : []).filter(Boolean);
+    const skills = (Array.isArray(plugin?.skills) ? plugin.skills : []).filter(Boolean);
+    const total = mcpServers.length + skills.length;
+
+    const boundMCP = this.getBoundComponentNames(
+      this.host.workspace?.mcp_bindings,
+      'server_name',
+      'serverName'
+    );
+    const boundSkill = this.getBoundComponentNames(
+      this.host.workspace?.skill_bindings,
+      'skill_name',
+      'skillName'
+    );
+
+    const bound =
+      mcpServers.filter(name => boundMCP.has(this.normalize(name))).length +
+      skills.filter(name => boundSkill.has(this.normalize(name))).length;
+
+    let status = 'detached';
+    if (total > 0 && bound >= total) status = 'attached';
+    else if (bound > 0) status = 'partial';
+
+    return { total, bound, mcpServers, skills, status };
+  }
+
+  renderPluginCard(plugin) {
+    const name = String(plugin?.name || '').trim() || 'unknown';
+    const escName = this.host.escapeHtml(name);
+    const version = String(plugin?.version || '').trim();
+    const description = String(plugin?.description || '').trim();
+    const format = String(plugin?.format || '').trim();
+    const { total, bound, mcpServers, skills, status } = this.describePluginAttachment(plugin);
+    const busy = this.busyPlugins.has(this.normalize(name));
+
+    const componentBits = [];
+    if (mcpServers.length > 0) {
+      componentBits.push(`${mcpServers.length} MCP server${mcpServers.length === 1 ? '' : 's'}`);
+    }
+    if (skills.length > 0) {
+      componentBits.push(`${skills.length} skill${skills.length === 1 ? '' : 's'}`);
+    }
+    const componentSummary = componentBits.length > 0 ? componentBits.join(' · ') : 'No bindable components';
+
+    const statusChip =
+      status === 'attached'
+        ? '<span class="workspace-detail-mcp-chip status">In this workspace</span>'
+        : status === 'partial'
+          ? `<span class="workspace-detail-mcp-chip status is-disabled">Partially added (${bound}/${total})</span>`
+          : '<span class="workspace-detail-mcp-chip source">Not in workspace</span>';
+
+    const chips = [
+      statusChip,
+      format ? `<span class="workspace-detail-mcp-chip source">${this.host.escapeHtml(format)}</span>` : '',
+      `<span class="workspace-detail-mcp-chip scope">${this.host.escapeHtml(componentSummary)}</span>`,
+      plugin?.enabled === false
+        ? '<span class="workspace-detail-mcp-chip status is-disabled">Globally disabled</span>'
+        : ''
+    ]
+      .filter(Boolean)
+      .join('');
+
+    let actionButton = '';
+    if (total === 0) {
+      actionButton = '';
+    } else if (status === 'detached') {
+      actionButton = `
+        <button type="button"
+                class="workspace-detail-panel-btn workspace-detail-panel-btn-primary"
+                data-workspace-plugin-action="add"
+                data-plugin-name="${escName}"
+                ${busy ? 'disabled' : ''}>
+          ${busy ? 'Adding…' : 'Add to workspace'}
+        </button>
+      `;
+    } else {
+      actionButton = `
+        <button type="button"
+                class="workspace-detail-panel-btn"
+                data-workspace-plugin-action="remove"
+                data-plugin-name="${escName}"
+                ${busy ? 'disabled' : ''}>
+          ${busy ? 'Removing…' : status === 'partial' ? 'Remove remaining' : 'Remove from workspace'}
+        </button>
+      `;
+    }
+
+    return `
+      <div class="workspace-detail-mcp-card" data-plugin-name="${escName}">
+        <div class="workspace-detail-mcp-card-top">
+          <div class="workspace-detail-mcp-card-top-main">
+            <div class="workspace-detail-mcp-server">
+              <span>${escName}</span>
+              ${version ? `<code>${this.host.escapeHtml(version)}</code>` : ''}
+            </div>
+            <div class="workspace-detail-mcp-meta">${this.host.escapeHtml(componentSummary)}</div>
+          </div>
+          ${actionButton ? `<div class="workspace-detail-mcp-card-actions">${actionButton}</div>` : ''}
+        </div>
+        ${description ? `<div class="workspace-detail-mcp-description">${this.host.escapeHtml(description)}</div>` : ''}
+        <div class="workspace-detail-mcp-chip-row">${chips}</div>
+      </div>
+    `;
+  }
+
+  handleListClick(event) {
+    const button = event.target.closest('[data-workspace-plugin-action]');
+    if (!button) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const action = String(button.dataset.workspacePluginAction || '').trim();
+    const name = String(button.dataset.pluginName || '').trim();
+    if (!name) return;
+
+    if (action === 'add') {
+      this.addPlugin(name);
+    } else if (action === 'remove') {
+      this.removePlugin(name);
+    }
+  }
+
+  findPlugin(name) {
+    const normalized = this.normalize(name);
+    return (
+      (Array.isArray(this.installedPlugins) ? this.installedPlugins : []).find(
+        plugin => this.normalize(plugin?.name) === normalized
+      ) || null
+    );
+  }
+
+  setPluginBusy(name, busy) {
+    const key = this.normalize(name);
+    if (busy) {
+      this.busyPlugins.add(key);
+    } else {
+      this.busyPlugins.delete(key);
+    }
+    this.render();
+  }
+
+  async addPlugin(name) {
+    const plugin = this.findPlugin(name);
+    if (!plugin) return;
+
+    if (
+      !window.WorkspaceBootstrapReview ||
+      typeof window.WorkspaceBootstrapReview.applySelectedPlan !== 'function'
+    ) {
+      if (window.Toast) window.Toast.error('Plugin setup is unavailable');
+      return;
+    }
+
+    this.setPluginBusy(name, true);
+    try {
+      const candidate = {
+        id: `plugin-${this.normalize(plugin.name).replace(/[^a-z0-9]+/g, '-')}`,
+        name: String(plugin.name || '').trim(),
+        action: 'attach',
+        mcpServers: (Array.isArray(plugin.mcp_servers) ? plugin.mcp_servers : []).filter(Boolean),
+        skills: (Array.isArray(plugin.skills) ? plugin.skills : []).filter(Boolean)
+      };
+
+      const result = await window.WorkspaceBootstrapReview.applySelectedPlan(this.host.workspaceId, {
+        agents: [],
+        mcps: [],
+        skills: [],
+        plugins: [candidate],
+        queries: []
+      });
+
+      await this.host.loadWorkspace();
+
+      const failures = Array.isArray(result?.failures) ? result.failures : [];
+      if (failures.length > 0) {
+        if (window.Toast) {
+          window.Toast.warning(`Added ${candidate.name} with issues: ${failures[0]}`);
+        }
+      } else if (window.Toast) {
+        window.Toast.success(`Added ${candidate.name} to this workspace`);
+      }
+    } catch (error) {
+      console.error('Failed to add plugin to workspace:', error);
+      if (window.Toast) window.Toast.error(error.message || 'Failed to add plugin to workspace');
+    } finally {
+      this.setPluginBusy(name, false);
+    }
+  }
+
+  async removePlugin(name) {
+    const plugin = this.findPlugin(name);
+    if (!plugin) return;
+
+    const label = String(plugin.name || '').trim();
+    if (
+      !window.confirm(
+        `Remove "${label}" from this workspace? Its MCP servers and skills will be unbound here (the plugin stays installed globally).`
+      )
+    ) {
+      return;
+    }
+
+    this.setPluginBusy(name, true);
+    try {
+      const mcpServers = new Set(
+        (Array.isArray(plugin.mcp_servers) ? plugin.mcp_servers : [])
+          .filter(Boolean)
+          .map(value => this.normalize(value))
+      );
+      const skills = new Set(
+        (Array.isArray(plugin.skills) ? plugin.skills : [])
+          .filter(Boolean)
+          .map(value => this.normalize(value))
+      );
+
+      const mcpBindings = (
+        Array.isArray(this.host.workspace?.mcp_bindings) ? this.host.workspace.mcp_bindings : []
+      ).filter(binding =>
+        mcpServers.has(this.normalize(binding?.server_name || binding?.serverName))
+      );
+      const skillBindings = (
+        Array.isArray(this.host.workspace?.skill_bindings) ? this.host.workspace.skill_bindings : []
+      ).filter(binding => skills.has(this.normalize(binding?.skill_name || binding?.skillName)));
+
+      const workspaceId = this.host.workspaceId;
+      for (const binding of mcpBindings) {
+        const id = String(binding?.id || '').trim();
+        if (!id) continue;
+        const response = await fetch(
+          `/api/workspaces/${encodeURIComponent(workspaceId)}/mcp-bindings/${encodeURIComponent(id)}`,
+          { method: 'DELETE' }
+        );
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || 'Failed to remove MCP binding');
+        }
+      }
+      for (const binding of skillBindings) {
+        const id = String(binding?.id || '').trim();
+        if (!id) continue;
+        const response = await fetch(
+          `/api/workspaces/${encodeURIComponent(workspaceId)}/skill-bindings/${encodeURIComponent(id)}`,
+          { method: 'DELETE' }
+        );
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || 'Failed to remove skill binding');
+        }
+      }
+
+      await this.host.loadWorkspace();
+      if (window.Toast) window.Toast.success(`Removed ${label} from this workspace`);
+    } catch (error) {
+      console.error('Failed to remove plugin from workspace:', error);
+      if (window.Toast) window.Toast.error(error.message || 'Failed to remove plugin from workspace');
+    } finally {
+      this.setPluginBusy(name, false);
+    }
+  }
+}

--- a/internal/web/static/js/modules/workspace-detail-skills.js
+++ b/internal/web/static/js/modules/workspace-detail-skills.js
@@ -283,6 +283,88 @@ export class WorkspaceSkillsManager {
       .filter(Boolean);
   }
 
+  /**
+   * Skill bindings that are effective for an agent in this workspace — the
+   * workspace skill bindings the agent's instances are allowed to use (after
+   * agent_skill_access rules). Mirrors the MCP manager's
+   * getEffectiveWorkspaceMCPBindingsForAgent so the agent info card stays
+   * workspace-scoped rather than showing the agent's global skill catalog.
+   */
+  getEffectiveWorkspaceSkillBindingsForAgent(agentName) {
+    const bindings = this.getWorkspaceSkillBindings();
+    if (bindings.length === 0) {
+      return [];
+    }
+
+    const instanceIds = this.host.getAgentInstanceIdsForName(agentName);
+    if (instanceIds.length === 0) {
+      return bindings;
+    }
+
+    const accessEntries = Array.isArray(this.host.workspace?.agent_skill_access)
+      ? this.host.workspace.agent_skill_access
+      : [];
+
+    const allowedByInstance = instanceIds.map(instanceID => {
+      const entry = accessEntries.find(
+        item => String(item?.agent_instance_id || '').trim() === instanceID
+      );
+      if (!entry) {
+        return bindings;
+      }
+      if (!Array.isArray(entry.enabled_binding_ids) || entry.enabled_binding_ids.length === 0) {
+        return [];
+      }
+
+      const allowedIDs = new Set(
+        entry.enabled_binding_ids
+          .map(value =>
+            String(value || '')
+              .trim()
+              .toLowerCase()
+          )
+          .filter(Boolean)
+      );
+      return bindings.filter(binding =>
+        allowedIDs.has(
+          String(binding.id || '')
+            .trim()
+            .toLowerCase()
+        )
+      );
+    });
+
+    const merged = [];
+    const seen = new Set();
+    allowedByInstance.flat().forEach(binding => {
+      const key =
+        String(binding?.id || '')
+          .trim()
+          .toLowerCase() ||
+        String(binding?.skillName || '')
+          .trim()
+          .toLowerCase();
+      if (!key || seen.has(key)) return;
+      seen.add(key);
+      merged.push(binding);
+    });
+    return merged;
+  }
+
+  getEffectiveWorkspaceSkillNamesForAgent(agentName) {
+    const names = [];
+    const seen = new Set();
+    this.getEffectiveWorkspaceSkillBindingsForAgent(agentName).forEach(binding => {
+      const name = String(binding?.skillName || '').trim();
+      if (!name) return;
+      const key = name.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      names.push(name);
+    });
+    return names;
+  }
+
   async loadAvailableSkills(force = false) {
     if (!force && Array.isArray(this.availableSkills) && this.availableSkills.length > 0) {
       return this.availableSkills;

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -2815,7 +2815,9 @@ export class WorkspaceDetailPage {
         ? 'data-workspace-intent-review-agent'
         : kind === 'mcp'
           ? 'data-workspace-intent-review-mcp'
-          : 'data-workspace-intent-review-skill';
+          : kind === 'plugin'
+            ? 'data-workspace-intent-review-plugin'
+            : 'data-workspace-intent-review-skill';
     const label =
       kind === 'mcp'
         ? item.action && item.action.indexOf('install') >= 0
@@ -2825,9 +2827,13 @@ export class WorkspaceDetailPage {
           ? item.action && item.action.indexOf('install') >= 0
             ? 'Install + Attach'
             : 'Attach'
-          : item.action === 'create'
-            ? 'Create'
-            : 'Invite';
+          : kind === 'plugin'
+            ? item.action && item.action.indexOf('install') >= 0
+              ? 'Install + Add'
+              : 'Add'
+            : item.action === 'create'
+              ? 'Create'
+              : 'Invite';
     const secondaryChipClass =
       item.action === 'create' || (item.action && item.action.indexOf('install') >= 0)
         ? 'source'
@@ -2863,6 +2869,7 @@ export class WorkspaceDetailPage {
       : [];
     const mcps = Array.isArray(plan.mcps) ? plan.mcps : [];
     const skills = Array.isArray(plan.skills) ? plan.skills : [];
+    const plugins = Array.isArray(plan.plugins) ? plan.plugins : [];
 
     const leadMarkup = lead
       ? `
@@ -2913,6 +2920,14 @@ export class WorkspaceDetailPage {
                 : '<div class="workspace-detail-empty">No workspace skill recommendations right now.</div>'
             }
           </div>
+          <div class="workspace-setup-section mt-3">
+            <div class="workspace-setup-label">Workspace Plugins</div>
+            ${
+              plugins.length > 0
+                ? plugins.map(item => this.buildWorkspaceIntentReviewCard(item, 'plugin')).join('')
+                : '<div class="workspace-detail-empty">No plugin recommendations right now.</div>'
+            }
+          </div>
         </div>
         <div class="col-12">
           <div class="workspace-detail-settings-summary-card">
@@ -2927,7 +2942,7 @@ export class WorkspaceDetailPage {
     this.elements.intentReviewPanel.hidden = false;
     this.elements.intentReviewResults
       .querySelectorAll(
-        'input[data-workspace-intent-review-agent], input[data-workspace-intent-review-mcp], input[data-workspace-intent-review-skill]'
+        'input[data-workspace-intent-review-agent], input[data-workspace-intent-review-mcp], input[data-workspace-intent-review-skill], input[data-workspace-intent-review-plugin]'
       )
       .forEach(input => {
         input.addEventListener('change', () => this.updateWorkspaceIntentReviewSelectionSummary());
@@ -2956,6 +2971,11 @@ export class WorkspaceDetailPage {
         'input[data-workspace-intent-review-skill]'
       ) || []
     ).filter(input => input.checked).length;
+    const pluginCount = Array.from(
+      this.elements.intentReviewResults?.querySelectorAll(
+        'input[data-workspace-intent-review-plugin]'
+      ) || []
+    ).filter(input => input.checked).length;
     const totalAgents =
       (this.workspaceIntentReviewPlan.agents?.some(agent => agent.role === 'lead') ? 1 : 0) +
       optionalAgentCount;
@@ -2963,6 +2983,7 @@ export class WorkspaceDetailPage {
     const parts = [`${totalAgents} agent${totalAgents === 1 ? '' : 's'}`];
     if (mcpCount > 0) parts.push(`${mcpCount} MCP${mcpCount === 1 ? '' : 's'}`);
     if (skillCount > 0) parts.push(`${skillCount} skill${skillCount === 1 ? '' : 's'}`);
+    if (pluginCount > 0) parts.push(`${pluginCount} plugin${pluginCount === 1 ? '' : 's'}`);
     this.elements.intentReviewMeta.textContent = `Selected for apply: ${parts.join(', ')}.`;
     this.setWorkspaceIntentBusy(false, 'apply');
   }
@@ -3006,10 +3027,24 @@ export class WorkspaceDetailPage {
       if (match) selectedSkills.push(match);
     });
 
+    const selectedPlugins = [];
+    Array.from(
+      this.elements.intentReviewResults?.querySelectorAll(
+        'input[data-workspace-intent-review-plugin]'
+      ) || []
+    ).forEach(input => {
+      if (!input.checked) return;
+      const match = (this.workspaceIntentReviewPlan.plugins || []).find(
+        item => item.id === input.value
+      );
+      if (match) selectedPlugins.push(match);
+    });
+
     return {
       agents: selectedAgents,
       mcps: selectedMCPs,
       skills: selectedSkills,
+      plugins: selectedPlugins,
       queries: this.workspaceIntentReviewPlan.queries || []
     };
   }
@@ -3176,6 +3211,10 @@ export class WorkspaceDetailPage {
       if (result.attachedSkills > 0)
         summaryParts.push(
           `${result.attachedSkills} skill${result.attachedSkills === 1 ? '' : 's'} attached`
+        );
+      if (result.addedPlugins > 0)
+        summaryParts.push(
+          `${result.addedPlugins} plugin${result.addedPlugins === 1 ? '' : 's'} added`
         );
       if (result.failures.length > 0) {
         this.setWorkspaceIntentStatus(

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -9,6 +9,7 @@
 import { WorkspaceDirectoryExplorer } from './workspace-detail-directory-explorer.js';
 import { WorkspaceMCPManager } from './workspace-detail-mcp.js';
 import { WorkspaceSkillsManager } from './workspace-detail-skills.js';
+import { WorkspacePluginsManager } from './workspace-detail-plugins.js';
 import { WorkspaceMemoryManager } from './workspace-detail-memory.js';
 import { WorkspaceFileModalManager } from './workspace-detail-file-modal.js';
 import { WorkspaceMembersPanel } from './workspace-detail-members.js';
@@ -226,6 +227,7 @@ export class WorkspaceDetailPage {
     this.agentSkillsPromises = new Map();
     this.mcpManager = new WorkspaceMCPManager(this);
     this.skillsManager = new WorkspaceSkillsManager(this);
+    this.pluginsManager = new WorkspacePluginsManager(this);
     this.memoryManager = new WorkspaceMemoryManager(this);
     this.workspaceSettings = null;
     this.workspaceSettingsEffectiveBehavior = null;
@@ -1020,6 +1022,7 @@ export class WorkspaceDetailPage {
       intentReviewResults: document.getElementById('workspace-detail-intent-review-results'),
       intentReviewMeta: document.getElementById('workspace-detail-intent-review-meta'),
       skillsList: document.getElementById('workspace-detail-skills-list'),
+      pluginsList: document.getElementById('workspace-detail-plugins-list'),
       schedulesList: document.getElementById('workspace-detail-schedules-list'),
       childrenList: document.getElementById('workspace-detail-children-list'),
 
@@ -1055,6 +1058,7 @@ export class WorkspaceDetailPage {
       refreshSettingsBtn: document.getElementById('workspace-detail-refresh-settings'),
       addSkillBtn: document.getElementById('workspace-detail-add-skill'),
       refreshSkillsBtn: document.getElementById('workspace-detail-refresh-skills'),
+      refreshPluginsBtn: document.getElementById('workspace-detail-refresh-plugins'),
       viewSchedulesBtn: document.getElementById('workspace-detail-view-schedules'),
       homeAssistantQuickPlanBtn: document.getElementById('homeAssistantQuickPlan'),
       homeAssistantQuickTasksBtn: document.getElementById('homeAssistantQuickTasks'),
@@ -1581,6 +1585,7 @@ export class WorkspaceDetailPage {
       await this.loadWorkspace();
     });
     this.skillsManager.bindEvents();
+    this.pluginsManager.bindEvents();
     this.memoryManager.bindEvents();
     this.elements.skillsModal?.addEventListener('shown.bs.modal', () => {
       this.applyTopBackdropLayer('workspace-detail-backdrop-skills');
@@ -2137,6 +2142,7 @@ export class WorkspaceDetailPage {
       this.renderWorkspaceMCPBindings();
       this.renderWorkspaceSettings();
       this.renderWorkspaceSkillBindings();
+      this.renderWorkspacePluginBindings();
       this.renderAgentGroups();
       this.refreshHomeAssistantQuickPrompts();
       this.renderWorkspaceHealth();
@@ -10764,6 +10770,10 @@ export class WorkspaceDetailPage {
 
   getWorkspaceSkillBindings(options = {}) {
     return this.skillsManager.getWorkspaceSkillBindings(options);
+  }
+
+  renderWorkspacePluginBindings() {
+    return this.pluginsManager.render();
   }
 
   // Planning-config helpers live with the skills manager since they shape the

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3818,8 +3818,7 @@ export class WorkspaceDetailPage {
     const levelLabel = stage ? `Lv ${level} · ${stage}` : `Lv ${level}`;
     const roleBadge = this.renderWorkspaceAgentRoleBadge(group.name);
 
-    const skillsState = this.getAgentSkillsState(group.name);
-    const skillsMarkup = this.renderAgentSkillsChips(skillsState, profile);
+    const skillsMarkup = this.renderAgentWorkspaceSkillChips(group.name);
 
     const mcpServers = this.getEffectiveWorkspaceMCPServerNames(group.name);
     const mcpMarkup =
@@ -3890,81 +3889,22 @@ export class WorkspaceDetailPage {
     `;
   }
 
-  getAgentSkillsState(agentName) {
-    const key = this.normalizeAgentName(agentName);
-    if (!key) return { status: 'idle', skills: [] };
-    return this.agentSkillsCache.get(key) || { status: 'idle', skills: [] };
-  }
-
-  renderAgentSkillsChips(skillsState, profile = null) {
-    const fallbackSkills = [];
-    const fallbackSeen = new Set();
-    const addFallbackSkill = value => {
-      const name = String(value || '').trim();
-      if (!name) return;
-      const key = name.toLowerCase();
-      if (fallbackSeen.has(key)) return;
-      fallbackSeen.add(key);
-      fallbackSkills.push(name);
-    };
-
-    if (Array.isArray(profile?.capabilities)) {
-      profile.capabilities.forEach(addFallbackSkill);
+  // Renders the agent info card's SKILLS chips from the skills that are
+  // effective for this agent *in this workspace* (workspace skill bindings the
+  // agent can use), matching the sibling "MCP Attached" block. This is
+  // intentionally workspace-scoped rather than the agent's global skill catalog
+  // returned by /api/skills.
+  renderAgentWorkspaceSkillChips(agentName) {
+    const skillNames = this.getEffectiveWorkspaceSkillNamesForAgent(agentName);
+    if (skillNames.length === 0) {
+      return '<span class="workspace-detail-agent-info-empty">No workspace skills attached.</span>';
     }
-    if (Array.isArray(profile?.enabledPlugins)) {
-      profile.enabledPlugins.forEach(addFallbackSkill);
-    }
-
-    if (!skillsState || skillsState.status === 'idle' || skillsState.status === 'loading') {
-      if (fallbackSkills.length > 0) {
-        return fallbackSkills
-          .slice(0, 8)
-          .map(
-            skill =>
-              `<span class="workspace-detail-agent-info-chip skill">${this.escapeHtml(skill)}</span>`
-          )
-          .join('');
-      }
-      return '<span class="workspace-detail-agent-info-empty">Loading skills...</span>';
-    }
-
-    if (skillsState.status === 'conflict') {
-      return '<span class="workspace-detail-agent-info-empty">Skill conflicts detected.</span>';
-    }
-
-    if (skillsState.status === 'error') {
-      if (fallbackSkills.length > 0) {
-        return fallbackSkills
-          .slice(0, 8)
-          .map(
-            skill =>
-              `<span class="workspace-detail-agent-info-chip skill">${this.escapeHtml(skill)}</span>`
-          )
-          .join('');
-      }
-      return '<span class="workspace-detail-agent-info-empty">Failed to load skills.</span>';
-    }
-
-    const enabledSkills = Array.isArray(skillsState.skills)
-      ? skillsState.skills.filter(skill => skill.enabled !== false && skill.name)
-      : [];
-
-    if (enabledSkills.length === 0) {
-      return '<span class="workspace-detail-agent-info-empty">No enabled skills.</span>';
-    }
-
-    const visibleSkills = enabledSkills.slice(0, 8);
-    const overflowCount = enabledSkills.length - visibleSkills.length;
-    const chips = visibleSkills
+    return skillNames
       .map(
         skill =>
-          `<span class="workspace-detail-agent-info-chip skill">${this.escapeHtml(skill.name)}</span>`
+          `<span class="workspace-detail-agent-info-chip skill">${this.escapeHtml(skill)}</span>`
       )
       .join('');
-
-    return overflowCount > 0
-      ? `${chips}<span class="workspace-detail-agent-info-chip count">+${overflowCount} more</span>`
-      : chips;
   }
 
   getAgentCardElementByKey(agentKey) {
@@ -3987,9 +3927,7 @@ export class WorkspaceDetailPage {
     const card = this.getAgentCardElementByKey(key);
     if (!card) return false;
 
-    const profile = this.getAgentProfile(agentName);
-    const skillsState = this.getAgentSkillsState(agentName);
-    const skillsMarkup = this.renderAgentSkillsChips(skillsState, profile);
+    const skillsMarkup = this.renderAgentWorkspaceSkillChips(agentName);
 
     const skillContainers = card.querySelectorAll(
       '.workspace-detail-agent-skills-list[data-agent-skills-key]'
@@ -4033,11 +3971,9 @@ export class WorkspaceDetailPage {
     } else {
       this.renderAgentGroups();
     }
-    this.ensureAgentSkillsLoaded(agentName);
-  }
-
-  async ensureAgentSkillsLoaded(agentName) {
-    await this.loadAgentSkills(agentName, { refreshUI: true });
+    // The agent info card's SKILLS now renders synchronously from
+    // workspace-effective skill bindings (see renderAgentWorkspaceSkillChips),
+    // so flipping no longer needs to fetch the agent's global skill catalog.
   }
 
   async loadAgentSkills(agentName, options = {}) {
@@ -9881,6 +9817,10 @@ export class WorkspaceDetailPage {
 
   getEffectiveWorkspaceMCPServerNames(agentName) {
     return this.mcpManager.getEffectiveWorkspaceMCPServerNames(agentName);
+  }
+
+  getEffectiveWorkspaceSkillNamesForAgent(agentName) {
+    return this.skillsManager.getEffectiveWorkspaceSkillNamesForAgent(agentName);
   }
 
   getWorkspaceMCPBindings(options = {}) {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -380,6 +380,17 @@
                 </button>
                 <button
                   class="nav-link workspace-detail-config-tab"
+                  id="workspace-detail-config-plugins-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#workspace-detail-config-plugins-pane"
+                  type="button"
+                  role="tab"
+                  aria-controls="workspace-detail-config-plugins-pane"
+                  aria-selected="false">
+                  Plugins
+                </button>
+                <button
+                  class="nav-link workspace-detail-config-tab"
                   id="workspace-detail-config-mission-tab"
                   data-bs-toggle="tab"
                   data-bs-target="#workspace-detail-config-mission-pane"
@@ -748,6 +759,36 @@
                   </div>
                   <div id="workspace-detail-skills-list" class="workspace-detail-mcp-list">
                     <div class="workspace-detail-empty">Loading workspace skill bindings...</div>
+                  </div>
+                </div>
+                <div
+                  class="tab-pane fade workspace-detail-config-pane"
+                  id="workspace-detail-config-plugins-pane"
+                  role="tabpanel"
+                  aria-labelledby="workspace-detail-config-plugins-tab"
+                  tabindex="0">
+                  <div class="workspace-detail-config-pane-header">
+                    <div>
+                      <div class="workspace-detail-config-pane-title">Workspace Plugins</div>
+                      <div class="workspace-detail-config-pane-copy">
+                        Add an installed plugin to this workspace to bind all of its MCP servers and skills at once. Added components are available to this workspace's agents by default.
+                      </div>
+                    </div>
+                    <div class="workspace-detail-config-pane-actions">
+                      <button id="workspace-detail-refresh-plugins" class="workspace-detail-panel-btn" type="button" title="Refresh installed plugins">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/>
+                        </svg>
+                      </button>
+                      <a id="workspace-detail-browse-plugins" class="workspace-detail-panel-btn" href="/plugins" title="Open the Plugins page to install more">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/>
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                  <div id="workspace-detail-plugins-list" class="workspace-detail-mcp-list">
+                    <div class="workspace-detail-empty">Loading installed plugins...</div>
                   </div>
                 </div>
                 <div


### PR DESCRIPTION
Builds on the new plugin support (#87) to make plugins usable from the workspace flows, plus a related fix to the agent info card's skills.

## Changes

### 1. Suggest plugins during workspace creation
The workspace bootstrap review modal now has a **Workspace Plugins** section alongside Agents / MCPs / Skills.
- Scores installed plugins **and** entries from added plugin marketplaces against the workspace description.
- On apply, installs/enables a selected plugin globally (if needed) and binds **all** of its MCP servers + skills to the workspace, granting the setup's agents access. Reuses the existing MCP/skill binding paths since plugin components are registered globally on install.
- Surfaces an "N plugins added" count in the create, Ask Ori, and workspace-detail summaries.

### 2. Plugins tab on the workspace details page
A new **Plugins** tab in the workspace config section (next to MCP / Workspace Skills).
- `WorkspacePluginsManager` lists installed plugins and derives per-plugin attachment status from the workspace's MCP/skill bindings (*in workspace* / *partially added* / *not in workspace*).
- **Add to workspace** reuses `WorkspaceBootstrapReview.applySelectedPlan`; **Remove from workspace** deletes the matching workspace bindings (the global install is untouched).

### 3. Fix: scope the agent info card's SKILLS to the workspace
The agent card's SKILLS block listed the agent's **entire global skill catalog** (`/api/skills?agent=`), disagreeing with the "Skills: N" header and the workspace-scoped MCP Attached block beside it.
- Added effective-for-agent skill helpers to the skills manager (workspace `skill_bindings` ∩ `agent_skill_access`), mirroring the MCP manager.
- The card now renders workspace-effective skills synchronously; removed the now-dead global-skills card helpers. The async `loadAgentSkills` path remains for task-requirement matching.

## Verification
- `npm run lint` clean (added the new ES module to eslint.config.js's module allowlist).
- `npm run test:modules` — 417 pass, 0 fail.
- `go vet ./...` clean; `go build ./cmd/server` succeeds.
- Smoke server (isolated `HOME`/`ORI_DATA_DIR`): plugin endpoints respond; the create modal's Workspace Plugins code, the detail-page Plugins tab/pane, and the workspace-effective skills path are all present in the rebuilt binary.

Frontend-only — no new backend endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)