### PR TITLE
Workspace agent roster UI + workspace-local model editing

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -833,6 +833,21 @@ func (s *Server) routeWorkspaceRuntimeRequest(w http.ResponseWriter, r *http.Req
 		return true
 	}
 
+	// Workspace-local agent profiles + in-place model editing.
+	//   GET   /api/workspaces/{id}/agents         -> list profiles (model/provider/type)
+	//   PATCH /api/workspaces/{id}/agents/{name}  -> update model + provider
+	// POST/DELETE fall through to the session handler (add/remove agent).
+	if len(parts) >= 2 && parts[1] == "agents" {
+		if len(parts) == 2 && r.Method == http.MethodGet {
+			s.Handlers.Workspace.ListWorkspaceAgentProfiles(w, r)
+			return true
+		}
+		if len(parts) >= 3 && r.Method == http.MethodPatch {
+			s.Handlers.Workspace.UpdateWorkspaceAgentModel(w, r)
+			return true
+		}
+	}
+
 	if strings.Contains(path, "/tasks") {
 		if strings.HasSuffix(path, "/execute") && r.Method == http.MethodPost {
 			s.Handlers.Workspace.ExecuteTaskManually(w, r)

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3649,6 +3649,196 @@ export class WorkspaceDetailPage {
     return '<span class="workspace-detail-agent-role-badge">Entry Agent</span>';
   }
 
+  getAgentGroupRolePresentation(group) {
+    const roles = Array.isArray(group?.roles)
+      ? group.roles
+          .map(role => String(role || '').trim())
+          .filter(Boolean)
+      : [];
+    const uniqueRoles = [];
+    const seen = new Set();
+    roles.forEach(role => {
+      const key = role.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      uniqueRoles.push(role);
+    });
+
+    if (uniqueRoles.length === 0) {
+      return { label: 'Agent', detail: 'Agent', roles: [] };
+    }
+    if (uniqueRoles.length === 1) {
+      return { label: uniqueRoles[0], detail: uniqueRoles[0], roles: uniqueRoles };
+    }
+    return {
+      label: 'Multiple roles',
+      detail: uniqueRoles.join(', '),
+      roles: uniqueRoles
+    };
+  }
+
+  getAgentAvatarPresentation(agentName) {
+    const normalizedName = String(agentName || '').trim();
+    const key = this.normalizeAgentName(normalizedName);
+    const words = normalizedName
+      .split(/[\s._-]+/)
+      .map(part => part.trim())
+      .filter(Boolean);
+    const initials = (words.length > 1 ? `${words[0][0]}${words[words.length - 1][0]}` : words[0]?.slice(0, 2) || 'A')
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, '')
+      .slice(0, 2) || 'A';
+
+    let hash = 0;
+    for (let index = 0; index < key.length; index += 1) {
+      hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+    }
+
+    const hue = hash % 360;
+    return {
+      initials,
+      hue,
+      style: `--agent-avatar-hue: ${hue};`,
+      label: `${normalizedName || 'Agent'} avatar`
+    };
+  }
+
+  getAgentModelPresentation(profile) {
+    const model = String(profile?.model || '').trim();
+    if (!model) {
+      return { model: '', tier: '', label: 'Model not set', empty: true };
+    }
+
+    const normalized = model.toLowerCase();
+    let tier = '';
+    if (normalized.includes('opus')) {
+      tier = 'High capacity';
+    } else if (normalized.includes('sonnet')) {
+      tier = 'Balanced';
+    } else if (normalized.includes('haiku')) {
+      tier = 'Fast';
+    }
+
+    return {
+      model,
+      tier,
+      label: tier ? `${model} · ${tier}` : model,
+      empty: false
+    };
+  }
+
+  getAgentRosterStatus(agentName) {
+    const key = this.normalizeAgentName(agentName);
+    if (!key || !Array.isArray(this.tasks)) {
+      return { key: 'idle', label: 'Idle', detail: 'No active tasks' };
+    }
+
+    let hasWaiting = false;
+    for (const task of this.tasks) {
+      if (!task) continue;
+      if (this.normalizeAgentName(task.to) !== key) continue;
+
+      const status = String(task.status || '').trim().toLowerCase();
+      if (status === 'in_progress') {
+        return { key: 'working', label: 'Working', detail: 'Task in progress' };
+      }
+      if (status === 'waiting_for_choice') {
+        hasWaiting = true;
+      }
+    }
+
+    if (hasWaiting) {
+      return { key: 'needs-input', label: 'Needs input', detail: 'Waiting for user input' };
+    }
+    return { key: 'idle', label: 'Idle', detail: 'No active tasks' };
+  }
+
+  getAgentSkillSummary(agentName, limit = 3) {
+    const skillNames = this.getEffectiveWorkspaceSkillNamesForAgent(agentName);
+    const visible = skillNames.slice(0, limit);
+    return {
+      names: skillNames,
+      visible,
+      overflow: Math.max(0, skillNames.length - visible.length),
+      count: skillNames.length,
+      label: `${skillNames.length} skill${skillNames.length === 1 ? '' : 's'}`
+    };
+  }
+
+  renderAgentSkillSummary(agentName) {
+    const summary = this.getAgentSkillSummary(agentName);
+    const key = this.normalizeAgentName(agentName);
+    if (summary.count === 0) {
+      return `<span class="workspace-detail-agent-skill-summary" data-agent-skill-summary-key="${this.escapeHtml(key)}" aria-label="0 skills"><span class="workspace-detail-agent-skill-empty">No skills</span></span>`;
+    }
+
+    const chips = summary.visible
+      .map(skill => `<span class="workspace-detail-agent-skill-chip">${this.escapeHtml(skill)}</span>`)
+      .join('');
+    const overflow =
+      summary.overflow > 0
+        ? `<span class="workspace-detail-agent-skill-chip overflow">+${summary.overflow}</span>`
+        : '';
+    return `
+      <span class="workspace-detail-agent-skill-summary" data-agent-skill-summary-key="${this.escapeHtml(key)}" aria-label="${this.escapeHtml(summary.label)}">
+        ${chips}
+        ${overflow}
+      </span>
+    `;
+  }
+
+  renderAgentRosterStatusChip(status) {
+    const safeKey = this.escapeHtml(status?.key || 'idle');
+    const label = this.escapeHtml(status?.label || 'Idle');
+    return `<span class="workspace-detail-agent-status-chip is-${safeKey}">${label}</span>`;
+  }
+
+  renderAgentRoleClassChip(rolePresentation) {
+    const label = rolePresentation?.label || 'Agent';
+    const title = rolePresentation?.detail || label;
+    return `<span class="workspace-detail-agent-class-chip" title="${this.escapeHtml(title)}">${this.escapeHtml(label)}</span>`;
+  }
+
+  renderAgentModelPowerBadge(agentName, profile, encodedAgentName = '') {
+    const presentation = this.getAgentModelPresentation(profile);
+    const editable = this.agentAllowsModelEditing(profile);
+    const title = presentation.empty ? `Set model for ${agentName}` : `Change model for ${agentName}`;
+    const badgeClass = `workspace-detail-agent-model-badge${editable ? ' is-editable' : ''}${presentation.empty ? ' is-empty' : ''}`;
+    const modelMarkup = presentation.empty
+      ? '<span>Model not set</span>'
+      : `
+        <span class="workspace-detail-agent-model-name">${this.escapeHtml(presentation.model)}</span>
+        ${presentation.tier ? `<span class="workspace-detail-agent-model-tier">${this.escapeHtml(presentation.tier)}</span>` : ''}
+      `;
+
+    if (!editable) {
+      return `<span class="${badgeClass}" title="${this.escapeHtml(presentation.label)}">${modelMarkup}</span>`;
+    }
+
+    return `
+      <button type="button"
+              class="${badgeClass}"
+              title="${this.escapeHtml(title)}"
+              aria-label="${this.escapeHtml(title)}"
+              onclick="event.stopPropagation(); window.workspaceDetail?.openAgentModelModal('${encodedAgentName}')">
+        ${modelMarkup}
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M14.06,9.02L14.98,9.94L5.92,19H5V18.08M17.66,3C17.4,3 17.15,3.1 16.95,3.29L15.13,5.11L18.88,8.86L20.7,7.04C21.09,6.65 21.09,6 20.7,5.63L18.37,3.29C18.17,3.1 17.92,3 17.66,3Z"/>
+        </svg>
+      </button>
+    `;
+  }
+
+  buildAgentCardSummary(group, rolePresentation, modelPresentation, skillSummary, status) {
+    const role = rolePresentation?.detail || rolePresentation?.label || 'Agent';
+    const model = modelPresentation?.label || 'Model not set';
+    const skills = skillSummary?.label || '0 skills';
+    const statusLabel = status?.label || 'Idle';
+    const taskCount = Number(group?.tasks?.length || 0);
+    const taskLabel = `${taskCount} task${taskCount === 1 ? '' : 's'}`;
+    return `${role}. ${model}. ${skills}. ${statusLabel}. ${taskLabel}.`;
+  }
+
   renderAgentGroups() {
     if (!this.elements.agentsList) return;
 
@@ -3683,7 +3873,37 @@ export class WorkspaceDetailPage {
         const encodedAgentName = encodeURIComponent(group.name);
         const modelLabel = group.isUnassigned
           ? ''
-          : this.renderAgentModelBadge(group.name, agentProfile, encodedAgentName);
+          : this.renderAgentModelPowerBadge(group.name, agentProfile, encodedAgentName);
+        const rolePresentation = group.isUnassigned
+          ? { label: 'Unassigned', detail: 'Tasks not assigned to an agent', roles: [] }
+          : this.getAgentGroupRolePresentation(group);
+        const modelPresentation = group.isUnassigned
+          ? { label: '', model: '', tier: '', empty: true }
+          : this.getAgentModelPresentation(agentProfile);
+        const skillSummary = group.isUnassigned
+          ? { count: 0, label: '0 skills', visible: [], overflow: 0, names: [] }
+          : this.getAgentSkillSummary(group.name);
+        const status = group.isUnassigned
+          ? { key: 'idle', label: 'Unassigned', detail: 'Tasks awaiting assignment' }
+          : this.getAgentRosterStatus(group.name);
+        const avatar = group.isUnassigned
+          ? { initials: '?', style: '--agent-avatar-hue: 210;', label: 'Unassigned tasks' }
+          : this.getAgentAvatarPresentation(group.name);
+        const summaryId = `agent-card-summary-${String(group.key || 'agent').replace(/[^a-z0-9_-]+/gi, '-')}`;
+        const cardSummary = group.isUnassigned
+          ? `${taskLabel}. Tasks awaiting assignment.`
+          : this.buildAgentCardSummary(
+              group,
+              rolePresentation,
+              modelPresentation,
+              skillSummary,
+              status
+            );
+        const roleClassChip = group.isUnassigned
+          ? ''
+          : this.renderAgentRoleClassChip(rolePresentation);
+        const skillMarkup = group.isUnassigned ? '' : this.renderAgentSkillSummary(group.name);
+        const statusChip = this.renderAgentRosterStatusChip(status);
         const canFlip = !group.isUnassigned;
         const isFlipped = canFlip && this.flippedAgentCards.has(group.key);
         const roleBadge = group.isUnassigned ? '' : this.renderWorkspaceAgentRoleBadge(group.name);
@@ -3735,26 +3955,69 @@ export class WorkspaceDetailPage {
           </svg>
         </button>
       `;
-        const backFace = canFlip ? this.renderAgentBackFace(group, cardMeta, encodedAgentName) : '';
+        const backFace = canFlip
+          ? this.renderAgentBackFace(group, cardMeta, encodedAgentName)
+          : '';
         const flippedClass = isFlipped ? ' is-flipped' : '';
+        const leaderClass = !group.isUnassigned && this.isWorkspaceEntryAgent(group.name) ? ' is-leader' : '';
+        const unassignedClass = group.isUnassigned ? ' is-unassigned' : '';
+        const detailLink = group.isUnassigned
+          ? `
+            <div class="workspace-detail-agent-identity-link is-static">
+              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
+              <span class="workspace-detail-agent-identity-copy">
+                <span class="workspace-detail-agent-name">${this.escapeHtml(group.name)}</span>
+                <span class="workspace-detail-agent-subtitle">Awaiting assignment</span>
+              </span>
+            </div>
+          `
+          : `
+            <a href="/agents/${encodedAgentName}"
+               class="workspace-detail-agent-identity-link"
+               title="Open ${this.escapeHtml(group.name)} details"
+               aria-label="Open ${this.escapeHtml(group.name)} details"
+               aria-describedby="${summaryId}"
+               onclick="event.stopPropagation();">
+              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
+              <span class="workspace-detail-agent-identity-copy">
+                <span class="workspace-detail-agent-name">${this.escapeHtml(group.name)}</span>
+                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(rolePresentation.label)}</span>
+              </span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M14,3H21V10H19V6.41L12.41,13L11,11.59L17.59,5H14V3M5,5H10V7H7V17H17V14H19V19H5V5Z"/>
+              </svg>
+            </a>
+          `;
 
         return `
-      <section class="workspace-detail-agent-card${flippedClass}" data-agent-name="${this.escapeHtml(group.name)}" data-agent-key="${this.escapeHtml(group.key)}">
+      <section class="workspace-detail-agent-card${flippedClass}${leaderClass}${unassignedClass}" data-agent-name="${this.escapeHtml(group.name)}" data-agent-key="${this.escapeHtml(group.key)}">
         <div class="workspace-detail-agent-card-flipper">
           <div class="workspace-detail-agent-card-face workspace-detail-agent-card-face-front">
+            <div id="${summaryId}" class="sr-only">${this.escapeHtml(cardSummary)}</div>
             <div class="workspace-detail-agent-card-header">
               <div class="workspace-detail-agent-card-title">
-                ${group.isUnassigned ? `<span>${this.escapeHtml(group.name)}</span>` : this.renderAgentDetailLink(group.name, encodedAgentName)}
-                ${roleBadge}
-                ${instanceChip}
-                ${capabilityBadges}
-                ${modelLabel}
+                ${detailLink}
               </div>
               <div class="workspace-detail-agent-card-meta-wrap">
                 <div class="workspace-detail-agent-card-meta">${cardMeta}</div>
                 ${removeButton}
                 ${frontFlipButton}
               </div>
+            </div>
+            <div class="workspace-detail-agent-roster-panel">
+              <div class="workspace-detail-agent-roster-row">
+                ${roleClassChip}
+                ${roleBadge}
+                ${instanceChip}
+                ${statusChip}
+              </div>
+              <div class="workspace-detail-agent-roster-row">
+                ${modelLabel}
+              </div>
+              <div class="workspace-detail-agent-roster-row workspace-detail-agent-skills-row">
+                ${skillMarkup}
+              </div>
+              ${capabilityBadges ? `<div class="workspace-detail-agent-roster-row workspace-detail-agent-capability-row">${capabilityBadges}</div>` : ''}
             </div>
             <div class="workspace-detail-agent-sections">
               <div class="workspace-detail-agent-section">
@@ -3811,12 +4074,9 @@ export class WorkspaceDetailPage {
   }
 
   renderAgentBackFace(group, cardMeta, encodedAgentName) {
-    const profile = this.getAgentProfile(group.name);
-    const levelValue = Number(profile?.evolution?.level ?? profile?.level);
-    const level = Number.isFinite(levelValue) ? Math.max(0, Math.floor(levelValue)) : 0;
-    const stage = String(profile?.evolution?.stage || profile?.stage || '').trim();
-    const levelLabel = stage ? `Lv ${level} · ${stage}` : `Lv ${level}`;
     const roleBadge = this.renderWorkspaceAgentRoleBadge(group.name);
+    const rolePresentation = this.getAgentGroupRolePresentation(group);
+    const status = this.getAgentRosterStatus(group.name);
 
     const skillsMarkup = this.renderAgentWorkspaceSkillChips(group.name);
 
@@ -3873,12 +4133,16 @@ export class WorkspaceDetailPage {
         </div>
         <div class="workspace-detail-agent-info-grid">
           <div class="workspace-detail-agent-info-block">
-            <div class="workspace-detail-agent-info-label">Agent Lvl</div>
-            <div class="workspace-detail-agent-info-value">${this.escapeHtml(levelLabel)}</div>
+            <div class="workspace-detail-agent-info-label">Status</div>
+            <div class="workspace-detail-agent-info-value">${this.escapeHtml(status.label)}</div>
           </div>
           <div class="workspace-detail-agent-info-block">
             <div class="workspace-detail-agent-info-label">Skills</div>
             <div class="workspace-detail-agent-chip-list workspace-detail-agent-skills-list" data-agent-skills-key="${this.escapeHtml(group.key)}">${skillsMarkup}</div>
+          </div>
+          <div class="workspace-detail-agent-info-block">
+            <div class="workspace-detail-agent-info-label">Role</div>
+            <div class="workspace-detail-agent-info-value">${this.escapeHtml(rolePresentation.detail)}</div>
           </div>
           <div class="workspace-detail-agent-info-block">
             <div class="workspace-detail-agent-info-label">MCP Attached</div>
@@ -3937,6 +4201,22 @@ export class WorkspaceDetailPage {
       if (container.getAttribute('data-agent-skills-key') === key) {
         container.innerHTML = skillsMarkup;
         updated = true;
+      }
+    });
+
+    const summaryMarkup = this.renderAgentSkillSummary(agentName);
+    const summaryContainers = card.querySelectorAll(
+      '.workspace-detail-agent-skill-summary[data-agent-skill-summary-key]'
+    );
+    summaryContainers.forEach(container => {
+      if (container.getAttribute('data-agent-skill-summary-key') === key) {
+        const wrapper = document.createElement('span');
+        wrapper.innerHTML = summaryMarkup.trim();
+        const replacement = wrapper.firstElementChild;
+        if (replacement) {
+          container.replaceWith(replacement);
+          updated = true;
+        }
       }
     });
 
@@ -4058,14 +4338,15 @@ export class WorkspaceDetailPage {
 
       let group = groupByKey.get(normalized);
       if (!group) {
-        group = {
-          key: normalized,
-          name: isUnassigned ? 'Unassigned' : String(name || '').trim(),
-          isWorkspaceAgent,
-          isUnassigned,
-          instanceCount: 0,
-          tasks: []
-        };
+          group = {
+            key: normalized,
+            name: isUnassigned ? 'Unassigned' : String(name || '').trim(),
+            isWorkspaceAgent,
+            isUnassigned,
+            instanceCount: 0,
+            roles: [],
+            tasks: []
+          };
         groupByKey.set(normalized, group);
         groups.push(group);
       } else if (isWorkspaceAgent) {
@@ -4083,6 +4364,10 @@ export class WorkspaceDetailPage {
         const group = ensureGroup(instance?.name, { isWorkspaceAgent: true, isUnassigned: false });
         if (group) {
           group.instanceCount += 1;
+          const role = String(instance?.role || '').trim();
+          if (role) {
+            group.roles.push(role);
+          }
         }
       });
     } else {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3521,7 +3521,11 @@ export class WorkspaceDetailPage {
     }
 
     const encodedAgentName = encodeURIComponent(normalizedName);
-    if (this.getAgentProfile(normalizedName)) {
+    // Only agents in the global catalog have a real /agents/<name> detail page.
+    // Workspace-local agents (entry/manager agents in config.json) must fall
+    // through to the workspace-local branch below — otherwise their name links
+    // to a 404 /agents/<name> route.
+    if (this.getGlobalAgentProfile(normalizedName)) {
       const title = `Open ${normalizedName} details`;
       return {
         kind: 'global',
@@ -9984,6 +9988,15 @@ export class WorkspaceDetailPage {
     }
 
     return names;
+  }
+
+  // Global agent catalog lookup only (no workspace-local fallback). Used to
+  // decide whether an agent has a real /agents/<name> detail page; workspace-
+  // local agents are stored in config.json and have no global detail route.
+  getGlobalAgentProfile(agentName) {
+    const key = this.normalizeAgentName(agentName);
+    if (!key) return null;
+    return this.agentIndex instanceof Map ? this.agentIndex.get(key) || null : null;
   }
 
   getAgentProfile(agentName) {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -245,6 +245,10 @@ export class WorkspaceDetailPage {
     this.agentCatalogLoaded = false;
     this.agentCatalogLoadFailed = false;
     this.workspaceAgentSnapshots = new Set();
+    // Workspace-local agent profiles (model/provider/type) keyed by normalized
+    // name. These agents live in the workspace's config.json, not the global
+    // agent catalog, so getAgentProfile() falls back to this map for them.
+    this.workspaceAgentProfiles = new Map();
     this.filesLoaded = false;
     this.filesLoadFailed = false;
     this.workspaceHealthCheckRunning = false;
@@ -9984,8 +9988,16 @@ export class WorkspaceDetailPage {
 
   getAgentProfile(agentName) {
     const key = this.normalizeAgentName(agentName);
-    if (!key || !this.agentIndex) return null;
-    return this.agentIndex.get(key) || null;
+    if (!key) return null;
+    const globalProfile = this.agentIndex instanceof Map ? this.agentIndex.get(key) : null;
+    if (globalProfile) return globalProfile;
+    // Fall back to workspace-local agents (entry/manager agents stored in the
+    // workspace's config.json, not the global agent catalog). This is what lets
+    // their model badge show the real model and become editable.
+    if (this.workspaceAgentProfiles instanceof Map) {
+      return this.workspaceAgentProfiles.get(key) || null;
+    }
+    return null;
   }
 
   async openAgentModelModal(encodedAgentName = '') {
@@ -10015,7 +10027,12 @@ export class WorkspaceDetailPage {
       agentName,
       agentType: String(profile.type || 'general').trim() || 'general',
       currentModel: String(profile.model || '').trim(),
-      currentProvider: String(profile.provider || '').trim()
+      currentProvider: String(profile.provider || '').trim(),
+      // Workspace-local agents persist to the workspace config.json via a
+      // workspace-scoped endpoint, and their model picker is not type-filtered.
+      isWorkspaceAgent:
+        String(profile.source || '').trim().toLowerCase() === 'workspace',
+      workspaceId: this.workspace?.id || ''
     };
 
     if (this.elements.agentModelAgentName) {
@@ -10054,6 +10071,9 @@ export class WorkspaceDetailPage {
         .toLowerCase() || 'general';
     const currentModel = String(editState.currentModel || '').trim();
     const currentProvider = String(editState.currentProvider || '').trim();
+    // Workspace-local agents list every available model (no agent-type filter),
+    // so users can pick any model/provider including local ones (lmstudio, ollama).
+    const skipTypeFilter = Boolean(editState.isWorkspaceAgent);
 
     select.innerHTML = '';
     let hasOptions = false;
@@ -10072,7 +10092,7 @@ export class WorkspaceDetailPage {
         const modelType = String(model?.type || '')
           .trim()
           .toLowerCase();
-        const include = modelType === normalizedType || value === currentModel;
+        const include = skipTypeFilter || modelType === normalizedType || value === currentModel;
         if (!include) return;
 
         const option = document.createElement('option');
@@ -10188,7 +10208,12 @@ export class WorkspaceDetailPage {
     submitBtn.textContent = 'Saving...';
 
     try {
-      const response = await fetch(`/api/agents/${encodeURIComponent(editState.agentName)}`, {
+      // Workspace-local agents persist to the workspace's config.json via the
+      // workspace-scoped endpoint; global agents use the global agent endpoint.
+      const endpoint = editState.isWorkspaceAgent
+        ? `/api/workspaces/${encodeURIComponent(editState.workspaceId)}/agents/${encodeURIComponent(editState.agentName)}`
+        : `/api/agents/${encodeURIComponent(editState.agentName)}`;
+      const response = await fetch(endpoint, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -10202,8 +10227,13 @@ export class WorkspaceDetailPage {
         throw new Error(errorText || 'Failed to update agent model');
       }
 
-      await this.loadAgentCatalog(true);
-      this.renderAgentGroups();
+      if (editState.isWorkspaceAgent) {
+        // Re-read workspace-local profiles (also re-renders the roster).
+        await this.loadWorkspaceAgentSnapshots();
+      } else {
+        await this.loadAgentCatalog(true);
+        this.renderAgentGroups();
+      }
 
       if (window.Toast) {
         window.Toast.success(`Updated ${editState.agentName} to ${model}.`);
@@ -11177,19 +11207,33 @@ export class WorkspaceDetailPage {
 
   async loadWorkspaceAgentSnapshots() {
     this.workspaceAgentSnapshots = new Set();
+    this.workspaceAgentProfiles = new Map();
     const id = this.workspace?.id;
     if (!id) return;
     try {
-      const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}/agent-snapshots`);
+      // The /agents endpoint returns full profiles (model/provider/type) for
+      // every workspace-local agent that has an on-disk snapshot. We derive both
+      // the advisory snapshot set and the profile map used by getAgentProfile()
+      // from the same response.
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}/agents`);
       if (!response.ok) return;
       const data = await response.json();
-      const names = Array.isArray(data?.agents) ? data.agents : [];
-      names.forEach(name => {
-        const trimmed = String(name || '').trim();
-        if (trimmed) this.workspaceAgentSnapshots.add(trimmed.toLowerCase());
+      const agents = Array.isArray(data?.agents) ? data.agents : [];
+      agents.forEach(agent => {
+        const name = String(agent?.name || '').trim();
+        if (!name) return;
+        const key = this.normalizeAgentName(name);
+        this.workspaceAgentSnapshots.add(key);
+        this.workspaceAgentProfiles.set(key, {
+          name,
+          type: String(agent?.type || '').trim(),
+          model: String(agent?.model || '').trim(),
+          provider: String(agent?.provider || '').trim(),
+          source: String(agent?.source || 'workspace').trim().toLowerCase() || 'workspace'
+        });
       });
     } catch (_err) {
-      // Snapshot info is advisory; failure just hides the recovery hint.
+      // Profile info is advisory; failure just hides the model badge / recovery hint.
     }
     this.renderAgentGroups();
   }

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3461,12 +3461,27 @@ export class WorkspaceDetailPage {
     }
 
     const safeAgentName = this.escapeHtml(agentName);
-    const safeHref = `/agents/${encodedAgentName}`;
+    const target = this.getAgentDetailTarget(agentName);
+    if (!target.interactive) {
+      const title = target.title || `${agentName} is managed inside this workspace`;
+      return `
+      <span class="workspace-detail-agent-link is-static"
+            title="${this.escapeAttribute(title)}"
+            aria-label="${this.escapeAttribute(target.ariaLabel || title)}">
+        <span class="workspace-detail-agent-link-label">${safeAgentName}</span>
+      </span>
+    `;
+    }
+
+    const safeHref = this.escapeAttribute(target.href);
+    const safeTitle = this.escapeAttribute(target.title || `Open ${agentName} details`);
+    const safeAriaLabel = this.escapeAttribute(target.ariaLabel || target.title || `Open ${agentName} details`);
     return `
       <a href="${safeHref}"
          class="workspace-detail-agent-link"
-         title="Open ${safeAgentName} details"
-         aria-label="Open ${safeAgentName} details"
+         data-agent-detail-kind="${this.escapeAttribute(target.kind || 'global')}"
+         title="${safeTitle}"
+         aria-label="${safeAriaLabel}"
          onclick="event.stopPropagation();">
         <span class="workspace-detail-agent-link-label">${safeAgentName}</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -3474,6 +3489,132 @@ export class WorkspaceDetailPage {
         </svg>
       </a>
     `;
+  }
+
+  buildWorkspaceAgentRecoveryURL(agentName) {
+    const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+    if (!workspaceId) return '';
+
+    const params = new URLSearchParams();
+    params.set('addAgent', '1');
+    const normalizedName = String(agentName || '').trim();
+    if (normalizedName) {
+      params.set('seedAgentName', normalizedName);
+    }
+    return `/workspaces/${encodeURIComponent(workspaceId)}?${params.toString()}`;
+  }
+
+  getAgentDetailTarget(agentName) {
+    const normalizedName = String(agentName || '').trim();
+    if (!normalizedName) {
+      return {
+        kind: 'none',
+        href: '',
+        interactive: false,
+        title: '',
+        ariaLabel: ''
+      };
+    }
+
+    const encodedAgentName = encodeURIComponent(normalizedName);
+    if (this.getAgentProfile(normalizedName)) {
+      const title = `Open ${normalizedName} details`;
+      return {
+        kind: 'global',
+        href: `/agents/${encodedAgentName}`,
+        interactive: true,
+        title,
+        ariaLabel: title
+      };
+    }
+
+    if (this.hasWorkspaceAgentSnapshot(normalizedName)) {
+      const title = `${normalizedName} is a workspace-local agent. Global agent details are not available.`;
+      return {
+        kind: 'workspace-local',
+        href: '',
+        interactive: false,
+        title,
+        ariaLabel: title
+      };
+    }
+
+    if (this.isWorkspaceEntryAgent(normalizedName)) {
+      const href = this.buildWorkspaceAgentRecoveryURL(normalizedName);
+      if (href) {
+        const title = `Create entry agent ${normalizedName}`;
+        return {
+          kind: 'missing-entry',
+          href,
+          interactive: true,
+          title,
+          ariaLabel: title
+        };
+      }
+    }
+
+    const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+    if (workspaceId) {
+      const title = `Open workspace to repair ${normalizedName}`;
+      return {
+        kind: 'workspace-reference',
+        href: `/workspaces/${encodeURIComponent(workspaceId)}`,
+        interactive: true,
+        title,
+        ariaLabel: title
+      };
+    }
+
+    const title = `${normalizedName} is referenced by this workspace, but no global detail page is available.`;
+    return {
+      kind: 'workspace-reference',
+      href: '',
+      interactive: false,
+      title,
+      ariaLabel: title
+    };
+  }
+
+  renderAgentIdentityLink(group, avatar, rolePresentation, summaryId) {
+    const safeName = this.escapeHtml(group.name);
+    const target = this.getAgentDetailTarget(group.name);
+    const title = target.title || `${group.name} is managed inside this workspace`;
+    const subtitle = rolePresentation?.label || 'Agent';
+
+    if (!target.interactive) {
+      return `
+            <div class="workspace-detail-agent-identity-link is-static"
+                 data-agent-detail-kind="${this.escapeAttribute(target.kind || 'workspace-local')}"
+                 title="${this.escapeAttribute(title)}"
+                 aria-label="${this.escapeAttribute(target.ariaLabel || title)}"
+                 aria-describedby="${summaryId}">
+              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
+              <span class="workspace-detail-agent-identity-copy">
+                <span class="workspace-detail-agent-name">${safeName}</span>
+                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(subtitle)}</span>
+              </span>
+            </div>
+          `;
+    }
+
+    return `
+            <a href="${this.escapeAttribute(target.href)}"
+               class="workspace-detail-agent-identity-link"
+               data-agent-detail-kind="${this.escapeAttribute(target.kind || 'global')}"
+               title="${this.escapeAttribute(title)}"
+               aria-label="${this.escapeAttribute(target.ariaLabel || title)}"
+               aria-describedby="${summaryId}"
+               onclick="event.stopPropagation();">
+              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
+              <span class="workspace-detail-agent-identity-copy">
+                <span class="workspace-detail-agent-name">${safeName}</span>
+                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(subtitle)}</span>
+              </span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M14,3H21V10H19V6.41L12.41,13L11,11.59L17.59,5H14V3M5,5H10V7H7V17H17V14H19V19H5V5Z"/>
+              </svg>
+            </a>
+          `;
   }
 
   getTaskTemplateReference(task) {
@@ -3639,9 +3780,28 @@ export class WorkspaceDetailPage {
   }
 
   isWorkspaceEntryAgent(agentName) {
-    const entryAgentName = String(this.workspace?.entry_agent_name || '').trim();
-    if (!entryAgentName || !agentName) return false;
-    return this.normalizeAgentName(entryAgentName) === this.normalizeAgentName(agentName);
+    const key = this.normalizeAgentName(agentName);
+    if (!key || !this.workspace) return false;
+
+    const directEntryAgentName = String(this.workspace.entry_agent_name || '').trim();
+    if (directEntryAgentName && this.normalizeAgentName(directEntryAgentName) === key) {
+      return true;
+    }
+
+    const sharedEntryAgentName = String(this.workspace.shared_data?.entry_agent_name || '').trim();
+    if (sharedEntryAgentName && this.normalizeAgentName(sharedEntryAgentName) === key) {
+      return true;
+    }
+
+    if (Array.isArray(this.workspace.agent_instances)) {
+      return this.workspace.agent_instances.some(
+        instance =>
+          Boolean(instance?.entry_point || instance?.entryPoint) &&
+          this.normalizeAgentName(instance?.name) === key
+      );
+    }
+
+    return false;
   }
 
   renderWorkspaceAgentRoleBadge(agentName) {
@@ -3971,23 +4131,7 @@ export class WorkspaceDetailPage {
               </span>
             </div>
           `
-          : `
-            <a href="/agents/${encodedAgentName}"
-               class="workspace-detail-agent-identity-link"
-               title="Open ${this.escapeHtml(group.name)} details"
-               aria-label="Open ${this.escapeHtml(group.name)} details"
-               aria-describedby="${summaryId}"
-               onclick="event.stopPropagation();">
-              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
-              <span class="workspace-detail-agent-identity-copy">
-                <span class="workspace-detail-agent-name">${this.escapeHtml(group.name)}</span>
-                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(rolePresentation.label)}</span>
-              </span>
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M14,3H21V10H19V6.41L12.41,13L11,11.59L17.59,5H14V3M5,5H10V7H7V17H17V14H19V19H5V5Z"/>
-              </svg>
-            </a>
-          `;
+          : this.renderAgentIdentityLink(group, avatar, rolePresentation, summaryId);
 
         return `
       <section class="workspace-detail-agent-card${flippedClass}${leaderClass}${unassignedClass}" data-agent-name="${this.escapeHtml(group.name)}" data-agent-key="${this.escapeHtml(group.key)}">
@@ -11047,6 +11191,7 @@ export class WorkspaceDetailPage {
     } catch (_err) {
       // Snapshot info is advisory; failure just hides the recovery hint.
     }
+    this.renderAgentGroups();
   }
 
   hasWorkspaceAgentSnapshot(agentName) {
@@ -11129,6 +11274,7 @@ export class WorkspaceDetailPage {
     }
 
     this.renderWorkspaceHealth();
+    this.renderAgentGroups();
 
     return this.agentCatalog;
   }

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -332,6 +332,86 @@ test('workspace detail skill summary uses workspace-effective skills', () => {
   assert.doesNotMatch(markup, /Browser<\/span>/);
 });
 
+test('workspace detail links catalog-backed agents to the global detail page', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    entry_agent_name: 'Catalog Manager',
+    agent_instances: [{ name: 'Catalog Manager', role: 'Coordinator', entry_point: true }]
+  };
+  page.agentIndex = new Map([['catalog manager', { name: 'Catalog Manager' }]]);
+  page.workspaceAgentSnapshots = new Set();
+
+  const target = page.getAgentDetailTarget('Catalog Manager');
+  const markup = page.renderAgentIdentityLink(
+    { name: 'Catalog Manager' },
+    page.getAgentAvatarPresentation('Catalog Manager'),
+    { label: 'Coordinator' },
+    'summary-catalog'
+  );
+
+  assert.equal(target.kind, 'global');
+  assert.equal(target.interactive, true);
+  assert.equal(target.href, '/agents/Catalog%20Manager');
+  assert.match(markup, /href="\/agents\/Catalog%20Manager"/);
+  assert.match(markup, /data-agent-detail-kind="global"/);
+});
+
+test('workspace detail keeps snapshot-backed local agents off the global detail route', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    entry_agent_name: 'Local Manager',
+    agent_instances: [{ name: 'Local Manager', role: 'Coordinator', entry_point: true }]
+  };
+  page.agentIndex = new Map();
+  page.workspaceAgentSnapshots = new Set(['local manager']);
+
+  const target = page.getAgentDetailTarget('Local Manager');
+  const markup = page.renderAgentIdentityLink(
+    { name: 'Local Manager' },
+    page.getAgentAvatarPresentation('Local Manager'),
+    { label: 'Coordinator' },
+    'summary-local'
+  );
+
+  assert.equal(target.kind, 'workspace-local');
+  assert.equal(target.interactive, false);
+  assert.equal(target.href, '');
+  assert.match(markup, /workspace-detail-agent-identity-link is-static/);
+  assert.match(markup, /data-agent-detail-kind="workspace-local"/);
+  assert.doesNotMatch(markup, /href="/);
+  assert.doesNotMatch(markup, /\/agents\/Local%20Manager/);
+});
+
+test('workspace detail routes missing entry agents to workspace recovery', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    entry_agent_name: 'Missing Manager',
+    agent_instances: [{ name: 'Missing Manager', role: 'Coordinator', entry_point: true }]
+  };
+  page.agentIndex = new Map();
+  page.workspaceAgentSnapshots = new Set();
+
+  const target = page.getAgentDetailTarget('Missing Manager');
+  const frontMarkup = page.renderAgentIdentityLink(
+    { name: 'Missing Manager' },
+    page.getAgentAvatarPresentation('Missing Manager'),
+    { label: 'Coordinator' },
+    'summary-missing'
+  );
+  const backMarkup = page.renderAgentDetailLink(
+    'Missing Manager',
+    encodeURIComponent('Missing Manager')
+  );
+
+  assert.equal(target.kind, 'missing-entry');
+  assert.equal(target.interactive, true);
+  assert.equal(target.href, '/workspaces/workspace-1?addAgent=1&seedAgentName=Missing+Manager');
+  assert.match(frontMarkup, /href="\/workspaces\/workspace-1\?addAgent=1&amp;seedAgentName=Missing\+Manager"/);
+  assert.match(backMarkup, /href="\/workspaces\/workspace-1\?addAgent=1&amp;seedAgentName=Missing\+Manager"/);
+  assert.doesNotMatch(frontMarkup, /\/agents\/Missing%20Manager/);
+  assert.doesNotMatch(backMarkup, /\/agents\/Missing%20Manager/);
+});
+
 test('workspace detail agent back face does not render agent level copy', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   page.getEffectiveWorkspaceSkillNamesForAgent = () => ['workspace-planning'];

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -430,3 +430,164 @@ test('workspace detail agent back face does not render agent level copy', () => 
   assert.match(markup, /Role/);
   assert.match(markup, /Lead/);
 });
+
+test('workspace-local agent profile resolves its model and renders an editable badge', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  // Not in the global catalog; only present as a workspace-local profile.
+  page.agentIndex = new Map();
+  page.workspaceAgentProfiles = new Map([
+    [
+      'reaperdaw manager',
+      {
+        name: 'ReaperDAW Manager',
+        type: 'orchestration',
+        model: 'google/gemma-4-e4b',
+        provider: 'lmstudio',
+        source: 'workspace'
+      }
+    ]
+  ]);
+
+  const profile = page.getAgentProfile('ReaperDAW Manager');
+  assert.ok(profile, 'profile resolves from the workspace-local map');
+  assert.equal(profile.model, 'google/gemma-4-e4b');
+  assert.equal(profile.source, 'workspace');
+
+  const presentation = page.getAgentModelPresentation(profile);
+  assert.equal(presentation.empty, false, 'model is set, must not show "Model not set"');
+  assert.match(presentation.label, /gemma-4-e4b/);
+
+  assert.equal(page.agentAllowsModelEditing(profile), true);
+
+  const badge = page.renderAgentModelPowerBadge(
+    'ReaperDAW Manager',
+    profile,
+    encodeURIComponent('ReaperDAW Manager')
+  );
+  assert.match(badge, /<button/);
+  assert.match(badge, /openAgentModelModal/);
+  assert.doesNotMatch(badge, /Model not set/);
+});
+
+test('workspace-local model picker lists every model; global picker filters by type', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.providerCatalog = [
+    {
+      name: 'claude',
+      display_name: 'Claude',
+      models: [
+        { value: 'claude-opus-4', type: 'orchestration', label: 'Opus' },
+        { value: 'claude-haiku', type: 'research', label: 'Haiku' }
+      ]
+    },
+    {
+      name: 'lmstudio',
+      display_name: 'LM Studio',
+      models: [{ value: 'google/gemma-4-e4b', type: 'research', label: 'Gemma' }]
+    }
+  ];
+
+  const makeEl = tag => ({
+    tagName: tag,
+    children: [],
+    attributes: {},
+    _text: '',
+    label: '',
+    value: '',
+    selected: false,
+    disabled: false,
+    set innerHTML(v) {
+      if (v === '') this.children = [];
+      this._html = v;
+    },
+    get innerHTML() {
+      return this._html || '';
+    },
+    set textContent(v) {
+      this._text = String(v || '');
+    },
+    get textContent() {
+      return this._text;
+    },
+    setAttribute(k, v) {
+      this.attributes[k] = v;
+    },
+    getAttribute(k) {
+      return this.attributes[k];
+    },
+    appendChild(c) {
+      this.children.push(c);
+      return c;
+    }
+  });
+
+  const origCreate = global.document.createElement;
+  global.document.createElement = tag => makeEl(tag);
+  try {
+    const select = makeEl('select');
+    page.elements = { agentModelSelect: select, agentModelSubmitBtn: makeEl('button') };
+    const values = () => select.children.flatMap(g => g.children.map(o => o.value));
+
+    // Workspace-local: no type filter, every model from every provider.
+    page.activeAgentModelEdit = {
+      agentType: 'orchestration',
+      currentModel: '',
+      currentProvider: '',
+      isWorkspaceAgent: true
+    };
+    page.populateAgentModelSelect();
+    const wsValues = values();
+    assert.equal(wsValues.length, 3, 'workspace-local lists every model');
+    assert.ok(wsValues.includes('google/gemma-4-e4b'), 'local provider model present');
+    assert.ok(wsValues.includes('claude-haiku'), 'non-matching type present');
+
+    // Global: only models whose type matches the agent type.
+    page.activeAgentModelEdit = {
+      agentType: 'orchestration',
+      currentModel: '',
+      currentProvider: '',
+      isWorkspaceAgent: false
+    };
+    page.populateAgentModelSelect();
+    assert.deepEqual(values(), ['claude-opus-4'], 'global picker keeps only matching type');
+  } finally {
+    global.document.createElement = origCreate;
+  }
+});
+
+test('workspace-local model save posts to the workspace-scoped endpoint', async () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.activeAgentModelEdit = {
+    agentName: 'ReaperDAW Manager',
+    isWorkspaceAgent: true,
+    workspaceId: 'ws-1',
+    currentModel: '',
+    currentProvider: ''
+  };
+  page.elements = {
+    agentModelSelect: { value: 'claude-opus-4', selectedOptions: [{ getAttribute: () => 'claude' }] },
+    agentModelSubmitBtn: { disabled: false, textContent: '' },
+    agentModelModal: null
+  };
+  page.loadWorkspaceAgentSnapshots = async () => {};
+  page.renderAgentGroups = () => {};
+
+  let captured = null;
+  const origFetch = global.fetch;
+  global.fetch = async (url, opts) => {
+    captured = { url, opts };
+    return { ok: true, text: async () => '' };
+  };
+  try {
+    await page.submitAgentModelChange();
+  } finally {
+    global.fetch = origFetch;
+  }
+
+  assert.ok(captured, 'fetch was called');
+  assert.equal(captured.url, '/api/workspaces/ws-1/agents/ReaperDAW%20Manager');
+  assert.equal(captured.opts.method, 'PATCH');
+  const body = JSON.parse(captured.opts.body);
+  assert.equal(body.model, 'claude-opus-4');
+  assert.equal(body.llm_provider, 'claude');
+});

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -231,3 +231,122 @@ test('workspace detail renders escaped read-only workspace tags', () => {
   assert.match(list.innerHTML, /title="&lt;script&gt;">&lt;script&gt;<\/span>/);
   assert.match(list.innerHTML, /title="Client &amp; Research">Client &amp; Research<\/span>/);
 });
+
+test('workspace detail aggregates agent group roles for roster cards', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+
+  assert.deepEqual(page.getAgentGroupRolePresentation({ roles: ['Lead', 'lead', '  '] }), {
+    label: 'Lead',
+    detail: 'Lead',
+    roles: ['Lead']
+  });
+
+  assert.deepEqual(page.getAgentGroupRolePresentation({ roles: ['Researcher', 'Writer'] }), {
+    label: 'Multiple roles',
+    detail: 'Researcher, Writer',
+    roles: ['Researcher', 'Writer']
+  });
+
+  assert.deepEqual(page.getAgentGroupRolePresentation({ roles: [] }), {
+    label: 'Agent',
+    detail: 'Agent',
+    roles: []
+  });
+});
+
+test('workspace detail carries agent instance roles into roster groups', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    agent_instances: [
+      { name: 'Manager', role: 'Lead' },
+      { name: 'Manager', role: 'Reviewer' },
+      { name: 'Writer', role: 'Drafting' }
+    ]
+  };
+  page.tasks = [];
+
+  const groups = page.buildAgentGroups();
+  const manager = groups.find(group => group.name === 'Manager');
+  const writer = groups.find(group => group.name === 'Writer');
+
+  assert.equal(manager.instanceCount, 2);
+  assert.deepEqual(manager.roles, ['Lead', 'Reviewer']);
+  assert.deepEqual(writer.roles, ['Drafting']);
+});
+
+test('workspace detail derives roster status from all assigned tasks and subtasks', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.tasks = [
+    { id: 'parent-1', to: 'Manager', status: 'pending' },
+    { id: 'subtask-1', parent_task_id: 'parent-1', to: 'Writer', status: 'waiting_for_choice' },
+    { id: 'subtask-2', parent_task_id: 'parent-1', to: 'Researcher', status: 'in_progress' },
+    { id: 'task-2', to: 'Writer', status: 'in_progress' }
+  ];
+
+  assert.equal(page.getAgentRosterStatus('Researcher').label, 'Working');
+  assert.equal(page.getAgentRosterStatus('Writer').label, 'Working');
+
+  page.tasks = [
+    { id: 'parent-1', to: 'Manager', status: 'pending' },
+    { id: 'subtask-1', parent_task_id: 'parent-1', to: 'Writer', status: 'waiting_for_choice' }
+  ];
+
+  assert.equal(page.getAgentRosterStatus('Writer').label, 'Needs input');
+  assert.equal(page.getAgentRosterStatus('Manager').label, 'Idle');
+});
+
+test('workspace detail generates stable deterministic agent avatars', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+
+  const first = page.getAgentAvatarPresentation('Trip Planning Manager');
+  const second = page.getAgentAvatarPresentation('Trip Planning Manager');
+  const other = page.getAgentAvatarPresentation('Trip Planning Writer');
+
+  assert.equal(first.initials, 'TM');
+  assert.equal(first.hue, second.hue);
+  assert.equal(first.style, second.style);
+  assert.notEqual(first.hue, other.hue);
+});
+
+test('workspace detail skill summary uses workspace-effective skills', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.getEffectiveWorkspaceSkillNamesForAgent = () => [
+    'workspace-planning',
+    'browser:control-in-app-browser',
+    'pdf:pdf',
+    'documents:documents'
+  ];
+
+  const summary = page.getAgentSkillSummary('Manager');
+  const markup = page.renderAgentSkillSummary('Manager');
+
+  assert.equal(summary.count, 4);
+  assert.deepEqual(summary.visible, [
+    'workspace-planning',
+    'browser:control-in-app-browser',
+    'pdf:pdf'
+  ]);
+  assert.equal(summary.overflow, 1);
+  assert.match(markup, /workspace-planning/);
+  assert.match(markup, /\+1/);
+  assert.doesNotMatch(markup, /Browser<\/span>/);
+});
+
+test('workspace detail agent back face does not render agent level copy', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.getEffectiveWorkspaceSkillNamesForAgent = () => ['workspace-planning'];
+  page.getEffectiveWorkspaceMCPServerNames = () => ['filesystem'];
+  page.workspace = { entry_agent_name: 'Manager' };
+
+  const markup = page.renderAgentBackFace(
+    { key: 'manager', name: 'Manager', instanceCount: 1, isWorkspaceAgent: true, roles: ['Lead'] },
+    '1 task',
+    'Manager'
+  );
+
+  assert.doesNotMatch(markup, /Agent Lvl/);
+  assert.doesNotMatch(markup, /Lv /);
+  assert.match(markup, /Status/);
+  assert.match(markup, /Role/);
+  assert.match(markup, /Lead/);
+});

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -4199,10 +4199,10 @@
     }
 
     .workspace-detail-agent-identity-link.is-static {
-      pointer-events: none;
+      cursor: default;
     }
 
-    .workspace-detail-agent-identity-link:hover .workspace-detail-agent-name {
+    .workspace-detail-agent-identity-link:not(.is-static):hover .workspace-detail-agent-name {
       color: #0369a1;
     }
 
@@ -4281,7 +4281,12 @@
       min-width: 0;
     }
 
-    .workspace-detail-agent-link:hover {
+    .workspace-detail-agent-link.is-static {
+      cursor: default;
+      opacity: 0.9;
+    }
+
+    .workspace-detail-agent-link:not(.is-static):hover {
       color: #7dd3fc;
       border-color: rgba(125, 211, 252, 0.45);
     }

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -4075,8 +4075,9 @@
     }
 
     .workspace-detail-agent-grid {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
+      align-items: start;
       gap: 0.65rem;
       padding-top: 0.5rem;
     }
@@ -4084,6 +4085,7 @@
     .workspace-detail-agent-card {
       perspective: 1200px;
       position: relative;
+      min-width: 0;
     }
 
     .workspace-detail-agent-card-flipper {
@@ -4102,13 +4104,17 @@
       grid-area: 1 / 1;
       -webkit-backface-visibility: hidden;
       backface-visibility: hidden;
-      border: 1px solid var(--border-color);
-      background: var(--bg-secondary);
-      border-radius: 10px;
-      padding: 0.6rem;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 34%),
+        var(--bg-secondary);
+      border-radius: 8px;
+      box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04);
+      padding: 0.7rem;
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.65rem;
+      min-width: 0;
     }
 
     .workspace-detail-agent-card-face-front {
@@ -4117,9 +4123,19 @@
 
     .workspace-detail-agent-card-face-back {
       transform: rotateX(180deg);
-      background:
-        radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 58%),
-        var(--bg-secondary);
+      background: var(--bg-secondary);
+    }
+
+    .workspace-detail-agent-card.is-leader .workspace-detail-agent-card-face {
+      border-color: rgba(245, 158, 11, 0.42);
+      box-shadow:
+        inset 3px 0 0 rgba(245, 158, 11, 0.82),
+        0 10px 24px rgba(15, 23, 42, 0.10);
+    }
+
+    .workspace-detail-agent-card.is-unassigned .workspace-detail-agent-card-face {
+      border-style: dashed;
+      background: var(--bg-primary);
     }
 
     .workspace-detail-agent-card-face-front .workspace-detail-agent-sections {
@@ -4143,8 +4159,7 @@
       align-items: flex-start;
       justify-content: space-between;
       gap: 0.75rem;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-      padding-bottom: 0.45rem;
+      min-width: 0;
     }
 
     .workspace-detail-agent-card-title {
@@ -4153,8 +4168,106 @@
       color: var(--text-primary);
       display: flex;
       align-items: center;
-      flex-wrap: wrap;
       gap: 0.35rem;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .workspace-detail-agent-card .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .workspace-detail-agent-identity-link {
+      display: grid;
+      grid-template-columns: 44px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 0.55rem;
+      min-width: 0;
+      width: 100%;
+      color: inherit;
+      text-decoration: none;
+      border-radius: 8px;
+      outline: none;
+    }
+
+    .workspace-detail-agent-identity-link.is-static {
+      pointer-events: none;
+    }
+
+    .workspace-detail-agent-identity-link:hover .workspace-detail-agent-name {
+      color: #0369a1;
+    }
+
+    .workspace-detail-agent-identity-link:focus-visible {
+      outline: 2px solid rgba(14, 165, 233, 0.85);
+      outline-offset: 3px;
+    }
+
+    .workspace-detail-agent-avatar {
+      width: 44px;
+      height: 44px;
+      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      border: 1px solid hsla(var(--agent-avatar-hue, 205), 70%, 34%, 0.35);
+      background:
+        linear-gradient(135deg, hsla(var(--agent-avatar-hue, 205), 72%, 42%, 0.88), hsla(var(--agent-avatar-hue, 205), 74%, 28%, 0.94));
+      color: #fff;
+      font-size: 0.8rem;
+      font-weight: 800;
+      letter-spacing: 0.04em;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    }
+
+    .workspace-detail-agent-card.is-leader .workspace-detail-agent-avatar {
+      border-color: rgba(245, 158, 11, 0.7);
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.18),
+        0 0 0 2px rgba(245, 158, 11, 0.12);
+    }
+
+    .workspace-detail-agent-identity-copy {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      gap: 0.12rem;
+    }
+
+    .workspace-detail-agent-name {
+      color: var(--text-primary);
+      font-size: 0.86rem;
+      font-weight: 700;
+      line-height: 1.2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      transition: color 0.15s ease;
+    }
+
+    .workspace-detail-agent-subtitle {
+      color: var(--text-secondary);
+      font-size: 0.66rem;
+      font-weight: 600;
+      line-height: 1.2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .workspace-detail-agent-identity-link > svg {
+      color: var(--text-secondary);
+      opacity: 0.7;
+      flex-shrink: 0;
     }
 
     .workspace-detail-agent-link {
@@ -4325,19 +4438,151 @@
       line-height: 1.2;
     }
 
+    .workspace-detail-agent-roster-panel {
+      display: grid;
+      gap: 0.45rem;
+      min-width: 0;
+    }
+
+    .workspace-detail-agent-roster-row {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.3rem;
+      min-width: 0;
+    }
+
+    .workspace-detail-agent-skills-row,
+    .workspace-detail-agent-capability-row {
+      align-items: flex-start;
+    }
+
+    .workspace-detail-agent-class-chip,
+    .workspace-detail-agent-status-chip,
+    .workspace-detail-agent-skill-chip,
+    .workspace-detail-agent-skill-empty {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+      border-radius: 999px;
+      font-size: 0.6rem;
+      font-weight: 700;
+      line-height: 1.2;
+      padding: 0.12rem 0.42rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .workspace-detail-agent-class-chip {
+      border: 1px solid rgba(59, 130, 246, 0.28);
+      background: rgba(59, 130, 246, 0.10);
+      color: #1d4ed8;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-class-chip {
+      color: #93c5fd;
+      border-color: rgba(147, 197, 253, 0.34);
+      background: rgba(59, 130, 246, 0.14);
+    }
+
+    .workspace-detail-agent-status-chip {
+      border: 1px solid rgba(100, 116, 139, 0.28);
+      background: rgba(100, 116, 139, 0.10);
+      color: #475569;
+    }
+
+    .workspace-detail-agent-status-chip.is-working {
+      border-color: rgba(34, 197, 94, 0.34);
+      background: rgba(34, 197, 94, 0.12);
+      color: #15803d;
+    }
+
+    .workspace-detail-agent-status-chip.is-needs-input {
+      border-color: rgba(245, 158, 11, 0.42);
+      background: rgba(245, 158, 11, 0.14);
+      color: #b45309;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-status-chip {
+      color: #cbd5e1;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-status-chip.is-working {
+      color: #86efac;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-status-chip.is-needs-input {
+      color: #fcd34d;
+    }
+
+    .workspace-detail-agent-skill-summary {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      min-width: 0;
+    }
+
+    .workspace-detail-agent-skill-chip {
+      max-width: 14rem;
+      border: 1px solid rgba(20, 184, 166, 0.32);
+      background: rgba(20, 184, 166, 0.11);
+      color: #0f766e;
+    }
+
+    .workspace-detail-agent-skill-chip.overflow {
+      border-color: rgba(100, 116, 139, 0.3);
+      background: rgba(100, 116, 139, 0.10);
+      color: var(--text-secondary);
+    }
+
+    .workspace-detail-agent-skill-empty {
+      border: 1px dashed rgba(100, 116, 139, 0.28);
+      color: var(--text-secondary);
+      background: transparent;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-skill-chip {
+      color: #5eead4;
+      border-color: rgba(94, 234, 212, 0.32);
+      background: rgba(20, 184, 166, 0.14);
+    }
+
     .workspace-detail-agent-model-badge {
       display: inline-flex;
       align-items: center;
-      gap: 0.28rem;
-      border-radius: 999px;
+      flex-wrap: wrap;
+      gap: 0.22rem 0.34rem;
+      max-width: 100%;
+      min-width: 0;
+      border-radius: 8px;
       border: 1px solid rgba(138, 138, 138, 0.25);
       background: rgba(138, 138, 138, 0.10);
       color: var(--text-secondary);
-      font-size: 0.56rem;
+      font-size: 0.62rem;
       font-weight: 600;
       letter-spacing: 0.02em;
-      padding: 0.08rem 0.36rem;
-      line-height: 1.2;
+      padding: 0.24rem 0.44rem;
+      line-height: 1.25;
+    }
+
+    .workspace-detail-agent-model-name,
+    .workspace-detail-agent-model-tier {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .workspace-detail-agent-model-name {
+      color: var(--text-primary);
+    }
+
+    .workspace-detail-agent-model-tier {
+      color: var(--text-secondary);
+      font-size: 0.58rem;
+      font-weight: 700;
     }
 
     .workspace-detail-agent-model-badge.is-editable {
@@ -4371,6 +4616,9 @@
       display: inline-flex;
       align-items: center;
       border-radius: 999px;
+      border: 1px solid rgba(245, 158, 11, 0.42);
+      background: rgba(245, 158, 11, 0.13);
+      color: #b45309;
       font-size: 0.56rem;
       font-weight: 700;
       letter-spacing: 0.04em;
@@ -4378,6 +4626,12 @@
       padding: 0.08rem 0.42rem;
       line-height: 1.2;
       white-space: nowrap;
+    }
+
+    [data-bs-theme="dark"] .workspace-detail-agent-role-badge {
+      color: #fcd34d;
+      border-color: rgba(252, 211, 77, 0.36);
+      background: rgba(245, 158, 11, 0.16);
     }
 
 
@@ -4398,14 +4652,14 @@
 
     .workspace-detail-agent-info-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.55rem;
       margin-top: 0.1rem;
     }
 
     .workspace-detail-agent-info-block {
-      background: var(--bg-primary);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(100, 116, 139, 0.06);
+      border: 1px solid rgba(100, 116, 139, 0.14);
       border-radius: 8px;
       padding: 0.55rem;
       display: flex;
@@ -5055,6 +5309,7 @@
          keeps the track shrinkable so the title ellipsis still works. */
       grid-template-columns: minmax(0, 1fr);
       gap: 0.55rem;
+      min-width: 0;
     }
 
     @media (max-width: 900px) {
@@ -5063,11 +5318,38 @@
       }
     }
 
+    @media (max-width: 520px) {
+      .workspace-detail-agent-card-header {
+        flex-direction: column;
+      }
+
+      .workspace-detail-agent-card-meta-wrap {
+        width: 100%;
+        justify-content: space-between;
+        margin-left: 0;
+      }
+
+      .workspace-detail-agent-identity-link {
+        grid-template-columns: 40px minmax(0, 1fr) auto;
+      }
+
+      .workspace-detail-agent-avatar {
+        width: 40px;
+        height: 40px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .workspace-detail-agent-card-flipper,
+      .workspace-detail-agent-card-face-back .workspace-detail-agent-info-grid,
+      .workspace-detail-agent-card-face-front .workspace-detail-agent-sections {
+        transition: none;
+      }
+    }
+
     .workspace-detail-agent-section {
-      background: var(--bg-primary);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 8px;
-      padding: 0.5rem;
+      border-top: 1px solid rgba(100, 116, 139, 0.14);
+      padding-top: 0.55rem;
       min-height: 120px;
       /* Grid items default to min-width: auto, which lets a long nowrap task
          title blow the 1fr track wider than the panel and force horizontal
@@ -5095,8 +5377,8 @@
     }
 
     .workspace-detail-agent-section-btn {
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      background: var(--bg-secondary);
+      border: 1px solid rgba(100, 116, 139, 0.24);
+      background: rgba(100, 116, 139, 0.06);
       color: var(--text-secondary);
       width: 22px;
       height: 22px;
@@ -5112,6 +5394,11 @@
       color: var(--text-primary);
       border-color: var(--primary-color);
       background: rgba(var(--primary-color-rgb, 255, 138, 86), 0.14);
+    }
+
+    .workspace-detail-agent-section-btn:focus-visible {
+      outline: 2px solid var(--primary-color);
+      outline-offset: 2px;
     }
 
     .workspace-detail-agent-list {
@@ -6626,12 +6913,15 @@
     .workspace-detail-agent-capabilities {
       display: inline-flex;
       align-items: center;
+      flex-wrap: wrap;
       gap: 0.2rem;
+      min-width: 0;
     }
 
     .workspace-detail-capability-chip {
       display: inline-flex;
       align-items: center;
+      max-width: 100%;
       padding: 0.05rem 0.32rem;
       border-radius: 999px;
       font-size: 0.6rem;
@@ -6640,6 +6930,8 @@
       border: 1px solid transparent;
       line-height: 1.2;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .workspace-detail-capability-chip.browser {

--- a/internal/workspace/agent_runtime_resolver_test.go
+++ b/internal/workspace/agent_runtime_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/mcp"
 	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
 )
 
 type resolverAgentStoreStub struct {
@@ -920,5 +921,62 @@ func TestResolveEffectiveSkills_NoSkillResolver(t *testing.T) {
 	}
 	if len(resolved.EffectiveSkills) != 0 {
 		t.Fatalf("expected 0 skills when no resolver set, got %d", len(resolved.EffectiveSkills))
+	}
+}
+
+// TestAgentRuntimeResolver_UsesUpdatedWorkspaceLocalModel verifies that the
+// runtime resolver reads a workspace-local agent's model from its config.json
+// (taking priority over the global agent store) and that a model update is
+// picked up on the next resolution — i.e. the PATCH endpoint's change takes
+// effect on the agent's next run with no stale caching.
+func TestAgentRuntimeResolver_UsesUpdatedWorkspaceLocalModel(t *testing.T) {
+	ws := &Workspace{
+		ID: "ws-model",
+		AgentInstances: []AgentInstance{
+			{ID: "inst-1", Name: "ReaperDAW Manager", NodeID: "rm-1"},
+		},
+	}
+
+	// Global agent has a different model; the workspace-local config must win.
+	agentStore := &resolverAgentStoreStub{agents: map[string]*agent.Agent{
+		"ReaperDAW Manager": {Settings: types.Settings{Model: "global-model", Provider: "openai"}},
+	}}
+	workspaceStore := newTestWorkspaceStore(t, ws)
+	registry := &runtimeRegistryStub{}
+	templates := &templateLookupStub{servers: map[string]mcp.ServerConfig{}}
+
+	if err := workspaceStore.SaveWorkspaceAgent(ws.ID, "ReaperDAW Manager", &agent.Agent{
+		Type:     "orchestration",
+		Settings: types.Settings{Model: "google/gemma-4-e4b", Provider: "lmstudio"},
+	}); err != nil {
+		t.Fatalf("seed workspace agent: %v", err)
+	}
+
+	resolver := NewAgentRuntimeResolver(agentStore, workspaceStore, registry, templates)
+
+	resolved, err := resolver.ResolveAgentForWorkspace("ReaperDAW Manager", ws.ID, "rm-1")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resolved.Agent.Settings.Model != "google/gemma-4-e4b" || resolved.Agent.Settings.Provider != "lmstudio" {
+		t.Fatalf("expected workspace-local model, got model=%q provider=%q",
+			resolved.Agent.Settings.Model, resolved.Agent.Settings.Provider)
+	}
+
+	// Simulate the PATCH endpoint updating model + provider.
+	if err := workspaceStore.SaveWorkspaceAgent(ws.ID, "ReaperDAW Manager", &agent.Agent{
+		Type:     "orchestration",
+		Settings: types.Settings{Model: "claude-opus-4", Provider: "claude"},
+	}); err != nil {
+		t.Fatalf("update workspace agent: %v", err)
+	}
+
+	resolved2, err := resolver.ResolveAgentForWorkspace("ReaperDAW Manager", ws.ID, "rm-1")
+	if err != nil {
+		t.Fatalf("resolve after update: %v", err)
+	}
+	if resolved2.Agent.Settings.Model != "claude-opus-4" || resolved2.Agent.Settings.Provider != "claude" {
+		t.Fatalf("model change did not take effect: model=%q provider=%q",
+			resolved2.Agent.Settings.Model, resolved2.Agent.Settings.Provider)
 	}
 }

--- a/internal/workspace/http_handlers_agent.go
+++ b/internal/workspace/http_handlers_agent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -227,6 +228,167 @@ func (h *HTTPHandler) ListAgentSnapshots(w http.ResponseWriter, r *http.Request)
 	if encErr := json.NewEncoder(w).Encode(map[string]any{
 		"workspace_id": workspaceID,
 		"agents":       available,
+	}); encErr != nil {
+		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
+	}
+}
+
+// WorkspaceAgentProfile is the lightweight model/provider view of a
+// workspace-local agent used by the workspace UI to render and edit the agent's
+// LLM model without going through the global agent store. The global agent
+// dashboard list does not include workspace-local agents, so this is what lets
+// the UI show their real model and offer in-place model editing.
+type WorkspaceAgentProfile struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Role     string `json:"role,omitempty"`
+	Model    string `json:"model"`
+	Provider string `json:"provider"`
+	Source   string `json:"source"` // always "workspace"
+}
+
+// ListWorkspaceAgentProfiles handles GET /api/workspaces/:id/agents and returns
+// the model/provider/type for each workspace-local agent that has an on-disk
+// config.json snapshot.
+func (h *HTTPHandler) ListWorkspaceAgentProfiles(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/api/workspaces/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 || parts[0] == "" {
+		orihttp.BadRequest(w, "Invalid URL format")
+		return
+	}
+	workspaceID := parts[0]
+
+	ws, err := h.store.Get(workspaceID)
+	if err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace %s not found", workspaceID))
+		return
+	}
+
+	profiles := make([]WorkspaceAgentProfile, 0)
+	for _, name := range referencedAgentNames(ws) {
+		ag, ok, agErr := h.store.GetWorkspaceAgent(workspaceID, name)
+		if agErr != nil || !ok || ag == nil {
+			continue
+		}
+		profiles = append(profiles, WorkspaceAgentProfile{
+			Name:     name,
+			Type:     ag.Type,
+			Role:     string(ag.Role),
+			Model:    ag.Settings.Model,
+			Provider: ag.Settings.Provider,
+			Source:   "workspace",
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(map[string]any{
+		"workspace_id": workspaceID,
+		"agents":       profiles,
+	}); encErr != nil {
+		logger.Error("Failed to encode workspace agent profiles", logger.Fields{"error": encErr})
+	}
+}
+
+// UpdateWorkspaceAgentModelRequest is the body for PATCH
+// /api/workspaces/:id/agents/:name. Only model + provider are editable here; all
+// other agent settings are intentionally left untouched.
+type UpdateWorkspaceAgentModelRequest struct {
+	Model       string `json:"model"`
+	LLMProvider string `json:"llm_provider"`
+}
+
+// UpdateWorkspaceAgentModel handles PATCH /api/workspaces/:id/agents/:name and
+// updates only the model + provider of a workspace-local agent's config.json. It
+// never touches the global agent store: the workspace config.json is the single
+// source of truth for these agents.
+func (h *HTTPHandler) UpdateWorkspaceAgentModel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/api/workspaces/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 3 || parts[0] == "" {
+		orihttp.BadRequest(w, "Invalid URL format")
+		return
+	}
+	workspaceID := parts[0]
+
+	agentName, decodeErr := url.PathUnescape(parts[2])
+	if decodeErr != nil {
+		agentName = parts[2]
+	}
+	// Drop any ":instance" suffix — model config is per agent name (slug),
+	// shared by all instances of that agent in the workspace.
+	if idx := strings.Index(agentName, ":"); idx >= 0 {
+		agentName = agentName[:idx]
+	}
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		orihttp.BadRequest(w, "Agent name is required")
+		return
+	}
+
+	var req UpdateWorkspaceAgentModelRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	model := strings.TrimSpace(req.Model)
+	provider := strings.TrimSpace(req.LLMProvider)
+	if model == "" {
+		orihttp.BadRequest(w, "model is required")
+		return
+	}
+	if provider == "" {
+		orihttp.BadRequest(w, "llm_provider is required")
+		return
+	}
+
+	if _, err := h.store.Get(workspaceID); err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace %s not found", workspaceID))
+		return
+	}
+
+	ag, ok, err := h.store.GetWorkspaceAgent(workspaceID, agentName)
+	if err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to read workspace agent: %v", err))
+		return
+	}
+	if !ok || ag == nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace agent %q not found", agentName))
+		return
+	}
+
+	// Update only model + provider; leave every other field intact.
+	ag.Settings.Model = model
+	ag.Settings.Provider = provider
+
+	if err := h.store.SaveWorkspaceAgent(workspaceID, agentName, ag); err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to save workspace agent: %v", err))
+		return
+	}
+
+	logger.Info("Updated workspace agent model", logger.Fields{
+		"workspace_id": workspaceID,
+		"agent":        agentName,
+		"model":        model,
+		"provider":     provider,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(map[string]any{
+		"message":  "Agent model updated",
+		"agent":    agentName,
+		"model":    model,
+		"provider": provider,
+		"source":   "workspace",
 	}); encErr != nil {
 		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
 	}

--- a/internal/workspace/http_handlers_agent_model_test.go
+++ b/internal/workspace/http_handlers_agent_model_test.go
@@ -1,0 +1,171 @@
+package workspace
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+func TestHTTPHandler_ListWorkspaceAgentProfiles(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:         "ws-prof",
+		Name:       "Profiles",
+		Status:     StatusActive,
+		Agents:     []string{"Manager", "Helper"},
+		SharedData: map[string]any{"entry_agent_name": "Manager"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Only Manager has an on-disk snapshot; Helper does not.
+	if err := store.SaveWorkspaceAgent(ws.ID, "Manager", &agent.Agent{
+		Type: "orchestration",
+		Role: "orchestrator",
+		Settings: types.Settings{
+			Model:    "google/gemma-4-e4b",
+			Provider: "lmstudio",
+		},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/ws-prof/agents", nil)
+	rec := httptest.NewRecorder()
+	handler.ListWorkspaceAgentProfiles(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		WorkspaceID string                  `json:"workspace_id"`
+		Agents      []WorkspaceAgentProfile `json:"agents"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.WorkspaceID != "ws-prof" {
+		t.Fatalf("workspace_id=%q", resp.WorkspaceID)
+	}
+	if len(resp.Agents) != 1 {
+		t.Fatalf("agents=%v, want 1 (only Manager has a snapshot)", resp.Agents)
+	}
+	got := resp.Agents[0]
+	if got.Name != "Manager" || got.Model != "google/gemma-4-e4b" ||
+		got.Provider != "lmstudio" || got.Type != "orchestration" || got.Source != "workspace" {
+		t.Fatalf("profile=%+v", got)
+	}
+}
+
+func TestHTTPHandler_ListWorkspaceAgentProfiles_UnknownWorkspace(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/nope/agents", nil)
+	rec := httptest.NewRecorder()
+	handler.ListWorkspaceAgentProfiles(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", rec.Code)
+	}
+}
+
+func TestHTTPHandler_UpdateWorkspaceAgentModel(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:         "ws-upd",
+		Name:       "Update",
+		Status:     StatusActive,
+		Agents:     []string{"ReaperDAW Manager"},
+		SharedData: map[string]any{"entry_agent_name": "ReaperDAW Manager"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SaveWorkspaceAgent(ws.ID, "ReaperDAW Manager", &agent.Agent{
+		Type: "orchestration",
+		Role: "orchestrator",
+		Settings: types.Settings{
+			Model:        "google/gemma-4-e4b",
+			Provider:     "lmstudio",
+			SystemPrompt: "keep me",
+			Temperature:  0.2,
+		},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"model":        "claude-opus-4",
+		"llm_provider": "claude",
+	})
+	// Path uses %20 for the space; net/http decodes URL.Path before our handler.
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-upd/agents/ReaperDAW%20Manager", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentModel(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	ag, ok, err := store.GetWorkspaceAgent(ws.ID, "ReaperDAW Manager")
+	if err != nil || !ok || ag == nil {
+		t.Fatalf("reload agent: ok=%v err=%v", ok, err)
+	}
+	if ag.Settings.Model != "claude-opus-4" || ag.Settings.Provider != "claude" {
+		t.Fatalf("model=%q provider=%q, want claude-opus-4/claude", ag.Settings.Model, ag.Settings.Provider)
+	}
+	// Unrelated settings must be preserved (model+provider only).
+	if ag.Settings.SystemPrompt != "keep me" || ag.Settings.Temperature != 0.2 {
+		t.Fatalf("other settings clobbered: prompt=%q temp=%v", ag.Settings.SystemPrompt, ag.Settings.Temperature)
+	}
+}
+
+func TestHTTPHandler_UpdateWorkspaceAgentModel_Validation(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:         "ws-val",
+		Name:       "Val",
+		Status:     StatusActive,
+		Agents:     []string{"Manager"},
+		SharedData: map[string]any{"entry_agent_name": "Manager"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SaveWorkspaceAgent(ws.ID, "Manager", &agent.Agent{
+		Type:     "general",
+		Settings: types.Settings{Model: "m", Provider: "p"},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	// Missing model -> 400.
+	body, _ := json.Marshal(map[string]string{"llm_provider": "claude"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-val/agents/Manager", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentModel(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing model: status=%d, want 400", rec.Code)
+	}
+
+	// Unknown agent -> 404.
+	body, _ = json.Marshal(map[string]string{"model": "m", "llm_provider": "p"})
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-val/agents/Ghost", bytes.NewReader(body))
+	rec = httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentModel(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown agent: status=%d, want 404", rec.Code)
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "eslint": "^9.39.2",
         "globals": "^15.15.0",
         "prettier": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -382,6 +382,150 @@ test.describe('API Health', () => {
   });
 });
 
+test.describe('Workspace Agent Character Roster', () => {
+  async function installRosterRoutes(page) {
+    const workspace = {
+      id: 'roster-ws',
+      name: 'Roster Workspace',
+      description: 'Workspace for roster UI smoke coverage',
+      entry_agent_name: 'Roster Manager',
+      agents: ['Roster Manager', 'Research Analyst'],
+      agent_instances: [
+        {
+          id: 'manager-1',
+          name: 'Roster Manager',
+          instance_number: 1,
+          node_id: 'Roster Manager-node-1',
+          role: 'Coordinator',
+          entry_point: true
+        },
+        {
+          id: 'analyst-1',
+          name: 'Research Analyst',
+          instance_number: 1,
+          node_id: 'Research Analyst-node-1',
+          role: 'Research'
+        },
+        {
+          id: 'analyst-2',
+          name: 'Research Analyst',
+          instance_number: 2,
+          node_id: 'Research Analyst-node-2',
+          role: 'Synthesis'
+        }
+      ],
+      shared_data: {},
+      skill_bindings: [
+        { id: 'skill-planning', skill_name: 'workspace-planning', enabled: true, trusted: true },
+        { id: 'skill-research', skill_name: 'browser:control-in-app-browser', enabled: true, trusted: true }
+      ],
+      agent_skill_access: [
+        { agent_instance_id: 'manager-1', enabled_binding_ids: ['skill-planning'] },
+        { agent_instance_id: 'analyst-1', enabled_binding_ids: ['skill-research'] },
+        { agent_instance_id: 'analyst-2', enabled_binding_ids: ['skill-research'] }
+      ],
+      mcp_bindings: [],
+      agent_mcp_access: [],
+      directory_references: [],
+      attachments: [],
+      tasks: [],
+      status: 'active'
+    };
+    const tasks = [
+      { id: 'task-1', workspace_id: 'roster-ws', to: 'Roster Manager', status: 'pending', description: 'Plan the work' },
+      { id: 'task-2', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'waiting_for_choice', description: 'Choose source' },
+      { id: 'task-3', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'in_progress', description: 'Read source', parent_task_id: 'task-1' }
+    ];
+
+    await page.route('**/api/orchestration/workspace?id=roster-ws', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(workspace) });
+    });
+    await page.route('**/api/workspaces/roster-ws/agent-snapshots', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ agents: [] }) });
+    });
+    await page.route('**/api/agents/dashboard/list', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [
+            { name: 'Roster Manager', type: 'general', source: 'user', model: 'claude-opus-4', provider: 'anthropic', capabilities: ['files'] },
+            { name: 'Research Analyst', type: 'research', source: 'user', model: 'claude-sonnet-4', provider: 'anthropic', allow_web_search: true }
+          ]
+        })
+      });
+    });
+    await page.route('**/api/skills?agent=default', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          skills: [
+            { name: 'workspace-planning', enabled: true },
+            { name: 'browser:control-in-app-browser', enabled: true }
+          ]
+        })
+      });
+    });
+    await page.route('**/api/orchestration/tasks?workspace_id=roster-ws', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ tasks }) });
+    });
+    await page.route('**/api/sessions?folder_id=roster-ws', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sessions: [] }) });
+    });
+    await page.route('**/api/workspaces/roster-ws/notes', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ notes: [] }) });
+    });
+    await page.route('**/api/workspaces/roster-ws', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(workspace) });
+    });
+    await page.route('**/api/workspaces?tree=true', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspaces: [workspace], folders: [workspace] }) });
+    });
+    await page.route('**/api/orchestration/workspace/activate?id=roster-ws', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+    });
+    await page.route('**/api/project-templates', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ templates: [] }) });
+    });
+  }
+
+  test('renders truthful character cards without losing roster actions', async ({ page }) => {
+    await installRosterRoutes(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/workspaces/roster-ws');
+
+    const cards = page.locator('#workspace-detail-agents-list .workspace-detail-agent-card');
+    await expect(cards).toHaveCount(2);
+    await expect(cards.first()).toHaveClass(/is-leader/);
+    await expect(cards.first().locator('.workspace-detail-agent-avatar')).toHaveText('RM');
+    await expect(cards.first().locator('.workspace-detail-agent-class-chip')).toHaveText('Coordinator');
+    await expect(cards.first().locator('.workspace-detail-agent-status-chip')).toHaveText('Idle');
+    await expect(cards.first().locator('.workspace-detail-agent-skill-summary')).toContainText('workspace-planning');
+    await expect(cards.first().locator('.workspace-detail-agent-model-badge')).toContainText('High capacity');
+    await expect(cards.nth(1).locator('.workspace-detail-agent-class-chip')).toHaveText('Multiple roles');
+    await expect(cards.nth(1).locator('.workspace-detail-agent-status-chip')).toHaveText('Working');
+    await expect(cards.nth(1).locator('.workspace-detail-agent-instance-tag')).toHaveText('2x');
+    await expect(cards.nth(1).locator('.workspace-detail-agent-skill-summary')).toContainText('browser:control-in-app-browser');
+
+    await expect(cards.first().locator('.workspace-detail-agent-identity-link[href="/agents/Roster%20Manager"]')).toBeVisible();
+    await expect(cards.first().locator('.workspace-detail-agent-section-btn')).toBeVisible();
+    await expect(cards.first().locator('.workspace-detail-agent-card-face-front .workspace-detail-agent-remove-btn')).toBeVisible();
+    await expect(cards.first().locator('.workspace-detail-agent-card-face-front .workspace-detail-agent-flip-btn')).toBeVisible();
+
+    await cards.first().locator('.workspace-detail-agent-identity-link').focus();
+    await expect(cards.first().locator('.workspace-detail-agent-identity-link')).toBeFocused();
+    await cards.first().locator('.workspace-detail-agent-card-face-front .workspace-detail-agent-flip-btn').click();
+    await expect(cards.first()).toHaveClass(/is-flipped/);
+    await expect(cards.first()).not.toContainText('Agent Lvl');
+    await expect(cards.first()).toContainText('Role');
+    await expect(cards.first()).toContainText('MCP Attached');
+
+    const overflow = await page.locator('#workspace-detail-agents-list').evaluate(el => el.scrollWidth - el.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});
+
 test.describe('Task Output Contracts', () => {
   test('opens append-to-CSV contract editor from task details', async ({ page, request }) => {
     let workspaceId = '';

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -383,7 +383,7 @@ test.describe('API Health', () => {
 });
 
 test.describe('Workspace Agent Character Roster', () => {
-  async function installRosterRoutes(page) {
+  async function installRosterRoutes(page, options = {}) {
     const workspace = {
       id: 'roster-ws',
       name: 'Roster Workspace',
@@ -436,23 +436,25 @@ test.describe('Workspace Agent Character Roster', () => {
       { id: 'task-2', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'waiting_for_choice', description: 'Choose source' },
       { id: 'task-3', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'in_progress', description: 'Read source', parent_task_id: 'task-1' }
     ];
+    const catalogAgents = [
+      ...(options.omitRosterManagerFromCatalog
+        ? []
+        : [{ name: 'Roster Manager', type: 'general', source: 'user', model: 'claude-opus-4', provider: 'anthropic', capabilities: ['files'] }]),
+      { name: 'Research Analyst', type: 'research', source: 'user', model: 'claude-sonnet-4', provider: 'anthropic', allow_web_search: true }
+    ];
+    const snapshotAgents = Array.isArray(options.snapshotAgents) ? options.snapshotAgents : [];
 
     await page.route('**/api/orchestration/workspace?id=roster-ws', async route => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(workspace) });
     });
     await page.route('**/api/workspaces/roster-ws/agent-snapshots', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ agents: [] }) });
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ agents: snapshotAgents }) });
     });
     await page.route('**/api/agents/dashboard/list', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          agents: [
-            { name: 'Roster Manager', type: 'general', source: 'user', model: 'claude-opus-4', provider: 'anthropic', capabilities: ['files'] },
-            { name: 'Research Analyst', type: 'research', source: 'user', model: 'claude-sonnet-4', provider: 'anthropic', allow_web_search: true }
-          ]
-        })
+        body: JSON.stringify({ agents: catalogAgents })
       });
     });
     await page.route('**/api/skills?agent=default', async route => {
@@ -523,6 +525,22 @@ test.describe('Workspace Agent Character Roster', () => {
 
     const overflow = await page.locator('#workspace-detail-agents-list').evaluate(el => el.scrollWidth - el.clientWidth);
     expect(overflow).toBeLessThanOrEqual(1);
+  });
+
+  test('does not send workspace-local agents to missing global detail pages', async ({ page }) => {
+    await installRosterRoutes(page, {
+      omitRosterManagerFromCatalog: true,
+      snapshotAgents: ['Roster Manager']
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/workspaces/roster-ws');
+
+    const managerIdentity = page.locator(
+      '#workspace-detail-agents-list .workspace-detail-agent-card.is-leader .workspace-detail-agent-identity-link'
+    );
+    await expect(managerIdentity).toContainText('Roster Manager');
+    await expect(managerIdentity).toHaveAttribute('data-agent-detail-kind', 'workspace-local');
+    await expect(managerIdentity).not.toHaveAttribute('href', /\/agents\/Roster%20Manager/);
   });
 });
 


### PR DESCRIPTION
## Summary

Workspace agent UI pass for the workspace detail page. Restyles the agent panel as a character roster, makes workspace-local agent models inline-editable, and fixes the agent links these changes touched.

## Changes

- **Restyle workspace agents as a character roster** — new card/roster layout, avatars, role/status chips, and skill summaries on the workspace detail page.
- **Enable model editing for workspace-local agents** — entry/manager agents stored in a workspace's `config.json` now surface an editable model badge. Backed by `/api/workspaces/{id}/agents` profiles and a `PATCH .../agents/{name}` model+provider update.
- **Fix workspace-local agent roster links** — earlier link-target cleanup for roster cards.
- **Fix workspace-local agent name linking to a 404 detail route** — `getAgentProfile()` now falls back to workspace-local profiles (so the model badge renders), but `getAgentDetailTarget()` reused it for the name link, so workspace-local agents linked to `/agents/<name>` — a route that only resolves global agents in `agents/<name>/`, yielding a 404. Added `getGlobalAgentProfile()` (global catalog only) for the link decision; workspace-local agents now fall through to the existing static, non-clickable label. The health check keeps the merged lookup since workspace-local agents are runnable/healthy.

## Testing

- `node --check` clean on `workspace-detail.js`
- Adds `workspace-detail.test.js`, `http_handlers_agent_model_test.go`, `agent_runtime_resolver_test.go`, and a `tests/smoke.spec.ts` for the model-editing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
