### PR TITLE
feat(mcp): server detail view (README + tools) + fix plugin command path doubling

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -26,15 +26,17 @@ type ServerConfig struct {
 
 // Server manages an MCP server process and client
 type Server struct {
-	config ServerConfig
-	client *sdkmcp.Client
-	cmd    *exec.Cmd
-	conn   *sdkmcp.ClientSession
-	tools  []Tool
-	ctx    context.Context
-	cancel context.CancelFunc
-	mu     sync.RWMutex
-	status ServerStatus
+	config       ServerConfig
+	client       *sdkmcp.Client
+	cmd          *exec.Cmd
+	conn         *sdkmcp.ClientSession
+	tools        []Tool
+	instructions string                 // server-provided usage hint from the initialize handshake
+	serverInfo   *sdkmcp.Implementation // server name/version reported during initialization
+	ctx          context.Context
+	cancel       context.CancelFunc
+	mu           sync.RWMutex
+	status       ServerStatus
 }
 
 // ServerStatus represents the current status of a server
@@ -136,6 +138,12 @@ func (s *Server) Start() error {
 	s.client = client
 	s.conn = session
 	s.cmd = cmd
+	// Capture the server's self-reported usage instructions and identity from
+	// the initialize handshake so callers can surface them in the UI.
+	if initRes := session.InitializeResult(); initRes != nil {
+		s.instructions = initRes.Instructions
+		s.serverInfo = initRes.ServerInfo
+	}
 	s.mu.Unlock()
 
 	// Discover tools
@@ -217,6 +225,23 @@ func (s *Server) GetTools() []Tool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.tools
+}
+
+// GetInstructions returns the server-provided usage instructions captured from
+// the MCP initialize handshake. May be empty if the server provided none or is
+// not running.
+func (s *Server) GetInstructions() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.instructions
+}
+
+// GetServerInfo returns the server's reported implementation info (name/title/
+// version) from initialization. Returns nil if the server is not running.
+func (s *Server) GetServerInfo() *sdkmcp.Implementation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.serverInfo
 }
 
 // CallTool calls a tool on the MCP server

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -4,3 +4,7 @@ import sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 type Tool = sdkmcp.Tool
 type ToolCallResult = sdkmcp.CallToolResult
+
+// Implementation describes an MCP server's reported identity (name/title/version)
+// from the initialize handshake.
+type Implementation = sdkmcp.Implementation

--- a/internal/mcphttp/details.go
+++ b/internal/mcphttp/details.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -197,15 +198,27 @@ func stripNpmVersion(pkg string) string {
 	return pkg
 }
 
+// npmPackageNamePattern matches a valid (optionally scoped) npm package name.
+// Restricting to this set keeps untrusted config from injecting anything other
+// than a registry path segment into the README fetch URL.
+var npmPackageNamePattern = regexp.MustCompile(`^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$`)
+
 // fetchNpmReadme retrieves the README markdown for an npm package from the public
 // registry. Returns nil on any error or when no README is published.
 func fetchNpmReadme(client *http.Client, pkg string) *readmeInfo {
+	if !npmPackageNamePattern.MatchString(pkg) {
+		return nil
+	}
+
 	escaped := pkg
 	if strings.HasPrefix(pkg, "@") {
 		// Scoped packages must have their slash percent-encoded.
 		escaped = strings.Replace(pkg, "/", "%2f", 1)
 	}
 
+	// #nosec G704 -- the host is a constant literal; only the URL path comes from
+	// pkg, which is validated above against a strict npm-name allowlist (no host,
+	// scheme, or traversal characters can be injected).
 	resp, err := client.Get("https://registry.npmjs.org/" + escaped)
 	if err != nil {
 		logger.Debug("npm README fetch failed", logger.Fields{"package": pkg, "error": err})

--- a/internal/mcphttp/details.go
+++ b/internal/mcphttp/details.go
@@ -1,0 +1,311 @@
+package mcphttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/mcp"
+)
+
+// maxReadmeBytes caps how much README content we hold in memory / return to the
+// browser, guarding against pathologically large files.
+const maxReadmeBytes = 256 * 1024
+
+// readmeInfo carries fetched README content plus where it came from.
+type readmeInfo struct {
+	Markdown  string `json:"markdown"`
+	Source    string `json:"source"`     // "npm" or "github"
+	SourceURL string `json:"source_url"` // human-facing link to the source
+}
+
+// serverDetailsResponse is the payload for GET /api/mcp/servers/{name}/details.
+// It bundles everything the detail modal needs in a single round-trip.
+type serverDetailsResponse struct {
+	Server       string              `json:"server"`
+	Status       mcp.ServerStatus    `json:"status"`
+	StartError   string              `json:"start_error,omitempty"`
+	Command      string              `json:"command"`
+	Args         []string            `json:"args"`
+	Transport    string              `json:"transport"`
+	Enabled      bool                `json:"enabled"`
+	EnvKeys      []string            `json:"env_keys,omitempty"` // keys only — values are never exposed
+	Instructions string              `json:"instructions,omitempty"`
+	ServerInfo   *mcp.Implementation `json:"server_info,omitempty"`
+	Readme       *readmeInfo         `json:"readme,omitempty"`
+	Tools        []mcp.Tool          `json:"tools"`
+}
+
+// GetServerDetailsHandler returns a consolidated detail view for a single MCP
+// server: config summary, the server's native initialize instructions, a
+// best-effort fetched README, and the live tool list.
+// GET /api/mcp/servers/{name}/details
+func (h *Handler) GetServerDetailsHandler(w http.ResponseWriter, r *http.Request) {
+	serverName := r.PathValue("name")
+	if serverName == "" {
+		orihttp.BadRequest(w, "Server name required")
+		return
+	}
+
+	server, err := h.registry.GetServer(serverName)
+	if err != nil {
+		orihttp.NotFound(w, err.Error())
+		return
+	}
+
+	// The README, config, and identity don't need a running server, so merely
+	// opening the detail view must not spawn a process. Tools and native
+	// instructions are only available from a live session, so we start the
+	// server only when the caller explicitly opts in via ?start=true.
+	status := server.GetStatus()
+	var startErr string
+	if r.URL.Query().Get("start") == "true" && (status == mcp.StatusStopped || status == mcp.StatusError) {
+		if status == mcp.StatusError {
+			_ = h.registry.StopServer(serverName)
+		}
+		if err := h.registry.StartServer(serverName); err != nil {
+			startErr = err.Error()
+			logger.Warn("Failed to start MCP server while loading details", logger.Fields{
+				"server": serverName,
+				"error":  err,
+			})
+		}
+	}
+
+	cfg := server.GetConfig()
+	resp := serverDetailsResponse{
+		Server:       serverName,
+		Status:       server.GetStatus(),
+		StartError:   startErr,
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Transport:    cfg.Transport,
+		Enabled:      cfg.Enabled,
+		EnvKeys:      envKeys(cfg.Env),
+		Instructions: server.GetInstructions(),
+		ServerInfo:   server.GetServerInfo(),
+		Tools:        server.GetTools(),
+	}
+
+	// README is a best-effort enrichment; never fail the whole request over it.
+	resp.Readme = h.resolveReadme(cfg)
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
+		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
+	}
+}
+
+// envKeys returns the sorted set of configured environment variable names. Only
+// names are surfaced — values may contain secrets and must never leave the server.
+func envKeys(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// resolveReadme tries, in order, the npm registry (for npx-style servers) and
+// then a GitHub homepage discovered from the registry cache. Returns nil when no
+// README can be found.
+func (h *Handler) resolveReadme(cfg mcp.ServerConfig) *readmeInfo {
+	client := &http.Client{Timeout: 8 * time.Second}
+
+	if pkg := npmPackageFromConfig(cfg); pkg != "" {
+		if rm := fetchNpmReadme(client, pkg); rm != nil {
+			return rm
+		}
+	}
+
+	if home := h.homepageFromRegistry(cfg.Name); home != "" {
+		if rm := fetchGithubReadme(client, home); rm != nil {
+			return rm
+		}
+	}
+
+	return nil
+}
+
+// homepageFromRegistry looks up a server's homepage URL from the cached registry
+// entries by name (case-insensitive). Returns "" when unknown.
+func (h *Handler) homepageFromRegistry(name string) string {
+	if h.regStore == nil {
+		return ""
+	}
+	for _, e := range h.regStore.GetCachedEntries() {
+		if strings.EqualFold(e.Name, name) && strings.TrimSpace(e.Homepage) != "" {
+			return e.Homepage
+		}
+	}
+	return ""
+}
+
+// npmPackageFromConfig extracts the npm package name from a command like
+// `npx -y @scope/pkg ...`. Returns "" when the command is not an npm-style
+// runner or no package can be identified.
+func npmPackageFromConfig(cfg mcp.ServerConfig) string {
+	base := strings.ToLower(strings.TrimSuffix(filepath.Base(cfg.Command), ".exe"))
+	runners := map[string]bool{"npx": true, "npm": true, "pnpm": true, "bunx": true, "yarn": true}
+	if !runners[base] {
+		return ""
+	}
+
+	for _, arg := range cfg.Args {
+		t := strings.TrimSpace(arg)
+		if t == "" || strings.HasPrefix(t, "-") {
+			continue
+		}
+		// Skip subcommand keywords used by some runners.
+		switch t {
+		case "dlx", "exec", "create", "run", "x":
+			continue
+		}
+		// Skip filesystem paths (allowed dirs etc.) — these aren't packages.
+		if strings.HasPrefix(t, "/") || strings.HasPrefix(t, ".") || strings.HasPrefix(t, "~") {
+			continue
+		}
+		return stripNpmVersion(t)
+	}
+	return ""
+}
+
+// stripNpmVersion drops a trailing "@version" specifier, preserving the leading
+// "@" of scoped package names (e.g. "@scope/pkg@1.2.3" -> "@scope/pkg").
+func stripNpmVersion(pkg string) string {
+	if strings.HasPrefix(pkg, "@") {
+		if i := strings.Index(pkg[1:], "@"); i >= 0 {
+			return pkg[:i+1]
+		}
+		return pkg
+	}
+	if before, _, found := strings.Cut(pkg, "@"); found {
+		return before
+	}
+	return pkg
+}
+
+// fetchNpmReadme retrieves the README markdown for an npm package from the public
+// registry. Returns nil on any error or when no README is published.
+func fetchNpmReadme(client *http.Client, pkg string) *readmeInfo {
+	escaped := pkg
+	if strings.HasPrefix(pkg, "@") {
+		// Scoped packages must have their slash percent-encoded.
+		escaped = strings.Replace(pkg, "/", "%2f", 1)
+	}
+
+	resp, err := client.Get("https://registry.npmjs.org/" + escaped)
+	if err != nil {
+		logger.Debug("npm README fetch failed", logger.Fields{"package": pkg, "error": err})
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var doc struct {
+		Readme   string `json:"readme"`
+		Homepage string `json:"homepage"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4*maxReadmeBytes)).Decode(&doc); err != nil {
+		return nil
+	}
+
+	md := strings.TrimSpace(doc.Readme)
+	if md == "" || strings.EqualFold(md, "ERROR: No README data found!") {
+		return nil
+	}
+
+	sourceURL := strings.TrimSpace(doc.Homepage)
+	if sourceURL == "" {
+		sourceURL = "https://www.npmjs.com/package/" + pkg
+	}
+
+	return &readmeInfo{
+		Markdown:  capString(md, maxReadmeBytes),
+		Source:    "npm",
+		SourceURL: sourceURL,
+	}
+}
+
+// fetchGithubReadme retrieves the raw README for a GitHub repository identified
+// by a homepage URL. Returns nil when the URL isn't a GitHub repo or the fetch
+// fails.
+func fetchGithubReadme(client *http.Client, homepage string) *readmeInfo {
+	owner, repo := parseGitHubRepo(homepage)
+	if owner == "" || repo == "" {
+		return nil
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/readme", owner, repo)
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil
+	}
+	// Ask for the raw README contents regardless of filename/branch.
+	req.Header.Set("Accept", "application/vnd.github.raw")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Debug("GitHub README fetch failed", logger.Fields{"repo": owner + "/" + repo, "error": err})
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxReadmeBytes))
+	if err != nil {
+		return nil
+	}
+	md := strings.TrimSpace(string(body))
+	if md == "" {
+		return nil
+	}
+
+	return &readmeInfo{
+		Markdown:  md,
+		Source:    "github",
+		SourceURL: homepage,
+	}
+}
+
+// parseGitHubRepo extracts owner/repo from a github.com URL. Returns empty
+// strings when the URL is not a recognizable GitHub repository.
+func parseGitHubRepo(raw string) (owner, repo string) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", ""
+	}
+	host := strings.ToLower(u.Host)
+	if host != "github.com" && host != "www.github.com" {
+		return "", ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", ""
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git")
+}
+
+// capString truncates s to at most n bytes, appending a notice when trimmed.
+func capString(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "\n\n_…(truncated)_"
+}

--- a/internal/mcphttp/details_test.go
+++ b/internal/mcphttp/details_test.go
@@ -1,0 +1,210 @@
+package mcphttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/mcp"
+)
+
+func TestNpmPackageFromConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  mcp.ServerConfig
+		want string
+	}{
+		{
+			name: "npx scoped with -y flag",
+			cfg:  mcp.ServerConfig{Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-memory"}},
+			want: "@modelcontextprotocol/server-memory",
+		},
+		{
+			name: "npx skips filesystem path arg",
+			cfg:  mcp.ServerConfig{Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-filesystem", "/Users/me/dir"}},
+			want: "@modelcontextprotocol/server-filesystem",
+		},
+		{
+			name: "pnpm dlx subcommand",
+			cfg:  mcp.ServerConfig{Command: "pnpm", Args: []string{"dlx", "some-mcp-server"}},
+			want: "some-mcp-server",
+		},
+		{
+			name: "strips version from unscoped",
+			cfg:  mcp.ServerConfig{Command: "npx", Args: []string{"cool-pkg@1.2.3"}},
+			want: "cool-pkg",
+		},
+		{
+			name: "strips version from scoped",
+			cfg:  mcp.ServerConfig{Command: "npx", Args: []string{"@scope/pkg@2.0.0"}},
+			want: "@scope/pkg",
+		},
+		{
+			name: "non-npm runner yields empty",
+			cfg:  mcp.ServerConfig{Command: "python", Args: []string{"-m", "server"}},
+			want: "",
+		},
+		{
+			name: "full path npx still recognized",
+			cfg:  mcp.ServerConfig{Command: "/usr/local/bin/npx", Args: []string{"-y", "pkg"}},
+			want: "pkg",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := npmPackageFromConfig(tc.cfg); got != tc.want {
+				t.Fatalf("npmPackageFromConfig() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseGitHubRepo(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"https://github.com/modelcontextprotocol/servers", "modelcontextprotocol", "servers"},
+		{"https://github.com/owner/repo.git", "owner", "repo"},
+		{"https://github.com/owner/repo/tree/main/sub", "owner", "repo"},
+		{"https://www.github.com/owner/repo", "owner", "repo"},
+		{"https://gitlab.com/owner/repo", "", ""},
+		{"not a url at all", "", ""},
+		{"https://github.com/owner", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			owner, repo := parseGitHubRepo(tc.in)
+			if owner != tc.wantOwner || repo != tc.wantRepo {
+				t.Fatalf("parseGitHubRepo(%q) = (%q, %q), want (%q, %q)", tc.in, owner, repo, tc.wantOwner, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestEnvKeysOnlyReturnsNamesSorted(t *testing.T) {
+	got := envKeys(map[string]string{"ZULU": "secret-value", "ALPHA": "another-secret"})
+	want := []string{"ALPHA", "ZULU"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("envKeys() = %v, want %v", got, want)
+	}
+	if envKeys(nil) != nil {
+		t.Fatalf("envKeys(nil) should be nil")
+	}
+}
+
+func TestCapString(t *testing.T) {
+	if got := capString("short", 100); got != "short" {
+		t.Fatalf("capString should not truncate short input, got %q", got)
+	}
+	long := strings.Repeat("a", 50)
+	got := capString(long, 10)
+	if len(got) <= 10 || !strings.HasPrefix(got, strings.Repeat("a", 10)) {
+		t.Fatalf("capString did not truncate as expected: %q", got)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("capString should append a truncation notice, got %q", got)
+	}
+}
+
+// With ?start=true, GetServerDetailsHandler attempts a lazy start and returns a
+// populated start_error when the command can't be launched, while still serving
+// the config summary — and it must never leak environment variable values.
+func TestGetServerDetailsHandler_StartErrorAndEnvRedaction(t *testing.T) {
+	configManager := mcp.NewConfigManager(t.TempDir())
+	registry := mcp.NewRegistry()
+	handler := NewHandler(registry, configManager)
+
+	if err := registry.AddServer(mcp.ServerConfig{
+		Name:      "broken",
+		Command:   "definitely-not-a-real-command-for-mcp-test",
+		Args:      []string{"--flag"},
+		Env:       map[string]string{"SECRET_TOKEN": "super-secret"},
+		Transport: "stdio",
+		Enabled:   false,
+	}); err != nil {
+		t.Fatalf("failed to add server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/servers/broken/details?start=true", nil)
+	req.SetPathValue("name", "broken")
+	rr := httptest.NewRecorder()
+
+	handler.GetServerDetailsHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	if strings.Contains(rr.Body.String(), "super-secret") {
+		t.Fatalf("env value leaked into details response: %s", rr.Body.String())
+	}
+
+	var payload serverDetailsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse response: %v body=%s", err, rr.Body.String())
+	}
+	if payload.Server != "broken" {
+		t.Fatalf("expected server name 'broken', got %q", payload.Server)
+	}
+	if payload.StartError == "" {
+		t.Fatalf("expected start_error to be populated for an unstartable server")
+	}
+	if want := []string{"SECRET_TOKEN"}; !reflect.DeepEqual(payload.EnvKeys, want) {
+		t.Fatalf("expected env_keys %v, got %v", want, payload.EnvKeys)
+	}
+}
+
+// Without ?start=true, opening details must not spawn the server: status stays
+// stopped and no start error is produced, while config still serves.
+func TestGetServerDetailsHandler_DoesNotStartByDefault(t *testing.T) {
+	registry := mcp.NewRegistry()
+	handler := NewHandler(registry, mcp.NewConfigManager(t.TempDir()))
+
+	if err := registry.AddServer(mcp.ServerConfig{
+		Name:      "idle",
+		Command:   "definitely-not-a-real-command-for-mcp-test",
+		Transport: "stdio",
+		Enabled:   false,
+	}); err != nil {
+		t.Fatalf("failed to add server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/servers/idle/details", nil)
+	req.SetPathValue("name", "idle")
+	rr := httptest.NewRecorder()
+
+	handler.GetServerDetailsHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	var payload serverDetailsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse response: %v body=%s", err, rr.Body.String())
+	}
+	if payload.Status != mcp.StatusStopped {
+		t.Fatalf("expected status to remain %q, got %q", mcp.StatusStopped, payload.Status)
+	}
+	if payload.StartError != "" {
+		t.Fatalf("expected no start_error when not starting, got %q", payload.StartError)
+	}
+}
+
+func TestGetServerDetailsHandler_UnknownServerReturnsNotFound(t *testing.T) {
+	handler := NewHandler(mcp.NewRegistry(), mcp.NewConfigManager(t.TempDir()))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp/servers/ghost/details", nil)
+	req.SetPathValue("name", "ghost")
+	rr := httptest.NewRecorder()
+
+	handler.GetServerDetailsHandler(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rr.Code)
+	}
+}

--- a/internal/plugin/register.go
+++ b/internal/plugin/register.go
@@ -40,6 +40,13 @@ func ToServerConfig(pluginName string, spec MCPServerSpec, installDir string) mc
 // command (plus its cwd) against installDir, because mcp.ServerConfig has no
 // cwd field. Bare PATH commands (e.g. "npx", "uvx") are left untouched.
 func resolveCommand(spec MCPServerSpec, installDir string) (string, []string) {
+	// Track whether the command used ${CLAUDE_PLUGIN_ROOT}: after expansion such
+	// a command is already rooted at installDir, so it must NOT be re-joined to
+	// installDir below — doing so doubles the path (e.g.
+	// "plugins/src/x/plugins/src/x/bin/...") whenever installDir is relative and
+	// thus slips past the IsAbs guard.
+	usedPluginRoot := strings.Contains(spec.Command, claudePluginRootVar)
+
 	cmd := strings.ReplaceAll(spec.Command, claudePluginRootVar, installDir)
 
 	args := make([]string, len(spec.Args))
@@ -47,13 +54,26 @@ func resolveCommand(spec MCPServerSpec, installDir string) (string, []string) {
 		args[i] = strings.ReplaceAll(a, claudePluginRootVar, installDir)
 	}
 
-	if !filepath.IsAbs(cmd) && !looksLikePATHCommand(cmd) {
+	// Only a *bare* relative command (e.g. Codex's relative "command" resolved
+	// against its "cwd") needs joining to installDir. A ${CLAUDE_PLUGIN_ROOT}
+	// command is already rooted by the expansion above.
+	if !usedPluginRoot && !filepath.IsAbs(cmd) && !looksLikePATHCommand(cmd) {
 		base := installDir
 		if strings.TrimSpace(spec.Cwd) != "" {
 			base = filepath.Join(installDir, spec.Cwd)
 		}
 		cmd = filepath.Join(base, cmd)
 	}
+
+	// Anchor a relative path command to an absolute path so it does not depend on
+	// the MCP server process's working directory. PATH commands (npx, uvx) and
+	// already-absolute commands are left untouched.
+	if !looksLikePATHCommand(cmd) && !filepath.IsAbs(cmd) {
+		if abs, err := filepath.Abs(cmd); err == nil {
+			cmd = abs
+		}
+	}
+
 	return cmd, args
 }
 

--- a/internal/plugin/register_test.go
+++ b/internal/plugin/register_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/mcp"
@@ -57,6 +58,28 @@ func TestResolveCommand(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Regression: a relative installDir must not cause ${CLAUDE_PLUGIN_ROOT} to be
+// joined twice (the doubled "plugins/src/x/plugins/src/x/bin/..." bug), and the
+// result must be anchored to an absolute path.
+func TestResolveCommand_RelativeInstallDirNotDoubled(t *testing.T) {
+	spec := MCPServerSpec{Command: "${CLAUDE_PLUGIN_ROOT}/bin/reaper-plugin"}
+	installDir := filepath.Join("plugins", "src", "reaper-plugin")
+
+	cmd, _ := resolveCommand(spec, installDir)
+
+	doubled := filepath.Join(installDir, installDir)
+	if strings.Contains(cmd, doubled) {
+		t.Fatalf("command path is doubled: %q", cmd)
+	}
+	wantSuffix := filepath.Join("plugins", "src", "reaper-plugin", "bin", "reaper-plugin")
+	if !strings.HasSuffix(cmd, wantSuffix) {
+		t.Fatalf("command = %q, want suffix %q", cmd, wantSuffix)
+	}
+	if !filepath.IsAbs(cmd) {
+		t.Fatalf("command should be anchored to an absolute path, got %q", cmd)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -375,6 +375,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("POST /api/mcp/servers/{name}/enable", s.Handlers.MCP.EnableServerHandler)
 	mux.HandleFunc("POST /api/mcp/servers/{name}/disable", s.Handlers.MCP.DisableServerHandler)
 	mux.HandleFunc("GET /api/mcp/servers/{name}/tools", s.Handlers.MCP.GetServerToolsHandler)
+	mux.HandleFunc("GET /api/mcp/servers/{name}/details", s.Handlers.MCP.GetServerDetailsHandler)
 	mux.HandleFunc("GET /api/mcp/servers/{name}/status", s.Handlers.MCP.GetServerStatusHandler)
 	mux.HandleFunc("POST /api/mcp/servers/{name}/test", s.Handlers.MCP.TestConnectionHandler)
 	mux.HandleFunc("POST /api/mcp/servers/{name}/retry", s.Handlers.MCP.RetryConnectionHandler)

--- a/internal/web/static/js/mcp.js
+++ b/internal/web/static/js/mcp.js
@@ -954,7 +954,6 @@ function renderDetailTools(data) {
   }
 
   return tools.map((tool, i) => {
-    const title = tool.title || tool.name;
     const params = renderToolParams(tool.inputSchema);
     const collapseId = `toolParams${i}`;
     return `

--- a/internal/web/static/js/mcp.js
+++ b/internal/web/static/js/mcp.js
@@ -336,7 +336,10 @@ function createServerCard(server) {
           ${pluginBadge}
         </div>
       </div>
-      <div class="d-flex gap-2">
+      <div class="d-flex gap-2 flex-wrap justify-content-end">
+        <button class="modern-btn modern-btn-secondary modern-btn-sm" onclick="viewServerDetails('${encodeURIComponent(server.name)}')">
+          Details
+        </button>
         <button class="modern-btn ${toggleClass} modern-btn-sm" onclick="toggleServerEnabled('${encodeURIComponent(server.name)}', ${server.enabled})">
           ${toggleLabel}
         </button>
@@ -831,6 +834,252 @@ function renderSourcesList(sources) {
       </div>`;
     container.appendChild(row);
   });
+}
+
+// ============================================================
+// SERVER DETAILS — README + tools modal
+// ============================================================
+
+/**
+ * Open the details modal for an installed server and load its README,
+ * native MCP instructions, and live tool list from the backend.
+ */
+async function viewServerDetails(encodedServerName) {
+  const serverName = decodeURIComponent(encodedServerName);
+  const modalEl = document.getElementById('serverDetailsModal');
+  if (!modalEl) return;
+
+  const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+  document.getElementById('serverDetailsTitle').textContent = serverName;
+  const body = document.getElementById('serverDetailsBody');
+  body.innerHTML = `
+    <div class="text-center py-5">
+      <div class="spinner-border text-primary" role="status"></div>
+      <p class="mt-3 mb-0 small" style="color: var(--text-secondary);">Loading details…</p>
+    </div>`;
+  modal.show();
+
+  // Opening details does NOT start the server — README/Info load without it.
+  await loadServerDetails(serverName, false);
+}
+
+/**
+ * Fetch and render the details payload. When start is true the backend will
+ * start a stopped server so its live tools/instructions can be read.
+ */
+async function loadServerDetails(serverName, start) {
+  const body = document.getElementById('serverDetailsBody');
+  if (start) {
+    body.innerHTML = `
+      <div class="text-center py-5">
+        <div class="spinner-border text-primary" role="status"></div>
+        <p class="mt-3 mb-0 small" style="color: var(--text-secondary);">Starting server &amp; loading tools…</p>
+      </div>`;
+  }
+
+  try {
+    const url = `/api/mcp/servers/${encodeURIComponent(serverName)}/details${start ? '?start=true' : ''}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    body.innerHTML = renderServerDetails(data);
+    if (start) {
+      loadServers(); // refresh the card list so the status badge reflects the now-running server
+    }
+  } catch (err) {
+    console.error('Failed to load server details:', err);
+    body.innerHTML = `<div class="alert alert-danger">Failed to load details: ${mcpEscapeHtml(err.message)}</div>`;
+  }
+}
+
+/** Explicitly start a server from within the details modal, then reload tools. */
+function startServerDetails(encodedServerName) {
+  loadServerDetails(decodeURIComponent(encodedServerName), true);
+}
+
+/** Build the inner HTML for the details modal (tabbed: Tools / README / Info). */
+function renderServerDetails(data) {
+  const tools = data.tools || [];
+  const hasInstructions = !!(data.instructions && data.instructions.trim());
+
+  return `
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#detailToolsPane" type="button" role="tab">
+          Tools <span class="badge bg-secondary ms-1">${tools.length}</span>
+        </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#detailReadmePane" type="button" role="tab">README</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#detailInfoPane" type="button" role="tab">Info</button>
+      </li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="detailToolsPane" role="tabpanel">
+        ${renderDetailTools(data)}
+      </div>
+      <div class="tab-pane fade" id="detailReadmePane" role="tabpanel">
+        ${renderDetailReadme(data.readme, hasInstructions ? data.instructions : '')}
+      </div>
+      <div class="tab-pane fade" id="detailInfoPane" role="tabpanel">
+        ${renderDetailInfo(data)}
+      </div>
+    </div>`;
+}
+
+/** Render the tools list, each with collapsible parameters. */
+function renderDetailTools(data) {
+  const tools = data.tools || [];
+
+  if (tools.length === 0) {
+    if (data.status !== 'running') {
+      const warning = data.start_error
+        ? `<div class="alert alert-warning">Couldn't start the server: <code>${mcpEscapeHtml(data.start_error)}</code></div>`
+        : '';
+      return `
+        ${warning}
+        <div class="text-center py-4">
+          <p style="color: var(--text-secondary);">
+            This server isn't running. Tools are listed once it starts —
+            but you can read the <strong>README</strong> and <strong>Info</strong> tabs without starting it.
+          </p>
+          <button class="modern-btn modern-btn-primary" onclick="startServerDetails('${encodeURIComponent(data.server)}')">
+            Start server &amp; load tools
+          </button>
+        </div>`;
+    }
+    return '<p class="text-muted">This server is running but reported no tools.</p>';
+  }
+
+  return tools.map((tool, i) => {
+    const title = tool.title || tool.name;
+    const params = renderToolParams(tool.inputSchema);
+    const collapseId = `toolParams${i}`;
+    return `
+      <div class="modern-card p-3 mb-2">
+        <div class="d-flex justify-content-between align-items-start">
+          <div class="flex-grow-1">
+            <code style="color: var(--text-primary); font-weight: 600;">${mcpEscapeHtml(tool.name)}</code>
+            ${tool.title && tool.title !== tool.name ? `<span class="ms-2 small" style="color: var(--text-secondary);">${mcpEscapeHtml(tool.title)}</span>` : ''}
+            ${tool.description ? `<p class="mb-0 mt-1 small" style="color: var(--text-secondary);">${mcpEscapeHtml(tool.description)}</p>` : ''}
+          </div>
+          ${params ? `
+          <button class="modern-btn modern-btn-secondary modern-btn-sm flex-shrink-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#${collapseId}">
+            Params
+          </button>` : ''}
+        </div>
+        ${params ? `<div class="collapse mt-2" id="${collapseId}">${params}</div>` : ''}
+      </div>`;
+  }).join('');
+}
+
+/** Render an input-schema's properties as a small parameter list. */
+function renderToolParams(schema) {
+  if (!schema || typeof schema !== 'object') return '';
+  const props = schema.properties || {};
+  const required = new Set(schema.required || []);
+  const names = Object.keys(props);
+  if (names.length === 0) return '<div class="small" style="color: var(--text-secondary);">No parameters.</div>';
+
+  return names.map(name => {
+    const p = props[name] || {};
+    let type = p.type || (Array.isArray(p.enum) ? 'enum' : '');
+    if (Array.isArray(type)) type = type.join(' | ');
+    const reqBadge = required.has(name)
+      ? '<span class="badge bg-danger ms-1" style="font-size:0.65rem;">required</span>'
+      : '';
+    const typeBadge = type
+      ? `<span class="badge bg-secondary ms-1" style="font-size:0.65rem;">${mcpEscapeHtml(type)}</span>`
+      : '';
+    return `
+      <div class="py-1" style="border-bottom: 1px solid var(--border-color);">
+        <code style="color: var(--text-primary);">${mcpEscapeHtml(name)}</code>${typeBadge}${reqBadge}
+        ${p.description ? `<div class="small mt-1" style="color: var(--text-secondary);">${mcpEscapeHtml(p.description)}</div>` : ''}
+      </div>`;
+  }).join('');
+}
+
+/** Render the README tab: native instructions (if any) + fetched README markdown. */
+function renderDetailReadme(readme, instructions) {
+  let html = '';
+
+  if (instructions && instructions.trim()) {
+    html += `
+      <div class="mb-4">
+        <h6 style="color: var(--text-primary);">Server instructions</h6>
+        <div class="mcp-markdown small">${renderMcpMarkdown(instructions)}</div>
+      </div>`;
+  }
+
+  if (readme && readme.markdown) {
+    const sourceLink = readme.source_url
+      ? `<a href="${mcpEscapeHtml(readme.source_url)}" target="_blank" rel="noopener noreferrer" class="small">View source (${mcpEscapeHtml(readme.source || 'link')})</a>`
+      : '';
+    html += `
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h6 class="mb-0" style="color: var(--text-primary);">README</h6>
+        ${sourceLink}
+      </div>
+      <div class="mcp-markdown">${renderMcpMarkdown(readme.markdown)}</div>`;
+  } else if (!instructions || !instructions.trim()) {
+    html = '<p class="text-muted">No README or instructions found for this server. It may not publish documentation, or the package homepage is unknown.</p>';
+  }
+
+  return html;
+}
+
+/** Render the Info tab: config summary + server identity. */
+function renderDetailInfo(data) {
+  const info = data.server_info || {};
+  const argsLine = (data.args || []).join(' ');
+  const envKeys = data.env_keys || [];
+  const enabledBadge = data.enabled
+    ? '<span class="badge bg-primary">Enabled globally</span>'
+    : '<span class="badge bg-secondary">Disabled globally</span>';
+
+  const rows = [
+    ['Status', getStatusBadge(data.status || 'stopped')],
+    ['Enabled', enabledBadge],
+    ['Command', `<code style="color: var(--text-primary);">${mcpEscapeHtml(data.command || '')} ${mcpEscapeHtml(argsLine)}</code>`],
+    ['Transport', mcpEscapeHtml(data.transport || 'stdio')],
+  ];
+
+  if (info.name) {
+    rows.push(['Reported name', mcpEscapeHtml(info.title || info.name)]);
+  }
+  if (info.version) {
+    rows.push(['Version', mcpEscapeHtml(info.version)]);
+  }
+  if (envKeys.length > 0) {
+    rows.push(['Environment', envKeys.map(k => `<span class="badge bg-secondary me-1">${mcpEscapeHtml(k)}</span>`).join('')]);
+  }
+
+  return `
+    <table class="table table-sm align-middle mb-0">
+      <tbody>
+        ${rows.map(([label, value]) => `
+          <tr>
+            <th scope="row" class="text-nowrap" style="color: var(--text-secondary); font-weight: 600; width: 140px;">${label}</th>
+            <td style="color: var(--text-primary);">${value}</td>
+          </tr>`).join('')}
+      </tbody>
+    </table>`;
+}
+
+/** Render markdown to sanitized HTML using marked + DOMPurify, with a safe fallback. */
+function renderMcpMarkdown(md) {
+  if (!md) return '';
+  try {
+    if (window.marked && window.DOMPurify) {
+      const html = window.marked.parse(md, { breaks: true, gfm: true });
+      return window.DOMPurify.sanitize(html);
+    }
+  } catch (err) {
+    console.error('Markdown render failed:', err);
+  }
+  return `<pre style="white-space: pre-wrap; color: var(--text-primary);">${mcpEscapeHtml(md)}</pre>`;
 }
 
 /** Safely escape HTML to prevent XSS when building innerHTML. */

--- a/internal/web/templates/pages/mcp.tmpl
+++ b/internal/web/templates/pages/mcp.tmpl
@@ -313,6 +313,19 @@
     </div>
   </div>
 
+  <!-- Server Details Modal -->
+  <div class="modal fade" id="serverDetailsModal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content" style="background: var(--bg-secondary); border: 1px solid var(--border-color);">
+        <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
+          <h5 class="modal-title" id="serverDetailsTitle" style="color: var(--text-primary);">Server Details</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" id="serverDetailsBody" style="color: var(--text-primary);"></div>
+      </div>
+    </div>
+  </div>
+
   {{template "modals.tmpl" .}}
 
   <style>
@@ -365,9 +378,39 @@
       border-color: var(--primary-color, #6366f1);
       box-shadow: 0 2px 8px rgba(99,102,241,0.12);
     }
+
+    /* Rendered README / instructions markdown inside the details modal */
+    .mcp-markdown {
+      color: var(--text-primary);
+      overflow-wrap: anywhere;
+    }
+    .mcp-markdown img { max-width: 100%; height: auto; }
+    .mcp-markdown pre {
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .mcp-markdown code {
+      background: var(--bg-tertiary);
+      padding: 0.1rem 0.3rem;
+      border-radius: 4px;
+    }
+    .mcp-markdown pre code { background: transparent; padding: 0; }
+    .mcp-markdown table { width: 100%; border-collapse: collapse; }
+    .mcp-markdown th, .mcp-markdown td {
+      border: 1px solid var(--border-color);
+      padding: 0.35rem 0.5rem;
+    }
+    .mcp-markdown a { color: var(--primary-color, #6366f1); }
+    .mcp-markdown h1, .mcp-markdown h2, .mcp-markdown h3 { color: var(--text-primary); }
   </style>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- Markdown rendering for MCP README / instructions -->
+  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
   <!-- DX Utilities -->
   <script src="/js/utils/logger.js"></script>
   <script src="/js/utils/event-bus.js"></script>


### PR DESCRIPTION
## Summary

Two related MCP changes:

### 1. MCP server detail view (README + tools)
Adds a **Details** modal to the My Servers tab on `/mcp` so a server can be inspected in place:
- New `GET /api/mcp/servers/{name}/details` bundling config, the server's native initialize instructions, a best-effort fetched README, and the live tool list.
- README resolved from the npm registry (npx-style commands) or a GitHub homepage from the registry cache; fetches are time/size-capped and never fail the request.
- Captures the MCP `initialize` instructions + server identity (`GetInstructions`/`GetServerInfo`).
- Env variable **names only** are surfaced — values are never returned.
- Opening Details does **not** start the server: README/Info load without it; tools load on an explicit "Start server & load tools" action (`?start=true`).
- README/instructions rendered as sanitized markdown (marked + DOMPurify).

### 2. Fix: doubled plugin command path for relative install dirs
A plugin installed from a git/marketplace source is cloned to the relative `plugins/src/<name>`, which becomes its `InstallDir`. `resolveCommand` expanded `${CLAUDE_PLUGIN_ROOT}` to that relative path and then joined `InstallDir` again (the `IsAbs` guard only catches absolute dirs), producing an unstartable doubled path like `plugins/src/x/plugins/src/x/bin/x`.

- Skip the install-dir join when the command already used `${CLAUDE_PLUGIN_ROOT}`.
- Anchor relative path commands to absolute via `filepath.Abs`.
- Regression test added.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- New + existing tests pass in `internal/mcp`, `internal/mcphttp`, `internal/plugin`.
- Live smoke (isolated server): details-without-start keeps server stopped but shows README; `?start=true` starts it and lists tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)