### PR TITLE
feat(plugins): browse & install official Claude plugins from a marketplace modal

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -9,6 +9,11 @@ Ori's MCP registry and drops its skills into a scanned skills directory.
 ## Installing a plugin
 
 **From the UI** — open **Plugins** in the sidebar:
+- **Browse official Claude plugins** — click **Browse official plugins** to open
+  Anthropic's official, managed directory in a modal (it loads on first open — no
+  setup step), then search/filter the card grid by keyword, category, or tag, open
+  **Details** to see what a plugin registers, and **Install** with one click
+  (confirmed inline in the modal). Already-installed plugins are marked.
 - Paste a **local path** or **git URL** under *Install a plugin*, click **Preview**,
   review what it will register, then **Confirm install**.
 - Or **add a marketplace** (git URL / local folder) and install a listed plugin by name.
@@ -24,10 +29,30 @@ POST /api/plugins/{name}/enable | /disable         # per-workspace binding state
 DELETE /api/plugins/{name}                         # uninstall (removes all components)
 
 # Marketplaces
-GET  /api/plugins/marketplaces
+GET  /api/plugins/marketplaces            # also returns {"official": {name, source, added}}
 POST /api/plugins/marketplaces            {"source": "<path|git>"}
 POST /api/plugins/marketplaces/install    {"marketplace": "...", "plugin": "...", "confirm": true}
 ```
+
+The **official marketplace** is `anthropics/claude-plugins-official`. Its source is
+held server-side and exposed via the `official` block of `GET /api/plugins/marketplaces`
+(with `added` reflecting whether it has been added). The browse modal adds it
+automatically on first open (POSTing that source — a one-time catalog clone), so there
+is no manual "add" step. Adding is idempotent (keyed by catalog name), and the official
+catalog is shown only in the browse modal, never duplicated in the user-added list.
+
+### Marketplace entry sources
+
+A catalog entry's `source` may be a string (a path relative to the catalog, or a git
+URL) or an object. Object forms are normalized to one installable source:
+
+- `{"source":"local","path":"./plugins/x"}` → path relative to the catalog
+- `{"source":"github","repo":"owner/name"}` → `https://github.com/owner/name.git`
+- `{"source":"git-subdir"|"url","url":"…","path":"plugins/x","ref":"v1","sha":"…"}` →
+  a **git repo + subdirectory**: Ori clones the repo, **pins to `sha` (preferred) or
+  `ref`**, and installs from the subpath. Pinned commits are fetched shallowly
+  (`git fetch --depth 1 <pin>`) into a per-commit clone directory so different pins of
+  the same repo don't collide.
 
 ## Trust
 

--- a/internal/plugin/lifecycle.go
+++ b/internal/plugin/lifecycle.go
@@ -184,6 +184,24 @@ func (m *Manager) Update(name string, confirm ConfirmFunc) (InstalledPlugin, err
 
 // reload re-resolves a descriptor for an installed plugin, refreshing git clones.
 func (m *Manager) reload(existing InstalledPlugin) (PluginDescriptor, error) {
+	if g, ok := parseGitSubdir(existing.Source); ok {
+		// Composite git repo + subdirectory. Pinned commits are immutable, so
+		// re-resolving is idempotent; unpinned subdir sources pull for latest.
+		if g.Sha == "" && g.Ref == "" {
+			if err := pullGit(existing.InstallDir); err != nil {
+				return PluginDescriptor{}, err
+			}
+		}
+		root, err := ResolveSource(existing.Source, m.cloneDir)
+		if err != nil {
+			return PluginDescriptor{}, err
+		}
+		mfst, err := DetectManifest(root, existing.Format)
+		if err != nil {
+			return PluginDescriptor{}, err
+		}
+		return Normalize(mfst, existing.Source)
+	}
 	if isGitURL(existing.Source) {
 		if err := pullGit(existing.InstallDir); err != nil {
 			return PluginDescriptor{}, err

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -9,6 +9,16 @@ import (
 	"sync"
 )
 
+const (
+	// OfficialMarketplaceName is the catalog name published by Anthropic's
+	// official, managed plugin directory.
+	OfficialMarketplaceName = "claude-plugins-official"
+	// OfficialMarketplaceSource is the git source for that directory. It is the
+	// single backend-held source the "Add official marketplace" button installs;
+	// the UI never hardcodes the URL.
+	OfficialMarketplaceSource = "https://github.com/anthropics/claude-plugins-official.git"
+)
+
 // Marketplace is a catalog of installable plugins (a marketplace.json),
 // compatible with Claude Code and Codex marketplace layouts.
 type Marketplace struct {
@@ -18,23 +28,44 @@ type Marketplace struct {
 	Plugins []MarketplaceEntry `json:"plugins"`
 }
 
-// MarketplaceEntry is one plugin listed in a marketplace. In real catalogs the
-// "source" is often an object (e.g. {"source":"local","path":"./..."} or
-// {"source":"github","repo":"owner/name"}) rather than a string; UnmarshalJSON
-// normalizes both to a single installable Source (a path relative to the
-// catalog, an absolute path, or a git URL).
-type MarketplaceEntry struct {
-	Name        string `json:"name"`
-	Source      string `json:"source"`
-	Description string `json:"description,omitempty"`
+// MarketplaceAuthor is a catalog entry's author. Catalogs use either a bare
+// string or an object with name/email; both normalize to this.
+type MarketplaceAuthor struct {
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
 }
 
-// UnmarshalJSON accepts both the string and object forms of "source".
+// MarketplaceEntry is one plugin listed in a marketplace. In real catalogs the
+// "source" is often an object (e.g. {"source":"local","path":"./..."},
+// {"source":"github","repo":"owner/name"}, or a git repo + subdirectory
+// {"source":"git-subdir","url":"...","path":"plugins/x","ref":"v1"}) rather than
+// a string; UnmarshalJSON normalizes all forms to a single installable Source (a
+// path relative to the catalog, an absolute path, a git URL, or a git repo +
+// subdirectory encoded by encodeGitSubdir). The remaining fields are display
+// metadata used by the browse UI (cards, search, and category/tag filtering).
+type MarketplaceEntry struct {
+	Name        string            `json:"name"`
+	Source      string            `json:"source"`
+	Description string            `json:"description,omitempty"`
+	Category    string            `json:"category,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
+	Keywords    []string          `json:"keywords,omitempty"`
+	Author      MarketplaceAuthor `json:"author,omitzero"`
+	Homepage    string            `json:"homepage,omitempty"`
+}
+
+// UnmarshalJSON accepts both the string and object forms of "source", and the
+// string or object forms of "author". Missing display fields default to empty.
 func (e *MarketplaceEntry) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Name        string          `json:"name"`
 		Description string          `json:"description"`
 		Source      json.RawMessage `json:"source"`
+		Category    string          `json:"category"`
+		Tags        []string        `json:"tags"`
+		Keywords    []string        `json:"keywords"`
+		Author      json.RawMessage `json:"author"`
+		Homepage    string          `json:"homepage"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -42,7 +73,28 @@ func (e *MarketplaceEntry) UnmarshalJSON(data []byte) error {
 	e.Name = raw.Name
 	e.Description = raw.Description
 	e.Source = normalizeEntrySource(raw.Source)
+	e.Category = raw.Category
+	e.Tags = raw.Tags
+	e.Keywords = raw.Keywords
+	e.Homepage = raw.Homepage
+	e.Author = parseMarketplaceAuthor(raw.Author)
 	return nil
+}
+
+// parseMarketplaceAuthor accepts the bare-string and object forms of "author".
+func parseMarketplaceAuthor(raw json.RawMessage) MarketplaceAuthor {
+	if len(raw) == 0 {
+		return MarketplaceAuthor{}
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return MarketplaceAuthor{Name: s}
+	}
+	var obj MarketplaceAuthor
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj
+	}
+	return MarketplaceAuthor{}
 }
 
 // normalizeEntrySource reduces a marketplace entry's "source" (a string or an
@@ -61,17 +113,31 @@ func normalizeEntrySource(raw json.RawMessage) string {
 		Path   string `json:"path"`
 		Repo   string `json:"repo"`
 		URL    string `json:"url"`
+		Ref    string `json:"ref"`
+		Sha    string `json:"sha"`
 	}
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return ""
 	}
+	gitURL := obj.URL
+	if gitURL == "" && obj.Repo != "" {
+		gitURL = "https://github.com/" + obj.Repo + ".git"
+	}
 	switch {
+	case gitURL != "" && obj.Path != "":
+		// git repo + subdirectory (the "git-subdir"/"url" entry types): clone the
+		// repo and install from the subpath, pinned to ref/sha when present. Must
+		// be checked before the bare-path case — these entries carry both a url
+		// and a path, and the path is relative to the repo, not the catalog dir.
+		return encodeGitSubdir(gitURL, obj.Path, obj.Ref, obj.Sha)
+	case gitURL != "" && (obj.Ref != "" || obj.Sha != ""):
+		// whole-repo plugin pinned to a specific commit
+		return encodeGitSubdir(gitURL, "", obj.Ref, obj.Sha)
+	case gitURL != "":
+		return gitURL
 	case obj.Path != "":
+		// path relative to (or absolute from) the catalog dir
 		return obj.Path
-	case obj.URL != "":
-		return obj.URL
-	case obj.Repo != "":
-		return "https://github.com/" + obj.Repo + ".git"
 	default:
 		return ""
 	}

--- a/internal/plugin/marketplace_test.go
+++ b/internal/plugin/marketplace_test.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"fmt"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -106,5 +108,135 @@ func TestParseMarketplaceObjectSource(t *testing.T) {
 	}
 	if byName["gh-one"] != "https://github.com/acme/gh-one.git" {
 		t.Errorf("github object source = %q", byName["gh-one"])
+	}
+}
+
+func TestParseMarketplaceMetadata(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "marketplace.json"), `{
+	  "name": "official",
+	  "plugins": [
+	    {
+	      "name": "rich",
+	      "description": "d",
+	      "category": "security",
+	      "tags": ["a", "b"],
+	      "keywords": ["k1"],
+	      "homepage": "https://example.com",
+	      "author": {"name": "Acme", "email": "x@acme.io"},
+	      "source": "./plugins/rich"
+	    },
+	    {"name": "legacy", "source": "./plugins/legacy"},
+	    {"name": "str-author", "author": "Just A Name", "source": "./plugins/sa"}
+	  ]
+	}`)
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]MarketplaceEntry{}
+	for _, p := range mp.Plugins {
+		byName[p.Name] = p
+	}
+
+	rich := byName["rich"]
+	if rich.Category != "security" {
+		t.Errorf("category = %q", rich.Category)
+	}
+	if len(rich.Tags) != 2 || rich.Tags[0] != "a" {
+		t.Errorf("tags = %v", rich.Tags)
+	}
+	if len(rich.Keywords) != 1 || rich.Keywords[0] != "k1" {
+		t.Errorf("keywords = %v", rich.Keywords)
+	}
+	if rich.Homepage != "https://example.com" {
+		t.Errorf("homepage = %q", rich.Homepage)
+	}
+	if rich.Author.Name != "Acme" || rich.Author.Email != "x@acme.io" {
+		t.Errorf("author = %+v", rich.Author)
+	}
+
+	// Legacy minimal entry still parses with zero-value metadata.
+	legacy := byName["legacy"]
+	if legacy.Source != "./plugins/legacy" || legacy.Category != "" || len(legacy.Tags) != 0 {
+		t.Errorf("legacy = %+v", legacy)
+	}
+
+	// Bare-string author normalizes to {Name}.
+	if byName["str-author"].Author.Name != "Just A Name" {
+		t.Errorf("string author = %+v", byName["str-author"].Author)
+	}
+}
+
+func TestNormalizeGitSubdirEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "marketplace.json"), `{
+	  "name": "official",
+	  "plugins": [
+	    {"name": "sub", "source": {"source": "git-subdir", "url": "https://github.com/x/y.git", "path": "plugins/sub", "ref": "v1.5.5", "sha": "deadbeef"}},
+	    {"name": "pinned-repo", "source": {"source": "url", "url": "https://github.com/x/z.git", "sha": "cafe"}}
+	  ]
+	}`)
+	mp, err := ParseMarketplace(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]string{}
+	for _, p := range mp.Plugins {
+		byName[p.Name] = p.Source
+	}
+
+	g, ok := parseGitSubdir(byName["sub"])
+	if !ok {
+		t.Fatalf("sub source not a git-subdir: %q", byName["sub"])
+	}
+	if g.URL != "https://github.com/x/y.git" || g.Subdir != "plugins/sub" || g.Ref != "v1.5.5" || g.Sha != "deadbeef" {
+		t.Errorf("git-subdir = %+v", g)
+	}
+
+	g2, ok := parseGitSubdir(byName["pinned-repo"])
+	if !ok {
+		t.Fatalf("pinned-repo not parsed: %q", byName["pinned-repo"])
+	}
+	if g2.URL != "https://github.com/x/z.git" || g2.Subdir != "" || g2.Sha != "cafe" {
+		t.Errorf("pinned-repo = %+v", g2)
+	}
+}
+
+func TestMarketplaceInstallGitSubdir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo, sha := gitInitPluginRepo(t)
+
+	catalog := t.TempDir()
+	entry := fmt.Sprintf(`{"name":"cat","plugins":[{"name":"demo","source":{"source":"git-subdir","url":%q,"path":"plugins/demo","sha":%q}}]}`, repo, sha)
+	writeFile(t, filepath.Join(catalog, "marketplace.json"), entry)
+
+	reg := &fakeRegistrar{}
+	sk := &fakeSkills{}
+	m := NewManager(reg, sk, t.TempDir(), t.TempDir())
+
+	if _, err := m.AddMarketplace(catalog); err != nil {
+		t.Fatalf("add marketplace: %v", err)
+	}
+
+	// Preview should disclose the MCP server without registering it.
+	if _, err := m.PreviewFromMarketplace("cat", "demo", ""); err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if len(reg.added) != 0 {
+		t.Errorf("preview should not register: %v", reg.added)
+	}
+
+	p, err := m.InstallFromMarketplace("cat", "demo", "", func(TrustReport) bool { return true })
+	if err != nil {
+		t.Fatalf("install from marketplace: %v", err)
+	}
+	if p.Name != "demo" {
+		t.Errorf("installed = %q", p.Name)
+	}
+	if _, ok := reg.added["demo/demo-mcp"]; !ok {
+		t.Errorf("server not registered: %v", reg.added)
 	}
 }

--- a/internal/plugin/source.go
+++ b/internal/plugin/source.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,12 +24,17 @@ func Load(source, cloneDir string, prefer SourceFormat) (PluginDescriptor, error
 }
 
 // ResolveSource returns a local directory containing the plugin bundle. A local
-// path is returned as-is; a git URL is cloned into cloneDir/<repo>. The caller
-// owns cloneDir (e.g. a managed plugins directory).
+// path is returned as-is; a git URL is cloned into cloneDir/<repo>; a git repo +
+// subdirectory (encoded by encodeGitSubdir) is cloned/fetched — pinned to its
+// ref/sha when present — and the subdirectory is returned. The caller owns
+// cloneDir (e.g. a managed plugins directory).
 func ResolveSource(source, cloneDir string) (string, error) {
 	source = strings.TrimSpace(source)
 	if source == "" {
 		return "", ErrEmptySource
+	}
+	if g, ok := parseGitSubdir(source); ok {
+		return resolveGitSubdir(g, cloneDir)
 	}
 	if isGitURL(source) {
 		return cloneGit(source, cloneDir)
@@ -91,4 +97,152 @@ func pullGit(dir string) error {
 		return fmt.Errorf("plugin: git pull failed: %v: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// gitSubdirSource is a git repo plus an optional subdirectory and pinned commit.
+type gitSubdirSource struct {
+	URL    string
+	Subdir string
+	Ref    string
+	Sha    string
+}
+
+// encodeGitSubdir packs a git repo + subdirectory (+ optional ref/sha) into one
+// source string of the form "<url>#<query>", so it can be recorded as a plugin's
+// source and re-resolved on update. Returns the bare URL when there is nothing
+// extra to encode. The "https://"/".git" prefix is preserved so isGitURL still
+// treats the result as a git source.
+func encodeGitSubdir(rawURL, subdir, ref, sha string) string {
+	v := neturl.Values{}
+	if s := strings.TrimSpace(subdir); s != "" {
+		v.Set("subdir", filepath.ToSlash(filepath.Clean(s)))
+	}
+	if ref != "" {
+		v.Set("ref", ref)
+	}
+	if sha != "" {
+		v.Set("sha", sha)
+	}
+	if len(v) == 0 {
+		return rawURL
+	}
+	return rawURL + "#" + v.Encode()
+}
+
+// parseGitSubdir reverses encodeGitSubdir. ok is false for a plain source (one
+// with no "#subdir=/ref=/sha=" fragment), which callers resolve the existing way.
+func parseGitSubdir(s string) (gitSubdirSource, bool) {
+	base, frag, ok := strings.Cut(s, "#")
+	if !ok {
+		return gitSubdirSource{}, false
+	}
+	v, err := neturl.ParseQuery(frag)
+	if err != nil {
+		return gitSubdirSource{}, false
+	}
+	g := gitSubdirSource{
+		URL:    base,
+		Subdir: v.Get("subdir"),
+		Ref:    v.Get("ref"),
+		Sha:    v.Get("sha"),
+	}
+	if g.Subdir == "" && g.Ref == "" && g.Sha == "" {
+		return gitSubdirSource{}, false
+	}
+	return g, true
+}
+
+// resolveGitSubdir clones (or pin-fetches) the repo and returns the requested
+// subdirectory. Pinned commits get a per-commit clone dir so two plugins from
+// the same repo at different pins don't collide, and so the existing-dir
+// shortcut is correct.
+func resolveGitSubdir(g gitSubdirSource, cloneDir string) (string, error) {
+	if strings.TrimSpace(cloneDir) == "" {
+		return "", fmt.Errorf("plugin: git source requires a clone directory")
+	}
+	if err := os.MkdirAll(cloneDir, 0o750); err != nil {
+		return "", fmt.Errorf("plugin: create clone dir: %w", err)
+	}
+
+	pin := g.Sha // most specific identifier wins for the directory name
+	if pin == "" {
+		pin = g.Ref
+	}
+	dirName := repoName(g.URL)
+	if pin != "" {
+		dirName += "@" + sanitizeRef(pin)
+	}
+	dest := filepath.Join(cloneDir, dirName)
+
+	if _, err := os.Stat(dest); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("plugin: stat clone dir: %w", err)
+		}
+		if pin == "" {
+			if err := runGit("clone", "--depth", "1", g.URL, dest); err != nil {
+				return "", err
+			}
+		} else if err := fetchPinned(g.URL, pin, dest); err != nil {
+			return "", err
+		}
+	}
+
+	root := dest
+	if g.Subdir != "" {
+		// Force-root the subpath so a crafted "../" entry can't escape the clone.
+		clean := filepath.Clean(string(filepath.Separator) + filepath.FromSlash(g.Subdir))
+		root = filepath.Join(dest, clean)
+		info, err := os.Stat(root)
+		if err != nil || !info.IsDir() {
+			return "", fmt.Errorf("plugin: subdirectory %q not found in %s", g.Subdir, g.URL)
+		}
+	}
+	return root, nil
+}
+
+// fetchPinned shallow-fetches a single commit/ref into a fresh repo and checks
+// it out detached. git clone --depth 1 cannot target an arbitrary commit, so an
+// init + fetch <pin> + checkout FETCH_HEAD is used instead (GitHub serves
+// reachable shas via allowReachableSHA1InWant; tags/branches always work).
+func fetchPinned(url, pin, dest string) error {
+	if err := os.MkdirAll(dest, 0o750); err != nil {
+		return fmt.Errorf("plugin: create clone dir: %w", err)
+	}
+	steps := [][]string{
+		{"-C", dest, "init", "-q"},
+		{"-C", dest, "fetch", "--depth", "1", url, pin},
+		{"-C", dest, "checkout", "-q", "FETCH_HEAD"},
+	}
+	for _, args := range steps {
+		if err := runGit(args...); err != nil {
+			_ = os.RemoveAll(dest) // don't leave a half-built repo that blocks retries
+			return err
+		}
+	}
+	return nil
+}
+
+// runGit runs a git command and wraps a non-zero exit with its output.
+func runGit(args ...string) error {
+	cmd := exec.Command("git", args...) // #nosec G204 -- git args derived from a user-added marketplace catalog
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("plugin: git %s failed: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// sanitizeRef makes a ref/sha safe to use as a directory-name suffix.
+func sanitizeRef(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+	if len(mapped) > 40 {
+		mapped = mapped[:40]
+	}
+	return mapped
 }

--- a/internal/plugin/source_test.go
+++ b/internal/plugin/source_test.go
@@ -1,0 +1,157 @@
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEncodeParseGitSubdirRoundTrip(t *testing.T) {
+	cases := []struct {
+		name                       string
+		url, subdir, ref, sha      string
+		wantOK                     bool
+		wantSubdir, wantRef, wantS string
+	}{
+		{name: "subdir+sha", url: "https://github.com/a/b.git", subdir: "plugins/x", sha: "abc123", wantOK: true, wantSubdir: "plugins/x", wantS: "abc123"},
+		{name: "subdir+ref", url: "https://github.com/a/b.git", subdir: "plugins/x", ref: "v1.2.3", wantOK: true, wantSubdir: "plugins/x", wantRef: "v1.2.3"},
+		{name: "whole-repo pinned", url: "https://github.com/a/b.git", ref: "v1", wantOK: true, wantRef: "v1"},
+		{name: "plain url has no fragment", url: "https://github.com/a/b.git", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := encodeGitSubdir(tc.url, tc.subdir, tc.ref, tc.sha)
+			g, ok := parseGitSubdir(enc)
+			if ok != tc.wantOK {
+				t.Fatalf("parse ok = %v, want %v (enc=%q)", ok, tc.wantOK, enc)
+			}
+			if !tc.wantOK {
+				if enc != tc.url {
+					t.Errorf("plain encode = %q, want %q", enc, tc.url)
+				}
+				return
+			}
+			if g.URL != tc.url {
+				t.Errorf("url = %q, want %q", g.URL, tc.url)
+			}
+			if g.Subdir != tc.wantSubdir {
+				t.Errorf("subdir = %q, want %q", g.Subdir, tc.wantSubdir)
+			}
+			if g.Ref != tc.wantRef {
+				t.Errorf("ref = %q, want %q", g.Ref, tc.wantRef)
+			}
+			if g.Sha != tc.wantS {
+				t.Errorf("sha = %q, want %q", g.Sha, tc.wantS)
+			}
+		})
+	}
+}
+
+func TestParseGitSubdirIgnoresPlainSource(t *testing.T) {
+	for _, s := range []string{"./plugins/x", "/abs/path", "https://github.com/a/b.git"} {
+		if _, ok := parseGitSubdir(s); ok {
+			t.Errorf("parseGitSubdir(%q) = ok, want not ok", s)
+		}
+	}
+}
+
+func TestResolveEntrySource(t *testing.T) {
+	cat := t.TempDir()
+	// relative path joins the catalog dir
+	if got := resolveEntrySource(cat, "./plugins/x"); got != filepath.Join(cat, "plugins", "x") {
+		t.Errorf("relative = %q, want %q", got, filepath.Join(cat, "plugins", "x"))
+	}
+	// git URL is returned as-is (not joined)
+	if got := resolveEntrySource(cat, "https://github.com/a/b.git"); got != "https://github.com/a/b.git" {
+		t.Errorf("git url = %q", got)
+	}
+	// composite git-subdir (https) is returned as-is
+	comp := encodeGitSubdir("https://github.com/a/b.git", "plugins/x", "v1", "")
+	if got := resolveEntrySource(cat, comp); got != comp {
+		t.Errorf("composite = %q, want %q", got, comp)
+	}
+}
+
+// gitInitPluginRepo builds a real git repo containing a Claude plugin under
+// plugins/demo, commits it, and returns the repo dir and the HEAD sha. The repo
+// is configured to serve arbitrary shas so a pinned fetch works over the local
+// transport.
+func gitInitPluginRepo(t *testing.T) (repoDir, sha string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	writeFile(t, filepath.Join(repoDir, "plugins", "demo", ".claude-plugin", "plugin.json"), `{"name":"demo","version":"0.1.0"}`)
+	writeFile(t, filepath.Join(repoDir, "plugins", "demo", ".mcp.json"), `{"demo-mcp":{"command":"/usr/bin/true"}}`)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "uploadpack.allowAnySHA1InWant", "true")
+	run("config", "uploadpack.allowReachableSHA1InWant", "true")
+	run("add", "-A")
+	run("commit", "-q", "-m", "init")
+
+	out, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	return repoDir, strings.TrimSpace(string(out))
+}
+
+func TestResolveSourceGitSubdirPinned(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo, sha := gitInitPluginRepo(t)
+
+	src := encodeGitSubdir(repo, "plugins/demo", "", sha)
+	root, err := ResolveSource(src, t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if filepath.Base(root) != "demo" {
+		t.Errorf("root = %q, want .../demo", root)
+	}
+	if !fileExists(filepath.Join(root, ".claude-plugin", "plugin.json")) {
+		t.Errorf("manifest missing under %q", root)
+	}
+}
+
+func TestResolveSourceGitWholeRepoPinned(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo, sha := gitInitPluginRepo(t)
+
+	// No subdir: a pinned whole-repo source resolves to the repo root.
+	src := encodeGitSubdir(repo, "", "", sha)
+	root, err := ResolveSource(src, t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !fileExists(filepath.Join(root, "plugins", "demo", ".claude-plugin", "plugin.json")) {
+		t.Errorf("repo root not resolved: %q", root)
+	}
+}
+
+func TestResolveSourceGitSubdirMissingSubdir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo, sha := gitInitPluginRepo(t)
+
+	src := encodeGitSubdir(repo, "plugins/does-not-exist", "", sha)
+	if _, err := ResolveSource(src, t.TempDir()); err == nil {
+		t.Error("expected error for missing subdirectory")
+	}
+}

--- a/internal/pluginhttp/handlers.go
+++ b/internal/pluginhttp/handlers.go
@@ -137,7 +137,23 @@ func (h *Handler) MarketplacesHandler(w http.ResponseWriter, r *http.Request) {
 			orihttp.InternalError(w, err.Error())
 			return
 		}
-		orihttp.WriteJSON(w, map[string]any{"marketplaces": list})
+		added := false
+		for _, mp := range list {
+			if mp.Name == plugin.OfficialMarketplaceName || mp.Source == plugin.OfficialMarketplaceSource {
+				added = true
+				break
+			}
+		}
+		orihttp.WriteJSON(w, map[string]any{
+			"marketplaces": list,
+			// official tells the UI the backend-held source for the one-click
+			// "Add official marketplace" button, and whether it's already added.
+			"official": map[string]any{
+				"name":   plugin.OfficialMarketplaceName,
+				"source": plugin.OfficialMarketplaceSource,
+				"added":  added,
+			},
+		})
 	case http.MethodPost:
 		var req struct {
 			Source string `json:"source"`

--- a/internal/pluginhttp/handlers_test.go
+++ b/internal/pluginhttp/handlers_test.go
@@ -96,6 +96,56 @@ func TestInstallConfirmThenList(t *testing.T) {
 	}
 }
 
+func TestMarketplacesOfficialStatus(t *testing.T) {
+	h := testHandler(t)
+
+	getMarketplaces := func() string {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		h.MarketplacesHandler(rr, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplaces", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET marketplaces: %d %s", rr.Code, rr.Body.String())
+		}
+		return rr.Body.String()
+	}
+
+	// Before adding: official block present, source exposed, added=false.
+	body := getMarketplaces()
+	if !strings.Contains(body, plugin.OfficialMarketplaceSource) {
+		t.Errorf("official source not exposed: %s", body)
+	}
+	if !strings.Contains(body, `"added":false`) {
+		t.Errorf("expected added:false, got %s", body)
+	}
+
+	// Add a local catalog whose name matches the official marketplace name; the
+	// status must flip to added=true (idempotent add keyed by name).
+	catalog := t.TempDir()
+	mustWrite(t, filepath.Join(catalog, "marketplace.json"),
+		`{"name":"`+plugin.OfficialMarketplaceName+`","plugins":[]}`)
+	addBody := `{"source":"` + catalog + `"}`
+	rr := httptest.NewRecorder()
+	h.MarketplacesHandler(rr, httptest.NewRequest(http.MethodPost, "/api/plugins/marketplaces", strings.NewReader(addBody)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST marketplace: %d %s", rr.Code, rr.Body.String())
+	}
+	// Re-add to prove idempotency (no duplicate record).
+	rr = httptest.NewRecorder()
+	h.MarketplacesHandler(rr, httptest.NewRequest(http.MethodPost, "/api/plugins/marketplaces", strings.NewReader(addBody)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-add marketplace: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Each added marketplace record carries a "dir" field (the official status
+	// block does not), so this counts records — proving the re-add didn't dupe.
+	if got := strings.Count(getMarketplaces(), `"dir":`); got != 1 {
+		t.Errorf("expected exactly 1 marketplace record, got %d: %s", got, getMarketplaces())
+	}
+	if !strings.Contains(getMarketplaces(), `"added":true`) {
+		t.Errorf("expected added:true after add, got %s", getMarketplaces())
+	}
+}
+
 func TestUninstall(t *testing.T) {
 	h := testHandler(t)
 	if rr := postInstall(t, h, claudeBundle(t), true); rr.Code != http.StatusOK {

--- a/internal/web/static/js/plugins.js
+++ b/internal/web/static/js/plugins.js
@@ -45,7 +45,8 @@
     byId('pluginTrustBody').innerHTML = '';
   };
 
-  function renderTrustBody(t) {
+  function trustHTML(t) {
+    t = t || {};
     const mcp = (t.MCPCommands || []).map((c) => '<li><code>' + esc(c) + '</code></li>').join('');
     const skills = (t.Skills || []).map(esc).join(', ');
     const unsupported = (t.Unsupported || []).map((u) => '<li>' + esc(u.kind) + ': ' + esc(u.detail) + '</li>').join('');
@@ -55,7 +56,11 @@
     if (skills) html += '<div class="small">Skills: ' + esc(skills) + '</div>';
     if (unsupported) html += '<div class="small fw-semibold mt-2">Skipped (not yet supported):</div><ul class="small">' + unsupported + '</ul>';
     if (warnings) html += '<ul class="small mb-0">' + warnings + '</ul>';
-    byId('pluginTrustBody').innerHTML = html || '<div class="small text-muted">Nothing to register.</div>';
+    return html || '<div class="small text-muted">Nothing to register.</div>';
+  }
+
+  function renderTrustBody(t) {
+    byId('pluginTrustBody').innerHTML = trustHTML(t);
   }
 
   // ---- installed plugins ----
@@ -146,19 +151,246 @@
     }
   };
 
-  // ---- marketplaces ----
+  // ---- marketplaces (official browse + user-added) ----
 
+  const officialState = { name: '', source: '', added: false, loaded: false, entries: [], installed: new Set() };
+
+  async function getInstalledNames() {
+    try {
+      const data = await api('GET', '/api/plugins');
+      return new Set(((data && data.plugins) || []).map((p) => p.name));
+    } catch (_) {
+      return new Set();
+    }
+  }
+
+  // loadMarketplaces drives the user-added list and records the official
+  // marketplace's identity (name/source/added) for the browse modal. The
+  // official catalog itself is loaded lazily when the modal opens, and is never
+  // duplicated in the user-added list.
   window.loadMarketplaces = async function () {
     const el = byId('marketplaceList');
-    if (!el) return;
+    let data;
     try {
-      const data = await api('GET', '/api/plugins/marketplaces');
-      const mps = (data && data.marketplaces) || [];
-      el.innerHTML = mps.length ? mps.map(renderMarketplace).join('') : '<p class="text-muted mb-0">No marketplaces added.</p>';
+      data = await api('GET', '/api/plugins/marketplaces');
     } catch (e) {
-      el.innerHTML = '<p class="text-danger mb-0">Failed to load marketplaces: ' + esc(e.message) + '</p>';
+      if (el) el.innerHTML = '<p class="text-danger mb-0">Failed to load marketplaces: ' + esc(e.message) + '</p>';
+      return;
+    }
+    const official = (data && data.official) || {};
+    officialState.name = official.name || '';
+    officialState.source = official.source || '';
+    officialState.added = !!official.added;
+
+    if (el) {
+      const others = ((data && data.marketplaces) || []).filter((m) => m.name !== officialState.name);
+      el.innerHTML = others.length ? others.map(renderMarketplace).join('') : '<p class="text-muted mb-0">No marketplaces added.</p>';
     }
   };
+
+  // ---- official browse (modal) ----
+
+  function officialGridMessage(html) {
+    const empty = byId('officialEmpty');
+    const grid = byId('officialGrid');
+    if (empty) empty.innerHTML = '';
+    if (grid) grid.innerHTML = html;
+  }
+
+  // ensureOfficialLoaded makes the official catalog browsable on demand: it adds
+  // the official marketplace if it isn't already (a one-time clone), then loads
+  // and renders its entries. Called when the modal opens, so the user never has
+  // to "add" anything — they just browse. Pass force=true to re-read (e.g. after
+  // an install or via Refresh).
+  async function ensureOfficialLoaded(force) {
+    if (officialState.loaded && !force) {
+      await refreshOfficialInstalled();
+      return;
+    }
+    officialGridMessage('<p class="text-muted mb-0">Loading official plugins&hellip;</p>');
+    try {
+      if (!officialState.added) {
+        await api('POST', '/api/plugins/marketplaces', { source: officialState.source });
+        officialState.added = true;
+      }
+      const data = await api('GET', '/api/plugins/marketplaces');
+      const off = ((data && data.marketplaces) || []).find((m) => m.name === officialState.name);
+      officialState.entries = (off && off.plugins) || [];
+      officialState.installed = await getInstalledNames();
+      officialState.loaded = true;
+
+      if (!officialState.entries.length) {
+        officialGridMessage('<p class="text-muted mb-0">The official catalog is empty or could not be read.</p>');
+        return;
+      }
+      populateOfficialFilters();
+      wireOfficialGrid();
+      renderOfficialGrid();
+    } catch (e) {
+      officialGridMessage('<p class="text-danger mb-0">Failed to load the official catalog: ' + esc(e.message) + '</p>');
+    }
+  }
+
+  async function refreshOfficialInstalled() {
+    if (!officialState.loaded) return;
+    officialState.installed = await getInstalledNames();
+    renderOfficialGrid();
+  }
+
+  function fillSelect(sel, allLabel, values) {
+    if (!sel) return;
+    const current = sel.value;
+    sel.innerHTML = '<option value="">' + esc(allLabel) + '</option>' +
+      values.map((v) => '<option value="' + esc(v) + '">' + esc(v) + '</option>').join('');
+    if (values.indexOf(current) !== -1) sel.value = current;
+  }
+
+  function populateOfficialFilters() {
+    const cats = new Set();
+    const tags = new Set();
+    officialState.entries.forEach((e) => {
+      if (e.category) cats.add(e.category);
+      (e.tags || []).forEach((t) => tags.add(t));
+    });
+    fillSelect(byId('officialCategory'), 'All categories', [...cats].sort());
+    fillSelect(byId('officialTag'), 'All tags', [...tags].sort());
+  }
+
+  function filteredEntries() {
+    const q = ((byId('officialSearch') && byId('officialSearch').value) || '').trim().toLowerCase();
+    const cat = (byId('officialCategory') && byId('officialCategory').value) || '';
+    const tag = (byId('officialTag') && byId('officialTag').value) || '';
+    return officialState.entries.filter((e) => {
+      if (cat && e.category !== cat) return false;
+      if (tag && (e.tags || []).indexOf(tag) === -1) return false;
+      if (q) {
+        const hay = [e.name, e.description, (e.tags || []).join(' '), (e.keywords || []).join(' ')].join(' ').toLowerCase();
+        if (hay.indexOf(q) === -1) return false;
+      }
+      return true;
+    });
+  }
+
+  window.officialFilter = function () { renderOfficialGrid(); };
+
+  function renderOfficialGrid() {
+    const grid = byId('officialGrid');
+    if (!grid) return;
+    const items = filteredEntries();
+    grid.innerHTML = items.length
+      ? items.map(renderOfficialCard).join('')
+      : '<p class="text-muted mb-0">No plugins match your filters.</p>';
+  }
+
+  function renderOfficialCard(e) {
+    const installed = officialState.installed.has(e.name);
+    const cat = e.category ? '<span class="badge bg-secondary">' + esc(e.category) + '</span>' : '';
+    const author = e.author && e.author.name ? '<div class="small text-muted">by ' + esc(e.author.name) + '</div>' : '';
+    const tags = (e.tags || []).map((t) => '<span class="badge bg-light text-dark border me-1">' + esc(t) + '</span>').join('');
+    const installBtn = installed
+      ? '<button class="modern-btn modern-btn-secondary" disabled>Installed</button>'
+      : '<button class="modern-btn modern-btn-primary" data-official-install="' + esc(e.name) + '">Install</button>';
+    return (
+      '<div class="col-md-6 col-lg-4">' +
+      '<div class="modern-card h-100 p-3">' +
+      '<div class="d-flex justify-content-between align-items-start gap-2">' +
+      '<div class="fw-semibold">' + esc(e.name) + '</div>' + cat +
+      '</div>' + author +
+      (e.description ? '<div class="small text-muted mt-1">' + esc(e.description) + '</div>' : '') +
+      (tags ? '<div class="mt-2">' + tags + '</div>' : '') +
+      '<div class="d-flex gap-2 mt-3">' +
+      installBtn +
+      '<button class="modern-btn modern-btn-secondary" data-official-details="' + esc(e.name) + '">Details</button>' +
+      '</div>' +
+      '<div class="official-detail small mt-2" data-detail="' + esc(e.name) + '" style="display:none;"></div>' +
+      '</div></div>'
+    );
+  }
+
+  // Delegated click handling survives grid re-renders (the grid element persists;
+  // only its innerHTML changes), so it is wired once.
+  function wireOfficialGrid() {
+    const grid = byId('officialGrid');
+    if (!grid || grid.dataset.wired) return;
+    grid.dataset.wired = '1';
+    grid.addEventListener('click', function (ev) {
+      const inst = ev.target.closest('[data-official-install]');
+      if (inst) { officialInstall(inst.getAttribute('data-official-install')); return; }
+      const conf = ev.target.closest('[data-official-confirm]');
+      if (conf) { officialConfirmInstall(conf.getAttribute('data-official-confirm')); return; }
+      const can = ev.target.closest('[data-official-cancel]');
+      if (can) { const b = detailBox(can.getAttribute('data-official-cancel')); if (b) { b.style.display = 'none'; b.dataset.loaded = ''; } return; }
+      const det = ev.target.closest('[data-official-details]');
+      if (det) { toggleOfficialDetails(det.getAttribute('data-official-details')); }
+    });
+  }
+
+  function detailBox(name) {
+    const sel = (window.CSS && CSS.escape) ? CSS.escape(name) : name;
+    return document.querySelector('.official-detail[data-detail="' + sel + '"]');
+  }
+
+  async function toggleOfficialDetails(name) {
+    const box = detailBox(name);
+    if (!box) return;
+    if (box.style.display !== 'none') { box.style.display = 'none'; return; }
+    box.style.display = 'block';
+    if (box.dataset.loaded) return;
+
+    const e = officialState.entries.find((x) => x.name === name) || {};
+    let meta = '';
+    if (e.author && (e.author.name || e.author.email)) {
+      meta += '<div>Author: ' + esc(e.author.name || '') + (e.author.email ? ' &lt;' + esc(e.author.email) + '&gt;' : '') + '</div>';
+    }
+    if (e.homepage) meta += '<div>Homepage: <a href="' + esc(e.homepage) + '" target="_blank" rel="noopener">' + esc(e.homepage) + '</a></div>';
+    if (e.category) meta += '<div>Category: ' + esc(e.category) + '</div>';
+    box.innerHTML = meta + '<div class="text-muted mt-2">Loading what it will register…</div>';
+
+    try {
+      const data = await api('POST', '/api/plugins/marketplaces/install', { marketplace: officialState.name, plugin: name, confirm: false });
+      box.innerHTML = meta + '<div class="fw-semibold mt-2">This plugin will register:</div>' + trustHTML(data.trust);
+      box.dataset.loaded = '1';
+    } catch (err) {
+      box.innerHTML = meta + '<div class="text-danger mt-2">Could not load details: ' + esc(err.message) + '</div>';
+    }
+  }
+
+  // Install is confirmed inline inside the card, not via the page-level trust
+  // panel — that panel renders behind the open modal and would be unclickable.
+  async function officialInstall(name) {
+    const box = detailBox(name);
+    if (!box) return;
+    box.dataset.loaded = '';
+    box.style.display = 'block';
+    box.innerHTML = '<div class="text-muted">Preparing install&hellip;</div>';
+    try {
+      const data = await api('POST', '/api/plugins/marketplaces/install', { marketplace: officialState.name, plugin: name, confirm: false });
+      box.innerHTML =
+        '<div class="fw-semibold">This plugin will register:</div>' + trustHTML(data.trust) +
+        '<div class="d-flex gap-2 mt-2">' +
+        '<button class="modern-btn modern-btn-primary" data-official-confirm="' + esc(name) + '">Confirm install</button>' +
+        '<button class="modern-btn modern-btn-secondary" data-official-cancel="' + esc(name) + '">Cancel</button>' +
+        '</div>';
+    } catch (e) {
+      box.innerHTML = '<div class="text-danger">Preview failed: ' + esc(e.message) + '</div>';
+    }
+  }
+
+  async function officialConfirmInstall(name) {
+    const box = detailBox(name);
+    if (box) box.innerHTML = '<div class="text-muted">Installing&hellip;</div>';
+    try {
+      await api('POST', '/api/plugins/marketplaces/install', { marketplace: officialState.name, plugin: name, confirm: true });
+      loadPlugins();
+      window.loadMarketplaces();
+      officialState.installed = await getInstalledNames();
+      renderOfficialGrid(); // card rebuilds showing "Installed"
+    } catch (e) {
+      if (box) box.innerHTML = '<div class="text-danger">Install failed: ' + esc(e.message) + '</div>';
+    }
+  }
+
+  // ---- user-added marketplaces ----
 
   function renderMarketplace(mp) {
     const name = esc(mp.name);
@@ -195,6 +427,8 @@
         await api('POST', '/api/plugins/marketplaces/install', { marketplace, plugin: pluginName, confirm: true });
         window.pluginCancelInstall();
         loadPlugins();
+        window.loadMarketplaces();
+        refreshOfficialInstalled(); // reflect new install in the official modal grid
       });
     } catch (e) {
       alert('Preview failed: ' + e.message);
@@ -204,5 +438,11 @@
   document.addEventListener('DOMContentLoaded', function () {
     loadPlugins();
     window.loadMarketplaces();
+    // Load the official catalog lazily when its modal opens (auto-adds on first
+    // open so the user just browses); the Refresh button re-reads it.
+    const modalEl = byId('officialModal');
+    if (modalEl) modalEl.addEventListener('shown.bs.modal', function () { ensureOfficialLoaded(false); });
+    const refreshBtn = byId('officialRefreshBtn');
+    if (refreshBtn) refreshBtn.onclick = function () { ensureOfficialLoaded(true); };
   });
 })();

--- a/internal/web/templates/pages/plugins.tmpl
+++ b/internal/web/templates/pages/plugins.tmpl
@@ -58,6 +58,17 @@
           </div>
         </div>
 
+        <!-- Official Claude plugins -->
+        <div class="modern-card p-4 mb-4">
+          <div class="d-flex align-items-start justify-content-between">
+            <div>
+              <h2 class="h6 mb-1">Official Claude plugins</h2>
+              <p class="text-muted small mb-0">Browse Anthropic's official, managed plugin directory and install with one click.</p>
+            </div>
+            <button type="button" class="modern-btn modern-btn-primary" data-bs-toggle="modal" data-bs-target="#officialModal">Browse official plugins</button>
+          </div>
+        </div>
+
         <!-- Marketplaces -->
         <div class="modern-card p-4 mb-4">
           <h2 class="h6 mb-3">Marketplaces</h2>
@@ -82,6 +93,37 @@
           <div id="pluginList"><p class="text-muted mb-0">Loading&hellip;</p></div>
         </div>
 
+      </div>
+    </div>
+  </div>
+
+  <!-- Official plugins browse modal -->
+  <div class="modal fade" id="officialModal" tabindex="-1" aria-labelledby="officialModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="officialModalLabel">Official Claude plugins</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row g-2 mb-3">
+            <div class="col-md-6">
+              <input type="text" class="form-control" id="officialSearch" placeholder="Search official plugins&hellip;" oninput="officialFilter()">
+            </div>
+            <div class="col-md-3">
+              <select class="form-select" id="officialCategory" onchange="officialFilter()"><option value="">All categories</option></select>
+            </div>
+            <div class="col-md-3">
+              <select class="form-select" id="officialTag" onchange="officialFilter()"><option value="">All tags</option></select>
+            </div>
+          </div>
+          <div id="officialGrid" class="row g-3"></div>
+          <div id="officialEmpty"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="modern-btn modern-btn-secondary" id="officialRefreshBtn">Refresh</button>
+          <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Adds a "Browse official Claude plugins" experience on the Plugins page, backed by Anthropic's official, managed directory (`anthropics/claude-plugins-official`). Users open a modal, search/filter the catalog, and install with one click — no manual marketplace URL needed.

## Backend
- Parse richer catalog metadata on `MarketplaceEntry`: `category`, `tags`, `keywords`, `author` (string or object), `homepage`.
- **Git-repo-plus-subdirectory sources** (`git-subdir`/`url` entry types): clone the repo and install from a subpath, **pinned** to the entry's `sha` (preferred) or `ref` via a shallow fetch into a per-commit clone dir. Fixes `normalizeEntrySource` collapsing these to an unusable path.
- Composite sources flow through preview, install, and update (`reload` re-resolves pinned sources idempotently).
- `GET /api/plugins/marketplaces` returns an `official` block (`name`/`source`/`added`) so the UI never hardcodes the URL; add is idempotent (keyed by catalog name).

## Frontend
- **Browse official plugins** opens a modal that loads the catalog on demand (auto-adds the official marketplace on first open — no explicit "add" step), with a card grid, search, category/tag filters, per-plugin **Details**, and **inline install confirmation** (kept in the modal, not the page-level trust panel which would render behind it). Already-installed plugins are marked; the official catalog isn't duplicated in the user-added list.

## Tests / verification
- Unit + integration tests: metadata parsing, git-subdir resolution & pinning (local git fixture), official status handler.
- `go build`/`go vet`/`gofmt`/`eslint` clean.
- Smoke-tested against the **real** official catalog (234 entries): installed a git-subdir plugin (cloned a third-party repo at a pinned sha) and an in-repo plugin.
- Modal UX verified in a headless browser (open → cards load → search/category filters → inline install → "Installed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)