### PR TITLE
feat(skills)!: default skills to opt-in (disabled) per agent

### DIFF
--- a/internal/skills/crud.go
+++ b/internal/skills/crud.go
@@ -64,7 +64,6 @@ func (m *Manager) CreateSkill(agentName string, input SkillInput) (Skill, error)
 	if err != nil {
 		return Skill{}, err
 	}
-	skill.Enabled = true
 	return skill, nil
 }
 
@@ -87,7 +86,17 @@ func (m *Manager) UpdateSkill(agentName, skillName string, input SkillInput) (Sk
 		return Skill{}, err
 	}
 	skillPath := filepath.Join(skillDir, "SKILL.md")
-	return m.updateSkillAtPath(skillPath, skillDir, skillName, SourceAgent, input)
+	skill, err := m.updateSkillAtPath(skillPath, skillDir, skillName, SourceAgent, input)
+	if err != nil {
+		return Skill{}, err
+	}
+	// Editing content must not change enablement; report the skill's real
+	// per-agent state (opt-in default for skills without explicit state).
+	resolved := []Skill{skill}
+	if stateErr := m.applySkillState(agentName, resolved); stateErr == nil {
+		skill = resolved[0]
+	}
+	return skill, nil
 }
 
 func (m *Manager) UpdateSkillAtPath(source, skillPath, skillName string, input SkillInput) (Skill, error) {
@@ -142,7 +151,8 @@ func (m *Manager) updateSkillAtPath(skillPath, skillDir, skillName, source strin
 	if err != nil {
 		return Skill{}, err
 	}
-	skill.Enabled = true
+	// Editing a skill's content must not change its enabled state; callers with
+	// agent context resolve the real state via applySkillState.
 	return skill, nil
 }
 

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -439,6 +439,8 @@ func (m *Manager) loadSkillWithPrompt(skill Skill) (*Skill, error) {
 
 func (m *Manager) applySkillState(agentName string, skills []Skill) error {
 	if agentName == "" {
+		// No agent context (global catalog / chat slash-command picker):
+		// surface every skill as available rather than per-agent enabled.
 		for i := range skills {
 			if !skills[i].Enabled {
 				skills[i].Enabled = true
@@ -466,9 +468,9 @@ func (m *Manager) applySkillState(agentName string, skills []Skill) error {
 			skills[i].Trusted = defaultState.Trusted
 			continue
 		}
-		if !skills[i].Enabled {
-			skills[i].Enabled = true
-		}
+		// Opt-in model: with no explicit per-skill state and no agent-wide
+		// ("*") default, keep the skill's loaded default. File-based skills load
+		// disabled (zero value); built-in CLI-agent skills load enabled.
 	}
 
 	return nil

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -182,7 +182,7 @@ func TestListSkills_PersonalSkillDuplicateDoesNotOverrideLocal(t *testing.T) {
 	}
 }
 
-func TestListSkills_DefaultEnabledWithoutRegistry(t *testing.T) {
+func TestListSkills_DefaultDisabledWithoutRegistry(t *testing.T) {
 	tmpDir := t.TempDir()
 	agentStorePath := filepath.Join(tmpDir, "agents.json")
 	if err := os.WriteFile(agentStorePath, []byte(`{}`), 0o644); err != nil {
@@ -200,8 +200,8 @@ func TestListSkills_DefaultEnabledWithoutRegistry(t *testing.T) {
 	if len(skills) != 1 {
 		t.Fatalf("expected 1 skill, got %d", len(skills))
 	}
-	if !skills[0].Enabled {
-		t.Fatalf("expected skill to default enabled when no registry is present")
+	if skills[0].Enabled {
+		t.Fatalf("expected skill to default disabled when no registry is present (opt-in model)")
 	}
 }
 
@@ -309,10 +309,15 @@ func TestListEnabledSkillsWithPrompts(t *testing.T) {
 	writeTestSkill(t, filepath.Join(tmpDir, "agents", "skills", "skill-a"), "skill-a", "Skill A", "Prompt A content")
 	writeTestSkill(t, filepath.Join(tmpDir, "agents", "skills", "skill-b"), "skill-b", "Skill B", "Prompt B content")
 
-	// Disable skill-b via registry
+	// Enable skill-a explicitly and disable skill-b via registry. Under the
+	// opt-in default a skill with no registry entry is disabled, so skill-a
+	// needs an explicit enabled entry to be returned.
 	registryPath := filepath.Join(tmpDir, "agents", "default", "skills_state.json")
 	registry := map[string]any{
 		"skills": map[string]any{
+			"skill-a": map[string]any{
+				"enabled": true,
+			},
 			"skill-b": map[string]any{
 				"enabled": false,
 			},

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -101,12 +101,14 @@ func (m *Manager) updateSkillState(agentName, skillName string, updateFn func(*S
 
 	state, exists := registry.Skills[key]
 	if !exists {
-		// Skills are enabled by default unless an agent-level default is defined.
+		// Opt-in model: skills are disabled by default unless an agent-level
+		// ("*") default says otherwise. Seeding disabled keeps side-effect
+		// updates (e.g. trusting a skill) from implicitly enabling it.
 		if defaultState, ok := registry.Skills["*"]; ok {
 			state.Enabled = defaultState.Enabled
 			state.Trusted = defaultState.Trusted
 		} else {
-			state.Enabled = true
+			state.Enabled = false
 		}
 	}
 	updateFn(&state)

--- a/internal/skillshttp/handlers.go
+++ b/internal/skillshttp/handlers.go
@@ -287,6 +287,13 @@ func (h *Handler) createSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Creating a skill is an explicit opt-in: enable it for this agent so it is
+	// active immediately regardless of which create path (CLI scaffold or local
+	// fallback) produced it. The global default for other skills stays disabled.
+	if enableErr := h.manager.SetSkillEnabled(agentName, name, true); enableErr == nil {
+		skill.Enabled = true
+	}
+
 	orihttp.Created(w, skill)
 }
 

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -13471,6 +13471,8 @@ export class WorkspaceDetailPage {
     this.renderWorkspaceHealth();
 
     try {
+      await this.syncWorkspaceFilesFromDisk();
+
       const response = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}`);
       if (!response.ok) {
         this.files = [];
@@ -13500,6 +13502,22 @@ export class WorkspaceDetailPage {
       this.renderFiles();
       this.refreshHomeAssistantQuickPrompts();
       this.renderWorkspaceHealth();
+    }
+  }
+
+  async syncWorkspaceFilesFromDisk() {
+    if (!this.workspaceId) return;
+
+    try {
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/files/tree`,
+        { cache: 'no-store' }
+      );
+      if (!response.ok) {
+        console.warn('Workspace file sync failed:', response.status);
+      }
+    } catch (error) {
+      console.warn('Workspace file sync failed:', error);
     }
   }
 

--- a/internal/workspace/file_sync.go
+++ b/internal/workspace/file_sync.go
@@ -323,15 +323,23 @@ func shouldIndexWorkspaceDiskFile(relativePath string, info os.FileInfo) bool {
 		return false
 	}
 	clean := sanitizeWorkspaceRelativePath(relativePath)
+	if clean == "" || isHiddenWorkspacePath(clean) {
+		return false
+	}
+	return true
+}
+
+func isHiddenWorkspacePath(relativePath string) bool {
+	clean := sanitizeWorkspaceRelativePath(relativePath)
 	if clean == "" {
 		return false
 	}
 	for _, part := range strings.Split(filepath.ToSlash(clean), "/") {
-		if part == "" || strings.HasPrefix(part, ".") {
-			return false
+		if strings.HasPrefix(part, ".") {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // snapshotWorkspaceDiskFiles returns the regular files under filesPath keyed by
@@ -349,15 +357,21 @@ func snapshotWorkspaceDiskFiles(filesPath string) (map[string]os.FileInfo, error
 			}
 			return nil
 		}
-		if entry.IsDir() {
-			return nil
-		}
 		rel, relErr := filepath.Rel(filesPath, p)
 		if relErr != nil {
 			return relErr
 		}
 		clean := sanitizeWorkspaceRelativePath(rel)
 		if clean == "" {
+			return nil
+		}
+		if isHiddenWorkspacePath(clean) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
 			return nil
 		}
 		info, infoErr := entry.Info()

--- a/internal/workspace/http_handlers_folder.go
+++ b/internal/workspace/http_handlers_folder.go
@@ -652,7 +652,7 @@ func buildWorkspaceFileTree(ws *Workspace, filesPath string) ([]FileInfo, error)
 	}
 	for _, folder := range ws.Folders {
 		clean := sanitizeWorkspaceRelativePath(folder.Path)
-		if clean == "" {
+		if clean == "" || isHiddenWorkspacePath(clean) {
 			continue
 		}
 		managedFolders[clean] = folder
@@ -687,6 +687,12 @@ func buildWorkspaceFileTree(ws *Workspace, filesPath string) ([]FileInfo, error)
 			}
 			clean := sanitizeWorkspaceRelativePath(rel)
 			if clean == "" {
+				if entry.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if isHiddenWorkspacePath(clean) {
 				if entry.IsDir() {
 					return filepath.SkipDir
 				}
@@ -736,7 +742,7 @@ func buildWorkspaceFileTree(ws *Workspace, filesPath string) ([]FileInfo, error)
 			continue
 		}
 		relativePath := extractAttachmentRelativePath(ws.ID, attachment.File)
-		if relativePath == "" {
+		if relativePath == "" || isHiddenWorkspacePath(relativePath) {
 			continue
 		}
 		ensureWorkspaceFileTreeAncestors(items, managedFolders, relativePath)

--- a/internal/workspace/http_handlers_folder_test.go
+++ b/internal/workspace/http_handlers_folder_test.go
@@ -50,6 +50,58 @@ func TestHTTPHandlerCreateWorkspaceFolderAndFileTree(t *testing.T) {
 	assertFileInfo(t, files, "loose.txt", false)
 }
 
+func TestGetWorkspaceFilesTreeIndexesRPPAndOmitsHiddenFiles(t *testing.T) {
+	store, ws, handler := newFolderHandlerTest(t, "ws-tree-rpp-hidden", "Tree RPP Hidden")
+	filesPath := store.GetFilesPath(ws.ID)
+	if err := os.WriteFile(filepath.Join(filesPath, ".DS_Store"), []byte("hidden"), 0644); err != nil {
+		t.Fatalf("WriteFile .DS_Store: %v", err)
+	}
+	hiddenChild := filepath.Join(filesPath, ".cache", "data.json")
+	if err := os.MkdirAll(filepath.Dir(hiddenChild), 0755); err != nil {
+		t.Fatalf("MkdirAll hidden child: %v", err)
+	}
+	if err := os.WriteFile(hiddenChild, []byte("{}"), 0644); err != nil {
+		t.Fatalf("WriteFile hidden child: %v", err)
+	}
+	rppPath := filepath.Join(filesPath, "House Test.RPP")
+	if err := os.WriteFile(rppPath, []byte("<REAPER_PROJECT 0.1 \"7.0\" 1690000000\n>"), 0644); err != nil {
+		t.Fatalf("WriteFile RPP: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID+"/files/tree", nil)
+	rr := httptest.NewRecorder()
+	handler.GetWorkspaceFilesTree(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	files := decodeFileTreeResponse(t, rr.Body.Bytes())
+	rpp := findFileInfo(files, "House Test.RPP")
+	if rpp == nil {
+		t.Fatalf("expected RPP file in tree, got %#v", files)
+	}
+	if rpp.AttachmentID == "" {
+		t.Fatalf("expected RPP file to be indexed as an attachment, got %#v", rpp)
+	}
+	if findFileInfo(files, ".DS_Store") != nil {
+		t.Fatalf("expected .DS_Store to be omitted from tree")
+	}
+	if findFileInfo(files, ".cache") != nil || findFileInfo(files, filepath.Join(".cache", "data.json")) != nil {
+		t.Fatalf("expected hidden directory entries to be omitted from tree, got %#v", files)
+	}
+
+	stored, err := store.Get(ws.ID)
+	if err != nil {
+		t.Fatalf("Get workspace: %v", err)
+	}
+	if len(stored.Attachments) != 1 {
+		t.Fatalf("expected exactly one indexed attachment, got %#v", stored.Attachments)
+	}
+	if stored.Attachments[0].File == nil || stored.Attachments[0].File.RelativePath != "House Test.RPP" {
+		t.Fatalf("expected indexed RPP attachment, got %#v", stored.Attachments[0].File)
+	}
+}
+
 func TestHTTPHandlerCreateWorkspaceFolderRejectsTraversalAndFileCollision(t *testing.T) {
 	store, ws, handler := newFolderHandlerTest(t, "ws-folder-invalid", "Folder Invalid")
 


### PR DESCRIPTION
## Summary
Flips the global default for agent skills from **opt-out** to **opt-in**. Previously any skill with no entry in an agent's `skills_state.json` was force-enabled, so the agent detail page showed every skill toggled on. Now a skill is enabled only when explicitly opted in.

### Skills change (primary)
- **`applySkillState`** now respects each skill's loaded default instead of forcing `enabled`. File-based skills load disabled (zero value); built-in CLI-agent skills (Claude Code / Codex) load enabled and stay on.
- **`updateSkillState`** seeds new state entries disabled, so trusting a skill no longer implicitly enables it.
- **Creating a skill** explicitly enables it for that agent (handler-level policy covering both the CLI-scaffold and local-fallback paths) — authoring a skill is itself the opt-in.
- **`UpdateSkill`** resolves the real per-agent state so editing a skill's content never flips its enablement.
- The no-agent catalog (chat `/`-command picker) still lists all runnable skills; workspace skill bindings remain the explicit opt-in.

### ⚠️ Breaking / upgrade impact
Agents **without** a `skills_state.json` will now show all skills **disabled**, and chat will no longer auto-inject their prompts, until each skill is enabled. The per-agent `*` wildcard (`{"skills":{"*":{"enabled":true}}}`) can bulk-enable an agent.

### Also included
This branch was based on local `dev`, so it also carries `0973304f fix(workspace): sync disk files before rendering files` (workspace `file_sync` + folder handlers + a JS module/test). That commit is unrelated to skills and is already on local `dev` / `feature/agents-skills-uiux-refresh`.

## Test plan
- `go build ./...` — clean
- `go vet ./internal/skills/... ./internal/skillshttp/...` — clean
- `go test ./internal/skills/... ./internal/skillshttp/... ./internal/workspace/... ./internal/chathttp/...` — pass
- Updated unit tests: `TestListSkills_DefaultDisabledWithoutRegistry`, `TestListEnabledSkillsWithPrompts` (explicit enable for skill-a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)