### PR TITLE
feat(agents): mark Ori as primary orchestrator and protect it

### DIFF
--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -446,6 +446,12 @@ func (h *DashboardHandler) UpdateAgentStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// The system assistant must always remain available for routing and chat.
+	if isSystemAssistantAgent(agentName) && req.Status == string(types.AgentStatusDisabled) {
+		orihttp.BadRequest(w, "system assistant cannot be disabled")
+		return
+	}
+
 	agent, ok := h.State.GetAgent(agentName)
 	if !ok || agent == nil {
 		if h.cliAgentRegistry != nil {

--- a/internal/agenthttp/system_assistant.go
+++ b/internal/agenthttp/system_assistant.go
@@ -54,6 +54,7 @@ func ensureSystemAssistantAgentWithSystemModel(st store.Store, systemProvider, s
 	if _, exists := st.GetAgent(systemAssistantAgentName); !exists {
 		cfg := &store.CreateAgentConfig{
 			Type:         agent.TypeGeneral,
+			Role:         types.RoleOrchestrator,
 			SystemPrompt: systemAssistantPrompt,
 		}
 		if hasSystemModel {
@@ -78,6 +79,13 @@ func ensureSystemAssistantAgentWithSystemModel(st store.Store, systemProvider, s
 	}
 	if ag.Status == "" {
 		ag.Status = types.AgentStatusActive
+		changed = true
+	}
+	// The system assistant is the primary orchestrator; keep its role aligned
+	// with that purpose so orchestration routing and the UI badge agree with
+	// the "System orchestrator" description.
+	if ag.Role != types.RoleOrchestrator {
+		ag.Role = types.RoleOrchestrator
 		changed = true
 	}
 	if strings.TrimSpace(ag.Settings.SystemPrompt) == "" {

--- a/internal/agenthttp/system_assistant_test.go
+++ b/internal/agenthttp/system_assistant_test.go
@@ -1,0 +1,118 @@
+package agenthttp
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+func newSystemAssistantTestStore(t *testing.T) store.Store {
+	t.Helper()
+	st, err := store.NewFileStore(filepath.Join(t.TempDir(), "agents.json"), types.Settings{})
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+	return st
+}
+
+func TestEnsureSystemAssistantAgentSetsOrchestratorRole(t *testing.T) {
+	st := newSystemAssistantTestStore(t)
+
+	if err := EnsureSystemAssistantAgent(st); err != nil {
+		t.Fatalf("EnsureSystemAssistantAgent() error = %v", err)
+	}
+
+	ag, ok := st.GetAgent(systemAssistantAgentName)
+	if !ok || ag == nil {
+		t.Fatalf("system assistant %q not found after ensure", systemAssistantAgentName)
+	}
+	if ag.Role != types.RoleOrchestrator {
+		t.Fatalf("system assistant role = %q, want %q", ag.Role, types.RoleOrchestrator)
+	}
+}
+
+func TestEnsureSystemAssistantAgentUpgradesExistingRole(t *testing.T) {
+	st := newSystemAssistantTestStore(t)
+
+	// Simulate a pre-existing Ori agent created before the orchestrator role
+	// was assigned (the historical default was the general role).
+	if err := st.CreateAgent(systemAssistantAgentName, &store.CreateAgentConfig{
+		Type: agent.TypeGeneral,
+		Role: types.RoleGeneral,
+	}); err != nil {
+		t.Fatalf("CreateAgent() error = %v", err)
+	}
+
+	if err := EnsureSystemAssistantAgent(st); err != nil {
+		t.Fatalf("EnsureSystemAssistantAgent() error = %v", err)
+	}
+
+	ag, ok := st.GetAgent(systemAssistantAgentName)
+	if !ok || ag == nil {
+		t.Fatalf("system assistant %q not found after ensure", systemAssistantAgentName)
+	}
+	if ag.Role != types.RoleOrchestrator {
+		t.Fatalf("system assistant role = %q, want %q", ag.Role, types.RoleOrchestrator)
+	}
+}
+
+func TestDashboardUpdateAgentStatusBlocksDisablingSystemAssistant(t *testing.T) {
+	st := newSystemAssistantTestStore(t)
+	if err := EnsureSystemAssistantAgent(st); err != nil {
+		t.Fatalf("EnsureSystemAssistantAgent() error = %v", err)
+	}
+
+	dashboard := NewDashboardHandler(st)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/"+systemAssistantAgentName+"/status",
+		bytes.NewBufferString(`{"status":"disabled"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	dashboard.UpdateAgentStatus(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateAgentStatus() status = %d, want %d body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+
+	ag, ok := st.GetAgent(systemAssistantAgentName)
+	if !ok || ag == nil {
+		t.Fatalf("system assistant %q not found", systemAssistantAgentName)
+	}
+	if ag.Status == types.AgentStatusDisabled {
+		t.Fatalf("system assistant was disabled despite guard; status = %q", ag.Status)
+	}
+}
+
+func TestDashboardUpdateAgentStatusAllowsReenablingSystemAssistant(t *testing.T) {
+	st := newSystemAssistantTestStore(t)
+	if err := EnsureSystemAssistantAgent(st); err != nil {
+		t.Fatalf("EnsureSystemAssistantAgent() error = %v", err)
+	}
+
+	dashboard := NewDashboardHandler(st)
+
+	// Re-enabling (status active) must not be blocked by the disable guard.
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/"+systemAssistantAgentName+"/status",
+		bytes.NewBufferString(`{"status":"active"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	dashboard.UpdateAgentStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("UpdateAgentStatus() status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -359,6 +359,15 @@ function createAgentCard(agent) {
   const deleteDisabledAttr = isSystemAgent
     ? 'disabled title="System assistant cannot be deleted." aria-disabled="true"'
     : 'title="Delete agent"';
+  const enableToggleDisabledAttr = isSystemAgent
+    ? 'disabled aria-disabled="true"'
+    : '';
+  const enableToggleTitle = isSystemAgent
+    ? 'The system assistant is always available and cannot be disabled.'
+    : 'Allow this agent to start chats and receive routing';
+  const systemBadge = isSystemAgent
+    ? '<span class="ops-system-pill" title="Primary system assistant — always available for chat and routing.">System · Primary</span>'
+    : '';
 
   card.innerHTML = `
     <div class="ops-card-top">
@@ -367,14 +376,15 @@ function createAgentCard(agent) {
         <div class="ops-agent-name-row">
           <h4 class="ops-agent-name" title="${safeEscapeHtml(name)}">${safeEscapeHtml(name)}</h4>
           <span class="ops-health-pill ${safeEscapeHtml(health.kind)}">${safeEscapeHtml(health.label)}</span>
+          ${systemBadge}
         </div>
         <p class="ops-agent-purpose" title="${safeEscapeHtml(description)}">${safeEscapeHtml(description)}</p>
         <div class="ops-agent-time">Last active: ${safeEscapeHtml(formatDate(agent?.statistics?.last_active || ''))}</div>
       </div>
       <div class="ops-card-controls">
-        <label class="ops-enable-toggle" title="Allow this agent to start chats and receive routing">
+        <label class="ops-enable-toggle" title="${safeEscapeHtml(enableToggleTitle)}">
           <span class="ops-enable-toggle-text">Enabled</span>
-          <input data-action="enabled" type="checkbox" ${enabledCheckedAttr} aria-label="Enable ${safeEscapeHtml(name)}">
+          <input data-action="enabled" type="checkbox" ${enabledCheckedAttr} ${enableToggleDisabledAttr} aria-label="Enable ${safeEscapeHtml(name)}">
           <span class="ops-enable-switch" aria-hidden="true"></span>
         </label>
         <button class="ops-icon-btn danger" data-action="delete" type="button" aria-label="Delete agent" ${deleteDisabledAttr}>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1158,6 +1158,24 @@
         background: rgba(239, 68, 68, 0.2);
     }
 
+    .ops-system-pill {
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.2px;
+        flex-shrink: 0;
+        color: #5b21b6;
+        background: #ede9fe;
+        border: 1px solid rgba(124, 58, 237, 0.25);
+    }
+
+    [data-bs-theme="dark"] .ops-system-pill {
+        color: #c4b5fd;
+        background: rgba(139, 92, 246, 0.18);
+        border-color: rgba(139, 92, 246, 0.35);
+    }
+
     .ops-agent-purpose {
         margin: 4px 0 0;
         color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Makes the canonical system assistant (**Ori**) a properly-recognized primary/orchestrator agent and protects it from being removed or turned off.

Motivation: on the Agents page Ori's only label was the model-tier `type` (`General`), even though its description calls it a *"System orchestrator."* The `type` field is a model capability tier (tool-calling / general / research) — it gates which models an agent may run, not its purpose. The right field for "what this agent is" is `role`, which Ori never actually had set to `orchestrator`. This PR aligns the data and the UI.

## Changes

- **Orchestrator role**: assign the system assistant the `orchestrator` role at creation, and reconcile existing Ori agents on startup, so its role matches its description and orchestration routing.
- **Disable guard**: block disabling the system assistant via `POST /api/agents/{name}/status` — it must stay available for chat and routing. (Delete was already guarded.)
- **UI**: show a violet **"System · Primary"** badge on the Ori dashboard card, and disable its *Enabled* toggle so it cannot be turned off from the UI.
- **Tests**: cover the orchestrator role (fresh-create + upgrade-existing paths) and the disable guard (block + still allow re-enable).

## Verification

- `go test ./internal/agenthttp/ ./internal/agent/ ./internal/store/` — pass; `go vet` + `gofmt` clean.
- Isolated smoke server (real HTTP): Ori created with `role=orchestrator`; `POST /status {disabled}` → `400 "system assistant cannot be disabled"` (status stays `active`); `DELETE` → `400 "system assistant cannot be deleted"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)