### PR TITLE
perf(web): cache static assets and defer page scripts

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -533,10 +533,22 @@ func (s *Server) serveStaticFile(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 	}
 
-	// Prevent browsers from caching embedded static assets during local dev.
-	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("Expires", "0")
+	// Embedded assets are immutable for the life of the process and only change
+	// when the binary is rebuilt. Allow the browser to cache them but always
+	// revalidate against a content-hash ETag, so we serve cheap 304s instead of
+	// re-downloading (and re-parsing) megabytes of JS/CSS on every page load,
+	// while never risking a stale asset after an update.
+	etag := staticETag(path, content)
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "public, max-age=0, must-revalidate")
+
+	if match := r.Header.Get("If-None-Match"); match != "" {
+		if match == "*" || strings.Contains(match, etag) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
 	orihttp.WriteBytes(w, content)
 }
 

--- a/internal/server/static_cache.go
+++ b/internal/server/static_cache.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// staticETags memoizes content-hash ETags for embedded static assets keyed by
+// request path. The embedded filesystem is immutable for the lifetime of the
+// process, so each asset's ETag only needs to be computed once.
+var staticETags sync.Map // map[string]string
+
+// staticETag returns a strong, quoted ETag derived from the asset content.
+// Because the value is content-derived, it changes automatically whenever the
+// embedded asset changes (i.e. on a new build), giving correct revalidation in
+// both development and release builds without any cache-busting query strings.
+func staticETag(path string, content []byte) string {
+	if v, ok := staticETags.Load(path); ok {
+		return v.(string)
+	}
+	sum := sha256.Sum256(content)
+	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+	staticETags.Store(path, etag)
+	return etag
+}

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -306,12 +306,21 @@
   {{template "file_relink_dialog"}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <script src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
+  <!--
+    All classic scripts use `defer`: they download in parallel with HTML parsing
+    and execute in document order just before DOMContentLoaded. Module scripts
+    (type="module") defer by default. Ordering between the two is preserved, so
+    "load before X" dependencies below still hold. The inline theme-init script
+    stays a parse-time script (defer is ignored on inline scripts) but only
+    references themeManager inside its DOMContentLoaded callback, by which point
+    the deferred themeManager.js has run.
+  -->
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <script>
     // Initialize theme manager immediately
     document.addEventListener('DOMContentLoaded', function() {
@@ -319,20 +328,20 @@
     });
   </script>
   <!-- DX Utilities - must load before modules that use them -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
   <!-- Sidebar modules - loaded before main app -->
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/location.js"></script>
-  <script src="/js/modules/task-modal-controller.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/location.js"></script>
+  <script defer src="/js/modules/task-modal-controller.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script type="module" src="/js/modules/note-editor.js"></script>
   <script type="module" src="/js/modules/note-toc.js"></script>
   <script type="module" src="/js/modules/note-staging.js"></script>
@@ -342,16 +351,16 @@
   <script type="module" src="/js/modules/note-rail-notes.js"></script>
   <script type="module" src="/js/modules/note-ai-assist.js"></script>
   <script type="module" src="/js/modules/search-palette.js"></script>
-  <script src="/js/modules/sessions.js"></script>
-  <script src="/js/modules/project-templates-manage.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/voice-input.js"></script>
-  <script src="/js/modules/form-validation.js"></script>
-  <script src="/js/file-manager.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/workspace-realtime.js"></script>
-  <script src="/js/modules/dashboard.js"></script>
+  <script defer src="/js/modules/sessions.js"></script>
+  <script defer src="/js/modules/project-templates-manage.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/voice-input.js"></script>
+  <script defer src="/js/modules/form-validation.js"></script>
+  <script defer src="/js/file-manager.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/workspace-realtime.js"></script>
+  <script defer src="/js/modules/dashboard.js"></script>
   <script type="module" src="/js/modules/relative-time.js"></script>
-  <script src="/js/modules/home-dashboard.js"></script>
+  <script defer src="/js/modules/home-dashboard.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/action-center.tmpl
+++ b/internal/web/templates/pages/action-center.tmpl
@@ -122,21 +122,21 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();
     });
   </script>
-  <script src="/js/modules/action-center.js"></script>
+  <script defer src="/js/modules/action-center.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/agents-create.tmpl
+++ b/internal/web/templates/pages/agents-create.tmpl
@@ -731,16 +731,16 @@
 
   {{template "modals.tmpl" .}}
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/agents-create.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/agents-create.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();

--- a/internal/web/templates/pages/agents-detail.tmpl
+++ b/internal/web/templates/pages/agents-detail.tmpl
@@ -917,18 +917,18 @@
   {{template "modals.tmpl" .}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <!-- DX Utilities - must load before modules that use them -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/agents-detail.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/agents-detail.js"></script>
   <script>
     // Initialize theme
     document.addEventListener('DOMContentLoaded', function() {

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1699,27 +1699,27 @@
     {{template "session-modals.tmpl" .}}
     {{template "chat-area.tmpl" .}}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- DX Utilities -->
-    <script src="/js/utils/logger.js"></script>
-    <script src="/js/utils/event-bus.js"></script>
-    <script src="/js/utils/api-client.js"></script>
-    <script src="/js/utils/dom-utils.js"></script>
-    <script src="/js/modules/toast.js"></script>
-    <script src="/js/modules/workspace-bootstrap-review.js"></script>
-    <script src="/js/modules/workspace-group-options.js"></script>
-    <script src="/js/modules/sessions.js"></script>
-    <script src="/js/app.js"></script>
-    <script src="/js/modules/agents.js"></script>
-    <script src="/js/modules/sidebar.js"></script>
-    <script src="/js/modules/themeManager.js"></script>
-    <script src="/js/modules/external-agents.js"></script>
+    <script defer src="/js/utils/logger.js"></script>
+    <script defer src="/js/utils/event-bus.js"></script>
+    <script defer src="/js/utils/api-client.js"></script>
+    <script defer src="/js/utils/dom-utils.js"></script>
+    <script defer src="/js/modules/toast.js"></script>
+    <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
+    <script defer src="/js/modules/workspace-group-options.js"></script>
+    <script defer src="/js/modules/sessions.js"></script>
+    <script defer src="/js/app.js"></script>
+    <script defer src="/js/modules/agents.js"></script>
+    <script defer src="/js/modules/sidebar.js"></script>
+    <script defer src="/js/modules/themeManager.js"></script>
+    <script defer src="/js/modules/external-agents.js"></script>
     <script>
         // Initialize theme on page load
         document.addEventListener('DOMContentLoaded', function() {
             themeManager.initialize();
         });
     </script>
-    <script src="/js/agents-dashboard.js"></script>
+    <script defer src="/js/agents-dashboard.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/mcp.tmpl
+++ b/internal/web/templates/pages/mcp.tmpl
@@ -407,26 +407,26 @@
     .mcp-markdown h1, .mcp-markdown h2, .mcp-markdown h3 { color: var(--text-primary); }
   </style>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Markdown rendering for MCP README / instructions -->
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <script>
     // Initialize theme on page load
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();
     });
   </script>
-  <script src="/js/mcp.js"></script>
+  <script defer src="/js/mcp.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/models.tmpl
+++ b/internal/web/templates/pages/models.tmpl
@@ -1812,16 +1812,16 @@ function showToast(message, type = 'info') {
 </script>
 
 <!-- Include app.js and sidebar dependencies -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <!-- DX Utilities -->
-<script src="/js/utils/logger.js"></script>
-<script src="/js/utils/event-bus.js"></script>
-<script src="/js/utils/api-client.js"></script>
-<script src="/js/utils/dom-utils.js"></script>
-<script src="/js/app.js?v=1694538177"></script>
-<script src="/js/modules/agents.js"></script>
-<script src="/js/modules/sidebar.js"></script>
-<script src="/js/modules/themeManager.js"></script>
+<script defer src="/js/utils/logger.js"></script>
+<script defer src="/js/utils/event-bus.js"></script>
+<script defer src="/js/utils/api-client.js"></script>
+<script defer src="/js/utils/dom-utils.js"></script>
+<script defer src="/js/app.js?v=1694538177"></script>
+<script defer src="/js/modules/agents.js"></script>
+<script defer src="/js/modules/sidebar.js"></script>
+<script defer src="/js/modules/themeManager.js"></script>
 <script>
   // Initialize theme on page load
   document.addEventListener('DOMContentLoaded', function() {

--- a/internal/web/templates/pages/note.tmpl
+++ b/internal/web/templates/pages/note.tmpl
@@ -189,15 +189,15 @@
   </main>
 
   <!-- Shared scripts (head loads bootstrap, marked, dompurify, etc.) -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <script type="module" src="/js/modules/note-editor.js"></script>
   <script type="module" src="/js/modules/note-toc.js"></script>
   <script type="module" src="/js/modules/note-staging.js"></script>

--- a/internal/web/templates/pages/personalize.tmpl
+++ b/internal/web/templates/pages/personalize.tmpl
@@ -154,8 +154,7 @@
     </div>
   </div>
 
-  <script src="/js/modules/api.js"></script>
-  <script src="/js/modules/personalize.js"></script>
+  <script defer src="/js/modules/personalize.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/plugins.tmpl
+++ b/internal/web/templates/pages/plugins.tmpl
@@ -130,22 +130,22 @@
 
   {{template "modals.tmpl" .}}
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       themeManager.initialize();
     });
   </script>
-  <script src="/js/plugins.js"></script>
+  <script defer src="/js/plugins.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/profile.tmpl
+++ b/internal/web/templates/pages/profile.tmpl
@@ -69,21 +69,21 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();
     });
   </script>
-  <script src="/js/modules/user-profile.js"></script>
+  <script defer src="/js/modules/user-profile.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/review.tmpl
+++ b/internal/web/templates/pages/review.tmpl
@@ -224,16 +224,16 @@
   {{template "modals.tmpl" .}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
 
   <script>
     let issues = [];

--- a/internal/web/templates/pages/settings.tmpl
+++ b/internal/web/templates/pages/settings.tmpl
@@ -1681,17 +1681,17 @@
   <!-- Scripts -->
   {{template "components/project-templates-manage.tmpl" .}}
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <script>
     // Initialize theme on page load
     document.addEventListener('DOMContentLoaded', function() {
@@ -1789,13 +1789,13 @@
       document.addEventListener('DOMContentLoaded', loadExternalAgentsSettings);
     })();
   </script>
-  <script src="/js/modules/settings-controller.js"></script>
-  <script src="/js/modules/settings-navigation.js"></script>
-  <script src="/js/modules/settings-page.js"></script>
-  <script src="/js/modules/project-templates-manage.js"></script>
-  <script src="/js/modules/location-settings.js"></script>
-  <script src="/js/modules/device-capabilities.js"></script>
-  <script src="/js/modules/web3-settings.js"></script>
+  <script defer src="/js/modules/settings-controller.js"></script>
+  <script defer src="/js/modules/settings-navigation.js"></script>
+  <script defer src="/js/modules/settings-page.js"></script>
+  <script defer src="/js/modules/project-templates-manage.js"></script>
+  <script defer src="/js/modules/location-settings.js"></script>
+  <script defer src="/js/modules/device-capabilities.js"></script>
+  <script defer src="/js/modules/web3-settings.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/skills.tmpl
+++ b/internal/web/templates/pages/skills.tmpl
@@ -246,19 +246,19 @@
   </div>
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <!-- DX Utilities - must load before modules that use them -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/skills.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/skills.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();

--- a/internal/web/templates/pages/usage.tmpl
+++ b/internal/web/templates/pages/usage.tmpl
@@ -161,16 +161,16 @@
   {{template "modals.tmpl" .}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
 
   <script>
     let usageData = null;

--- a/internal/web/templates/pages/vault.tmpl
+++ b/internal/web/templates/pages/vault.tmpl
@@ -28,21 +28,21 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/app.js?v=1694538177"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/app.js?v=1694538177"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();
     });
   </script>
-  <script src="/js/modules/vault-page.js"></script>
+  <script defer src="/js/modules/vault-page.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/workflows.tmpl
+++ b/internal/web/templates/pages/workflows.tmpl
@@ -1021,16 +1021,16 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/behavior-studio.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/behavior-studio.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -695,34 +695,34 @@
   {{template "modals.tmpl" .}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
-  <script src="/js/modules/workspace-group-options.js"></script>
-  <script src="/js/modules/sessions.js"></script>
-  <script src="/js/modules/dashboard.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/toast.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/sessions.js"></script>
+  <script defer src="/js/modules/dashboard.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
   <!-- Real-time workspace modules -->
-  <script src="/js/modules/workspace-realtime.js"></script>
-  <script src="/js/modules/message-timeline.js"></script>
+  <script defer src="/js/modules/workspace-realtime.js"></script>
+  <script defer src="/js/modules/message-timeline.js"></script>
   <script type="module" src="/js/modules/agent-canvas.js?v=1733603000"></script>
   <!-- Workspace management -->
   <link rel="stylesheet" href="/css/workspace.css">
-  <script src="/js/modules/workspace-canvas-helpers.js?v=1733602000"></script>
-  <script src="/js/modules/workflow-panel.js"></script>
+  <script defer src="/js/modules/workspace-canvas-helpers.js?v=1733602000"></script>
+  <script defer src="/js/modules/workflow-panel.js"></script>
 
   <script>
     // Workspace-specific canvas initialization
@@ -1363,8 +1363,8 @@
       }
     }
   </script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/modules/task-modal-controller.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/task-modal-controller.js"></script>
   <script>
     // Initialize theme on page load
     document.addEventListener('DOMContentLoaded', function() {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -9198,52 +9198,52 @@
   </style>
 
   <!-- Core Libraries -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
 
   <!-- Theme Manager (load early) -->
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
 
   <!-- Utils -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
 
   <!-- Core Modules -->
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/location.js"></script>
-  <script src="/js/modules/task-modal-controller.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
-  <script src="/js/modules/workspace-group-options.js"></script>
-  <script src="/js/modules/sessions.js"></script>
-  <script src="/js/modules/dashboard.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/voice-input.js"></script>
-  <script src="/js/modules/form-validation.js"></script>
-  <script src="/js/file-manager.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/workspace-realtime.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/location.js"></script>
+  <script defer src="/js/modules/task-modal-controller.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/sessions.js"></script>
+  <script defer src="/js/modules/dashboard.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/voice-input.js"></script>
+  <script defer src="/js/modules/form-validation.js"></script>
+  <script defer src="/js/file-manager.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/workspace-realtime.js"></script>
 
   <!-- Workspace Hub Modules (for task/session/file/note management) -->
-  <script src="/js/modules/workspace-hub-utils.js"></script>
-  <script src="/js/modules/workspace-hub-state.js"></script>
-  <script src="/js/modules/workspace-hub-modals.js"></script>
-  <script src="/js/modules/workspace-hub-selection.js"></script>
-  <script src="/js/modules/workspace-hub-tasks.js"></script>
-  <script src="/js/modules/workspace-hub-sessions.js"></script>
-  <script src="/js/modules/workspace-hub-notes.js"></script>
-  <script src="/js/modules/workspace-hub-files.js"></script>
-  <script src="/js/modules/workspace-mission.js"></script>
-  <script src="/js/modules/workspace-triggers.js"></script>
-  <script src="/js/modules/project-templates-manage.js"></script>
-  <script src="/js/modules/workspace-hub-support-chat.js"></script>
+  <script defer src="/js/modules/workspace-hub-utils.js"></script>
+  <script defer src="/js/modules/workspace-hub-state.js"></script>
+  <script defer src="/js/modules/workspace-hub-modals.js"></script>
+  <script defer src="/js/modules/workspace-hub-selection.js"></script>
+  <script defer src="/js/modules/workspace-hub-tasks.js"></script>
+  <script defer src="/js/modules/workspace-hub-sessions.js"></script>
+  <script defer src="/js/modules/workspace-hub-notes.js"></script>
+  <script defer src="/js/modules/workspace-hub-files.js"></script>
+  <script defer src="/js/modules/workspace-mission.js"></script>
+  <script defer src="/js/modules/workspace-triggers.js"></script>
+  <script defer src="/js/modules/project-templates-manage.js"></script>
+  <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
 
   <!-- Workspace Detail Page -->
   <script type="module">

--- a/internal/web/templates/pages/workspace-diagnostics.tmpl
+++ b/internal/web/templates/pages/workspace-diagnostics.tmpl
@@ -72,7 +72,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module">
     import { WorkspaceDetailPage } from '/js/modules/workspace-detail.js';
 

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -6660,37 +6660,41 @@
 
   {{template "support-chat.tmpl" .}}
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <script src="/js/modules/themeManager.js"></script>
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/location.js"></script>
-  <script src="/js/modules/task-modal-controller.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
-  <script src="/js/modules/workspace-group-options.js"></script>
-  <script src="/js/modules/sessions.js"></script>
-  <script src="/js/modules/dashboard.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/voice-input.js"></script>
-  <script src="/js/modules/form-validation.js"></script>
-  <script src="/js/file-manager.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/workspace-realtime.js"></script>
-  <script src="/js/modules/workspace-hub-support-chat.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/location.js"></script>
+  <script defer src="/js/modules/task-modal-controller.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/sessions.js"></script>
+  <script defer src="/js/modules/dashboard.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/voice-input.js"></script>
+  <script defer src="/js/modules/form-validation.js"></script>
+  <script defer src="/js/file-manager.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/workspace-realtime.js"></script>
+  <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
   <script>
-    if (typeof themeManager !== 'undefined' && themeManager && typeof themeManager.initialize === 'function') {
-      themeManager.initialize();
-    }
+    // Wait for DOMContentLoaded so this works whether themeManager.js is a
+    // blocking or deferred script (deferred scripts run before this event).
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof themeManager !== 'undefined' && themeManager && typeof themeManager.initialize === 'function') {
+        themeManager.initialize();
+      }
+    });
   </script>
 
   <script type="module">

--- a/internal/web/templates/pages/workspaces-hub.tmpl
+++ b/internal/web/templates/pages/workspaces-hub.tmpl
@@ -65,30 +65,30 @@
 
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <!-- Workspace management -->
   <link rel="stylesheet" href="/css/workspace.css">
-  <script src="/js/modules/workspace-listing.js?v=1732920000"></script>
-  <script src="/js/modules/workspace-agent-modals.js?v=1764212000"></script>
-  <script src="/js/modules/workspace-templates.js?v=1764212001"></script>
-  <script src="/js/modules/workspace-group-options.js"></script>
-  <script src="/js/modules/project-templates-manage.js"></script>
-  <script src="/js/modules/workspace-create.js?v=1764212001"></script>
+  <script defer src="/js/modules/workspace-listing.js?v=1732920000"></script>
+  <script defer src="/js/modules/workspace-agent-modals.js?v=1764212000"></script>
+  <script defer src="/js/modules/workspace-templates.js?v=1764212001"></script>
+  <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/project-templates-manage.js"></script>
+  <script defer src="/js/modules/workspace-create.js?v=1764212001"></script>
 
 
   <script>
@@ -105,7 +105,7 @@
     // All initialization is handled by the modules via their own DOMContentLoaded handlers
     // No additional page-specific initialization needed
   </script>
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <script>
     // Initialize theme on page load
     document.addEventListener('DOMContentLoaded', function() {

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -31,58 +31,58 @@
   {{template "file_relink_dialog"}}
 
   <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
-  <script src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <script src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
+  <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
-  <script src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       themeManager.initialize();
     });
   </script>
   <!-- DX Utilities -->
-  <script src="/js/utils/logger.js"></script>
-  <script src="/js/utils/event-bus.js"></script>
-  <script src="/js/utils/api-client.js"></script>
-  <script src="/js/utils/dom-utils.js"></script>
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>
   <!-- Sidebar modules -->
-  <script src="/js/modules/resizer.js"></script>
-  <script src="/js/modules/settings.js"></script>
-  <script src="/js/modules/agents.js"></script>
-  <script src="/js/modules/apikey.js"></script>
-  <script src="/js/modules/sidebar.js"></script>
-  <script src="/js/modules/file-upload.js"></script>
-  <script src="/js/modules/location.js"></script>
-  <script src="/js/modules/task-modal-controller.js"></script>
-  <script src="/js/modules/workspace-bootstrap-review.js"></script>
-  <script src="/js/modules/workspace-group-options.js"></script>
-  <script src="/js/modules/sessions.js"></script>
-  <script src="/js/modules/dashboard.js"></script>
-  <script src="/js/modules/toast.js"></script>
-  <script src="/js/modules/voice-input.js"></script>
-  <script src="/js/modules/form-validation.js"></script>
-  <script src="/js/file-manager.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/modules/workspace-realtime.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/settings.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/apikey.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/file-upload.js"></script>
+  <script defer src="/js/modules/location.js"></script>
+  <script defer src="/js/modules/task-modal-controller.js"></script>
+  <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
+  <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/sessions.js"></script>
+  <script defer src="/js/modules/dashboard.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/voice-input.js"></script>
+  <script defer src="/js/modules/form-validation.js"></script>
+  <script defer src="/js/file-manager.js"></script>
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/workspace-realtime.js"></script>
   <!-- Workspace Hub modules -->
-  <script src="/js/modules/workspace-hub-utils.js"></script>
-  <script src="/js/modules/workspace-hub-state.js"></script>
-  <script src="/js/modules/project-templates-manage.js"></script>
-  <script src="/js/modules/workspace-hub-modals.js"></script>
-  <script src="/js/modules/workspace-hub-selection.js"></script>
-  <script src="/js/modules/workspace-hub-tasks.js"></script>
-  <script src="/js/modules/workspace-hub-sessions.js"></script>
-  <script src="/js/modules/workspace-hub-notes.js"></script>
-  <script src="/js/modules/workspace-hub-files.js"></script>
-  <script src="/js/modules/workspace-input-router.js"></script>
-  <script src="/js/modules/workspace-hub-smart-input.js"></script>
-  <script src="/js/modules/workspace-hub-panels.js"></script>
-  <script src="/js/modules/workspace-hub.js"></script>
-  <script src="/js/modules/workspace-hub-board.js"></script>
-  <script src="/js/modules/workspace-hub-support-chat.js"></script>
-  <script src="/js/modules/workspace-sync.js"></script>
+  <script defer src="/js/modules/workspace-hub-utils.js"></script>
+  <script defer src="/js/modules/workspace-hub-state.js"></script>
+  <script defer src="/js/modules/project-templates-manage.js"></script>
+  <script defer src="/js/modules/workspace-hub-modals.js"></script>
+  <script defer src="/js/modules/workspace-hub-selection.js"></script>
+  <script defer src="/js/modules/workspace-hub-tasks.js"></script>
+  <script defer src="/js/modules/workspace-hub-sessions.js"></script>
+  <script defer src="/js/modules/workspace-hub-notes.js"></script>
+  <script defer src="/js/modules/workspace-hub-files.js"></script>
+  <script defer src="/js/modules/workspace-input-router.js"></script>
+  <script defer src="/js/modules/workspace-hub-smart-input.js"></script>
+  <script defer src="/js/modules/workspace-hub-panels.js"></script>
+  <script defer src="/js/modules/workspace-hub.js"></script>
+  <script defer src="/js/modules/workspace-hub-board.js"></script>
+  <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
+  <script defer src="/js/modules/workspace-sync.js"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
## Summary
Two zero-cost frontend UX wins, browser-verified.

### 1. Static asset caching + ETag
`serveStaticFile` previously sent `Cache-Control: no-cache, no-store, must-revalidate` on **every** CSS/JS/SVG — a leftover dev convenience. Since assets are `go:embed`-ed (immutable per build) and the UI is a multi-page app (full reload per route), the browser re-downloaded **and re-parsed** megabytes of JS on every navigation, and back/forward cache was disabled.

- New `internal/server/static_cache.go`: memoized content-hash ETags.
- `serveStaticFile` now sends `ETag` + `Cache-Control: public, max-age=0, must-revalidate` and answers `If-None-Match` with `304`.
- Content-derived ETag ⇒ auto-invalidates on rebuild ⇒ **zero staleness risk**, no `?v=` churn.

Verified:
| Request | Result |
|---|---|
| `GET /css/variables.css` | `200` + `ETag` |
| + matching `If-None-Match` | `304`, empty body |
| + stale `If-None-Match` | `200`, full body |

### 2. `defer` on page scripts
The shared `head.tmpl` scripts were already deferred. This adds `defer` to the **319** classic `<script src>` tags in `base.tmpl` + all 22 page templates so they download in parallel and stop blocking parse. `type="module"` scripts already defer by default and were left untouched; inline scripts were not modified.

- Fixed the one risky spot: `workspace-task.tmpl`'s *guarded immediate* `themeManager.initialize()` is now `DOMContentLoaded`-wrapped, so theme init still runs once `themeManager.js` is deferred.

### 3. Incidental fix
Removed a dead `/js/modules/api.js` reference on `/personalize` that 404'd on every load (the file doesn't exist).

## Verification
- `go build`, `go vet`, `go test ./internal/server/` pass; `gofmt` clean.
- Playwright (Chromium) sweep of all 15 data-free pages **+ a seeded workspace-detail page** (38 deferred scripts): **16/16 passed** — no uncaught exceptions, no script-ordering errors (`is not defined` / `is not a function`), `data-bs-theme` applied on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)