### PR TITLE
refactor(web): extract shared theme-init and DX-utils script partials

### DIFF
--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -70,6 +70,8 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	templatePaths := []string{
 		"templates/layout/base.tmpl",
 		"templates/layout/head.tmpl",
+		"templates/layout/scripts-dx-utils.tmpl",
+		"templates/layout/theme-init.tmpl",
 		"templates/components/sidebar.tmpl",
 		"templates/components/workspace-hub.tmpl",
 		"templates/components/support-chat.tmpl",

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -321,17 +321,8 @@
   <script defer src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
   <script defer src="/js/modules/themeManager.js"></script>
-  <script>
-    // Initialize theme manager immediately
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
-  <!-- DX Utilities - must load before modules that use them -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "theme-init.tmpl" .}}
+  {{template "scripts-dx-utils.tmpl" .}}
   <!-- Sidebar modules - loaded before main app -->
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/settings.js"></script>

--- a/internal/web/templates/layout/scripts-dx-utils.tmpl
+++ b/internal/web/templates/layout/scripts-dx-utils.tmpl
@@ -1,0 +1,5 @@
+  <!-- Shared DX utilities - must load before modules that use them -->
+  <script defer src="/js/utils/logger.js"></script>
+  <script defer src="/js/utils/event-bus.js"></script>
+  <script defer src="/js/utils/api-client.js"></script>
+  <script defer src="/js/utils/dom-utils.js"></script>

--- a/internal/web/templates/layout/theme-init.tmpl
+++ b/internal/web/templates/layout/theme-init.tmpl
@@ -1,0 +1,6 @@
+  <script>
+    // Initialize the theme manager once the DOM is ready.
+    document.addEventListener('DOMContentLoaded', function() {
+      themeManager.initialize();
+    });
+  </script>

--- a/internal/web/templates/pages/action-center.tmpl
+++ b/internal/web/templates/pages/action-center.tmpl
@@ -123,19 +123,12 @@
   </div>
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js?v=1694538177"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script defer src="/js/modules/action-center.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/agents-create.tmpl
+++ b/internal/web/templates/pages/agents-create.tmpl
@@ -733,19 +733,12 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/toast.js"></script>
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/agents-create.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/agents-detail.tmpl
+++ b/internal/web/templates/pages/agents-detail.tmpl
@@ -920,21 +920,12 @@
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
   <script defer src="/js/modules/themeManager.js"></script>
-  <!-- DX Utilities - must load before modules that use them -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/toast.js"></script>
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/agents-detail.js"></script>
-  <script>
-    // Initialize theme
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1700,11 +1700,7 @@
     {{template "chat-area.tmpl" .}}
 
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- DX Utilities -->
-    <script defer src="/js/utils/logger.js"></script>
-    <script defer src="/js/utils/event-bus.js"></script>
-    <script defer src="/js/utils/api-client.js"></script>
-    <script defer src="/js/utils/dom-utils.js"></script>
+    {{template "scripts-dx-utils.tmpl" .}}
     <script defer src="/js/modules/toast.js"></script>
     <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
     <script defer src="/js/modules/workspace-group-options.js"></script>
@@ -1714,12 +1710,7 @@
     <script defer src="/js/modules/sidebar.js"></script>
     <script defer src="/js/modules/themeManager.js"></script>
     <script defer src="/js/modules/external-agents.js"></script>
-    <script>
-        // Initialize theme on page load
-        document.addEventListener('DOMContentLoaded', function() {
-            themeManager.initialize();
-        });
-    </script>
+    {{template "theme-init.tmpl" .}}
     <script defer src="/js/agents-dashboard.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/mcp.tmpl
+++ b/internal/web/templates/pages/mcp.tmpl
@@ -411,21 +411,12 @@
   <!-- Markdown rendering for MCP README / instructions -->
   <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
   <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js?v=1694538177"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script>
-    // Initialize theme on page load
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script defer src="/js/mcp.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/models.tmpl
+++ b/internal/web/templates/pages/models.tmpl
@@ -1813,21 +1813,12 @@ function showToast(message, type = 'info') {
 
 <!-- Include app.js and sidebar dependencies -->
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<!-- DX Utilities -->
-<script defer src="/js/utils/logger.js"></script>
-<script defer src="/js/utils/event-bus.js"></script>
-<script defer src="/js/utils/api-client.js"></script>
-<script defer src="/js/utils/dom-utils.js"></script>
+{{template "scripts-dx-utils.tmpl" .}}
 <script defer src="/js/app.js?v=1694538177"></script>
 <script defer src="/js/modules/agents.js"></script>
 <script defer src="/js/modules/sidebar.js"></script>
 <script defer src="/js/modules/themeManager.js"></script>
-<script>
-  // Initialize theme on page load
-  document.addEventListener('DOMContentLoaded', function() {
-    themeManager.initialize();
-  });
-</script>
+{{template "theme-init.tmpl" .}}
 
       </div>
     </div>

--- a/internal/web/templates/pages/note.tmpl
+++ b/internal/web/templates/pages/note.tmpl
@@ -193,10 +193,7 @@
   <script defer src="/js/vendor/marked-14.1.4.min.js"></script>
   <script defer src="/js/vendor/dompurify-3.1.6.min.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/toast.js"></script>
   <script type="module" src="/js/modules/note-editor.js"></script>
   <script type="module" src="/js/modules/note-toc.js"></script>
@@ -209,11 +206,7 @@
   <script type="module" src="/js/modules/note-ai-assist.js"></script>
   <script type="module" src="/js/modules/search-palette.js"></script>
   <script type="module" src="/js/modules/note-page.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/plugins.tmpl
+++ b/internal/web/templates/pages/plugins.tmpl
@@ -131,20 +131,12 @@
   {{template "modals.tmpl" .}}
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
   <script defer src="/js/modules/toast.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script defer src="/js/plugins.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/profile.tmpl
+++ b/internal/web/templates/pages/profile.tmpl
@@ -70,19 +70,12 @@
   </div>
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js?v=1694538177"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
   <script defer src="/js/modules/toast.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script defer src="/js/modules/user-profile.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/review.tmpl
+++ b/internal/web/templates/pages/review.tmpl
@@ -225,11 +225,7 @@
 
   <!-- Scripts -->
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>

--- a/internal/web/templates/pages/settings.tmpl
+++ b/internal/web/templates/pages/settings.tmpl
@@ -1682,22 +1682,13 @@
   {{template "components/project-templates-manage.tmpl" .}}
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js?v=1694538177"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
   <script defer src="/js/modules/toast.js"></script>
-  <script>
-    // Initialize theme on page load
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script>
     // External Agents Settings
     (function() {

--- a/internal/web/templates/pages/skills.tmpl
+++ b/internal/web/templates/pages/skills.tmpl
@@ -249,21 +249,13 @@
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
   <script defer src="/js/modules/themeManager.js"></script>
-  <!-- DX Utilities - must load before modules that use them -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/toast.js"></script>
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/skills.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/usage.tmpl
+++ b/internal/web/templates/pages/usage.tmpl
@@ -162,11 +162,7 @@
 
   <!-- Scripts -->
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/agents.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>

--- a/internal/web/templates/pages/vault.tmpl
+++ b/internal/web/templates/pages/vault.tmpl
@@ -29,19 +29,12 @@
   </div>
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/app.js?v=1694538177"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
   <script defer src="/js/modules/toast.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
   <script defer src="/js/modules/vault-page.js"></script>
 </body>
 </html>

--- a/internal/web/templates/pages/workflows.tmpl
+++ b/internal/web/templates/pages/workflows.tmpl
@@ -1023,19 +1023,12 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/toast.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/behavior-studio.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 
 </html>

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -698,11 +698,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
   <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/settings.js"></script>
   <script defer src="/js/modules/agents.js"></script>
@@ -1365,12 +1361,7 @@
   </script>
   <script defer src="/js/modules/themeManager.js"></script>
   <script defer src="/js/modules/task-modal-controller.js"></script>
-  <script>
-    // Initialize theme on page load
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 
   <!-- Shared Task Modal -->
   {{template "task-modal" .}}

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -9205,11 +9205,7 @@
   <!-- Theme Manager (load early) -->
   <script defer src="/js/modules/themeManager.js"></script>
 
-  <!-- Utils -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
 
   <!-- Core Modules -->
   <script defer src="/js/modules/resizer.js"></script>

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -6664,10 +6664,7 @@
   <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
   <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/settings.js"></script>
   <script defer src="/js/modules/agents.js"></script>

--- a/internal/web/templates/pages/workspaces-hub.tmpl
+++ b/internal/web/templates/pages/workspaces-hub.tmpl
@@ -68,11 +68,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script defer src="/js/vendor/marked-14.1.4.min.js" integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"></script>
   <script defer src="/js/vendor/dompurify-3.1.6.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"></script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/settings.js"></script>
   <script defer src="/js/modules/agents.js"></script>
@@ -106,12 +102,7 @@
     // No additional page-specific initialization needed
   </script>
   <script defer src="/js/modules/themeManager.js"></script>
-  <script>
-    // Initialize theme on page load
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
+  {{template "theme-init.tmpl" .}}
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -37,16 +37,8 @@
   <script defer src="https://cdn.jsdelivr.net/npm/ethers@6/dist/ethers.umd.min.js"></script>
   <!-- Theme Manager - must load before other modules -->
   <script defer src="/js/modules/themeManager.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      themeManager.initialize();
-    });
-  </script>
-  <!-- DX Utilities -->
-  <script defer src="/js/utils/logger.js"></script>
-  <script defer src="/js/utils/event-bus.js"></script>
-  <script defer src="/js/utils/api-client.js"></script>
-  <script defer src="/js/utils/dom-utils.js"></script>
+  {{template "theme-init.tmpl" .}}
+  {{template "scripts-dx-utils.tmpl" .}}
   <!-- Sidebar modules -->
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/settings.js"></script>


### PR DESCRIPTION
## Summary
Tier 1 of the refactoring scan: kill the template script duplication that made the recent `defer` change (PR #100) a 22-file edit.

The DX-utils script quartet (`logger`, `event-bus`, `api-client`, `dom-utils`) and the `themeManager` `DOMContentLoaded` init block were hand-duplicated across `base.tmpl` and ~20 page templates.

## Changes
- New partials `layout/scripts-dx-utils.tmpl` + `layout/theme-init.tmpl` (registered in `templates.go`).
- Replaced the duplicated blocks with `{{template ...}}` includes: **dx-utils in 21 templates**, **theme-init in 17** (skips `review`/`usage`, which embed the init inside larger page scripts, and `workspace-task`'s guarded variant).
- **Net −140 lines.** Future shared-script changes (defer, caching, add/remove a util) are now a single edit.

## Verification — behavior-preserving
- **Rendered-HTML diff:** captured rendered output of every page on `origin/dev` vs this branch (UUIDs/timestamps normalized). The only differences are comment/whitespace *inside* the two extracted blocks — the script tags, order, and JS are byte-identical.
- **Playwright sweep** (Chromium) of all 15 data-free pages + a seeded workspace-detail page: **16/16 passed** — no uncaught exceptions, no script-ordering errors, `data-bs-theme` applied everywhere.
- `go build`, `go vet ./internal/web/`, `go test ./internal/web/` pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)