### PR TITLE
feat(templates): /templates page — metadata, tags & lifecycle (seam 1/3)

### DIFF
--- a/internal/projecttemplates/manage.go
+++ b/internal/projecttemplates/manage.go
@@ -17,6 +17,10 @@ import (
 // library template.
 var ErrTemplateExists = errors.New("template already exists in the library")
 
+// ErrInvalidTemplateName reports a create/duplicate request whose name is empty
+// or slugifies to nothing usable.
+var ErrInvalidTemplateName = errors.New("template name is invalid")
+
 // ImportFolder copies an arbitrary folder into the library as a new template.
 // The copy is verbatim — no token substitution, since template files may
 // legitimately carry {{name}}/{{date}} in their names — with symlinks skipped.
@@ -68,10 +72,97 @@ func ImportFolder(libDir, srcPath, displayName string) (Template, error) {
 	}
 
 	if strings.TrimSpace(displayName) != "" {
-		if _, err := UpdateManifest(absLib, id, displayName, src.Description); err != nil {
+		if _, err := UpdateManifest(absLib, id, displayName, src.Description, nil); err != nil {
 			_ = os.RemoveAll(dest)
 			return Template{}, err
 		}
+	}
+	return newTemplate(dest), nil
+}
+
+// CreateBlank creates a new, empty library template from a display name: a fresh
+// folder carrying only a minimal template.json (the name). The id is the
+// slugified name; a name that slugifies to nothing is rejected, and a colliding
+// id yields ErrTemplateExists.
+func CreateBlank(libDir, name string) (Template, error) {
+	libDir = strings.TrimSpace(libDir)
+	if libDir == "" {
+		return Template{}, fmt.Errorf("templates library is not configured")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Template{}, fmt.Errorf("%w: name is required", ErrInvalidTemplateName)
+	}
+	// Slugify never returns empty (it falls back to "untitled"), so any non-empty
+	// name yields a usable id.
+	id := workspace.Slugify(name)
+
+	absLib, err := filepath.Abs(libDir)
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to resolve templates directory: %w", err)
+	}
+	absLib = filepath.Clean(absLib)
+	if err := os.MkdirAll(absLib, 0o750); err != nil {
+		return Template{}, fmt.Errorf("failed to create templates directory: %w", err)
+	}
+
+	dest := filepath.Join(absLib, id)
+	if _, err := os.Lstat(dest); err == nil {
+		return Template{}, fmt.Errorf("%w: %q", ErrTemplateExists, id)
+	} else if !os.IsNotExist(err) {
+		return Template{}, fmt.Errorf("failed to inspect %s: %w", dest, err)
+	}
+	if err := os.MkdirAll(dest, 0o750); err != nil {
+		return Template{}, fmt.Errorf("failed to create template folder: %w", err)
+	}
+
+	// Seed a minimal manifest so the display name is explicit from the start.
+	if _, err := UpdateManifest(absLib, id, name, "", nil); err != nil {
+		_ = os.RemoveAll(dest)
+		return Template{}, err
+	}
+	return newTemplate(dest), nil
+}
+
+// Duplicate copies an existing library template into a new one. The copy is
+// verbatim (like ImportFolder), so the source's files, tags, and onboarding
+// block carry over. newName, when empty, defaults to "<source name> copy"; the
+// new id is the slugified result, and a collision yields ErrTemplateExists. The
+// duplicate's manifest display name is always set to the resolved name so the
+// two templates stay distinguishable.
+func Duplicate(libDir, id, newName string) (Template, error) {
+	src, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return Template{}, err
+	}
+
+	absLib, err := filepath.Abs(strings.TrimSpace(libDir))
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to resolve templates directory: %w", err)
+	}
+	absLib = filepath.Clean(absLib)
+
+	basis := strings.TrimSpace(newName)
+	if basis == "" {
+		basis = src.Name + " copy"
+	}
+	newID := workspace.Slugify(basis)
+
+	dest := filepath.Join(absLib, newID)
+	if _, err := os.Lstat(dest); err == nil {
+		return Template{}, fmt.Errorf("%w: %q", ErrTemplateExists, newID)
+	} else if !os.IsNotExist(err) {
+		return Template{}, fmt.Errorf("failed to inspect %s: %w", dest, err)
+	}
+
+	if err := copyFolderVerbatim(src.Path, dest); err != nil {
+		_ = os.RemoveAll(dest)
+		return Template{}, err
+	}
+	// Set the duplicate's display name (tags/onboarding/unknown keys preserved).
+	if _, err := UpdateManifest(absLib, newID, basis, src.Description, nil); err != nil {
+		_ = os.RemoveAll(dest)
+		return Template{}, err
 	}
 	return newTemplate(dest), nil
 }
@@ -109,8 +200,13 @@ func copyFolderVerbatim(srcRoot, destRoot string) error {
 
 // UpdateManifest writes display metadata into a library template's
 // template.json, preserving any unknown fields a user may have added. Empty
-// values remove the corresponding key (falling back to folder-name display).
-func UpdateManifest(libDir, id, name, description string) (Template, error) {
+// name/description values remove the corresponding key (falling back to
+// folder-name display).
+//
+// tags is tri-state so older callers can't clobber author-set tags: nil
+// preserves whatever the manifest already has, a non-empty slice replaces the
+// tags with the normalized set, and an explicit empty slice clears the key.
+func UpdateManifest(libDir, id, name, description string, tags *[]string) (Template, error) {
 	tpl, err := FindLibraryTemplate(libDir, id)
 	if err != nil {
 		return Template{}, err
@@ -135,6 +231,14 @@ func UpdateManifest(libDir, id, name, description string) (Template, error) {
 	}
 	setOrDelete("name", name)
 	setOrDelete("description", description)
+
+	if tags != nil {
+		if normalized := workspace.NormalizeWorkspaceTags(*tags); len(normalized) > 0 {
+			raw["tags"] = normalized
+		} else {
+			delete(raw, "tags")
+		}
+	}
 
 	data, err := json.MarshalIndent(raw, "", "  ")
 	if err != nil {

--- a/internal/projecttemplates/manage_test.go
+++ b/internal/projecttemplates/manage_test.go
@@ -86,7 +86,7 @@ func TestUpdateManifest(t *testing.T) {
 	libDir := filepath.Join(t.TempDir(), "templates")
 	writeFile(t, filepath.Join(libDir, "demo", ManifestFileName), `{"name":"Old","description":"old desc","tags":["music","reaper"],"custom_field":42}`)
 
-	tpl, err := UpdateManifest(libDir, "demo", "New Name", "new desc")
+	tpl, err := UpdateManifest(libDir, "demo", "New Name", "new desc", nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestUpdateManifest(t *testing.T) {
 	}
 
 	// Clearing the name falls back to the folder name.
-	tpl, err = UpdateManifest(libDir, "demo", "", "")
+	tpl, err = UpdateManifest(libDir, "demo", "", "", nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(clear): %v", err)
 	}
@@ -116,18 +116,133 @@ func TestUpdateManifest(t *testing.T) {
 	}
 
 	// Unknown template.
-	if _, err := UpdateManifest(libDir, "missing", "x", ""); !errors.Is(err, ErrTemplateNotFound) {
+	if _, err := UpdateManifest(libDir, "missing", "x", "", nil); !errors.Is(err, ErrTemplateNotFound) {
 		t.Errorf("expected ErrTemplateNotFound, got %v", err)
 	}
 
 	// A template with no manifest gains one.
 	writeFile(t, filepath.Join(libDir, "plain", "a.txt"), "x")
-	tpl, err = UpdateManifest(libDir, "plain", "Named Now", "")
+	tpl, err = UpdateManifest(libDir, "plain", "Named Now", "", nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(plain): %v", err)
 	}
 	if tpl.Name != "Named Now" {
 		t.Fatalf("manifest not created: %+v", tpl)
+	}
+}
+
+func TestUpdateManifestTagsTriState(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	writeFile(t, filepath.Join(libDir, "demo", ManifestFileName), `{"name":"Demo","tags":["music","reaper"]}`)
+
+	// nil preserves existing tags — the legacy manage modal never sends tags.
+	tpl, err := UpdateManifest(libDir, "demo", "Demo", "", nil)
+	if err != nil {
+		t.Fatalf("UpdateManifest(nil tags): %v", err)
+	}
+	if len(tpl.Tags) != 2 {
+		t.Fatalf("nil tags should preserve existing, got %v", tpl.Tags)
+	}
+
+	// A non-empty slice replaces and normalizes (lowercase/trim/dedupe).
+	newTags := []string{"Synth", "synth", "  Bass  "}
+	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &newTags)
+	if err != nil {
+		t.Fatalf("UpdateManifest(set tags): %v", err)
+	}
+	if len(tpl.Tags) != 2 || tpl.Tags[0] != "synth" || tpl.Tags[1] != "bass" {
+		t.Fatalf("expected normalized [synth bass], got %v", tpl.Tags)
+	}
+
+	// An explicit empty slice clears the key entirely.
+	empty := []string{}
+	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &empty)
+	if err != nil {
+		t.Fatalf("UpdateManifest(clear tags): %v", err)
+	}
+	if len(tpl.Tags) != 0 {
+		t.Fatalf("expected tags cleared, got %v", tpl.Tags)
+	}
+	data, err := os.ReadFile(filepath.Join(libDir, "demo", ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"tags"`) {
+		t.Errorf("tags key should be removed, manifest: %s", data)
+	}
+}
+
+func TestCreateBlank(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+
+	tpl, err := CreateBlank(libDir, "My New Template")
+	if err != nil {
+		t.Fatalf("CreateBlank: %v", err)
+	}
+	if tpl.ID != "my-new-template" || tpl.Name != "My New Template" {
+		t.Fatalf("unexpected template: %+v", tpl)
+	}
+	if _, err := os.Stat(filepath.Join(libDir, "my-new-template", ManifestFileName)); err != nil {
+		t.Errorf("manifest not written: %v", err)
+	}
+
+	// Re-create collides.
+	if _, err := CreateBlank(libDir, "My New Template"); !errors.Is(err, ErrTemplateExists) {
+		t.Errorf("expected ErrTemplateExists, got %v", err)
+	}
+
+	// A blank name is rejected.
+	if _, err := CreateBlank(libDir, "   "); !errors.Is(err, ErrInvalidTemplateName) {
+		t.Errorf("expected ErrInvalidTemplateName for blank name, got %v", err)
+	}
+}
+
+func TestDuplicate(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	writeFile(t, filepath.Join(libDir, "drum-kit", ManifestFileName), `{"name":"Drum Kit","tags":["music"],"onboarding":{"version":"1"}}`)
+	writeFile(t, filepath.Join(libDir, "drum-kit", "{{name}}.rpp"), "seed")
+
+	// Default name → "<source name> copy".
+	dup, err := Duplicate(libDir, "drum-kit", "")
+	if err != nil {
+		t.Fatalf("Duplicate: %v", err)
+	}
+	if dup.ID != "drum-kit-copy" || dup.Name != "Drum Kit copy" {
+		t.Fatalf("unexpected duplicate: %+v", dup)
+	}
+	// Verbatim copy: token filename preserved.
+	if _, err := os.Stat(filepath.Join(libDir, "drum-kit-copy", "{{name}}.rpp")); err != nil {
+		t.Errorf("template file not copied: %v", err)
+	}
+	// Tags and onboarding block carry over.
+	if len(dup.Tags) != 1 || dup.Tags[0] != "music" {
+		t.Errorf("tags not carried, got %v", dup.Tags)
+	}
+	data, err := os.ReadFile(filepath.Join(libDir, "drum-kit-copy", ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"onboarding"`) {
+		t.Errorf("onboarding block not carried: %s", data)
+	}
+
+	// Explicit new name seeds id and display name.
+	dup2, err := Duplicate(libDir, "drum-kit", "Fancy Kit")
+	if err != nil {
+		t.Fatalf("Duplicate(named): %v", err)
+	}
+	if dup2.ID != "fancy-kit" || dup2.Name != "Fancy Kit" {
+		t.Fatalf("unexpected named duplicate: %+v", dup2)
+	}
+
+	// Duplicating the same default name again collides.
+	if _, err := Duplicate(libDir, "drum-kit", ""); !errors.Is(err, ErrTemplateExists) {
+		t.Errorf("expected ErrTemplateExists, got %v", err)
+	}
+
+	// Unknown source.
+	if _, err := Duplicate(libDir, "missing", ""); !errors.Is(err, ErrTemplateNotFound) {
+		t.Errorf("expected ErrTemplateNotFound, got %v", err)
 	}
 }
 

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -59,22 +59,63 @@ func (s *Server) handleProjectTemplateImport(w http.ResponseWriter, r *http.Requ
 }
 
 // handleProjectTemplateUpdate serves PUT /api/project-templates/{templateID}:
-// edit a template's display metadata (template.json).
+// edit a template's display metadata (template.json). The optional `tags` field
+// is tri-state: omitted preserves existing tags, an explicit empty array clears
+// them — so the legacy manage modal (which never sends tags) can't wipe them.
 func (s *Server) handleProjectTemplateUpdate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string    `json:"name"`
+		Description string    `json:"description"`
+		Tags        *[]string `json:"tags"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
 
-	tpl, err := projecttemplates.UpdateManifest(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name, req.Description)
+	tpl, err := projecttemplates.UpdateManifest(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name, req.Description, req.Tags)
 	if err != nil {
 		s.respondProjectTemplateError(w, err)
 		return
 	}
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "template": tpl})
+}
+
+// handleProjectTemplateCreate serves POST /api/project-templates: create a new,
+// empty template in the library from a display name.
+func (s *Server) handleProjectTemplateCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	tpl, err := projecttemplates.CreateBlank(resolveTemplatesRoot(s.Core.ConfigManager), req.Name)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondCreated(w, map[string]any{"success": true, "template": tpl})
+}
+
+// handleProjectTemplateDuplicate serves POST
+// /api/project-templates/{templateID}/duplicate: copy an existing template into a
+// new one. The (optional) `name` seeds the copy's display name and id; send `{}`
+// for a default "<source> copy".
+func (s *Server) handleProjectTemplateDuplicate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name,omitempty"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	tpl, err := projecttemplates.Duplicate(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondCreated(w, map[string]any{"success": true, "template": tpl})
 }
 
 // handleProjectTemplateDelete serves DELETE /api/project-templates/{templateID}.
@@ -130,6 +171,8 @@ func (s *Server) respondProjectTemplateError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, projecttemplates.ErrTemplateNotFound):
 		_ = orihttp.RespondNotFound(w, err.Error())
+	case errors.Is(err, projecttemplates.ErrInvalidTemplateName):
+		_ = orihttp.RespondBadRequest(w, err.Error())
 	case errors.Is(err, projecttemplates.ErrTemplateExists):
 		_ = orihttp.RespondConflict(w, err.Error())
 	default:

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -42,6 +42,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		http.Redirect(w, r, "/vaults", http.StatusMovedPermanently)
 	})
 	mux.HandleFunc("/skills", s.serveSkills)
+	mux.HandleFunc("/templates", s.serveTemplates)
 	mux.HandleFunc("/workflows", s.serveWorkflows)
 	mux.HandleFunc("/mcp", s.serveMCP)
 	mux.HandleFunc("/plugins", s.servePlugins)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -597,8 +597,10 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 
 		// Project template library (used by the workspace creation flow)
 		mux.HandleFunc("/api/project-templates", s.handleProjectTemplates)
+		mux.HandleFunc("POST /api/project-templates", s.handleProjectTemplateCreate)
 		mux.HandleFunc("POST /api/project-templates/import", s.handleProjectTemplateImport)
 		mux.HandleFunc("POST /api/project-templates/reveal", s.handleProjectTemplateReveal)
+		mux.HandleFunc("POST /api/project-templates/{templateID}/duplicate", s.handleProjectTemplateDuplicate)
 		mux.HandleFunc("PUT /api/project-templates/{templateID}", s.handleProjectTemplateUpdate)
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}", s.handleProjectTemplateDelete)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -316,6 +316,14 @@ func (s *Server) serveSkills(w http.ResponseWriter, r *http.Request) {
 	s.renderAndWritePage(w, "skills", data)
 }
 
+func (s *Server) serveTemplates(w http.ResponseWriter, r *http.Request) {
+	data := s.prepareBasePageData("templates")
+	data.Title = "Templates - Ori Agent"
+	data.BrandText = "Ori Agent"
+	data.ShowSidebarToggle = true
+	s.renderAndWritePage(w, "templates", data)
+}
+
 func (s *Server) serveModels(w http.ResponseWriter, r *http.Request) {
 	data := s.prepareBasePageData("models")
 	data.ShowSidebarToggle = true

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -1,0 +1,443 @@
+/**
+ * Templates page controller (/templates).
+ *
+ * Owns the dedicated project-template library page: master list (search + tag
+ * filter), detail Overview (edit name/description/tags), and lifecycle actions
+ * (create blank, import folder, duplicate, delete, reveal). The Files and
+ * Onboarding tabs are placeholders here — they are filled in by later seams.
+ *
+ * The library is disk-first (a template is a folder), so every action is a thin
+ * veneer over the project-templates HTTP API. Tag editing/filtering reuse the
+ * shared widgets exposed on window by tag-input.js / tag-filter-bar.js (loaded
+ * globally in head.tmpl).
+ */
+
+const tplState = {
+  templates: [],
+  root: '',
+  selectedId: '',
+  search: '',
+  activeTags: [],
+  tagsWidget: null,
+  filterBar: null,
+  nameAction: null // { title, label, confirm, initial, run(name) }
+};
+
+function tplToast(message, kind) {
+  if (typeof window.showToast === 'function') {
+    window.showToast(message, kind || 'info');
+  } else if (kind === 'error') {
+    console.error(message);
+  }
+}
+
+function tplEl(id) {
+  return document.getElementById(id);
+}
+
+async function tplFetchJSON(url, options) {
+  const response = await fetch(url, options);
+  const result = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(result.message || result.error || `Request failed (${response.status})`);
+  }
+  return result;
+}
+
+function tplShowError(message) {
+  const box = tplEl('tplError');
+  if (!box) return;
+  if (!message) {
+    box.classList.add('d-none');
+    box.textContent = '';
+    return;
+  }
+  box.textContent = message;
+  box.classList.remove('d-none');
+}
+
+function tplSelected() {
+  return tplState.templates.find((t) => t.id === tplState.selectedId) || null;
+}
+
+// --- Loading & list rendering ---
+
+async function tplRefresh(selectId) {
+  try {
+    const data = await tplFetchJSON('/api/project-templates');
+    tplState.templates = Array.isArray(data.templates) ? data.templates : [];
+    tplState.root = data.templates_root || '';
+    tplShowError('');
+  } catch (error) {
+    console.error('Failed to load templates:', error);
+    tplShowError('Could not load the template library.');
+    tplState.templates = [];
+  }
+
+  const rootPath = tplEl('tplRootPath');
+  if (rootPath) rootPath.textContent = tplState.root;
+
+  // Keep selection valid; default to the requested or first template.
+  if (selectId && tplState.templates.some((t) => t.id === selectId)) {
+    tplState.selectedId = selectId;
+  } else if (!tplState.templates.some((t) => t.id === tplState.selectedId)) {
+    tplState.selectedId = '';
+  }
+
+  tplSyncFilterTags();
+  tplRenderList();
+  tplRenderDetail();
+}
+
+function tplVisibleTemplates() {
+  let items = tplState.templates;
+  const fb = window.OriTagFilterBar;
+  if (fb && tplState.activeTags.length) {
+    items = fb.filterItems(items, tplState.activeTags, (t) => t.tags || []);
+  }
+  const q = tplState.search.trim().toLowerCase();
+  if (q) {
+    items = items.filter((t) =>
+      [t.name, t.id, t.description].filter(Boolean).some((v) => v.toLowerCase().includes(q))
+    );
+  }
+  return items;
+}
+
+function tplRenderList() {
+  const list = tplEl('tplList');
+  const empty = tplEl('tplEmpty');
+  const count = tplEl('tplCount');
+  if (!list) return;
+
+  const visible = tplVisibleTemplates();
+  if (count) count.textContent = String(visible.length);
+  if (empty) empty.hidden = tplState.templates.length > 0;
+
+  list.innerHTML = '';
+  if (tplState.templates.length === 0) return;
+  if (visible.length === 0) {
+    const none = document.createElement('div');
+    none.className = 'text-center py-3';
+    none.style.cssText = 'color: var(--text-secondary); font-size: 13px;';
+    none.textContent = 'No templates match the current filters.';
+    list.appendChild(none);
+    return;
+  }
+
+  for (const template of visible) {
+    list.appendChild(tplBuildRow(template));
+  }
+}
+
+function tplBuildRow(template) {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'modern-card p-2 text-start w-100';
+  row.setAttribute('role', 'listitem');
+  row.style.cssText =
+    'border: 1px solid var(--border-color); background: var(--bg-secondary);' +
+    (template.id === tplState.selectedId ? ' outline: 2px solid var(--accent-color, #6366f1);' : '');
+  row.addEventListener('click', () => {
+    if (tplState.selectedId === template.id) return;
+    tplState.selectedId = template.id;
+    tplRenderList();
+    tplRenderDetail();
+  });
+
+  const title = document.createElement('div');
+  title.style.cssText = 'color: var(--text-primary); font-size: 14px; font-weight: 600; word-break: break-word;';
+  title.textContent = template.name || template.id;
+  row.appendChild(title);
+
+  const id = document.createElement('div');
+  id.style.cssText = 'font-size: 11px; color: var(--text-secondary); font-family: var(--font-mono, monospace);';
+  id.textContent = template.id;
+  row.appendChild(id);
+
+  if (template.description) {
+    const desc = document.createElement('div');
+    desc.style.cssText =
+      'font-size: 12px; color: var(--text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;';
+    desc.textContent = template.description;
+    row.appendChild(desc);
+  }
+
+  if (Array.isArray(template.tags) && template.tags.length) {
+    const tags = document.createElement('div');
+    tags.className = 'd-flex gap-1 flex-wrap mt-1';
+    for (const tag of template.tags) {
+      const chip = document.createElement('span');
+      chip.className = 'badge';
+      chip.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 500; font-size: 10px;';
+      chip.textContent = tag;
+      tags.appendChild(chip);
+    }
+    row.appendChild(tags);
+  }
+
+  return row;
+}
+
+// --- Tag filter bar ---
+
+function tplEnsureFilterBar() {
+  if (tplState.filterBar || !window.OriTagFilterBar) return;
+  const container = tplEl('tplTagFilter');
+  if (!container) return;
+  tplState.filterBar = window.OriTagFilterBar.createTagFilterBar({
+    container,
+    label: 'Tags',
+    onChange: (active) => {
+      tplState.activeTags = active;
+      tplRenderList();
+    }
+  });
+}
+
+function tplSyncFilterTags() {
+  tplEnsureFilterBar();
+  if (!tplState.filterBar || !window.OriTagFilterBar) return;
+  const available = window.OriTagFilterBar.collectTags(tplState.templates, (t) => t.tags || []);
+  tplState.filterBar.setAvailableTags(available);
+  tplState.activeTags = tplState.filterBar.getActiveTags();
+}
+
+// --- Detail / Overview ---
+
+function tplEnsureTagsWidget() {
+  if (tplState.tagsWidget || !window.OriTagInput) return;
+  const container = tplEl('tplEditTags');
+  if (!container) return;
+  tplState.tagsWidget = window.OriTagInput.createTagInput({
+    container,
+    placeholder: 'Add a tag…',
+    onChange: () => {}
+  });
+}
+
+function tplRenderDetail() {
+  const detail = tplEl('tplDetail');
+  const emptyDetail = tplEl('tplDetailEmpty');
+  const template = tplSelected();
+
+  if (!template) {
+    if (detail) detail.hidden = true;
+    if (emptyDetail) emptyDetail.hidden = false;
+    return;
+  }
+  if (emptyDetail) emptyDetail.hidden = true;
+  if (detail) detail.hidden = false;
+
+  const nameHeading = tplEl('tplDetailName');
+  if (nameHeading) nameHeading.textContent = template.name || template.id;
+  const idLabel = tplEl('tplDetailId');
+  if (idLabel) idLabel.textContent = template.id;
+
+  tplResetOverviewFields();
+}
+
+function tplResetOverviewFields() {
+  const template = tplSelected();
+  if (!template) return;
+  const nameInput = tplEl('tplEditName');
+  const descInput = tplEl('tplEditDescription');
+  // A name equal to the id is a folder-name fallback, not an explicit name.
+  if (nameInput) nameInput.value = template.name && template.name !== template.id ? template.name : '';
+  if (descInput) descInput.value = template.description || '';
+  tplEnsureTagsWidget();
+  if (tplState.tagsWidget) tplState.tagsWidget.setTags(template.tags || []);
+}
+
+async function tplSaveOverview() {
+  const template = tplSelected();
+  if (!template) return;
+  const nameInput = tplEl('tplEditName');
+  const descInput = tplEl('tplEditDescription');
+  const tags = tplState.tagsWidget ? tplState.tagsWidget.getTags() : (template.tags || []);
+  try {
+    await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: nameInput ? nameInput.value.trim() : '',
+        description: descInput ? descInput.value.trim() : '',
+        tags
+      })
+    });
+    tplToast('Template saved.', 'success');
+    await tplRefresh(template.id);
+  } catch (error) {
+    tplToast(error.message || 'Failed to save template', 'error');
+  }
+}
+
+// --- Lifecycle ---
+
+function tplOpenNameModal(action) {
+  tplState.nameAction = action;
+  const titleEl = tplEl('tplNameModalTitle');
+  const labelEl = tplEl('tplNameModalLabel');
+  const confirmEl = tplEl('tplNameModalConfirm');
+  const input = tplEl('tplNameModalInput');
+  if (titleEl) titleEl.textContent = action.title;
+  if (labelEl) labelEl.textContent = action.label;
+  if (confirmEl) confirmEl.textContent = action.confirm;
+  if (input) input.value = action.initial || '';
+  const modalEl = tplEl('tplNameModal');
+  if (!modalEl) return;
+  const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+  modal.show();
+  if (input) setTimeout(() => input.focus(), 200);
+}
+
+async function tplRunNameAction() {
+  const action = tplState.nameAction;
+  const input = tplEl('tplNameModalInput');
+  if (!action || !input) return;
+  const name = input.value.trim();
+  try {
+    await action.run(name);
+    const modalEl = tplEl('tplNameModal');
+    if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+  } catch (error) {
+    tplToast(error.message || 'Action failed', 'error');
+  }
+}
+
+function tplCreate() {
+  tplOpenNameModal({
+    title: 'New Template',
+    label: 'Template name',
+    confirm: 'Create',
+    initial: '',
+    run: async (name) => {
+      if (!name) throw new Error('Please enter a name.');
+      const result = await tplFetchJSON('/api/project-templates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+      });
+      const created = result.template || {};
+      tplToast(`Created "${created.name || created.id || name}".`, 'success');
+      await tplRefresh(created.id);
+    }
+  });
+}
+
+function tplDuplicate() {
+  const template = tplSelected();
+  if (!template) return;
+  tplOpenNameModal({
+    title: 'Duplicate Template',
+    label: 'New template name',
+    confirm: 'Duplicate',
+    initial: `${template.name || template.id} copy`,
+    run: async (name) => {
+      const result = await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}/duplicate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+      });
+      const created = result.template || {};
+      tplToast(`Duplicated to "${created.name || created.id}".`, 'success');
+      await tplRefresh(created.id);
+    }
+  });
+}
+
+async function tplImport() {
+  try {
+    const picked = await tplFetchJSON('/api/folder-picker/select-path', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Select a Folder to Import as a Template' })
+    });
+    if (!picked.selected || !picked.path) return;
+    const result = await tplFetchJSON('/api/project-templates/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: picked.path })
+    });
+    const imported = result.template || {};
+    tplToast(`Imported "${imported.name || imported.id || 'template'}".`, 'success');
+    await tplRefresh(imported.id);
+  } catch (error) {
+    tplToast(error.message || 'Failed to import folder', 'error');
+  }
+}
+
+async function tplDelete() {
+  const template = tplSelected();
+  if (!template) return;
+  const label = template.name || template.id;
+  if (!window.confirm(`Delete the template "${label}"? It will be moved to the Trash when possible.`)) {
+    return;
+  }
+  try {
+    const result = await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, { method: 'DELETE' });
+    tplToast(result.trashed ? `"${label}" moved to Trash.` : `"${label}" deleted.`, 'success');
+    tplState.selectedId = '';
+    await tplRefresh();
+  } catch (error) {
+    tplToast(error.message || 'Failed to delete template', 'error');
+  }
+}
+
+async function tplReveal(id) {
+  try {
+    await tplFetchJSON('/api/project-templates/reveal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: id || '' })
+    });
+  } catch (error) {
+    tplToast(error.message || 'Failed to open folder', 'error');
+  }
+}
+
+// --- Init ---
+
+function tplInit() {
+  const page = tplEl('templatesPage');
+  if (!page) return;
+
+  tplEl('tplCreateBtn')?.addEventListener('click', tplCreate);
+  tplEl('tplImportBtn')?.addEventListener('click', () => void tplImport());
+  tplEl('tplOpenLibraryBtn')?.addEventListener('click', () => void tplReveal(''));
+  tplEl('tplRefreshBtn')?.addEventListener('click', () => void tplRefresh(tplState.selectedId));
+
+  tplEl('tplDuplicateBtn')?.addEventListener('click', tplDuplicate);
+  tplEl('tplRevealBtn')?.addEventListener('click', () => {
+    const t = tplSelected();
+    if (t) void tplReveal(t.id);
+  });
+  tplEl('tplDeleteBtn')?.addEventListener('click', () => void tplDelete());
+
+  tplEl('tplSaveBtn')?.addEventListener('click', () => void tplSaveOverview());
+  tplEl('tplResetBtn')?.addEventListener('click', tplResetOverviewFields);
+
+  const search = tplEl('tplSearch');
+  if (search) {
+    search.addEventListener('input', () => {
+      tplState.search = search.value;
+      tplRenderList();
+    });
+  }
+
+  tplEl('tplNameModalConfirm')?.addEventListener('click', () => void tplRunNameAction());
+  tplEl('tplNameModalInput')?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      void tplRunNameAction();
+    }
+  });
+
+  void tplRefresh();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', tplInit);
+} else {
+  tplInit();
+}

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -111,6 +111,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/models.tmpl",
 		"templates/pages/review.tmpl",
 		"templates/pages/skills.tmpl",
+		"templates/pages/templates.tmpl",
 		"templates/pages/workspaces.tmpl",
 		"templates/pages/personalize.tmpl",
 		"templates/pages/note.tmpl",
@@ -154,6 +155,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["models"] = tmpl
 	tr.templates["review"] = tmpl
 	tr.templates["skills"] = tmpl
+	tr.templates["templates"] = tmpl
 	tr.templates["workspaces"] = tmpl
 	tr.templates["personalize"] = tmpl
 	tr.templates["note-page"] = tmpl
@@ -179,7 +181,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-create", "skills", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspaces-hub", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/components/sidebar.tmpl
+++ b/internal/web/templates/components/sidebar.tmpl
@@ -56,6 +56,13 @@
         <span>Skills</span>
       </a>
 
+      <a href="/templates" class="sidebar-nav-link {{if eq .CurrentPage "templates"}}active{{end}}" data-title="Templates">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M15,7H20.5L15,1.5V7M8,0H16L22,6V18A2,2 0 0,1 20,20H8C6.89,20 6,19.1 6,18V2A2,2 0 0,1 8,0M4,4V22H20V24H4A2,2 0 0,1 2,22V4H4Z"/>
+        </svg>
+        <span>Templates</span>
+      </a>
+
       <a href="/usage" class="sidebar-nav-link {{if eq .CurrentPage "usage"}}active{{end}}" data-title="Usage & Costs">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M16,11.78L20.24,4.45L21.97,5.45L16.74,14.5L10.23,10.75L5.46,19H22V21H2V3H4V17.54L9.5,8L16,11.78Z"/>

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -1,0 +1,194 @@
+{{define "templates"}}
+<!DOCTYPE html>
+<html data-bs-theme="light">
+{{template "head.tmpl" .}}
+
+<body class="bg-light">
+  <!-- Navigation -->
+  {{template "navbar.tmpl" .}}
+
+  <div class="main-content-wrapper" id="templatesPage" data-current-agent="{{index .Extra "DefaultAgentName"}}">
+    {{template "sidebar.tmpl" .}}
+
+    <!-- Main Content -->
+    <div class="main-content">
+      <div class="container-fluid py-4">
+        <!-- Header -->
+        <div class="modern-card p-4 mb-4">
+          <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+            <div style="min-width: 0;">
+              <h2 class="mb-2" style="color: var(--text-primary);">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" class="me-2" style="vertical-align: text-bottom;">
+                  <path d="M15,7H20.5L15,1.5V7M8,0H16L22,6V18A2,2 0 0,1 20,20H8C6.89,20 6,19.1 6,18V2A2,2 0 0,1 8,0M4,4V22H20V24H4A2,2 0 0,1 2,22V4H4Z"/>
+                </svg>
+                Templates
+              </h2>
+              <p class="mb-0" style="color: var(--text-secondary);">
+                Project templates are folder skeletons copied into a workspace to become its project.
+                A template is just a folder — drop one into the library or create one here.
+              </p>
+              <div class="mt-2 d-flex align-items-baseline gap-2 flex-wrap">
+                <span style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Library</span>
+                <span id="tplRootPath" style="font-size: 12px; color: var(--text-primary); font-family: var(--font-mono, monospace); overflow-wrap: anywhere;"></span>
+                <a href="/settings#templates" style="font-size: 12px;">Change…</a>
+              </div>
+            </div>
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+              <button id="tplCreateBtn" class="modern-btn modern-btn-primary btn-sm">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="me-1"><path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/></svg>
+                New Template
+              </button>
+              <button id="tplImportBtn" class="modern-btn modern-btn-secondary btn-sm">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="me-1"><path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,3.5L18.5,9H13V3.5M12,19L8,15H10.5V12H13.5V15H16L12,19Z"/></svg>
+                Import Folder…
+              </button>
+              <button id="tplOpenLibraryBtn" class="modern-btn modern-btn-secondary btn-sm">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="me-1"><path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/></svg>
+                Open Library
+              </button>
+              <button id="tplRefreshBtn" class="modern-btn modern-btn-secondary btn-sm" aria-label="Refresh">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div id="tplError" class="alert alert-danger d-none" style="font-size: 0.875rem;"></div>
+
+        <!-- Master / detail -->
+        <div class="row g-3">
+          <!-- Master list -->
+          <div class="col-12 col-lg-4">
+            <div class="modern-card p-3">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h6 class="mb-0" style="color: var(--text-primary);">Library</h6>
+                <span id="tplCount" class="badge bg-secondary" style="font-size: 12px;">0</span>
+              </div>
+              <input id="tplSearch" type="text" class="modern-input w-100 mb-2" placeholder="Search templates…" aria-label="Search templates">
+              <div id="tplTagFilter" class="mb-2"></div>
+              <div id="tplEmpty" class="text-center py-4" style="font-size: 13px; color: var(--text-secondary);" hidden>
+                No templates yet. Create one above, import a folder, or drop a folder into the library.
+              </div>
+              <div id="tplList" class="d-flex flex-column gap-2" role="list" aria-label="Project templates">
+                <div class="text-center py-3" style="color: var(--text-secondary);">Loading templates…</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Detail -->
+          <div class="col-12 col-lg-8">
+            <div class="modern-card p-4">
+              <!-- Empty detail -->
+              <div id="tplDetailEmpty" class="text-center py-5" style="color: var(--text-secondary);">
+                <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor" style="opacity: 0.4;"><path d="M15,7H20.5L15,1.5V7M8,0H16L22,6V18A2,2 0 0,1 20,20H8C6.89,20 6,19.1 6,18V2A2,2 0 0,1 8,0M4,4V22H20V24H4A2,2 0 0,1 2,22V4H4Z"/></svg>
+                <div class="mt-2">Select a template to view and edit it.</div>
+              </div>
+
+              <!-- Detail body -->
+              <div id="tplDetail" hidden>
+                <div class="d-flex justify-content-between align-items-start gap-3 mb-3 flex-wrap">
+                  <div style="min-width: 0;">
+                    <h4 id="tplDetailName" class="mb-1" style="color: var(--text-primary); word-break: break-word;">Template</h4>
+                    <code id="tplDetailId" style="font-size: 12px; color: var(--text-secondary);"></code>
+                  </div>
+                  <div class="d-flex gap-2 flex-wrap">
+                    <button id="tplDuplicateBtn" class="modern-btn modern-btn-secondary btn-sm">Duplicate</button>
+                    <button id="tplRevealBtn" class="modern-btn modern-btn-secondary btn-sm">Reveal</button>
+                    <button id="tplDeleteBtn" class="modern-btn modern-btn-secondary btn-sm" style="color: #ef4444;">Delete</button>
+                  </div>
+                </div>
+
+                <ul class="nav nav-tabs mb-3" role="tablist">
+                  <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tplTabOverview" data-bs-toggle="tab" data-bs-target="#tplOverviewPane" type="button" role="tab" aria-controls="tplOverviewPane" aria-selected="true">Overview</button>
+                  </li>
+                  <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tplTabFiles" data-bs-toggle="tab" data-bs-target="#tplFilesPane" type="button" role="tab" aria-controls="tplFilesPane" aria-selected="false">Files</button>
+                  </li>
+                  <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tplTabOnboarding" data-bs-toggle="tab" data-bs-target="#tplOnboardingPane" type="button" role="tab" aria-controls="tplOnboardingPane" aria-selected="false">Onboarding</button>
+                  </li>
+                </ul>
+
+                <div class="tab-content">
+                  <!-- Overview / metadata -->
+                  <div class="tab-pane fade show active" id="tplOverviewPane" role="tabpanel" aria-labelledby="tplTabOverview">
+                    <div class="mb-3">
+                      <label for="tplEditName" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Display name</label>
+                      <input id="tplEditName" type="text" class="modern-input w-100" maxlength="120" placeholder="Defaults to the folder id">
+                    </div>
+                    <div class="mb-3">
+                      <label for="tplEditDescription" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Description</label>
+                      <textarea id="tplEditDescription" class="form-control" rows="3" style="background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.9em; resize: vertical;" placeholder="What is this template for?"></textarea>
+                    </div>
+                    <div class="mb-3">
+                      <label class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Tags</label>
+                      <div id="tplEditTags"></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      <button id="tplSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save changes</button>
+                      <button id="tplResetBtn" class="modern-btn modern-btn-secondary btn-sm">Reset</button>
+                    </div>
+                  </div>
+
+                  <!-- Files (Seam PR 2) -->
+                  <div class="tab-pane fade" id="tplFilesPane" role="tabpanel" aria-labelledby="tplTabFiles">
+                    <div class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;">
+                      In-app file editing is coming soon. For now, use <strong>Reveal</strong> to open the
+                      template folder and edit its files on disk.
+                    </div>
+                  </div>
+
+                  <!-- Onboarding (Seam PR 3) -->
+                  <div class="tab-pane fade" id="tplOnboardingPane" role="tabpanel" aria-labelledby="tplTabOnboarding">
+                    <div class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;">
+                      The onboarding intake editor is coming soon. Onboarding blocks authored in
+                      <code>template.json</code> still run when a workspace is created.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Shared modals (sidebar add-agent, etc.) -->
+  {{template "modals.tmpl" .}}
+
+  <!-- Name modal: reused for Create and Duplicate -->
+  <div class="modal fade" id="tplNameModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content" style="background: var(--bg-primary); border: 1px solid var(--border-color);">
+        <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
+          <h5 class="modal-title" id="tplNameModalTitle" style="color: var(--text-primary);">New Template</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" style="color: var(--text-primary);">
+          <label for="tplNameModalInput" id="tplNameModalLabel" class="form-label">Template name</label>
+          <input id="tplNameModalInput" type="text" class="modern-input w-100" maxlength="120" placeholder="e.g. REAPER Song">
+          <small class="form-helper">The folder id is derived from the name (lowercase, hyphenated).</small>
+        </div>
+        <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
+          <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" id="tplNameModalConfirm" class="modern-btn modern-btn-primary">Create</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Scripts -->
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/agents.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/templates-page.js"></script>
+  {{template "theme-init.tmpl" .}}
+</body>
+</html>
+{{end}}

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -46,6 +46,41 @@ func TestRenderWorkspaceDetailGroupScaffold(t *testing.T) {
 	}
 }
 
+// TestRenderTemplatesPage confirms the /templates page renders, carries the
+// master/detail scaffold and lifecycle controls, and highlights its sidebar
+// link when CurrentPage is "templates".
+func TestRenderTemplatesPage(t *testing.T) {
+	r := NewTemplateRenderer()
+	if err := r.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+
+	data := TemplateData{Title: "Templates - Ori Agent", CurrentPage: "templates"}
+	html, err := r.RenderTemplate("templates", data)
+	if err != nil {
+		t.Fatalf("RenderTemplate(templates) failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`id="tplList"`,
+		`id="tplCreateBtn"`,
+		`id="tplImportBtn"`,
+		`id="tplDetail"`,
+		`id="tplEditTags"`,
+		`id="tplNameModal"`,
+		`/js/modules/templates-page.js`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered templates page missing %q", want)
+		}
+	}
+
+	// The Templates sidebar link should be marked active for this page.
+	if !strings.Contains(html, `href="/templates" class="sidebar-nav-link active"`) {
+		t.Errorf("templates sidebar link not highlighted as active")
+	}
+}
+
 func TestRenderAgentsDetailDefaultsSidebarHidden(t *testing.T) {
 	r := NewTemplateRenderer()
 	if err := r.LoadTemplates(); err != nil {


### PR DESCRIPTION
## Templates page — Seam PR 1 of 3

First slice of the in-app project-template maintenance epic: promote template
management from the cramped `projectTemplatesManageModal` into a dedicated,
first-class `/templates` page (sibling of `/skills`, `/workflows`). The
existing manage modal is left untouched — this page is additive.

### Backend (`f882c12`)
- `UpdateManifest` gains a tri-state `tags *[]string`: omitted preserves
  existing tags (so the legacy modal can't wipe them), a non-empty slice
  replaces with the normalized set, an explicit `[]` clears the key; unknown
  manifest keys still preserved.
- `CreateBlank` — new empty template from a name (409 collision, 400 blank).
- `Duplicate` — verbatim copy (files, tags, onboarding carry over); default
  name `"<source> copy"`.
- New endpoints: `POST /api/project-templates` (create),
  `POST /api/project-templates/{id}/duplicate`, plus `tags` on the existing
  `PUT`. `ErrInvalidTemplateName` → 400.

### Frontend (`cf23952`)
- `serveTemplates` + `/templates` route + page-template registration + sidebar
  link.
- `templates.tmpl`: master/detail layout — left list (search + tag filter),
  right detail with **Overview / Files / Onboarding** tabs. **Files and
  Onboarding are inert placeholders**, filled in by Seams 2 and 3.
- `templates-page.js`: list render, search + tag filtering (reuses
  `OriTagFilterBar`), Overview metadata editing (name/description +
  `OriTagInput` tags) saved via `PUT`, and lifecycle actions (create, import,
  duplicate, delete→Trash, reveal, open library).

### Verification
- New `TestRenderTemplatesPage` (renders + sidebar highlight); `go test`
  (web/server/projecttemplates), `go vet`, and ESLint all green.
- Backend unit tests: tags tri-state, create-blank, duplicate.
- Live isolated-server **browser smoke**: list render, tag filter, selection,
  create flow, and tag-edit→save (persisted + reflected in the filter pool),
  with no console errors.

### Scope note
This is **seam 1 of 3**. Follow-ups: Seam 2 = in-app file authoring (tree +
editor, path-jailed CRUD); Seam 3 = onboarding visual editor. Each lands as its
own PR; interim states stay shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)