### PR TITLE
feat(templates): in-app file authoring — path-jailed tree + editor (seam 2/3)

### DIFF
--- a/internal/projecttemplates/files.go
+++ b/internal/projecttemplates/files.go
@@ -1,0 +1,351 @@
+package projecttemplates
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MaxEditableFileSize caps the bytes the in-app editor will read/return. Larger
+// files are surfaced read-only with a "reveal in the file manager" affordance.
+const MaxEditableFileSize = 512 * 1024
+
+// File-operation sentinels. They map to HTTP status codes in the handler layer:
+// ErrInvalidPath→400, ErrFileNotFound→404, ErrFileExists→409, ErrFileTooLarge→413.
+var (
+	// ErrInvalidPath reports a path that is empty, absolute, escapes the
+	// template folder, traverses a symlink, or is otherwise unusable.
+	ErrInvalidPath = errors.New("invalid file path")
+	// ErrFileNotFound reports a read/write/rename/delete targeting a path that
+	// does not exist inside the template.
+	ErrFileNotFound = errors.New("file not found")
+	// ErrFileExists reports a create/rename onto a path that already exists.
+	ErrFileExists = errors.New("file already exists")
+	// ErrFileTooLarge reports a read of a file above MaxEditableFileSize.
+	ErrFileTooLarge = errors.New("file is too large to edit")
+)
+
+// Node is one entry in a template's file tree. Path is always forward-slash
+// relative to the template folder.
+type Node struct {
+	Path       string `json:"path"`
+	Type       string `json:"type"` // "file" or "dir"
+	Size       int64  `json:"size"`
+	IsManifest bool   `json:"is_manifest,omitempty"` // template.json — display metadata, read-only here
+}
+
+// FileContent is one file's bytes for the editor. Binary or manifest files are
+// returned read-only (Content empty for binary).
+type FileContent struct {
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	Size     int64  `json:"size"`
+	ReadOnly bool   `json:"read_only"`
+	Binary   bool   `json:"binary"`
+}
+
+// resolveTemplatePath is the single jail every file operation goes through. It
+// resolves the template id against the library (FindLibraryTemplate already
+// rejects ids outside the library), then resolves rel strictly within the
+// template folder, rejecting traversal, absolute paths, backslashes, NUL bytes,
+// and any component that is (or passes through) a symlink.
+func resolveTemplatePath(libDir, id, rel string) (string, error) {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return "", err
+	}
+	root, err := filepath.Abs(tpl.Path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve template path: %w", err)
+	}
+	return resolveWithinRoot(filepath.Clean(root), rel)
+}
+
+func resolveWithinRoot(root, rel string) (string, error) {
+	if strings.IndexByte(rel, 0) != -1 {
+		return "", fmt.Errorf("%w: path contains a NUL byte", ErrInvalidPath)
+	}
+	// Accept only forward-slash relative paths so behavior is identical on every
+	// OS (on non-Windows a backslash would otherwise be a literal filename rune).
+	if strings.ContainsRune(rel, '\\') {
+		return "", fmt.Errorf("%w: backslashes are not allowed", ErrInvalidPath)
+	}
+
+	clean := filepath.Clean(filepath.FromSlash(rel))
+	if clean == "." || clean == "" {
+		return "", fmt.Errorf("%w: path is empty", ErrInvalidPath)
+	}
+	// IsLocal rejects absolute paths and any path that climbs out via "..".
+	if !filepath.IsLocal(clean) {
+		return "", fmt.Errorf("%w: %q escapes the template", ErrInvalidPath, rel)
+	}
+
+	abs := filepath.Join(root, clean)
+	// Defense in depth against any Join/Clean surprise.
+	if abs != root && !strings.HasPrefix(abs, root+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q escapes the template", ErrInvalidPath, rel)
+	}
+	if err := ensureNoSymlink(root, clean); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// ensureNoSymlink walks every existing component of clean under root and rejects
+// the operation if any is a symlink — so a user can't drop a symlink inside a
+// template to read or write outside it. Components that don't exist yet (a file
+// being created) are fine. The library root itself is trusted and not checked.
+func ensureNoSymlink(root, clean string) error {
+	cur := root
+	for _, part := range strings.Split(clean, string(filepath.Separator)) {
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // remaining components don't exist yet
+			}
+			return fmt.Errorf("failed to inspect %q: %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: %q is a symlink", ErrInvalidPath, cur)
+		}
+	}
+	return nil
+}
+
+// ListTree returns every file and folder inside a template (excluding the
+// template folder itself), sorted by path. Symlinks are skipped, never followed.
+func ListTree(libDir, id string) ([]Node, error) {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Clean(tpl.Path)
+
+	nodes := []Node{}
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			return nil
+		}
+		// WalkDir does not follow symlinks; skip listing them too.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		nodes = append(nodes, nodeFrom(d, rel))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("failed to list template files: %w", walkErr)
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Path < nodes[j].Path })
+	return nodes, nil
+}
+
+func nodeFrom(d fs.DirEntry, rel string) Node {
+	node := Node{Path: filepath.ToSlash(rel), Type: "file"}
+	if d.IsDir() {
+		node.Type = "dir"
+		return node
+	}
+	if info, err := d.Info(); err == nil {
+		node.Size = info.Size()
+	}
+	if rel == ManifestFileName {
+		node.IsManifest = true
+	}
+	return node
+}
+
+// ReadFileContent returns a file's contents for the editor. A directory or
+// missing file is an error; files above the size cap return ErrFileTooLarge;
+// binary files (and template.json) come back read-only.
+func ReadFileContent(libDir, id, rel string) (FileContent, error) {
+	abs, err := resolveTemplatePath(libDir, id, rel)
+	if err != nil {
+		return FileContent{}, err
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return FileContent{}, fmt.Errorf("%w: %q", ErrFileNotFound, rel)
+		}
+		return FileContent{}, fmt.Errorf("failed to inspect %q: %w", rel, err)
+	}
+	if info.IsDir() {
+		return FileContent{}, fmt.Errorf("%w: %q is a directory", ErrInvalidPath, rel)
+	}
+	if info.Size() > MaxEditableFileSize {
+		return FileContent{}, fmt.Errorf("%w: %q is %d bytes", ErrFileTooLarge, rel, info.Size())
+	}
+
+	data, err := os.ReadFile(abs) // #nosec G304 -- abs is jailed by resolveTemplatePath (library id + path jail, symlinks rejected)
+	if err != nil {
+		return FileContent{}, fmt.Errorf("failed to read %q: %w", rel, err)
+	}
+
+	out := FileContent{Path: relSlash(rel), Size: info.Size()}
+	if isBinary(data) {
+		out.Binary = true
+		out.ReadOnly = true
+		return out, nil
+	}
+	out.Content = string(data)
+	if out.Path == ManifestFileName {
+		out.ReadOnly = true // template.json is edited via the metadata/onboarding editors
+	}
+	return out, nil
+}
+
+// WriteFileContent overwrites an existing file's contents verbatim, preserving
+// its permission bits. The file must already exist (create new files with
+// CreateEntry); a missing path returns ErrFileNotFound. Bytes are written as-is
+// — {{name}}/{{date}} tokens are never substituted.
+func WriteFileContent(libDir, id, rel, content string) error {
+	abs, err := resolveTemplatePath(libDir, id, rel)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: %q", ErrFileNotFound, rel)
+		}
+		return fmt.Errorf("failed to inspect %q: %w", rel, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%w: %q is a directory", ErrInvalidPath, rel)
+	}
+	if err := os.WriteFile(abs, []byte(content), info.Mode().Perm()); err != nil { // #nosec G304 -- abs is jailed by resolveTemplatePath
+		return fmt.Errorf("failed to write %q: %w", rel, err)
+	}
+	return nil
+}
+
+// CreateEntry creates a new file or folder ("file" or "dir") inside a template.
+// Missing parent folders are created. A path that already exists returns
+// ErrFileExists.
+func CreateEntry(libDir, id, rel, entryType string) (Node, error) {
+	abs, err := resolveTemplatePath(libDir, id, rel)
+	if err != nil {
+		return Node{}, err
+	}
+	if _, err := os.Lstat(abs); err == nil {
+		return Node{}, fmt.Errorf("%w: %q", ErrFileExists, rel)
+	} else if !os.IsNotExist(err) {
+		return Node{}, fmt.Errorf("failed to inspect %q: %w", rel, err)
+	}
+
+	switch entryType {
+	case "dir":
+		if err := os.MkdirAll(abs, 0o750); err != nil {
+			return Node{}, fmt.Errorf("failed to create folder %q: %w", rel, err)
+		}
+	case "file":
+		if err := os.MkdirAll(filepath.Dir(abs), 0o750); err != nil {
+			return Node{}, fmt.Errorf("failed to create parent of %q: %w", rel, err)
+		}
+		f, err := os.OpenFile(abs, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640) // #nosec G304 G302 -- abs is jailed by resolveTemplatePath; 0o640 matches the package's template-file permission convention
+		if err != nil {
+			return Node{}, fmt.Errorf("failed to create file %q: %w", rel, err)
+		}
+		_ = f.Close()
+	default:
+		return Node{}, fmt.Errorf("%w: type must be \"file\" or \"dir\"", ErrInvalidPath)
+	}
+	return statNode(abs, rel)
+}
+
+// RenameEntry moves a file or folder within a template. The source must exist
+// and the destination must not (ErrFileExists otherwise).
+func RenameEntry(libDir, id, from, to string) (Node, error) {
+	fromAbs, err := resolveTemplatePath(libDir, id, from)
+	if err != nil {
+		return Node{}, err
+	}
+	toAbs, err := resolveTemplatePath(libDir, id, to)
+	if err != nil {
+		return Node{}, err
+	}
+	if _, err := os.Lstat(fromAbs); err != nil {
+		if os.IsNotExist(err) {
+			return Node{}, fmt.Errorf("%w: %q", ErrFileNotFound, from)
+		}
+		return Node{}, fmt.Errorf("failed to inspect %q: %w", from, err)
+	}
+	if _, err := os.Lstat(toAbs); err == nil {
+		return Node{}, fmt.Errorf("%w: %q", ErrFileExists, to)
+	} else if !os.IsNotExist(err) {
+		return Node{}, fmt.Errorf("failed to inspect %q: %w", to, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(toAbs), 0o750); err != nil {
+		return Node{}, fmt.Errorf("failed to create destination parent: %w", err)
+	}
+	if err := os.Rename(fromAbs, toAbs); err != nil {
+		return Node{}, fmt.Errorf("failed to rename %q: %w", from, err)
+	}
+	return statNode(toAbs, to)
+}
+
+// DeleteEntry removes a file or folder (recursively) from a template. A missing
+// path returns ErrFileNotFound.
+func DeleteEntry(libDir, id, rel string) error {
+	abs, err := resolveTemplatePath(libDir, id, rel)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(abs); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: %q", ErrFileNotFound, rel)
+		}
+		return fmt.Errorf("failed to inspect %q: %w", rel, err)
+	}
+	if err := os.RemoveAll(abs); err != nil {
+		return fmt.Errorf("failed to delete %q: %w", rel, err)
+	}
+	return nil
+}
+
+func statNode(abs, rel string) (Node, error) {
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return Node{}, fmt.Errorf("failed to inspect %q: %w", rel, err)
+	}
+	node := Node{Path: relSlash(rel), Type: "file"}
+	if info.IsDir() {
+		node.Type = "dir"
+		return node, nil
+	}
+	node.Size = info.Size()
+	if node.Path == ManifestFileName {
+		node.IsManifest = true
+	}
+	return node, nil
+}
+
+// relSlash normalizes a caller-supplied relative path to the same forward-slash
+// form ListTree emits, so responses echo a canonical path.
+func relSlash(rel string) string {
+	return filepath.ToSlash(filepath.Clean(filepath.FromSlash(rel)))
+}
+
+// isBinary reports whether data looks binary (a NUL byte in the leading chunk),
+// the same cheap heuristic editors use to refuse non-text files.
+func isBinary(data []byte) bool {
+	const sniff = 8000
+	if len(data) > sniff {
+		data = data[:sniff]
+	}
+	return bytes.IndexByte(data, 0) != -1
+}

--- a/internal/projecttemplates/files_test.go
+++ b/internal/projecttemplates/files_test.go
@@ -1,0 +1,234 @@
+package projecttemplates
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// seedFileTemplate creates a library template "tpl" with a small file tree.
+func seedFileTemplate(t *testing.T) string {
+	t.Helper()
+	libDir := filepath.Join(t.TempDir(), "templates")
+	writeFile(t, filepath.Join(libDir, "tpl", "README.md"), "# hi")
+	writeFile(t, filepath.Join(libDir, "tpl", "src", "main.go"), "package main")
+	writeFile(t, filepath.Join(libDir, "tpl", ManifestFileName), `{"name":"Tpl"}`)
+	return libDir
+}
+
+func TestResolveTemplatePathRejectsEscapes(t *testing.T) {
+	libDir := seedFileTemplate(t)
+
+	for _, rel := range []string{
+		"",            // empty
+		".",           // current dir
+		"..",          // parent
+		"../escape",   // traversal
+		"/etc/passwd", // absolute
+		"a/../../etc", // climbs out after cleaning
+		"a\\b",        // backslash
+		"a\x00b",      // NUL byte
+	} {
+		if _, err := resolveTemplatePath(libDir, "tpl", rel); !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("resolveTemplatePath(%q) = %v, want ErrInvalidPath", rel, err)
+		}
+	}
+
+	// A legitimate nested path resolves inside the template.
+	abs, err := resolveTemplatePath(libDir, "tpl", "src/main.go")
+	if err != nil {
+		t.Fatalf("resolveTemplatePath(src/main.go): %v", err)
+	}
+	if !strings.HasSuffix(abs, filepath.Join("tpl", "src", "main.go")) {
+		t.Errorf("unexpected resolved path: %s", abs)
+	}
+
+	// Unknown template id is rejected before any path handling.
+	if _, err := resolveTemplatePath(libDir, "nope", "a.txt"); !errors.Is(err, ErrTemplateNotFound) {
+		t.Errorf("unknown template = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+func TestSymlinkAncestorRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks")
+	}
+	libDir := seedFileTemplate(t)
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.txt"), "TOP SECRET")
+
+	// A symlink dropped inside the template that points outside it.
+	if err := os.Symlink(outside, filepath.Join(libDir, "tpl", "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reading through the symlink ancestor must be refused, not followed.
+	if _, err := ReadFileContent(libDir, "tpl", "escape/secret.txt"); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("read through symlink = %v, want ErrInvalidPath", err)
+	}
+	// The symlink itself as a target is refused too.
+	if _, err := resolveTemplatePath(libDir, "tpl", "escape"); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("symlink target = %v, want ErrInvalidPath", err)
+	}
+}
+
+func TestListTree(t *testing.T) {
+	libDir := seedFileTemplate(t)
+	nodes, err := ListTree(libDir, "tpl")
+	if err != nil {
+		t.Fatalf("ListTree: %v", err)
+	}
+
+	byPath := map[string]Node{}
+	for _, n := range nodes {
+		byPath[n.Path] = n
+	}
+	for _, want := range []string{"README.md", "src", "src/main.go", ManifestFileName} {
+		if _, ok := byPath[want]; !ok {
+			t.Errorf("ListTree missing %q (got %v)", want, byPath)
+		}
+	}
+	if byPath["src"].Type != "dir" {
+		t.Errorf("src should be a dir, got %q", byPath["src"].Type)
+	}
+	if !byPath[ManifestFileName].IsManifest {
+		t.Errorf("template.json should be flagged as manifest")
+	}
+}
+
+func TestListTreeSkipsSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks")
+	}
+	libDir := seedFileTemplate(t)
+	if err := os.Symlink(t.TempDir(), filepath.Join(libDir, "tpl", "link")); err != nil {
+		t.Fatal(err)
+	}
+	nodes, err := ListTree(libDir, "tpl")
+	if err != nil {
+		t.Fatalf("ListTree: %v", err)
+	}
+	for _, n := range nodes {
+		if n.Path == "link" {
+			t.Errorf("symlink should not be listed in the tree")
+		}
+	}
+}
+
+func TestReadWriteFileContent(t *testing.T) {
+	libDir := seedFileTemplate(t)
+
+	fc, err := ReadFileContent(libDir, "tpl", "README.md")
+	if err != nil {
+		t.Fatalf("ReadFileContent: %v", err)
+	}
+	if fc.Content != "# hi" || fc.ReadOnly || fc.Binary {
+		t.Fatalf("unexpected file content: %+v", fc)
+	}
+
+	// template.json is returned read-only (edited via metadata/onboarding, not here).
+	mfc, err := ReadFileContent(libDir, "tpl", ManifestFileName)
+	if err != nil {
+		t.Fatalf("ReadFileContent(manifest): %v", err)
+	}
+	if !mfc.ReadOnly {
+		t.Errorf("template.json should be read-only")
+	}
+
+	// Saving over an existing file is a normal update, not a collision.
+	if err := WriteFileContent(libDir, "tpl", "README.md", "# updated"); err != nil {
+		t.Fatalf("WriteFileContent: %v", err)
+	}
+	fc, _ = ReadFileContent(libDir, "tpl", "README.md")
+	if fc.Content != "# updated" {
+		t.Errorf("content not saved, got %q", fc.Content)
+	}
+
+	// Writing a path that does not exist is 404, not an implicit create.
+	if err := WriteFileContent(libDir, "tpl", "missing.txt", "x"); !errors.Is(err, ErrFileNotFound) {
+		t.Errorf("write missing = %v, want ErrFileNotFound", err)
+	}
+}
+
+func TestReadFileContentBinaryAndOversize(t *testing.T) {
+	libDir := seedFileTemplate(t)
+
+	// Binary file (embedded NUL) comes back read-only with no content.
+	writeFile(t, filepath.Join(libDir, "tpl", "blob.bin"), "abc\x00def")
+	bfc, err := ReadFileContent(libDir, "tpl", "blob.bin")
+	if err != nil {
+		t.Fatalf("ReadFileContent(binary): %v", err)
+	}
+	if !bfc.Binary || !bfc.ReadOnly || bfc.Content != "" {
+		t.Errorf("binary should be read-only with empty content: %+v", bfc)
+	}
+
+	// A file above the cap is refused before reading.
+	big := filepath.Join(libDir, "tpl", "big.txt")
+	if err := os.WriteFile(big, make([]byte, MaxEditableFileSize+1), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileContent(libDir, "tpl", "big.txt"); !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("oversize read = %v, want ErrFileTooLarge", err)
+	}
+}
+
+func TestCreateRenameDelete(t *testing.T) {
+	libDir := seedFileTemplate(t)
+
+	// Create a folder, then a nested file whose name carries a token.
+	if _, err := CreateEntry(libDir, "tpl", "assets", "dir"); err != nil {
+		t.Fatalf("CreateEntry(dir): %v", err)
+	}
+	node, err := CreateEntry(libDir, "tpl", "assets/{{name}}.txt", "file")
+	if err != nil {
+		t.Fatalf("CreateEntry(file): %v", err)
+	}
+	if node.Type != "file" || node.Path != "assets/{{name}}.txt" {
+		t.Fatalf("unexpected node: %+v", node)
+	}
+	// The {{name}} token in the filename is preserved verbatim on disk.
+	if _, err := os.Lstat(filepath.Join(libDir, "tpl", "assets", "{{name}}.txt")); err != nil {
+		t.Errorf("token filename not preserved: %v", err)
+	}
+
+	// Creating onto an existing path collides.
+	if _, err := CreateEntry(libDir, "tpl", "README.md", "file"); !errors.Is(err, ErrFileExists) {
+		t.Errorf("create collision = %v, want ErrFileExists", err)
+	}
+	// An unknown entry type is rejected.
+	if _, err := CreateEntry(libDir, "tpl", "weird", "symlink"); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("bad type = %v, want ErrInvalidPath", err)
+	}
+
+	// Rename (move) the token file; token still preserved.
+	if _, err := RenameEntry(libDir, "tpl", "assets/{{name}}.txt", "assets/{{date}}.txt"); err != nil {
+		t.Fatalf("RenameEntry: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(libDir, "tpl", "assets", "{{date}}.txt")); err != nil {
+		t.Errorf("renamed file missing: %v", err)
+	}
+	// Rename onto an existing destination collides.
+	if _, err := RenameEntry(libDir, "tpl", "assets/{{date}}.txt", "README.md"); !errors.Is(err, ErrFileExists) {
+		t.Errorf("rename collision = %v, want ErrFileExists", err)
+	}
+	// Renaming a missing source is 404.
+	if _, err := RenameEntry(libDir, "tpl", "nope.txt", "x.txt"); !errors.Is(err, ErrFileNotFound) {
+		t.Errorf("rename missing = %v, want ErrFileNotFound", err)
+	}
+
+	// Delete the folder (recursive).
+	if err := DeleteEntry(libDir, "tpl", "assets"); err != nil {
+		t.Fatalf("DeleteEntry: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(libDir, "tpl", "assets")); !os.IsNotExist(err) {
+		t.Errorf("folder still present after delete")
+	}
+	// Deleting a missing path is 404.
+	if err := DeleteEntry(libDir, "tpl", "ghost"); !errors.Is(err, ErrFileNotFound) {
+		t.Errorf("delete missing = %v, want ErrFileNotFound", err)
+	}
+}

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -131,6 +131,102 @@ func (s *Server) handleProjectTemplateDelete(w http.ResponseWriter, r *http.Requ
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "trashed": trashed})
 }
 
+// handleProjectTemplateFilesList serves GET
+// /api/project-templates/{templateID}/files: the template's file/folder tree.
+func (s *Server) handleProjectTemplateFilesList(w http.ResponseWriter, r *http.Request) {
+	nodes, err := projecttemplates.ListTree(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"))
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"files": nodes})
+}
+
+// handleProjectTemplateFileRead serves GET
+// /api/project-templates/{templateID}/files/content?path=<rel>: one file's
+// contents for the editor (read-only for binary/manifest, 413 if oversized).
+func (s *Server) handleProjectTemplateFileRead(w http.ResponseWriter, r *http.Request) {
+	content, err := projecttemplates.ReadFileContent(
+		resolveTemplatesRoot(s.Core.ConfigManager),
+		r.PathValue("templateID"),
+		r.URL.Query().Get("path"),
+	)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, content)
+}
+
+// handleProjectTemplateFileWrite serves PUT
+// /api/project-templates/{templateID}/files/content: overwrite an existing
+// file's bytes verbatim. The file must already exist (use the create endpoint
+// for new files).
+func (s *Server) handleProjectTemplateFileWrite(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if err := projecttemplates.WriteFileContent(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Path, req.Content); err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "path": req.Path})
+}
+
+// handleProjectTemplateFileCreate serves POST
+// /api/project-templates/{templateID}/files: create a new file or folder
+// ({"path": ..., "type": "file"|"dir"}).
+func (s *Server) handleProjectTemplateFileCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	node, err := projecttemplates.CreateEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Path, req.Type)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondCreated(w, map[string]any{"success": true, "node": node})
+}
+
+// handleProjectTemplateFileRename serves POST
+// /api/project-templates/{templateID}/files/rename: move a file or folder
+// ({"from": ..., "to": ...}); the destination must not already exist.
+func (s *Server) handleProjectTemplateFileRename(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	node, err := projecttemplates.RenameEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.From, req.To)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "node": node})
+}
+
+// handleProjectTemplateFileDelete serves DELETE
+// /api/project-templates/{templateID}/files?path=<rel>: remove a file or folder
+// (recursive for folders).
+func (s *Server) handleProjectTemplateFileDelete(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if err := projecttemplates.DeleteEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), path); err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "path": path})
+}
+
 // handleProjectTemplateReveal serves POST /api/project-templates/reveal:
 // open the library root ({} or empty id) or reveal one template ({"id": ...})
 // in the OS file manager. Local-first only, like workspace file open.
@@ -169,12 +265,14 @@ func (s *Server) handleProjectTemplateReveal(w http.ResponseWriter, r *http.Requ
 
 func (s *Server) respondProjectTemplateError(w http.ResponseWriter, err error) {
 	switch {
-	case errors.Is(err, projecttemplates.ErrTemplateNotFound):
+	case errors.Is(err, projecttemplates.ErrTemplateNotFound), errors.Is(err, projecttemplates.ErrFileNotFound):
 		_ = orihttp.RespondNotFound(w, err.Error())
-	case errors.Is(err, projecttemplates.ErrInvalidTemplateName):
+	case errors.Is(err, projecttemplates.ErrInvalidTemplateName), errors.Is(err, projecttemplates.ErrInvalidPath):
 		_ = orihttp.RespondBadRequest(w, err.Error())
-	case errors.Is(err, projecttemplates.ErrTemplateExists):
+	case errors.Is(err, projecttemplates.ErrTemplateExists), errors.Is(err, projecttemplates.ErrFileExists):
 		_ = orihttp.RespondConflict(w, err.Error())
+	case errors.Is(err, projecttemplates.ErrFileTooLarge):
+		_ = orihttp.RespondError(w, http.StatusRequestEntityTooLarge, err.Error())
 	default:
 		// Non-sentinel errors here are filesystem/server faults (copy
 		// failures, unreadable library dir), not bad client input.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -604,6 +604,13 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("POST /api/project-templates/{templateID}/duplicate", s.handleProjectTemplateDuplicate)
 		mux.HandleFunc("PUT /api/project-templates/{templateID}", s.handleProjectTemplateUpdate)
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}", s.handleProjectTemplateDelete)
+		// In-app file authoring (path-jailed to the template folder)
+		mux.HandleFunc("GET /api/project-templates/{templateID}/files", s.handleProjectTemplateFilesList)
+		mux.HandleFunc("POST /api/project-templates/{templateID}/files", s.handleProjectTemplateFileCreate)
+		mux.HandleFunc("GET /api/project-templates/{templateID}/files/content", s.handleProjectTemplateFileRead)
+		mux.HandleFunc("PUT /api/project-templates/{templateID}/files/content", s.handleProjectTemplateFileWrite)
+		mux.HandleFunc("POST /api/project-templates/{templateID}/files/rename", s.handleProjectTemplateFileRename)
+		mux.HandleFunc("DELETE /api/project-templates/{templateID}/files", s.handleProjectTemplateFileDelete)
 
 		mux.HandleFunc("/api/tags", s.Handlers.Session.HandleTags)
 		mux.HandleFunc("/api/tags/usage", s.Handlers.Session.HandleTagUsage)

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -23,6 +23,18 @@ const tplState = {
   nameAction: null // { title, label, confirm, initial, run(name) }
 };
 
+// Files-tab state. `templateId` records which template the loaded tree belongs
+// to (the tree lazy-loads when the Files tab is shown). `dirty` gates navigation.
+const tplFiles = {
+  templateId: '',
+  tree: [],
+  selectedPath: '',
+  loadedContent: '',
+  readOnly: false,
+  dirty: false,
+  pending: null // callback to run once a dirty prompt resolves
+};
+
 function tplToast(message, kind) {
   if (typeof window.showToast === 'function') {
     window.showToast(message, kind || 'info');
@@ -84,6 +96,12 @@ async function tplRefresh(selectId) {
     tplState.selectedId = '';
   }
 
+  // If the selected template changed out from under a loaded tree, drop it so
+  // the Files tab doesn't show another template's files/editor.
+  if (tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) {
+    tplFilesReset();
+  }
+
   tplSyncFilterTags();
   tplRenderList();
   tplRenderDetail();
@@ -140,9 +158,7 @@ function tplBuildRow(template) {
     (template.id === tplState.selectedId ? ' outline: 2px solid var(--accent-color, #6366f1);' : '');
   row.addEventListener('click', () => {
     if (tplState.selectedId === template.id) return;
-    tplState.selectedId = template.id;
-    tplRenderList();
-    tplRenderDetail();
+    tplGuardDirty(() => tplSelectTemplate(template.id));
   });
 
   const title = document.createElement('div');
@@ -396,6 +412,299 @@ async function tplReveal(id) {
   }
 }
 
+// --- Files tab: tree + editor ---
+
+function tplApiBase() {
+  return `/api/project-templates/${encodeURIComponent(tplState.selectedId)}`;
+}
+
+// tplSelectTemplate switches the active template and resets the Files tab so a
+// stale tree/editor never leaks across templates.
+function tplSelectTemplate(id) {
+  tplState.selectedId = id;
+  tplFilesReset();
+  tplRenderList();
+  tplRenderDetail();
+}
+
+function tplFilesReset() {
+  tplFiles.templateId = '';
+  tplFiles.selectedPath = '';
+  tplFiles.loadedContent = '';
+  tplFiles.readOnly = false;
+  tplClearDirty();
+  const editor = tplEl('tplEditor');
+  const empty = tplEl('tplEditorEmpty');
+  if (editor) editor.hidden = true;
+  if (empty) empty.hidden = false;
+}
+
+// tplFilesEnsureTree lazy-loads the tree the first time the Files tab is shown
+// for the selected template.
+function tplFilesEnsureTree() {
+  if (!tplState.selectedId) return;
+  if (tplFiles.templateId === tplState.selectedId) return;
+  void tplFilesLoadTree();
+}
+
+async function tplFilesLoadTree() {
+  const tree = tplEl('tplFileTree');
+  if (!tree || !tplState.selectedId) return;
+  try {
+    const data = await tplFetchJSON(`${tplApiBase()}/files`);
+    tplFiles.templateId = tplState.selectedId;
+    tplFiles.tree = Array.isArray(data.files) ? data.files : [];
+    tplRenderTree();
+  } catch (error) {
+    tree.innerHTML = '';
+    const err = document.createElement('div');
+    err.className = 'text-center py-3';
+    err.style.cssText = 'color: var(--text-secondary); font-size: 13px;';
+    err.textContent = 'Could not load files.';
+    tree.appendChild(err);
+    tplToast(error.message || 'Failed to load files', 'error');
+  }
+}
+
+function tplRenderTree() {
+  const tree = tplEl('tplFileTree');
+  if (!tree) return;
+  const nodes = tplFiles.tree;
+  tree.innerHTML = '';
+  if (nodes.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'text-center py-3';
+    empty.style.cssText = 'color: var(--text-secondary); font-size: 13px;';
+    empty.textContent = 'This template is empty. Use New File or New Folder above.';
+    tree.appendChild(empty);
+    return;
+  }
+  for (const node of nodes) {
+    tree.appendChild(tplBuildTreeRow(node));
+  }
+}
+
+function tplBuildTreeRow(node) {
+  const depth = node.path.split('/').length - 1;
+  const isDir = node.type === 'dir';
+  const name = node.path.split('/').pop();
+
+  const row = document.createElement(isDir ? 'div' : 'button');
+  if (!isDir) row.type = 'button';
+  row.className = 'd-flex align-items-center gap-2 px-2 py-1 text-start w-100';
+  row.style.cssText =
+    `border: none; border-radius: 4px; font-size: 13px; padding-left: ${8 + depth * 16}px !important;` +
+    (isDir ? ' background: transparent; color: var(--text-secondary);' : ' background: var(--bg-secondary); color: var(--text-primary);') +
+    (node.path === tplFiles.selectedPath ? ' outline: 2px solid var(--accent-color, #6366f1);' : '');
+  row.setAttribute('role', 'treeitem');
+
+  const icon = document.createElement('span');
+  icon.textContent = isDir ? '📁' : '📄';
+  icon.style.fontSize = '12px';
+  row.appendChild(icon);
+
+  const label = document.createElement('span');
+  label.textContent = name;
+  label.style.cssText = 'overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
+  row.appendChild(label);
+
+  if (node.is_manifest) {
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = 'metadata';
+    badge.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 9px; font-weight: 500;';
+    row.appendChild(badge);
+  }
+
+  if (!isDir) {
+    row.addEventListener('click', () => {
+      if (node.path === tplFiles.selectedPath) return;
+      tplGuardDirty(() => void tplOpenFile(node.path));
+    });
+  }
+  return row;
+}
+
+async function tplOpenFile(path) {
+  if (!tplState.selectedId) return;
+  try {
+    const res = await fetch(`${tplApiBase()}/files/content?path=${encodeURIComponent(path)}`);
+    if (res.status === 413) {
+      tplEditorShow(path, '', true, 'This file is larger than 512 KB and can’t be edited here. Use Reveal to open the template folder on disk.');
+      return;
+    }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      tplToast(data.message || `Failed to open file (${res.status})`, 'error');
+      return;
+    }
+    let notice = '';
+    if (data.binary) {
+      notice = 'Binary file — read-only. Use Reveal to open it on disk.';
+    } else if (data.read_only) {
+      notice = 'template.json is managed by the Overview and Onboarding tabs — read-only here.';
+    }
+    tplEditorShow(data.path || path, data.content || '', Boolean(data.read_only), notice);
+  } catch (error) {
+    tplToast(error.message || 'Failed to open file', 'error');
+  }
+}
+
+function tplEditorShow(path, content, readOnly, notice) {
+  tplFiles.selectedPath = path;
+  tplFiles.loadedContent = content;
+  tplFiles.readOnly = readOnly;
+
+  const editor = tplEl('tplEditor');
+  const empty = tplEl('tplEditorEmpty');
+  const pathEl = tplEl('tplEditorPath');
+  const textarea = tplEl('tplEditorTextarea');
+  const noticeEl = tplEl('tplEditorNotice');
+  const saveBtn = tplEl('tplEditorSaveBtn');
+
+  if (empty) empty.hidden = true;
+  if (editor) editor.hidden = false;
+  if (pathEl) pathEl.textContent = path;
+  if (textarea) {
+    textarea.value = content;
+    textarea.readOnly = readOnly;
+  }
+  if (noticeEl) {
+    noticeEl.textContent = notice || '';
+    noticeEl.hidden = !notice;
+  }
+  if (saveBtn) saveBtn.disabled = readOnly;
+  tplClearDirty();
+  tplRenderTree(); // re-render to move the selection highlight to this file
+}
+
+async function tplEditorSave() {
+  const path = tplFiles.selectedPath;
+  const textarea = tplEl('tplEditorTextarea');
+  if (!path || tplFiles.readOnly || !textarea) return false;
+  try {
+    await tplFetchJSON(`${tplApiBase()}/files/content`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, content: textarea.value })
+    });
+    tplFiles.loadedContent = textarea.value;
+    tplClearDirty();
+    tplToast('File saved.', 'success');
+    return true;
+  } catch (error) {
+    tplToast(error.message || 'Failed to save file', 'error');
+    return false;
+  }
+}
+
+function tplMarkDirty() {
+  tplFiles.dirty = true;
+  const ind = tplEl('tplEditorDirty');
+  if (ind) ind.hidden = false;
+}
+
+function tplClearDirty() {
+  tplFiles.dirty = false;
+  const ind = tplEl('tplEditorDirty');
+  if (ind) ind.hidden = true;
+}
+
+// tplGuardDirty runs `proceed` immediately unless the editor has unsaved
+// changes, in which case it opens the save / discard / keep-editing prompt.
+function tplGuardDirty(proceed) {
+  if (!tplFiles.dirty) {
+    proceed();
+    return;
+  }
+  tplFiles.pending = proceed;
+  const fileEl = tplEl('tplDirtyFile');
+  if (fileEl) fileEl.textContent = tplFiles.selectedPath || '(file)';
+  const modalEl = tplEl('tplDirtyModal');
+  if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
+}
+
+async function tplDirtyResolve(action) {
+  const modalEl = tplEl('tplDirtyModal');
+  const proceed = tplFiles.pending;
+  if (action === 'cancel') {
+    tplFiles.pending = null;
+    if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+    return;
+  }
+  if (action === 'save') {
+    const ok = await tplEditorSave();
+    if (!ok) return; // keep the prompt open on save failure
+  }
+  tplClearDirty();
+  tplFiles.pending = null;
+  if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+  if (typeof proceed === 'function') proceed();
+}
+
+function tplFileCreate(type) {
+  if (!tplState.selectedId) return;
+  tplOpenNameModal({
+    title: type === 'dir' ? 'New Folder' : 'New File',
+    label: 'Path (relative to the template)',
+    confirm: 'Create',
+    initial: '',
+    run: async (path) => {
+      if (!path) throw new Error('Please enter a path.');
+      const result = await tplFetchJSON(`${tplApiBase()}/files`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, type })
+      });
+      await tplFilesLoadTree();
+      const node = result.node || {};
+      if (type === 'file') void tplOpenFile(node.path || path);
+    }
+  });
+}
+
+function tplFileRename() {
+  const path = tplFiles.selectedPath;
+  if (!path) return;
+  tplGuardDirty(() => {
+    tplOpenNameModal({
+      title: 'Rename / Move',
+      label: 'New path (relative to the template)',
+      confirm: 'Rename',
+      initial: path,
+      run: async (to) => {
+        if (!to || to === path) return;
+        const result = await tplFetchJSON(`${tplApiBase()}/files/rename`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ from: path, to })
+        });
+        await tplFilesLoadTree();
+        const node = result.node || {};
+        void tplOpenFile(node.path || to);
+      }
+    });
+  });
+}
+
+async function tplFileDelete() {
+  const path = tplFiles.selectedPath;
+  if (!path) return;
+  if (!window.confirm(`Delete "${path}" from the template? This cannot be undone from the app.`)) {
+    return;
+  }
+  try {
+    await tplFetchJSON(`${tplApiBase()}/files?path=${encodeURIComponent(path)}`, { method: 'DELETE' });
+    tplToast(`Deleted "${path}".`, 'success');
+    tplClearDirty();
+    tplFilesReset();
+    tplFiles.templateId = '';
+    await tplFilesLoadTree();
+  } catch (error) {
+    tplToast(error.message || 'Failed to delete', 'error');
+  }
+}
+
 // --- Init ---
 
 function tplInit() {
@@ -432,6 +741,45 @@ function tplInit() {
       void tplRunNameAction();
     }
   });
+
+  // Files tab wiring.
+  tplEl('tplFileNewBtn')?.addEventListener('click', () => tplFileCreate('file'));
+  tplEl('tplFolderNewBtn')?.addEventListener('click', () => tplFileCreate('dir'));
+  tplEl('tplFilesRefreshBtn')?.addEventListener('click', () => {
+    tplFiles.templateId = '';
+    void tplFilesLoadTree();
+  });
+  tplEl('tplFileRenameBtn')?.addEventListener('click', tplFileRename);
+  tplEl('tplFileDeleteBtn')?.addEventListener('click', () => void tplFileDelete());
+  tplEl('tplEditorSaveBtn')?.addEventListener('click', () => void tplEditorSave());
+
+  const textarea = tplEl('tplEditorTextarea');
+  if (textarea) {
+    textarea.addEventListener('input', () => {
+      if (tplFiles.readOnly) return;
+      if (textarea.value === tplFiles.loadedContent) tplClearDirty();
+      else tplMarkDirty();
+    });
+  }
+
+  // Dirty-prompt buttons.
+  tplEl('tplDirtySave')?.addEventListener('click', () => void tplDirtyResolve('save'));
+  tplEl('tplDirtyDiscard')?.addEventListener('click', () => void tplDirtyResolve('discard'));
+  tplEl('tplDirtyCancel')?.addEventListener('click', () => void tplDirtyResolve('cancel'));
+
+  // Lazy-load the tree when the Files tab is shown; guard tab-switch when dirty.
+  const filesTab = tplEl('tplTabFiles');
+  if (filesTab) {
+    filesTab.addEventListener('shown.bs.tab', () => tplFilesEnsureTree());
+    filesTab.addEventListener('hide.bs.tab', (event) => {
+      if (!tplFiles.dirty) return;
+      const target = event.relatedTarget;
+      event.preventDefault();
+      tplGuardDirty(() => {
+        if (target) bootstrap.Tab.getOrCreateInstance(target).show();
+      });
+    });
+  }
 
   void tplRefresh();
 }

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -131,11 +131,43 @@
                     </div>
                   </div>
 
-                  <!-- Files (Seam PR 2) -->
+                  <!-- Files: in-app tree + editor -->
                   <div class="tab-pane fade" id="tplFilesPane" role="tabpanel" aria-labelledby="tplTabFiles">
-                    <div class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;">
-                      In-app file editing is coming soon. For now, use <strong>Reveal</strong> to open the
-                      template folder and edit its files on disk.
+                    <div class="d-flex gap-2 mb-2 flex-wrap align-items-center">
+                      <button id="tplFileNewBtn" class="modern-btn modern-btn-secondary btn-sm">New File</button>
+                      <button id="tplFolderNewBtn" class="modern-btn modern-btn-secondary btn-sm">New Folder</button>
+                      <button id="tplFilesRefreshBtn" class="modern-btn modern-btn-secondary btn-sm">Refresh</button>
+                      <span class="ms-auto" style="font-size: 11px; color: var(--text-secondary);">
+                        <code>{{`{{name}}`}}</code> / <code>{{`{{date}}`}}</code> in names are filled in when a project is created.
+                      </span>
+                    </div>
+                    <div class="row g-2">
+                      <div class="col-12 col-md-5">
+                        <div id="tplFileTree" class="d-flex flex-column gap-1" style="max-height: 440px; overflow: auto;" role="tree" aria-label="Template files">
+                          <div class="text-center py-3" style="color: var(--text-secondary); font-size: 13px;">Loading files…</div>
+                        </div>
+                      </div>
+                      <div class="col-12 col-md-7">
+                        <div id="tplEditorEmpty" class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;">
+                          Select a file to view or edit it.
+                        </div>
+                        <div id="tplEditor" hidden>
+                          <div class="d-flex justify-content-between align-items-center mb-1 gap-2 flex-wrap">
+                            <code id="tplEditorPath" style="font-size: 12px; color: var(--text-primary); word-break: break-all;"></code>
+                            <div class="d-flex gap-2">
+                              <button id="tplFileRenameBtn" class="modern-btn modern-btn-secondary btn-sm">Rename</button>
+                              <button id="tplFileDeleteBtn" class="modern-btn modern-btn-secondary btn-sm" style="color: #ef4444;">Delete</button>
+                            </div>
+                          </div>
+                          <div id="tplEditorNotice" class="alert alert-secondary py-2 mb-2" style="font-size: 12px;" hidden></div>
+                          <textarea id="tplEditorTextarea" class="form-control" spellcheck="false" wrap="off"
+                                    style="min-height: 360px; background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace; font-size: 0.85em; resize: vertical;"></textarea>
+                          <div class="d-flex gap-2 mt-2 align-items-center">
+                            <button id="tplEditorSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save</button>
+                            <span id="tplEditorDirty" style="font-size: 12px; color: #f59e0b;" hidden>● Unsaved changes</span>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
 
@@ -174,6 +206,26 @@
         <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
           <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
           <button type="button" id="tplNameModalConfirm" class="modern-btn modern-btn-primary">Create</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Dirty-editor guard: shown when switching away with unsaved file edits -->
+  <div class="modal fade" id="tplDirtyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content" style="background: var(--bg-primary); border: 1px solid var(--border-color);">
+        <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
+          <h5 class="modal-title" style="color: var(--text-primary);">Unsaved changes</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" style="color: var(--text-primary);">
+          You have unsaved changes to <code id="tplDirtyFile"></code>. What would you like to do?
+        </div>
+        <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
+          <button type="button" id="tplDirtyCancel" class="modern-btn modern-btn-secondary">Keep editing</button>
+          <button type="button" id="tplDirtyDiscard" class="modern-btn modern-btn-secondary">Discard</button>
+          <button type="button" id="tplDirtySave" class="modern-btn modern-btn-primary">Save</button>
         </div>
       </div>
     </div>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -68,6 +68,9 @@ func TestRenderTemplatesPage(t *testing.T) {
 		`id="tplDetail"`,
 		`id="tplEditTags"`,
 		`id="tplNameModal"`,
+		`id="tplFileTree"`,
+		`id="tplEditorTextarea"`,
+		`id="tplDirtyModal"`,
 		`/js/modules/templates-page.js`,
 	} {
 		if !strings.Contains(html, want) {


### PR DESCRIPTION
## Templates page — Seam PR 2 of 3

Builds on #110. Makes the Templates page's **Files** tab real: browse and edit a
template's files inside the app, backed by path-jailed file endpoints.

### Backend (`577e0ff`)
Every file operation goes through one jail — `resolveTemplatePath`: resolve the
id via `FindLibraryTemplate`, normalize the relative path, require
`filepath.IsLocal`, and reject empty/absolute/`..`/backslash/NUL paths plus any
component that is (or passes through) a **symlink**. The library root is trusted;
a symlink dropped inside a template can't be used to read or write outside it.

- `ListTree` (symlinks skipped, `template.json` flagged metadata)
- `ReadFileContent` — 512 KB cap (413), binary/manifest returned read-only
- `WriteFileContent` — overwrite an existing file verbatim, perms preserved;
  missing path is 404 (never an implicit create); tokens never substituted
- `CreateEntry` / `RenameEntry` / `DeleteEntry` — create (409 on collision),
  move (409 if dest exists), recursive delete
- Endpoints map errors 400/404/409/413/500 and return the affected node.

### Frontend (`4bb5650`)
- File tree → monospace `<textarea>` editor; Save, New File/Folder, Rename,
  recursive Delete wired to the endpoints (each reloads the affected tree).
- Binary/`template.json` open read-only with a notice; oversized (413) shows a
  read-only "use Reveal" message.
- **Dirty-state guard**: switching file/template/tab with unsaved edits opens a
  Save / Discard / Keep-editing modal (a Bootstrap modal — never a blocking
  dialog); Save persists then proceeds.
- `{{name}}`/`{{date}}` tokens in file names are surfaced and never mutated.

### Verification
- Unit tests: traversal/backslash/NUL/symlink-ancestor rejection, create/rename
  collisions, content-save-of-existing (not a collision), oversize (413), binary
  read-only, `{{name}}` filename preservation. **gosec-clean.**
- Live API smoke: every status code + a blocked **symlink escape to `/etc`**.
- Live browser smoke: tree render, open, edit→dirty, tab-switch guard modal,
  **Save persisted to disk** then proceeded. eslint + `go test`/`vet` green; no
  page console errors.

### Scope note
**Seam 2 of 3.** Next: Seam 3 = onboarding visual editor (the Onboarding tab is
still an inert placeholder here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)