### PR TITLE
feat(templates): onboarding visual editor (seam 3/3)

### DIFF
--- a/internal/projecttemplates/onboarding_manifest.go
+++ b/internal/projecttemplates/onboarding_manifest.go
@@ -1,0 +1,52 @@
+package projecttemplates
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SetOnboarding writes (or clears) the `onboarding` block in a template's
+// template.json, preserving every other key. A nil/empty/`null` value clears the
+// key (the template falls back to having no onboarding).
+//
+// The block is stored as-is — this package never interprets it, keeping the
+// file-copy engine domain-blind. Callers (the templateonboarding-aware HTTP
+// layer) validate the spec with ParseSpec + Validate before calling here.
+func SetOnboarding(libDir, id string, onboarding json.RawMessage) (Template, error) {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return Template{}, err
+	}
+
+	// manifestPath is the resolved library template's folder (FindLibraryTemplate
+	// rejects ids outside the library) joined with the fixed ManifestFileName.
+	manifestPath := filepath.Join(tpl.Path, ManifestFileName)
+	raw := map[string]any{}
+	if data, err := os.ReadFile(manifestPath); err == nil { // #nosec G304 -- manifestPath is libDir/<validated id>/template.json, not user-controlled
+		// A malformed manifest is replaced rather than failing the edit.
+		_ = json.Unmarshal(data, &raw)
+	}
+
+	trimmed := bytes.TrimSpace(onboarding)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		delete(raw, "onboarding")
+	} else {
+		var v any
+		if err := json.Unmarshal(trimmed, &v); err != nil {
+			return Template{}, fmt.Errorf("onboarding is not valid JSON: %w", err)
+		}
+		raw["onboarding"] = v
+	}
+
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o640); err != nil { // #nosec G304 G306 -- manifestPath is libDir/<validated id>/template.json; 0o640 matches the package's manifest-write convention
+		return Template{}, fmt.Errorf("failed to write manifest: %w", err)
+	}
+	return newTemplate(tpl.Path), nil
+}

--- a/internal/projecttemplates/onboarding_manifest_test.go
+++ b/internal/projecttemplates/onboarding_manifest_test.go
@@ -1,0 +1,66 @@
+package projecttemplates
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetOnboarding(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	writeFile(t, filepath.Join(libDir, "tpl", ManifestFileName),
+		`{"name":"Tpl","tags":["music"],"custom_field":42}`)
+
+	spec := json.RawMessage(`{"version":"1","fields":[{"id":"bpm","label":"BPM","type":"number"}],"completion":{"type":"none"}}`)
+
+	tpl, err := SetOnboarding(libDir, "tpl", spec)
+	if err != nil {
+		t.Fatalf("SetOnboarding: %v", err)
+	}
+	if !tpl.HasOnboarding() {
+		t.Fatalf("template should report onboarding after set")
+	}
+
+	// The onboarding block is written, and every other key survives.
+	data, err := os.ReadFile(filepath.Join(libDir, "tpl", ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"onboarding"`, `"bpm"`, `"custom_field"`, `"tags"`, `"name"`} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("manifest missing %s after set: %s", want, data)
+		}
+	}
+
+	// Clearing removes only the onboarding key; unknown keys remain.
+	tpl, err = SetOnboarding(libDir, "tpl", nil)
+	if err != nil {
+		t.Fatalf("SetOnboarding(clear): %v", err)
+	}
+	if tpl.HasOnboarding() {
+		t.Fatalf("template should report no onboarding after clear")
+	}
+	data, err = os.ReadFile(filepath.Join(libDir, "tpl", ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"onboarding"`) {
+		t.Errorf("onboarding key should be removed: %s", data)
+	}
+	if !strings.Contains(string(data), `"custom_field"`) {
+		t.Errorf("unknown key dropped on clear: %s", data)
+	}
+
+	// A "null" payload clears as well.
+	if _, err := SetOnboarding(libDir, "tpl", json.RawMessage("null")); err != nil {
+		t.Fatalf("SetOnboarding(null): %v", err)
+	}
+
+	// Unknown template id is rejected.
+	if _, err := SetOnboarding(libDir, "missing", spec); !errors.Is(err, ErrTemplateNotFound) {
+		t.Errorf("unknown template = %v, want ErrTemplateNotFound", err)
+	}
+}

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/platform"
 	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/templateonboarding"
 )
 
 // handleProjectTemplates serves GET /api/project-templates: the project
@@ -225,6 +227,77 @@ func (s *Server) handleProjectTemplateFileDelete(w http.ResponseWriter, r *http.
 		return
 	}
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "path": path})
+}
+
+// handleProjectTemplateOnboardingGet serves GET
+// /api/project-templates/{templateID}/onboarding: the parsed onboarding spec
+// (plus the raw block for the JSON editor), or an absent/invalid state.
+func (s *Server) handleProjectTemplateOnboardingGet(w http.ResponseWriter, r *http.Request) {
+	tpl, err := projecttemplates.FindLibraryTemplate(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"))
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+
+	resp := map[string]any{
+		"present":    false,
+		"onboarding": nil,
+		"raw":        strings.TrimSpace(string(tpl.Onboarding)),
+	}
+	spec, perr := templateonboarding.ParseSpec(tpl.Onboarding)
+	switch {
+	case perr != nil:
+		// Malformed block on disk: report it so the raw-JSON editor can repair it.
+		resp["present"] = true
+		resp["error"] = perr.Error()
+	case spec != nil:
+		resp["present"] = true
+		resp["onboarding"] = spec
+	}
+	_ = orihttp.RespondSuccess(w, resp)
+}
+
+// handleProjectTemplateOnboardingSet serves PUT
+// /api/project-templates/{templateID}/onboarding: validate the submitted spec
+// (ParseSpec + Validate) and write it into template.json. A `null` body clears
+// onboarding. Validation problems are returned as a 400 with a problems list.
+func (s *Server) handleProjectTemplateOnboardingSet(w http.ResponseWriter, r *http.Request) {
+	var body json.RawMessage
+	if !orihttp.ParseJSONBody(w, r, &body) {
+		return
+	}
+
+	spec, perr := templateonboarding.ParseSpec(body)
+	if perr != nil {
+		_ = orihttp.RespondBadRequest(w, perr.Error())
+		return
+	}
+	if spec != nil {
+		if res := templateonboarding.Validate(spec); !res.OK() {
+			_ = orihttp.RespondJSON(w, http.StatusBadRequest, map[string]any{
+				"error":    "onboarding spec is invalid",
+				"problems": res.Problems,
+			})
+			return
+		}
+	}
+
+	tpl, err := projecttemplates.SetOnboarding(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), body)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "present": tpl.HasOnboarding()})
+}
+
+// handleProjectTemplateOnboardingDelete serves DELETE
+// /api/project-templates/{templateID}/onboarding: remove the onboarding block.
+func (s *Server) handleProjectTemplateOnboardingDelete(w http.ResponseWriter, r *http.Request) {
+	if _, err := projecttemplates.SetOnboarding(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), nil); err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "present": false})
 }
 
 // handleProjectTemplateReveal serves POST /api/project-templates/reveal:

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -611,6 +611,10 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("PUT /api/project-templates/{templateID}/files/content", s.handleProjectTemplateFileWrite)
 		mux.HandleFunc("POST /api/project-templates/{templateID}/files/rename", s.handleProjectTemplateFileRename)
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}/files", s.handleProjectTemplateFileDelete)
+		// Onboarding intake block authoring
+		mux.HandleFunc("GET /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingGet)
+		mux.HandleFunc("PUT /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingSet)
+		mux.HandleFunc("DELETE /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingDelete)
 
 		mux.HandleFunc("/api/tags", s.Handlers.Session.HandleTags)
 		mux.HandleFunc("/api/tags/usage", s.Handlers.Session.HandleTagUsage)

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -96,10 +96,12 @@ async function tplRefresh(selectId) {
     tplState.selectedId = '';
   }
 
-  // If the selected template changed out from under a loaded tree, drop it so
-  // the Files tab doesn't show another template's files/editor.
-  if (tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) {
+  // If the selected template changed out from under a loaded Files tree or
+  // onboarding editor, drop them so neither tab shows another template's data.
+  if ((tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) ||
+      (tplOnb.templateId && tplOnb.templateId !== tplState.selectedId)) {
     tplFilesReset();
+    tplOnbReset();
   }
 
   tplSyncFilterTags();
@@ -423,6 +425,7 @@ function tplApiBase() {
 function tplSelectTemplate(id) {
   tplState.selectedId = id;
   tplFilesReset();
+  tplOnbReset();
   tplRenderList();
   tplRenderDetail();
 }
@@ -705,6 +708,406 @@ async function tplFileDelete() {
   }
 }
 
+// --- Onboarding tab: visual intake editor ---
+
+const tplOnb = { templateId: '', present: false, rawMode: false };
+
+function tplOnbApi() {
+  return `/api/project-templates/${encodeURIComponent(tplState.selectedId)}/onboarding`;
+}
+
+function tplOnbReset() {
+  tplOnb.templateId = '';
+  tplOnb.present = false;
+  tplOnb.rawMode = false;
+  const empty = tplEl('tplOnbEmpty');
+  const editor = tplEl('tplOnbEditor');
+  if (empty) empty.hidden = true;
+  if (editor) editor.hidden = true;
+}
+
+function tplOnbEnsure() {
+  if (!tplState.selectedId) return;
+  if (tplOnb.templateId === tplState.selectedId) return;
+  void tplOnbLoad();
+}
+
+async function tplOnbLoad() {
+  const empty = tplEl('tplOnbEmpty');
+  const editor = tplEl('tplOnbEditor');
+  if (!editor) return;
+  try {
+    const data = await tplFetchJSON(tplOnbApi());
+    tplOnb.templateId = tplState.selectedId;
+    tplOnb.present = Boolean(data.present);
+    tplOnbHideProblems();
+    if (!data.present) {
+      if (empty) empty.hidden = false;
+      editor.hidden = true;
+      return;
+    }
+    if (empty) empty.hidden = true;
+    editor.hidden = false;
+    if (data.onboarding) {
+      tplOnbSetRawMode(false);
+      tplOnbRenderForm(data.onboarding);
+    } else {
+      // Present but unparseable on disk — drop into JSON mode to repair it.
+      tplOnbSetRawMode(true);
+      const ta = tplEl('tplOnbJsonText');
+      if (ta) ta.value = data.raw || '';
+      if (data.error) tplOnbShowProblems([data.error]);
+    }
+  } catch (error) {
+    tplToast(error.message || 'Failed to load onboarding', 'error');
+  }
+}
+
+function tplOnbStartNew() {
+  tplOnb.templateId = tplState.selectedId;
+  tplOnb.present = true;
+  const empty = tplEl('tplOnbEmpty');
+  const editor = tplEl('tplOnbEditor');
+  if (empty) empty.hidden = true;
+  if (editor) editor.hidden = false;
+  tplOnbSetRawMode(false);
+  tplOnbRenderForm({ version: '1', fields: [], completion: { type: 'none' }, dependencies: [] });
+}
+
+function tplOnbRenderForm(spec) {
+  const fields = tplEl('tplOnbFields');
+  if (fields) {
+    fields.innerHTML = '';
+    (spec.fields || []).forEach((f) => fields.appendChild(tplOnbFieldCard(f)));
+  }
+  tplOnbRenderCompletion(spec.completion || { type: 'none' });
+  const deps = tplEl('tplOnbDeps');
+  if (deps) {
+    deps.innerHTML = '';
+    (spec.dependencies || []).forEach((d) => deps.appendChild(tplOnbDepRow(d)));
+  }
+}
+
+// --- DOM helpers ---
+
+function onbCol(width, node) {
+  const c = document.createElement('div');
+  c.className = `col-${width}`;
+  c.appendChild(node);
+  return c;
+}
+
+function onbLabeled(labelText, control) {
+  const wrap = document.createElement('div');
+  const lbl = document.createElement('label');
+  lbl.textContent = labelText;
+  lbl.style.cssText = 'font-size: 11px; color: var(--text-secondary); display: block;';
+  wrap.appendChild(lbl);
+  wrap.appendChild(control);
+  return wrap;
+}
+
+function onbInput(value, placeholder, key) {
+  const i = document.createElement('input');
+  i.className = 'modern-input w-100';
+  i.value = value == null ? '' : String(value);
+  if (placeholder) i.placeholder = placeholder;
+  if (key) i.dataset.k = key;
+  return i;
+}
+
+function onbSelect(options, value, key) {
+  const s = document.createElement('select');
+  s.className = 'form-select form-select-sm';
+  s.style.cssText = 'background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-primary);';
+  for (const [v, label] of options) {
+    const o = document.createElement('option');
+    o.value = v;
+    o.textContent = label;
+    if (v === value) o.selected = true;
+    s.appendChild(o);
+  }
+  if (key) s.dataset.k = key;
+  return s;
+}
+
+function onbCheckbox(checked, key) {
+  const c = document.createElement('input');
+  c.type = 'checkbox';
+  c.className = 'form-check-input';
+  c.checked = Boolean(checked);
+  if (key) c.dataset.k = key;
+  return c;
+}
+
+function onbActionBtn(label, onClick, danger) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'modern-btn modern-btn-secondary btn-sm';
+  b.style.fontSize = '12px';
+  if (danger) b.style.color = '#ef4444';
+  b.textContent = label;
+  b.addEventListener('click', onClick);
+  return b;
+}
+
+function tplOnbFieldCard(f) {
+  const card = document.createElement('div');
+  card.className = 'modern-card p-2';
+  card.dataset.role = 'field';
+
+  const grid = document.createElement('div');
+  grid.className = 'row g-2';
+  grid.appendChild(onbCol(4, onbLabeled('Field id', onbInput(f.id, 'snake_case', 'id'))));
+  grid.appendChild(onbCol(5, onbLabeled('Label', onbInput(f.label, 'Question label', 'label'))));
+  grid.appendChild(onbCol(3, onbLabeled('Type', onbSelect(
+    [['string', 'string'], ['number', 'number'], ['enum', 'enum'], ['boolean', 'boolean']], f.type || 'string', 'type'))));
+  grid.appendChild(onbCol(6, onbLabeled('Prompt', onbInput(f.prompt, 'Chat prompt (optional)', 'prompt'))));
+  grid.appendChild(onbCol(3, onbLabeled('Default', onbInput(f.default == null ? '' : f.default, 'optional', 'default'))));
+  grid.appendChild(onbCol(3, onbLabeled('Required', onbCheckbox(f.required, 'required'))));
+  grid.appendChild(onbCol(12, onbLabeled('Options (enum, comma-separated)', onbInput((f.options || []).join(', '), 'a, b, c', 'options'))));
+  const v = f.validation || {};
+  grid.appendChild(onbCol(4, onbLabeled('Min', onbInput(v.min == null ? '' : v.min, 'min', 'min'))));
+  grid.appendChild(onbCol(4, onbLabeled('Max', onbInput(v.max == null ? '' : v.max, 'max', 'max'))));
+  grid.appendChild(onbCol(4, onbLabeled('Pattern', onbInput(v.pattern, 'regex', 'pattern'))));
+  card.appendChild(grid);
+
+  const actions = document.createElement('div');
+  actions.className = 'd-flex gap-2 mt-1';
+  actions.appendChild(onbActionBtn('↑', () => {
+    const prev = card.previousElementSibling;
+    if (prev) card.parentNode.insertBefore(card, prev);
+  }));
+  actions.appendChild(onbActionBtn('↓', () => {
+    const next = card.nextElementSibling;
+    if (next) card.parentNode.insertBefore(next, card);
+  }));
+  actions.appendChild(onbActionBtn('Remove', () => card.remove(), true));
+  card.appendChild(actions);
+  return card;
+}
+
+function tplOnbRenderCompletion(c) {
+  const root = tplEl('tplOnbCompletion');
+  if (!root) return;
+  root.innerHTML = '';
+
+  const grid = document.createElement('div');
+  grid.className = 'row g-2';
+  grid.appendChild(onbCol(4, onbLabeled('Type', onbSelect([
+    ['none', 'none'], ['task', 'task'],
+    ['tool', 'tool (reserved — not run in v1)'],
+    ['workflow_template', 'workflow_template (reserved — not run in v1)']
+  ], c.type || 'none', 'type'))));
+  grid.appendChild(onbCol(8, onbLabeled('Ref (required for reserved types)', onbInput(c.ref, 'ref', 'ref'))));
+
+  const instr = document.createElement('textarea');
+  instr.className = 'form-control';
+  instr.rows = 2;
+  instr.style.cssText = 'background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.85em;';
+  instr.value = c.instructions || '';
+  instr.dataset.k = 'instructions';
+  grid.appendChild(onbCol(12, onbLabeled('Instructions', instr)));
+  grid.appendChild(onbCol(8, onbLabeled('Skill refs (comma-separated)', onbInput((c.skill_refs || []).join(', '), 'skill-a, skill-b', 'skill_refs'))));
+  grid.appendChild(onbCol(4, onbLabeled('Instantiate skeleton', onbCheckbox(c.instantiate_skeleton, 'instantiate_skeleton'))));
+  root.appendChild(grid);
+
+  const inputsWrap = document.createElement('div');
+  inputsWrap.className = 'mt-2';
+  const hdr = document.createElement('div');
+  hdr.className = 'd-flex justify-content-between align-items-center mb-1';
+  const h = document.createElement('span');
+  h.textContent = 'Inputs (literal or ${fields.id})';
+  h.style.cssText = 'font-size: 11px; color: var(--text-secondary);';
+  const list = document.createElement('div');
+  list.className = 'd-flex flex-column gap-1';
+  list.dataset.role = 'inputs';
+  hdr.appendChild(h);
+  hdr.appendChild(onbActionBtn('Add input', () => list.appendChild(tplOnbInputRow('', ''))));
+  Object.entries(c.inputs || {}).forEach(([k, val]) => list.appendChild(tplOnbInputRow(k, val)));
+  inputsWrap.appendChild(hdr);
+  inputsWrap.appendChild(list);
+  root.appendChild(inputsWrap);
+}
+
+function tplOnbInputRow(k, val) {
+  const row = document.createElement('div');
+  row.className = 'd-flex gap-2';
+  row.dataset.role = 'input-row';
+  row.appendChild(onbInput(k, 'key', 'key'));
+  row.appendChild(onbInput(val, 'value or ${fields.id}', 'value'));
+  row.appendChild(onbActionBtn('×', () => row.remove(), true));
+  return row;
+}
+
+function tplOnbDepRow(d) {
+  const row = document.createElement('div');
+  row.className = 'd-flex gap-2';
+  row.dataset.role = 'dep';
+  row.appendChild(onbSelect([
+    ['skill', 'skill'], ['mcp_server', 'mcp_server'], ['tool', 'tool'], ['workflow_template', 'workflow_template']
+  ], d.type || 'skill', 'type'));
+  row.appendChild(onbInput(d.ref, 'ref', 'ref'));
+  row.appendChild(onbActionBtn('×', () => row.remove(), true));
+  return row;
+}
+
+// tplOnbBuildSpec reads the visual form into an OnboardingSpec object. The server
+// is the validation authority; this only assembles the shape.
+function tplOnbBuildSpec() {
+  const spec = { version: '1', fields: [], completion: { type: 'none' } };
+
+  tplEl('tplOnbFields')?.querySelectorAll('[data-role="field"]').forEach((card) => {
+    const get = (k) => card.querySelector(`[data-k="${k}"]`);
+    const type = get('type').value;
+    const field = { id: get('id').value.trim(), label: get('label').value.trim(), type };
+    if (get('required').checked) field.required = true;
+    const prompt = get('prompt').value.trim();
+    if (prompt) field.prompt = prompt;
+    const opts = get('options').value.split(',').map((s) => s.trim()).filter(Boolean);
+    if (opts.length) field.options = opts;
+    const def = get('default').value.trim();
+    if (def !== '') {
+      if (type === 'number') field.default = Number(def);
+      else if (type === 'boolean') field.default = def === 'true';
+      else field.default = def;
+    }
+    const validation = {};
+    const min = get('min').value.trim();
+    if (min !== '') validation.min = Number(min);
+    const max = get('max').value.trim();
+    if (max !== '') validation.max = Number(max);
+    const pattern = get('pattern').value.trim();
+    if (pattern) validation.pattern = pattern;
+    if (Object.keys(validation).length) field.validation = validation;
+    spec.fields.push(field);
+  });
+
+  const cRoot = tplEl('tplOnbCompletion');
+  if (cRoot) {
+    const get = (k) => cRoot.querySelector(`[data-k="${k}"]`);
+    const completion = { type: get('type').value };
+    const ref = get('ref').value.trim();
+    if (ref) completion.ref = ref;
+    const instructions = get('instructions').value.trim();
+    if (instructions) completion.instructions = instructions;
+    const skillRefs = get('skill_refs').value.split(',').map((s) => s.trim()).filter(Boolean);
+    if (skillRefs.length) completion.skill_refs = skillRefs;
+    if (get('instantiate_skeleton').checked) completion.instantiate_skeleton = true;
+    const inputs = {};
+    cRoot.querySelectorAll('[data-role="input-row"]').forEach((row) => {
+      const key = row.querySelector('[data-k="key"]').value.trim();
+      if (key) inputs[key] = row.querySelector('[data-k="value"]').value;
+    });
+    if (Object.keys(inputs).length) completion.inputs = inputs;
+    spec.completion = completion;
+  }
+
+  const deps = [];
+  tplEl('tplOnbDeps')?.querySelectorAll('[data-role="dep"]').forEach((row) => {
+    deps.push({ type: row.querySelector('[data-k="type"]').value, ref: row.querySelector('[data-k="ref"]').value.trim() });
+  });
+  if (deps.length) spec.dependencies = deps;
+
+  return spec;
+}
+
+function tplOnbSetRawMode(on) {
+  tplOnb.rawMode = on;
+  const visual = tplEl('tplOnbVisual');
+  const json = tplEl('tplOnbJson');
+  const toggle = tplEl('tplOnbJsonToggle');
+  if (visual) visual.hidden = on;
+  if (json) json.hidden = !on;
+  if (toggle) toggle.textContent = on ? 'Edit visually' : 'Edit as JSON';
+}
+
+function tplOnbToggleJson() {
+  if (!tplOnb.rawMode) {
+    const ta = tplEl('tplOnbJsonText');
+    if (ta) ta.value = JSON.stringify(tplOnbBuildSpec(), null, 2);
+    tplOnbSetRawMode(true);
+    return;
+  }
+  const ta = tplEl('tplOnbJsonText');
+  try {
+    tplOnbRenderForm(JSON.parse(ta.value));
+    tplOnbHideProblems();
+    tplOnbSetRawMode(false);
+  } catch (error) {
+    tplOnbShowProblems([`Invalid JSON: ${error.message}`]);
+  }
+}
+
+async function tplOnbSave() {
+  let body;
+  if (tplOnb.rawMode) {
+    try {
+      body = JSON.parse(tplEl('tplOnbJsonText').value);
+    } catch (error) {
+      tplOnbShowProblems([`Invalid JSON: ${error.message}`]);
+      return;
+    }
+  } else {
+    body = tplOnbBuildSpec();
+  }
+  try {
+    const res = await fetch(tplOnbApi(), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 400 && Array.isArray(data.problems)) {
+      tplOnbShowProblems(data.problems);
+      return;
+    }
+    if (!res.ok) {
+      tplToast(data.message || data.error || 'Failed to save onboarding', 'error');
+      return;
+    }
+    tplOnbHideProblems();
+    tplToast('Onboarding saved.', 'success');
+    tplOnb.templateId = '';
+    await tplOnbLoad();
+  } catch (error) {
+    tplToast(error.message || 'Failed to save onboarding', 'error');
+  }
+}
+
+async function tplOnbRemove() {
+  if (!window.confirm('Remove the onboarding intake from this template?')) return;
+  try {
+    await tplFetchJSON(tplOnbApi(), { method: 'DELETE' });
+    tplToast('Onboarding removed.', 'success');
+    tplOnb.templateId = '';
+    await tplOnbLoad();
+  } catch (error) {
+    tplToast(error.message || 'Failed to remove onboarding', 'error');
+  }
+}
+
+function tplOnbShowProblems(problems) {
+  const box = tplEl('tplOnbProblems');
+  if (!box) return;
+  box.innerHTML = '';
+  const ul = document.createElement('ul');
+  ul.className = 'mb-0';
+  ul.style.paddingLeft = '18px';
+  for (const p of problems) {
+    const li = document.createElement('li');
+    li.textContent = p;
+    ul.appendChild(li);
+  }
+  box.appendChild(ul);
+  box.hidden = false;
+}
+
+function tplOnbHideProblems() {
+  const box = tplEl('tplOnbProblems');
+  if (box) box.hidden = true;
+}
+
 // --- Init ---
 
 function tplInit() {
@@ -780,6 +1183,19 @@ function tplInit() {
       });
     });
   }
+
+  // Onboarding tab wiring.
+  tplEl('tplTabOnboarding')?.addEventListener('shown.bs.tab', () => tplOnbEnsure());
+  tplEl('tplOnbAddBtn')?.addEventListener('click', tplOnbStartNew);
+  tplEl('tplOnbAddFieldBtn')?.addEventListener('click', () => {
+    tplEl('tplOnbFields')?.appendChild(tplOnbFieldCard({ type: 'string' }));
+  });
+  tplEl('tplOnbAddDepBtn')?.addEventListener('click', () => {
+    tplEl('tplOnbDeps')?.appendChild(tplOnbDepRow({ type: 'skill' }));
+  });
+  tplEl('tplOnbJsonToggle')?.addEventListener('click', tplOnbToggleJson);
+  tplEl('tplOnbRemoveBtn')?.addEventListener('click', () => void tplOnbRemove());
+  tplEl('tplOnbSaveBtn')?.addEventListener('click', () => void tplOnbSave());
 
   void tplRefresh();
 }

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -171,11 +171,49 @@
                     </div>
                   </div>
 
-                  <!-- Onboarding (Seam PR 3) -->
+                  <!-- Onboarding: visual intake editor -->
                   <div class="tab-pane fade" id="tplOnboardingPane" role="tabpanel" aria-labelledby="tplTabOnboarding">
-                    <div class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;">
-                      The onboarding intake editor is coming soon. Onboarding blocks authored in
-                      <code>template.json</code> still run when a workspace is created.
+                    <div id="tplOnbEmpty" class="text-center py-4" style="color: var(--text-secondary); font-size: 13px;" hidden>
+                      <div class="mb-2">This template has no onboarding intake. Add one to ask the entry agent
+                        questions (e.g. BPM, key) when a workspace is created from it.</div>
+                      <button id="tplOnbAddBtn" class="modern-btn modern-btn-primary btn-sm">Add onboarding</button>
+                    </div>
+
+                    <div id="tplOnbEditor" hidden>
+                      <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
+                        <div style="font-size: 12px; color: var(--text-secondary);">Intake runs when a workspace is created from this template.</div>
+                        <div class="d-flex gap-2">
+                          <button id="tplOnbJsonToggle" class="modern-btn modern-btn-secondary btn-sm">Edit as JSON</button>
+                          <button id="tplOnbRemoveBtn" class="modern-btn modern-btn-secondary btn-sm" style="color: #ef4444;">Remove</button>
+                        </div>
+                      </div>
+
+                      <div id="tplOnbVisual">
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                          <h6 class="mb-0" style="color: var(--text-primary);">Intake fields</h6>
+                          <button id="tplOnbAddFieldBtn" class="modern-btn modern-btn-secondary btn-sm">Add field</button>
+                        </div>
+                        <div id="tplOnbFields" class="d-flex flex-column gap-2 mb-3"></div>
+
+                        <h6 class="mb-1" style="color: var(--text-primary);">Completion action</h6>
+                        <div id="tplOnbCompletion" class="mb-3"></div>
+
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                          <h6 class="mb-0" style="color: var(--text-primary);">Dependencies</h6>
+                          <button id="tplOnbAddDepBtn" class="modern-btn modern-btn-secondary btn-sm">Add dependency</button>
+                        </div>
+                        <div id="tplOnbDeps" class="d-flex flex-column gap-2 mb-3"></div>
+                      </div>
+
+                      <div id="tplOnbJson" hidden>
+                        <textarea id="tplOnbJsonText" class="form-control" spellcheck="false" rows="16"
+                                  style="background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace; font-size: 0.85em; resize: vertical;"></textarea>
+                      </div>
+
+                      <div id="tplOnbProblems" class="alert alert-danger py-2" style="font-size: 12px;" hidden></div>
+                      <div class="d-flex gap-2 mt-2">
+                        <button id="tplOnbSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save onboarding</button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -71,6 +71,9 @@ func TestRenderTemplatesPage(t *testing.T) {
 		`id="tplFileTree"`,
 		`id="tplEditorTextarea"`,
 		`id="tplDirtyModal"`,
+		`id="tplOnbFields"`,
+		`id="tplOnbCompletion"`,
+		`id="tplOnbSaveBtn"`,
 		`/js/modules/templates-page.js`,
 	} {
 		if !strings.Contains(html, want) {


### PR DESCRIPTION
## Templates page — Seam PR 3 of 3 (final)

Builds on #110 and #111. Makes the Templates page's **Onboarding** tab a full
visual editor over the real `OnboardingSpec`, so authors can build a template's
intake block (the questions the entry agent asks at workspace creation) without
hand-editing JSON. Completes the in-app template-authoring epic.

### Backend (`83bf027`)
- `projecttemplates.SetOnboarding`: read-merge-write the `onboarding` key in
  template.json, preserving every other key; nil/empty/null clears. Stays
  domain-blind — stores the bytes verbatim, never imports `templateonboarding`
  (that package imports `projecttemplates`, so the reverse would cycle).
- Handlers validate in the `templateonboarding`-aware server layer:
  - `GET …/onboarding` — parsed spec (+ raw block for the JSON editor), or an
    absent/invalid state.
  - `PUT …/onboarding` — `ParseSpec` + `Validate` before writing; invalid specs
    return **400 with a `problems` list**. `DELETE …/onboarding` clears.

### Frontend (`e0d6bd6`)
- Intake fields: add/remove/reorder (↑/↓), each with id, label, type, required,
  default (type-coerced), options, prompt, validation (min/max/pattern).
- Completion action: type (`none`/`task`; `tool`/`workflow_template` labeled
  "reserved — not run in v1"), ref, instructions, skill_refs, inputs (literal or
  `${fields.id}`), instantiate_skeleton.
- Dependencies: rows of type + ref.
- **Raw-JSON escape hatch**: toggle visual ↔ JSON (visual→JSON serializes the
  form; JSON→visual re-renders); server validates either way.
- Save surfaces server validation problems inline; Remove clears; state resets
  on template switch.

### Verification
- Unit test: set/clear round-trip + unknown-key preservation. **gosec-clean.**
- Live API smoke: GET starter intake, PUT valid, 400+problems on invalid, DELETE.
- Live browser smoke: loaded the reaper-song `bpm/key/song_name` intake,
  JSON round-trip with correct typing (number default, validation), **Save
  persisted to disk** then reloaded the visual form. eslint + `go test`/`vet`
  green; no page console errors.

### Epic complete
Seam 1 (#110) + Seam 2 (#111) + this. The Onboarding tab was the last inert
placeholder; the Templates page now supports full in-app maintenance:
metadata/tags/lifecycle, path-jailed file authoring, and onboarding intake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)