### PR TITLE
feat(templates): default tools — skills / MCP / plugins (seam 4)

### DIFF
--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -33,6 +33,10 @@ type Template struct {
 	// This package only carries the bytes; the templateonboarding package parses
 	// and validates them at workspace-creation time. Excluded from API JSON.
 	Onboarding json.RawMessage `json:"-"`
+	// Tools are the default skills/MCP servers/plugins a workspace created from
+	// this template binds (apply-if-present). Names only — bound in the
+	// workspace-creation layer, not here.
+	Tools ToolDefaults `json:"tools"`
 }
 
 // HasOnboarding reports whether the template carries a non-empty onboarding
@@ -53,6 +57,7 @@ type manifest struct {
 	Description string          `json:"description"`
 	Tags        []string        `json:"tags,omitempty"`
 	Onboarding  json.RawMessage `json:"onboarding,omitempty"`
+	Tools       *ToolDefaults   `json:"tools,omitempty"`
 }
 
 // readManifest loads template.json from dir. A missing or malformed manifest
@@ -87,6 +92,9 @@ func newTemplate(path string) Template {
 	t.Description = strings.TrimSpace(m.Description)
 	t.Tags = workspace.NormalizeWorkspaceTags(m.Tags)
 	t.Onboarding = m.Onboarding
+	if m.Tools != nil {
+		t.Tools = normalizeToolDefaults(*m.Tools)
+	}
 	return t
 }
 

--- a/internal/projecttemplates/tools.go
+++ b/internal/projecttemplates/tools.go
@@ -1,0 +1,100 @@
+package projecttemplates
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ToolDefaults declares the tools a template pre-binds onto a workspace created
+// from it. Values are names only — this package never resolves what a tool does;
+// apply-if-present binding happens in the workspace-creation layer, keeping the
+// file-copy engine domain-blind.
+type ToolDefaults struct {
+	Skills     []string `json:"skills,omitempty"`
+	MCPServers []string `json:"mcp_servers,omitempty"`
+	Plugins    []string `json:"plugins,omitempty"`
+}
+
+// IsEmpty reports whether no tools are declared.
+func (t ToolDefaults) IsEmpty() bool {
+	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.Plugins) == 0
+}
+
+func normalizeToolDefaults(t ToolDefaults) ToolDefaults {
+	return ToolDefaults{
+		Skills:     normalizeNameList(t.Skills),
+		MCPServers: normalizeNameList(t.MCPServers),
+		Plugins:    normalizeNameList(t.Plugins),
+	}
+}
+
+// normalizeNameList trims, drops blanks, de-duplicates case-insensitively
+// (keeping first-seen casing), and sorts for stable output.
+func normalizeNameList(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		key := strings.ToLower(n)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, n)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		li, lj := strings.ToLower(out[i]), strings.ToLower(out[j])
+		if li == lj {
+			return out[i] < out[j]
+		}
+		return li < lj
+	})
+	return out
+}
+
+// SetTools writes (or clears) the `tools` block in a template's template.json,
+// preserving every other key. An all-empty ToolDefaults clears the key. Like the
+// onboarding writer, this stores names only and never interprets them.
+func SetTools(libDir, id string, tools ToolDefaults) (Template, error) {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return Template{}, err
+	}
+
+	// manifestPath is the resolved library template's folder (FindLibraryTemplate
+	// rejects ids outside the library) joined with the fixed ManifestFileName.
+	manifestPath := filepath.Join(tpl.Path, ManifestFileName)
+	raw := map[string]any{}
+	if data, err := os.ReadFile(manifestPath); err == nil { // #nosec G304 -- manifestPath is libDir/<validated id>/template.json, not user-controlled
+		_ = json.Unmarshal(data, &raw)
+	}
+
+	tools = normalizeToolDefaults(tools)
+	if tools.IsEmpty() {
+		delete(raw, "tools")
+	} else {
+		encoded, err := json.Marshal(tools)
+		if err != nil {
+			return Template{}, fmt.Errorf("failed to encode tools: %w", err)
+		}
+		var v any
+		_ = json.Unmarshal(encoded, &v)
+		raw["tools"] = v
+	}
+
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o640); err != nil { // #nosec G304 G306 -- manifestPath is libDir/<validated id>/template.json; 0o640 matches the package's manifest-write convention
+		return Template{}, fmt.Errorf("failed to write manifest: %w", err)
+	}
+	return newTemplate(tpl.Path), nil
+}

--- a/internal/projecttemplates/tools_test.go
+++ b/internal/projecttemplates/tools_test.go
@@ -1,0 +1,78 @@
+package projecttemplates
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeNameList(t *testing.T) {
+	got := normalizeNameList([]string{" Skill-B ", "skill-a", "Skill-A", "", "skill-b"})
+	want := []string{"skill-a", "Skill-B"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("normalizeNameList = %v, want %v (trim/dedupe-ci/sort)", got, want)
+	}
+}
+
+func TestSetTools(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	writeFile(t, filepath.Join(libDir, "tpl", ManifestFileName),
+		`{"name":"Tpl","tags":["music"],"custom_field":42}`)
+
+	tpl, err := SetTools(libDir, "tpl", ToolDefaults{
+		Skills:     []string{"summarize", "summarize"}, // dup collapses
+		MCPServers: []string{"reaper"},
+		Plugins:    []string{"  "}, // blank dropped
+	})
+	if err != nil {
+		t.Fatalf("SetTools: %v", err)
+	}
+	if len(tpl.Tools.Skills) != 1 || tpl.Tools.Skills[0] != "summarize" {
+		t.Fatalf("unexpected skills: %v", tpl.Tools.Skills)
+	}
+	if len(tpl.Tools.MCPServers) != 1 || tpl.Tools.MCPServers[0] != "reaper" {
+		t.Fatalf("unexpected mcp_servers: %v", tpl.Tools.MCPServers)
+	}
+	if len(tpl.Tools.Plugins) != 0 {
+		t.Fatalf("blank plugin should be dropped: %v", tpl.Tools.Plugins)
+	}
+
+	// Block written; every other key survives.
+	data, err := os.ReadFile(filepath.Join(libDir, "tpl", ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"tools"`, `"mcp_servers"`, `"custom_field"`, `"tags"`} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("manifest missing %s: %s", want, data)
+		}
+	}
+
+	// Re-reading the template round-trips the tools.
+	reread, err := FindLibraryTemplate(libDir, "tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reread.Tools.IsEmpty() {
+		t.Fatalf("re-read template lost its tools")
+	}
+
+	// An all-empty ToolDefaults clears the key; unknown keys remain.
+	if _, err := SetTools(libDir, "tpl", ToolDefaults{}); err != nil {
+		t.Fatalf("SetTools(clear): %v", err)
+	}
+	data, _ = os.ReadFile(filepath.Join(libDir, "tpl", ManifestFileName))
+	if strings.Contains(string(data), `"tools"`) {
+		t.Errorf("tools key should be removed: %s", data)
+	}
+	if !strings.Contains(string(data), `"custom_field"`) {
+		t.Errorf("unknown key dropped on clear: %s", data)
+	}
+
+	// Unknown template id is rejected.
+	if _, err := SetTools(libDir, "missing", ToolDefaults{Skills: []string{"x"}}); !errors.Is(err, ErrTemplateNotFound) {
+		t.Errorf("unknown template = %v, want ErrTemplateNotFound", err)
+	}
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -332,6 +332,13 @@ func (b *ServerBuilder) initializeHandlers() {
 	if b.mcpConfigManager != nil && b.mcpRegistry != nil {
 		b.pluginHandler = pluginhttp.NewHandler(b.mcpConfigManager, b.mcpRegistry, personalSkillsDir, "plugins")
 	}
+
+	// Let workspaces created from a template bind its declared default tools
+	// (skills / MCP servers / plugins) at creation, applying only what is present.
+	// The applier reads the SyncStore + MCP config lazily at request time.
+	if b.sessionHandler != nil {
+		b.sessionHandler.SetTemplateToolApplier(makeTemplateToolApplier(b))
+	}
 }
 
 func (b *ServerBuilder) registerWorkspaceRunTaskValidationMirror() {

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -300,6 +300,24 @@ func (s *Server) handleProjectTemplateOnboardingDelete(w http.ResponseWriter, r 
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "present": false})
 }
 
+// handleProjectTemplateToolsSet serves PUT
+// /api/project-templates/{templateID}/tools: set the template's default tool
+// bindings (skills / MCP servers / plugins), referenced by name. The names are
+// applied (if present on the machine) when a workspace is created from the
+// template; reading them is covered by the list endpoint's Template.Tools.
+func (s *Server) handleProjectTemplateToolsSet(w http.ResponseWriter, r *http.Request) {
+	var req projecttemplates.ToolDefaults
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	tpl, err := projecttemplates.SetTools(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "template": tpl})
+}
+
 // handleProjectTemplateReveal serves POST /api/project-templates/reveal:
 // open the library root ({} or empty id) or reveal one template ({"id": ...})
 // in the OS file manager. Local-first only, like workspace file open.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -615,6 +615,8 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("GET /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingGet)
 		mux.HandleFunc("PUT /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingSet)
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingDelete)
+		// Default tool bindings (skills / MCP servers / plugins), applied if present at creation
+		mux.HandleFunc("PUT /api/project-templates/{templateID}/tools", s.handleProjectTemplateToolsSet)
 
 		mux.HandleFunc("/api/tags", s.Handlers.Session.HandleTags)
 		mux.HandleFunc("/api/tags/usage", s.Handlers.Session.HandleTagUsage)

--- a/internal/server/template_tools.go
+++ b/internal/server/template_tools.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// templatePluginsDir is the managed plugins directory the plugin handler uses;
+// the applier reads installed.json from here to expand plugin references.
+const templatePluginsDir = "plugins"
+
+// makeTemplateToolApplier returns a function that binds a template's declared
+// default tools onto a freshly created workspace, applying only what resolves on
+// the machine and reporting the rest (apply-if-present):
+//
+//   - skills bind by name (resolved downstream by the skill manager);
+//   - MCP servers bind when configured (else reported missing);
+//   - plugins expand to their installed component skills + MCP servers.
+//
+// It binds through the same workspace store the binding endpoints read from (the
+// SyncStore), Get→bind→Save by id, so the new bindings are immediately visible —
+// writing through the raw FileStore would land on disk but bypass the read path.
+// Builder fields are read at apply time (request time), so wiring order is moot.
+func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.ToolDefaults) ([]string, []string) {
+	return func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string) {
+		store := b.workspaceStore
+		if store == nil {
+			return nil, nil
+		}
+		ws, err := store.Get(workspaceID)
+		if err != nil || ws == nil {
+			return nil, nil
+		}
+		now := time.Now()
+
+		boundSkills := map[string]bool{}
+		for _, bnd := range ws.GetSkillBindings() {
+			boundSkills[strings.ToLower(strings.TrimSpace(bnd.SkillName))] = true
+		}
+		boundMCP := map[string]bool{}
+		for _, bnd := range ws.GetMCPBindings() {
+			boundMCP[strings.ToLower(strings.TrimSpace(bnd.ServerName))] = true
+		}
+
+		bindSkill := func(name string) {
+			name = strings.TrimSpace(name)
+			key := strings.ToLower(name)
+			if name == "" || boundSkills[key] {
+				return
+			}
+			boundSkills[key] = true
+			if err := ws.UpsertSkillBinding(workspace.WorkspaceSkillBinding{
+				ID: uuid.NewString(), SkillName: name, Enabled: true, CreatedAt: now, UpdatedAt: now,
+			}); err == nil {
+				applied = append(applied, "skill:"+name)
+			}
+		}
+		bindMCP := func(name string) {
+			name = strings.TrimSpace(name)
+			key := strings.ToLower(name)
+			if name == "" || boundMCP[key] {
+				return
+			}
+			boundMCP[key] = true
+			if err := ws.UpsertMCPBinding(workspace.WorkspaceMCPBinding{
+				ID: uuid.NewString(), ServerName: name, Enabled: true, CreatedAt: now, UpdatedAt: now,
+			}); err == nil {
+				applied = append(applied, "mcp:"+name)
+			}
+		}
+
+		// Skills: bound by name; presence is resolved at runtime by the manager.
+		for _, s := range tools.Skills {
+			bindSkill(s)
+		}
+
+		// MCP servers: bind when the server is configured, else report missing.
+		for _, srv := range tools.MCPServers {
+			if cfg := b.mcpConfigManager; cfg != nil {
+				if _, err := cfg.GetServer(strings.TrimSpace(srv)); err != nil {
+					missing = append(missing, "mcp:"+srv)
+					continue
+				}
+			}
+			bindMCP(srv)
+		}
+
+		// Plugins: expand each installed plugin to its component skills + servers.
+		if len(tools.Plugins) > 0 {
+			installed, _ := plugin.NewStore(templatePluginsDir).List()
+			byName := make(map[string]plugin.InstalledPlugin, len(installed))
+			for _, p := range installed {
+				byName[strings.ToLower(p.Name)] = p
+			}
+			for _, pl := range tools.Plugins {
+				p, ok := byName[strings.ToLower(strings.TrimSpace(pl))]
+				if !ok {
+					missing = append(missing, "plugin:"+pl)
+					continue
+				}
+				for _, s := range p.Skills {
+					bindSkill(s)
+				}
+				for _, srv := range p.MCPServers {
+					bindMCP(srv)
+				}
+			}
+		}
+
+		if len(applied) > 0 {
+			if err := store.Save(ws); err != nil {
+				return nil, missing
+			}
+		}
+		return applied, missing
+	}
+}

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -12,6 +12,7 @@ import (
 
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/store"
 	"github.com/johnjallday/ori-agent/internal/templateonboarding"
@@ -29,6 +30,11 @@ type Handler struct {
 	workspaceAllowlist    *workspace.Allowlist
 	eventBus              *workspace.EventBus // optional, for project.created events
 	templateOnboarding    *templateonboarding.Service
+	// applyTemplateTools binds a template's declared default tools onto a newly
+	// created workspace (apply-if-present), returning the applied and skipped
+	// names. Injected by the server, which holds the tool registries and binds
+	// through the same store the binding endpoints read from.
+	applyTemplateTools func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string)
 
 	// rescanMu serializes disk reconciles so concurrent rescan requests
 	// (e.g. several hub tabs loading at once) don't run overlapping filesystem
@@ -59,6 +65,13 @@ func (h *Handler) SetWorkspaceRootResolver(fn func() string) {
 // SetAgentStore sets the agent store used for workspace entry-agent provisioning.
 func (h *Handler) SetAgentStore(agentStore store.Store) {
 	h.agentStore = agentStore
+}
+
+// SetTemplateToolApplier injects the function that binds a template's declared
+// default tools (skills / MCP servers / plugins) onto a freshly created
+// workspace. The server supplies it because the tool registries live there.
+func (h *Handler) SetTemplateToolApplier(fn func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string)) {
+	h.applyTemplateTools = fn
 }
 
 // SetTemplatesRootResolver sets the resolver used to locate the project

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -424,6 +424,26 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 							projectWarning = ""
 						}
 					}
+
+					// Bind the template's declared default tools (skills / MCP /
+					// plugins) onto the workspace, independent of onboarding. Tools
+					// not present on the machine are skipped and noted; never fatal.
+					if templateResolved && !resolvedTemplate.Tools.IsEmpty() && h.applyTemplateTools != nil {
+						// The applier binds through the read store and persists itself.
+						applied, missing := h.applyTemplateTools(ws.ID, resolvedTemplate.Tools)
+						if len(applied) > 0 {
+							logger.Info("Applied template default tools", logger.Fields{"id": ws.ID, "applied": applied})
+						}
+						if len(missing) > 0 {
+							logger.Info("Template default tools not found (skipped)", logger.Fields{"id": ws.ID, "missing": missing})
+							warn := fmt.Sprintf("some template tools were not found and were skipped: %s", strings.Join(missing, ", "))
+							if projectWarning == "" {
+								projectWarning = warn
+							} else {
+								projectWarning = projectWarning + "; " + warn
+							}
+						}
+					}
 				}
 			}
 		}

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -99,9 +99,11 @@ async function tplRefresh(selectId) {
   // If the selected template changed out from under a loaded Files tree or
   // onboarding editor, drop them so neither tab shows another template's data.
   if ((tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) ||
-      (tplOnb.templateId && tplOnb.templateId !== tplState.selectedId)) {
+      (tplOnb.templateId && tplOnb.templateId !== tplState.selectedId) ||
+      (tplTools.templateId && tplTools.templateId !== tplState.selectedId)) {
     tplFilesReset();
     tplOnbReset();
+    tplToolsReset();
   }
 
   tplSyncFilterTags();
@@ -426,6 +428,7 @@ function tplSelectTemplate(id) {
   tplState.selectedId = id;
   tplFilesReset();
   tplOnbReset();
+  tplToolsReset();
   tplRenderList();
   tplRenderDetail();
 }
@@ -1108,6 +1111,153 @@ function tplOnbHideProblems() {
   if (box) box.hidden = true;
 }
 
+// --- Tools tab: default skills / MCP servers / plugins ---
+
+const tplTools = { templateId: '' };
+
+function tplToolsReset() {
+  tplTools.templateId = '';
+  for (const id of ['tplToolsSkills', 'tplToolsMcp', 'tplToolsPlugins']) {
+    const el = tplEl(id);
+    if (el) el.innerHTML = '';
+  }
+}
+
+function tplToolsEnsure() {
+  if (!tplState.selectedId) return;
+  if (tplTools.templateId === tplState.selectedId) return;
+  void tplToolsLoad();
+}
+
+function tplToolsDeclared() {
+  const tools = (tplSelected() || {}).tools || {};
+  return {
+    skills: tools.skills || [],
+    mcp_servers: tools.mcp_servers || [],
+    plugins: tools.plugins || []
+  };
+}
+
+async function tplToolsLoad() {
+  if (!tplState.selectedId) return;
+  tplTools.templateId = tplState.selectedId;
+  const declared = tplToolsDeclared();
+  await Promise.all([
+    tplToolsRenderSection('tplToolsSkills', '/api/skills', ['skills', 'items'], declared.skills),
+    tplToolsRenderSection('tplToolsMcp', '/api/mcp/servers', ['servers', 'items'], declared.mcp_servers),
+    tplToolsRenderSection('tplToolsPlugins', '/api/plugins', ['plugins', 'items'], declared.plugins)
+  ]);
+}
+
+async function tplToolsRenderSection(containerId, url, listKeys, declaredNames) {
+  const container = tplEl(containerId);
+  if (!container) return;
+  container.innerHTML = '';
+
+  let installed = [];
+  try {
+    const data = await tplFetchJSON(url);
+    installed = tplToolsExtractList(data, listKeys).map(tplToolsItemName).filter(Boolean);
+  } catch (error) {
+    console.warn(`Failed to load ${url}:`, error);
+  }
+
+  const declaredSet = new Set(declaredNames.map((n) => n.toLowerCase()));
+  const seen = new Set();
+  const rows = [];
+  for (const name of installed) {
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push({ name, installed: true, checked: declaredSet.has(key) });
+  }
+  // Keep declared names that aren't currently installed rather than dropping them.
+  for (const name of declaredNames) {
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push({ name, installed: false, checked: true });
+  }
+
+  if (rows.length === 0) {
+    const empty = document.createElement('div');
+    empty.style.cssText = 'font-size: 12px; color: var(--text-secondary);';
+    empty.textContent = 'None available.';
+    container.appendChild(empty);
+    return;
+  }
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  for (const row of rows) container.appendChild(tplToolsRow(row));
+}
+
+function tplToolsRow(row) {
+  const label = document.createElement('label');
+  label.className = 'd-flex align-items-center gap-2';
+  label.style.cssText = 'font-size: 13px; color: var(--text-primary); cursor: pointer;';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.className = 'form-check-input';
+  cb.checked = row.checked;
+  cb.dataset.name = row.name;
+  label.appendChild(cb);
+  const span = document.createElement('span');
+  span.textContent = row.name;
+  label.appendChild(span);
+  if (!row.installed) {
+    const tag = document.createElement('span');
+    tag.className = 'badge';
+    tag.textContent = 'not installed';
+    tag.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 10px;';
+    label.appendChild(tag);
+  }
+  return label;
+}
+
+function tplToolsExtractList(data, keys) {
+  if (Array.isArray(data)) return data;
+  for (const k of keys) {
+    if (Array.isArray(data && data[k])) return data[k];
+  }
+  return [];
+}
+
+function tplToolsItemName(item) {
+  if (typeof item === 'string') return item.trim();
+  if (!item || typeof item !== 'object') return '';
+  return (item.name || item.id || item.server_name || item.skill_name || '').trim();
+}
+
+function tplToolsCollect(containerId) {
+  const container = tplEl(containerId);
+  if (!container) return [];
+  return Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
+    .map((cb) => cb.dataset.name)
+    .filter(Boolean);
+}
+
+async function tplToolsSave() {
+  const template = tplSelected();
+  if (!template) return;
+  const body = {
+    skills: tplToolsCollect('tplToolsSkills'),
+    mcp_servers: tplToolsCollect('tplToolsMcp'),
+    plugins: tplToolsCollect('tplToolsPlugins')
+  };
+  try {
+    await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}/tools`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    tplToast('Tools saved.', 'success');
+    await tplRefresh(template.id);
+    tplTools.templateId = '';
+    await tplToolsLoad();
+  } catch (error) {
+    tplToast(error.message || 'Failed to save tools', 'error');
+  }
+}
+
 // --- Init ---
 
 function tplInit() {
@@ -1196,6 +1346,10 @@ function tplInit() {
   tplEl('tplOnbJsonToggle')?.addEventListener('click', tplOnbToggleJson);
   tplEl('tplOnbRemoveBtn')?.addEventListener('click', () => void tplOnbRemove());
   tplEl('tplOnbSaveBtn')?.addEventListener('click', () => void tplOnbSave());
+
+  // Tools tab wiring.
+  tplEl('tplTabTools')?.addEventListener('shown.bs.tab', () => tplToolsEnsure());
+  tplEl('tplToolsSaveBtn')?.addEventListener('click', () => void tplToolsSave());
 
   void tplRefresh();
 }

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -36,9 +36,14 @@ const tplFiles = {
 };
 
 function tplToast(message, kind) {
-  if (typeof window.showToast === 'function') {
-    window.showToast(message, kind || 'info');
-  } else if (kind === 'error') {
+  const type = kind || 'info';
+  if (typeof window.notifyToast === 'function') {
+    window.notifyToast(message, type);
+  } else if (window.Toast && typeof window.Toast.show === 'function') {
+    window.Toast.show(message, type);
+  } else if (typeof window.showToast === 'function') {
+    window.showToast(message, type);
+  } else if (type === 'error') {
     console.error(message);
   }
 }

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -108,6 +108,9 @@
                   <li class="nav-item" role="presentation">
                     <button class="nav-link" id="tplTabOnboarding" data-bs-toggle="tab" data-bs-target="#tplOnboardingPane" type="button" role="tab" aria-controls="tplOnboardingPane" aria-selected="false">Onboarding</button>
                   </li>
+                  <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tplTabTools" data-bs-toggle="tab" data-bs-target="#tplToolsPane" type="button" role="tab" aria-controls="tplToolsPane" aria-selected="false">Tools</button>
+                  </li>
                 </ul>
 
                 <div class="tab-content">
@@ -215,6 +218,21 @@
                         <button id="tplOnbSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save onboarding</button>
                       </div>
                     </div>
+                  </div>
+
+                  <!-- Tools: default skills / MCP servers / plugins bound on workspace creation -->
+                  <div class="tab-pane fade" id="tplToolsPane" role="tabpanel" aria-labelledby="tplTabTools">
+                    <div style="font-size: 12px; color: var(--text-secondary);" class="mb-2">
+                      Tools checked here are bound to a workspace when it's created from this template —
+                      applied if present on the machine (missing ones are skipped with a note at creation).
+                    </div>
+                    <h6 class="mb-1" style="color: var(--text-primary);">Skills</h6>
+                    <div id="tplToolsSkills" class="d-flex flex-column gap-1 mb-3"></div>
+                    <h6 class="mb-1" style="color: var(--text-primary);">MCP Servers</h6>
+                    <div id="tplToolsMcp" class="d-flex flex-column gap-1 mb-3"></div>
+                    <h6 class="mb-1" style="color: var(--text-primary);">Plugins</h6>
+                    <div id="tplToolsPlugins" class="d-flex flex-column gap-1 mb-3"></div>
+                    <button id="tplToolsSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save tools</button>
                   </div>
                 </div>
               </div>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -74,6 +74,10 @@ func TestRenderTemplatesPage(t *testing.T) {
 		`id="tplOnbFields"`,
 		`id="tplOnbCompletion"`,
 		`id="tplOnbSaveBtn"`,
+		`id="tplToolsSkills"`,
+		`id="tplToolsMcp"`,
+		`id="tplToolsPlugins"`,
+		`id="tplToolsSaveBtn"`,
 		`/js/modules/templates-page.js`,
 	} {
 		if !strings.Contains(html, want) {


### PR DESCRIPTION
## Templates page — Seam PR 4: default tools

Lands on top of the merged Seam 1–3 (#110, #111, #112). Lets a template declare
default **skills, MCP servers, and plugins** so a workspace created from it comes
pre-equipped — referenced by name, applied if present on the machine. Distinct
from the onboarding block's `dependencies` (which gate the onboarding action);
this binds tools to the workspace itself.

### Backend (`6ad8f43`)
- `template.json` gains a `tools` block (`{skills, mcp_servers, plugins}` — names
  only). `projecttemplates` carries it domain-blind: typed `ToolDefaults` parsed
  in `newTemplate` (trim/dedupe-ci/sort), in `Template` JSON; `SetTools`
  read-merge-writes preserving other keys. `PUT /api/project-templates/{id}/tools`.
- **Apply-on-create**: an injected applier binds the declared tools onto the new
  workspace — skills by name (resolved downstream), MCP servers when configured,
  plugins expanded to their installed component skills + MCP servers. Missing
  names are skipped and surfaced as a non-fatal creation warning; existing
  bindings (e.g. the auto filesystem root) aren't duplicated.
  - Key detail: it binds **through the SyncStore** (`Get`→bind→`Save` by id), the
    same store the binding endpoints read from. Writing via the raw FileStore
    would persist to disk but bypass the read path.

### Frontend (`24500d7`)
- A **Tools** tab on the template detail pane with Skills / MCP Servers / Plugins
  sections, each fetching the installed list (`/api/skills`, `/api/mcp/servers`,
  `/api/plugins`) as checkable rows, pre-checked for what the template declares.
  Declared-but-not-installed names are kept (badged "not installed"). Save →
  `PUT …/tools`.

### Drive-by fix (`7f50693`)
- `tplToast` was calling `window.showToast`, which is never defined — so every
  templates-page toast silently no-op'd. Switched to the real
  `window.notifyToast` / `window.Toast` API, restoring toasts across the page
  (Save tools, metadata, onboarding, file edits, lifecycle).

### Verification
- Unit tests: `SetTools` round-trip + unknown-key preservation + clear +
  name normalization. gosec-clean.
- Live API smoke: set tools → create workspace → declared skills bound and
  visible via the skill-bindings API; a configured MCP server (`fetch`) bound;
  missing MCP/plugin reported in the creation warning; auto filesystem root not
  duplicated.
- Live browser smoke: Tools tab pickers, save persists, and the Save-tools toast
  fires (confirmed in the DOM).
- eslint + `go test`/`vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)