### PR TITLE
Agents UI fixes + Claude Code ~/.claude sync

### DIFF
--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -82,6 +82,10 @@ type Handler struct {
 	cliAgentRegistry *cliagent.CLIAgentRegistry
 	workspaceStore   workspace.Store
 	sessionPurger    SessionPurger
+	// claudeSync returns read-only synced ~/.claude data for the Claude Code
+	// agent (or nil when disabled). Injected so agenthttp stays decoupled from
+	// the externalagents package.
+	claudeSync func() any
 }
 
 func New(state store.Store) *Handler {
@@ -109,6 +113,12 @@ func (h *Handler) SetWorkspaceStore(s workspace.Store) {
 // keep referring to a deleted agent through restored session state.
 func (h *Handler) SetSessionPurger(p SessionPurger) {
 	h.sessionPurger = p
+}
+
+// SetClaudeSyncProvider wires a provider of read-only ~/.claude data, attached
+// to the Claude Code agent's detail response when available.
+func (h *Handler) SetClaudeSyncProvider(provider func() any) {
+	h.claudeSync = provider
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -649,7 +659,7 @@ func (h *Handler) getCLIAgentDetail(name string) (map[string]any, bool) {
 	if len(models) > 0 {
 		defaultModel = models[0]
 	}
-	return map[string]any{
+	detail := map[string]any{
 		"name":               cliAgentDisplayName(backend),
 		"type":               "research",
 		"role":               types.RoleCLIAgent,
@@ -661,5 +671,14 @@ func (h *Handler) getCLIAgentDetail(name string) (map[string]any, bool) {
 		"status":             getCLIAgentOperationalStatus(backend),
 		"max_context_window": caps.MaxContextWindow,
 		"source":             "cli",
-	}, true
+	}
+
+	// Attach read-only synced ~/.claude state for the Claude Code agent.
+	if backend == cliagent.BackendClaude && h.claudeSync != nil {
+		if data := h.claudeSync(); data != nil {
+			detail["claude_sync"] = data
+		}
+	}
+
+	return detail, true
 }

--- a/internal/agenthttp/dashboard_claude_sync_test.go
+++ b/internal/agenthttp/dashboard_claude_sync_test.go
@@ -1,0 +1,94 @@
+package agenthttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/cliagent"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+func newClaudeDetailHandler(t *testing.T) *DashboardHandler {
+	t.Helper()
+	st, err := store.NewFileStore(filepath.Join(t.TempDir(), "agents.json"), types.Settings{})
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+	registry := cliagent.NewRegistry(dashboardCLIStubAdapter{
+		backend: cliagent.BackendClaude,
+		models:  []string{"opus"},
+	})
+	dashboard := NewDashboardHandler(st)
+	dashboard.SetCLIAgentRegistry(registry)
+	return dashboard
+}
+
+func TestGetAgentDetail_ClaudeSyncAttached(t *testing.T) {
+	dashboard := newClaudeDetailHandler(t)
+	dashboard.SetClaudeSyncProvider(func() any {
+		return map[string]any{"model": "opus", "mcpServers": []any{}}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/Claude%20Code/detail", nil)
+	rr := httptest.NewRecorder()
+	dashboard.GetAgentDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GetAgentDetail() status = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		Provider   string         `json:"provider"`
+		ClaudeSync map[string]any `json:"claude_sync"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if body.Provider != cliagent.BackendClaude {
+		t.Errorf("provider = %q, want %q", body.Provider, cliagent.BackendClaude)
+	}
+	if body.ClaudeSync == nil {
+		t.Fatal("expected claude_sync to be attached for the Claude Code agent")
+	}
+	if body.ClaudeSync["model"] != "opus" {
+		t.Errorf("claude_sync.model = %v, want opus", body.ClaudeSync["model"])
+	}
+}
+
+func TestGetAgentDetail_NoClaudeSyncWhenProviderReturnsNil(t *testing.T) {
+	dashboard := newClaudeDetailHandler(t)
+	// Provider present but disabled (returns nil) — mirrors the opt-out path.
+	dashboard.SetClaudeSyncProvider(func() any { return nil })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/Claude%20Code/detail", nil)
+	rr := httptest.NewRecorder()
+	dashboard.GetAgentDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GetAgentDetail() status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte("claude_sync")) {
+		t.Errorf("claude_sync must be omitted when provider returns nil: %s", rr.Body.String())
+	}
+}
+
+func TestGetAgentDetail_NoClaudeSyncWhenProviderUnset(t *testing.T) {
+	dashboard := newClaudeDetailHandler(t)
+	// No provider wired at all.
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/Claude%20Code/detail", nil)
+	rr := httptest.NewRecorder()
+	dashboard.GetAgentDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GetAgentDetail() status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte("claude_sync")) {
+		t.Errorf("claude_sync must be omitted when no provider is set: %s", rr.Body.String())
+	}
+}

--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -23,6 +23,10 @@ type DashboardHandler struct {
 	ActivityLogger   *ActivityLogger
 	cliAgentRegistry *cliagent.CLIAgentRegistry
 	workspaceStore   workspace.Store
+	// claudeSync returns read-only synced ~/.claude data for the Claude Code
+	// agent (or nil when disabled). Injected to keep agenthttp decoupled from
+	// the externalagents package.
+	claudeSync func() any
 }
 
 // NewDashboardHandler creates a new dashboard handler
@@ -40,6 +44,12 @@ func (h *DashboardHandler) SetCLIAgentRegistry(r *cliagent.CLIAgentRegistry) {
 // workspace entry agents from the top-level agents list.
 func (h *DashboardHandler) SetWorkspaceStore(s workspace.Store) {
 	h.workspaceStore = s
+}
+
+// SetClaudeSyncProvider wires a provider of read-only ~/.claude data, attached
+// to the Claude Code agent's detail response when available.
+func (h *DashboardHandler) SetClaudeSyncProvider(provider func() any) {
+	h.claudeSync = provider
 }
 
 // AgentListItem represents an agent in the dashboard list view
@@ -76,6 +86,8 @@ type AgentDetailResponse struct {
 	MaxOutputTokens int                    `json:"max_output_tokens,omitempty"`
 	SystemPrompt    string                 `json:"system_prompt"`
 	AllowWebSearch  bool                   `json:"allow_web_search"`
+	// ClaudeSync carries read-only ~/.claude state for the Claude Code agent.
+	ClaudeSync any `json:"claude_sync,omitempty"`
 }
 
 // ListAgentsWithStats handles GET /api/agents/dashboard/list
@@ -240,6 +252,10 @@ func (h *DashboardHandler) GetAgentDetail(w http.ResponseWriter, r *http.Request
 						Status:       getCLIAgentOperationalStatus(backend),
 						Model:        defaultModel,
 						Provider:     backend,
+					}
+					// Attach read-only synced ~/.claude state for the Claude Code agent.
+					if backend == cliagent.BackendClaude && h.claudeSync != nil {
+						response.ClaudeSync = h.claudeSync()
 					}
 					_ = caps // context window info available via /api/cli-agents
 					w.Header().Set("Content-Type", "application/json")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,8 +78,9 @@ type Settings struct {
 	Web3ConnectedAt   string `json:"web3_connected_at,omitempty"`   // ISO timestamp of when wallet was connected
 
 	// External agents settings
-	ExternalAgentsClaudeEnabled bool `json:"external_agents_claude_enabled"` // Enable reading agents from Claude Code ~/.claude (default: false)
-	ExternalAgentsCodexEnabled  bool `json:"external_agents_codex_enabled"`  // Enable reading agents from Codex CLI ~/.codex (default: false)
+	ExternalAgentsClaudeEnabled  bool `json:"external_agents_claude_enabled"`            // Force-enable reading from Claude Code ~/.claude (opt-in)
+	ExternalAgentsClaudeDisabled bool `json:"external_agents_claude_disabled,omitempty"` // Explicit opt-out: suppresses auto-enable even when the Claude CLI is detected
+	ExternalAgentsCodexEnabled   bool `json:"external_agents_codex_enabled"`             // Enable reading agents from Codex CLI ~/.codex (default: false)
 
 	// Speech settings
 	SpeechProvider string `json:"speech_provider,omitempty"` // auto, browser, openai, off
@@ -1425,6 +1426,35 @@ func (m *Manager) SetExternalAgentsClaudeEnabled(enabled bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.settings.ExternalAgentsClaudeEnabled = enabled
+}
+
+// GetExternalAgentsClaudeDisabled returns whether the user explicitly opted out
+// of Claude Code agent reading (overrides auto-enable on CLI detection).
+func (m *Manager) GetExternalAgentsClaudeDisabled() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.settings.ExternalAgentsClaudeDisabled
+}
+
+// SetExternalAgentsClaudeDisabled updates the explicit Claude opt-out setting.
+func (m *Manager) SetExternalAgentsClaudeDisabled(disabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.settings.ExternalAgentsClaudeDisabled = disabled
+}
+
+// EffectiveExternalAgentsClaudeEnabled reports whether Claude Code agent reading
+// is active, given whether the Claude CLI was detected. Precedence: an explicit
+// opt-out always wins; otherwise the feature is on when force-enabled OR the CLI
+// is detected (auto-enable). A legacy enabled=false simply means "not opted in"
+// and still auto-enables on detection.
+func (m *Manager) EffectiveExternalAgentsClaudeEnabled(cliDetected bool) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.settings.ExternalAgentsClaudeDisabled {
+		return false
+	}
+	return m.settings.ExternalAgentsClaudeEnabled || cliDetected
 }
 
 // GetExternalAgentsCodexEnabled returns whether Codex CLI agents reading is enabled

--- a/internal/externalagents/cache.go
+++ b/internal/externalagents/cache.go
@@ -11,16 +11,21 @@ type Cache struct {
 	claudeReader ClaudeReader
 	codexReader  CodexReader
 
-	claudeAgents   []ExternalAgent
-	claudeSettings *ClaudeSettings
-	claudePlugins  []ClaudePlugin
-	codexAgents    []ExternalAgent
-	codexConfig    *CodexConfig
-	codexSkills    []CodexSkill
-	codexRules     []CodexRule
+	claudeAgents         []ExternalAgent
+	claudeSettings       *ClaudeSettings
+	claudePlugins        []ClaudePlugin
+	claudeMCPServers     []ClaudeMCPServer
+	claudeRecentProjects []ClaudeRecentProject
+	codexAgents          []ExternalAgent
+	codexConfig          *CodexConfig
+	codexSkills          []CodexSkill
+	codexRules           []CodexRule
 
 	loaded bool
 }
+
+// claudeRecentProjectsLimit caps how many recent projects the cache loads.
+const claudeRecentProjectsLimit = 5
 
 // NewCache creates a new Cache with the given readers.
 func NewCache(claudeReader ClaudeReader, codexReader CodexReader) *Cache {
@@ -60,6 +65,21 @@ func (c *Cache) loadLocked() error {
 			return err
 		}
 		c.claudePlugins = plugins
+
+		// MCP servers and recent projects come from ~/.claude.json and must fail
+		// independently: a missing or malformed file leaves these sections empty
+		// rather than breaking the rest of the Claude data.
+		if mcpServers, mcpErr := c.claudeReader.ReadMCPServers(); mcpErr == nil {
+			c.claudeMCPServers = mcpServers
+		} else {
+			c.claudeMCPServers = nil
+		}
+
+		if recentProjects, projErr := c.claudeReader.ReadRecentProjects(claudeRecentProjectsLimit); projErr == nil {
+			c.claudeRecentProjects = recentProjects
+		} else {
+			c.claudeRecentProjects = nil
+		}
 	}
 
 	// Read Codex data
@@ -102,6 +122,8 @@ func (c *Cache) Refresh() error {
 	c.claudeAgents = nil
 	c.claudeSettings = nil
 	c.claudePlugins = nil
+	c.claudeMCPServers = nil
+	c.claudeRecentProjects = nil
 	c.codexAgents = nil
 	c.codexConfig = nil
 	c.codexSkills = nil
@@ -130,6 +152,20 @@ func (c *Cache) GetClaudePlugins() []ClaudePlugin {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.claudePlugins
+}
+
+// GetClaudeMCPServers returns cached Claude MCP servers.
+func (c *Cache) GetClaudeMCPServers() []ClaudeMCPServer {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.claudeMCPServers
+}
+
+// GetClaudeRecentProjects returns cached recent Claude projects.
+func (c *Cache) GetClaudeRecentProjects() []ClaudeRecentProject {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.claudeRecentProjects
 }
 
 // GetCodexAgents returns cached Codex agents (skills).
@@ -166,9 +202,11 @@ func (c *Cache) GetClaudeData() *ClaudeData {
 	defer c.mu.RUnlock()
 
 	return &ClaudeData{
-		Agents:   c.claudeAgents,
-		Settings: c.claudeSettings,
-		Plugins:  c.claudePlugins,
+		Agents:         c.claudeAgents,
+		Settings:       c.claudeSettings,
+		Plugins:        c.claudePlugins,
+		MCPServers:     c.claudeMCPServers,
+		RecentProjects: c.claudeRecentProjects,
 	}
 }
 
@@ -192,9 +230,11 @@ func (c *Cache) GetAll() *ExternalAgentsData {
 
 	return &ExternalAgentsData{
 		Claude: &ClaudeData{
-			Agents:   c.claudeAgents,
-			Settings: c.claudeSettings,
-			Plugins:  c.claudePlugins,
+			Agents:         c.claudeAgents,
+			Settings:       c.claudeSettings,
+			Plugins:        c.claudePlugins,
+			MCPServers:     c.claudeMCPServers,
+			RecentProjects: c.claudeRecentProjects,
 		},
 		Codex: &CodexData{
 			Agents: c.codexAgents,

--- a/internal/externalagents/cache_test.go
+++ b/internal/externalagents/cache_test.go
@@ -1,0 +1,45 @@
+package externalagents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCacheLoad_MalformedClaudeJSONIsIsolated verifies that a malformed
+// ~/.claude.json leaves the MCP-server and recent-project sections empty
+// without breaking the agents that load from ~/.claude (PRD req 6 — each
+// section fails independently).
+func TestCacheLoad_MalformedClaudeJSONIsIsolated(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Valid agent under ~/.claude/agents.
+	agentsDir := filepath.Join(tmpDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	agentContent := "---\nname: a\ndescription: d\nmodel: opus\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(agentsDir, "a.md"), []byte(agentContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Malformed ~/.claude.json (test fixture lives at <baseDir>/.claude.json).
+	if err := os.WriteFile(filepath.Join(tmpDir, ".claude.json"), []byte("{ not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewCache(NewClaudeReader(tmpDir), nil)
+	if err := cache.Load(); err != nil {
+		t.Fatalf("Load() should not fail on malformed ~/.claude.json: %v", err)
+	}
+
+	if got := cache.GetClaudeAgents(); len(got) != 1 {
+		t.Errorf("expected 1 claude agent despite malformed claude.json, got %d", len(got))
+	}
+	if got := cache.GetClaudeMCPServers(); len(got) != 0 {
+		t.Errorf("expected 0 MCP servers from malformed claude.json, got %d", len(got))
+	}
+	if got := cache.GetClaudeRecentProjects(); len(got) != 0 {
+		t.Errorf("expected 0 recent projects from malformed claude.json, got %d", len(got))
+	}
+}

--- a/internal/externalagents/claude.go
+++ b/internal/externalagents/claude.go
@@ -5,10 +5,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// defaultRecentProjectsLimit is used when ReadRecentProjects is called with a
+// non-positive limit.
+const defaultRecentProjectsLimit = 5
 
 // DefaultClaudeReader implements ClaudeReader for reading Claude Code data from ~/.claude.
 type DefaultClaudeReader struct {
@@ -250,4 +256,175 @@ func (r *DefaultClaudeReader) ReadPlugins() ([]ClaudePlugin, error) {
 	}
 
 	return plugins, nil
+}
+
+// claudeJSONFile is a partial view of ~/.claude.json. Only the fields needed by
+// the reader are declared so the (large, secret-bearing) file is never fully
+// decoded or re-serialized.
+type claudeJSONFile struct {
+	MCPServers map[string]claudeJSONMCPServer `json:"mcpServers"`
+	Projects   map[string]claudeJSONProject   `json:"projects"`
+}
+
+type claudeJSONMCPServer struct {
+	Type    string            `json:"type"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env"`
+}
+
+type claudeJSONProject struct {
+	LastSessionID    string  `json:"lastSessionId"`
+	LastCost         float64 `json:"lastCost"`
+	LastDuration     int64   `json:"lastDuration"`
+	LastLinesAdded   int     `json:"lastLinesAdded"`
+	LastLinesRemoved int     `json:"lastLinesRemoved"`
+}
+
+// getClaudeJSONPath returns the path to ~/.claude.json. Note this file is a
+// SIBLING of the ~/.claude directory, not inside it. When baseDir is set (for
+// testing), the fixture file is expected at <baseDir>/.claude.json so tests stay
+// self-contained.
+func (r *DefaultClaudeReader) getClaudeJSONPath() (string, error) {
+	if r.baseDir != "" {
+		return filepath.Join(r.baseDir, ".claude.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude.json"), nil
+}
+
+// readClaudeJSON reads and parses ~/.claude.json. A missing file is not an
+// error (returns nil, nil) so callers degrade to empty sections.
+func (r *DefaultClaudeReader) readClaudeJSON() (*claudeJSONFile, error) {
+	path, err := r.getClaudeJSONPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path) // #nosec G304 -- reads the user's own ~/.claude.json config file
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var file claudeJSONFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	return &file, nil
+}
+
+// ReadMCPServers reads the top-level MCP servers configured for Claude Code from
+// ~/.claude.json. Env variable VALUES are deliberately discarded — only the
+// names are surfaced, since values may contain secrets/API keys.
+func (r *DefaultClaudeReader) ReadMCPServers() ([]ClaudeMCPServer, error) {
+	file, err := r.readClaudeJSON()
+	if err != nil {
+		return nil, err
+	}
+	if file == nil || len(file.MCPServers) == 0 {
+		return []ClaudeMCPServer{}, nil
+	}
+
+	servers := make([]ClaudeMCPServer, 0, len(file.MCPServers))
+	for name, s := range file.MCPServers {
+		server := ClaudeMCPServer{
+			Name:      name,
+			Transport: s.Type,
+			Command:   s.Command,
+			Args:      s.Args,
+		}
+		if len(s.Env) > 0 {
+			names := make([]string, 0, len(s.Env))
+			for k := range s.Env {
+				names = append(names, k)
+			}
+			sort.Strings(names)
+			server.EnvNames = names
+		}
+		servers = append(servers, server)
+	}
+
+	// Stable ordering by server name.
+	sort.Slice(servers, func(i, j int) bool { return servers[i].Name < servers[j].Name })
+	return servers, nil
+}
+
+// ReadRecentProjects returns the most recently used Claude Code projects from
+// ~/.claude.json, ordered by the modification time of their session directory
+// under ~/.claude/projects/. Projects with no session directory are kept but
+// sort last (zero time). limit <= 0 falls back to defaultRecentProjectsLimit.
+func (r *DefaultClaudeReader) ReadRecentProjects(limit int) ([]ClaudeRecentProject, error) {
+	if limit <= 0 {
+		limit = defaultRecentProjectsLimit
+	}
+
+	file, err := r.readClaudeJSON()
+	if err != nil {
+		return nil, err
+	}
+	if file == nil || len(file.Projects) == 0 {
+		return []ClaudeRecentProject{}, nil
+	}
+
+	claudeDir, err := r.getClaudeDir()
+	if err != nil {
+		return nil, err
+	}
+	projectsDir := filepath.Join(claudeDir, "projects")
+
+	type scoredProject struct {
+		project ClaudeRecentProject
+		modTime time.Time
+	}
+
+	scored := make([]scoredProject, 0, len(file.Projects))
+	for path, p := range file.Projects {
+		var modTime time.Time
+		if info, statErr := os.Stat(filepath.Join(projectsDir, encodeProjectDirName(path))); statErr == nil {
+			modTime = info.ModTime()
+		}
+		scored = append(scored, scoredProject{
+			project: ClaudeRecentProject{
+				Path:             path,
+				LastSessionID:    p.LastSessionID,
+				LastCost:         p.LastCost,
+				LastDuration:     p.LastDuration,
+				LastLinesAdded:   p.LastLinesAdded,
+				LastLinesRemoved: p.LastLinesRemoved,
+			},
+			modTime: modTime,
+		})
+	}
+
+	// Most recent first; deterministic path tie-break for equal/zero mtimes.
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].modTime.Equal(scored[j].modTime) {
+			return scored[i].project.Path < scored[j].project.Path
+		}
+		return scored[i].modTime.After(scored[j].modTime)
+	})
+
+	if len(scored) > limit {
+		scored = scored[:limit]
+	}
+
+	result := make([]ClaudeRecentProject, 0, len(scored))
+	for _, s := range scored {
+		result = append(result, s.project)
+	}
+	return result, nil
+}
+
+// encodeProjectDirName converts an absolute project path to the directory name
+// Claude Code uses under ~/.claude/projects. Claude replaces path separators and
+// dots with hyphens (e.g. /Users/me/.config -> -Users-me--config). Projects
+// whose encoded name has no matching directory simply get a zero mtime.
+func encodeProjectDirName(path string) string {
+	return strings.NewReplacer("/", "-", ".", "-").Replace(path)
 }

--- a/internal/externalagents/claude_test.go
+++ b/internal/externalagents/claude_test.go
@@ -1,9 +1,13 @@
 package externalagents
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseFrontmatter(t *testing.T) {
@@ -192,6 +196,204 @@ func TestReadSettings_MissingFile(t *testing.T) {
 	}
 	if settings != nil {
 		t.Error("settings should be nil for missing file")
+	}
+}
+
+func TestReadSettings_Model(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(`{"model":"opus"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewClaudeReader(tmpDir)
+	settings, err := reader.ReadSettings()
+	if err != nil {
+		t.Fatalf("ReadSettings() error = %v", err)
+	}
+	if settings == nil {
+		t.Fatal("settings should not be nil")
+	}
+	if settings.Model != "opus" {
+		t.Errorf("Model = %q, want %q", settings.Model, "opus")
+	}
+}
+
+func TestReadMCPServers(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	claudeJSON := `{
+  "mcpServers": {
+    "ori-reaper": {
+      "type": "stdio",
+      "command": "/usr/local/bin/reaper-plugin",
+      "args": ["serve", "--port", "9000"],
+      "env": { "API_KEY": "super-secret-value", "TOKEN": "another-secret" }
+    },
+    "remote-sse": {
+      "type": "sse"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".claude.json"), []byte(claudeJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewClaudeReader(tmpDir)
+	servers, err := reader.ReadMCPServers()
+	if err != nil {
+		t.Fatalf("ReadMCPServers() error = %v", err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+
+	// Servers are sorted by name: "ori-reaper" < "remote-sse".
+	reaper := servers[0]
+	if reaper.Name != "ori-reaper" {
+		t.Errorf("Name = %q, want %q", reaper.Name, "ori-reaper")
+	}
+	if reaper.Transport != "stdio" {
+		t.Errorf("Transport = %q, want %q", reaper.Transport, "stdio")
+	}
+	if reaper.Command != "/usr/local/bin/reaper-plugin" {
+		t.Errorf("Command = %q", reaper.Command)
+	}
+	if len(reaper.Args) != 3 {
+		t.Errorf("expected 3 args, got %d", len(reaper.Args))
+	}
+	if !reflect.DeepEqual(reaper.EnvNames, []string{"API_KEY", "TOKEN"}) {
+		t.Errorf("EnvNames = %v, want [API_KEY TOKEN]", reaper.EnvNames)
+	}
+
+	// Critical: env VALUES must never leak through the serialized result.
+	blob, _ := json.Marshal(servers)
+	for _, secret := range []string{"super-secret-value", "another-secret"} {
+		if strings.Contains(string(blob), secret) {
+			t.Errorf("serialized servers leaked secret %q: %s", secret, blob)
+		}
+	}
+}
+
+func TestReadMCPServers_MissingFile(t *testing.T) {
+	reader := NewClaudeReader(t.TempDir())
+
+	servers, err := reader.ReadMCPServers()
+	if err != nil {
+		t.Fatalf("ReadMCPServers() should not error for missing file, got: %v", err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(servers))
+	}
+}
+
+func TestReadRecentProjects(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	claudeJSON := `{
+  "projects": {
+    "/Users/test/old": { "lastSessionId": "s-old", "lastCost": 0.1 },
+    "/Users/test/new": { "lastSessionId": "s-new", "lastCost": 0.2 },
+    "/Users/test/mid": { "lastSessionId": "s-mid", "lastCost": 0.3 }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".claude.json"), []byte(claudeJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectsDir := filepath.Join(tmpDir, "projects")
+	mkProjectDir := func(path string, mod time.Time) {
+		dir := filepath.Join(projectsDir, encodeProjectDirName(path))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(dir, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+	base := time.Now()
+	mkProjectDir("/Users/test/old", base.Add(-2*time.Hour))
+	mkProjectDir("/Users/test/mid", base.Add(-1*time.Hour))
+	mkProjectDir("/Users/test/new", base)
+
+	reader := NewClaudeReader(tmpDir)
+	projects, err := reader.ReadRecentProjects(5)
+	if err != nil {
+		t.Fatalf("ReadRecentProjects() error = %v", err)
+	}
+	if len(projects) != 3 {
+		t.Fatalf("expected 3 projects, got %d", len(projects))
+	}
+
+	wantOrder := []string{"/Users/test/new", "/Users/test/mid", "/Users/test/old"}
+	for i, want := range wantOrder {
+		if projects[i].Path != want {
+			t.Errorf("projects[%d].Path = %q, want %q", i, projects[i].Path, want)
+		}
+	}
+	// Metrics must travel with the project entry.
+	if projects[0].LastSessionID != "s-new" {
+		t.Errorf("LastSessionID = %q, want %q", projects[0].LastSessionID, "s-new")
+	}
+}
+
+func TestReadRecentProjects_LimitAndMissingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	claudeJSON := `{
+  "projects": {
+    "/p/a": {}, "/p/b": {}, "/p/c": {}, "/p/d": {},
+    "/p/e": {}, "/p/f": {}, "/p/g": {}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".claude.json"), []byte(claudeJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectsDir := filepath.Join(tmpDir, "projects")
+	base := time.Now()
+	// a (oldest) ... f (newest) each get a session dir; g gets none.
+	for i, p := range []string{"/p/a", "/p/b", "/p/c", "/p/d", "/p/e", "/p/f"} {
+		dir := filepath.Join(projectsDir, encodeProjectDirName(p))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		mod := base.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(dir, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	reader := NewClaudeReader(tmpDir)
+	projects, err := reader.ReadRecentProjects(5)
+	if err != nil {
+		t.Fatalf("ReadRecentProjects() error = %v", err)
+	}
+	if len(projects) != 5 {
+		t.Fatalf("expected limit of 5, got %d", len(projects))
+	}
+
+	wantTop := []string{"/p/f", "/p/e", "/p/d", "/p/c", "/p/b"}
+	for i, want := range wantTop {
+		if projects[i].Path != want {
+			t.Errorf("projects[%d].Path = %q, want %q", i, projects[i].Path, want)
+		}
+	}
+	for _, p := range projects {
+		if p.Path == "/p/g" {
+			t.Error("/p/g has no session dir and must not appear in the recent top 5")
+		}
+	}
+}
+
+func TestReadRecentProjects_MissingFile(t *testing.T) {
+	reader := NewClaudeReader(t.TempDir())
+
+	projects, err := reader.ReadRecentProjects(5)
+	if err != nil {
+		t.Fatalf("ReadRecentProjects() should not error for missing file, got: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Errorf("expected 0 projects, got %d", len(projects))
 	}
 }
 

--- a/internal/externalagents/types.go
+++ b/internal/externalagents/types.go
@@ -20,9 +20,33 @@ type ExternalAgent struct {
 
 // ClaudeSettings represents the global settings from ~/.claude/settings.json.
 type ClaudeSettings struct {
+	Model          string            `json:"model,omitempty"`
 	Permissions    ClaudePermissions `json:"permissions"`
 	EnabledPlugins map[string]bool   `json:"enabledPlugins"`
 	StatusLine     map[string]any    `json:"statusLine,omitempty"`
+}
+
+// ClaudeMCPServer represents an MCP server configured for Claude Code in
+// ~/.claude.json. Env values are intentionally NOT included — only variable
+// names are surfaced, to avoid leaking secrets/API keys to the API/UI.
+type ClaudeMCPServer struct {
+	Name      string   `json:"name"`
+	Transport string   `json:"transport,omitempty"` // from the "type" field, e.g. "stdio", "sse", "http"
+	Command   string   `json:"command,omitempty"`
+	Args      []string `json:"args,omitempty"`
+	EnvNames  []string `json:"envNames,omitempty"` // variable names only — never values
+}
+
+// ClaudeRecentProject represents a recently used Claude Code project, read from
+// the "projects" map in ~/.claude.json. Only lightweight last-session metrics
+// are surfaced; no transcript bodies are read.
+type ClaudeRecentProject struct {
+	Path             string  `json:"path"`
+	LastSessionID    string  `json:"lastSessionId,omitempty"`
+	LastCost         float64 `json:"lastCost,omitempty"`
+	LastDuration     int64   `json:"lastDuration,omitempty"`
+	LastLinesAdded   int     `json:"lastLinesAdded,omitempty"`
+	LastLinesRemoved int     `json:"lastLinesRemoved,omitempty"`
 }
 
 // ClaudePermissions represents the permissions configuration in Claude settings.
@@ -64,9 +88,11 @@ type CodexRule struct {
 
 // ClaudeData holds all data read from the Claude Code configuration.
 type ClaudeData struct {
-	Agents   []ExternalAgent `json:"agents"`
-	Settings *ClaudeSettings `json:"settings,omitempty"`
-	Plugins  []ClaudePlugin  `json:"plugins"`
+	Agents         []ExternalAgent       `json:"agents"`
+	Settings       *ClaudeSettings       `json:"settings,omitempty"`
+	Plugins        []ClaudePlugin        `json:"plugins"`
+	MCPServers     []ClaudeMCPServer     `json:"mcpServers"`
+	RecentProjects []ClaudeRecentProject `json:"recentProjects"`
 }
 
 // CodexData holds all data read from the Codex configuration.
@@ -88,6 +114,8 @@ type ClaudeReader interface {
 	ReadAgents() ([]ExternalAgent, error)
 	ReadSettings() (*ClaudeSettings, error)
 	ReadPlugins() ([]ClaudePlugin, error)
+	ReadMCPServers() ([]ClaudeMCPServer, error)
+	ReadRecentProjects(limit int) ([]ClaudeRecentProject, error)
 }
 
 // CodexReader defines the interface for reading Codex data.

--- a/internal/externalagentshttp/handlers.go
+++ b/internal/externalagentshttp/handlers.go
@@ -14,14 +14,30 @@ import (
 type Handler struct {
 	cache         *externalagents.Cache
 	configManager *config.Manager
+	// claudeDetected reports whether the Claude Code CLI is available. It is
+	// evaluated lazily (per request) so it works regardless of init ordering.
+	// May be nil, in which case detection is treated as false.
+	claudeDetected func() bool
 }
 
 // New creates a new Handler with the given cache and config manager.
-func New(cache *externalagents.Cache, configManager *config.Manager) *Handler {
+// claudeDetected reports whether the Claude Code CLI is available (may be nil).
+func New(cache *externalagents.Cache, configManager *config.Manager, claudeDetected func() bool) *Handler {
 	return &Handler{
-		cache:         cache,
-		configManager: configManager,
+		cache:          cache,
+		configManager:  configManager,
+		claudeDetected: claudeDetected,
 	}
+}
+
+// claudeEnabled reports whether Claude Code agent reading is effectively active,
+// honoring the explicit opt-out and auto-enable-on-CLI-detection.
+func (h *Handler) claudeEnabled() bool {
+	detected := false
+	if h.claudeDetected != nil {
+		detected = h.claudeDetected()
+	}
+	return h.configManager.EffectiveExternalAgentsClaudeEnabled(detected)
 }
 
 // GetAll handles GET /api/external-agents
@@ -32,7 +48,7 @@ func (h *Handler) GetAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claudeEnabled := h.configManager.GetExternalAgentsClaudeEnabled()
+	claudeEnabled := h.claudeEnabled()
 	codexEnabled := h.configManager.GetExternalAgentsCodexEnabled()
 
 	response := map[string]any{
@@ -59,7 +75,7 @@ func (h *Handler) GetClaude(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.configManager.GetExternalAgentsClaudeEnabled() {
+	if !h.claudeEnabled() {
 		orihttp.WriteJSON(w, map[string]any{
 			"enabled": false,
 			"message": "Claude Code agents are disabled. Enable in Settings.",
@@ -99,7 +115,7 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claudeEnabled := h.configManager.GetExternalAgentsClaudeEnabled()
+	claudeEnabled := h.claudeEnabled()
 	codexEnabled := h.configManager.GetExternalAgentsCodexEnabled()
 
 	if !claudeEnabled && !codexEnabled {

--- a/internal/externalagentshttp/handlers.go
+++ b/internal/externalagentshttp/handlers.go
@@ -40,6 +40,17 @@ func (h *Handler) claudeEnabled() bool {
 	return h.configManager.EffectiveExternalAgentsClaudeEnabled(detected)
 }
 
+// ClaudeSyncData returns the cached, read-only Claude ~/.claude data when Claude
+// agent reading is effectively enabled, or nil otherwise. The agent-detail
+// endpoints use this to attach synced state to the Claude Code agent without
+// importing the externalagents package.
+func (h *Handler) ClaudeSyncData() any {
+	if !h.claudeEnabled() {
+		return nil
+	}
+	return h.cache.GetClaudeData()
+}
+
 // GetAll handles GET /api/external-agents
 // Returns all external agent data from all sources.
 func (h *Handler) GetAll(w http.ResponseWriter, r *http.Request) {

--- a/internal/externalagentshttp/handlers_test.go
+++ b/internal/externalagentshttp/handlers_test.go
@@ -66,7 +66,7 @@ model_reasoning_effort = "high"
 
 func TestGetAll(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -109,7 +109,7 @@ func TestGetAll(t *testing.T) {
 
 func TestGetAll_MethodNotAllowed(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -123,7 +123,7 @@ func TestGetAll_MethodNotAllowed(t *testing.T) {
 
 func TestGetClaude(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/claude", nil)
 	w := httptest.NewRecorder()
@@ -149,7 +149,7 @@ func TestGetClaude(t *testing.T) {
 
 func TestGetCodex(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/codex", nil)
 	w := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestGetCodex(t *testing.T) {
 
 func TestRefresh(t *testing.T) {
 	cache, configManager, tmpDir := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	// Verify initial state
 	agents := cache.GetClaudeAgents()
@@ -217,7 +217,7 @@ New agent prompt.
 
 func TestRefresh_MethodNotAllowed(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/refresh", nil)
 	w := httptest.NewRecorder()
@@ -233,7 +233,7 @@ func TestGetAll_Disabled(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
 	configManager.SetExternalAgentsClaudeEnabled(false)
 	configManager.SetExternalAgentsCodexEnabled(false)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -268,11 +268,58 @@ func TestGetAll_Disabled(t *testing.T) {
 	}
 }
 
+func TestClaudeEffectiveEnabled_TruthTable(t *testing.T) {
+	cache, configManager, _ := setupTestCache(t)
+	configManager.SetExternalAgentsCodexEnabled(false)
+
+	cases := []struct {
+		name        string
+		enabled     bool
+		disabled    bool
+		cliDetected bool
+		want        bool
+	}{
+		{"unset, no CLI", false, false, false, false},
+		{"unset, CLI detected -> auto-enable", false, false, true, true},
+		{"force-enabled, no CLI", true, false, false, true},
+		{"force-enabled, CLI detected", true, false, true, true},
+		{"opt-out beats CLI detection", false, true, true, false},
+		{"opt-out beats force-enable", true, true, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configManager.SetExternalAgentsClaudeEnabled(tc.enabled)
+			configManager.SetExternalAgentsClaudeDisabled(tc.disabled)
+			handler := New(cache, configManager, func() bool { return tc.cliDetected })
+
+			req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
+			w := httptest.NewRecorder()
+			handler.GetAll(w, req)
+
+			var data struct {
+				ClaudeEnabled bool                       `json:"claude_enabled"`
+				Claude        *externalagents.ClaudeData `json:"claude"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&data); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if data.ClaudeEnabled != tc.want {
+				t.Errorf("claude_enabled = %v, want %v", data.ClaudeEnabled, tc.want)
+			}
+			// Data must only be present when effectively enabled.
+			if (data.Claude != nil) != tc.want {
+				t.Errorf("claude data present = %v, want %v", data.Claude != nil, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetAll_PartialEnabled(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
 	configManager.SetExternalAgentsClaudeEnabled(true)
 	configManager.SetExternalAgentsCodexEnabled(false)
-	handler := New(cache, configManager)
+	handler := New(cache, configManager, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()

--- a/internal/externalagentshttp/handlers_test.go
+++ b/internal/externalagentshttp/handlers_test.go
@@ -268,6 +268,41 @@ func TestGetAll_Disabled(t *testing.T) {
 	}
 }
 
+func TestClaudeSyncData(t *testing.T) {
+	cache, configManager, _ := setupTestCache(t)
+
+	// Explicit opt-out -> nil even when the CLI is detected.
+	configManager.SetExternalAgentsClaudeEnabled(false)
+	configManager.SetExternalAgentsClaudeDisabled(true)
+	h := New(cache, configManager, func() bool { return true })
+	if h.ClaudeSyncData() != nil {
+		t.Error("expected nil sync data when opted out")
+	}
+
+	// Force-enabled -> returns the cached ClaudeData (with the test agent).
+	configManager.SetExternalAgentsClaudeDisabled(false)
+	configManager.SetExternalAgentsClaudeEnabled(true)
+	h = New(cache, configManager, func() bool { return false })
+	data := h.ClaudeSyncData()
+	if data == nil {
+		t.Fatal("expected sync data when enabled")
+	}
+	cd, ok := data.(*externalagents.ClaudeData)
+	if !ok {
+		t.Fatalf("expected *externalagents.ClaudeData, got %T", data)
+	}
+	if len(cd.Agents) != 1 {
+		t.Errorf("expected 1 claude agent, got %d", len(cd.Agents))
+	}
+
+	// Auto-enable purely via CLI detection -> returns data.
+	configManager.SetExternalAgentsClaudeEnabled(false)
+	h = New(cache, configManager, func() bool { return true })
+	if h.ClaudeSyncData() == nil {
+		t.Error("expected sync data when CLI detected (auto-enable)")
+	}
+}
+
 func TestClaudeEffectiveEnabled_TruthTable(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
 	configManager.SetExternalAgentsCodexEnabled(false)

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -223,7 +223,13 @@ func (b *ServerBuilder) initializeHandlers() {
 		logger.Warn("Failed to load external agents cache", logger.Fields{"error": err})
 		// Non-fatal: continue without external agents
 	}
-	b.externalAgentsHandler = externalagentshttp.New(b.externalAgentsCache, b.configManager)
+	// claudeCLIDetected is evaluated lazily so it reflects the CLI registry,
+	// which is created just below (after this handler). By request time the
+	// registry has run AutoDetect.
+	claudeCLIDetected := func() bool {
+		return b.cliAgentRegistry != nil && b.cliAgentRegistry.IsAvailable(cliagent.BackendClaude)
+	}
+	b.externalAgentsHandler = externalagentshttp.New(b.externalAgentsCache, b.configManager, claudeCLIDetected)
 	logger.Info("External agents support initialized", logger.Fields{})
 
 	// Initialize CLI agent adapter (delegatable CLI agents)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -98,6 +98,9 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	if s.Storage.SessionStore != nil {
 		agentHandler.SetSessionPurger(s.Storage.SessionStore)
 	}
+	if s.Handlers.ExternalAgents != nil {
+		agentHandler.SetClaudeSyncProvider(s.Handlers.ExternalAgents.ClaudeSyncData)
+	}
 	avatarHandler := agenthttp.NewAvatarHandler(s.Storage.AgentStore)
 	mux.Handle("/api/agents", agentHandler)
 	if s.Handlers.Evolution != nil {
@@ -110,6 +113,9 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	dashboardHandler.ActivityLogger = s.Handlers.ActivityLogger
 	dashboardHandler.SetCLIAgentRegistry(s.Handlers.CLIAgentRegistry)
 	dashboardHandler.SetWorkspaceStore(s.Storage.WorkspaceStore)
+	if s.Handlers.ExternalAgents != nil {
+		dashboardHandler.SetClaudeSyncProvider(s.Handlers.ExternalAgents.ClaudeSyncData)
+	}
 	mux.HandleFunc("/api/agents/dashboard/list", dashboardHandler.ListAgentsWithStats)
 	mux.HandleFunc("/api/agents/dashboard/stats", dashboardHandler.GetDashboardStats)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/cliagent"
 	"github.com/johnjallday/ori-agent/internal/featureflags"
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
@@ -251,6 +252,29 @@ func (s *Server) serveAgentsDetail(w http.ResponseWriter, r *http.Request) {
 	data.BrandText = "Ori Agent"
 	data.ShowSidebarToggle = true
 	s.renderAndWritePage(w, "agents-detail", data)
+}
+
+// isClaudeCodeAgentName reports whether the given agent name refers to the
+// built-in Claude Code CLI agent and that backend is currently available.
+func (s *Server) isClaudeCodeAgentName(name string) bool {
+	if s.Handlers == nil || s.Handlers.CLIAgentRegistry == nil {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower != "claude code" && lower != cliagent.BackendClaude {
+		return false
+	}
+	return s.Handlers.CLIAgentRegistry.IsAvailable(cliagent.BackendClaude)
+}
+
+// serveClaudeAgentDetail serves the dedicated, read-only Claude Code agent page
+// that mirrors the user's ~/.claude state.
+func (s *Server) serveClaudeAgentDetail(w http.ResponseWriter, r *http.Request) {
+	data := s.prepareBasePageData("agents")
+	data.Title = "Claude Code - Ori Agent"
+	data.BrandText = "Ori Agent"
+	data.ShowSidebarToggle = true
+	s.renderAndWritePage(w, "agents-claude-detail", data)
 }
 
 func (s *Server) serveAgentsEdit(w http.ResponseWriter, r *http.Request) {
@@ -594,7 +618,16 @@ func (s *Server) serveAgentFiles(w http.ResponseWriter, r *http.Request) {
 	// (not a file request like /agents/{agent-name}/config.json)
 	pathAfterAgents := strings.TrimPrefix(r.URL.Path, "/agents/")
 	if !strings.Contains(pathAfterAgents, "/") && !strings.Contains(pathAfterAgents, ".") && pathAfterAgents != "" {
-		// This is a request for /agents/{agent-name} - serve the agent detail page
+		// This is a request for /agents/{agent-name} - serve the agent detail page.
+		// The Claude Code CLI agent gets its own dedicated read-only page.
+		agentName, err := url.PathUnescape(pathAfterAgents)
+		if err != nil {
+			agentName = pathAfterAgents
+		}
+		if s.isClaudeCodeAgentName(agentName) {
+			s.serveClaudeAgentDetail(w, r)
+			return
+		}
 		s.serveAgentsDetail(w, r)
 		return
 	}

--- a/internal/settingshttp/handlers.go
+++ b/internal/settingshttp/handlers.go
@@ -1433,8 +1433,9 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 	switch r.Method {
 	case http.MethodGet:
 		orihttp.WriteJSON(w, map[string]bool{
-			"claude_enabled": h.configManager.GetExternalAgentsClaudeEnabled(),
-			"codex_enabled":  h.configManager.GetExternalAgentsCodexEnabled(),
+			"claude_enabled":  h.configManager.GetExternalAgentsClaudeEnabled(),
+			"claude_disabled": h.configManager.GetExternalAgentsClaudeDisabled(),
+			"codex_enabled":   h.configManager.GetExternalAgentsCodexEnabled(),
 		})
 
 	case http.MethodPost:
@@ -1449,6 +1450,9 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 		// Update only the settings that were provided
 		if req.ClaudeEnabled != nil {
 			h.configManager.SetExternalAgentsClaudeEnabled(*req.ClaudeEnabled)
+			// Toggling off records an explicit opt-out so it overrides
+			// auto-enable-on-CLI-detection; toggling on clears the opt-out.
+			h.configManager.SetExternalAgentsClaudeDisabled(!*req.ClaudeEnabled)
 			if *req.ClaudeEnabled {
 				// Register Claude provider if discovery works
 				apiKey := h.configManager.GetAnthropicAPIKey()
@@ -1474,6 +1478,7 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 
 		orihttp.WriteJSON(w, map[string]any{
 			"claude_enabled":        h.configManager.GetExternalAgentsClaudeEnabled(),
+			"claude_disabled":       h.configManager.GetExternalAgentsClaudeDisabled(),
 			"codex_enabled":         h.configManager.GetExternalAgentsCodexEnabled(),
 			"codex_exchange_status": codexExchangeStatus,
 		})

--- a/internal/web/static/css/claude-sync.css
+++ b/internal/web/static/css/claude-sync.css
@@ -1,0 +1,72 @@
+/* Shared styling for the read-only Claude Code (~/.claude) synced section.
+   Used by the agent details drawer (agents page) and the dedicated Claude
+   Code agent page. Self-contained class names so it does not depend on any
+   page-specific styles. */
+
+.claude-sync {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.claude-sync-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.claude-sync-readonly {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.claude-sync-card {
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    padding: 12px;
+}
+
+.claude-sync-label {
+    display: block;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    font-weight: 700;
+}
+
+.claude-sync-value {
+    color: var(--text-primary);
+    font-size: 13px;
+    word-break: break-word;
+}
+
+.claude-sync-list {
+    margin: 0;
+    padding-left: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text-primary);
+    font-size: 13px;
+    word-break: break-word;
+}
+
+.claude-sync-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 13px;
+}
+
+.claude-sync-muted {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.claude-sync-path {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+}

--- a/internal/web/static/css/common.css
+++ b/internal/web/static/css/common.css
@@ -302,6 +302,20 @@ a:focus-visible {
     border-color: rgba(239, 68, 68, 0.65);
 }
 
+/* Built-in agents (system assistant, CLI agents) cannot be deleted. */
+.sidebar-agent-delete.disabled,
+.sidebar-agent-delete.disabled:hover,
+.sidebar-agent-delete.disabled:focus-visible,
+[data-bs-theme="dark"] .sidebar-agent-delete.disabled,
+[data-bs-theme="dark"] .sidebar-agent-delete.disabled:hover,
+[data-bs-theme="dark"] .sidebar-agent-delete.disabled:focus-visible {
+    background: var(--bg-tertiary, rgba(148, 163, 184, 0.12));
+    color: var(--text-muted, #94a3b8);
+    border-color: var(--border-color, rgba(148, 163, 184, 0.35));
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
 /* Ghost button - subtle, text-only appearance */
 .modern-btn-ghost {
     background: transparent;

--- a/internal/web/static/js/agents-claude-detail.js
+++ b/internal/web/static/js/agents-claude-detail.js
@@ -1,0 +1,73 @@
+// Dedicated, read-only details page for the Claude Code CLI agent.
+// Renders the synced ~/.claude state via the shared ClaudeSync module.
+
+function getClaudeAgentNameFromURL() {
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  // /agents/{name}
+  const raw = parts.length >= 2 ? parts[1] : 'Claude Code';
+  try {
+    return decodeURIComponent(raw);
+  } catch (error) {
+    return raw;
+  }
+}
+
+const claudeAgentName = getClaudeAgentNameFromURL();
+
+function setClaudeDetailMessage(message) {
+  const missing = document.getElementById('claudeDetailMissing');
+  const content = document.getElementById('claudeSyncContent');
+  if (missing) {
+    missing.hidden = !message;
+    missing.textContent = message || '';
+  }
+  if (content && message) {
+    content.innerHTML = '';
+  }
+}
+
+function renderClaudeAgentPage(detail) {
+  const content = document.getElementById('claudeSyncContent');
+  if (!content || !window.ClaudeSync) {
+    return;
+  }
+
+  const titleEl = document.getElementById('claudeDetailTitle');
+  if (titleEl && detail?.name) {
+    titleEl.textContent = detail.name;
+  }
+
+  setClaudeDetailMessage('');
+  content.innerHTML = window.ClaudeSync.renderHtml(detail?.claude_sync || null);
+  window.ClaudeSync.wireRefresh(content, claudeAgentName, (reloaded) => {
+    renderClaudeAgentPage(reloaded);
+  });
+}
+
+async function loadClaudeAgentDetail() {
+  setClaudeDetailMessage('Loading…');
+  try {
+    const response = await fetch(`/api/agents/${encodeURIComponent(claudeAgentName)}/detail`);
+    if (response.status === 404) {
+      setClaudeDetailMessage('Claude Code agent not found. The Claude Code CLI may not be installed or detected.');
+      return;
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to load (${response.status})`);
+    }
+    const detail = await response.json();
+
+    if (!window.ClaudeSync || !window.ClaudeSync.isClaudeCodeAgent(detail)) {
+      // Not actually the Claude Code agent — send the user to the generic page.
+      window.location.replace('/agents');
+      return;
+    }
+
+    renderClaudeAgentPage(detail);
+  } catch (error) {
+    console.error('Failed to load Claude Code agent detail:', error);
+    setClaudeDetailMessage(error?.message || 'Failed to load Claude Code agent details.');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadClaudeAgentDetail);

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -723,7 +723,7 @@ function closeAgentDrawer() {
 
 function setDrawerTab(tabName, options = {}) {
   const { focusPanel = false } = options;
-  const normalized = tabName === 'tools' || tabName === 'advanced' ? tabName : 'overview';
+  const normalized = tabName === 'tools' || tabName === 'advanced' || tabName === 'claude' ? tabName : 'overview';
 
   document.querySelectorAll('.ops-drawer-tab').forEach((button) => {
     const isActive = button.dataset.tab === normalized;
@@ -750,6 +750,7 @@ function setDrawerLoadingState() {
   const overview = document.getElementById('drawerOverviewContent');
   const tools = document.getElementById('drawerToolsContent');
   const advanced = document.getElementById('drawerAdvancedContent');
+  const claude = document.getElementById('drawerClaudeContent');
 
   if (overview) {
     overview.innerHTML = loadingHtml;
@@ -761,6 +762,10 @@ function setDrawerLoadingState() {
 
   if (advanced) {
     advanced.innerHTML = loadingHtml;
+  }
+
+  if (claude) {
+    claude.innerHTML = loadingHtml;
   }
 }
 
@@ -852,6 +857,147 @@ function renderDrawerContent() {
       </div>
     `;
   }
+
+  updateClaudeDrawerTab(detail);
+}
+
+// The Claude Code agent gets an extra "Claude Code" drawer tab mirroring the
+// real ~/.claude state. The tab is hidden for every other agent.
+function isClaudeCodeAgentDetail(detail) {
+  const provider = String(detail?.provider || '').toLowerCase();
+  const role = String(detail?.role || '').toLowerCase();
+  return provider === 'claude' && role === 'cli_agent';
+}
+
+function updateClaudeDrawerTab(detail) {
+  const tabBtn = document.getElementById('drawerClaudeTabBtn');
+  const panel = document.getElementById('drawerClaudeTab');
+  const content = document.getElementById('drawerClaudeContent');
+  if (!tabBtn || !panel || !content) {
+    return;
+  }
+
+  const isClaude = isClaudeCodeAgentDetail(detail);
+  tabBtn.hidden = !isClaude;
+
+  if (!isClaude) {
+    // If the now-hidden tab was active (switched agents), fall back to overview.
+    if (panel.classList.contains('active')) {
+      setDrawerTab('overview');
+    }
+    content.innerHTML = '';
+    return;
+  }
+
+  content.innerHTML = renderClaudeSyncHtml(detail?.claude_sync || null);
+  wireClaudeRefreshButton();
+}
+
+function renderClaudeSyncHtml(sync) {
+  const actions = `
+    <div class="ops-claude-actions">
+      <button id="drawerClaudeRefreshBtn" type="button" class="modern-btn modern-btn-secondary ops-claude-refresh">Refresh from ~/.claude</button>
+      <span class="ops-claude-readonly">Read-only mirror of your Claude Code setup</span>
+    </div>`;
+
+  if (!sync) {
+    return `
+      ${actions}
+      <div class="ops-data-card">
+        <span class="ops-data-label">Claude Code sync</span>
+        <div class="ops-data-value ops-claude-empty">Not available. Enable Claude Code agents in Settings, or install the Claude Code CLI — synced details from ~/.claude will appear here.</div>
+      </div>`;
+  }
+
+  const settings = sync.settings || {};
+  const model = settings.model || sync.model || '';
+  const defaultMode = (settings.permissions && settings.permissions.defaultMode) || '';
+
+  const agents = Array.isArray(sync.agents) ? sync.agents : [];
+  const mcpServers = Array.isArray(sync.mcpServers) ? sync.mcpServers : [];
+  const plugins = Array.isArray(sync.plugins) ? sync.plugins : [];
+  const recent = Array.isArray(sync.recentProjects) ? sync.recentProjects : [];
+
+  return `
+    ${actions}
+    <div class="ops-data-card">
+      <span class="ops-data-label">Model &amp; Settings</span>
+      <div class="ops-data-value">
+        <div>Model: ${safeEscapeHtml(model || 'Not configured')}</div>
+        <div>Permission mode: ${safeEscapeHtml(defaultMode || '—')}</div>
+      </div>
+    </div>
+    ${renderClaudeListCard(`Subagents (${agents.length})`, agents, (a) =>
+      `<strong>${safeEscapeHtml(a?.name || 'Unnamed')}</strong>${a?.description ? ' — ' + safeEscapeHtml(a.description) : ''}`,
+      'No subagents found in ~/.claude/agents.')}
+    ${renderClaudeListCard(`MCP Servers (${mcpServers.length})`, mcpServers, (s) =>
+      `<strong>${safeEscapeHtml(s?.name || 'Unnamed')}</strong>${s?.transport ? ` <span class="ops-claude-muted">(${safeEscapeHtml(s.transport)})</span>` : ''}`,
+      'No MCP servers configured.')}
+    ${renderClaudeListCard(`Plugins (${plugins.length})`, plugins, (p) =>
+      safeEscapeHtml(p?.name || 'Unnamed'),
+      'No plugins installed.')}
+    ${renderClaudeListCard(`Recent Projects (${recent.length})`, recent, (p) => {
+      const cost = Number(p?.lastCost || 0);
+      const costStr = cost > 0 ? ` <span class="ops-claude-muted">$${cost.toFixed(4)}</span>` : '';
+      return `<span class="ops-claude-path">${safeEscapeHtml(p?.path || '')}</span>${costStr}`;
+    }, 'No recent projects.')}
+  `;
+}
+
+function renderClaudeListCard(label, items, itemHtml, emptyText) {
+  let body;
+  if (!Array.isArray(items) || items.length === 0) {
+    body = `<div class="ops-data-value ops-claude-empty">${safeEscapeHtml(emptyText)}</div>`;
+  } else {
+    body = `<ul class="ops-claude-list">${items.map((item) => `<li>${itemHtml(item)}</li>`).join('')}</ul>`;
+  }
+  return `
+    <div class="ops-data-card">
+      <span class="ops-data-label">${safeEscapeHtml(label)}</span>
+      ${body}
+    </div>`;
+}
+
+function wireClaudeRefreshButton() {
+  const btn = document.getElementById('drawerClaudeRefreshBtn');
+  if (!btn) {
+    return;
+  }
+
+  btn.addEventListener('click', async () => {
+    const agentName = selectedAgentName;
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Refreshing…';
+
+    try {
+      const resp = await fetch('/api/external-agents/refresh', { method: 'POST' });
+      if (!resp.ok) {
+        throw new Error(`Refresh failed (${resp.status})`);
+      }
+      // Re-fetch the agent detail so the reloaded ~/.claude data is picked up.
+      const detail = await fetchAgentDetail(agentName);
+      if (selectedAgentName !== agentName) {
+        return;
+      }
+      selectedAgentDetail = detail;
+      const content = document.getElementById('drawerClaudeContent');
+      if (content) {
+        content.innerHTML = renderClaudeSyncHtml(detail?.claude_sync || null);
+        wireClaudeRefreshButton();
+      }
+      if (window.Toast) {
+        Toast.success('Claude Code data refreshed.');
+      }
+    } catch (error) {
+      console.error('Claude refresh failed:', error);
+      if (window.Toast) {
+        Toast.error(error?.message || 'Failed to refresh Claude Code data.');
+      }
+      btn.disabled = false;
+      btn.textContent = originalText;
+    }
+  });
 }
 
 async function fetchAgentDetail(agentName) {

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -356,8 +356,12 @@ function createAgentCard(agent) {
     : '';
   const enabledCheckedAttr = isDisabled ? '' : 'checked';
   const isSystemAgent = isSystemAssistantAgentName(name);
-  const deleteDisabledAttr = isSystemAgent
-    ? 'disabled title="System assistant cannot be deleted." aria-disabled="true"'
+  const isCLIAgent = isCLIAgentEntry(agent);
+  const deleteBlockedReason = isSystemAgent
+    ? 'System assistant cannot be deleted.'
+    : (isCLIAgent ? 'Built-in CLI agent cannot be deleted.' : '');
+  const deleteDisabledAttr = deleteBlockedReason
+    ? `disabled title="${safeEscapeHtml(deleteBlockedReason)}" aria-disabled="true"`
     : 'title="Delete agent"';
   const enableToggleDisabledAttr = isSystemAgent
     ? 'disabled aria-disabled="true"'
@@ -446,8 +450,8 @@ function createAgentCard(agent) {
   if (deleteButton) {
     deleteButton.setAttribute('type', 'button');
     deleteButton.addEventListener('click', async () => {
-      if (isSystemAgent) {
-        notifyError('System assistant cannot be deleted.');
+      if (deleteBlockedReason) {
+        notifyError(deleteBlockedReason);
         return;
       }
       await deleteAgentFromDashboard(name, deleteButton);
@@ -909,6 +913,14 @@ function getHealthState(agent) {
 
 function isSystemAssistantAgentName(name) {
   return String(name || '').trim().toLowerCase() === 'ori';
+}
+
+// Built-in CLI agents (Claude Code, Codex, Gemini CLI) are projected from the
+// CLI registry, not stored records — the backend rejects deleting them, so the
+// delete control is disabled to match the system assistant.
+function isCLIAgentEntry(agent) {
+  return String(agent?.source || '').trim().toLowerCase() === 'cli'
+    || String(agent?.role || '').trim().toLowerCase() === 'cli_agent';
 }
 
 function getAgentColor(agent) {

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -862,22 +862,17 @@ function renderDrawerContent() {
 }
 
 // The Claude Code agent gets an extra "Claude Code" drawer tab mirroring the
-// real ~/.claude state. The tab is hidden for every other agent.
-function isClaudeCodeAgentDetail(detail) {
-  const provider = String(detail?.provider || '').toLowerCase();
-  const role = String(detail?.role || '').toLowerCase();
-  return provider === 'claude' && role === 'cli_agent';
-}
-
+// real ~/.claude state, rendered by the shared ClaudeSync module. The tab is
+// hidden for every other agent.
 function updateClaudeDrawerTab(detail) {
   const tabBtn = document.getElementById('drawerClaudeTabBtn');
   const panel = document.getElementById('drawerClaudeTab');
   const content = document.getElementById('drawerClaudeContent');
-  if (!tabBtn || !panel || !content) {
+  if (!tabBtn || !panel || !content || !window.ClaudeSync) {
     return;
   }
 
-  const isClaude = isClaudeCodeAgentDetail(detail);
+  const isClaude = window.ClaudeSync.isClaudeCodeAgent(detail);
   tabBtn.hidden = !isClaude;
 
   if (!isClaude) {
@@ -889,114 +884,17 @@ function updateClaudeDrawerTab(detail) {
     return;
   }
 
-  content.innerHTML = renderClaudeSyncHtml(detail?.claude_sync || null);
-  wireClaudeRefreshButton();
+  renderClaudeDrawerInto(content, detail);
 }
 
-function renderClaudeSyncHtml(sync) {
-  const actions = `
-    <div class="ops-claude-actions">
-      <button id="drawerClaudeRefreshBtn" type="button" class="modern-btn modern-btn-secondary ops-claude-refresh">Refresh from ~/.claude</button>
-      <span class="ops-claude-readonly">Read-only mirror of your Claude Code setup</span>
-    </div>`;
-
-  if (!sync) {
-    return `
-      ${actions}
-      <div class="ops-data-card">
-        <span class="ops-data-label">Claude Code sync</span>
-        <div class="ops-data-value ops-claude-empty">Not available. Enable Claude Code agents in Settings, or install the Claude Code CLI — synced details from ~/.claude will appear here.</div>
-      </div>`;
-  }
-
-  const settings = sync.settings || {};
-  const model = settings.model || sync.model || '';
-  const defaultMode = (settings.permissions && settings.permissions.defaultMode) || '';
-
-  const agents = Array.isArray(sync.agents) ? sync.agents : [];
-  const mcpServers = Array.isArray(sync.mcpServers) ? sync.mcpServers : [];
-  const plugins = Array.isArray(sync.plugins) ? sync.plugins : [];
-  const recent = Array.isArray(sync.recentProjects) ? sync.recentProjects : [];
-
-  return `
-    ${actions}
-    <div class="ops-data-card">
-      <span class="ops-data-label">Model &amp; Settings</span>
-      <div class="ops-data-value">
-        <div>Model: ${safeEscapeHtml(model || 'Not configured')}</div>
-        <div>Permission mode: ${safeEscapeHtml(defaultMode || '—')}</div>
-      </div>
-    </div>
-    ${renderClaudeListCard(`Subagents (${agents.length})`, agents, (a) =>
-      `<strong>${safeEscapeHtml(a?.name || 'Unnamed')}</strong>${a?.description ? ' — ' + safeEscapeHtml(a.description) : ''}`,
-      'No subagents found in ~/.claude/agents.')}
-    ${renderClaudeListCard(`MCP Servers (${mcpServers.length})`, mcpServers, (s) =>
-      `<strong>${safeEscapeHtml(s?.name || 'Unnamed')}</strong>${s?.transport ? ` <span class="ops-claude-muted">(${safeEscapeHtml(s.transport)})</span>` : ''}`,
-      'No MCP servers configured.')}
-    ${renderClaudeListCard(`Plugins (${plugins.length})`, plugins, (p) =>
-      safeEscapeHtml(p?.name || 'Unnamed'),
-      'No plugins installed.')}
-    ${renderClaudeListCard(`Recent Projects (${recent.length})`, recent, (p) => {
-      const cost = Number(p?.lastCost || 0);
-      const costStr = cost > 0 ? ` <span class="ops-claude-muted">$${cost.toFixed(4)}</span>` : '';
-      return `<span class="ops-claude-path">${safeEscapeHtml(p?.path || '')}</span>${costStr}`;
-    }, 'No recent projects.')}
-  `;
-}
-
-function renderClaudeListCard(label, items, itemHtml, emptyText) {
-  let body;
-  if (!Array.isArray(items) || items.length === 0) {
-    body = `<div class="ops-data-value ops-claude-empty">${safeEscapeHtml(emptyText)}</div>`;
-  } else {
-    body = `<ul class="ops-claude-list">${items.map((item) => `<li>${itemHtml(item)}</li>`).join('')}</ul>`;
-  }
-  return `
-    <div class="ops-data-card">
-      <span class="ops-data-label">${safeEscapeHtml(label)}</span>
-      ${body}
-    </div>`;
-}
-
-function wireClaudeRefreshButton() {
-  const btn = document.getElementById('drawerClaudeRefreshBtn');
-  if (!btn) {
-    return;
-  }
-
-  btn.addEventListener('click', async () => {
-    const agentName = selectedAgentName;
-    const originalText = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = 'Refreshing…';
-
-    try {
-      const resp = await fetch('/api/external-agents/refresh', { method: 'POST' });
-      if (!resp.ok) {
-        throw new Error(`Refresh failed (${resp.status})`);
-      }
-      // Re-fetch the agent detail so the reloaded ~/.claude data is picked up.
-      const detail = await fetchAgentDetail(agentName);
-      if (selectedAgentName !== agentName) {
-        return;
-      }
-      selectedAgentDetail = detail;
-      const content = document.getElementById('drawerClaudeContent');
-      if (content) {
-        content.innerHTML = renderClaudeSyncHtml(detail?.claude_sync || null);
-        wireClaudeRefreshButton();
-      }
-      if (window.Toast) {
-        Toast.success('Claude Code data refreshed.');
-      }
-    } catch (error) {
-      console.error('Claude refresh failed:', error);
-      if (window.Toast) {
-        Toast.error(error?.message || 'Failed to refresh Claude Code data.');
-      }
-      btn.disabled = false;
-      btn.textContent = originalText;
+function renderClaudeDrawerInto(content, detail) {
+  content.innerHTML = window.ClaudeSync.renderHtml(detail?.claude_sync || null);
+  window.ClaudeSync.wireRefresh(content, selectedAgentName, (reloaded, agentName) => {
+    if (selectedAgentName !== agentName) {
+      return;
     }
+    selectedAgentDetail = reloaded;
+    renderClaudeDrawerInto(content, reloaded);
   });
 }
 

--- a/internal/web/static/js/modules/agents.js
+++ b/internal/web/static/js/modules/agents.js
@@ -1540,6 +1540,14 @@ function isSystemAssistantAgentName(agentName) {
   return String(agentName || '').trim().toLowerCase() === SYSTEM_ASSISTANT_AGENT_NAME.toLowerCase();
 }
 
+// Built-in CLI agents (Claude Code, Codex, Gemini CLI) are projected from the
+// CLI registry, not stored records; the backend rejects deleting them.
+function isCLIAgentEntry(agent) {
+  if (typeof agent === 'string') return false;
+  return String(agent?.source || '').trim().toLowerCase() === 'cli'
+    || String(agent?.role || '').trim().toLowerCase() === 'cli_agent';
+}
+
 function normalizeAgentEvolution(agent) {
   const evolution = typeof agent === 'string' ? null : agent?.evolution;
   if (!evolution || typeof evolution !== 'object') {
@@ -1654,6 +1662,22 @@ function createAgentElement(agent, currentAgent) {
         New Chat
       </span>`;
 
+  // Built-in agents (system assistant + CLI agents) cannot be deleted; the
+  // backend rejects it, so render the control as a disabled, non-clickable icon.
+  const deleteBlockedReason = isSystemAssistant
+    ? 'System assistant cannot be deleted.'
+    : (isCLIAgentEntry(agent) ? 'Built-in CLI agent cannot be deleted.' : '');
+  const deleteIconSvg = `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+            </svg>`;
+  const deleteAction = deleteBlockedReason
+    ? `<span class="sidebar-agent-delete disabled" title="${escapeAttr(deleteBlockedReason)}" role="button" aria-disabled="true" tabindex="-1">
+            ${deleteIconSvg}
+          </span>`
+    : `<span class="sidebar-agent-delete" onclick="event.stopPropagation(); deleteAgent('${safeAgentNameJs}')" title="Delete agent" role="button" tabindex="0">
+            ${deleteIconSvg}
+          </span>`;
+
   agentDiv.innerHTML = `
     <div class="accordion-header" id="heading-${accordionId}">
       <button class="d-flex align-items-center justify-content-between p-2 w-100 border-0 accordion-button collapsed"
@@ -1673,11 +1697,7 @@ function createAgentElement(agent, currentAgent) {
         </div>
         <div class="agent-actions d-flex align-items-center gap-2">
           ${newChatAction}
-          <span class="sidebar-agent-delete" onclick="event.stopPropagation(); deleteAgent('${safeAgentNameJs}')" title="Delete agent" role="button" tabindex="0">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
-            </svg>
-          </span>
+          ${deleteAction}
         </div>
       </button>
     </div>

--- a/internal/web/static/js/modules/claude-sync.js
+++ b/internal/web/static/js/modules/claude-sync.js
@@ -1,0 +1,139 @@
+// Shared rendering for the read-only Claude Code (~/.claude) synced section.
+// Used by the agent details drawer (agents dashboard) and the dedicated Claude
+// Code agent page. Exposes window.ClaudeSync.
+(function () {
+  function esc(value) {
+    if (typeof window.safeEscapeHtml === 'function') {
+      return window.safeEscapeHtml(value);
+    }
+    if (typeof window.escapeHtml === 'function') {
+      return window.escapeHtml(value);
+    }
+    return String(value == null ? '' : value).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+    );
+  }
+
+  // A detail response describes the Claude Code agent when it is the Claude CLI
+  // backend (provider "claude" + role "cli_agent").
+  function isClaudeCodeAgent(detail) {
+    const provider = String(detail?.provider || '').toLowerCase();
+    const role = String(detail?.role || '').toLowerCase();
+    return provider === 'claude' && role === 'cli_agent';
+  }
+
+  function listCard(label, items, itemHtml, emptyText) {
+    let body;
+    if (!Array.isArray(items) || items.length === 0) {
+      body = `<div class="claude-sync-value claude-sync-empty">${esc(emptyText)}</div>`;
+    } else {
+      body = `<ul class="claude-sync-list">${items.map((item) => `<li>${itemHtml(item)}</li>`).join('')}</ul>`;
+    }
+    return `
+      <div class="claude-sync-card">
+        <span class="claude-sync-label">${esc(label)}</span>
+        ${body}
+      </div>`;
+  }
+
+  // Renders the synced section HTML for a claude_sync payload (or null when the
+  // reader is disabled / ~/.claude is absent).
+  function renderHtml(sync) {
+    const actions = `
+      <div class="claude-sync-actions">
+        <button type="button" class="modern-btn modern-btn-secondary claude-sync-refresh">Refresh from ~/.claude</button>
+        <span class="claude-sync-readonly">Read-only mirror of your Claude Code setup</span>
+      </div>`;
+
+    if (!sync) {
+      return `
+        <div class="claude-sync">
+          ${actions}
+          <div class="claude-sync-card">
+            <span class="claude-sync-label">Claude Code sync</span>
+            <div class="claude-sync-value claude-sync-empty">Not available. Enable Claude Code agents in Settings, or install the Claude Code CLI — synced details from ~/.claude will appear here.</div>
+          </div>
+        </div>`;
+    }
+
+    const settings = sync.settings || {};
+    const model = settings.model || sync.model || '';
+    const defaultMode = (settings.permissions && settings.permissions.defaultMode) || '';
+
+    const agents = Array.isArray(sync.agents) ? sync.agents : [];
+    const mcpServers = Array.isArray(sync.mcpServers) ? sync.mcpServers : [];
+    const plugins = Array.isArray(sync.plugins) ? sync.plugins : [];
+    const recent = Array.isArray(sync.recentProjects) ? sync.recentProjects : [];
+
+    return `
+      <div class="claude-sync">
+        ${actions}
+        <div class="claude-sync-card">
+          <span class="claude-sync-label">Model &amp; Settings</span>
+          <div class="claude-sync-value">
+            <div>Model: ${esc(model || 'Not configured')}</div>
+            <div>Permission mode: ${esc(defaultMode || '—')}</div>
+          </div>
+        </div>
+        ${listCard(`Subagents (${agents.length})`, agents, (a) =>
+          `<strong>${esc(a?.name || 'Unnamed')}</strong>${a?.description ? ' — ' + esc(a.description) : ''}`,
+          'No subagents found in ~/.claude/agents.')}
+        ${listCard(`MCP Servers (${mcpServers.length})`, mcpServers, (s) =>
+          `<strong>${esc(s?.name || 'Unnamed')}</strong>${s?.transport ? ` <span class="claude-sync-muted">(${esc(s.transport)})</span>` : ''}`,
+          'No MCP servers configured.')}
+        ${listCard(`Plugins (${plugins.length})`, plugins, (p) =>
+          esc(p?.name || 'Unnamed'),
+          'No plugins installed.')}
+        ${listCard(`Recent Projects (${recent.length})`, recent, (p) => {
+          const cost = Number(p?.lastCost || 0);
+          const costStr = cost > 0 ? ` <span class="claude-sync-muted">$${cost.toFixed(4)}</span>` : '';
+          return `<span class="claude-sync-path">${esc(p?.path || '')}</span>${costStr}`;
+        }, 'No recent projects.')}
+      </div>`;
+  }
+
+  // Wires the "Refresh from ~/.claude" button inside root: reloads the cache,
+  // re-fetches the agent detail, and calls onReloaded(detail, agentName).
+  function wireRefresh(root, agentName, onReloaded) {
+    if (!root) {
+      return;
+    }
+    const btn = root.querySelector('.claude-sync-refresh');
+    if (!btn) {
+      return;
+    }
+
+    btn.addEventListener('click', async () => {
+      const originalText = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Refreshing…';
+
+      try {
+        const resp = await fetch('/api/external-agents/refresh', { method: 'POST' });
+        if (!resp.ok) {
+          throw new Error(`Refresh failed (${resp.status})`);
+        }
+        const detailResp = await fetch(`/api/agents/${encodeURIComponent(agentName)}/detail`);
+        if (!detailResp.ok) {
+          throw new Error(`Failed to reload (${detailResp.status})`);
+        }
+        const detail = await detailResp.json();
+        if (typeof onReloaded === 'function') {
+          onReloaded(detail, agentName);
+        }
+        if (window.Toast) {
+          window.Toast.success('Claude Code data refreshed.');
+        }
+      } catch (error) {
+        console.error('Claude refresh failed:', error);
+        if (window.Toast) {
+          window.Toast.error(error?.message || 'Failed to refresh Claude Code data.');
+        }
+        btn.disabled = false;
+        btn.textContent = originalText;
+      }
+    });
+  }
+
+  window.ClaudeSync = { isClaudeCodeAgent, renderHtml, wireRefresh };
+})();

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -94,6 +94,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/index.tmpl",
 		"templates/pages/agents.tmpl",
 		"templates/pages/agents-detail.tmpl",
+		"templates/pages/agents-claude-detail.tmpl",
 		"templates/pages/agents-create.tmpl",
 		"templates/pages/settings.tmpl",
 		"templates/pages/profile.tmpl",
@@ -137,6 +138,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["index"] = tmpl
 	tr.templates["agents"] = tmpl
 	tr.templates["agents-detail"] = tmpl
+	tr.templates["agents-claude-detail"] = tmpl
 	tr.templates["agents-create"] = tmpl
 	tr.templates["settings"] = tmpl
 	tr.templates["profile"] = tmpl
@@ -179,7 +181,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -61,6 +61,7 @@
   <link href="/css/ui-refresh.css" rel="stylesheet">
   <link href="/css/tag-input.css" rel="stylesheet">
   <link href="/css/keyboard-navigation.css" rel="stylesheet">
+  <link href="/css/claude-sync.css" rel="stylesheet">
   {{if eq .CurrentPage "vault"}}<link href="/css/vault-page.css" rel="stylesheet">{{end}}
   <!-- Shared tag input widget (deferred ES module; exposes window.OriTagInput) -->
   <script type="module" src="/js/modules/tag-input.js"></script>

--- a/internal/web/templates/pages/agents-claude-detail.tmpl
+++ b/internal/web/templates/pages/agents-claude-detail.tmpl
@@ -1,0 +1,127 @@
+{{define "agents-claude-detail"}}
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+{{template "head.tmpl" .}}
+
+<body class="bg-light" data-sidebar-default="visible">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      overflow-x: hidden;
+      background: var(--bg-primary);
+    }
+
+    .claude-detail-container {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 24px 20px 36px;
+    }
+
+    .claude-detail-header {
+      margin-bottom: 18px;
+      padding: 22px 24px;
+      border-radius: var(--radius-lg, 16px);
+      background: linear-gradient(145deg, color-mix(in srgb, var(--bg-primary) 86%, var(--primary-color) 14%), var(--bg-primary));
+      border: 1px solid color-mix(in srgb, var(--border-color) 78%, var(--primary-color) 22%);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .claude-detail-header h1 {
+      font-size: clamp(24px, 4vw, 30px);
+      margin: 0 0 4px 0;
+      color: var(--text-primary);
+    }
+
+    .claude-detail-header p {
+      color: var(--text-secondary);
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .claude-detail-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+    }
+
+    .claude-detail-card {
+      border: 1px solid var(--border-color);
+      border-radius: 16px;
+      background: var(--bg-primary);
+      padding: 20px 22px;
+    }
+
+    .claude-detail-back {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 13px;
+    }
+
+    .claude-detail-back:hover {
+      color: var(--text-primary);
+    }
+
+    #claudeDetailMissing {
+      color: var(--text-secondary);
+      font-size: 14px;
+    }
+  </style>
+
+  {{template "navbar.tmpl" .}}
+
+  <a class="skip-link" href="#claude-detail-main">Skip to Main Content</a>
+
+  <div class="main-content-wrapper">
+    {{template "sidebar.tmpl" .}}
+
+    <main class="main-content" id="claude-detail-main" role="main" aria-labelledby="claudeDetailTitle">
+      <div class="claude-detail-container">
+        <a href="/agents" class="claude-detail-back">← Back to Agents</a>
+
+        <div class="claude-detail-header">
+          <div style="flex: 1 1 auto;">
+            <h1 id="claudeDetailTitle">Claude Code</h1>
+            <p>Synced from <code>~/.claude</code> — read-only</p>
+          </div>
+          <span class="claude-detail-badge">CLI · Read-only</span>
+        </div>
+
+        <div class="claude-detail-card">
+          <div id="claudeDetailMissing" hidden>Loading…</div>
+          <div id="claudeSyncContent"></div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  {{template "modals.tmpl" .}}
+
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/claude-sync.js"></script>
+  <script defer src="/js/agents-claude-detail.js"></script>
+  {{template "theme-init.tmpl" .}}
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/pages/agents-create.tmpl
+++ b/internal/web/templates/pages/agents-create.tmpl
@@ -3,7 +3,7 @@
 <html lang="en" data-bs-theme="light">
 {{template "head.tmpl" .}}
 
-<body class="bg-light" data-sidebar-default="visible">
+<body class="bg-light" data-sidebar-default="hidden">
   <style>
     body {
       margin: 0;
@@ -674,7 +674,7 @@
 
           <div class="form-group">
             <div class="form-check">
-              <input class="form-check-input" type="checkbox" id="allowWebSearch" name="allow_web_search" checked>
+              <input class="form-check-input" type="checkbox" id="allowWebSearch" name="allow_web_search">
               <label class="form-label mb-0" for="allowWebSearch">Allow Web Tools</label>
             </div>
             <div class="form-help">If enabled, this agent can use `web_search`, `web_fetch`, and `browser` utility tools.</div>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1490,46 +1490,6 @@
         word-break: break-word;
     }
 
-    /* Claude Code synced (~/.claude) drawer section — read-only mirror. */
-    .ops-claude-actions {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        flex-wrap: wrap;
-        margin-bottom: 4px;
-    }
-
-    .ops-claude-readonly {
-        font-size: 11px;
-        color: var(--text-muted);
-    }
-
-    .ops-claude-list {
-        margin: 0;
-        padding-left: 18px;
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        color: var(--text-primary);
-        font-size: 13px;
-        word-break: break-word;
-    }
-
-    .ops-claude-empty {
-        color: var(--text-muted);
-        font-style: italic;
-    }
-
-    .ops-claude-muted {
-        color: var(--text-muted);
-        font-size: 12px;
-    }
-
-    .ops-claude-path {
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-        font-size: 12px;
-    }
-
     .ops-drawer-footer {
         border-top: 1px solid var(--border-color);
         padding: 14px 20px 18px;
@@ -1754,6 +1714,7 @@
     <script defer src="/js/modules/sidebar.js"></script>
     <script defer src="/js/modules/themeManager.js"></script>
     <script defer src="/js/modules/external-agents.js"></script>
+    <script defer src="/js/modules/claude-sync.js"></script>
     {{template "theme-init.tmpl" .}}
     <script defer src="/js/agents-dashboard.js"></script>
 </body>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1490,6 +1490,46 @@
         word-break: break-word;
     }
 
+    /* Claude Code synced (~/.claude) drawer section — read-only mirror. */
+    .ops-claude-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 4px;
+    }
+
+    .ops-claude-readonly {
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+
+    .ops-claude-list {
+        margin: 0;
+        padding-left: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        color: var(--text-primary);
+        font-size: 13px;
+        word-break: break-word;
+    }
+
+    .ops-claude-empty {
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .ops-claude-muted {
+        color: var(--text-muted);
+        font-size: 12px;
+    }
+
+    .ops-claude-path {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 12px;
+    }
+
     .ops-drawer-footer {
         border-top: 1px solid var(--border-color);
         padding: 14px 20px 18px;
@@ -1677,6 +1717,7 @@
             <button id="drawerOverviewTabBtn" class="ops-drawer-tab active" type="button" role="tab" aria-selected="true" aria-controls="drawerOverviewTab" data-tab="overview">Overview</button>
             <button id="drawerToolsTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerToolsTab" data-tab="tools" tabindex="-1">Tools</button>
             <button id="drawerAdvancedTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerAdvancedTab" data-tab="advanced" tabindex="-1">Advanced</button>
+            <button id="drawerClaudeTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerClaudeTab" data-tab="claude" tabindex="-1" hidden>Claude Code</button>
         </div>
         <div class="ops-drawer-body">
             <section id="drawerOverviewTab" class="ops-drawer-panel active" role="tabpanel" aria-labelledby="drawerOverviewTabBtn" tabindex="0">
@@ -1687,6 +1728,9 @@
             </section>
             <section id="drawerAdvancedTab" class="ops-drawer-panel" role="tabpanel" aria-labelledby="drawerAdvancedTabBtn" tabindex="0" hidden>
                 <div id="drawerAdvancedContent" class="ops-drawer-content"></div>
+            </section>
+            <section id="drawerClaudeTab" class="ops-drawer-panel" role="tabpanel" aria-labelledby="drawerClaudeTabBtn" tabindex="0" hidden>
+                <div id="drawerClaudeContent" class="ops-drawer-content"></div>
             </section>
         </div>
         <div class="ops-drawer-footer">


### PR DESCRIPTION
Bundles a set of agents UI/UX fixes with a new read-only **Claude Code agent sync** feature (mirrors the user's `~/.claude` into the app).

## Agents UI fixes
- **agents/create defaults**: "Allow Web Tools" loads unchecked and the sidebar loads collapsed.
- **Delete-gating for built-in agents**: the dashboard and sidebar now disable the delete control for the system assistant and the built-in CLI agents (Claude Code, Codex, Gemini CLI) — the backend already rejected these, the UI now reflects it.

## Claude Code `~/.claude` sync (read-only)
When the Claude Code CLI is detected, the Claude Code agent mirrors real `~/.claude` state. Implemented per `tasks/prd-claude-code-sync.md`.

- **Reader** (`internal/externalagents`): MCP servers from `~/.claude.json` (env **names only** — values never surfaced), 5 most recent projects (ordered by session-dir mtime), and the configured model. Sections fail independently.
- **Auto-enable**: turns on automatically on CLI detection via `EffectiveExternalAgentsClaudeEnabled` (`!disabled && (enabled || cliDetected)`); the Settings toggle remains an explicit opt-out override. Migration-safe (existing `enabled:false` means "not opted in").
- **API**: `claude_sync` attached to the Claude Code agent detail (`/api/agents/{name}` and `/detail`), read-only.
- **Drawer**: a "Claude Code" tab in the agent details drawer renders the synced groups with empty states + refresh.
- **Dedicated page**: the Claude Code agent routes to its own read-only page (`/agents/Claude Code`) instead of the generic editable one — model & settings, subagents, MCP servers, plugins, recent projects, + refresh. Shared `ClaudeSync` JS/CSS module powers both the drawer and the page.

## Verification
- `go test ./...` green except the known pre-existing `tests/e2e TestSettingsEndpoint` flake; `go vet` clean; `npx eslint` clean; gosec adds no new findings.
- In-browser smoke against a fixture `~/.claude`: all sections render and the MCP `env` secret value is never exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)