### PR TITLE
feat(agents): add Codex CLI detail page

### DIFF
--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -86,6 +86,10 @@ type Handler struct {
 	// agent (or nil when disabled). Injected so agenthttp stays decoupled from
 	// the externalagents package.
 	claudeSync func() any
+	// codexSync returns read-only synced ~/.codex data for the Codex agent (or
+	// nil when disabled). Injected so agenthttp stays decoupled from the
+	// externalagents package.
+	codexSync func() any
 }
 
 func New(state store.Store) *Handler {
@@ -119,6 +123,12 @@ func (h *Handler) SetSessionPurger(p SessionPurger) {
 // to the Claude Code agent's detail response when available.
 func (h *Handler) SetClaudeSyncProvider(provider func() any) {
 	h.claudeSync = provider
+}
+
+// SetCodexSyncProvider wires a provider of read-only ~/.codex data, attached
+// to the Codex agent's detail response when available.
+func (h *Handler) SetCodexSyncProvider(provider func() any) {
+	h.codexSync = provider
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -677,6 +687,12 @@ func (h *Handler) getCLIAgentDetail(name string) (map[string]any, bool) {
 	if backend == cliagent.BackendClaude && h.claudeSync != nil {
 		if data := h.claudeSync(); data != nil {
 			detail["claude_sync"] = data
+		}
+	}
+	// Attach read-only synced ~/.codex state for the Codex CLI agent.
+	if backend == cliagent.BackendCodex && h.codexSync != nil {
+		if data := h.codexSync(); data != nil {
+			detail["codex_sync"] = data
 		}
 	}
 

--- a/internal/agenthttp/dashboard_claude_sync_test.go
+++ b/internal/agenthttp/dashboard_claude_sync_test.go
@@ -14,14 +14,22 @@ import (
 )
 
 func newClaudeDetailHandler(t *testing.T) *DashboardHandler {
+	return newCLIDetailHandler(t, cliagent.BackendClaude, []string{"opus"})
+}
+
+func newCodexDetailHandler(t *testing.T) *DashboardHandler {
+	return newCLIDetailHandler(t, cliagent.BackendCodex, []string{"gpt-5.2-codex"})
+}
+
+func newCLIDetailHandler(t *testing.T, backend string, models []string) *DashboardHandler {
 	t.Helper()
 	st, err := store.NewFileStore(filepath.Join(t.TempDir(), "agents.json"), types.Settings{})
 	if err != nil {
 		t.Fatalf("NewFileStore() error = %v", err)
 	}
 	registry := cliagent.NewRegistry(dashboardCLIStubAdapter{
-		backend: cliagent.BackendClaude,
-		models:  []string{"opus"},
+		backend: backend,
+		models:  models,
 	})
 	dashboard := NewDashboardHandler(st)
 	dashboard.SetCLIAgentRegistry(registry)
@@ -90,5 +98,61 @@ func TestGetAgentDetail_NoClaudeSyncWhenProviderUnset(t *testing.T) {
 	}
 	if bytes.Contains(rr.Body.Bytes(), []byte("claude_sync")) {
 		t.Errorf("claude_sync must be omitted when no provider is set: %s", rr.Body.String())
+	}
+}
+
+func TestGetAgentDetail_CodexSyncAttached(t *testing.T) {
+	dashboard := newCodexDetailHandler(t)
+	dashboard.SetCodexSyncProvider(func() any {
+		return map[string]any{"config": map[string]any{"model": "gpt-5.2-codex"}, "mcpServers": []any{}}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/Codex/detail", nil)
+	rr := httptest.NewRecorder()
+	dashboard.GetAgentDetail(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GetAgentDetail() status = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		Provider  string         `json:"provider"`
+		CodexSync map[string]any `json:"codex_sync"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if body.Provider != cliagent.BackendCodex {
+		t.Errorf("provider = %q, want %q", body.Provider, cliagent.BackendCodex)
+	}
+	if body.CodexSync == nil {
+		t.Fatal("expected codex_sync to be attached for the Codex agent")
+	}
+}
+
+func TestAgentHandler_CodexSyncAttached(t *testing.T) {
+	st, err := store.NewFileStore(filepath.Join(t.TempDir(), "agents.json"), types.Settings{})
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+	registry := cliagent.NewRegistry(dashboardCLIStubAdapter{
+		backend: cliagent.BackendCodex,
+		models:  []string{"gpt-5.2-codex"},
+	})
+	handler := New(st)
+	handler.SetCLIAgentRegistry(registry)
+	handler.SetCodexSyncProvider(func() any {
+		return map[string]any{"config": map[string]any{"model": "gpt-5.2-codex"}}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/Codex", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ServeHTTP() status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte("codex_sync")) {
+		t.Fatalf("expected codex_sync in /api/agents/Codex response: %s", rr.Body.String())
 	}
 }

--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -27,6 +27,10 @@ type DashboardHandler struct {
 	// agent (or nil when disabled). Injected to keep agenthttp decoupled from
 	// the externalagents package.
 	claudeSync func() any
+	// codexSync returns read-only synced ~/.codex data for the Codex agent (or
+	// nil when disabled). Injected to keep agenthttp decoupled from the
+	// externalagents package.
+	codexSync func() any
 }
 
 // NewDashboardHandler creates a new dashboard handler
@@ -50,6 +54,12 @@ func (h *DashboardHandler) SetWorkspaceStore(s workspace.Store) {
 // to the Claude Code agent's detail response when available.
 func (h *DashboardHandler) SetClaudeSyncProvider(provider func() any) {
 	h.claudeSync = provider
+}
+
+// SetCodexSyncProvider wires a provider of read-only ~/.codex data, attached
+// to the Codex agent's detail response when available.
+func (h *DashboardHandler) SetCodexSyncProvider(provider func() any) {
+	h.codexSync = provider
 }
 
 // AgentListItem represents an agent in the dashboard list view
@@ -88,6 +98,8 @@ type AgentDetailResponse struct {
 	AllowWebSearch  bool                   `json:"allow_web_search"`
 	// ClaudeSync carries read-only ~/.claude state for the Claude Code agent.
 	ClaudeSync any `json:"claude_sync,omitempty"`
+	// CodexSync carries read-only ~/.codex state for the Codex CLI agent.
+	CodexSync any `json:"codex_sync,omitempty"`
 }
 
 // ListAgentsWithStats handles GET /api/agents/dashboard/list
@@ -256,6 +268,10 @@ func (h *DashboardHandler) GetAgentDetail(w http.ResponseWriter, r *http.Request
 					// Attach read-only synced ~/.claude state for the Claude Code agent.
 					if backend == cliagent.BackendClaude && h.claudeSync != nil {
 						response.ClaudeSync = h.claudeSync()
+					}
+					// Attach read-only synced ~/.codex state for the Codex CLI agent.
+					if backend == cliagent.BackendCodex && h.codexSync != nil {
+						response.CodexSync = h.codexSync()
 					}
 					_ = caps // context window info available via /api/cli-agents
 					w.Header().Set("Content-Type", "application/json")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,8 @@ type Settings struct {
 	// External agents settings
 	ExternalAgentsClaudeEnabled  bool `json:"external_agents_claude_enabled"`            // Force-enable reading from Claude Code ~/.claude (opt-in)
 	ExternalAgentsClaudeDisabled bool `json:"external_agents_claude_disabled,omitempty"` // Explicit opt-out: suppresses auto-enable even when the Claude CLI is detected
-	ExternalAgentsCodexEnabled   bool `json:"external_agents_codex_enabled"`             // Enable reading agents from Codex CLI ~/.codex (default: false)
+	ExternalAgentsCodexEnabled   bool `json:"external_agents_codex_enabled"`             // Force-enable reading from Codex CLI ~/.codex (opt-in)
+	ExternalAgentsCodexDisabled  bool `json:"external_agents_codex_disabled,omitempty"`  // Explicit opt-out: suppresses auto-enable even when the Codex CLI is detected
 
 	// Speech settings
 	SpeechProvider string `json:"speech_provider,omitempty"` // auto, browser, openai, off
@@ -1469,6 +1470,35 @@ func (m *Manager) SetExternalAgentsCodexEnabled(enabled bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.settings.ExternalAgentsCodexEnabled = enabled
+}
+
+// GetExternalAgentsCodexDisabled returns whether the user explicitly opted out
+// of Codex external agent reading.
+func (m *Manager) GetExternalAgentsCodexDisabled() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.settings.ExternalAgentsCodexDisabled
+}
+
+// SetExternalAgentsCodexDisabled updates the explicit Codex opt-out setting.
+func (m *Manager) SetExternalAgentsCodexDisabled(disabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.settings.ExternalAgentsCodexDisabled = disabled
+}
+
+// EffectiveExternalAgentsCodexEnabled reports whether Codex agent reading is
+// active, given whether the Codex CLI was detected. Precedence: an explicit
+// opt-out always wins; otherwise the feature is on when force-enabled OR the
+// CLI is detected (auto-enable). A legacy enabled=false simply means "not opted
+// in" and still auto-enables on detection.
+func (m *Manager) EffectiveExternalAgentsCodexEnabled(cliDetected bool) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.settings.ExternalAgentsCodexDisabled {
+		return false
+	}
+	return m.settings.ExternalAgentsCodexEnabled || cliDetected
 }
 
 // validateWeb3Address validates an Ethereum address format

--- a/internal/externalagents/cache.go
+++ b/internal/externalagents/cache.go
@@ -20,6 +20,7 @@ type Cache struct {
 	codexConfig          *CodexConfig
 	codexSkills          []CodexSkill
 	codexRules           []CodexRule
+	codexMCPServers      []CodexMCPServer
 
 	loaded bool
 }
@@ -107,6 +108,12 @@ func (c *Cache) loadLocked() error {
 			return err
 		}
 		c.codexRules = rules
+
+		mcpServers, err := c.codexReader.ReadMCPServers()
+		if err != nil {
+			return err
+		}
+		c.codexMCPServers = mcpServers
 	}
 
 	c.loaded = true
@@ -128,6 +135,7 @@ func (c *Cache) Refresh() error {
 	c.codexConfig = nil
 	c.codexSkills = nil
 	c.codexRules = nil
+	c.codexMCPServers = nil
 	c.loaded = false
 
 	return c.loadLocked()
@@ -196,6 +204,13 @@ func (c *Cache) GetCodexRules() []CodexRule {
 	return c.codexRules
 }
 
+// GetCodexMCPServers returns cached Codex MCP servers.
+func (c *Cache) GetCodexMCPServers() []CodexMCPServer {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.codexMCPServers
+}
+
 // GetClaudeData returns all cached Claude data.
 func (c *Cache) GetClaudeData() *ClaudeData {
 	c.mu.RLock()
@@ -216,10 +231,11 @@ func (c *Cache) GetCodexData() *CodexData {
 	defer c.mu.RUnlock()
 
 	return &CodexData{
-		Agents: c.codexAgents,
-		Config: c.codexConfig,
-		Skills: c.codexSkills,
-		Rules:  c.codexRules,
+		Agents:     c.codexAgents,
+		Config:     c.codexConfig,
+		Skills:     c.codexSkills,
+		Rules:      c.codexRules,
+		MCPServers: c.codexMCPServers,
 	}
 }
 
@@ -237,10 +253,11 @@ func (c *Cache) GetAll() *ExternalAgentsData {
 			RecentProjects: c.claudeRecentProjects,
 		},
 		Codex: &CodexData{
-			Agents: c.codexAgents,
-			Config: c.codexConfig,
-			Skills: c.codexSkills,
-			Rules:  c.codexRules,
+			Agents:     c.codexAgents,
+			Config:     c.codexConfig,
+			Skills:     c.codexSkills,
+			Rules:      c.codexRules,
+			MCPServers: c.codexMCPServers,
 		},
 	}
 }

--- a/internal/externalagents/codex.go
+++ b/internal/externalagents/codex.go
@@ -3,6 +3,7 @@ package externalagents
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -33,12 +34,20 @@ func (r *DefaultCodexReader) getCodexDir() (string, error) {
 
 // codexConfigFile represents the structure of config.toml.
 type codexConfigFile struct {
-	Model                string `toml:"model"`
-	ModelReasoningEffort string `toml:"model_reasoning_effort"`
+	Model                string                        `toml:"model"`
+	ModelReasoningEffort string                        `toml:"model_reasoning_effort"`
+	MCPServers           map[string]codexMCPServerFile `toml:"mcp_servers"`
 }
 
-// ReadConfig reads the configuration from ~/.codex/config.toml.
-func (r *DefaultCodexReader) ReadConfig() (*CodexConfig, error) {
+type codexMCPServerFile struct {
+	Command   string         `toml:"command"`
+	Args      []string       `toml:"args"`
+	Env       map[string]any `toml:"env"`
+	Transport string         `toml:"transport"`
+	URL       string         `toml:"url"`
+}
+
+func (r *DefaultCodexReader) readConfigFile() (*codexConfigFile, error) {
 	codexDir, err := r.getCodexDir()
 	if err != nil {
 		return nil, err
@@ -58,10 +67,76 @@ func (r *DefaultCodexReader) ReadConfig() (*CodexConfig, error) {
 		return nil, err
 	}
 
+	return &config, nil
+}
+
+// ReadConfig reads the configuration from ~/.codex/config.toml.
+func (r *DefaultCodexReader) ReadConfig() (*CodexConfig, error) {
+	config, err := r.readConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, nil
+	}
+
 	return &CodexConfig{
 		Model:                config.Model,
 		ModelReasoningEffort: config.ModelReasoningEffort,
 	}, nil
+}
+
+// ReadMCPServers reads the global MCP servers configured for Codex from
+// ~/.codex/config.toml. Env values are intentionally redacted to variable names.
+func (r *DefaultCodexReader) ReadMCPServers() ([]CodexMCPServer, error) {
+	config, err := r.readConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	if config == nil || len(config.MCPServers) == 0 {
+		return []CodexMCPServer{}, nil
+	}
+
+	names := make([]string, 0, len(config.MCPServers))
+	for name := range config.MCPServers {
+		if strings.TrimSpace(name) != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	servers := make([]CodexMCPServer, 0, len(names))
+	for _, name := range names {
+		raw := config.MCPServers[name]
+		envNames := make([]string, 0, len(raw.Env))
+		for envName := range raw.Env {
+			if strings.TrimSpace(envName) != "" {
+				envNames = append(envNames, envName)
+			}
+		}
+		sort.Strings(envNames)
+
+		transport := strings.TrimSpace(raw.Transport)
+		if transport == "" {
+			switch {
+			case strings.TrimSpace(raw.URL) != "":
+				transport = "sse"
+			case strings.TrimSpace(raw.Command) != "":
+				transport = "stdio"
+			}
+		}
+
+		servers = append(servers, CodexMCPServer{
+			Name:      strings.TrimSpace(name),
+			Transport: transport,
+			Command:   raw.Command,
+			Args:      append([]string{}, raw.Args...),
+			URL:       raw.URL,
+			EnvNames:  envNames,
+		})
+	}
+
+	return servers, nil
 }
 
 // ReadSkills reads skill directories from ~/.codex/skills/.

--- a/internal/externalagents/codex_test.go
+++ b/internal/externalagents/codex_test.go
@@ -1,8 +1,10 @@
 package externalagents
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +72,55 @@ func TestReadConfig_MinimalConfig(t *testing.T) {
 	}
 	if config.ModelReasoningEffort != "" {
 		t.Errorf("ModelReasoningEffort should be empty, got %q", config.ModelReasoningEffort)
+	}
+}
+
+func TestReadCodexMCPServers_RedactsEnvValues(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `model = "gpt-5.2-codex"
+
+[mcp_servers.local]
+command = "node"
+args = ["server.js"]
+
+[mcp_servers.local.env]
+API_KEY = "secret-value"
+TOKEN = "another-secret"
+
+[mcp_servers.remote]
+transport = "sse"
+url = "https://example.com/sse"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.toml"), []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewCodexReader(tmpDir)
+	servers, err := reader.ReadMCPServers()
+	if err != nil {
+		t.Fatalf("ReadMCPServers() error = %v", err)
+	}
+
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 MCP servers, got %d", len(servers))
+	}
+	if servers[0].Name != "local" {
+		t.Fatalf("first server = %q, want local", servers[0].Name)
+	}
+	if servers[0].Transport != "stdio" {
+		t.Errorf("local transport = %q, want stdio", servers[0].Transport)
+	}
+	if got := strings.Join(servers[0].EnvNames, ","); got != "API_KEY,TOKEN" {
+		t.Errorf("env names = %q, want API_KEY,TOKEN", got)
+	}
+
+	payload, err := json.Marshal(servers)
+	if err != nil {
+		t.Fatalf("marshal servers: %v", err)
+	}
+	if strings.Contains(string(payload), "secret-value") || strings.Contains(string(payload), "another-secret") {
+		t.Fatalf("MCP env secret value leaked in payload: %s", string(payload))
 	}
 }
 

--- a/internal/externalagents/types.go
+++ b/internal/externalagents/types.go
@@ -86,6 +86,18 @@ type CodexRule struct {
 	Path string `json:"path"`
 }
 
+// CodexMCPServer represents an MCP server configured for Codex in
+// ~/.codex/config.toml. Env values are intentionally NOT included — only
+// variable names are surfaced, to avoid leaking secrets/API keys to the API/UI.
+type CodexMCPServer struct {
+	Name      string   `json:"name"`
+	Transport string   `json:"transport,omitempty"`
+	Command   string   `json:"command,omitempty"`
+	Args      []string `json:"args,omitempty"`
+	URL       string   `json:"url,omitempty"`
+	EnvNames  []string `json:"envNames,omitempty"` // variable names only — never values
+}
+
 // ClaudeData holds all data read from the Claude Code configuration.
 type ClaudeData struct {
 	Agents         []ExternalAgent       `json:"agents"`
@@ -97,10 +109,11 @@ type ClaudeData struct {
 
 // CodexData holds all data read from the Codex configuration.
 type CodexData struct {
-	Agents []ExternalAgent `json:"agents"`
-	Config *CodexConfig    `json:"config,omitempty"`
-	Skills []CodexSkill    `json:"skills"`
-	Rules  []CodexRule     `json:"rules"`
+	Agents     []ExternalAgent  `json:"agents"`
+	Config     *CodexConfig     `json:"config,omitempty"`
+	Skills     []CodexSkill     `json:"skills"`
+	Rules      []CodexRule      `json:"rules"`
+	MCPServers []CodexMCPServer `json:"mcpServers"`
 }
 
 // ExternalAgentsData holds all external agent data from all sources.
@@ -124,4 +137,5 @@ type CodexReader interface {
 	ReadConfig() (*CodexConfig, error)
 	ReadSkills() ([]CodexSkill, error)
 	ReadRules() ([]CodexRule, error)
+	ReadMCPServers() ([]CodexMCPServer, error)
 }

--- a/internal/externalagentshttp/handlers.go
+++ b/internal/externalagentshttp/handlers.go
@@ -18,15 +18,21 @@ type Handler struct {
 	// evaluated lazily (per request) so it works regardless of init ordering.
 	// May be nil, in which case detection is treated as false.
 	claudeDetected func() bool
+	// codexDetected reports whether the Codex CLI is available. It is evaluated
+	// lazily (per request) so it works regardless of init ordering. May be nil,
+	// in which case detection is treated as false.
+	codexDetected func() bool
 }
 
 // New creates a new Handler with the given cache and config manager.
-// claudeDetected reports whether the Claude Code CLI is available (may be nil).
-func New(cache *externalagents.Cache, configManager *config.Manager, claudeDetected func() bool) *Handler {
+// claudeDetected and codexDetected report whether the corresponding CLI is
+// available (may be nil).
+func New(cache *externalagents.Cache, configManager *config.Manager, claudeDetected func() bool, codexDetected func() bool) *Handler {
 	return &Handler{
 		cache:          cache,
 		configManager:  configManager,
 		claudeDetected: claudeDetected,
+		codexDetected:  codexDetected,
 	}
 }
 
@@ -40,6 +46,16 @@ func (h *Handler) claudeEnabled() bool {
 	return h.configManager.EffectiveExternalAgentsClaudeEnabled(detected)
 }
 
+// codexEnabled reports whether Codex agent reading is effectively active,
+// honoring the explicit opt-out and auto-enable-on-CLI-detection.
+func (h *Handler) codexEnabled() bool {
+	detected := false
+	if h.codexDetected != nil {
+		detected = h.codexDetected()
+	}
+	return h.configManager.EffectiveExternalAgentsCodexEnabled(detected)
+}
+
 // ClaudeSyncData returns the cached, read-only Claude ~/.claude data when Claude
 // agent reading is effectively enabled, or nil otherwise. The agent-detail
 // endpoints use this to attach synced state to the Claude Code agent without
@@ -51,6 +67,17 @@ func (h *Handler) ClaudeSyncData() any {
 	return h.cache.GetClaudeData()
 }
 
+// CodexSyncData returns the cached, read-only Codex ~/.codex data when Codex
+// agent reading is enabled, or nil otherwise. The agent-detail endpoints use
+// this to attach synced state to the Codex CLI agent without importing the
+// externalagents package.
+func (h *Handler) CodexSyncData() any {
+	if !h.codexEnabled() {
+		return nil
+	}
+	return h.cache.GetCodexData()
+}
+
 // GetAll handles GET /api/external-agents
 // Returns all external agent data from all sources.
 func (h *Handler) GetAll(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +87,7 @@ func (h *Handler) GetAll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	claudeEnabled := h.claudeEnabled()
-	codexEnabled := h.configManager.GetExternalAgentsCodexEnabled()
+	codexEnabled := h.codexEnabled()
 
 	response := map[string]any{
 		"claude_enabled": claudeEnabled,
@@ -106,7 +133,7 @@ func (h *Handler) GetCodex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.configManager.GetExternalAgentsCodexEnabled() {
+	if !h.codexEnabled() {
 		orihttp.WriteJSON(w, map[string]any{
 			"enabled": false,
 			"message": "Codex CLI agents are disabled. Enable in Settings.",
@@ -127,7 +154,7 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	claudeEnabled := h.claudeEnabled()
-	codexEnabled := h.configManager.GetExternalAgentsCodexEnabled()
+	codexEnabled := h.codexEnabled()
 
 	if !claudeEnabled && !codexEnabled {
 		orihttp.WriteJSON(w, map[string]any{

--- a/internal/externalagentshttp/handlers_test.go
+++ b/internal/externalagentshttp/handlers_test.go
@@ -66,7 +66,7 @@ model_reasoning_effort = "high"
 
 func TestGetAll(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -109,7 +109,7 @@ func TestGetAll(t *testing.T) {
 
 func TestGetAll_MethodNotAllowed(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -123,7 +123,7 @@ func TestGetAll_MethodNotAllowed(t *testing.T) {
 
 func TestGetClaude(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/claude", nil)
 	w := httptest.NewRecorder()
@@ -149,7 +149,7 @@ func TestGetClaude(t *testing.T) {
 
 func TestGetCodex(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/codex", nil)
 	w := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestGetCodex(t *testing.T) {
 
 func TestRefresh(t *testing.T) {
 	cache, configManager, tmpDir := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	// Verify initial state
 	agents := cache.GetClaudeAgents()
@@ -217,7 +217,7 @@ New agent prompt.
 
 func TestRefresh_MethodNotAllowed(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents/refresh", nil)
 	w := httptest.NewRecorder()
@@ -233,7 +233,7 @@ func TestGetAll_Disabled(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
 	configManager.SetExternalAgentsClaudeEnabled(false)
 	configManager.SetExternalAgentsCodexEnabled(false)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()
@@ -274,7 +274,7 @@ func TestClaudeSyncData(t *testing.T) {
 	// Explicit opt-out -> nil even when the CLI is detected.
 	configManager.SetExternalAgentsClaudeEnabled(false)
 	configManager.SetExternalAgentsClaudeDisabled(true)
-	h := New(cache, configManager, func() bool { return true })
+	h := New(cache, configManager, func() bool { return true }, nil)
 	if h.ClaudeSyncData() != nil {
 		t.Error("expected nil sync data when opted out")
 	}
@@ -282,7 +282,7 @@ func TestClaudeSyncData(t *testing.T) {
 	// Force-enabled -> returns the cached ClaudeData (with the test agent).
 	configManager.SetExternalAgentsClaudeDisabled(false)
 	configManager.SetExternalAgentsClaudeEnabled(true)
-	h = New(cache, configManager, func() bool { return false })
+	h = New(cache, configManager, func() bool { return false }, nil)
 	data := h.ClaudeSyncData()
 	if data == nil {
 		t.Fatal("expected sync data when enabled")
@@ -297,9 +297,39 @@ func TestClaudeSyncData(t *testing.T) {
 
 	// Auto-enable purely via CLI detection -> returns data.
 	configManager.SetExternalAgentsClaudeEnabled(false)
-	h = New(cache, configManager, func() bool { return true })
+	h = New(cache, configManager, func() bool { return true }, nil)
 	if h.ClaudeSyncData() == nil {
 		t.Error("expected sync data when CLI detected (auto-enable)")
+	}
+}
+
+func TestCodexSyncData(t *testing.T) {
+	cache, configManager, _ := setupTestCache(t)
+
+	configManager.SetExternalAgentsCodexDisabled(false)
+	configManager.SetExternalAgentsCodexEnabled(false)
+	h := New(cache, configManager, nil, nil)
+	if h.CodexSyncData() != nil {
+		t.Error("expected nil sync data when Codex external agents are disabled")
+	}
+
+	configManager.SetExternalAgentsCodexEnabled(true)
+	data := h.CodexSyncData()
+	if data == nil {
+		t.Fatal("expected sync data when Codex external agents are enabled")
+	}
+	cd, ok := data.(*externalagents.CodexData)
+	if !ok {
+		t.Fatalf("expected *externalagents.CodexData, got %T", data)
+	}
+	if cd.Config == nil || cd.Config.Model != "gpt-4" {
+		t.Fatalf("unexpected codex config: %#v", cd.Config)
+	}
+
+	configManager.SetExternalAgentsCodexEnabled(false)
+	h = New(cache, configManager, nil, func() bool { return true })
+	if h.CodexSyncData() == nil {
+		t.Error("expected sync data when Codex CLI detected (auto-enable)")
 	}
 }
 
@@ -326,7 +356,7 @@ func TestClaudeEffectiveEnabled_TruthTable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			configManager.SetExternalAgentsClaudeEnabled(tc.enabled)
 			configManager.SetExternalAgentsClaudeDisabled(tc.disabled)
-			handler := New(cache, configManager, func() bool { return tc.cliDetected })
+			handler := New(cache, configManager, func() bool { return tc.cliDetected }, nil)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 			w := httptest.NewRecorder()
@@ -350,11 +380,58 @@ func TestClaudeEffectiveEnabled_TruthTable(t *testing.T) {
 	}
 }
 
+func TestCodexEffectiveEnabled_TruthTable(t *testing.T) {
+	cache, configManager, _ := setupTestCache(t)
+	configManager.SetExternalAgentsClaudeEnabled(false)
+	configManager.SetExternalAgentsClaudeDisabled(true)
+
+	cases := []struct {
+		name        string
+		enabled     bool
+		disabled    bool
+		cliDetected bool
+		want        bool
+	}{
+		{"unset, no CLI", false, false, false, false},
+		{"unset, CLI detected -> auto-enable", false, false, true, true},
+		{"force-enabled, no CLI", true, false, false, true},
+		{"force-enabled, CLI detected", true, false, true, true},
+		{"opt-out beats CLI detection", false, true, true, false},
+		{"opt-out beats force-enable", true, true, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configManager.SetExternalAgentsCodexEnabled(tc.enabled)
+			configManager.SetExternalAgentsCodexDisabled(tc.disabled)
+			handler := New(cache, configManager, nil, func() bool { return tc.cliDetected })
+
+			req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
+			w := httptest.NewRecorder()
+			handler.GetAll(w, req)
+
+			var data struct {
+				CodexEnabled bool                      `json:"codex_enabled"`
+				Codex        *externalagents.CodexData `json:"codex"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&data); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if data.CodexEnabled != tc.want {
+				t.Errorf("codex_enabled = %v, want %v", data.CodexEnabled, tc.want)
+			}
+			if (data.Codex != nil) != tc.want {
+				t.Errorf("codex data present = %v, want %v", data.Codex != nil, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetAll_PartialEnabled(t *testing.T) {
 	cache, configManager, _ := setupTestCache(t)
 	configManager.SetExternalAgentsClaudeEnabled(true)
 	configManager.SetExternalAgentsCodexEnabled(false)
-	handler := New(cache, configManager, nil)
+	handler := New(cache, configManager, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/external-agents", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -229,7 +229,10 @@ func (b *ServerBuilder) initializeHandlers() {
 	claudeCLIDetected := func() bool {
 		return b.cliAgentRegistry != nil && b.cliAgentRegistry.IsAvailable(cliagent.BackendClaude)
 	}
-	b.externalAgentsHandler = externalagentshttp.New(b.externalAgentsCache, b.configManager, claudeCLIDetected)
+	codexCLIDetected := func() bool {
+		return b.cliAgentRegistry != nil && b.cliAgentRegistry.IsAvailable(cliagent.BackendCodex)
+	}
+	b.externalAgentsHandler = externalagentshttp.New(b.externalAgentsCache, b.configManager, claudeCLIDetected, codexCLIDetected)
 	logger.Info("External agents support initialized", logger.Fields{})
 
 	// Initialize CLI agent adapter (delegatable CLI agents)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -100,6 +100,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	}
 	if s.Handlers.ExternalAgents != nil {
 		agentHandler.SetClaudeSyncProvider(s.Handlers.ExternalAgents.ClaudeSyncData)
+		agentHandler.SetCodexSyncProvider(s.Handlers.ExternalAgents.CodexSyncData)
 	}
 	avatarHandler := agenthttp.NewAvatarHandler(s.Storage.AgentStore)
 	mux.Handle("/api/agents", agentHandler)
@@ -115,6 +116,7 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 	dashboardHandler.SetWorkspaceStore(s.Storage.WorkspaceStore)
 	if s.Handlers.ExternalAgents != nil {
 		dashboardHandler.SetClaudeSyncProvider(s.Handlers.ExternalAgents.ClaudeSyncData)
+		dashboardHandler.SetCodexSyncProvider(s.Handlers.ExternalAgents.CodexSyncData)
 	}
 	mux.HandleFunc("/api/agents/dashboard/list", dashboardHandler.ListAgentsWithStats)
 	mux.HandleFunc("/api/agents/dashboard/stats", dashboardHandler.GetDashboardStats)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -267,6 +267,19 @@ func (s *Server) isClaudeCodeAgentName(name string) bool {
 	return s.Handlers.CLIAgentRegistry.IsAvailable(cliagent.BackendClaude)
 }
 
+// isCodexAgentName reports whether the given agent name refers to the built-in
+// Codex CLI agent and that backend is currently available.
+func (s *Server) isCodexAgentName(name string) bool {
+	if s.Handlers == nil || s.Handlers.CLIAgentRegistry == nil {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower != "codex" && lower != cliagent.BackendCodex {
+		return false
+	}
+	return s.Handlers.CLIAgentRegistry.IsAvailable(cliagent.BackendCodex)
+}
+
 // serveClaudeAgentDetail serves the dedicated, read-only Claude Code agent page
 // that mirrors the user's ~/.claude state.
 func (s *Server) serveClaudeAgentDetail(w http.ResponseWriter, r *http.Request) {
@@ -275,6 +288,16 @@ func (s *Server) serveClaudeAgentDetail(w http.ResponseWriter, r *http.Request) 
 	data.BrandText = "Ori Agent"
 	data.ShowSidebarToggle = true
 	s.renderAndWritePage(w, "agents-claude-detail", data)
+}
+
+// serveCodexAgentDetail serves the dedicated, read-only Codex agent page that
+// mirrors the user's ~/.codex state.
+func (s *Server) serveCodexAgentDetail(w http.ResponseWriter, r *http.Request) {
+	data := s.prepareBasePageData("agents")
+	data.Title = "Codex - Ori Agent"
+	data.BrandText = "Ori Agent"
+	data.ShowSidebarToggle = true
+	s.renderAndWritePage(w, "agents-codex-detail", data)
 }
 
 func (s *Server) serveAgentsEdit(w http.ResponseWriter, r *http.Request) {
@@ -626,6 +649,10 @@ func (s *Server) serveAgentFiles(w http.ResponseWriter, r *http.Request) {
 		}
 		if s.isClaudeCodeAgentName(agentName) {
 			s.serveClaudeAgentDetail(w, r)
+			return
+		}
+		if s.isCodexAgentName(agentName) {
+			s.serveCodexAgentDetail(w, r)
 			return
 		}
 		s.serveAgentsDetail(w, r)

--- a/internal/settingshttp/handlers.go
+++ b/internal/settingshttp/handlers.go
@@ -1436,6 +1436,7 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 			"claude_enabled":  h.configManager.GetExternalAgentsClaudeEnabled(),
 			"claude_disabled": h.configManager.GetExternalAgentsClaudeDisabled(),
 			"codex_enabled":   h.configManager.GetExternalAgentsCodexEnabled(),
+			"codex_disabled":  h.configManager.GetExternalAgentsCodexDisabled(),
 		})
 
 	case http.MethodPost:
@@ -1469,6 +1470,9 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 			// This toggle controls external Codex agent/skills visibility only.
 			// Codex model-provider availability is handled independently at startup.
 			h.configManager.SetExternalAgentsCodexEnabled(*req.CodexEnabled)
+			// Toggling off records an explicit opt-out so it overrides
+			// auto-enable-on-CLI-detection; toggling on clears the opt-out.
+			h.configManager.SetExternalAgentsCodexDisabled(!*req.CodexEnabled)
 		}
 
 		if err := h.configManager.Save(); err != nil {
@@ -1480,6 +1484,7 @@ func (h *Handler) ExternalAgentsSettingsHandler(w http.ResponseWriter, r *http.R
 			"claude_enabled":        h.configManager.GetExternalAgentsClaudeEnabled(),
 			"claude_disabled":       h.configManager.GetExternalAgentsClaudeDisabled(),
 			"codex_enabled":         h.configManager.GetExternalAgentsCodexEnabled(),
+			"codex_disabled":        h.configManager.GetExternalAgentsCodexDisabled(),
 			"codex_exchange_status": codexExchangeStatus,
 		})
 

--- a/internal/web/static/css/claude-sync.css
+++ b/internal/web/static/css/claude-sync.css
@@ -1,34 +1,38 @@
-/* Shared styling for the read-only Claude Code (~/.claude) synced section.
-   Used by the agent details drawer (agents page) and the dedicated Claude
-   Code agent page. Self-contained class names so it does not depend on any
-   page-specific styles. */
+/* Shared styling for read-only external CLI synced sections. Used by the
+   agent details drawer and dedicated Claude Code / Codex agent pages.
+   Self-contained class names so it does not depend on page-specific styles. */
 
-.claude-sync {
+.claude-sync,
+.codex-sync {
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
 
-.claude-sync-actions {
+.claude-sync-actions,
+.codex-sync-actions {
     display: flex;
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
 }
 
-.claude-sync-readonly {
+.claude-sync-readonly,
+.codex-sync-readonly {
     font-size: 11px;
     color: var(--text-muted);
 }
 
-.claude-sync-card {
+.claude-sync-card,
+.codex-sync-card {
     border: 1px solid var(--border-color);
     border-radius: 10px;
     background: var(--bg-secondary);
     padding: 12px;
 }
 
-.claude-sync-label {
+.claude-sync-label,
+.codex-sync-label {
     display: block;
     font-size: 11px;
     text-transform: uppercase;
@@ -38,13 +42,15 @@
     font-weight: 700;
 }
 
-.claude-sync-value {
+.claude-sync-value,
+.codex-sync-value {
     color: var(--text-primary);
     font-size: 13px;
     word-break: break-word;
 }
 
-.claude-sync-list {
+.claude-sync-list,
+.codex-sync-list {
     margin: 0;
     padding-left: 18px;
     display: flex;
@@ -55,18 +61,21 @@
     word-break: break-word;
 }
 
-.claude-sync-empty {
+.claude-sync-empty,
+.codex-sync-empty {
     color: var(--text-muted);
     font-style: italic;
     font-size: 13px;
 }
 
-.claude-sync-muted {
+.claude-sync-muted,
+.codex-sync-muted {
     color: var(--text-muted);
     font-size: 12px;
 }
 
-.claude-sync-path {
+.claude-sync-path,
+.codex-sync-path {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     font-size: 12px;
 }

--- a/internal/web/static/js/agents-codex-detail.js
+++ b/internal/web/static/js/agents-codex-detail.js
@@ -1,0 +1,73 @@
+// Dedicated, read-only details page for the Codex CLI agent.
+// Renders the synced ~/.codex state via the shared CodexSync module.
+
+function getCodexAgentNameFromURL() {
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  // /agents/{name}
+  const raw = parts.length >= 2 ? parts[1] : 'Codex';
+  try {
+    return decodeURIComponent(raw);
+  } catch (error) {
+    return raw;
+  }
+}
+
+const codexAgentName = getCodexAgentNameFromURL();
+
+function setCodexDetailMessage(message) {
+  const missing = document.getElementById('codexDetailMissing');
+  const content = document.getElementById('codexSyncContent');
+  if (missing) {
+    missing.hidden = !message;
+    missing.textContent = message || '';
+  }
+  if (content && message) {
+    content.innerHTML = '';
+  }
+}
+
+function renderCodexAgentPage(detail) {
+  const content = document.getElementById('codexSyncContent');
+  if (!content || !window.CodexSync) {
+    return;
+  }
+
+  const titleEl = document.getElementById('codexDetailTitle');
+  if (titleEl && detail?.name) {
+    titleEl.textContent = detail.name;
+  }
+
+  setCodexDetailMessage('');
+  content.innerHTML = window.CodexSync.renderHtml(detail?.codex_sync || null);
+  window.CodexSync.wireRefresh(content, codexAgentName, (reloaded) => {
+    renderCodexAgentPage(reloaded);
+  });
+}
+
+async function loadCodexAgentDetail() {
+  setCodexDetailMessage('Loading...');
+  try {
+    const response = await fetch(`/api/agents/${encodeURIComponent(codexAgentName)}/detail`);
+    if (response.status === 404) {
+      setCodexDetailMessage('Codex agent not found. The Codex CLI may not be installed or detected.');
+      return;
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to load (${response.status})`);
+    }
+    const detail = await response.json();
+
+    if (!window.CodexSync || !window.CodexSync.isCodexAgent(detail)) {
+      // Not actually the Codex agent - send the user to the generic page.
+      window.location.replace('/agents');
+      return;
+    }
+
+    renderCodexAgentPage(detail);
+  } catch (error) {
+    console.error('Failed to load Codex agent detail:', error);
+    setCodexDetailMessage(error?.message || 'Failed to load Codex agent details.');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadCodexAgentDetail);

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -723,7 +723,7 @@ function closeAgentDrawer() {
 
 function setDrawerTab(tabName, options = {}) {
   const { focusPanel = false } = options;
-  const normalized = tabName === 'tools' || tabName === 'advanced' || tabName === 'claude' ? tabName : 'overview';
+  const normalized = tabName === 'tools' || tabName === 'advanced' || tabName === 'claude' || tabName === 'codex' ? tabName : 'overview';
 
   document.querySelectorAll('.ops-drawer-tab').forEach((button) => {
     const isActive = button.dataset.tab === normalized;
@@ -751,6 +751,7 @@ function setDrawerLoadingState() {
   const tools = document.getElementById('drawerToolsContent');
   const advanced = document.getElementById('drawerAdvancedContent');
   const claude = document.getElementById('drawerClaudeContent');
+  const codex = document.getElementById('drawerCodexContent');
 
   if (overview) {
     overview.innerHTML = loadingHtml;
@@ -766,6 +767,10 @@ function setDrawerLoadingState() {
 
   if (claude) {
     claude.innerHTML = loadingHtml;
+  }
+
+  if (codex) {
+    codex.innerHTML = loadingHtml;
   }
 }
 
@@ -859,6 +864,7 @@ function renderDrawerContent() {
   }
 
   updateClaudeDrawerTab(detail);
+  updateCodexDrawerTab(detail);
 }
 
 // The Claude Code agent gets an extra "Claude Code" drawer tab mirroring the
@@ -895,6 +901,43 @@ function renderClaudeDrawerInto(content, detail) {
     }
     selectedAgentDetail = reloaded;
     renderClaudeDrawerInto(content, reloaded);
+  });
+}
+
+// The Codex agent gets an extra "Codex" drawer tab mirroring the real ~/.codex
+// state, rendered by the shared CodexSync module. The tab is hidden for every
+// other agent.
+function updateCodexDrawerTab(detail) {
+  const tabBtn = document.getElementById('drawerCodexTabBtn');
+  const panel = document.getElementById('drawerCodexTab');
+  const content = document.getElementById('drawerCodexContent');
+  if (!tabBtn || !panel || !content || !window.CodexSync) {
+    return;
+  }
+
+  const isCodex = window.CodexSync.isCodexAgent(detail);
+  tabBtn.hidden = !isCodex;
+
+  if (!isCodex) {
+    // If the now-hidden tab was active (switched agents), fall back to overview.
+    if (panel.classList.contains('active')) {
+      setDrawerTab('overview');
+    }
+    content.innerHTML = '';
+    return;
+  }
+
+  renderCodexDrawerInto(content, detail);
+}
+
+function renderCodexDrawerInto(content, detail) {
+  content.innerHTML = window.CodexSync.renderHtml(detail?.codex_sync || null);
+  window.CodexSync.wireRefresh(content, selectedAgentName, (reloaded, agentName) => {
+    if (selectedAgentName !== agentName) {
+      return;
+    }
+    selectedAgentDetail = reloaded;
+    renderCodexDrawerInto(content, reloaded);
   });
 }
 

--- a/internal/web/static/js/modules/codex-sync.js
+++ b/internal/web/static/js/modules/codex-sync.js
@@ -1,0 +1,150 @@
+// Shared rendering for the read-only Codex (~/.codex) synced section.
+// Used by the agent details drawer (agents dashboard) and the dedicated Codex
+// agent page. Exposes window.CodexSync.
+(function () {
+  function esc(value) {
+    if (typeof window.safeEscapeHtml === 'function') {
+      return window.safeEscapeHtml(value);
+    }
+    if (typeof window.escapeHtml === 'function') {
+      return window.escapeHtml(value);
+    }
+    return String(value == null ? '' : value).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+    );
+  }
+
+  // A detail response describes the Codex agent when it is the Codex CLI backend
+  // (provider "codex" + role "cli_agent").
+  function isCodexAgent(detail) {
+    const provider = String(detail?.provider || '').toLowerCase();
+    const role = String(detail?.role || '').toLowerCase();
+    return provider === 'codex' && role === 'cli_agent';
+  }
+
+  function listCard(label, items, itemHtml, emptyText) {
+    let body;
+    if (!Array.isArray(items) || items.length === 0) {
+      body = `<div class="codex-sync-value codex-sync-empty">${esc(emptyText)}</div>`;
+    } else {
+      body = `<ul class="codex-sync-list">${items.map((item) => `<li>${itemHtml(item)}</li>`).join('')}</ul>`;
+    }
+    return `
+      <div class="codex-sync-card">
+        <span class="codex-sync-label">${esc(label)}</span>
+        ${body}
+      </div>`;
+  }
+
+  function renderMCPServer(server) {
+    const meta = [];
+    if (server?.transport) {
+      meta.push(esc(server.transport));
+    }
+    const envNames = Array.isArray(server?.envNames) ? server.envNames.filter(Boolean) : [];
+    if (envNames.length > 0) {
+      meta.push(`env: ${esc(envNames.join(', '))}`);
+    }
+    const metaHtml = meta.length > 0
+      ? ` <span class="codex-sync-muted">(${meta.join(' / ')})</span>`
+      : '';
+    return `<strong>${esc(server?.name || 'Unnamed')}</strong>${metaHtml}`;
+  }
+
+  // Renders the synced section HTML for a codex_sync payload (or null when the
+  // reader is disabled / ~/.codex is absent).
+  function renderHtml(sync) {
+    const actions = `
+      <div class="codex-sync-actions">
+        <button type="button" class="modern-btn modern-btn-secondary codex-sync-refresh">Refresh from ~/.codex</button>
+        <span class="codex-sync-readonly">Read-only mirror of your Codex setup</span>
+      </div>`;
+
+    if (!sync) {
+      return `
+        <div class="codex-sync">
+          ${actions}
+          <div class="codex-sync-card">
+            <span class="codex-sync-label">Codex sync</span>
+            <div class="codex-sync-value codex-sync-empty">Not available. Enable Codex agents in Settings, or install the Codex CLI - synced details from ~/.codex will appear here.</div>
+          </div>
+        </div>`;
+    }
+
+    const config = sync.config || {};
+    const model = config.model || sync.model || '';
+    const reasoning = config.modelReasoningEffort || '';
+
+    const agents = Array.isArray(sync.agents) ? sync.agents : [];
+    const mcpServers = Array.isArray(sync.mcpServers) ? sync.mcpServers : [];
+    const skills = Array.isArray(sync.skills) ? sync.skills : [];
+    const rules = Array.isArray(sync.rules) ? sync.rules : [];
+
+    return `
+      <div class="codex-sync">
+        ${actions}
+        <div class="codex-sync-card">
+          <span class="codex-sync-label">Model &amp; Settings</span>
+          <div class="codex-sync-value">
+            <div>Model: ${esc(model || 'Not configured')}</div>
+            <div>Reasoning effort: ${esc(reasoning || '-')}</div>
+          </div>
+        </div>
+        ${listCard(`Skill Agents (${agents.length})`, agents, (a) =>
+          `<strong>${esc(a?.name || 'Unnamed')}</strong>${a?.description ? ' - ' + esc(a.description) : ''}`,
+          'No Codex skill agents found in ~/.codex/skills.')}
+        ${listCard(`MCP Servers (${mcpServers.length})`, mcpServers, renderMCPServer, 'No MCP servers configured.')}
+        ${listCard(`Skill Folders (${skills.length})`, skills, (s) =>
+          `<strong>${esc(s?.name || 'Unnamed')}</strong>${s?.path ? ` <span class="codex-sync-path">${esc(s.path)}</span>` : ''}`,
+          'No Codex skill folders found.')}
+        ${listCard(`Rules (${rules.length})`, rules, (r) =>
+          `<strong>${esc(r?.name || 'Unnamed')}</strong>${r?.path ? ` <span class="codex-sync-path">${esc(r.path)}</span>` : ''}`,
+          'No Codex rules found.')}
+      </div>`;
+  }
+
+  // Wires the "Refresh from ~/.codex" button inside root: reloads the cache,
+  // re-fetches the agent detail, and calls onReloaded(detail, agentName).
+  function wireRefresh(root, agentName, onReloaded) {
+    if (!root) {
+      return;
+    }
+    const btn = root.querySelector('.codex-sync-refresh');
+    if (!btn) {
+      return;
+    }
+
+    btn.addEventListener('click', async () => {
+      const originalText = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Refreshing...';
+
+      try {
+        const resp = await fetch('/api/external-agents/refresh', { method: 'POST' });
+        if (!resp.ok) {
+          throw new Error(`Refresh failed (${resp.status})`);
+        }
+        const detailResp = await fetch(`/api/agents/${encodeURIComponent(agentName)}/detail`);
+        if (!detailResp.ok) {
+          throw new Error(`Failed to reload (${detailResp.status})`);
+        }
+        const detail = await detailResp.json();
+        if (typeof onReloaded === 'function') {
+          onReloaded(detail, agentName);
+        }
+        if (window.Toast) {
+          window.Toast.success('Codex data refreshed.');
+        }
+      } catch (error) {
+        console.error('Codex refresh failed:', error);
+        if (window.Toast) {
+          window.Toast.error(error?.message || 'Failed to refresh Codex data.');
+        }
+        btn.disabled = false;
+        btn.textContent = originalText;
+      }
+    });
+  }
+
+  window.CodexSync = { isCodexAgent, renderHtml, wireRefresh };
+})();

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -95,6 +95,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/agents.tmpl",
 		"templates/pages/agents-detail.tmpl",
 		"templates/pages/agents-claude-detail.tmpl",
+		"templates/pages/agents-codex-detail.tmpl",
 		"templates/pages/agents-create.tmpl",
 		"templates/pages/settings.tmpl",
 		"templates/pages/profile.tmpl",
@@ -139,6 +140,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["agents"] = tmpl
 	tr.templates["agents-detail"] = tmpl
 	tr.templates["agents-claude-detail"] = tmpl
+	tr.templates["agents-codex-detail"] = tmpl
 	tr.templates["agents-create"] = tmpl
 	tr.templates["settings"] = tmpl
 	tr.templates["profile"] = tmpl
@@ -181,7 +183,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-codex-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/pages/agents-codex-detail.tmpl
+++ b/internal/web/templates/pages/agents-codex-detail.tmpl
@@ -1,0 +1,127 @@
+{{define "agents-codex-detail"}}
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+{{template "head.tmpl" .}}
+
+<body class="bg-light" data-sidebar-default="visible">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      overflow-x: hidden;
+      background: var(--bg-primary);
+    }
+
+    .codex-detail-container {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 24px 20px 36px;
+    }
+
+    .codex-detail-header {
+      margin-bottom: 18px;
+      padding: 22px 24px;
+      border-radius: var(--radius-lg, 16px);
+      background: linear-gradient(145deg, color-mix(in srgb, var(--bg-primary) 88%, #10a37f 12%), var(--bg-primary));
+      border: 1px solid color-mix(in srgb, var(--border-color) 78%, #10a37f 22%);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .codex-detail-header h1 {
+      font-size: clamp(24px, 4vw, 30px);
+      margin: 0 0 4px 0;
+      color: var(--text-primary);
+    }
+
+    .codex-detail-header p {
+      color: var(--text-secondary);
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .codex-detail-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+    }
+
+    .codex-detail-card {
+      border: 1px solid var(--border-color);
+      border-radius: 16px;
+      background: var(--bg-primary);
+      padding: 20px 22px;
+    }
+
+    .codex-detail-back {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 14px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 13px;
+    }
+
+    .codex-detail-back:hover {
+      color: var(--text-primary);
+    }
+
+    #codexDetailMissing {
+      color: var(--text-secondary);
+      font-size: 14px;
+    }
+  </style>
+
+  {{template "navbar.tmpl" .}}
+
+  <a class="skip-link" href="#codex-detail-main">Skip to Main Content</a>
+
+  <div class="main-content-wrapper">
+    {{template "sidebar.tmpl" .}}
+
+    <main class="main-content" id="codex-detail-main" role="main" aria-labelledby="codexDetailTitle">
+      <div class="codex-detail-container">
+        <a href="/agents" class="codex-detail-back">&larr; Back to Agents</a>
+
+        <div class="codex-detail-header">
+          <div style="flex: 1 1 auto;">
+            <h1 id="codexDetailTitle">Codex</h1>
+            <p>Synced from <code>~/.codex</code> - read-only</p>
+          </div>
+          <span class="codex-detail-badge">CLI / Read-only</span>
+        </div>
+
+        <div class="codex-detail-card">
+          <div id="codexDetailMissing" hidden>Loading...</div>
+          <div id="codexSyncContent"></div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  {{template "modals.tmpl" .}}
+
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  {{template "scripts-dx-utils.tmpl" .}}
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/resizer.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/codex-sync.js"></script>
+  <script defer src="/js/agents-codex-detail.js"></script>
+  {{template "theme-init.tmpl" .}}
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1678,6 +1678,7 @@
             <button id="drawerToolsTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerToolsTab" data-tab="tools" tabindex="-1">Tools</button>
             <button id="drawerAdvancedTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerAdvancedTab" data-tab="advanced" tabindex="-1">Advanced</button>
             <button id="drawerClaudeTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerClaudeTab" data-tab="claude" tabindex="-1" hidden>Claude Code</button>
+            <button id="drawerCodexTabBtn" class="ops-drawer-tab" type="button" role="tab" aria-selected="false" aria-controls="drawerCodexTab" data-tab="codex" tabindex="-1" hidden>Codex</button>
         </div>
         <div class="ops-drawer-body">
             <section id="drawerOverviewTab" class="ops-drawer-panel active" role="tabpanel" aria-labelledby="drawerOverviewTabBtn" tabindex="0">
@@ -1691,6 +1692,9 @@
             </section>
             <section id="drawerClaudeTab" class="ops-drawer-panel" role="tabpanel" aria-labelledby="drawerClaudeTabBtn" tabindex="0" hidden>
                 <div id="drawerClaudeContent" class="ops-drawer-content"></div>
+            </section>
+            <section id="drawerCodexTab" class="ops-drawer-panel" role="tabpanel" aria-labelledby="drawerCodexTabBtn" tabindex="0" hidden>
+                <div id="drawerCodexContent" class="ops-drawer-content"></div>
             </section>
         </div>
         <div class="ops-drawer-footer">
@@ -1715,6 +1719,7 @@
     <script defer src="/js/modules/themeManager.js"></script>
     <script defer src="/js/modules/external-agents.js"></script>
     <script defer src="/js/modules/claude-sync.js"></script>
+    <script defer src="/js/modules/codex-sync.js"></script>
     {{template "theme-init.tmpl" .}}
     <script defer src="/js/agents-dashboard.js"></script>
 </body>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -109,3 +109,26 @@ func TestRenderAgentsDetailDefaultsSidebarHidden(t *testing.T) {
 		t.Fatalf("rendered agents-detail page should not default the sidebar to visible")
 	}
 }
+
+func TestRenderAgentsCodexDetailPage(t *testing.T) {
+	r := NewTemplateRenderer()
+	if err := r.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+
+	html, err := r.RenderTemplate("agents-codex-detail", TemplateData{Title: "Codex - Ori Agent"})
+	if err != nil {
+		t.Fatalf("RenderTemplate(agents-codex-detail) failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`id="codexDetailTitle"`,
+		`id="codexSyncContent"`,
+		`/js/modules/codex-sync.js`,
+		`/js/agents-codex-detail.js`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered agents-codex-detail page missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add read-only Codex CLI agent page at /agents/Codex
- attach codex_sync to Codex CLI detail responses and render it in the Agents drawer
- read ~/.codex MCP servers with env values redacted to env names only
- auto-enable Codex sync when the Codex CLI is detected unless explicitly disabled

## Verification
- go test ./internal/config ./internal/externalagents ./internal/externalagentshttp ./internal/agenthttp ./internal/server ./internal/settingshttp ./internal/web
- go vet ./internal/config ./internal/externalagents ./internal/externalagentshttp ./internal/agenthttp ./internal/server ./internal/settingshttp ./internal/web
- npx eslint internal/web/static/js/agents-dashboard.js internal/web/static/js/agents-codex-detail.js internal/web/static/js/modules/codex-sync.js
- local smoke: /agents/Codex rendered and /api/agents/Codex/detail returned codex_sync with MCP env names only

## Notes
- Full go test ./... still hits existing unrelated failures in tests/e2e TestSettingsEndpoint and tests/user/workflows requiring bin/ori-agent.