### PR TITLE
Unify /templates authoring: new manifest fields, read-only built-ins

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -854,13 +854,23 @@ GET /api/project-templates
 ```json
 {
   "templates": [
-    { "id": "reaper-song", "name": "Reaper Song", "description": "A minimal REAPER project..." }
+    {
+      "id": "research-project", "name": "Research Project", "description": "Synthesis docs...",
+      "icon": "📚", "behavior_profile": "research", "builtin": true, "has_skeleton": false,
+      "tags": ["research"],
+      "starter_tasks": [{ "description": "Build the synthesis doc", "details": "..." }],
+      "tools": { "skills": [], "mcp_servers": [], "plugins": [] }
+    },
+    {
+      "id": "reaper-song", "name": "Reaper Song", "description": "A minimal REAPER project...",
+      "icon": "🎵", "behavior_profile": "general", "builtin": true, "has_skeleton": true
+    }
   ],
   "templates_root": "/path/to/templates"
 }
 ```
 
-The library directory is configurable via the `templates_root` setting (then the `ORI_TEMPLATES_DIR` environment variable, then `<data dir>/templates`). Every immediate subfolder is a template; an optional `template.json` provides display `name`/`description` metadata only.
+The library directory is configurable via the `templates_root` setting (then the `ORI_TEMPLATES_DIR` environment variable, then `<data dir>/templates`). Every immediate subfolder is a template. The optional `template.json` carries declarative metadata: `name`, `description`, `tags`, `icon`, `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks`, `tools`, `onboarding`, and `builtin`. `has_skeleton` is derived (false ⇒ a metadata-only template that scaffolds no project folder). Built-ins (`builtin: true`) are read-only.
 
 **Create a workspace with a project** — `POST /api/workspaces` accepts three additional optional fields:
 
@@ -890,11 +900,15 @@ Responds `201` with `project_path` and the refreshed workspace; `409` when the w
 **Managing the library:**
 
 ```http
+POST   /api/project-templates                 { "name": "Display Name" }   // create a blank (metadata-only) template
 POST   /api/project-templates/import          { "path": "/any/folder", "name": "Display Name" }
-PUT    /api/project-templates/:id             { "name": "...", "description": "..." }   // template.json metadata
+POST   /api/project-templates/:id/duplicate   { "name": "..." }   // editable copy (a built-in's copy is never builtin)
+PUT    /api/project-templates/:id             { "name", "description", "tags", "icon", "behavior_profile", "starter_tasks" }
 DELETE /api/project-templates/:id             → { "success": true, "trashed": true|false }
 POST   /api/project-templates/reveal          { "id": "..." }   // empty id opens the library root (local-first)
 ```
+
+Mutating a built-in template (`PUT`/`DELETE`, file edits, onboarding/tools) is rejected with `403` — duplicate it first. The same `template.json` config (`behavior_profile`, `starter_tasks`, `tools`, `onboarding`) is also editable via the `/templates` page; see [Project Templates](../features/project-templates.md).
 
 Import copies the folder **verbatim** (no token substitution — `{{name}}` in file names is preserved for instantiation time; symlinks skipped). Delete prefers the system Trash; deleted starter templates are re-materialized on the next server start. Metadata updates preserve unknown `template.json` fields.
 

--- a/docs/features/project-templates.md
+++ b/docs/features/project-templates.md
@@ -1,6 +1,15 @@
 # Project Templates
 
-Project templates let a workspace start with a ready-made **project folder** — a Reaper song, a writing project, a code scaffold, anything — without Ori containing any domain-specific code. A template is just a folder; instantiating it copies the folder's contents into the workspace and records the result as the workspace's `project_path`.
+A **template** describes how a workspace starts. It is presented as a single **Template** picker in the create-workspace modal (there is no separate "starting point" vs. "project template" choice). One template may carry any combination of:
+
+- a **name/description** prefill,
+- a default **agent behavior** profile (`general` | `research` | `software_project`),
+- **starter tasks** seeded into the new workspace,
+- default **tools** (skills / MCP servers / plugins, applied if present),
+- an **onboarding** intake flow, and
+- a **project folder skeleton** — a Reaper song, a writing project, a code scaffold, anything.
+
+A template that ships a skeleton scaffolds it into the workspace and records the result as the workspace's `project_path`. A **metadata-only** template (no files beyond `template.json`) contributes behavior/tasks/tools but creates no project folder. Either way, Ori contains no domain-specific code: a template is just a folder, and all domain specificity lives in template data.
 
 ## Why this design
 
@@ -18,7 +27,7 @@ The library is a directory of folders. Resolution order:
 2. `ORI_TEMPLATES_DIR` environment variable
 3. `<data dir>/templates` (default; created on startup)
 
-Two starter templates (`reaper-song`, `writing-project`) are materialized on first start — only when absent, so your edits are never overwritten.
+A set of **built-in** templates is materialized on first start — only when absent, so your edits are never overwritten. These are the five metadata-only starting points (`travels`, `daily-briefings`, `content-production`, `research-project`, `personal-ops`) plus the two folder-skeleton starters (`reaper-song`, `writing-project`). Built-ins are flagged `"builtin": true` and are **read-only** in the authoring UI — use **Duplicate to customize** to make an editable copy.
 
 ## Authoring a template
 
@@ -32,7 +41,8 @@ templates/
     assets/
 ```
 
-- `template.json` may set `"name"` and `"description"` for the picker. It carries **metadata only** — no hooks, scripts, or post-create actions, by design.
+- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details" }]`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `onboarding` (intake spec), and `builtin`. Unknown keys are preserved untouched.
+- A folder containing **only** `template.json` is a valid metadata-only template (it scaffolds no files).
 - `{{name}}` becomes the slugified project name; `{{date}}` becomes `YYYY-MM-DD`. Substitution applies to file and folder **names only**; file contents are byte-copied untouched, so binary files are always safe.
 - Symlinks are skipped during instantiation (they would break portability or reach outside the template).
 - Keep templates small: instantiation is synchronous, and seeds are meant to be starting points, not finished projects.
@@ -41,7 +51,7 @@ templates/
 
 Entry points:
 
-- **Workspace creation** — the "Project (optional)" card in the create-workspace modal: pick a library template or any folder on disk ("Choose folder…"), optionally set a project name (defaults to the workspace name).
+- **Workspace creation** — the unified **Template** picker in the create-workspace modal: a card grid of built-ins plus a compact list of your own templates. Selecting one applies its prefill/behavior/tasks/tools and, if it has a skeleton, scaffolds the project (optionally set a project name; defaults to the workspace name). The "use any folder as a template" escape hatch lives under **Advanced**. A metadata-only template skips scaffolding entirely.
 - **Chat** — agents in a workspace can call `workspace_project_templates` and `workspace_create_project`.
 - **API** — `POST /api/workspaces` with `template_id` or `template_path` (+ optional `project_name`); see the [API reference](../api/API_REFERENCE.md#project-templates).
 
@@ -62,11 +72,12 @@ Because `project_path` is relative and stored in `workspace.json` (its canonical
 
 ## Managing the library
 
-The filesystem is the primary management surface — but the app provides a thin veneer over it:
+The filesystem is the primary management surface — but the app provides a full authoring UI over it:
 
-- **Manage modal** (reachable from the create-workspace modal's Project card, the workspace page's project dialog, and Settings → Project Templates): list installed templates, **Import Folder…** (verbatim copy into the library), **Edit** display name/description (writes `template.json`, preserving any extra fields), **Delete** (system Trash when supported), and **Reveal** in the file manager.
-- **Settings → Project Templates**: configure `templates_root` (Browse/Save/Clear, mirroring the workspace and vault directory settings), open the library folder, and launch the manage modal. Changing the directory materializes the library there, including any absent starter templates.
-- Deleting a starter template lasts until the next server start, which re-adds absent starters; edit a starter instead of deleting it if you want it gone-but-different.
+- **`/templates` page** — the dedicated authoring surface. Per template: edit the Overview (name, description, tags, **icon**, **agent behavior**, **starter tasks**), browse/edit Files, configure Onboarding and Tools, **Duplicate**, **Reveal**, and **Delete**. Built-ins show a read-only badge and disable the mutating controls; **Duplicate to customize** makes an editable copy (the copy is never marked built-in). Mutating a built-in is also rejected server-side with `403` (defense in depth), so the read-only guarantee does not depend on the UI.
+- **Manage modal** (reachable from the create-workspace modal and Settings → Project Templates): a lighter list/import/edit/delete/reveal veneer over the same library.
+- **Settings → Project Templates**: configure `templates_root` (Browse/Save/Clear), open the library folder, and launch the authoring page. Changing the directory materializes the library there, including any absent built-ins.
+- Deleting a built-in lasts until the next server start, which re-adds absent built-ins; duplicate-and-edit instead if you want one gone-but-different.
 
 ## Rules and guarantees
 

--- a/internal/projecttemplates/manage.go
+++ b/internal/projecttemplates/manage.go
@@ -72,7 +72,7 @@ func ImportFolder(libDir, srcPath, displayName string) (Template, error) {
 	}
 
 	if strings.TrimSpace(displayName) != "" {
-		if _, err := UpdateManifest(absLib, id, displayName, src.Description, nil); err != nil {
+		if _, err := UpdateManifest(absLib, id, displayName, src.Description, nil, nil); err != nil {
 			_ = os.RemoveAll(dest)
 			return Template{}, err
 		}
@@ -117,7 +117,7 @@ func CreateBlank(libDir, name string) (Template, error) {
 	}
 
 	// Seed a minimal manifest so the display name is explicit from the start.
-	if _, err := UpdateManifest(absLib, id, name, "", nil); err != nil {
+	if _, err := UpdateManifest(absLib, id, name, "", nil, nil); err != nil {
 		_ = os.RemoveAll(dest)
 		return Template{}, err
 	}
@@ -159,12 +159,45 @@ func Duplicate(libDir, id, newName string) (Template, error) {
 		_ = os.RemoveAll(dest)
 		return Template{}, err
 	}
+	// A duplicate is always an editable user template: never inherit the
+	// source's builtin flag (copyFolderVerbatim copied it verbatim).
+	if err := deleteManifestKeys(dest, "builtin"); err != nil {
+		_ = os.RemoveAll(dest)
+		return Template{}, err
+	}
 	// Set the duplicate's display name (tags/onboarding/unknown keys preserved).
-	if _, err := UpdateManifest(absLib, newID, basis, src.Description, nil); err != nil {
+	if _, err := UpdateManifest(absLib, newID, basis, src.Description, nil, nil); err != nil {
 		_ = os.RemoveAll(dest)
 		return Template{}, err
 	}
 	return newTemplate(dest), nil
+}
+
+// deleteManifestKeys removes the given keys from a template folder's
+// template.json, preserving everything else. A missing/malformed manifest is a
+// no-op. dir is a library template folder resolved by the caller; the filename
+// is always the fixed ManifestFileName constant.
+func deleteManifestKeys(dir string, keys ...string) error {
+	manifestPath := filepath.Join(dir, ManifestFileName)
+	data, err := os.ReadFile(manifestPath) // #nosec G304 -- dir is a resolved library template folder; filename is the fixed ManifestFileName constant
+	if err != nil {
+		return nil
+	}
+	raw := map[string]any{}
+	if json.Unmarshal(data, &raw) != nil {
+		return nil
+	}
+	for _, key := range keys {
+		delete(raw, key)
+	}
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, append(out, '\n'), 0o640); err != nil { // #nosec G304 -- manifestPath is a resolved library template folder + the fixed ManifestFileName constant
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+	return nil
 }
 
 // copyFolderVerbatim copies a directory tree without name substitution,
@@ -198,6 +231,35 @@ func copyFolderVerbatim(srcRoot, destRoot string) error {
 	})
 }
 
+// ErrTemplateReadOnly reports an attempt to mutate a built-in template. The
+// authoring UI and API treat built-ins as read-only; "Duplicate to customize"
+// is the supported way to edit one.
+var ErrTemplateReadOnly = errors.New("template is built-in and read-only")
+
+// EnsureMutable returns ErrTemplateReadOnly when id resolves to a built-in
+// template. Mutating endpoints guard with it so a built-in can never be edited,
+// renamed, file-modified, or deleted in place.
+func EnsureMutable(libDir, id string) error {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return err
+	}
+	if tpl.Builtin {
+		return fmt.Errorf("%w: %q", ErrTemplateReadOnly, id)
+	}
+	return nil
+}
+
+// ManifestEdit carries the unified-template config fields editable on the
+// /templates page. Each pointer is tri-state: nil preserves the manifest's
+// current value, a set pointer replaces it (empty icon clears the key; empty
+// starter_tasks clears the key; behavior_profile is normalized).
+type ManifestEdit struct {
+	Icon            *string
+	BehaviorProfile *string
+	StarterTasks    *[]StarterTask
+}
+
 // UpdateManifest writes display metadata into a library template's
 // template.json, preserving any unknown fields a user may have added. Empty
 // name/description values remove the corresponding key (falling back to
@@ -206,7 +268,8 @@ func copyFolderVerbatim(srcRoot, destRoot string) error {
 // tags is tri-state so older callers can't clobber author-set tags: nil
 // preserves whatever the manifest already has, a non-empty slice replaces the
 // tags with the normalized set, and an explicit empty slice clears the key.
-func UpdateManifest(libDir, id, name, description string, tags *[]string) (Template, error) {
+// edit is nil for callers that only touch name/description/tags.
+func UpdateManifest(libDir, id, name, description string, tags *[]string, edit *ManifestEdit) (Template, error) {
 	tpl, err := FindLibraryTemplate(libDir, id)
 	if err != nil {
 		return Template{}, err
@@ -237,6 +300,22 @@ func UpdateManifest(libDir, id, name, description string, tags *[]string) (Templ
 			raw["tags"] = normalized
 		} else {
 			delete(raw, "tags")
+		}
+	}
+
+	if edit != nil {
+		if edit.Icon != nil {
+			setOrDelete("icon", *edit.Icon)
+		}
+		if edit.BehaviorProfile != nil {
+			raw["behavior_profile"] = NormalizeBehaviorProfile(*edit.BehaviorProfile)
+		}
+		if edit.StarterTasks != nil {
+			if tasks := normalizeStarterTasks(*edit.StarterTasks); len(tasks) > 0 {
+				raw["starter_tasks"] = tasks
+			} else {
+				delete(raw, "starter_tasks")
+			}
 		}
 	}
 

--- a/internal/projecttemplates/manage_test.go
+++ b/internal/projecttemplates/manage_test.go
@@ -86,7 +86,7 @@ func TestUpdateManifest(t *testing.T) {
 	libDir := filepath.Join(t.TempDir(), "templates")
 	writeFile(t, filepath.Join(libDir, "demo", ManifestFileName), `{"name":"Old","description":"old desc","tags":["music","reaper"],"custom_field":42}`)
 
-	tpl, err := UpdateManifest(libDir, "demo", "New Name", "new desc", nil)
+	tpl, err := UpdateManifest(libDir, "demo", "New Name", "new desc", nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestUpdateManifest(t *testing.T) {
 	}
 
 	// Clearing the name falls back to the folder name.
-	tpl, err = UpdateManifest(libDir, "demo", "", "", nil)
+	tpl, err = UpdateManifest(libDir, "demo", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(clear): %v", err)
 	}
@@ -116,13 +116,13 @@ func TestUpdateManifest(t *testing.T) {
 	}
 
 	// Unknown template.
-	if _, err := UpdateManifest(libDir, "missing", "x", "", nil); !errors.Is(err, ErrTemplateNotFound) {
+	if _, err := UpdateManifest(libDir, "missing", "x", "", nil, nil); !errors.Is(err, ErrTemplateNotFound) {
 		t.Errorf("expected ErrTemplateNotFound, got %v", err)
 	}
 
 	// A template with no manifest gains one.
 	writeFile(t, filepath.Join(libDir, "plain", "a.txt"), "x")
-	tpl, err = UpdateManifest(libDir, "plain", "Named Now", "", nil)
+	tpl, err = UpdateManifest(libDir, "plain", "Named Now", "", nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(plain): %v", err)
 	}
@@ -136,7 +136,7 @@ func TestUpdateManifestTagsTriState(t *testing.T) {
 	writeFile(t, filepath.Join(libDir, "demo", ManifestFileName), `{"name":"Demo","tags":["music","reaper"]}`)
 
 	// nil preserves existing tags — the legacy manage modal never sends tags.
-	tpl, err := UpdateManifest(libDir, "demo", "Demo", "", nil)
+	tpl, err := UpdateManifest(libDir, "demo", "Demo", "", nil, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(nil tags): %v", err)
 	}
@@ -146,7 +146,7 @@ func TestUpdateManifestTagsTriState(t *testing.T) {
 
 	// A non-empty slice replaces and normalizes (lowercase/trim/dedupe).
 	newTags := []string{"Synth", "synth", "  Bass  "}
-	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &newTags)
+	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &newTags, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(set tags): %v", err)
 	}
@@ -156,7 +156,7 @@ func TestUpdateManifestTagsTriState(t *testing.T) {
 
 	// An explicit empty slice clears the key entirely.
 	empty := []string{}
-	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &empty)
+	tpl, err = UpdateManifest(libDir, "demo", "Demo", "", &empty, nil)
 	if err != nil {
 		t.Fatalf("UpdateManifest(clear tags): %v", err)
 	}

--- a/internal/projecttemplates/manage_unified_test.go
+++ b/internal/projecttemplates/manage_unified_test.go
@@ -1,0 +1,100 @@
+package projecttemplates
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureMutableRejectsBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "shipped", ManifestFileName), `{"name":"Shipped","builtin":true}`)
+	writeFile(t, filepath.Join(dir, "mine", ManifestFileName), `{"name":"Mine"}`)
+
+	if err := EnsureMutable(dir, "shipped"); !errors.Is(err, ErrTemplateReadOnly) {
+		t.Errorf("EnsureMutable(builtin) = %v, want ErrTemplateReadOnly", err)
+	}
+	if err := EnsureMutable(dir, "mine"); err != nil {
+		t.Errorf("EnsureMutable(user) = %v, want nil", err)
+	}
+	if err := EnsureMutable(dir, "missing"); !errors.Is(err, ErrTemplateNotFound) {
+		t.Errorf("EnsureMutable(missing) = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+// TestDuplicateStripsBuiltin covers "Duplicate to customize": a copy of a
+// built-in must be an editable user template, not another built-in.
+func TestDuplicateStripsBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "shipped", ManifestFileName),
+		`{"name":"Shipped","builtin":true,"icon":"✈","behavior_profile":"research","starter_tasks":[{"description":"Do a thing"}]}`)
+
+	dup, err := Duplicate(dir, "shipped", "My Copy")
+	if err != nil {
+		t.Fatalf("Duplicate: %v", err)
+	}
+	if dup.Builtin {
+		t.Errorf("duplicate is still builtin: %+v", dup)
+	}
+	// Other fields carry over (icon/behavior/tasks copied verbatim).
+	if dup.Icon != "✈" || dup.BehaviorProfile != BehaviorProfileResearch || len(dup.StarterTasks) != 1 {
+		t.Errorf("duplicate lost carried fields: %+v", dup)
+	}
+	// And the copy is now mutable.
+	if err := EnsureMutable(dir, dup.ID); err != nil {
+		t.Errorf("duplicate should be mutable, got %v", err)
+	}
+}
+
+func TestUpdateManifestMetaRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "demo", ManifestFileName), `{"name":"Demo"}`)
+
+	icon := "📚"
+	profile := "research"
+	tasks := []StarterTask{
+		{Description: "  Build the doc  ", Details: "  capture the question  "},
+		{Description: "   ", Details: "dropped: blank"},
+	}
+	tpl, err := UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{
+		Icon:            &icon,
+		BehaviorProfile: &profile,
+		StarterTasks:    &tasks,
+	})
+	if err != nil {
+		t.Fatalf("UpdateManifest(meta): %v", err)
+	}
+	if tpl.Icon != "📚" || tpl.BehaviorProfile != BehaviorProfileResearch {
+		t.Errorf("meta not applied: %+v", tpl)
+	}
+	if len(tpl.StarterTasks) != 1 || tpl.StarterTasks[0].Description != "Build the doc" || tpl.StarterTasks[0].Details != "capture the question" {
+		t.Errorf("starter tasks not normalized: %+v", tpl.StarterTasks)
+	}
+
+	// Re-read from disk to confirm persistence.
+	reread, err := FindLibraryTemplate(dir, "demo")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if reread.Icon != "📚" || reread.BehaviorProfile != BehaviorProfileResearch || len(reread.StarterTasks) != 1 {
+		t.Errorf("meta did not persist: %+v", reread)
+	}
+
+	// Clearing icon (empty pointer) and starter_tasks (empty slice) removes them.
+	empty := ""
+	noTasks := []StarterTask{}
+	tpl, err = UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{
+		Icon:         &empty,
+		StarterTasks: &noTasks,
+	})
+	if err != nil {
+		t.Fatalf("UpdateManifest(clear meta): %v", err)
+	}
+	if tpl.Icon != "" || len(tpl.StarterTasks) != 0 {
+		t.Errorf("meta not cleared: %+v", tpl)
+	}
+	// behavior_profile was not in this edit (nil) so it is preserved.
+	if tpl.BehaviorProfile != BehaviorProfileResearch {
+		t.Errorf("behavior_profile should be preserved, got %q", tpl.BehaviorProfile)
+	}
+}

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -66,20 +66,42 @@ func (s *Server) handleProjectTemplateImport(w http.ResponseWriter, r *http.Requ
 // them — so the legacy manage modal (which never sends tags) can't wipe them.
 func (s *Server) handleProjectTemplateUpdate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name        string    `json:"name"`
-		Description string    `json:"description"`
-		Tags        *[]string `json:"tags"`
+		Name            string                          `json:"name"`
+		Description     string                          `json:"description"`
+		Tags            *[]string                       `json:"tags"`
+		Icon            *string                         `json:"icon"`
+		BehaviorProfile *string                         `json:"behavior_profile"`
+		StarterTasks    *[]projecttemplates.StarterTask `json:"starter_tasks"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 
-	tpl, err := projecttemplates.UpdateManifest(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name, req.Description, req.Tags)
+	edit := &projecttemplates.ManifestEdit{
+		Icon:            req.Icon,
+		BehaviorProfile: req.BehaviorProfile,
+		StarterTasks:    req.StarterTasks,
+	}
+	tpl, err := projecttemplates.UpdateManifest(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name, req.Description, req.Tags, edit)
 	if err != nil {
 		s.respondProjectTemplateError(w, err)
 		return
 	}
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "template": tpl})
+}
+
+// guardTemplateMutable rejects mutating operations on built-in templates,
+// responding 403 and returning false. Built-ins are read-only; "Duplicate to
+// customize" is the supported way to edit one.
+func (s *Server) guardTemplateMutable(w http.ResponseWriter, templateID string) bool {
+	if err := projecttemplates.EnsureMutable(resolveTemplatesRoot(s.Core.ConfigManager), templateID); err != nil {
+		s.respondProjectTemplateError(w, err)
+		return false
+	}
+	return true
 }
 
 // handleProjectTemplateCreate serves POST /api/project-templates: create a new,
@@ -125,6 +147,9 @@ func (s *Server) handleProjectTemplateDuplicate(w http.ResponseWriter, r *http.R
 // response reports which path was taken. Deleted starter templates reappear
 // on the next server start (materialize-if-absent).
 func (s *Server) handleProjectTemplateDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	trashed, err := projecttemplates.Delete(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"))
 	if err != nil {
 		s.respondProjectTemplateError(w, err)
@@ -172,6 +197,9 @@ func (s *Server) handleProjectTemplateFileWrite(w http.ResponseWriter, r *http.R
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	if err := projecttemplates.WriteFileContent(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Path, req.Content); err != nil {
 		s.respondProjectTemplateError(w, err)
 		return
@@ -188,6 +216,9 @@ func (s *Server) handleProjectTemplateFileCreate(w http.ResponseWriter, r *http.
 		Type string `json:"type"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
 		return
 	}
 	node, err := projecttemplates.CreateEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Path, req.Type)
@@ -209,6 +240,9 @@ func (s *Server) handleProjectTemplateFileRename(w http.ResponseWriter, r *http.
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	node, err := projecttemplates.RenameEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.From, req.To)
 	if err != nil {
 		s.respondProjectTemplateError(w, err)
@@ -221,6 +255,9 @@ func (s *Server) handleProjectTemplateFileRename(w http.ResponseWriter, r *http.
 // /api/project-templates/{templateID}/files?path=<rel>: remove a file or folder
 // (recursive for folders).
 func (s *Server) handleProjectTemplateFileDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	path := r.URL.Query().Get("path")
 	if err := projecttemplates.DeleteEntry(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), path); err != nil {
 		s.respondProjectTemplateError(w, err)
@@ -282,6 +319,9 @@ func (s *Server) handleProjectTemplateOnboardingSet(w http.ResponseWriter, r *ht
 		}
 	}
 
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	tpl, err := projecttemplates.SetOnboarding(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), body)
 	if err != nil {
 		s.respondProjectTemplateError(w, err)
@@ -293,6 +333,9 @@ func (s *Server) handleProjectTemplateOnboardingSet(w http.ResponseWriter, r *ht
 // handleProjectTemplateOnboardingDelete serves DELETE
 // /api/project-templates/{templateID}/onboarding: remove the onboarding block.
 func (s *Server) handleProjectTemplateOnboardingDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
 	if _, err := projecttemplates.SetOnboarding(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), nil); err != nil {
 		s.respondProjectTemplateError(w, err)
 		return
@@ -308,6 +351,9 @@ func (s *Server) handleProjectTemplateOnboardingDelete(w http.ResponseWriter, r 
 func (s *Server) handleProjectTemplateToolsSet(w http.ResponseWriter, r *http.Request) {
 	var req projecttemplates.ToolDefaults
 	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
 		return
 	}
 	tpl, err := projecttemplates.SetTools(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req)
@@ -362,6 +408,8 @@ func (s *Server) respondProjectTemplateError(w http.ResponseWriter, err error) {
 		_ = orihttp.RespondBadRequest(w, err.Error())
 	case errors.Is(err, projecttemplates.ErrTemplateExists), errors.Is(err, projecttemplates.ErrFileExists):
 		_ = orihttp.RespondConflict(w, err.Error())
+	case errors.Is(err, projecttemplates.ErrTemplateReadOnly):
+		_ = orihttp.RespondForbidden(w, err.Error())
 	case errors.Is(err, projecttemplates.ErrFileTooLarge):
 		_ = orihttp.RespondError(w, http.StatusRequestEntityTooLarge, err.Error())
 	default:

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -172,7 +172,14 @@ function tplBuildRow(template) {
 
   const title = document.createElement('div');
   title.style.cssText = 'color: var(--text-primary); font-size: 14px; font-weight: 600; word-break: break-word;';
-  title.textContent = template.name || template.id;
+  title.textContent = (template.icon ? `${template.icon} ` : '') + (template.name || template.id);
+  if (template.builtin) {
+    const badge = document.createElement('span');
+    badge.className = 'badge ms-1';
+    badge.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 600; font-size: 9px; vertical-align: middle;';
+    badge.textContent = 'BUILT-IN';
+    title.appendChild(badge);
+  }
   row.appendChild(title);
 
   const id = document.createElement('div');
@@ -260,6 +267,31 @@ function tplRenderDetail() {
   if (idLabel) idLabel.textContent = template.id;
 
   tplResetOverviewFields();
+  tplApplyReadOnly();
+}
+
+// tplStarterTasksToText serializes starter tasks to one-per-line text, with
+// optional details after a pipe.
+function tplStarterTasksToText(tasks) {
+  return (Array.isArray(tasks) ? tasks : [])
+    .map((t) => (t && t.details ? `${t.description} | ${t.details}` : (t ? t.description : '')))
+    .filter(Boolean)
+    .join('\n');
+}
+
+// tplParseStarterTasks parses the textarea back into {description, details}
+// objects: one task per non-empty line, details after the first pipe.
+function tplParseStarterTasks(text) {
+  return String(text || '')
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return null;
+      const idx = trimmed.indexOf('|');
+      if (idx === -1) return { description: trimmed, details: '' };
+      return { description: trimmed.slice(0, idx).trim(), details: trimmed.slice(idx + 1).trim() };
+    })
+    .filter((t) => t && t.description);
 }
 
 function tplResetOverviewFields() {
@@ -270,6 +302,12 @@ function tplResetOverviewFields() {
   // A name equal to the id is a folder-name fallback, not an explicit name.
   if (nameInput) nameInput.value = template.name && template.name !== template.id ? template.name : '';
   if (descInput) descInput.value = template.description || '';
+  const iconInput = tplEl('tplEditIcon');
+  if (iconInput) iconInput.value = template.icon || '';
+  const behaviorSelect = tplEl('tplEditBehavior');
+  if (behaviorSelect) behaviorSelect.value = template.behavior_profile || 'general';
+  const starterInput = tplEl('tplEditStarterTasks');
+  if (starterInput) starterInput.value = tplStarterTasksToText(template.starter_tasks);
   tplEnsureTagsWidget();
   if (tplState.tagsWidget) tplState.tagsWidget.setTags(template.tags || []);
 }
@@ -279,6 +317,9 @@ async function tplSaveOverview() {
   if (!template) return;
   const nameInput = tplEl('tplEditName');
   const descInput = tplEl('tplEditDescription');
+  const iconInput = tplEl('tplEditIcon');
+  const behaviorSelect = tplEl('tplEditBehavior');
+  const starterInput = tplEl('tplEditStarterTasks');
   const tags = tplState.tagsWidget ? tplState.tagsWidget.getTags() : (template.tags || []);
   try {
     await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, {
@@ -287,13 +328,42 @@ async function tplSaveOverview() {
       body: JSON.stringify({
         name: nameInput ? nameInput.value.trim() : '',
         description: descInput ? descInput.value.trim() : '',
-        tags
+        tags,
+        icon: iconInput ? iconInput.value.trim() : '',
+        behavior_profile: behaviorSelect ? behaviorSelect.value : 'general',
+        starter_tasks: tplParseStarterTasks(starterInput ? starterInput.value : '')
       })
     });
     tplToast('Template saved.', 'success');
     await tplRefresh(template.id);
   } catch (error) {
     tplToast(error.message || 'Failed to save template', 'error');
+  }
+}
+
+// tplApplyReadOnly toggles the built-in badge/notice and disables every
+// mutating control for built-in templates (the backend also rejects mutations).
+function tplApplyReadOnly() {
+  const template = tplSelected();
+  const builtin = Boolean(template && template.builtin);
+  const badge = tplEl('tplDetailBuiltinBadge');
+  if (badge) badge.hidden = !builtin;
+  const notice = tplEl('tplReadOnlyNotice');
+  if (notice) notice.hidden = !builtin;
+  [
+    'tplEditName', 'tplEditDescription', 'tplEditIcon', 'tplEditBehavior', 'tplEditStarterTasks',
+    'tplSaveBtn', 'tplResetBtn', 'tplDeleteBtn',
+    'tplFileNewBtn', 'tplFolderNewBtn', 'tplFileRenameBtn', 'tplFileDeleteBtn', 'tplEditorSaveBtn',
+    'tplOnbSaveBtn', 'tplToolsSaveBtn'
+  ].forEach((id) => {
+    const el = tplEl(id);
+    if (el) el.disabled = builtin;
+  });
+  // The tags widget is a custom component; dim + block interaction for built-ins.
+  const tagsWrap = tplEl('tplEditTags');
+  if (tagsWrap) {
+    tagsWrap.style.pointerEvents = builtin ? 'none' : '';
+    tagsWrap.style.opacity = builtin ? '0.6' : '';
   }
 }
 
@@ -1283,6 +1353,7 @@ function tplInit() {
 
   tplEl('tplSaveBtn')?.addEventListener('click', () => void tplSaveOverview());
   tplEl('tplResetBtn')?.addEventListener('click', tplResetOverviewFields);
+  tplEl('tplDuplicateToCustomizeBtn')?.addEventListener('click', tplDuplicate);
 
   const search = tplEl('tplSearch');
   if (search) {

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -88,7 +88,9 @@
               <div id="tplDetail" hidden>
                 <div class="d-flex justify-content-between align-items-start gap-3 mb-3 flex-wrap">
                   <div style="min-width: 0;">
-                    <h4 id="tplDetailName" class="mb-1" style="color: var(--text-primary); word-break: break-word;">Template</h4>
+                    <h4 id="tplDetailName" class="mb-1" style="color: var(--text-primary); word-break: break-word;">Template
+                      <span id="tplDetailBuiltinBadge" hidden style="display: inline-block; margin-left: 6px; padding: 2px 8px; font-size: 11px; font-weight: 600; vertical-align: middle; border-radius: 999px; background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-secondary);">Built-in · read-only</span>
+                    </h4>
                     <code id="tplDetailId" style="font-size: 12px; color: var(--text-secondary);"></code>
                   </div>
                   <div class="d-flex gap-2 flex-wrap">
@@ -116,6 +118,10 @@
                 <div class="tab-content">
                   <!-- Overview / metadata -->
                   <div class="tab-pane fade show active" id="tplOverviewPane" role="tabpanel" aria-labelledby="tplTabOverview">
+                    <div id="tplReadOnlyNotice" hidden class="mb-3" style="padding: 10px 12px; border-radius: 8px; border: 1px solid var(--border-color); background: var(--bg-tertiary); font-size: 12px; color: var(--text-secondary);">
+                      This is a built-in template and is read-only.
+                      <button id="tplDuplicateToCustomizeBtn" class="modern-btn modern-btn-primary btn-sm ms-2">Duplicate to customize</button>
+                    </div>
                     <div class="mb-3">
                       <label for="tplEditName" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Display name</label>
                       <input id="tplEditName" type="text" class="modern-input w-100" maxlength="120" placeholder="Defaults to the folder id">
@@ -124,9 +130,28 @@
                       <label for="tplEditDescription" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Description</label>
                       <textarea id="tplEditDescription" class="form-control" rows="3" style="background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.9em; resize: vertical;" placeholder="What is this template for?"></textarea>
                     </div>
+                    <div class="row g-3 mb-3">
+                      <div class="col-12 col-sm-4">
+                        <label for="tplEditIcon" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Icon</label>
+                        <input id="tplEditIcon" type="text" class="modern-input w-100" maxlength="8" placeholder="✈" autocomplete="off">
+                      </div>
+                      <div class="col-12 col-sm-8">
+                        <label for="tplEditBehavior" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Agent behavior</label>
+                        <select id="tplEditBehavior" class="modern-input w-100">
+                          <option value="general">General</option>
+                          <option value="research">Research</option>
+                          <option value="software_project">Software Project</option>
+                        </select>
+                      </div>
+                    </div>
                     <div class="mb-3">
                       <label class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Tags</label>
                       <div id="tplEditTags"></div>
+                    </div>
+                    <div class="mb-3">
+                      <label for="tplEditStarterTasks" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Starter tasks</label>
+                      <textarea id="tplEditStarterTasks" class="form-control" rows="3" style="background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.9em; resize: vertical;" placeholder="One task per line. Optional details after a pipe:&#10;Plan an upcoming trip | destination, dates, budget"></textarea>
+                      <div style="margin-top: 4px; font-size: 11px; color: var(--text-secondary);">One task per line; add details after a <code>|</code>. Seeded into the workspace on creation.</div>
                     </div>
                     <div class="d-flex gap-2">
                       <button id="tplSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save changes</button>


### PR DESCRIPTION
Follow-up to #119 (which merged the create-workspace "Starting point" + "Project template" controls into one unified Template picker). This completes the epic: the `/templates` page can now author the **full** unified template, and built-ins are protected.

## What changed

**Authoring editor** (`/templates` Overview tab)
- Added an **Icon** field, an **Agent behavior** select (`general` | `research` | `software_project`), and a one-per-line **Starter tasks** textarea (`description | details`).
- `UpdateManifest` extended with a `ManifestEdit` (icon / behavior_profile / starter_tasks, tri-state preserve); the `PUT /api/project-templates/:id` handler accepts and persists them. List rows show each template's icon + a BUILT-IN badge.

**Read-only built-ins**
- `EnsureMutable` + `ErrTemplateReadOnly` reject **every** mutating endpoint (update / delete / file write·create·rename·delete / onboarding set·delete / tools set) with **403** — defense in depth, not UI-only.
- The page shows a "built-in · read-only" badge + notice, disables the mutating controls, and offers **Duplicate to customize**.
- `Duplicate` strips the source's `builtin` flag, so a copy of a built-in is an editable user template (other fields carry over verbatim).

**Docs**
- `docs/features/project-templates.md` + `docs/api/API_REFERENCE.md` rewritten for the unified model (one Template picker, manifest config fields, metadata-only templates, read-only built-ins + 403, duplicate-to-customize).

## Verification

- New unit tests (`manage_unified_test.go`): `EnsureMutable` rejects built-ins; `Duplicate` yields an editable copy; `UpdateManifest` meta round-trips and clears.
- `go test ./...` — 65 packages pass; only failure is the known pre-existing `tests/e2e TestSettingsEndpoint`. `go vet` + `eslint internal/web/static/js/` clean.
- Smoke-verified against an isolated server + browser: `PUT`/`DELETE` of a built-in → 403; duplicate `travels` → editable `my-travels` (`builtin=false`); icon 🌍 + Research behavior persist and render; built-in shows read-only notice; full create flow across built-in / user template / **Blank** (no project) / **any-folder escape hatch** (scaffolds files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)