### PR TITLE
Entry agent owns unassigned tasks (default-on-create + claim sweep)

### DIFF
--- a/internal/orchestrationhttp/task_handler.go
+++ b/internal/orchestrationhttp/task_handler.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/johnjallday/ori-agent/internal/agentcomm"
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
@@ -324,6 +326,14 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 		task.OutputContract = task.OutputSpec.Contract
 	}
 
+	// Default an otherwise-unassigned task to the workspace coordinator (entry
+	// agent) so created work is owned and routable instead of orphaned. No-op
+	// when the request named an assignee or no coordinator can be resolved. Runs
+	// before the scheduled-task validation below so a coordinator-defaulted
+	// schedule is not rejected as unassigned (FR8), and before provenance
+	// reconciliation so the entry_agent_default stamp it writes is preserved.
+	defaultedToEntryAgent := ws.ApplyEntryAgentDefault(&task)
+
 	// Validate: scheduled tasks must be assigned to an agent
 	if task.ScheduleEnabled && task.Schedule != nil {
 		if task.To == "" || task.To == "unassigned" {
@@ -348,9 +358,23 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 
 	// Record assignment provenance. This endpoint serves both manual creates and
 	// coordinator-planned (auto-parse) creates, so honor explicit, valid
-	// provenance from the request and default to manual otherwise.
-	task.AssignmentMode, task.AssignedBy, task.AssignmentReason = resolveCreateTaskProvenance(
-		req.AssignmentMode, req.AssignedBy, req.AssignmentReason)
+	// provenance from the request and default to manual otherwise. When the task
+	// was defaulted to the entry agent above and the request carried no explicit
+	// provenance, keep the entry_agent_default stamp instead of overwriting it
+	// back to manual (FR9a).
+	reqMode := workspace.TaskAssignmentMode(strings.TrimSpace(req.AssignmentMode))
+	hasExplicitProvenance := workspace.IsValidTaskAssignmentMode(reqMode) && reqMode != workspace.TaskAssignmentModeLegacyUnknown
+	if hasExplicitProvenance || !defaultedToEntryAgent {
+		task.AssignmentMode, task.AssignedBy, task.AssignmentReason = resolveCreateTaskProvenance(
+			req.AssignmentMode, req.AssignedBy, req.AssignmentReason)
+	}
+
+	// Pre-assign the ID so the created task can be located unambiguously after
+	// save; matching on the request's To no longer works once defaulting may
+	// have changed it (FR9).
+	if task.ID == "" {
+		task.ID = uuid.New().String()
+	}
 
 	// Add task to workspace
 	if err := ws.AddTask(task); err != nil {
@@ -369,18 +393,10 @@ func (th *TaskHandler) handleCreateTask(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Get the task we just added (it now has an ID)
-	// Find the most recently added task with matching properties
-	var createdTask *workspace.Task
-	for i := len(ws.Tasks) - 1; i >= 0; i-- {
-		if ws.Tasks[i].Description == req.Description && ws.Tasks[i].From == req.From && ws.Tasks[i].To == req.To {
-			createdTask = &ws.Tasks[i]
-			break
-		}
-	}
-
-	if createdTask == nil {
-		logger.Error("Could not find created task", logger.Fields{})
+	// Get the task we just added by its pre-assigned ID.
+	createdTask, err := ws.GetTask(task.ID)
+	if err != nil || createdTask == nil {
+		logger.Error("Could not find created task", logger.Fields{"task_id": task.ID, "error": err})
 		orihttp.InternalError(w, "Task created but could not be retrieved")
 		return
 	}

--- a/internal/orchestrationhttp/task_handler_entry_default_test.go
+++ b/internal/orchestrationhttp/task_handler_entry_default_test.go
@@ -1,0 +1,141 @@
+package orchestrationhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agentcomm"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// soloCoordinatorWorkspace builds a single-agent workspace whose lone member is
+// the coordinator via the single-agent default, saved into store.
+func soloCoordinatorWorkspace(t *testing.T, store workspace.Store, id string) {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: id})
+	ws.ID = id
+	ws.Agents = []string{"Solo"}
+	ws.AgentInstances = []workspace.AgentInstance{{Name: "Solo", NodeID: "Solo-node-1"}}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+}
+
+type createdTaskResponse struct {
+	Success bool `json:"success"`
+	Task    struct {
+		ID             string `json:"id"`
+		To             string `json:"to"`
+		AssignedBy     string `json:"assigned_by"`
+		AssignmentMode string `json:"assignment_mode"`
+	} `json:"task"`
+}
+
+func postCreateTask(t *testing.T, store workspace.Store, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := &TaskHandler{
+		workspaceStore: store,
+		communicator:   agentcomm.NewCommunicator(store),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/orchestration/tasks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.TasksHandler(rec, req)
+	return rec
+}
+
+// TestHandleCreateTaskDefaultsToCoordinator: an unassigned create defaults to the
+// coordinator and keeps entry_agent_default provenance (not clobbered to manual).
+func TestHandleCreateTaskDefaultsToCoordinator(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	soloCoordinatorWorkspace(t, store, "ws-default-create")
+
+	rec := postCreateTask(t, store, `{"workspace_id":"ws-default-create","from":"user","description":"do it"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createdTaskResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task.ID == "" {
+		t.Fatal("created task was not returned (createdTask capture broke)")
+	}
+	if resp.Task.To != "Solo" ||
+		resp.Task.AssignmentMode != string(workspace.TaskAssignmentModeEntryAgentDefault) ||
+		resp.Task.AssignedBy != "Solo" {
+		t.Fatalf("task not defaulted with entry_agent_default provenance: %+v", resp.Task)
+	}
+}
+
+// TestHandleCreateTaskHonorsExplicitAssignee: an explicit assignee is not
+// overridden by defaulting and stays manual.
+func TestHandleCreateTaskHonorsExplicitAssignee(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	soloCoordinatorWorkspace(t, store, "ws-explicit")
+
+	rec := postCreateTask(t, store, `{"workspace_id":"ws-explicit","from":"user","to":"Solo","description":"do it"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createdTaskResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task.To != "Solo" || resp.Task.AssignmentMode != string(workspace.TaskAssignmentModeManual) {
+		t.Fatalf("explicit assignee should stay manual: %+v", resp.Task)
+	}
+}
+
+// TestHandleCreateTaskNoCoordinatorStaysUnassigned: with no resolvable
+// coordinator, an unassigned create stays unassigned (claimed later).
+func TestHandleCreateTaskNoCoordinatorStaysUnassigned(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "multi"})
+	ws.ID = "ws-multi"
+	ws.Agents = []string{"Writer", "Researcher"}
+	ws.AgentInstances = []workspace.AgentInstance{
+		{Name: "Writer", NodeID: "Writer-node-1"},
+		{Name: "Researcher", NodeID: "Researcher-node-1"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	rec := postCreateTask(t, store, `{"workspace_id":"ws-multi","from":"user","description":"do it"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createdTaskResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task.To != "" {
+		t.Fatalf("task should stay unassigned with no coordinator: %+v", resp.Task)
+	}
+}
+
+// TestHandleCreateScheduledTaskDefaultsBeforeValidation: a scheduled task with
+// no assignee is defaulted to the coordinator before schedule validation, so it
+// is accepted rather than rejected as unassigned (FR8).
+func TestHandleCreateScheduledTaskDefaultsBeforeValidation(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	soloCoordinatorWorkspace(t, store, "ws-sched")
+
+	body := `{"workspace_id":"ws-sched","from":"user","description":"morning briefing",` +
+		`"schedule_enabled":true,"schedule":{"type":"interval","interval_minutes":60}}`
+	rec := postCreateTask(t, store, body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("scheduled task without assignee should default + pass validation; status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp createdTaskResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task.To != "Solo" || resp.Task.AssignmentMode != string(workspace.TaskAssignmentModeEntryAgentDefault) {
+		t.Fatalf("scheduled task not defaulted to coordinator: %+v", resp.Task)
+	}
+}

--- a/internal/orchestrationhttp/workflow_create_handler.go
+++ b/internal/orchestrationhttp/workflow_create_handler.go
@@ -209,6 +209,13 @@ func (th *TaskHandler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Reque
 		})
 	}
 
+	// Default any parent/subtask left without an explicit assignee to the
+	// workspace coordinator (entry agent); a no-op for tasks that already name
+	// one, so deliberate workflow assignments are preserved (FR15).
+	for i := range tasks {
+		ws.ApplyEntryAgentDefault(&tasks[i])
+	}
+
 	if err := ws.AddTasks(tasks); err != nil {
 		if respondTaskGraphError(w, err, "Failed to create workflow") {
 			return

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -217,6 +217,13 @@ func (b *ServerBuilder) initializeWorkspaceStore() error {
 	// Set workspace store on chat handler (uses SyncStore when available)
 	b.chatHandler.SetWorkspaceStore(ws)
 
+	// Give the session handler the primary store for task mutations (the
+	// entry-agent claim sweep) so claimed tasks are written through the same
+	// store orchestration reads from, not just the raw folder store.
+	if b.sessionHandler != nil {
+		b.sessionHandler.SetWorkspaceTaskStore(ws)
+	}
+
 	return nil
 }
 

--- a/internal/server/home_assistant_ask.go
+++ b/internal/server/home_assistant_ask.go
@@ -162,6 +162,10 @@ func (m homeActionMutator) CreateTask(ctx context.Context, workspaceID, descript
 			Status:      workspace.TaskStatusPending,
 			Priority:    3,
 		}
+		// Default the unassigned task to the workspace coordinator (entry agent)
+		// when one can be resolved, so assistant-created work is owned, not
+		// orphaned in the Unassigned column.
+		ws.ApplyEntryAgentDefault(&task)
 		if addErr := ws.AddTask(task); addErr != nil {
 			return addErr
 		}

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -22,8 +22,13 @@ import (
 
 // Handler handles session-related HTTP requests.
 type Handler struct {
-	store                 session.HybridStore
-	workspaceStore        *workspace.FileStore // optional folder-based workspace store
+	store          session.HybridStore
+	workspaceStore *workspace.FileStore // optional folder-based workspace store
+	// workspaceTaskStore is the primary (SyncStore-wrapped) workspace store used
+	// for task mutations such as the entry-agent claim sweep. It must be the same
+	// store orchestration reads from (SQLite primary + disk write-through), not
+	// the raw folder store, or task changes won't be visible to task reads.
+	workspaceTaskStore    workspace.Store
 	workspaceRootResolver func() string
 	templatesRootResolver func() string // resolves the project templates library directory
 	agentStore            store.Store
@@ -54,6 +59,13 @@ func (h *Handler) SetWorkspaceStore(ws *workspace.FileStore) {
 	if ws != nil && h.templateOnboarding == nil {
 		h.templateOnboarding = templateonboarding.NewService(templateonboarding.NewStore(ws))
 	}
+}
+
+// SetWorkspaceTaskStore sets the primary workspace store used for task
+// mutations (e.g. the entry-agent claim sweep). Pass the same SyncStore-wrapped
+// store orchestration uses so claimed tasks are visible to task reads.
+func (h *Handler) SetWorkspaceTaskStore(ws workspace.Store) {
+	h.workspaceTaskStore = ws
 }
 
 // SetWorkspaceRootResolver sets the resolver used to determine the default

--- a/internal/sessionhttp/workspace_entry.go
+++ b/internal/sessionhttp/workspace_entry.go
@@ -24,6 +24,19 @@ const workspaceEntryAgentNameKey = "entry_agent_name"
 // success.
 var errNoTasksClaimed = errors.New("no unassigned tasks to claim")
 
+// taskMutationStore returns the store the claim sweep should write through:
+// the primary (SyncStore-wrapped) store when wired, so changes reach the store
+// orchestration reads from, falling back to the raw folder store (e.g. in tests).
+func (h *Handler) taskMutationStore() agentworkspace.Store {
+	if h.workspaceTaskStore != nil {
+		return h.workspaceTaskStore
+	}
+	if h.workspaceStore != nil {
+		return h.workspaceStore
+	}
+	return nil
+}
+
 // claimUnassignedTasksForEntryAgent hands every currently-unassigned task in the
 // workspace to its resolved coordinator (entry agent). Tasks live in the folder
 // store, so the sweep runs inside workspaceStore.Update for lost-update safety.
@@ -33,7 +46,11 @@ var errNoTasksClaimed = errors.New("no unassigned tasks to claim")
 // Call it after the workspace's entry-agent state has been synced to the folder
 // store, so the coordinator it resolves reflects the just-applied change.
 func (h *Handler) claimUnassignedTasksForEntryAgent(workspaceID string) (int, error) {
-	if h == nil || h.workspaceStore == nil {
+	if h == nil {
+		return 0, nil
+	}
+	store := h.taskMutationStore()
+	if store == nil {
 		return 0, nil
 	}
 	id := strings.TrimSpace(workspaceID)
@@ -42,7 +59,7 @@ func (h *Handler) claimUnassignedTasksForEntryAgent(workspaceID string) (int, er
 	}
 
 	claimed := 0
-	err := h.workspaceStore.Update(id, func(ws *agentworkspace.Workspace) error {
+	err := store.Update(id, func(ws *agentworkspace.Workspace) error {
 		claimed = ws.ClaimUnassignedTasksForCoordinator()
 		if claimed == 0 {
 			return errNoTasksClaimed

--- a/internal/sessionhttp/workspace_entry.go
+++ b/internal/sessionhttp/workspace_entry.go
@@ -2,6 +2,7 @@ package sessionhttp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +17,59 @@ import (
 )
 
 const workspaceEntryAgentNameKey = "entry_agent_name"
+
+// errNoTasksClaimed is an internal sentinel returned from the claim sweep's
+// Update closure to skip the otherwise-unconditional folder-store Save (and its
+// task-markdown rewrite) when there is nothing to claim. The caller treats it as
+// success.
+var errNoTasksClaimed = errors.New("no unassigned tasks to claim")
+
+// claimUnassignedTasksForEntryAgent hands every currently-unassigned task in the
+// workspace to its resolved coordinator (entry agent). Tasks live in the folder
+// store, so the sweep runs inside workspaceStore.Update for lost-update safety.
+// It is best-effort and self-gating: it returns 0 when there is no folder
+// workspace, no resolvable coordinator, or no unassigned task.
+//
+// Call it after the workspace's entry-agent state has been synced to the folder
+// store, so the coordinator it resolves reflects the just-applied change.
+func (h *Handler) claimUnassignedTasksForEntryAgent(workspaceID string) (int, error) {
+	if h == nil || h.workspaceStore == nil {
+		return 0, nil
+	}
+	id := strings.TrimSpace(workspaceID)
+	if id == "" {
+		return 0, nil
+	}
+
+	claimed := 0
+	err := h.workspaceStore.Update(id, func(ws *agentworkspace.Workspace) error {
+		claimed = ws.ClaimUnassignedTasksForCoordinator()
+		if claimed == 0 {
+			return errNoTasksClaimed
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errNoTasksClaimed) {
+		return 0, err
+	}
+	return claimed, nil
+}
+
+// claimUnassignedTasksForEntryAgentLogged runs the claim sweep as a best-effort
+// side effect of an entry-agent lifecycle change, logging the outcome and
+// returning the number of tasks claimed (0 on failure, so a failed sweep is
+// never reported as success). Callers may surface the count in their response.
+func (h *Handler) claimUnassignedTasksForEntryAgentLogged(workspaceID string) int {
+	claimed, err := h.claimUnassignedTasksForEntryAgent(workspaceID)
+	if err != nil {
+		logger.Warn("Failed to claim unassigned tasks for entry agent", logger.Fields{"workspace_id": workspaceID, "error": err})
+		return 0
+	}
+	if claimed > 0 {
+		logger.Info("Claimed unassigned tasks for entry agent", logger.Fields{"workspace_id": workspaceID, "claimed": claimed})
+	}
+	return claimed
+}
 
 func workspaceHasAgentName(workspace *session.Workspace, agentName string) bool {
 	if workspace == nil {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -294,6 +294,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	// chat-ready immediately. Concrete workspaces are created without an entry
 	// agent; the UI prompts the user to create one with their choice of
 	// model/provider.
+	entryAgentSet := false
 	if req.EntryAgentName != "" {
 		entryAgentName, err := h.validateWorkspaceEntryAgent(req.EntryAgentName)
 		if err != nil {
@@ -303,10 +304,12 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		}
 		if entryAgentName != "" {
 			setWorkspaceEntryAgent(ws, entryAgentName)
+			entryAgentSet = true
 		}
 	} else if kind == session.WorkspaceKindGroup {
 		if agentName := h.autoCreateGroupEntryAgent(ws); agentName != "" {
 			setWorkspaceEntryAgent(ws, agentName)
+			entryAgentSet = true
 		}
 	}
 
@@ -463,6 +466,16 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	// Completeness/ordering backstop: when the workspace was created with an
+	// entry agent (an explicit one, or a group's auto-created manager), claim any
+	// tasks that already exist on the folder workspace. The common flow seeds
+	// starter tasks from the client after this response — where default-on-create
+	// assigns them to the coordinator directly — so this is a no-op there and the
+	// safety net for create-time/import-style seeds.
+	if entryAgentSet {
+		h.claimUnassignedTasksForEntryAgentLogged(ws.ID)
 	}
 
 	logger.Info("Workspace created", logger.Fields{"id": ws.ID, "name": req.Name, "folder_slug": ws.FolderSlug, "kind": ws.Kind})

--- a/internal/sessionhttp/workspace_handler_agents.go
+++ b/internal/sessionhttp/workspace_handler_agents.go
@@ -83,7 +83,11 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		CreatedAt:      time.Now(),
 	}
 
-	// Add to workspace
+	// Add to workspace. Capture the prior agent count first: adding the first
+	// agent to an otherwise-agentless workspace makes it the coordinator (via the
+	// single-agent default), which is when pre-existing unassigned tasks should
+	// be claimed.
+	firstAgentAdded := len(workspace.AgentInstances) == 0
 	workspace.AgentInstances = append(workspace.AgentInstances, newInstance)
 
 	// Also add to legacy agents array for backward compatibility
@@ -98,10 +102,8 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		workspace.Agents = append(workspace.Agents, req.AgentName)
 	}
 
-	entryAgentJustSet := false
 	if strings.TrimSpace(currentWorkspaceEntryAgentName(workspace)) == "" {
 		setWorkspaceEntryAgent(workspace, req.AgentName)
-		entryAgentJustSet = true
 	}
 
 	workspace.UpdatedAt = time.Now()
@@ -115,12 +117,12 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		logger.Warn("Failed to sync workspace.json after adding workspace agent", logger.Fields{"id": workspaceID, "error": err})
 	}
 
-	// When this add established the workspace's entry agent, claim any tasks that
-	// were created before a coordinator existed (e.g. template starter tasks) so
-	// they are owned, not orphaned. Runs after the folder-store sync above so the
-	// sweep resolves the just-set coordinator.
+	// When this add established the workspace's coordinator (its first agent),
+	// claim any tasks that were created before a coordinator existed (e.g.
+	// template starter tasks) so they are owned, not orphaned. Runs after the
+	// folder-store sync above so the sweep resolves the now-coordinator agent.
 	tasksClaimed := 0
-	if entryAgentJustSet {
+	if firstAgentAdded {
 		tasksClaimed = h.claimUnassignedTasksForEntryAgentLogged(workspaceID)
 	}
 

--- a/internal/sessionhttp/workspace_handler_agents.go
+++ b/internal/sessionhttp/workspace_handler_agents.go
@@ -98,8 +98,10 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		workspace.Agents = append(workspace.Agents, req.AgentName)
 	}
 
+	entryAgentJustSet := false
 	if strings.TrimSpace(currentWorkspaceEntryAgentName(workspace)) == "" {
 		setWorkspaceEntryAgent(workspace, req.AgentName)
+		entryAgentJustSet = true
 	}
 
 	workspace.UpdatedAt = time.Now()
@@ -111,6 +113,15 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 	}
 	if err := h.syncWorkspacePortableStateToFileStore(workspace); err != nil {
 		logger.Warn("Failed to sync workspace.json after adding workspace agent", logger.Fields{"id": workspaceID, "error": err})
+	}
+
+	// When this add established the workspace's entry agent, claim any tasks that
+	// were created before a coordinator existed (e.g. template starter tasks) so
+	// they are owned, not orphaned. Runs after the folder-store sync above so the
+	// sweep resolves the just-set coordinator.
+	tasksClaimed := 0
+	if entryAgentJustSet {
+		tasksClaimed = h.claimUnassignedTasksForEntryAgentLogged(workspaceID)
 	}
 
 	onboardingSummary, _, onboardingErr := h.resumeTemplateOnboardingForEntryAgent(r.Context(), workspace)
@@ -132,6 +143,9 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 	}
 	if onboardingSummary != nil {
 		response["onboarding"] = onboardingSummary
+	}
+	if tasksClaimed > 0 {
+		response["tasks_claimed"] = tasksClaimed
 	}
 	_ = orihttp.RespondCreated(w, response)
 }
@@ -252,6 +266,12 @@ func (h *Handler) removeWorkspaceAgent(w http.ResponseWriter, r *http.Request, w
 	}
 	if err := h.syncWorkspacePortableStateToFileStore(workspace); err != nil {
 		logger.Warn("Failed to sync workspace.json after removing workspace agent", logger.Fields{"id": workspaceID, "error": err})
+	}
+
+	// If removing the entry agent promoted a different member to coordinator,
+	// hand any now-unassigned tasks to the new entry agent.
+	if entryAgentRemoved && len(newInstances) > 0 {
+		h.claimUnassignedTasksForEntryAgentLogged(workspaceID)
 	}
 
 	logger.Info("Agent removed from workspace", logger.Fields{

--- a/internal/sessionhttp/workspace_handler_import.go
+++ b/internal/sessionhttp/workspace_handler_import.go
@@ -324,6 +324,10 @@ func (h *Handler) handleWorkspaceImport(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// A supplied entry agent owns any tasks the imported folder carried that were
+	// created before a coordinator existed. No-op when none was supplied/resolved.
+	h.claimUnassignedTasksForEntryAgentLogged(workspace.ID)
+
 	logger.Info("Workspace imported from folder", logger.Fields{
 		"workspace_id": workspace.ID,
 		"name":         workspaceName,
@@ -454,6 +458,11 @@ func (h *Handler) restoreImportedWorkspace(ctx context.Context, folderPath strin
 		if err := adapter.Save(item); err != nil {
 			return nil, warning, fmt.Errorf("sync imported workspace %s: %w", item.ID, err)
 		}
+
+		// Imported folders can carry tasks created before this machine knew the
+		// workspace's entry agent; claim any unassigned ones for the coordinator
+		// resolved from the just-saved folder workspace. No-op without one.
+		h.claimUnassignedTasksForEntryAgentLogged(item.ID)
 
 		sessionWorkspace, err := h.store.GetWorkspace(ctx, item.ID)
 		if err != nil {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3287,9 +3287,8 @@ const sessionManager = {
       payload.schedule = taskConfig.schedule;
       payload.schedule_enabled = Boolean(taskConfig.schedule_enabled);
       payload.schedule_name = taskConfig.schedule_name || '';
-      if (!payload.to) {
-        payload.to = 'ori';
-      }
+      // No hard-coded assignee fallback: the backend defaults an unassigned task
+      // to the workspace coordinator (entry agent) before schedule validation.
     }
 
     const response = await fetch('/api/orchestration/tasks', {

--- a/internal/workspace/coordinator.go
+++ b/internal/workspace/coordinator.go
@@ -63,6 +63,85 @@ func stampAssignment(task *Task, agent string, a TaskAssignment) {
 	task.AssignmentReason = strings.TrimSpace(a.Reason)
 }
 
+// taskAssigneeIsDefaultable reports whether a task's current assignee is empty
+// or the "unassigned" sentinel — i.e. eligible for entry-agent defaulting. A
+// task that already names a real assignee is left untouched.
+func taskAssigneeIsDefaultable(to string) bool {
+	t := strings.TrimSpace(to)
+	return t == "" || strings.EqualFold(t, "unassigned")
+}
+
+// ApplyEntryAgentDefault assigns an otherwise-unassigned task to the workspace
+// coordinator (entry agent) at creation time. It returns true only when it made
+// the assignment.
+//
+// It is a no-op when the task already names an assignee, or when no coordinator
+// can be resolved (a multi-agent workspace with no explicit entry agent): such
+// tasks stay unassigned until a coordinator becomes available, at which point
+// ClaimUnassignedTasksForCoordinator picks them up. Assignment funnels through
+// ApplyTaskAssignment, so it never auto-adds an agent — the resolver only ever
+// returns a current workspace member.
+func (w *Workspace) ApplyEntryAgentDefault(task *Task) bool {
+	if w == nil || task == nil {
+		return false
+	}
+	if !taskAssigneeIsDefaultable(task.To) {
+		return false
+	}
+	coordinator, source := w.ResolveCoordinator()
+	if source == CoordinatorSourceMissing || strings.TrimSpace(coordinator) == "" {
+		return false
+	}
+	if err := w.ApplyTaskAssignment(task, TaskAssignment{
+		AgentName:  coordinator,
+		Mode:       TaskAssignmentModeEntryAgentDefault,
+		AssignedBy: coordinator,
+		Reason:     "defaulted to entry agent (coordinator)",
+	}); err != nil {
+		return false
+	}
+	return true
+}
+
+// ClaimUnassignedTasksForCoordinator hands every currently-unassigned task in the
+// workspace to the resolved coordinator, returning the number of tasks claimed.
+// It is the sweep that fixes the timing gap where tasks (e.g. template starter
+// tasks) were created before an entry agent existed.
+//
+// It is a no-op when no coordinator can be resolved, and it never touches a task
+// that already names an assignee, preserving manual assignments and prior
+// delegations. Claimed tasks are stamped TaskAssignmentModeEntryAgentDefault and
+// attributed to TaskAssignedBySystem (the coordinator did not actively choose
+// them), distinguishing a sweep from a create-time default in audits.
+//
+// Callers persist the result; the workspace store's Update closure is the
+// expected caller so the sweep observes an exclusively-held workspace.
+func (w *Workspace) ClaimUnassignedTasksForCoordinator() int {
+	if w == nil {
+		return 0
+	}
+	coordinator, source := w.ResolveCoordinator()
+	if source == CoordinatorSourceMissing || strings.TrimSpace(coordinator) == "" {
+		return 0
+	}
+	claimed := 0
+	for i := range w.Tasks {
+		if !taskAssigneeIsDefaultable(w.Tasks[i].To) {
+			continue
+		}
+		if err := w.ApplyTaskAssignment(&w.Tasks[i], TaskAssignment{
+			AgentName:  coordinator,
+			Mode:       TaskAssignmentModeEntryAgentDefault,
+			AssignedBy: TaskAssignedBySystem,
+			Reason:     "claimed by entry agent (coordinator)",
+		}); err != nil {
+			continue
+		}
+		claimed++
+	}
+	return claimed
+}
+
 // ResolveCoordinatorForAssignment returns the coordinator agent to drive
 // coordinator-owned assignment, or ErrCoordinatorMissing when a multi-agent
 // workspace has no explicit entry agent. The single-agent default is allowed.

--- a/internal/workspace/coordinator_test.go
+++ b/internal/workspace/coordinator_test.go
@@ -253,3 +253,182 @@ func TestUpdateTaskReassignmentStampsManualProvenance(t *testing.T) {
 		t.Fatalf("reassignment did not stamp manual provenance: %+v", resp.Task)
 	}
 }
+
+// --- entry-agent default + claim sweep (1.2 / 1.3) ---
+
+func TestApplyEntryAgentDefault(t *testing.T) {
+	t.Run("explicit entry agent claims unassigned task", func(t *testing.T) {
+		ws := memberWorkspace("Manager", "Writer")
+		ws.SharedData = map[string]any{sharedDataEntryAgentNameKey: "Manager"}
+		task := &Task{ID: "t1"}
+		if !ws.ApplyEntryAgentDefault(task) {
+			t.Fatal("ApplyEntryAgentDefault() = false, want true")
+		}
+		if task.To != "Manager" || task.AssignmentMode != TaskAssignmentModeEntryAgentDefault || task.AssignedBy != "Manager" {
+			t.Fatalf("unexpected provenance: %+v", task)
+		}
+	})
+
+	t.Run("single-agent default claims unassigned task", func(t *testing.T) {
+		ws := memberWorkspace("Solo")
+		task := &Task{ID: "t1"}
+		if !ws.ApplyEntryAgentDefault(task) || task.To != "Solo" ||
+			task.AssignmentMode != TaskAssignmentModeEntryAgentDefault {
+			t.Fatalf("single-agent default not applied: %+v", task)
+		}
+	})
+
+	t.Run("unassigned sentinel is defaultable", func(t *testing.T) {
+		ws := memberWorkspace("Solo")
+		task := &Task{ID: "t1", To: "unassigned"}
+		if !ws.ApplyEntryAgentDefault(task) || task.To != "Solo" {
+			t.Fatalf("sentinel not defaulted: %+v", task)
+		}
+	})
+
+	t.Run("missing coordinator leaves task untouched", func(t *testing.T) {
+		ws := memberWorkspace("Writer", "Researcher") // multi-agent, no entry agent
+		task := &Task{ID: "t1"}
+		if ws.ApplyEntryAgentDefault(task) {
+			t.Fatal("ApplyEntryAgentDefault() = true, want false when no coordinator")
+		}
+		if task.To != "" || task.AssignmentMode != "" {
+			t.Fatalf("task should be untouched: %+v", task)
+		}
+	})
+
+	t.Run("explicit assignee preserved", func(t *testing.T) {
+		ws := memberWorkspace("Manager", "Writer")
+		ws.SharedData = map[string]any{sharedDataEntryAgentNameKey: "Manager"}
+		task := &Task{ID: "t1", To: "Writer", AssignmentMode: TaskAssignmentModeManual, AssignedBy: TaskAssignedByManual}
+		if ws.ApplyEntryAgentDefault(task) {
+			t.Fatal("ApplyEntryAgentDefault() = true, want false for an explicit assignee")
+		}
+		if task.To != "Writer" || task.AssignmentMode != TaskAssignmentModeManual {
+			t.Fatalf("explicit assignee changed: %+v", task)
+		}
+	})
+
+	t.Run("nil task is a no-op", func(t *testing.T) {
+		ws := memberWorkspace("Solo")
+		if ws.ApplyEntryAgentDefault(nil) {
+			t.Fatal("ApplyEntryAgentDefault(nil) = true, want false")
+		}
+	})
+}
+
+func TestClaimUnassignedTasksForCoordinator(t *testing.T) {
+	t.Run("claims only unassigned, preserves assigned", func(t *testing.T) {
+		ws := memberWorkspace("Manager", "Writer")
+		ws.SharedData = map[string]any{sharedDataEntryAgentNameKey: "Manager"}
+		ws.Tasks = []Task{
+			{ID: "a"},                   // unassigned -> claimed
+			{ID: "b", To: "unassigned"}, // sentinel -> claimed
+			{ID: "c", To: "Writer", AssignmentMode: TaskAssignmentModeManual},     // manual -> preserved
+			{ID: "d", To: "Writer", AssignmentMode: TaskAssignmentModeStaticPlan}, // delegated -> preserved
+		}
+
+		if claimed := ws.ClaimUnassignedTasksForCoordinator(); claimed != 2 {
+			t.Fatalf("claimed = %d, want 2", claimed)
+		}
+		if ws.Tasks[0].To != "Manager" || ws.Tasks[0].AssignmentMode != TaskAssignmentModeEntryAgentDefault ||
+			ws.Tasks[0].AssignedBy != TaskAssignedBySystem {
+			t.Fatalf("task a not claimed by system: %+v", ws.Tasks[0])
+		}
+		if ws.Tasks[1].To != "Manager" {
+			t.Fatalf("sentinel task b not claimed: %+v", ws.Tasks[1])
+		}
+		if ws.Tasks[2].To != "Writer" || ws.Tasks[2].AssignmentMode != TaskAssignmentModeManual {
+			t.Fatalf("manual task c changed: %+v", ws.Tasks[2])
+		}
+		if ws.Tasks[3].To != "Writer" || ws.Tasks[3].AssignmentMode != TaskAssignmentModeStaticPlan {
+			t.Fatalf("delegated task d changed: %+v", ws.Tasks[3])
+		}
+	})
+
+	t.Run("no coordinator is a no-op", func(t *testing.T) {
+		ws := memberWorkspace("Writer", "Researcher") // multi-agent, no entry agent
+		ws.Tasks = []Task{{ID: "a"}, {ID: "b"}}
+		if claimed := ws.ClaimUnassignedTasksForCoordinator(); claimed != 0 {
+			t.Fatalf("claimed = %d, want 0 with no coordinator", claimed)
+		}
+		if ws.Tasks[0].To != "" {
+			t.Fatalf("task changed despite no coordinator: %+v", ws.Tasks[0])
+		}
+	})
+}
+
+// TestCreateTaskDefaultsToEntryAgentCoordinator covers the workspace task HTTP
+// API (CreateTask) defaulting an omitted assignee to the coordinator (4.5).
+func TestCreateTaskDefaultsToEntryAgentCoordinator(t *testing.T) {
+	store, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := memberWorkspace("Solo") // single-agent default coordinator
+	ws.ID = "ws-default"
+	ws.Name = "Default"
+	ws.Status = StatusActive
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/ws-default/tasks",
+		strings.NewReader(`{"description":"do it"}`)) // no "to"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.CreateTask(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp taskProvenanceResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task.To != "Solo" || resp.Task.AssignmentMode != string(TaskAssignmentModeEntryAgentDefault) {
+		t.Fatalf("task not defaulted to coordinator: %+v", resp.Task)
+	}
+}
+
+// TestClaimSweepThroughStoreUpdate exercises the claim sweep over the
+// lost-update-safe Store.Update path and verifies it persists (4.6).
+func TestClaimSweepThroughStoreUpdate(t *testing.T) {
+	store, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ws := memberWorkspace("Manager", "Writer")
+	ws.SharedData = map[string]any{sharedDataEntryAgentNameKey: "Manager"}
+	ws.ID = "ws-sweep"
+	ws.Name = "Sweep"
+	ws.Status = StatusActive
+	ws.Tasks = []Task{{ID: "a", WorkspaceID: "ws-sweep", Description: "orphan", Status: TaskStatusPending}}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save workspace: %v", err)
+	}
+
+	claimed := 0
+	if err := store.Update("ws-sweep", func(fresh *Workspace) error {
+		claimed = fresh.ClaimUnassignedTasksForCoordinator()
+		return nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if claimed != 1 {
+		t.Fatalf("claimed = %d, want 1", claimed)
+	}
+
+	reloaded, err := store.Get("ws-sweep")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if reloaded.Tasks[0].To != "Manager" || reloaded.Tasks[0].AssignmentMode != TaskAssignmentModeEntryAgentDefault {
+		t.Fatalf("claim not persisted: %+v", reloaded.Tasks[0])
+	}
+}

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -126,10 +126,15 @@ func (h *HTTPHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 		task.OutputContract = task.OutputSpec.Contract
 	}
 
-	// The workspace task HTTP API is the manual (user-driven) path, so stamp
-	// manual assignment provenance. Membership is validated by the shared
-	// assignment service — assigning to a non-member workspace agent is rejected.
-	if err := workspace.ApplyTaskAssignment(&task, TaskAssignment{
+	// The workspace task HTTP API is the manual (user-driven) path. An explicit
+	// assignee is stamped manual; an omitted (empty/"unassigned") assignee
+	// defaults to the workspace coordinator (entry agent) when one can be
+	// resolved, otherwise it stays unassigned to be claimed later. Membership is
+	// validated by the shared assignment service — assigning to a non-member
+	// workspace agent is rejected.
+	if taskAssigneeIsDefaultable(req.To) {
+		workspace.ApplyEntryAgentDefault(&task)
+	} else if err := workspace.ApplyTaskAssignment(&task, TaskAssignment{
 		AgentName:  req.To,
 		Mode:       TaskAssignmentModeManual,
 		AssignedBy: TaskAssignedByManual,

--- a/internal/workspace/task_assignment.go
+++ b/internal/workspace/task_assignment.go
@@ -17,10 +17,21 @@ const (
 	// TaskAssignmentModeLegacyUnknown — provenance could not be determined; backfilled
 	// onto tasks that predate assignment provenance during migration.
 	TaskAssignmentModeLegacyUnknown TaskAssignmentMode = "legacy_unknown"
+	// TaskAssignmentModeEntryAgentDefault — assigned to the workspace coordinator
+	// (entry agent) because the task was created or seeded without an explicit
+	// assignee, or claimed by the coordinator once it became available. Distinct
+	// from a deliberate manual or coordinator-planned assignment.
+	TaskAssignmentModeEntryAgentDefault TaskAssignmentMode = "entry_agent_default"
 )
 
 // TaskAssignedByManual is the sentinel AssignedBy value for user-driven assignments.
 const TaskAssignedByManual = "manual"
+
+// TaskAssignedBySystem is the sentinel AssignedBy value for assignments the system
+// made on the coordinator's behalf without the coordinator actively choosing —
+// e.g. the claim sweep that hands pre-existing unassigned tasks to a newly
+// available entry agent.
+const TaskAssignedBySystem = "system"
 
 // IsValidTaskAssignmentMode reports whether mode is one of the known values.
 func IsValidTaskAssignmentMode(mode TaskAssignmentMode) bool {
@@ -28,7 +39,8 @@ func IsValidTaskAssignmentMode(mode TaskAssignmentMode) bool {
 	case TaskAssignmentModeStaticPlan,
 		TaskAssignmentModeManual,
 		TaskAssignmentModeDynamicDelegation,
-		TaskAssignmentModeLegacyUnknown:
+		TaskAssignmentModeLegacyUnknown,
+		TaskAssignmentModeEntryAgentDefault:
 		return true
 	}
 	return false

--- a/internal/workspace/task_assignment_test.go
+++ b/internal/workspace/task_assignment_test.go
@@ -54,3 +54,14 @@ func TestIsValidTaskAssignmentMode(t *testing.T) {
 		t.Error("IsValidTaskAssignmentMode accepted an invalid value")
 	}
 }
+
+func TestEntryAgentDefaultModeIsValid(t *testing.T) {
+	if !IsValidTaskAssignmentMode(TaskAssignmentModeEntryAgentDefault) {
+		t.Fatalf("IsValidTaskAssignmentMode(%q) = false, want true", TaskAssignmentModeEntryAgentDefault)
+	}
+	// The sweep attributes claimed tasks to the system sentinel, distinct from
+	// the manual sentinel, so audits can tell a claim from a user assignment.
+	if TaskAssignedBySystem == TaskAssignedByManual {
+		t.Fatal("TaskAssignedBySystem must differ from TaskAssignedByManual")
+	}
+}

--- a/internal/workspace/task_markdown_sync.go
+++ b/internal/workspace/task_markdown_sync.go
@@ -485,6 +485,10 @@ func applyMarkdownItemsToWorkspace(ws *Workspace, items []taskMarkdownItem, warn
 			}
 			task.CompletedAt = &now
 		}
+		// Default to the workspace coordinator (entry agent) when the markdown
+		// line named no assignee; a no-op when the line specified one, so
+		// markdown-declared assignees are preserved.
+		ws.ApplyEntryAgentDefault(&task)
 		if err := ws.AddTask(task); err != nil {
 			*warnings = append(*warnings, fmt.Sprintf("failed to add task from line %d: %v", item.LineIndex+1, err))
 			continue


### PR DESCRIPTION
## Summary

Makes the workspace **entry agent (coordinator) the default owner of every otherwise-unassigned task**, so template starter tasks (and any task created without an assignee) no longer get stranded in the **Unassigned** column. Closes the gap behind the screenshotted "Morning briefing / Unassigned" behavior.

The entry-agent-as-coordinator model already existed (`ResolveCoordinator`, coordinator-only `delegate_task`, chat/auto-parse defaulting). This PR closes the one hole: programmatic/seeded task creation bypassed it. No new routing engine — routing onward still uses the existing `delegate_task`.

## What it does

Two composing mechanisms (order-independent):

1. **Default-on-create** — a task created/seeded with no assignee defaults to the resolved coordinator, stamped `entry_agent_default`. Wired into every create path: orchestration create, workspace `CreateTask`, home-assistant, markdown import, workflow batches, and the frontend starter-task seed (dropped its hard-coded `"ori"` fallback).
2. **Claim-on-coordinator-availability** — when a workspace's entry agent is first established/changed, unassigned tasks are swept onto it (attributed to `system`). Covers first-agent-added, entry-agent replacement, create-time/group-manager, and import.

Provenance: new `entry_agent_default` `TaskAssignmentMode`; create-time defaults attribute to the coordinator, claim-sweeps attribute to `system`. Existing/manual/delegated assignees are never overridden.

## Notable details

- All assignment funnels through the existing `ApplyTaskAssignment` chokepoint (membership-validated; never auto-adds agents).
- `handleCreateTask`: defaulting runs **before** scheduled-task validation (so a coordinator-defaulted schedule isn't rejected) and the created task is captured by **ID** (the request's `to` no longer matches after defaulting); the existing `manual` provenance fallback is reconciled so it doesn't clobber `entry_agent_default`.
- The claim sweep runs through the **primary** workspace store (SyncStore: SQLite + disk write-through), not the raw folder store, so claimed tasks are visible to orchestration reads. (This was a bug the e2e smoke caught.)

## Not in scope (deliberate)

- **No retroactive backfill.** Tasks already Unassigned in an existing workspace are *not* moved on upgrade; they're claimed only when an entry-agent event fires or on next create. New workspaces work end-to-end.
- No auto-creation of entry agents; no forced re-ownership of already-assigned tasks; single-level delegation unchanged.

## Testing

- Unit/integration: default + claim helpers, provenance validity, `handleCreateTask` (defaulting, provenance reconciliation, created-task capture, scheduled-before-validation), `CreateTask` parity, claim sweep through `Store.Update`.
- Full non-e2e suite green; pre-existing `TestSettingsEndpoint` e2e failure unrelated.
- Isolated e2e smoke reproduces the screenshot: unassigned task created before an entry agent → claimed when the entry agent is added; subsequent unassigned tasks default to the coordinator immediately.

PRD + task list: `tasks/prd-entry-agent-task-routing.md`, `tasks/tasks-entry-agent-task-routing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)