### PR TITLE
Template-declared agent rosters (+ templates/workspace-setup UI polish)

### DIFF
--- a/docs/features/project-templates.md
+++ b/docs/features/project-templates.md
@@ -6,7 +6,8 @@ A **template** describes how a workspace starts. It is presented as a single **T
 - a default **agent behavior** profile (`general` | `research` | `software_project`),
 - **starter tasks** seeded into the new workspace,
 - default **tools** (skills / MCP servers / plugins, applied if present),
-- an **onboarding** intake flow, and
+- an **onboarding** intake flow,
+- an **agent roster** — the agents created on the new workspace (entry agent + specialists), and
 - a **project folder skeleton** — a Reaper song, a writing project, a code scaffold, anything.
 
 A template that ships a skeleton scaffolds it into the workspace and records the result as the workspace's `project_path`. A **metadata-only** template (no files beyond `template.json`) contributes behavior/tasks/tools but creates no project folder. Either way, Ori contains no domain-specific code: a template is just a folder, and all domain specificity lives in template data.
@@ -41,17 +42,57 @@ templates/
     assets/
 ```
 
-- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details" }]`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `onboarding` (intake spec), and `builtin`. Unknown keys are preserved untouched.
+- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details" }]`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `onboarding` (intake spec), `agents` (agent roster — see below), and `builtin`. Unknown keys are preserved untouched.
 - A folder containing **only** `template.json` is a valid metadata-only template (it scaffolds no files).
 - `{{name}}` becomes the slugified project name; `{{date}}` becomes `YYYY-MM-DD`. Substitution applies to file and folder **names only**; file contents are byte-copied untouched, so binary files are always safe.
 - Symlinks are skipped during instantiation (they would break portability or reach outside the template).
 - Keep templates small: instantiation is synchronous, and seeds are meant to be starting points, not finished projects.
 
+## Agents
+
+A template can declare an `agents` roster that is seeded onto the workspace when it is created. The roster is an **ordered** array:
+
+- the **first agent is the entry agent** — the one required agent every workspace needs. Seeding it satisfies that requirement, so the "create an entry agent" prompt does not appear.
+- the **rest are specialist sub-agents** the entry agent delegates to.
+
+A template with **no** `agents` block behaves exactly as before: the workspace starts without agents and prompts for an entry agent.
+
+```json
+"agents": [
+  {
+    "name": "Research Lead",
+    "role": "orchestrator",
+    "type": "general",
+    "model": "",
+    "system_prompt": "You are the research lead for this workspace…",
+    "tools": { "skills": ["citations"], "mcp_servers": ["web-search"] }
+  },
+  { "name": "Source Scout", "role": "researcher", "system_prompt": "You find and vet sources…" }
+]
+```
+
+Per-agent fields (all optional except `name`):
+
+- `name` — the agent's display name (required).
+- `role` — `orchestrator` | `researcher` | `analyzer` | `synthesizer` | `validator` | `specialist` | `general` (unknown values fall back to the default).
+- `type` — `tool-calling` | `general` | `research` (unknown values fall back to the default).
+- `model` — omit to use the workspace/global default model.
+- `system_prompt` — the agent's instructions.
+- `tools` — per-agent `skills` (enabled on the agent) and `mcp_servers` (bound at the workspace level, since MCP has no per-agent scope), applied if present.
+
+Rules:
+
+- **Reuse on name match.** If an agent with that name already exists, it is **reused as-is** — the template's prompt/model/tools for that entry are ignored, so editing a reused agent affects every workspace that shares it. Only unmatched names create a new agent.
+- The roster is **capped at 10**; blank-named and duplicate entries are dropped.
+- If the entry agent (first) fails to create, the workspace is left agent-less and the prompt fires; a specialist that fails is skipped with a non-blocking notice.
+
+Authoring: edit the roster in the **Agents** tab of the `/templates` page — add/remove agents, drag to reorder (drag to the top to set the entry agent). Built-in templates are read-only there.
+
 ## Instantiation
 
 Entry points:
 
-- **Workspace creation** — the unified **Template** picker in the create-workspace modal: a card grid of built-ins plus a compact list of your own templates. Selecting one applies its prefill/behavior/tasks/tools and, if it has a skeleton, scaffolds the project (optionally set a project name; defaults to the workspace name). The "use any folder as a template" escape hatch lives under **Advanced**. A metadata-only template skips scaffolding entirely.
+- **Workspace creation** — the unified **Template** picker in the create-workspace modal: a card grid of built-ins plus a compact list of your own templates. Selecting one applies its prefill/behavior/tasks/tools, seeds its agent roster (if any), and, if it has a skeleton, scaffolds the project (optionally set a project name; defaults to the workspace name). The "use any folder as a template" escape hatch lives under **Advanced**. A metadata-only template skips scaffolding entirely.
 - **Chat** — agents in a workspace can call `workspace_project_templates` and `workspace_create_project`.
 - **API** — `POST /api/workspaces` with `template_id` or `template_path` (+ optional `project_name`); see the [API reference](../api/API_REFERENCE.md#project-templates).
 

--- a/docs/features/project-templates.md
+++ b/docs/features/project-templates.md
@@ -30,6 +30,8 @@ The library is a directory of folders. Resolution order:
 
 A set of **built-in** templates is materialized on first start — only when absent, so your edits are never overwritten. These are the five metadata-only starting points (`travels`, `daily-briefings`, `content-production`, `research-project`, `personal-ops`) plus the two folder-skeleton starters (`reaper-song`, `writing-project`). Built-ins are flagged `"builtin": true` and are **read-only** in the authoring UI — use **Duplicate to customize** to make an editable copy.
 
+**Keeping built-ins current.** Each built-in carries a `builtin_version` (integer). When a release ships a newer version of a built-in's manifest, the next start refreshes that built-in's `template.json` in place so the change (e.g. an updated agent roster) reaches existing installs. **Only the manifest is refreshed** — scaffold seed files and everything else in the folder are left untouched, so hand-edited seed files survive. User templates and duplicates are never affected (they have no `builtin_version` and are not shipped starters).
+
 ## Authoring a template
 
 Drop a folder into the templates directory. That's the whole registration process — it appears in the workspace-creation picker on next load.
@@ -42,7 +44,7 @@ templates/
     assets/
 ```
 
-- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details" }]`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `onboarding` (intake spec), `agents` (agent roster — see below), and `builtin`. Unknown keys are preserved untouched.
+- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details" }]`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `onboarding` (intake spec), `agents` (agent roster — see below), `builtin`, and `builtin_version` (shipped manifest revision for built-ins — see "Keeping built-ins current"). Unknown keys are preserved untouched.
 - A folder containing **only** `template.json` is a valid metadata-only template (it scaffolds no files).
 - `{{name}}` becomes the slugified project name; `{{date}}` becomes `YYYY-MM-DD`. Substitution applies to file and folder **names only**; file contents are byte-copied untouched, so binary files are always safe.
 - Symlinks are skipped during instantiation (they would break portability or reach outside the template).

--- a/internal/projecttemplates/agents.go
+++ b/internal/projecttemplates/agents.go
@@ -1,0 +1,66 @@
+package projecttemplates
+
+import "strings"
+
+// MaxTemplateAgents caps how many agents a single template may declare. Extra
+// entries beyond the cap are dropped during normalization rather than failing
+// the load: a roster this large would slow workspace creation and is an easy
+// abuse vector for an imported template. The cap is a soft limit (drop-extra),
+// not a load error.
+const MaxTemplateAgents = 10
+
+// AgentSpec declares one agent a template seeds onto a workspace created from
+// it. Like ToolDefaults, this package carries the spec as data only — it never
+// creates or resolves agents. Role/Type/Model are trimmed and carried verbatim;
+// canonicalizing them against the real agent enums and resolving empty values to
+// defaults happens in the workspace-creation (seeding) layer, keeping this
+// file-copy engine domain-blind. The first surviving entry in a template's
+// roster is the workspace entry agent; the rest are specialist sub-agents.
+type AgentSpec struct {
+	Name         string       `json:"name"`
+	Role         string       `json:"role,omitempty"`
+	Type         string       `json:"type,omitempty"`
+	SystemPrompt string       `json:"system_prompt,omitempty"`
+	Model        string       `json:"model,omitempty"`
+	Tools        ToolDefaults `json:"tools"`
+}
+
+// normalizeAgentSpecs cleans a raw roster: it trims string fields, drops entries
+// with a blank name, de-duplicates by case-insensitive name (keeping the first
+// occurrence), preserves declaration order (the first survivor is the entry
+// agent — order is never sorted), normalizes each agent's tool lists, and caps
+// the roster at MaxTemplateAgents. A nil/empty input (or one that normalizes
+// away entirely) returns nil so a template with no agents stays a no-op.
+func normalizeAgentSpecs(specs []AgentSpec) []AgentSpec {
+	if len(specs) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(specs))
+	out := make([]AgentSpec, 0, len(specs))
+	for _, s := range specs {
+		name := strings.TrimSpace(s.Name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, AgentSpec{
+			Name:         name,
+			Role:         strings.TrimSpace(s.Role),
+			Type:         strings.TrimSpace(s.Type),
+			SystemPrompt: strings.TrimSpace(s.SystemPrompt),
+			Model:        strings.TrimSpace(s.Model),
+			Tools:        normalizeToolDefaults(s.Tools),
+		})
+		if len(out) >= MaxTemplateAgents {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/projecttemplates/agents.go
+++ b/internal/projecttemplates/agents.go
@@ -1,6 +1,12 @@
 package projecttemplates
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // MaxTemplateAgents caps how many agents a single template may declare. Extra
 // entries beyond the cap are dropped during normalization rather than failing
@@ -63,4 +69,44 @@ func normalizeAgentSpecs(specs []AgentSpec) []AgentSpec {
 		return nil
 	}
 	return out
+}
+
+// SetAgents writes (or clears) the `agents` block in a template's template.json,
+// preserving every other key. The roster is normalized first; an empty result
+// clears the key. Like the tools/onboarding writers, this stores agent specs as
+// data and never creates agents.
+func SetAgents(libDir, id string, agents []AgentSpec) (Template, error) {
+	tpl, err := FindLibraryTemplate(libDir, id)
+	if err != nil {
+		return Template{}, err
+	}
+
+	// manifestPath is the resolved library template's folder (FindLibraryTemplate
+	// rejects ids outside the library) joined with the fixed ManifestFileName.
+	manifestPath := filepath.Join(tpl.Path, ManifestFileName)
+	raw := map[string]any{}
+	if data, err := os.ReadFile(manifestPath); err == nil { // #nosec G304 -- manifestPath is libDir/<validated id>/template.json, not user-controlled
+		_ = json.Unmarshal(data, &raw)
+	}
+
+	if normalized := normalizeAgentSpecs(agents); len(normalized) > 0 {
+		encoded, err := json.Marshal(normalized)
+		if err != nil {
+			return Template{}, fmt.Errorf("failed to encode agents: %w", err)
+		}
+		var v any
+		_ = json.Unmarshal(encoded, &v)
+		raw["agents"] = v
+	} else {
+		delete(raw, "agents")
+	}
+
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return Template{}, fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o640); err != nil { // #nosec G304 G306 -- manifestPath is libDir/<validated id>/template.json; 0o640 matches the package's manifest-write convention
+		return Template{}, fmt.Errorf("failed to write manifest: %w", err)
+	}
+	return newTemplate(tpl.Path), nil
 }

--- a/internal/projecttemplates/agents_test.go
+++ b/internal/projecttemplates/agents_test.go
@@ -1,0 +1,136 @@
+package projecttemplates
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeAgentSpecs_TrimDropDedupeOrder(t *testing.T) {
+	in := []AgentSpec{
+		{Name: "  Producer  ", Role: " orchestrator ", Type: " general ", SystemPrompt: "  lead  ", Model: " gpt-5.5 "},
+		{Name: ""},    // blank name -> dropped
+		{Name: "   "}, // whitespace-only -> dropped
+		{Name: "Copywriter"},
+		{Name: "producer"}, // case-insensitive duplicate of "Producer" -> dropped
+		{Name: "Designer"},
+	}
+
+	out := normalizeAgentSpecs(in)
+
+	gotNames := make([]string, len(out))
+	for i, a := range out {
+		gotNames[i] = a.Name
+	}
+	want := []string{"Producer", "Copywriter", "Designer"}
+	if len(gotNames) != len(want) {
+		t.Fatalf("expected %d agents, got %d (%v)", len(want), len(gotNames), gotNames)
+	}
+	for i := range want {
+		if gotNames[i] != want[i] {
+			t.Fatalf("order/name mismatch at %d: got %q want %q (full %v)", i, gotNames[i], want[i], gotNames)
+		}
+	}
+
+	first := out[0]
+	if first.Role != "orchestrator" || first.Type != "general" || first.SystemPrompt != "lead" || first.Model != "gpt-5.5" {
+		t.Fatalf("fields not trimmed: %+v", first)
+	}
+}
+
+func TestNormalizeAgentSpecs_EmptyReturnsNil(t *testing.T) {
+	if got := normalizeAgentSpecs(nil); got != nil {
+		t.Fatalf("expected nil for nil input, got %v", got)
+	}
+	if got := normalizeAgentSpecs([]AgentSpec{{Name: "  "}, {Name: ""}}); got != nil {
+		t.Fatalf("expected nil when all entries drop out, got %v", got)
+	}
+}
+
+func TestNormalizeAgentSpecs_SoftCap(t *testing.T) {
+	in := make([]AgentSpec, MaxTemplateAgents+5)
+	for i := range in {
+		in[i] = AgentSpec{Name: fmt.Sprintf("Agent %d", i)}
+	}
+	out := normalizeAgentSpecs(in)
+	if len(out) != MaxTemplateAgents {
+		t.Fatalf("expected cap of %d, got %d", MaxTemplateAgents, len(out))
+	}
+	// Cap keeps the first N in declaration order (entry agent must survive).
+	if out[0].Name != "Agent 0" {
+		t.Fatalf("expected first entry preserved, got %q", out[0].Name)
+	}
+}
+
+func TestNormalizeAgentSpecs_NormalizesTools(t *testing.T) {
+	out := normalizeAgentSpecs([]AgentSpec{
+		{Name: "Mixer", Tools: ToolDefaults{
+			Skills:     []string{" b-skill ", "a-skill", "a-skill", ""},
+			MCPServers: []string{"reaper"},
+		}},
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(out))
+	}
+	skills := out[0].Tools.Skills
+	// normalizeNameList trims, drops blanks, de-dupes, and sorts.
+	if len(skills) != 2 || skills[0] != "a-skill" || skills[1] != "b-skill" {
+		t.Fatalf("tools not normalized: %v", skills)
+	}
+}
+
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ManifestFileName), []byte(body), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+func TestNewTemplate_ParsesAgents(t *testing.T) {
+	dir := writeManifest(t, `{
+      "name": "Campaign",
+      "agents": [
+        {"name": "Campaign Lead", "role": "orchestrator", "system_prompt": "Run the campaign", "model": "gpt-5.5",
+         "tools": {"skills": ["planning"], "mcp_servers": ["drive"]}},
+        {"name": "Copywriter", "type": "general", "unknown_field": "ignored"}
+      ]
+    }`)
+
+	tpl := newTemplate(dir)
+
+	if !tpl.HasAgents() {
+		t.Fatal("expected HasAgents() true")
+	}
+	if len(tpl.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(tpl.Agents))
+	}
+	if tpl.Agents[0].Name != "Campaign Lead" || tpl.Agents[1].Name != "Copywriter" {
+		t.Fatalf("unexpected roster order: %+v", tpl.Agents)
+	}
+	if tpl.Agents[0].Tools.Skills[0] != "planning" || tpl.Agents[0].Tools.MCPServers[0] != "drive" {
+		t.Fatalf("per-agent tools not parsed: %+v", tpl.Agents[0].Tools)
+	}
+}
+
+func TestNewTemplate_NoAgentsBackwardsCompat(t *testing.T) {
+	dir := writeManifest(t, `{"name": "Plain"}`)
+	tpl := newTemplate(dir)
+	if tpl.HasAgents() {
+		t.Fatal("expected HasAgents() false for a manifest without an agents key")
+	}
+	if tpl.Agents != nil {
+		t.Fatalf("expected nil Agents, got %v", tpl.Agents)
+	}
+}
+
+func TestNewTemplate_MalformedManifestDegrades(t *testing.T) {
+	dir := writeManifest(t, `{ this is not valid json `)
+	tpl := newTemplate(dir)
+	// A malformed manifest falls back to folder-name display and no agents.
+	if tpl.HasAgents() {
+		t.Fatal("expected no agents from a malformed manifest")
+	}
+}

--- a/internal/projecttemplates/agents_test.go
+++ b/internal/projecttemplates/agents_test.go
@@ -134,3 +134,47 @@ func TestNewTemplate_MalformedManifestDegrades(t *testing.T) {
 		t.Fatal("expected no agents from a malformed manifest")
 	}
 }
+
+func TestSetAgents_RoundTripAndPreservesName(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "demo"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "demo", ManifestFileName), []byte(`{"name":"Demo","description":"keep me"}`), 0o600); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	tpl, err := SetAgents(dir, "demo", []AgentSpec{
+		{Name: "  Lead  ", Role: "orchestrator", SystemPrompt: "run"},
+		{Name: ""}, // dropped
+		{Name: "Writer", Tools: ToolDefaults{Skills: []string{"draft"}}},
+	})
+	if err != nil {
+		t.Fatalf("SetAgents: %v", err)
+	}
+	if len(tpl.Agents) != 2 || tpl.Agents[0].Name != "Lead" || tpl.Agents[1].Name != "Writer" {
+		t.Fatalf("agents not normalized/persisted: %+v", tpl.Agents)
+	}
+	// Other keys are preserved (no clobber of name/description).
+	if tpl.Name != "Demo" || tpl.Description != "keep me" {
+		t.Fatalf("SetAgents clobbered metadata: name=%q desc=%q", tpl.Name, tpl.Description)
+	}
+
+	// Re-read from disk to confirm persistence and order.
+	reread, err := FindLibraryTemplate(dir, "demo")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if len(reread.Agents) != 2 || reread.Agents[0].Name != "Lead" || reread.Agents[1].Tools.Skills[0] != "draft" {
+		t.Fatalf("agents did not persist: %+v", reread.Agents)
+	}
+
+	// An empty roster clears the key but keeps the rest of the manifest.
+	tpl, err = SetAgents(dir, "demo", nil)
+	if err != nil {
+		t.Fatalf("SetAgents(clear): %v", err)
+	}
+	if tpl.HasAgents() || tpl.Name != "Demo" {
+		t.Fatalf("expected agents cleared with metadata intact, got %+v", tpl)
+	}
+}

--- a/internal/projecttemplates/starter.go
+++ b/internal/projecttemplates/starter.go
@@ -56,9 +56,14 @@ func IsBuiltinStarterID(id string) bool {
 }
 
 // EnsureLibrary creates the templates library directory if missing and
-// materializes each starter template whose folder is absent. A folder that
-// already exists is never touched, so user edits (or deletions replaced by
-// their own content) survive restarts.
+// materializes each starter template whose folder is absent. An existing folder
+// is left as-is, with one exception: a shipped built-in whose embedded
+// builtin_version exceeds the on-disk copy has its template.json refreshed in
+// place, so shipped metadata changes (agent rosters, tags, behavior, …) reach
+// existing installs. Only the manifest is refreshed — scaffold seed files and
+// any other folder contents are never touched, so user edits survive. User
+// templates are never in starterFS, so this loop only ever sees shipped
+// starters.
 func EnsureLibrary(dir string) error {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
@@ -77,13 +82,21 @@ func EnsureLibrary(dir string) error {
 		if !starter.IsDir() {
 			continue
 		}
-		dest := filepath.Join(dir, starter.Name())
+		name := starter.Name()
+		dest := filepath.Join(dir, name)
 		if _, err := os.Lstat(dest); err == nil {
+			// Folder exists: refresh only a built-in whose shipped manifest is
+			// newer than the on-disk copy; otherwise leave it untouched.
+			if IsBuiltinStarterID(name) && embeddedBuiltinVersion(name) > diskBuiltinVersion(dest) {
+				if err := refreshBuiltinManifest(name, dest); err != nil {
+					return err
+				}
+			}
 			continue
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("failed to inspect %s: %w", dest, err)
 		}
-		if err := materializeStarter(starter.Name(), dest); err != nil {
+		if err := materializeStarter(name, dest); err != nil {
 			// Leave no half-written starter behind: a partial folder would
 			// block re-materialization on the next start.
 			_ = os.RemoveAll(dest)
@@ -91,6 +104,51 @@ func EnsureLibrary(dir string) error {
 		}
 	}
 	return nil
+}
+
+// refreshBuiltinManifest overwrites dest/template.json with the embedded
+// starter's manifest. It propagates shipped metadata changes to an existing
+// install without disturbing scaffold seed files or any other folder contents.
+func refreshBuiltinManifest(name, dest string) error {
+	data, err := starterFS.ReadFile(path.Join(starterRoot, name, ManifestFileName))
+	if err != nil {
+		return fmt.Errorf("failed to read embedded manifest for %s: %w", name, err)
+	}
+	// target is the configured templates dir joined with a shipped starter name
+	// and the fixed ManifestFileName constant — not influenced by user input.
+	target := filepath.Join(dest, ManifestFileName)
+	if err := os.WriteFile(target, data, 0o640); err != nil { // #nosec G304 G306 -- target is templatesDir/<shipped starter>/template.json; 0o640 matches the package manifest-write convention
+		return fmt.Errorf("failed to refresh built-in manifest %s: %w", target, err)
+	}
+	return nil
+}
+
+// embeddedBuiltinVersion returns the builtin_version an embedded starter's
+// manifest declares (0 when absent or unparseable).
+func embeddedBuiltinVersion(name string) int {
+	data, err := starterFS.ReadFile(path.Join(starterRoot, name, ManifestFileName))
+	if err != nil {
+		return 0
+	}
+	return parseBuiltinVersion(data)
+}
+
+// diskBuiltinVersion returns the builtin_version an on-disk template's manifest
+// declares (0 when missing or unparseable).
+func diskBuiltinVersion(dest string) int {
+	data, err := os.ReadFile(filepath.Join(dest, ManifestFileName)) // #nosec G304 -- dest is templatesDir/<shipped starter>; filename is the fixed ManifestFileName constant
+	if err != nil {
+		return 0
+	}
+	return parseBuiltinVersion(data)
+}
+
+func parseBuiltinVersion(data []byte) int {
+	var m struct {
+		BuiltinVersion int `json:"builtin_version"`
+	}
+	_ = json.Unmarshal(data, &m)
+	return m.BuiltinVersion
 }
 
 // materializeStarter copies one embedded starter template to dest.

--- a/internal/projecttemplates/starter/content-production/template.json
+++ b/internal/projecttemplates/starter/content-production/template.json
@@ -4,6 +4,7 @@
   "icon": "✏",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": ["content"],
   "starter_tasks": [
     {

--- a/internal/projecttemplates/starter/content-production/template.json
+++ b/internal/projecttemplates/starter/content-production/template.json
@@ -14,5 +14,27 @@
       "description": "Draft this week's posts",
       "details": "List the topics, then ask the agent to draft each in the brand voice. Schedule this task weekly once the style guide is settled."
     }
+  ],
+  "agents": [
+    {
+      "name": "Content Lead",
+      "role": "orchestrator",
+      "system_prompt": "You are the content lead for this workspace. Hold the brand voice and the content calendar, turn ideas into clear briefs, and delegate drafting, editing, and distribution to the specialist agents. Answer directly when a request only needs shared context."
+    },
+    {
+      "name": "Brand Copywriter",
+      "role": "specialist",
+      "system_prompt": "You draft posts and copy from the brief, strictly in the brand voice defined by the style guide. Match the audience and tone, and flag anything the brief leaves ambiguous instead of guessing."
+    },
+    {
+      "name": "Content Editor",
+      "role": "validator",
+      "system_prompt": "You edit drafts for clarity, accuracy, and brand voice. Tighten the writing, fix errors, and flag anything off-brand or unsupported before it is scheduled."
+    },
+    {
+      "name": "Distribution Planner",
+      "role": "specialist",
+      "system_prompt": "You adapt approved content for each channel and schedule it against the content calendar. Tailor length and format per platform without changing the core message."
+    }
   ]
 }

--- a/internal/projecttemplates/starter/daily-briefings/template.json
+++ b/internal/projecttemplates/starter/daily-briefings/template.json
@@ -10,5 +10,12 @@
       "description": "Morning briefing",
       "details": "Customize the topics (e.g. headlines, market open, calendar conflicts) then schedule this task to run every weekday morning."
     }
+  ],
+  "agents": [
+    {
+      "name": "Briefing Editor",
+      "role": "orchestrator",
+      "system_prompt": "You produce the daily briefing for this workspace. Pull from the configured sources, summarize what changed and why it matters, and keep it skimmable — lead with the headline, then the detail. Call out anything that needs a decision or follow-up."
+    }
   ]
 }

--- a/internal/projecttemplates/starter/daily-briefings/template.json
+++ b/internal/projecttemplates/starter/daily-briefings/template.json
@@ -4,6 +4,7 @@
   "icon": "📊",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": ["briefing"],
   "starter_tasks": [
     {

--- a/internal/projecttemplates/starter/personal-ops/template.json
+++ b/internal/projecttemplates/starter/personal-ops/template.json
@@ -4,6 +4,7 @@
   "icon": "🗓",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": ["personal"],
   "starter_tasks": [
     {

--- a/internal/projecttemplates/starter/personal-ops/template.json
+++ b/internal/projecttemplates/starter/personal-ops/template.json
@@ -14,5 +14,12 @@
       "description": "End-of-day journal",
       "details": "Write a short reflection on what shipped today and what carries over. Schedule this task to run at the end of your workday."
     }
+  ],
+  "agents": [
+    {
+      "name": "Personal Chief of Staff",
+      "role": "orchestrator",
+      "system_prompt": "You are the chief of staff for this personal command center. Run the morning briefing and the end-of-day journal, track open follow-ups across calendar and email, and surface what needs attention before it slips. Keep it concise and action-oriented."
+    }
   ]
 }

--- a/internal/projecttemplates/starter/reaper-song/template.json
+++ b/internal/projecttemplates/starter/reaper-song/template.json
@@ -4,6 +4,7 @@
   "icon": "🎵",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": [
     "music",
     "reaper"

--- a/internal/projecttemplates/starter/research-project/template.json
+++ b/internal/projecttemplates/starter/research-project/template.json
@@ -14,5 +14,22 @@
       "description": "Compile this week's reading list",
       "details": "Ask the agent for new sources on the topic and a 1-paragraph TL;DR of each. Schedule this task weekly to keep the synthesis fresh."
     }
+  ],
+  "agents": [
+    {
+      "name": "Research Lead",
+      "role": "orchestrator",
+      "system_prompt": "You are the research lead for this workspace. Clarify the research question, keep the synthesis doc and sources index current, and delegate source-finding and write-ups to the specialist agents. Answer directly when a request only needs shared context."
+    },
+    {
+      "name": "Source Scout",
+      "role": "researcher",
+      "system_prompt": "You find and vet sources for the research question. For each source, capture a citation and a one-paragraph TL;DR, and flag how it relates to the open gaps in the synthesis doc."
+    },
+    {
+      "name": "Synthesis Writer",
+      "role": "synthesizer",
+      "system_prompt": "You maintain the synthesis document. Fold new findings into the current best understanding, keep the open-gaps list honest, and write clear, well-attributed summaries."
+    }
   ]
 }

--- a/internal/projecttemplates/starter/research-project/template.json
+++ b/internal/projecttemplates/starter/research-project/template.json
@@ -4,6 +4,7 @@
   "icon": "📚",
   "behavior_profile": "research",
   "builtin": true,
+  "builtin_version": 1,
   "tags": ["research"],
   "starter_tasks": [
     {

--- a/internal/projecttemplates/starter/travels/template.json
+++ b/internal/projecttemplates/starter/travels/template.json
@@ -10,5 +10,17 @@
       "description": "Plan an upcoming trip",
       "details": "Replace this with destination, dates, budget, and any constraints. The agent will research flights and hotels and propose an itinerary."
     }
+  ],
+  "agents": [
+    {
+      "name": "Trip Planner",
+      "role": "orchestrator",
+      "system_prompt": "You are the trip planner for this workspace. Own the itinerary, balance budget, dates, and preferences, keep bookings and confirmations organized, and delegate options research. Answer directly when a request only needs shared context."
+    },
+    {
+      "name": "Flights & Lodging Scout",
+      "role": "researcher",
+      "system_prompt": "You research flight, lodging, and local-transit options for the trip. Present a few ranked choices with clear trade-offs (price, timing, location) rather than a single pick."
+    }
   ]
 }

--- a/internal/projecttemplates/starter/travels/template.json
+++ b/internal/projecttemplates/starter/travels/template.json
@@ -4,6 +4,7 @@
   "icon": "✈",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": ["travel"],
   "starter_tasks": [
     {

--- a/internal/projecttemplates/starter/writing-project/template.json
+++ b/internal/projecttemplates/starter/writing-project/template.json
@@ -4,6 +4,7 @@
   "icon": "📝",
   "behavior_profile": "general",
   "builtin": true,
+  "builtin_version": 1,
   "tags": [
     "writing"
   ],

--- a/internal/projecttemplates/starter/writing-project/template.json
+++ b/internal/projecttemplates/starter/writing-project/template.json
@@ -6,5 +6,22 @@
   "builtin": true,
   "tags": [
     "writing"
+  ],
+  "agents": [
+    {
+      "name": "Writing Coach",
+      "role": "orchestrator",
+      "system_prompt": "You are the writing coach for this long-form project. Own the outline and continuity across chapters, turn the author's intent into chapter goals, and delegate drafting and line editing. Answer directly when a request only needs shared context."
+    },
+    {
+      "name": "Chapter Drafter",
+      "role": "specialist",
+      "system_prompt": "You draft chapters from the outline, matching the established voice and maintaining continuity with what came before. Flag plot or continuity gaps rather than papering over them."
+    },
+    {
+      "name": "Line Editor",
+      "role": "validator",
+      "system_prompt": "You edit prose for clarity, rhythm, and consistency while preserving the author's voice. Suggest tightening and fixes; never rewrite wholesale or flatten the style."
+    }
   ]
 }

--- a/internal/projecttemplates/starter_test.go
+++ b/internal/projecttemplates/starter_test.go
@@ -60,6 +60,12 @@ func TestEnsureLibraryMaterializesStarters(t *testing.T) {
 	if research := byID["research-project"]; research.BehaviorProfile != BehaviorProfileResearch {
 		t.Errorf("research-project behavior_profile = %q, want research", research.BehaviorProfile)
 	}
+	// The research-project starter ships an agent roster (entry + specialists).
+	if research := byID["research-project"]; !research.HasAgents() {
+		t.Errorf("research-project should declare an agent roster, got none")
+	} else if len(research.Agents) != 3 || research.Agents[0].Name != "Research Lead" {
+		t.Errorf("research-project roster wrong: %+v", research.Agents)
+	}
 
 	// Seed file with token name plus the dot-file under chapters/ made it out
 	// of the embed (all: prefix) and onto disk.

--- a/internal/projecttemplates/starter_test.go
+++ b/internal/projecttemplates/starter_test.go
@@ -100,6 +100,60 @@ func TestEnsureLibraryNeverOverwritesUserEdits(t *testing.T) {
 	}
 }
 
+func TestEnsureLibraryRefreshesBuiltinManifestOnVersionBump(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "templates")
+	if err := EnsureLibrary(dir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	// Simulate an old install: an on-disk built-in with no agents and a stale
+	// builtin_version (the embedded research-project is version >= 1 with a
+	// roster), plus a user-edited seed file that must survive the refresh.
+	wp := filepath.Join(dir, "writing-project")
+	manifestPath := filepath.Join(wp, ManifestFileName)
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"Writing Project","builtin":true,"builtin_version":0}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	seed := filepath.Join(wp, "outline.md")
+	if err := os.WriteFile(seed, []byte("user-edited outline"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second EnsureLibrary should refresh the stale manifest (embedded
+	// version > 0) but leave the hand-edited seed file untouched.
+	if err := EnsureLibrary(dir); err != nil {
+		t.Fatalf("EnsureLibrary (refresh): %v", err)
+	}
+
+	refreshed, err := FindLibraryTemplate(dir, "writing-project")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if !refreshed.HasAgents() {
+		t.Error("expected the stale built-in manifest to be refreshed with its shipped roster")
+	}
+	if refreshed.BuiltinVersion < 1 {
+		t.Errorf("expected builtin_version refreshed to the shipped value, got %d", refreshed.BuiltinVersion)
+	}
+	// The hand-edited seed file is preserved (manifest-only refresh).
+	data, err := os.ReadFile(seed)
+	if err != nil || string(data) != "user-edited outline" {
+		t.Errorf("seed file should survive a manifest refresh, got %q err=%v", string(data), err)
+	}
+
+	// A third run is a no-op now that on-disk version matches the embed.
+	stamp, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureLibrary(dir); err != nil {
+		t.Fatalf("EnsureLibrary (no-op): %v", err)
+	}
+	if again, _ := os.Stat(manifestPath); again.ModTime() != stamp.ModTime() {
+		t.Error("manifest was rewritten when versions already matched")
+	}
+}
+
 func TestStarterInstantiatesEndToEnd(t *testing.T) {
 	// Generality gate (PRD success metric 2): both starters run through the
 	// identical engine path; the music template is in no way special.

--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -75,6 +75,11 @@ type Template struct {
 	// Builtin marks a template shipped with the app: read-only in the authoring
 	// UI and grouped as a built-in in the create-modal picker.
 	Builtin bool `json:"builtin"`
+	// BuiltinVersion is the shipped revision of a built-in's manifest. When the
+	// embedded version exceeds the on-disk copy, EnsureLibrary refreshes the
+	// built-in's template.json so metadata changes (rosters, tags, …) reach
+	// existing installs. Zero/absent for user templates.
+	BuiltinVersion int `json:"builtin_version,omitempty"`
 	// HasSkeleton reports whether the template has instantiable files beyond
 	// template.json. A metadata-only template (false) creates no project folder.
 	HasSkeleton bool `json:"has_skeleton"`
@@ -121,6 +126,7 @@ type manifest struct {
 	BehaviorProfile string          `json:"behavior_profile,omitempty"`
 	StarterTasks    []StarterTask   `json:"starter_tasks,omitempty"`
 	Builtin         bool            `json:"builtin,omitempty"`
+	BuiltinVersion  int             `json:"builtin_version,omitempty"`
 	Onboarding      json.RawMessage `json:"onboarding,omitempty"`
 	Tools           *ToolDefaults   `json:"tools,omitempty"`
 	Agents          []AgentSpec     `json:"agents,omitempty"`
@@ -161,6 +167,7 @@ func newTemplate(path string) Template {
 	t.BehaviorProfile = NormalizeBehaviorProfile(m.BehaviorProfile)
 	t.StarterTasks = normalizeStarterTasks(m.StarterTasks)
 	t.Builtin = m.Builtin || IsBuiltinStarterID(t.ID)
+	t.BuiltinVersion = m.BuiltinVersion
 	t.HasSkeleton = hasSkeletonFiles(t.Path)
 	t.Onboarding = m.Onboarding
 	if m.Tools != nil {

--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -88,6 +88,11 @@ type Template struct {
 	// this template binds (apply-if-present). Names only — bound in the
 	// workspace-creation layer, not here.
 	Tools ToolDefaults `json:"tools"`
+	// Agents is the roster of agents seeded onto a workspace created from this
+	// template, in declaration order: the first is the workspace entry agent,
+	// the rest are specialist sub-agents. Carried as data only; agents are
+	// created/attached in the workspace-creation layer (see AgentSpec).
+	Agents []AgentSpec `json:"agents,omitempty"`
 }
 
 // HasOnboarding reports whether the template carries a non-empty onboarding
@@ -96,6 +101,11 @@ type Template struct {
 func (t Template) HasOnboarding() bool {
 	s := bytes.TrimSpace(t.Onboarding)
 	return len(s) > 0 && !bytes.Equal(s, []byte("null"))
+}
+
+// HasAgents reports whether the template declares at least one agent to seed.
+func (t Template) HasAgents() bool {
+	return len(t.Agents) > 0
 }
 
 // manifest is the on-disk shape of template.json. Unknown fields are ignored
@@ -113,6 +123,7 @@ type manifest struct {
 	Builtin         bool            `json:"builtin,omitempty"`
 	Onboarding      json.RawMessage `json:"onboarding,omitempty"`
 	Tools           *ToolDefaults   `json:"tools,omitempty"`
+	Agents          []AgentSpec     `json:"agents,omitempty"`
 }
 
 // readManifest loads template.json from dir. A missing or malformed manifest
@@ -155,6 +166,7 @@ func newTemplate(path string) Template {
 	if m.Tools != nil {
 		t.Tools = normalizeToolDefaults(*m.Tools)
 	}
+	t.Agents = normalizeAgentSpecs(m.Agents)
 	return t
 }
 

--- a/internal/server/agent_tools.go
+++ b/internal/server/agent_tools.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// makeAgentToolApplier returns a function that binds a seeded template agent's
+// per-agent tools, applying only what resolves on the machine (apply-if-present)
+// and reporting the rest:
+//
+//   - skills are enabled on the agent itself (per-agent skill state); agent
+//     skills are disabled-by-default, so binding == enabling here;
+//   - MCP servers have no per-agent scope, so they bind at the workspace level.
+//
+// Builder fields are read at apply time, so wiring order is moot.
+func makeAgentToolApplier(b *ServerBuilder) func(string, string, projecttemplates.ToolDefaults) ([]string, []string) {
+	return func(workspaceID, agentName string, tools projecttemplates.ToolDefaults) (applied, missing []string) {
+		if mgr := b.skillsManager; mgr != nil {
+			for _, s := range tools.Skills {
+				name := strings.TrimSpace(s)
+				if name == "" {
+					continue
+				}
+				if _, ok, err := mgr.ResolveSkillByName(name); err != nil || !ok {
+					missing = append(missing, "skill:"+name)
+					continue
+				}
+				if err := mgr.SetSkillEnabled(agentName, name, true); err != nil {
+					missing = append(missing, "skill:"+name)
+					continue
+				}
+				applied = append(applied, "skill:"+name)
+			}
+		}
+
+		a, m := bindWorkspaceMCPServers(b, workspaceID, tools.MCPServers)
+		applied = append(applied, a...)
+		missing = append(missing, m...)
+		return applied, missing
+	}
+}
+
+// bindWorkspaceMCPServers binds MCP servers onto a workspace (apply-if-present),
+// returning applied + missing labels. MCP has no per-agent scope, so per-agent
+// template MCP servers land here at the workspace level. It binds through the
+// same workspace store the binding endpoints read from so the result is visible.
+func bindWorkspaceMCPServers(b *ServerBuilder, workspaceID string, servers []string) (applied, missing []string) {
+	store := b.workspaceStore
+	if store == nil || len(servers) == 0 {
+		return nil, nil
+	}
+	ws, err := store.Get(workspaceID)
+	if err != nil || ws == nil {
+		return nil, nil
+	}
+	now := time.Now()
+
+	bound := map[string]bool{}
+	for _, bnd := range ws.GetMCPBindings() {
+		bound[strings.ToLower(strings.TrimSpace(bnd.ServerName))] = true
+	}
+
+	changed := false
+	for _, srv := range servers {
+		name := strings.TrimSpace(srv)
+		key := strings.ToLower(name)
+		if name == "" || bound[key] {
+			continue
+		}
+		if cfg := b.mcpConfigManager; cfg != nil {
+			if _, err := cfg.GetServer(name); err != nil {
+				missing = append(missing, "mcp:"+name)
+				continue
+			}
+		}
+		bound[key] = true
+		if err := ws.UpsertMCPBinding(workspace.WorkspaceMCPBinding{
+			ID: uuid.NewString(), ServerName: name, Enabled: true, CreatedAt: now, UpdatedAt: now,
+		}); err == nil {
+			applied = append(applied, "mcp:"+name)
+			changed = true
+		}
+	}
+
+	if changed {
+		if err := store.Save(ws); err != nil {
+			return nil, missing
+		}
+	}
+	return applied, missing
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -347,6 +347,7 @@ func (b *ServerBuilder) initializeHandlers() {
 	// The applier reads the SyncStore + MCP config lazily at request time.
 	if b.sessionHandler != nil {
 		b.sessionHandler.SetTemplateToolApplier(makeTemplateToolApplier(b))
+		b.sessionHandler.SetAgentToolApplier(makeAgentToolApplier(b))
 	}
 }
 

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -364,6 +364,29 @@ func (s *Server) handleProjectTemplateToolsSet(w http.ResponseWriter, r *http.Re
 	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "template": tpl})
 }
 
+// handleProjectTemplateAgentsSet serves PUT
+// /api/project-templates/{templateID}/agents: set the template's agent roster
+// (first = entry agent, rest = specialists). Seeding happens when a workspace is
+// created from the template; reading is covered by the list endpoint's
+// Template.Agents.
+func (s *Server) handleProjectTemplateAgentsSet(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Agents []projecttemplates.AgentSpec `json:"agents"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if !s.guardTemplateMutable(w, r.PathValue("templateID")) {
+		return
+	}
+	tpl, err := projecttemplates.SetAgents(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Agents)
+	if err != nil {
+		s.respondProjectTemplateError(w, err)
+		return
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "template": tpl})
+}
+
 // handleProjectTemplateReveal serves POST /api/project-templates/reveal:
 // open the library root ({} or empty id) or reveal one template ({"id": ...})
 // in the OS file manager. Local-first only, like workspace file open.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -625,6 +625,8 @@ func registerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("DELETE /api/project-templates/{templateID}/onboarding", s.handleProjectTemplateOnboardingDelete)
 		// Default tool bindings (skills / MCP servers / plugins), applied if present at creation
 		mux.HandleFunc("PUT /api/project-templates/{templateID}/tools", s.handleProjectTemplateToolsSet)
+		// Agent roster (first = entry agent, rest = specialists), seeded at creation
+		mux.HandleFunc("PUT /api/project-templates/{templateID}/agents", s.handleProjectTemplateAgentsSet)
 
 		mux.HandleFunc("/api/tags", s.Handlers.Session.HandleTags)
 		mux.HandleFunc("/api/tags/usage", s.Handlers.Session.HandleTagUsage)

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -40,6 +40,11 @@ type Handler struct {
 	// names. Injected by the server, which holds the tool registries and binds
 	// through the same store the binding endpoints read from.
 	applyTemplateTools func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string)
+	// applyAgentTools binds a seeded template agent's per-agent tools after the
+	// agent and workspace exist: skills are enabled on the agent (apply-if-
+	// present); MCP servers — which have no per-agent scope — bind at the
+	// workspace level. Injected by the server, which holds the skills manager.
+	applyAgentTools func(workspaceID, agentName string, tools projecttemplates.ToolDefaults) (applied, missing []string)
 
 	// rescanMu serializes disk reconciles so concurrent rescan requests
 	// (e.g. several hub tabs loading at once) don't run overlapping filesystem
@@ -84,6 +89,12 @@ func (h *Handler) SetAgentStore(agentStore store.Store) {
 // workspace. The server supplies it because the tool registries live there.
 func (h *Handler) SetTemplateToolApplier(fn func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string)) {
 	h.applyTemplateTools = fn
+}
+
+// SetAgentToolApplier injects the function that binds a seeded template agent's
+// per-agent tools (skills enabled on the agent; MCP servers on the workspace).
+func (h *Handler) SetAgentToolApplier(fn func(workspaceID, agentName string, tools projecttemplates.ToolDefaults) (applied, missing []string)) {
+	h.applyAgentTools = fn
 }
 
 // SetTemplatesRootResolver sets the resolver used to locate the project

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -145,9 +145,9 @@ func (h *Handler) bindSeededAgentTools(workspaceID string, created []createdAgen
 	return warnings
 }
 
-// attachWorkspaceSpecialist adds a non-entry agent to the workspace — a fresh
-// AgentInstance plus the legacy Agents entry — mirroring the add-agent endpoint.
-// It is a no-op if an instance for the agent already exists.
+// attachWorkspaceSpecialist adds a non-entry agent to the workspace as a fresh
+// AgentInstance, mirroring the add-agent endpoint. It is a no-op if an instance
+// for the agent already exists.
 func attachWorkspaceSpecialist(ws *session.Workspace, name string) {
 	name = strings.TrimSpace(name)
 	if ws == nil || name == "" {
@@ -165,5 +165,4 @@ func attachWorkspaceSpecialist(ws *session.Workspace, name string) {
 		NodeID:         fmt.Sprintf("%s-1-node-%s", name, uuid.New().String()[:8]),
 		CreatedAt:      time.Now(),
 	})
-	ensureLegacyWorkspaceAgentName(ws, name)
 }

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -1,0 +1,133 @@
+package sessionhttp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// seedAgentsResult is the outcome of seeding a template's agent roster.
+// Per-agent tool binding for the created agents is a follow-up (PRD FR14); this
+// result will grow to carry the created agents + specs when that lands.
+type seedAgentsResult struct {
+	Warnings []string
+	EntrySet bool
+}
+
+// validAgentTypes canonicalizes a template-declared agent type to the real
+// vocabulary; an empty/unrecognized value maps to "" so the store applies its
+// own default (PRD FR8).
+var validAgentTypes = map[string]string{
+	agent.TypeToolCalling: agent.TypeToolCalling,
+	agent.TypeGeneral:     agent.TypeGeneral,
+	agent.TypeResearch:    agent.TypeResearch,
+}
+
+// validAgentRoles canonicalizes a template-declared role. cli_agent is
+// intentionally omitted: CLI agents are a v1 non-goal, so a template cannot mint
+// one — an unrecognized role falls back to the store default.
+var validAgentRoles = map[string]string{
+	string(types.RoleOrchestrator): string(types.RoleOrchestrator),
+	string(types.RoleResearcher):   string(types.RoleResearcher),
+	string(types.RoleAnalyzer):     string(types.RoleAnalyzer),
+	string(types.RoleSynthesizer):  string(types.RoleSynthesizer),
+	string(types.RoleValidator):    string(types.RoleValidator),
+	string(types.RoleSpecialist):   string(types.RoleSpecialist),
+	string(types.RoleGeneral):      string(types.RoleGeneral),
+}
+
+func canonicalAgentType(s string) string {
+	return validAgentTypes[strings.ToLower(strings.TrimSpace(s))]
+}
+
+func canonicalAgentRole(s string) string {
+	return validAgentRoles[strings.ToLower(strings.TrimSpace(s))]
+}
+
+// seedTemplateAgents creates (or reuses) the agents a template declares and
+// attaches them to ws in roster order. The first declared agent becomes the
+// workspace entry agent; the rest are specialist sub-agents. It runs before the
+// workspace is persisted so the roster is part of the stored agent list and the
+// entry agent suppresses the mandatory "create an entry agent" prompt.
+//
+// Reuse-on-name-match (PRD FR13): a name that already exists as a global agent is
+// attached as-is and never mutated — the template's prompt/model/tools for that
+// entry are ignored. Only unmatched names create a new global agent.
+//
+// Failure handling (PRD FR15): a specialist that fails to create is recorded as a
+// warning and skipped; if the entry agent (first) fails, seeding stops and the
+// workspace is left agent-less so the mandatory-prompt fallback runs — no
+// specialist is promoted in its place.
+func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates.Template) seedAgentsResult {
+	var result seedAgentsResult
+	if h == nil || h.agentStore == nil || ws == nil || !tpl.HasAgents() {
+		return result
+	}
+
+	for i, spec := range tpl.Agents {
+		isEntry := i == 0
+		if _, exists := h.agentStore.GetAgent(spec.Name); !exists {
+			cfg := &store.CreateAgentConfig{
+				Type:         canonicalAgentType(spec.Type),
+				Role:         types.AgentRole(canonicalAgentRole(spec.Role)),
+				Model:        spec.Model, // empty -> the store's global default model
+				SystemPrompt: spec.SystemPrompt,
+			}
+			if err := h.agentStore.CreateAgent(spec.Name, cfg); err != nil {
+				if isEntry {
+					logger.Warn("Failed to seed template entry agent; falling back to entry-agent prompt",
+						logger.Fields{"workspace": ws.ID, "agent": spec.Name, "error": err})
+					result.Warnings = append(result.Warnings,
+						fmt.Sprintf("Entry agent %q could not be created — you'll be prompted to add one.", spec.Name))
+					return result
+				}
+				logger.Warn("Failed to seed template specialist agent (skipped)",
+					logger.Fields{"workspace": ws.ID, "agent": spec.Name, "error": err})
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("Specialist agent %q could not be created and was skipped.", spec.Name))
+				continue
+			}
+		}
+
+		if isEntry {
+			setWorkspaceEntryAgent(ws, spec.Name)
+			result.EntrySet = true
+		} else {
+			attachWorkspaceSpecialist(ws, spec.Name)
+		}
+	}
+
+	return result
+}
+
+// attachWorkspaceSpecialist adds a non-entry agent to the workspace — a fresh
+// AgentInstance plus the legacy Agents entry — mirroring the add-agent endpoint.
+// It is a no-op if an instance for the agent already exists.
+func attachWorkspaceSpecialist(ws *session.Workspace, name string) {
+	name = strings.TrimSpace(name)
+	if ws == nil || name == "" {
+		return
+	}
+	for _, inst := range ws.AgentInstances {
+		if strings.EqualFold(strings.TrimSpace(inst.Name), name) {
+			return
+		}
+	}
+	ws.AgentInstances = append(ws.AgentInstances, session.AgentInstance{
+		ID:             uuid.New().String(),
+		Name:           name,
+		InstanceNumber: 1,
+		NodeID:         fmt.Sprintf("%s-1-node-%s", name, uuid.New().String()[:8]),
+		CreatedAt:      time.Now(),
+	})
+	ensureLegacyWorkspaceAgentName(ws, name)
+}

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -15,10 +15,17 @@ import (
 	"github.com/johnjallday/ori-agent/internal/types"
 )
 
+// createdAgent is a roster entry the seeder newly created (not reused), carried
+// so the post-persist pass can bind its per-agent tools. Reused agents are
+// omitted — their existing tools are left untouched (PRD FR13/FR14).
+type createdAgent struct {
+	Name  string
+	Tools projecttemplates.ToolDefaults
+}
+
 // seedAgentsResult is the outcome of seeding a template's agent roster.
-// Per-agent tool binding for the created agents is a follow-up (PRD FR14); this
-// result will grow to carry the created agents + specs when that lands.
 type seedAgentsResult struct {
+	Created  []createdAgent
 	Warnings []string
 	EntrySet bool
 }
@@ -75,7 +82,8 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 
 	for i, spec := range tpl.Agents {
 		isEntry := i == 0
-		if _, exists := h.agentStore.GetAgent(spec.Name); !exists {
+		_, exists := h.agentStore.GetAgent(spec.Name)
+		if !exists {
 			cfg := &store.CreateAgentConfig{
 				Type:         canonicalAgentType(spec.Type),
 				Role:         types.AgentRole(canonicalAgentRole(spec.Role)),
@@ -104,9 +112,37 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 		} else {
 			attachWorkspaceSpecialist(ws, spec.Name)
 		}
+		// Only newly-created agents get the template's per-agent tools; a reused
+		// agent keeps its own (PRD FR14).
+		if !exists && !spec.Tools.IsEmpty() {
+			result.Created = append(result.Created, createdAgent{Name: spec.Name, Tools: spec.Tools})
+		}
 	}
 
 	return result
+}
+
+// bindSeededAgentTools binds per-agent tools for the agents the seeder created,
+// after the workspace is persisted (MCP binding reads the stored workspace).
+// Apply-if-present and non-fatal: a missing skill/server becomes a warning, not
+// a failure. Returns warnings to surface to the user.
+func (h *Handler) bindSeededAgentTools(workspaceID string, created []createdAgent) []string {
+	if h == nil || h.applyAgentTools == nil || len(created) == 0 {
+		return nil
+	}
+	var warnings []string
+	for _, ca := range created {
+		if ca.Tools.IsEmpty() {
+			continue
+		}
+		if _, missing := h.applyAgentTools(workspaceID, ca.Name, ca.Tools); len(missing) > 0 {
+			logger.Info("Some template agent tools were not found (skipped)",
+				logger.Fields{"workspace": workspaceID, "agent": ca.Name, "missing": missing})
+			warnings = append(warnings,
+				fmt.Sprintf("Some tools for agent %q were not found and were skipped: %s", ca.Name, strings.Join(missing, ", ")))
+		}
+	}
+	return warnings
 }
 
 // attachWorkspaceSpecialist adds a non-entry agent to the workspace — a fresh

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -3,6 +3,7 @@ package sessionhttp
 import (
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
@@ -113,6 +114,87 @@ func TestCanonicalAgentTypeAndRole(t *testing.T) {
 	// cli_agent is a non-goal and must not pass through.
 	if got := canonicalAgentRole("cli_agent"); got != "" {
 		t.Fatalf("cli_agent should be excluded, got %q", got)
+	}
+}
+
+func TestSeedTemplateAgents_TracksCreatedAgentsWithTools(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	if err := handler.agentStore.CreateAgent("Reused", &agentstore.CreateAgentConfig{}); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "NewLead", Tools: projecttemplates.ToolDefaults{Skills: []string{"plan"}}},
+		projecttemplates.AgentSpec{Name: "Reused", Tools: projecttemplates.ToolDefaults{Skills: []string{"ignored"}}},
+		projecttemplates.AgentSpec{Name: "NewWriter"}, // no tools
+		projecttemplates.AgentSpec{Name: "NewDesigner", Tools: projecttemplates.ToolDefaults{MCPServers: []string{"drive"}}},
+	)
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	// Only newly-created agents that declare tools are tracked for binding:
+	// the reused agent and the tool-less agent are excluded.
+	if len(res.Created) != 2 {
+		t.Fatalf("expected 2 tracked agents, got %d (%+v)", len(res.Created), res.Created)
+	}
+	if res.Created[0].Name != "NewLead" || res.Created[1].Name != "NewDesigner" {
+		t.Fatalf("unexpected tracked agents: %+v", res.Created)
+	}
+	if res.Created[0].Tools.Skills[0] != "plan" {
+		t.Fatalf("tools not carried: %+v", res.Created[0].Tools)
+	}
+}
+
+func TestBindSeededAgentTools(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	var calls []string
+	handler.SetAgentToolApplier(func(workspaceID, agentName string, tools projecttemplates.ToolDefaults) ([]string, []string) {
+		calls = append(calls, agentName)
+		if agentName == "Missing" {
+			return nil, []string{"skill:foo"}
+		}
+		return []string{"skill:ok"}, nil
+	})
+
+	created := []createdAgent{
+		{Name: "Good", Tools: projecttemplates.ToolDefaults{Skills: []string{"ok"}}},
+		{Name: "Missing", Tools: projecttemplates.ToolDefaults{Skills: []string{"foo"}}},
+		{Name: "Empty"}, // no tools -> applier not called
+	}
+
+	warnings := handler.bindSeededAgentTools("ws1", created)
+
+	if len(calls) != 2 || calls[0] != "Good" || calls[1] != "Missing" {
+		t.Fatalf("applier called for %v, want [Good Missing]", calls)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0], "Missing") || !strings.Contains(warnings[0], "skill:foo") {
+		t.Fatalf("warning missing detail: %q", warnings[0])
+	}
+}
+
+func TestBindSeededAgentTools_NoApplierOrEmpty(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	// No applier wired -> no-op.
+	if w := handler.bindSeededAgentTools("ws1", []createdAgent{{Name: "A", Tools: projecttemplates.ToolDefaults{Skills: []string{"x"}}}}); w != nil {
+		t.Fatalf("expected nil warnings without an applier, got %v", w)
+	}
+	// Applier wired but no created agents -> no-op.
+	handler.SetAgentToolApplier(func(string, string, projecttemplates.ToolDefaults) ([]string, []string) {
+		t.Fatal("applier should not be called for an empty roster")
+		return nil, nil
+	})
+	if w := handler.bindSeededAgentTools("ws1", nil); w != nil {
+		t.Fatalf("expected nil warnings for empty created list, got %v", w)
 	}
 }
 

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -2,7 +2,6 @@ package sessionhttp
 
 import (
 	"errors"
-	"slices"
 	"strings"
 	"testing"
 
@@ -17,7 +16,12 @@ func rosterTemplate(specs ...projecttemplates.AgentSpec) projecttemplates.Templa
 }
 
 func wsHasAgent(ws *session.Workspace, name string) bool {
-	return slices.Contains(ws.Agents, name)
+	for _, inst := range ws.AgentInstances {
+		if inst.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSeedTemplateAgents_CreatesRosterAndSetsEntry(t *testing.T) {
@@ -96,8 +100,8 @@ func TestSeedTemplateAgents_EmptyRosterNoop(t *testing.T) {
 	if res.EntrySet || len(res.Warnings) != 0 {
 		t.Fatalf("expected empty no-op, got EntrySet=%v warnings=%v", res.EntrySet, res.Warnings)
 	}
-	if len(ws.Agents) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
-		t.Fatalf("expected no agents seeded, got %v / %q", ws.Agents, currentWorkspaceEntryAgentName(ws))
+	if len(ws.AgentInstances) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
+		t.Fatalf("expected no agents seeded, got %v / %q", ws.AgentInstances, currentWorkspaceEntryAgentName(ws))
 	}
 }
 
@@ -234,7 +238,7 @@ func TestSeedTemplateAgents_EntryFailureFallsBack(t *testing.T) {
 	if len(res.Warnings) != 1 {
 		t.Fatalf("expected one warning, got %v", res.Warnings)
 	}
-	if len(ws.Agents) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
+	if len(ws.AgentInstances) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
 		t.Fatal("expected workspace left agent-less so the prompt fires")
 	}
 }

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -1,0 +1,189 @@
+package sessionhttp
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/session"
+	agentstore "github.com/johnjallday/ori-agent/internal/store"
+)
+
+func rosterTemplate(specs ...projecttemplates.AgentSpec) projecttemplates.Template {
+	return projecttemplates.Template{Agents: specs}
+}
+
+func wsHasAgent(ws *session.Workspace, name string) bool {
+	return slices.Contains(ws.Agents, name)
+}
+
+func TestSeedTemplateAgents_CreatesRosterAndSetsEntry(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Lead", Role: "orchestrator", SystemPrompt: "run it"},
+		projecttemplates.AgentSpec{Name: "Writer"},
+		projecttemplates.AgentSpec{Name: "Editor"},
+	)
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected EntrySet true")
+	}
+	if len(res.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", res.Warnings)
+	}
+	for _, name := range []string{"Lead", "Writer", "Editor"} {
+		if _, ok := handler.agentStore.GetAgent(name); !ok {
+			t.Fatalf("expected agent %q to be created", name)
+		}
+		if !wsHasAgent(ws, name) {
+			t.Fatalf("expected workspace to list agent %q", name)
+		}
+	}
+	if got := currentWorkspaceEntryAgentName(ws); got != "Lead" {
+		t.Fatalf("expected entry agent Lead, got %q", got)
+	}
+}
+
+func TestSeedTemplateAgents_ReuseOnNameMatchDoesNotMutate(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	if err := handler.agentStore.CreateAgent("Shared", &agentstore.CreateAgentConfig{SystemPrompt: "ORIGINAL"}); err != nil {
+		t.Fatalf("pre-create agent: %v", err)
+	}
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Shared", SystemPrompt: "IGNORED-ON-REUSE", Model: "some-model"},
+		projecttemplates.AgentSpec{Name: "Fresh", SystemPrompt: "new"},
+	)
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected EntrySet true")
+	}
+	reused, ok := handler.agentStore.GetAgent("Shared")
+	if !ok {
+		t.Fatal("expected reused agent to still exist")
+	}
+	if reused.Settings.SystemPrompt != "ORIGINAL" {
+		t.Fatalf("reused agent was mutated: prompt = %q", reused.Settings.SystemPrompt)
+	}
+	if got := currentWorkspaceEntryAgentName(ws); got != "Shared" {
+		t.Fatalf("expected entry agent Shared, got %q", got)
+	}
+	if _, ok := handler.agentStore.GetAgent("Fresh"); !ok {
+		t.Fatal("expected unmatched specialist to be created")
+	}
+}
+
+func TestSeedTemplateAgents_EmptyRosterNoop(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	ws := &session.Workspace{ID: "ws1", Name: "Plain"}
+	res := handler.seedTemplateAgents(ws, projecttemplates.Template{})
+
+	if res.EntrySet || len(res.Warnings) != 0 {
+		t.Fatalf("expected empty no-op, got EntrySet=%v warnings=%v", res.EntrySet, res.Warnings)
+	}
+	if len(ws.Agents) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
+		t.Fatalf("expected no agents seeded, got %v / %q", ws.Agents, currentWorkspaceEntryAgentName(ws))
+	}
+}
+
+func TestCanonicalAgentTypeAndRole(t *testing.T) {
+	if got := canonicalAgentType("General"); got != agent.TypeGeneral {
+		t.Fatalf("type General -> %q", got)
+	}
+	if got := canonicalAgentType("bogus"); got != "" {
+		t.Fatalf("invalid type should be empty, got %q", got)
+	}
+	if got := canonicalAgentRole("Orchestrator"); got != "orchestrator" {
+		t.Fatalf("role Orchestrator -> %q", got)
+	}
+	// cli_agent is a non-goal and must not pass through.
+	if got := canonicalAgentRole("cli_agent"); got != "" {
+		t.Fatalf("cli_agent should be excluded, got %q", got)
+	}
+}
+
+// stubAgentStore embeds the store interface so only the two methods the seeder
+// uses need bodies; existing holds names that GetAgent reports as present, and
+// CreateAgent always fails so the seeding failure paths can be exercised.
+type stubAgentStore struct {
+	agentstore.Store
+	existing map[string]*agent.Agent
+}
+
+func (s *stubAgentStore) GetAgent(name string) (*agent.Agent, bool) {
+	a, ok := s.existing[name]
+	return a, ok
+}
+
+func (s *stubAgentStore) CreateAgent(string, *agentstore.CreateAgentConfig) error {
+	return errors.New("boom")
+}
+
+func TestSeedTemplateAgents_EntryFailureFallsBack(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+	handler.SetAgentStore(&stubAgentStore{existing: map[string]*agent.Agent{}})
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Lead"},
+		projecttemplates.AgentSpec{Name: "Writer"},
+	)
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if res.EntrySet {
+		t.Fatal("expected EntrySet false when the entry agent fails")
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("expected one warning, got %v", res.Warnings)
+	}
+	if len(ws.Agents) != 0 || currentWorkspaceEntryAgentName(ws) != "" {
+		t.Fatal("expected workspace left agent-less so the prompt fires")
+	}
+}
+
+func TestSeedTemplateAgents_SpecialistFailureContinues(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+	// Entry "Lead" already exists (reused, no create); specialist "Writer" is
+	// unmatched and CreateAgent fails for it.
+	handler.SetAgentStore(&stubAgentStore{existing: map[string]*agent.Agent{
+		"Lead": {},
+	}})
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Lead"},
+		projecttemplates.AgentSpec{Name: "Writer"},
+	)
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected entry agent set from the reused agent")
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("expected one specialist warning, got %v", res.Warnings)
+	}
+	if currentWorkspaceEntryAgentName(ws) != "Lead" {
+		t.Fatalf("expected entry Lead, got %q", currentWorkspaceEntryAgentName(ws))
+	}
+	if wsHasAgent(ws, "Writer") {
+		t.Fatal("failed specialist should not be attached")
+	}
+}

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -243,6 +244,65 @@ func TestCreateWorkspaceWithTemplate(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("project.created event not published")
+	}
+}
+
+func TestCreateWorkspaceSeedsTemplateAgentRoster(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	// A metadata-only template (no skeleton files) that declares an agent roster.
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator","system_prompt":"lead it"},
+			{"name":"Copywriter","type":"general"},
+			{"name":"Designer"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := postCreateWorkspace(t, handler, `{"name":"Launch","template_id":"roster-template"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if warnings, present := resp["agent_warnings"]; present {
+		t.Fatalf("unexpected agent_warnings: %v", warnings)
+	}
+
+	for _, name := range []string{"Campaign Lead", "Copywriter", "Designer"} {
+		if _, ok := handler.agentStore.GetAgent(name); !ok {
+			t.Fatalf("expected agent %q seeded into the agent store", name)
+		}
+	}
+
+	folder, ok := resp["folder"].(map[string]any)
+	if !ok {
+		t.Fatal("expected folder in response")
+	}
+	wsID, _ := folder["id"].(string)
+	if wsID == "" {
+		t.Fatal("missing workspace id in response")
+	}
+
+	sessWS, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	// First declared agent is the entry agent (suppresses the mandatory prompt).
+	if got := currentWorkspaceEntryAgentName(sessWS); got != "Campaign Lead" {
+		t.Fatalf("entry agent = %q, want Campaign Lead", got)
+	}
+	for _, name := range []string{"Campaign Lead", "Copywriter", "Designer"} {
+		if !slices.Contains(sessWS.Agents, name) {
+			t.Fatalf("workspace agents %v missing %q", sessWS.Agents, name)
+		}
 	}
 }
 

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -299,9 +299,13 @@ func TestCreateWorkspaceSeedsTemplateAgentRoster(t *testing.T) {
 	if got := currentWorkspaceEntryAgentName(sessWS); got != "Campaign Lead" {
 		t.Fatalf("entry agent = %q, want Campaign Lead", got)
 	}
+	instanceNames := make([]string, len(sessWS.AgentInstances))
+	for i, inst := range sessWS.AgentInstances {
+		instanceNames[i] = inst.Name
+	}
 	for _, name := range []string{"Campaign Lead", "Copywriter", "Designer"} {
-		if !slices.Contains(sessWS.Agents, name) {
-			t.Fatalf("workspace agents %v missing %q", sessWS.Agents, name)
+		if !slices.Contains(instanceNames, name) {
+			t.Fatalf("workspace agent instances %v missing %q", instanceNames, name)
 		}
 	}
 }

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -295,6 +295,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	// agent; the UI prompts the user to create one with their choice of
 	// model/provider.
 	entryAgentSet := false
+	var agentSeedWarnings []string
 	if req.EntryAgentName != "" {
 		entryAgentName, err := h.validateWorkspaceEntryAgent(req.EntryAgentName)
 		if err != nil {
@@ -306,6 +307,14 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 			setWorkspaceEntryAgent(ws, entryAgentName)
 			entryAgentSet = true
 		}
+	} else if templateResolved && resolvedTemplate.HasAgents() {
+		// The template declares an agent roster: seed it (first = entry agent,
+		// rest = specialists). A seeded entry agent suppresses the mandatory
+		// "create an entry agent" prompt; if it fails, the workspace is left
+		// agent-less and the prompt fires as the fallback.
+		seedResult := h.seedTemplateAgents(ws, resolvedTemplate)
+		agentSeedWarnings = seedResult.Warnings
+		entryAgentSet = seedResult.EntrySet
 	} else if kind == session.WorkspaceKindGroup {
 		if agentName := h.autoCreateGroupEntryAgent(ws); agentName != "" {
 			setWorkspaceEntryAgent(ws, agentName)
@@ -485,6 +494,9 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	if projectWarning != "" {
 		response["project_warning"] = projectWarning
+	}
+	if len(agentSeedWarnings) > 0 {
+		response["agent_warnings"] = agentSeedWarnings
 	}
 	if onboardingSummary != nil {
 		response["onboarding"] = onboardingSummary

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -296,6 +296,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	// model/provider.
 	entryAgentSet := false
 	var agentSeedWarnings []string
+	var seededAgents []createdAgent
 	if req.EntryAgentName != "" {
 		entryAgentName, err := h.validateWorkspaceEntryAgent(req.EntryAgentName)
 		if err != nil {
@@ -315,6 +316,7 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		seedResult := h.seedTemplateAgents(ws, resolvedTemplate)
 		agentSeedWarnings = seedResult.Warnings
 		entryAgentSet = seedResult.EntrySet
+		seededAgents = seedResult.Created
 	} else if kind == session.WorkspaceKindGroup {
 		if agentName := h.autoCreateGroupEntryAgent(ws); agentName != "" {
 			setWorkspaceEntryAgent(ws, agentName)
@@ -392,6 +394,12 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 			logger.Warn("Failed to create workspace folder on disk", logger.Fields{"id": ws.ID, "error": folderErr})
 			// Non-fatal: SQLite creation succeeded, folder is supplementary
 		} else if folderPath, err := h.workspaceStore.GetFolderPath(ws.ID); err == nil {
+			// Bind per-agent tools for any seeded template agents now that the
+			// workspace is persisted (skills enable on the agent; MCP binds on
+			// the workspace). Apply-if-present and non-fatal.
+			if toolWarnings := h.bindSeededAgentTools(ws.ID, seededAgents); len(toolWarnings) > 0 {
+				agentSeedWarnings = append(agentSeedWarnings, toolWarnings...)
+			}
 			if ws.Kind == session.WorkspaceKindGroup {
 				// Groups physically nest members under sub-workspaces/, so
 				// their linked folder and MCP roots are scoped to the group's

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -333,8 +333,6 @@ function ptcElements() {
     description: document.getElementById('projectTemplateDescription'),
     emptyHint: document.getElementById('projectTemplateEmptyHint'),
     pathInput: document.getElementById('projectTemplatePathInput'),
-    nameRow: document.getElementById('projectNameRow'),
-    nameInput: document.getElementById('projectNameInput'),
     browseBtn: document.getElementById('projectTemplateBrowseBtn'),
     manageLink: document.getElementById('projectTemplateManageLink'),
     importToggle: document.getElementById('folderImportToggle')
@@ -351,10 +349,6 @@ function ptcGetPayloadFields() {
     fields.template_path = templatePath;
   } else if (templateId) {
     fields.template_id = templateId;
-  }
-  const projectName = els.nameInput?.value?.trim() || '';
-  if ((fields.template_id || fields.template_path) && projectName) {
-    fields.project_name = projectName;
   }
   return fields;
 }
@@ -449,11 +443,6 @@ function ptcUpdateUI() {
     els.description.textContent = showDesc ? ptcSelected.description : '';
     els.description.hidden = !showDesc;
   }
-  if (els.nameRow) {
-    const hasPath = Boolean(els.pathInput?.value?.trim());
-    const scaffolds = Boolean(ptcSelected && !ptcSelected.blank && ptcSelected.has_skeleton);
-    els.nameRow.hidden = !(scaffolds || hasPath);
-  }
 }
 
 function ptcBlankCard() {
@@ -463,7 +452,6 @@ function ptcBlankCard() {
 function ptcReset() {
   const els = ptcElements();
   if (els.pathInput) els.pathInput.value = '';
-  if (els.nameInput) els.nameInput.value = '';
   ptcSelect(PTC_BLANK, ptcBlankCard());
 }
 
@@ -474,7 +462,6 @@ function ptcSyncImportVisibility() {
   // existing folder as the workspace itself.
   if (els.picker) els.picker.hidden = importMode;
   if (importMode) {
-    if (els.nameRow) els.nameRow.hidden = true;
     if (els.description) els.description.hidden = true;
   }
 }

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3473,6 +3473,12 @@ const sessionManager = {
       if (typeof result.project_warning === 'string' && result.project_warning) {
         this.showToast(result.project_warning, 'warning');
       }
+      // Seeded template agents that could not be created surface here (non-fatal).
+      if (Array.isArray(result.agent_warnings)) {
+        result.agent_warnings
+          .filter((msg) => typeof msg === 'string' && msg)
+          .forEach((msg) => this.showToast(msg, 'warning'));
+      }
       if (window.ProjectTemplateCard) window.ProjectTemplateCard.reset();
       if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
       window.OriTagInput?.clearTagPoolCache?.();

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3410,8 +3410,9 @@ const sessionManager = {
         payload.entry_point = this.importEntryPoint || 'workspace_hub_create';
       } else {
         if (window.ProjectTemplateCard) {
-          // Optional project scaffolding from the "Project (optional)" card
-          // (template_id/template_path + project_name).
+          // Optional project scaffolding from the template picker
+          // (template_id/template_path). The scaffolded project folder name
+          // defaults to the workspace name server-side.
           Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
         }
         if (window.WorkspaceTagsCard) {

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -267,6 +267,9 @@ function tplRenderDetail() {
   if (idLabel) idLabel.textContent = template.id;
 
   tplResetOverviewFields();
+  // Reset the agents editor so it reloads for the newly-selected template.
+  tplAgents.templateId = '';
+  tplAgentsLoad();
   tplApplyReadOnly();
 }
 
@@ -354,7 +357,7 @@ function tplApplyReadOnly() {
     'tplEditName', 'tplEditDescription', 'tplEditIcon', 'tplEditBehavior', 'tplEditStarterTasks',
     'tplSaveBtn', 'tplResetBtn', 'tplDeleteBtn',
     'tplFileNewBtn', 'tplFolderNewBtn', 'tplFileRenameBtn', 'tplFileDeleteBtn', 'tplEditorSaveBtn',
-    'tplOnbSaveBtn', 'tplToolsSaveBtn'
+    'tplOnbSaveBtn', 'tplToolsSaveBtn', 'tplAgentsAddBtn', 'tplAgentsSaveBtn'
   ].forEach((id) => {
     const el = tplEl(id);
     if (el) el.disabled = builtin;
@@ -364,6 +367,12 @@ function tplApplyReadOnly() {
   if (tagsWrap) {
     tagsWrap.style.pointerEvents = builtin ? 'none' : '';
     tagsWrap.style.opacity = builtin ? '0.6' : '';
+  }
+  // Agent cards are rendered dynamically; disable their controls + drag for built-ins.
+  const agentsList = tplEl('tplAgentsList');
+  if (agentsList) {
+    agentsList.querySelectorAll('input, select, textarea, button').forEach((el) => { el.disabled = builtin; });
+    agentsList.querySelectorAll('.tpl-agent-card').forEach((card) => { card.draggable = !builtin; });
   }
 }
 
@@ -1333,6 +1342,232 @@ async function tplToolsSave() {
   }
 }
 
+// --- Agents tab: roster editor ---
+//
+// The working roster lives in the DOM (one card per agent); edits are read back
+// with tplAgentsCollect() before any structural change (add/remove/reorder) so
+// in-progress input is never lost. The first card is the entry agent.
+
+const TPL_AGENT_ROLES = ['', 'orchestrator', 'specialist', 'researcher', 'analyzer', 'synthesizer', 'validator', 'general'];
+const TPL_AGENT_TYPES = ['', 'tool-calling', 'general', 'research'];
+
+const tplAgents = { templateId: '', dragIndex: -1 };
+
+function tplAgentsBlank() {
+  return { name: '', role: '', type: '', model: '', system_prompt: '', tools: { skills: [], mcp_servers: [] } };
+}
+
+function tplAgentsNormalizeList(agents) {
+  return (Array.isArray(agents) ? agents : []).map((a) => ({
+    name: a.name || '',
+    role: a.role || '',
+    type: a.type || '',
+    model: a.model || '',
+    system_prompt: a.system_prompt || '',
+    tools: {
+      skills: (a.tools && Array.isArray(a.tools.skills)) ? a.tools.skills : [],
+      mcp_servers: (a.tools && Array.isArray(a.tools.mcp_servers)) ? a.tools.mcp_servers : []
+    }
+  }));
+}
+
+// tplAgentsLoad seeds the editor from the selected template, but only when the
+// template changes — so re-showing the tab keeps unsaved edits.
+function tplAgentsLoad() {
+  const template = tplSelected();
+  if (!template) return;
+  if (tplAgents.templateId === template.id) return;
+  tplAgents.templateId = template.id;
+  tplAgentsRender(template.agents);
+}
+
+function tplAgentsField(label, input) {
+  const wrap = document.createElement('div');
+  wrap.className = 'mb-2';
+  const lab = document.createElement('label');
+  lab.className = 'form-label';
+  lab.style.cssText = 'color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;';
+  lab.textContent = label;
+  wrap.appendChild(lab);
+  wrap.appendChild(input);
+  return wrap;
+}
+
+function tplAgentsCol(label, input) {
+  const col = document.createElement('div');
+  col.className = 'col-6';
+  col.appendChild(tplAgentsField(label, input));
+  return col;
+}
+
+function tplAgentsSelect(cls, values, selected) {
+  const sel = document.createElement('select');
+  sel.className = `modern-input w-100 ${cls}`;
+  values.forEach((v) => {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v === '' ? 'Default' : v;
+    if (v === selected) opt.selected = true;
+    sel.appendChild(opt);
+  });
+  return sel;
+}
+
+function tplAgentsInput(cls, value, placeholder) {
+  const i = document.createElement('input');
+  i.type = 'text';
+  i.className = `modern-input w-100 ${cls}`;
+  i.value = value || '';
+  i.placeholder = placeholder || '';
+  return i;
+}
+
+function tplAgentsCard(agent, index) {
+  const card = document.createElement('div');
+  card.className = 'tpl-agent-card';
+  card.dataset.index = String(index);
+  card.draggable = true;
+  card.style.cssText = 'border: 1px solid var(--border-color); border-radius: 8px; padding: 10px; background: var(--bg-tertiary);';
+
+  const header = document.createElement('div');
+  header.className = 'd-flex align-items-center gap-2 mb-2';
+  const handle = document.createElement('span');
+  handle.textContent = '⠿';
+  handle.title = 'Drag to reorder';
+  handle.style.cssText = 'cursor: grab; color: var(--text-secondary); user-select: none;';
+  header.appendChild(handle);
+  const tag = document.createElement('span');
+  if (index === 0) {
+    tag.className = 'badge';
+    tag.textContent = 'Entry agent';
+    tag.style.cssText = 'background: #22c55e; color: #fff; font-size: 10px;';
+  } else {
+    tag.textContent = 'Specialist';
+    tag.style.cssText = 'font-size: 11px; color: var(--text-secondary);';
+  }
+  header.appendChild(tag);
+  const remove = document.createElement('button');
+  remove.type = 'button';
+  remove.className = 'modern-btn modern-btn-secondary btn-sm ms-auto';
+  remove.textContent = 'Remove';
+  remove.style.color = '#ef4444';
+  remove.addEventListener('click', () => tplAgentsRemove(index));
+  header.appendChild(remove);
+  card.appendChild(header);
+
+  card.appendChild(tplAgentsField('Name', tplAgentsInput('tpl-agent-name', agent.name, 'Agent name')));
+
+  const rt = document.createElement('div');
+  rt.className = 'row g-2 mb-2';
+  rt.appendChild(tplAgentsCol('Role', tplAgentsSelect('tpl-agent-role', TPL_AGENT_ROLES, agent.role || '')));
+  rt.appendChild(tplAgentsCol('Type', tplAgentsSelect('tpl-agent-type', TPL_AGENT_TYPES, agent.type || '')));
+  card.appendChild(rt);
+
+  card.appendChild(tplAgentsField('Model', tplAgentsInput('tpl-agent-model', agent.model, 'Defaults to the workspace model')));
+
+  const prompt = document.createElement('textarea');
+  prompt.className = 'form-control tpl-agent-prompt';
+  prompt.rows = 2;
+  prompt.style.cssText = 'background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.85em; resize: vertical;';
+  prompt.value = agent.system_prompt || '';
+  prompt.placeholder = "This agent's instructions";
+  card.appendChild(tplAgentsField('System prompt', prompt));
+
+  const sm = document.createElement('div');
+  sm.className = 'row g-2';
+  const skillsVal = (agent.tools && agent.tools.skills ? agent.tools.skills : []).join(', ');
+  const mcpVal = (agent.tools && agent.tools.mcp_servers ? agent.tools.mcp_servers : []).join(', ');
+  sm.appendChild(tplAgentsCol('Skills', tplAgentsInput('tpl-agent-skills', skillsVal, 'comma-separated')));
+  sm.appendChild(tplAgentsCol('MCP servers', tplAgentsInput('tpl-agent-mcp', mcpVal, 'comma-separated')));
+  card.appendChild(sm);
+
+  card.addEventListener('dragstart', (event) => {
+    tplAgents.dragIndex = index;
+    card.style.opacity = '0.5';
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+  });
+  card.addEventListener('dragend', () => { card.style.opacity = ''; });
+  card.addEventListener('dragover', (event) => event.preventDefault());
+  card.addEventListener('drop', (event) => {
+    event.preventDefault();
+    tplAgentsReorder(tplAgents.dragIndex, index);
+  });
+
+  return card;
+}
+
+function tplAgentsRender(agents) {
+  const list = tplEl('tplAgentsList');
+  const empty = tplEl('tplAgentsEmpty');
+  if (!list) return;
+  const items = tplAgentsNormalizeList(agents);
+  list.innerHTML = '';
+  items.forEach((agent, idx) => list.appendChild(tplAgentsCard(agent, idx)));
+  if (empty) empty.hidden = items.length > 0;
+  tplApplyReadOnly();
+}
+
+function tplAgentsParseNames(value) {
+  return String(value || '').split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function tplAgentsCollect() {
+  const list = tplEl('tplAgentsList');
+  if (!list) return [];
+  return Array.from(list.querySelectorAll('.tpl-agent-card')).map((card) => ({
+    name: (card.querySelector('.tpl-agent-name')?.value || '').trim(),
+    role: card.querySelector('.tpl-agent-role')?.value || '',
+    type: card.querySelector('.tpl-agent-type')?.value || '',
+    model: (card.querySelector('.tpl-agent-model')?.value || '').trim(),
+    system_prompt: (card.querySelector('.tpl-agent-prompt')?.value || '').trim(),
+    tools: {
+      skills: tplAgentsParseNames(card.querySelector('.tpl-agent-skills')?.value),
+      mcp_servers: tplAgentsParseNames(card.querySelector('.tpl-agent-mcp')?.value)
+    }
+  }));
+}
+
+function tplAgentsAdd() {
+  const list = tplAgentsCollect();
+  list.push(tplAgentsBlank());
+  tplAgentsRender(list);
+}
+
+function tplAgentsRemove(index) {
+  const list = tplAgentsCollect();
+  list.splice(index, 1);
+  tplAgentsRender(list);
+}
+
+function tplAgentsReorder(from, to) {
+  tplAgents.dragIndex = -1;
+  if (from < 0 || to < 0 || from === to) return;
+  const list = tplAgentsCollect();
+  if (from >= list.length || to >= list.length) return;
+  const [moved] = list.splice(from, 1);
+  list.splice(to, 0, moved);
+  tplAgentsRender(list);
+}
+
+async function tplAgentsSave() {
+  const template = tplSelected();
+  if (!template) return;
+  const agents = tplAgentsCollect().filter((a) => a.name);
+  try {
+    await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}/agents`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agents })
+    });
+    tplToast('Agents saved.', 'success');
+    tplAgents.templateId = '';
+    await tplRefresh(template.id);
+    tplAgentsLoad();
+  } catch (error) {
+    tplToast(error.message || 'Failed to save agents', 'error');
+  }
+}
+
 // --- Init ---
 
 function tplInit() {
@@ -1426,6 +1661,11 @@ function tplInit() {
   // Tools tab wiring.
   tplEl('tplTabTools')?.addEventListener('shown.bs.tab', () => tplToolsEnsure());
   tplEl('tplToolsSaveBtn')?.addEventListener('click', () => void tplToolsSave());
+
+  // Agents tab wiring.
+  tplEl('tplTabAgents')?.addEventListener('shown.bs.tab', () => tplAgentsLoad());
+  tplEl('tplAgentsAddBtn')?.addEventListener('click', tplAgentsAdd);
+  tplEl('tplAgentsSaveBtn')?.addEventListener('click', () => void tplAgentsSave());
 
   void tplRefresh();
 }

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -353,6 +353,8 @@ function tplApplyReadOnly() {
   if (badge) badge.hidden = !builtin;
   const notice = tplEl('tplReadOnlyNotice');
   if (notice) notice.hidden = !builtin;
+  const agentsNotice = tplEl('tplAgentsReadOnlyNotice');
+  if (agentsNotice) agentsNotice.hidden = !builtin;
   [
     'tplEditName', 'tplEditDescription', 'tplEditIcon', 'tplEditBehavior', 'tplEditStarterTasks',
     'tplSaveBtn', 'tplResetBtn', 'tplDeleteBtn',
@@ -1666,6 +1668,7 @@ function tplInit() {
   tplEl('tplTabAgents')?.addEventListener('shown.bs.tab', () => tplAgentsLoad());
   tplEl('tplAgentsAddBtn')?.addEventListener('click', tplAgentsAdd);
   tplEl('tplAgentsSaveBtn')?.addEventListener('click', () => void tplAgentsSave());
+  tplEl('tplAgentsDuplicateBtn')?.addEventListener('click', tplDuplicate);
 
   void tplRefresh();
 }

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -1135,6 +1135,7 @@ export class WorkspaceDetailPage {
         'workspace-detail-task-confirm-step-mode-input'
       ),
       taskConfirmCancelBtn: document.getElementById('workspace-detail-task-confirm-cancel'),
+      taskConfirmCloseBtn: document.getElementById('workspace-detail-task-confirm-close'),
       taskConfirmConfirmBtn: document.getElementById('workspace-detail-task-confirm-confirm'),
 
       // Project template modal
@@ -4573,14 +4574,6 @@ export class WorkspaceDetailPage {
     }
   }
 
-  markEntryAgentPromptDismissed() {
-    try {
-      window.sessionStorage?.setItem(this.getEntryAgentPromptDismissalStorageKey(), '1');
-    } catch (_error) {
-      // Ignore storage errors; this only prevents repeated prompts in the same tab.
-    }
-  }
-
   shouldPromptForMissingEntryAgent() {
     const entryAgentName = String(this.workspace?.entry_agent_name || '').trim();
     if (entryAgentName) {
@@ -4635,12 +4628,15 @@ export class WorkspaceDetailPage {
 
     const workspaceName = String(this.workspace?.name || '').trim() || 'this workspace';
     const entryAgentDefaults = this.buildWorkspaceEntryAgentDefaults();
-    const confirmed = await this.showTaskConfirmDialog({
+    // An entry agent is required for the workspace to operate, so this prompt is
+    // mandatory: there is no "create later" escape and it resolves only when the
+    // user proceeds to create one.
+    await this.showTaskConfirmDialog({
       eyebrow: 'Workspace Setup',
       title: 'Create an entry agent for this workspace?',
       message: `"${workspaceName}" cannot function until it has an entry agent.`,
       confirmLabel: 'Create Entry Agent',
-      cancelLabel: 'Not Now',
+      mandatory: true,
       metaItems: [workspaceName, entryAgentDefaults.seedName, 'No entry agent'],
       details: [
         'The entry agent is required for this workspace to operate normally.',
@@ -4649,17 +4645,6 @@ export class WorkspaceDetailPage {
         'You can rename or replace it later.'
       ]
     });
-
-    if (!confirmed) {
-      this.markEntryAgentPromptDismissed();
-      if (window.Toast) {
-        window.Toast.warning(
-          `"${workspaceName}" cannot function until you create an entry agent.`,
-          { title: 'Entry Agent Required' }
-        );
-      }
-      return;
-    }
 
     this.clearEntryAgentPromptDismissal();
     this.openWorkspaceEntryAgentCreateFlow();
@@ -4730,6 +4715,10 @@ export class WorkspaceDetailPage {
     }
     if (this.elements.taskConfirmCancelBtn) {
       this.elements.taskConfirmCancelBtn.textContent = 'Cancel';
+      this.elements.taskConfirmCancelBtn.classList.remove('d-none');
+    }
+    if (this.elements.taskConfirmCloseBtn) {
+      this.elements.taskConfirmCloseBtn.classList.remove('d-none');
     }
     if (this.elements.taskConfirmConfirmBtn) {
       this.elements.taskConfirmConfirmBtn.textContent = 'Continue';
@@ -4856,8 +4845,26 @@ export class WorkspaceDetailPage {
     this.elements.taskConfirmSequence.classList.remove('d-none');
   }
 
-  getTaskConfirmModalInstance() {
+  getTaskConfirmModalInstance(options = null) {
     if (!this.elements.taskConfirmModal || !window.bootstrap) return null;
+
+    // Bootstrap locks backdrop/keyboard at construction, so when a caller asks
+    // for a different dismissibility mode than the active instance, dispose and
+    // rebuild it. A mandatory dialog uses a static backdrop and ignores Escape.
+    if (options && typeof options.mandatory === 'boolean') {
+      if (this.taskConfirmModalMandatory !== options.mandatory) {
+        const existing = bootstrap.Modal.getInstance(this.elements.taskConfirmModal);
+        if (existing) existing.dispose();
+        this.taskConfirmModalMandatory = options.mandatory;
+        return new bootstrap.Modal(
+          this.elements.taskConfirmModal,
+          options.mandatory
+            ? { backdrop: 'static', keyboard: false }
+            : { backdrop: true, keyboard: true }
+        );
+      }
+    }
+
     return typeof bootstrap.Modal.getOrCreateInstance === 'function'
       ? bootstrap.Modal.getOrCreateInstance(this.elements.taskConfirmModal)
       : bootstrap.Modal.getInstance(this.elements.taskConfirmModal) ||
@@ -4917,6 +4924,9 @@ export class WorkspaceDetailPage {
     const sequenceItems = this.normalizeTaskConfirmSequenceItems(options?.sequenceItems);
     const allowStepThrough = options?.allowStepThrough === true;
     const defaultStepThrough = options?.defaultStepThrough === true;
+    // A mandatory dialog has no escape hatch: no cancel/close button, and the
+    // backdrop/Escape are disabled. The promise can only resolve via confirm.
+    const mandatory = options?.mandatory === true;
 
     if (!this.elements.taskConfirmModal || !window.bootstrap) {
       const fallbackSequence =
@@ -4950,6 +4960,10 @@ export class WorkspaceDetailPage {
     }
     if (this.elements.taskConfirmCancelBtn) {
       this.elements.taskConfirmCancelBtn.textContent = cancelLabel || 'Cancel';
+      this.elements.taskConfirmCancelBtn.classList.toggle('d-none', mandatory);
+    }
+    if (this.elements.taskConfirmCloseBtn) {
+      this.elements.taskConfirmCloseBtn.classList.toggle('d-none', mandatory);
     }
     if (this.elements.taskConfirmConfirmBtn) {
       this.elements.taskConfirmConfirmBtn.textContent = confirmLabel || 'Continue';
@@ -4962,7 +4976,7 @@ export class WorkspaceDetailPage {
 
     return new Promise(resolve => {
       this.pendingTaskConfirm = { resolve, resolved: false };
-      const modal = this.getTaskConfirmModalInstance();
+      const modal = this.getTaskConfirmModalInstance({ mandatory });
       modal?.show();
       window.setTimeout(() => {
         this.elements.taskConfirmConfirmBtn?.focus();

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -23,10 +23,6 @@
             </div>
             <div id="projectTemplateDescription" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
             <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
-            <div id="projectNameRow" class="mb-2" hidden>
-              <label for="projectNameInput" style="font-size: 12px; color: var(--text-secondary);">Project name</label>
-              <input type="text" id="projectNameInput" class="modern-input w-100" placeholder="Defaults to the workspace name" autocomplete="off">
-            </div>
             <div style="margin-bottom: 12px; font-size: 12px; color: var(--text-secondary);">
               Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
             </div>

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -113,6 +113,9 @@
                   <li class="nav-item" role="presentation">
                     <button class="nav-link" id="tplTabTools" data-bs-toggle="tab" data-bs-target="#tplToolsPane" type="button" role="tab" aria-controls="tplToolsPane" aria-selected="false">Tools</button>
                   </li>
+                  <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tplTabAgents" data-bs-toggle="tab" data-bs-target="#tplAgentsPane" type="button" role="tab" aria-controls="tplAgentsPane" aria-selected="false">Agents</button>
+                  </li>
                 </ul>
 
                 <div class="tab-content">
@@ -258,6 +261,24 @@
                     <h6 class="mb-1" style="color: var(--text-primary);">Plugins</h6>
                     <div id="tplToolsPlugins" class="d-flex flex-column gap-1 mb-3"></div>
                     <button id="tplToolsSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save tools</button>
+                  </div>
+
+                  <!-- Agents: roster seeded when a workspace is created from this template -->
+                  <div class="tab-pane fade" id="tplAgentsPane" role="tabpanel" aria-labelledby="tplTabAgents">
+                    <div style="font-size: 12px; color: var(--text-secondary);" class="mb-2">
+                      Agents are created when a workspace is made from this template. The
+                      <strong>first agent is the entry agent</strong> (the one required agent every workspace
+                      needs) — drag an agent to the top to make it the entry agent. The rest are specialist
+                      sub-agents. A name that already exists is reused as-is.
+                    </div>
+                    <div id="tplAgentsEmpty" class="text-center py-3" style="color: var(--text-secondary); font-size: 13px;" hidden>
+                      This template seeds no agents. Workspaces created from it will prompt for an entry agent.
+                    </div>
+                    <div id="tplAgentsList" class="d-flex flex-column gap-2 mb-3"></div>
+                    <div class="d-flex gap-2">
+                      <button id="tplAgentsAddBtn" class="modern-btn modern-btn-secondary btn-sm">Add agent</button>
+                      <button id="tplAgentsSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save agents</button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -265,6 +265,10 @@
 
                   <!-- Agents: roster seeded when a workspace is created from this template -->
                   <div class="tab-pane fade" id="tplAgentsPane" role="tabpanel" aria-labelledby="tplTabAgents">
+                    <div id="tplAgentsReadOnlyNotice" hidden class="mb-3" style="padding: 10px 12px; border-radius: 8px; border: 1px solid var(--border-color); background: var(--bg-tertiary); font-size: 12px; color: var(--text-secondary);">
+                      This is a built-in template and is read-only.
+                      <button id="tplAgentsDuplicateBtn" class="modern-btn modern-btn-primary btn-sm ms-2">Duplicate to customize</button>
+                    </div>
                     <div style="font-size: 12px; color: var(--text-secondary);" class="mb-2">
                       Agents are created when a workspace is made from this template. The
                       <strong>first agent is the entry agent</strong> (the one required agent every workspace

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -1980,7 +1980,7 @@
     <div class="modal-dialog modal-dialog-centered workspace-detail-task-confirm-dialog">
       <div class="modal-content workspace-detail-task-confirm-content">
         <div class="modal-body workspace-detail-task-confirm-body">
-          <button type="button" class="btn-close workspace-detail-task-confirm-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <button type="button" id="workspace-detail-task-confirm-close" class="btn-close workspace-detail-task-confirm-close" data-bs-dismiss="modal" aria-label="Close"></button>
           <div class="workspace-detail-task-confirm-header">
             <div class="workspace-detail-task-confirm-icon" aria-hidden="true">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
## Summary

Lets workspace **templates declare an agent roster** that is seeded when a workspace is created from the template. The first agent becomes the workspace **entry agent** (the one required agent), so a templated workspace is immediately operational; the rest are specialist sub-agents. Also bundles related templates/workspace-setup UI polish.

## What's included

**Agent rosters (the core feature)**
- `agents` array in `template.json` (name, role, type, model, system_prompt, per-agent skills/MCP); ordered, first = entry agent. Parsed domain-blind in `projecttemplates` (dedupe, blank-drop, soft cap of 10).
- Seeding on workspace create: create-or-**reuse-on-name-match** (a matching global agent is attached as-is, never mutated), entry agent set (suppresses the mandatory prompt), specialists attached; per-agent **skills enabled** on the agent, MCP bound at workspace level (no per-agent scope). Best-effort: a specialist that fails to create is skipped with a non-blocking `agent_warnings` toast; an entry-agent failure falls back to the prompt.
- **Authoring UI**: an "Agents" tab on `/templates` — add/edit/remove, drag-to-reorder (drag to top = entry agent), entry-agent badge, empty state, built-in read-only notice. Persists via a dedicated `PUT /api/project-templates/{id}/agents` endpoint.
- **Sample rosters shipped in every built-in** (Research Project, Content Production, Writing Project, Travels, Daily Briefings, Personal Ops; Reaper Song intentionally roster-less). All agent names are globally unique so reuse-on-name-match never cross-contaminates templates.
- **Versioned built-ins** (`builtin_version`): when a shipped built-in's manifest is newer than the on-disk copy, its `template.json` is refreshed in place so updates (like these rosters) reach existing installs — manifest-only, so hand-edited seed files and user templates are untouched.

**Bundled UI polish (same templates/workspace-setup theme)**
- Drop the redundant "Project name" input from the Create Workspace flow (folder name defaults to the workspace name server-side).
- Make the missing-entry-agent prompt mandatory (no "Not Now" escape; static backdrop), opt-in so other confirm dialogs are unaffected.

## Testing
- Unit + HTTP tests for parsing, seeding (create/reuse/failure paths), persistence round-trip, and the version-bump refresh. `go build ./...`, `go vet`, and touched-package tests all green.
- Live smoke on isolated servers: roster template → entry + specialists, no prompt; no-roster → prompt fires; reuse-on-name-match (no duplicate agents); stale built-in auto-refreshed its roster on startup while a hand-edited seed file and a user template survived.
- Q8 confirmed: seeded agents carry no autonomy/permission fields — a template cannot grant elevated autonomy.

## Notes
- Browser visual pass of the Agents tab was done manually by the author (the automation extension couldn't reach localhost).
- Deferred (SHOULD, not blocking): a per-row "unconfigured model" warning in the authoring UI — no clean configured-models source on the page; the model field is free text with a default-model hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
