### PR TITLE
feat(workspace-map): add inert scaffolding for map view

### DIFF
--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -1,0 +1,45 @@
+/*
+ * workspace-map.css — Workspace Map view ("tactical command-center")
+ *
+ * Everything is scoped under `.ws-map` (the map view root). The map is an
+ * intentional DARK surface regardless of the app's `data-bs-theme`, so its
+ * tokens are defined here rather than inherited. Rules must NOT leak into the
+ * Cards/Tree views — keep every selector under `.ws-map`.
+ *
+ * Rules: no edits to ui-refresh.css, no `!important`.
+ *
+ * Phase 0.0 = design tokens only. Panels/tiles/overview land in Phase 1–2.
+ */
+
+.ws-map {
+  /* surface */
+  --ws-bg: #070b0c;
+  --ws-bg-2: #0b1113;
+  --ws-panel: #0e1618;
+  --ws-panel-2: #101e1f;
+  --ws-line: #1c2e2c;
+  --ws-line-bright: #28413c;
+
+  /* ink */
+  --ws-ink: #cfe8df;
+  --ws-ink-dim: #7f998f;
+  --ws-ink-faint: #4d655d;
+
+  /* semantic accents */
+  --ws-faction: #46d39a;       /* active workspace / primary */
+  --ws-faction-deep: #0f3b30;
+  --ws-keeper: #e8b54b;        /* entry agent (locked) */
+  --ws-keeper-deep: #3a2c0c;
+  --ws-idle: #4ec5e6;          /* idle status */
+  --ws-working: #46d39a;       /* working status (agent in progress) */
+  --ws-alert: #e2654d;
+
+  /* geometry */
+  --ws-clip: 14px;             /* panel corner notch */
+  --ws-clip-sm: 8px;
+  --ws-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+
+  /* type (families self-hosted in Phase 1; fall back to system for now) */
+  --ws-font-display: "Chakra Petch", system-ui, sans-serif;
+  --ws-font-mono: "JetBrains Mono", ui-monospace, monospace;
+}

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -1,0 +1,31 @@
+/*
+ * workspace-map.js — Workspace Map view ("tactical command-center")
+ *
+ * Opt-in third view on the /workspaces hub, beside Cards and Tree. Loaded as a
+ * plain deferred script (not an ES module), so it exposes itself on a global
+ * namespace that workspace-hub.js calls when the "map" view is activated.
+ *
+ * Phase 0.0 = inert scaffolding. mount/unmount are safe no-ops; the real
+ * command bar, building tiles, districts, and Overview land in Phase 1–2.
+ */
+(function () {
+  'use strict';
+
+  /**
+   * Mount the map view into its container.
+   * @param {HTMLElement} container - the #launcherMap element.
+   * @param {object} [state] - shared hub state (workspaces, selection, etc.).
+   */
+  function mount(container /*, state */) {
+    if (!container) return;
+    // Inert until Phase 1. Intentionally renders nothing yet.
+  }
+
+  /** Tear down the map view (called when switching away). */
+  function unmount(container) {
+    if (!container) return;
+    // Inert until Phase 1.
+  }
+
+  window.OriWorkspaceMap = { mount, unmount };
+})();

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -64,6 +64,12 @@
                 <path d="M3,5H9V7H5V17H9V19H3V5M11,5H21V9H11V5M11,10H21V14H11V10M11,15H21V19H11V15Z"/>
               </svg>
             </button>
+            <!-- Map view — inert scaffolding (Phase 0.0); revealed in Phase 1. -->
+            <button id="launcherViewMap" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherMap" aria-label="Map view" title="Map View" data-launcher-view="map" hidden>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M15,19L9,16.89V5L15,7.11M20.5,3C20.44,3 20.39,3 20.34,3L15,5.1L9,3L3.36,4.9C3.15,4.97 3,5.15 3,5.38V20.5A0.5,0.5 0 0,0 3.5,21C3.55,21 3.61,21 3.66,20.97L9,18.9L15,21L20.64,19.1C20.85,19 21,18.85 21,18.62V3.5A0.5,0.5 0 0,0 20.5,3Z"/>
+              </svg>
+            </button>
           </div>
           <button id="launcherRefreshBtn" class="modern-btn modern-btn-secondary modern-btn-icon" type="button" title="Refresh" aria-label="Refresh workspaces">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -137,6 +143,8 @@
         </div>
         <div id="launcherGrid" class="launcher-grid"></div>
         <div id="launcherEmptyState" class="launcher-empty" style="display: none;">No workspaces yet. Create one to get started.</div>
+        <!-- Map view mount point — inert scaffolding (Phase 0.0); populated by workspace-map.js in Phase 1. -->
+        <div id="launcherMap" class="ws-map" hidden></div>
       </section>
 
       <section id="launcherSummaryPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabSummary" hidden>

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -57,6 +57,7 @@
   <link href="/css/sessions.css" rel="stylesheet">
   <link href="/css/file-manager.css" rel="stylesheet">
   <link href="/css/workspace-hub.css" rel="stylesheet">
+  <link href="/css/workspace-map.css" rel="stylesheet">
   <link href="/css/settings.css" rel="stylesheet">
   <link href="/css/ui-refresh.css" rel="stylesheet">
   <link href="/css/tag-input.css" rel="stylesheet">

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -72,6 +72,7 @@
   <script defer src="/js/modules/workspace-hub-smart-input.js"></script>
   <script defer src="/js/modules/workspace-hub-panels.js"></script>
   <script defer src="/js/modules/workspace-hub.js"></script>
+  <script defer src="/js/modules/workspace-map.js"></script>
   <script defer src="/js/modules/workspace-hub-board.js"></script>
   <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
   <script defer src="/js/modules/workspace-sync.js"></script>


### PR DESCRIPTION
## What

First seam-PR (PR A) of the **Workspace Map** epic — an opt-in tactical
"command-center" view of the `/workspaces` hub, beside the existing Cards and
Tree views. This PR is **inert scaffolding only**: it lands the plumbing with
**zero user-visible change** so later phases stack cleanly.

## Changes (5 files, +86 lines)

- **`static/css/workspace-map.css`** *(new)* — scoped `.ws-map` dark design
  tokens only. No rules that touch Cards/Tree, **no `ui-refresh.css` edits, no
  `!important`**.
- **`static/js/modules/workspace-map.js`** *(new)* — inert `mount`/`unmount` on
  `window.OriWorkspaceMap` (plain deferred script, matching the hub modules).
- **`layout/head.tmpl`** — link the new CSS (after `workspace-hub.css`).
- **`pages/workspaces.tmpl`** — link the new JS (hub-module group).
- **`components/workspace-hub.tmpl`** — hidden **Map** toggle button
  (`#launcherViewMap`, `data-launcher-view="map"`) + empty `#launcherMap`
  container.

## Verification

Isolated smoke server (`HOME`/`ORI_DATA_DIR` redirected): `/workspaces` renders
unchanged; Map toggle + container present but `hidden`; both new assets serve
`200`; no console errors; Cards/Tree untouched.

## Not in this PR

Backend list enrichment, the map shell, building tiles/auto-layout, the Overview
panel, and revealing the toggle land in subsequent seam-PRs (B–D). Plan:
`tasks/prd-workspace-map-view.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)