### PR TITLE
feat(workspace-map): polish, accessibility, and live-refresh consistency

### DIFF
--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -173,6 +173,7 @@
   font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; padding: 2px 9px;
 }
 .ws-map-district-tag:hover { background: rgba(232, 134, 77, 0.12); }
+.ws-map-district-tag:focus-visible { outline: 2px solid var(--ws-keeper); outline-offset: 2px; }
 
 /* building tile */
 .ws-map-tile {
@@ -192,8 +193,15 @@
   font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; color: var(--ws-ink-dim);
 }
 .ws-map-led { width: 7px; height: 7px; border-radius: 50%; background: var(--ws-idle); box-shadow: 0 0 7px var(--ws-idle); }
-.ws-map-led.is-working { background: var(--ws-working); box-shadow: 0 0 8px var(--ws-working); animation: ws-map-pulse 1.5s ease-in-out infinite; }
+.ws-map-led.is-working { background: var(--ws-working); box-shadow: 0 0 8px var(--ws-working); }
 @keyframes ws-map-pulse { 50% { opacity: 0.3; } }
+@keyframes ws-map-rise { from { opacity: 0; transform: translateY(10px); } }
+
+/* Auto-playing motion is opt-in via the OS "reduce motion" preference. */
+@media (prefers-reduced-motion: no-preference) {
+  .ws-map-tile { animation: ws-map-rise 0.4s ease both; animation-delay: calc(var(--i, 0) * 28ms); }
+  .ws-map-led.is-working { animation: ws-map-pulse 1.5s ease-in-out infinite; }
+}
 .ws-map-tile-crest {
   position: absolute; top: 30px; left: 50%; transform: translateX(-50%); z-index: 4; font-size: 13px; color: #04110c;
   text-shadow: 0 0 3px var(--ws-keeper); pointer-events: none;

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -310,6 +310,15 @@ test('launcher view preference defaults to cards and persists valid values', () 
   assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'tree');
 });
 
+test('launcher view registers the map view and persists it', () => {
+  const { helpers, storage } = loadWorkspaceHub();
+
+  assert.equal(helpers.normalizeLauncherView('map'), 'map');
+  assert.equal(helpers.normalizeLauncherView('MAP'), 'map');
+  assert.equal(helpers.setLauncherViewPreference('map'), 'map');
+  assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'map');
+});
+
 test('launcher tree renders minimal hierarchy with always-available workspace checkboxes', () => {
   const workspaces = [
     {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -213,7 +213,7 @@
     );
   }
 
-  function tileHTML(tile, selectedId) {
+  function tileHTML(tile, selectedId, index) {
     var ws = tile.ws || {};
     var pal = paletteFor(ws.id);
     var active = !!ws.active;
@@ -229,9 +229,9 @@
       openTasks + (openTasks === 1 ? ' task' : ' tasks');
 
     return (
-      '<button type="button" class="ws-map-tile' + selected + '" role="listitem" ' +
+      '<button type="button" class="ws-map-tile' + selected + '" ' +
       'data-ws-id="' + escapeHtml(ws.id) + '" ' +
-      'style="left:' + left + 'px;top:' + top + 'px" ' +
+      'style="left:' + left + 'px;top:' + top + 'px;--i:' + (index || 0) + '" ' +
       'aria-label="' + escapeHtml(ws.name || 'Workspace') + ', ' + meta + ', ' + statusText +
       (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') + '">' +
       '<span class="ws-map-tile-flag"><span class="ws-map-led' + (active ? ' is-working' : '') + '"></span>' +
@@ -251,10 +251,13 @@
     var top = PAD + d.row * CELL_H - 6;
     var width = d.w * CELL_W - 8;
     var height = d.h * CELL_H - 10;
+    var label = (ws.name || 'Group') + ' group';
     return (
-      '<div class="ws-map-district" data-group-id="' + escapeHtml(ws.id) + '" ' +
+      '<div class="ws-map-district" role="group" aria-label="' + escapeHtml(label) + '" ' +
+      'data-group-id="' + escapeHtml(ws.id) + '" ' +
       'style="left:' + left + 'px;top:' + top + 'px;width:' + width + 'px;height:' + height + 'px">' +
-      '<button type="button" class="ws-map-district-tag" data-ws-id="' + escapeHtml(ws.id) + '">▢ ' +
+      '<button type="button" class="ws-map-district-tag" data-ws-id="' + escapeHtml(ws.id) + '" ' +
+      'aria-label="' + escapeHtml('Open ' + label) + '">▢ ' +
       escapeHtml(ws.name || 'Group') + ' · Group</button>' +
       '</div>'
     );
@@ -275,7 +278,7 @@
     var layout = computeMapLayout(workspaces);
     var parts = [];
     layout.districts.forEach(function (d) { parts.push(districtHTML(d)); });
-    layout.tiles.forEach(function (t) { parts.push(tileHTML(t, selectedId)); });
+    layout.tiles.forEach(function (t, i) { parts.push(tileHTML(t, selectedId, i)); });
 
     // place the "new workspace" pad in the next free cell on the last shelf
     var lastRow = 0;
@@ -287,7 +290,7 @@
 
     var height = PAD * 2 + (lastRow + 1) * CELL_H;
     return {
-      html: '<div class="ws-map-canvas" role="list" aria-label="Workspaces" style="height:' + height + 'px">' +
+      html: '<div class="ws-map-canvas" role="group" aria-label="Workspaces map" style="height:' + height + 'px">' +
         parts.join('') + '</div>',
       empty: layout.tiles.length === 0
     };


### PR DESCRIPTION
## What

Final seam-PR (**PR D**, Group 4.0) of the Workspace Map epic — the production
polish pass. Pure frontend + one test.

## Changes (3 files, +28 / −8)

- **Accessibility** (`workspace-map.js`): the canvas is a labeled group
  (`role="group"`, `aria-label`); each building tile is a focusable `<button>`
  with a descriptive `aria-label` (`"<name>, N agents · M tasks, <status>"`) —
  removed the incorrect `listitem` role; districts are labeled groups with a
  labeled open control; status is text, not color alone; visible focus outlines
  on tiles, the create pad, and district labels. Keyboard: focus a tile and
  Enter/Space selects it and fills the Overview.
- **Motion** (`workspace-map.css`): staggered tile load-in and the working-status
  LED pulse are gated behind `prefers-reduced-motion: no-preference`, so a
  reduce-motion preference disables all auto-playing animation. No `!important`.
- **Tests** (`workspace-hub.test.js`): a map-view registration/persistence case
  (19 hub tests pass); the 7 layout tests still pass.

## Live refresh

The map re-mounts through the hub's existing `renderLauncherActiveView` path, so
create/delete/refresh already update tiles + counts (verified: create → 6 tiles,
selection preserved). Continuous status polling is intentionally **not** added —
Cards/Tree don't poll either; that belongs in a cross-view enhancement, not a
single view.

## Verification

Smoke + DOM checks: `role="group"` canvas with labeled focusable `<button>` tiles;
keyboard focus + Enter selects and fills the Overview; list refresh reflects on the
map with selection preserved; no console errors. 19 hub + 7 layout unit tests pass;
ESLint + `go vet` clean.

## Epic complete

Scaffolding (#126) → enriched list + tiles (#127) → overview/nav (#128) → this
polish/a11y pass. The opt-in Workspace Map view ships end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)