### PR TITLE
feat(workspace-command): inert scaffolding for the command view

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,7 @@ export default defineConfig([
       'internal/web/static/js/modules/tag-filter-bar.js',
       'internal/web/static/js/modules/template-onboarding.js',
       'internal/web/static/js/modules/workspace-tags-card.js',
+      'internal/web/static/js/modules/workspace-command.js',
     ],
     languageOptions: {
       sourceType: 'module'

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -1,0 +1,52 @@
+/*
+ * workspace-command.css — Workspace Command view (interior "tactical" reskin)
+ *
+ * Opt-in tactical layout on the workspace detail page, scoped under `.ws-cmd`.
+ * A dark surface regardless of the app's `data-bs-theme`. Mirrors the Map's
+ * `.ws-map` visual system; the self-hosted @font-face declarations are already
+ * provided globally by workspace-map.css, so this file only references them.
+ *
+ * Rules must NOT leak outside `.ws-cmd`. No ui-refresh.css edits, no `!important`.
+ *
+ * Phase 0.0 = design tokens only. Command bar / garrison / rail land in Phase 1-3.
+ */
+
+.ws-cmd {
+  /* surface */
+  --ws-bg: #070b0c;
+  --ws-bg-2: #0b1113;
+  --ws-panel: #0e1618;
+  --ws-panel-2: #101e1f;
+  --ws-line: #1c2e2c;
+  --ws-line-bright: #28413c;
+
+  /* ink */
+  --ws-ink: #cfe8df;
+  --ws-ink-dim: #7f998f;
+  --ws-ink-faint: #4d655d;
+
+  /* semantic accents */
+  --ws-faction: #46d39a;
+  --ws-faction-deep: #0f3b30;
+  --ws-keeper: #e8b54b;
+  --ws-keeper-deep: #3a2c0c;
+  --ws-idle: #4ec5e6;
+  --ws-working: #46d39a;
+  --ws-alert: #e2654d;
+
+  /* geometry */
+  --ws-clip: 14px;
+  --ws-clip-sm: 8px;
+  --ws-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+
+  /* type (families vendored globally by workspace-map.css) */
+  --ws-font-display: 'Chakra Petch', system-ui, sans-serif;
+  --ws-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  display: block;
+  color: var(--ws-ink);
+  font-family: var(--ws-font-display);
+  letter-spacing: 0.2px;
+}
+
+.ws-cmd[hidden] { display: none; }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -1,0 +1,33 @@
+/*
+ * workspace-command.js — Workspace Command view (interior "tactical" reskin)
+ *
+ * An opt-in tactical layout on the workspace detail page, beside the existing
+ * detailed view. It reuses the live WorkspaceDetailPage instance (data + helpers
+ * like buildAgentGroups / isWorkspaceEntryAgent) and renders into
+ * #workspaceCommandView — no backend, no rewrite of the detailed page.
+ *
+ * Phase 0.0 = inert scaffolding. mount()/unmount() are safe no-ops; the command
+ * bar, garrison, quest logs, and right rail land in Phase 1-3.
+ */
+export class WorkspaceCommandView {
+  /**
+   * @param {object} page - the live WorkspaceDetailPage instance (window.workspaceDetail).
+   */
+  constructor(page) {
+    this.page = page || null;
+    this.container = document.getElementById('workspaceCommandView');
+    this.detailedView = document.getElementById('workspace-detail-view');
+    this.active = false;
+  }
+
+  /** Render/refresh the command view into its container. Inert until Phase 1. */
+  mount() {
+    if (!this.container) return;
+    // Intentionally renders nothing yet.
+  }
+
+  /** Tear down the command view. Inert until Phase 1. */
+  unmount() {
+    if (!this.container) return;
+  }
+}

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -58,6 +58,7 @@
   <link href="/css/file-manager.css" rel="stylesheet">
   <link href="/css/workspace-hub.css" rel="stylesheet">
   <link href="/css/workspace-map.css" rel="stylesheet">
+  <link href="/css/workspace-command.css" rel="stylesheet">
   <link href="/css/settings.css" rel="stylesheet">
   <link href="/css/ui-refresh.css" rel="stylesheet">
   <link href="/css/tag-input.css" rel="stylesheet">

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -11,6 +11,8 @@
 
     <div class="main-content">
       <div class="container-fluid py-4">
+        <!-- Command view mount point — inert scaffolding (Phase 0.0); populated by workspace-command.js in Phase 1. -->
+        <div id="workspaceCommandView" class="ws-cmd" hidden></div>
         <!-- Workspace Detail View -->
         <div id="workspace-detail-view">
           <!-- Header Card -->
@@ -35,6 +37,13 @@
               </div>
 
               <div class="d-flex align-items-center gap-2">
+                <!-- Command view toggle — inert scaffolding (Phase 0.0); revealed in Phase 1. -->
+                <button id="workspace-command-toggle" type="button" class="modern-btn modern-btn-secondary" aria-pressed="false" title="Switch to Command view" hidden>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                    <path d="M4,5H10V11H4V5M14,5H20V11H14V5M4,13H10V19H4V13M14,13H20V19H14V13Z"/>
+                  </svg>
+                  Command
+                </button>
                 <a id="open-workflows-btn" href="/workflows" class="modern-btn modern-btn-secondary">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
                     <path d="M7,5A2,2 0 0,0 5,7V10A2,2 0 0,0 7,12H10A2,2 0 0,0 12,10V7A2,2 0 0,0 10,5H7M14,5A2,2 0 0,0 12,7V10A2,2 0 0,0 14,12H17A2,2 0 0,0 19,10V7A2,2 0 0,0 17,5H14M7,12A2,2 0 0,0 5,14V17A2,2 0 0,0 7,19H10A2,2 0 0,0 12,17V14A2,2 0 0,0 10,12H7M13,13H19V15H13V13M13,17H19V19H13V17Z"/>
@@ -9246,6 +9255,7 @@
   <!-- Workspace Detail Page -->
   <script type="module">
     import { WorkspaceDetailPage } from '/js/modules/workspace-detail.js';
+    import { WorkspaceCommandView } from '/js/modules/workspace-command.js';
 
     function initializeWorkspaceDetailPage() {
       themeManager.initialize();
@@ -9261,6 +9271,9 @@
         const detailPage = new WorkspaceDetailPage(workspaceId);
         window.workspaceDetail = detailPage;
         detailPage.init();
+
+        // Opt-in Command view (inert until Phase 1).
+        window.workspaceCommand = new WorkspaceCommandView(detailPage);
       } else {
         console.error('No workspace ID found in URL');
         window.location.href = '/';


### PR DESCRIPTION
## What

First seam-PR (PR A) of the **Workspace Command view** epic — an opt-in tactical
"command center" view on the workspace detail page (`/workspaces/{id}`), the interior
counterpart to the hub's Map view. This PR is **inert scaffolding only**: it lands the
plumbing with **zero user-visible change** so later phases stack cleanly.

The detailed page is untouched; a future toggle switches Detailed ⇄ Command. The
Command view will be a *curated* tactical layout (command bar + garrison of agent unit
cards + quest logs + right rail) rendered from the data the page already loads — no
backend, no rewrite of the ~25k-line detailed page.

## Changes (5 files, +100)

- **`static/css/workspace-command.css`** *(new)* — scoped `.ws-cmd` dark tokens only.
  Fonts reused from `workspace-map.css`'s `@font-face` (no re-vendoring). No
  `ui-refresh.css` edits, no `!important`.
- **`static/js/modules/workspace-command.js`** *(new)* — ES-module `WorkspaceCommandView`
  that takes the live `WorkspaceDetailPage` instance; `mount`/`unmount` are no-ops.
- **`layout/head.tmpl`** / **`pages/workspace-detail.tmpl`** — link the CSS; import +
  instantiate the module (`window.workspaceCommand`); hidden **Command** toggle in the
  header action bar + hidden `#workspaceCommandView` container.
- **`eslint.config.js`** — register the new ES module in the sourceType-module allowlist.

## Verification

Live workspace detail page: renders unchanged; toggle + container present but `hidden`;
the ES-module import resolves; `window.workspaceCommand` is instantiated with a `mount()`;
new assets serve `200`; no console errors.

## Not in this PR

The command bar + Detailed/Command toggle (1.0), garrison unit cards + quest logs (2.0),
right rail (3.0), and polish/a11y (4.0) land in subsequent seam-PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)