### PR TITLE
feat(workspace-command): command bar + garrison (interior command view)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -107,6 +107,68 @@
   font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;
 }
 
+/* ---------- garrison ---------- */
+.ws-cmd-garrison { padding: 14px; }
+.ws-cmd-garrison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+.ws-cmd-unit {
+  border: 1px solid var(--ws-line); background: linear-gradient(165deg, #0f1a1b, #0b1112); overflow: hidden;
+  clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+}
+.ws-cmd-unit.is-keeper { border-color: rgba(232, 181, 75, 0.32); }
+.ws-cmd-unit-top { display: flex; gap: 12px; padding: 13px 13px 11px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-av {
+  width: 46px; height: 46px; flex: 0 0 auto; display: grid; place-items: center;
+  font-family: var(--ws-font-mono); font-weight: 700; font-size: 14px; color: #04110c;
+  background: hsl(var(--agent-avatar-hue, 160) 52% 48%);
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+}
+.ws-cmd-unit-id { flex: 1 1 auto; min-width: 0; }
+.ws-cmd-unit-name { font-size: 15px; font-weight: 700; letter-spacing: 0.4px; text-transform: uppercase; color: #f1fff8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-unit-role { display: flex; align-items: center; gap: 8px; margin-top: 5px; flex-wrap: wrap; }
+.ws-cmd-badge {
+  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase;
+  padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim);
+}
+.ws-cmd-badge.is-keeper { color: var(--ws-keeper); border-color: rgba(232, 181, 75, 0.4); background: rgba(232, 181, 75, 0.08); }
+.ws-cmd-state { display: flex; align-items: center; gap: 6px; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-dim); }
+.ws-cmd-led { width: 7px; height: 7px; border-radius: 50%; background: var(--ws-idle); box-shadow: 0 0 7px var(--ws-idle); }
+.ws-cmd-led.working { background: var(--ws-working); box-shadow: 0 0 8px var(--ws-working); }
+.ws-cmd-led.alert { background: var(--ws-alert); box-shadow: 0 0 8px var(--ws-alert); }
+.ws-cmd-led.idle { background: var(--ws-idle); }
+.ws-cmd-unit-ctl { display: flex; align-items: flex-start; gap: 6px; }
+.ws-cmd-lock { color: var(--ws-keeper); font-size: 13px; line-height: 26px; }
+.ws-cmd-icon-btn {
+  width: 26px; height: 26px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2); color: var(--ws-faction); cursor: pointer; font-size: 14px; transition: 0.15s;
+}
+.ws-cmd-icon-btn.sm { width: 22px; height: 22px; font-size: 12px; }
+.ws-cmd-icon-btn:hover { background: rgba(70, 211, 154, 0.1); border-color: var(--ws-faction-deep); }
+.ws-cmd-icon-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+
+.ws-cmd-unit-rows { padding: 11px 13px; display: flex; flex-direction: column; gap: 8px; }
+.ws-cmd-row { display: flex; justify-content: space-between; align-items: center; }
+.ws-cmd-rk { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-ink-faint); }
+.ws-cmd-rv { font-family: var(--ws-font-mono); font-size: 12px; color: #eafff5; }
+
+.ws-cmd-questlog { margin: 2px 13px 13px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
+.ws-cmd-ql-head { display: flex; justify-content: space-between; align-items: center; padding: 8px 11px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-ql-t { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-dim); }
+.ws-cmd-ql-empty { padding: 13px 11px; text-align: center; font-family: var(--ws-font-mono); font-size: 10.5px; color: var(--ws-ink-faint); letter-spacing: 1px; }
+.ws-cmd-quest { display: flex; align-items: center; gap: 9px; padding: 9px 11px; }
+.ws-cmd-quest + .ws-cmd-quest { border-top: 1px solid var(--ws-line); }
+.ws-cmd-q-glyph { width: 22px; height: 22px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-keeper-deep); color: var(--ws-keeper); font-size: 11px; }
+.ws-cmd-q-name { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eafff5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-q-status { font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
+.ws-cmd-q-status.pending { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); }
+.ws-cmd-q-status.working { color: var(--ws-working); border-color: var(--ws-faction-deep); }
+.ws-cmd-q-status.alert { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
+.ws-cmd-q-status.done { color: var(--ws-ink-faint); }
+.ws-cmd-q-run { width: 28px; height: 28px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-faction-deep); color: var(--ws-faction); background: rgba(70, 211, 154, 0.07); cursor: pointer; transition: 0.15s; }
+.ws-cmd-q-run:hover { background: var(--ws-faction); color: #04110c; }
+.ws-cmd-q-run:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+
+@media (max-width: 1100px) { .ws-cmd-garrison-grid { grid-template-columns: 1fr; } }
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
 }

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -50,3 +50,63 @@
 }
 
 .ws-cmd[hidden] { display: none; }
+
+.ws-cmd .ws-tick {
+  font-family: var(--ws-font-mono); font-size: 10.5px; letter-spacing: 2.5px; text-transform: uppercase; color: var(--ws-ink-faint);
+}
+
+/* ---------- command bar ---------- */
+.ws-cmd-topbar {
+  display: flex; align-items: center; gap: 16px;
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
+  padding: 14px 18px; margin-bottom: 18px;
+  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  box-shadow: var(--ws-glow);
+}
+.ws-cmd-back {
+  align-self: stretch; display: flex; align-items: center; padding: 0 14px; border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer;
+  font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; transition: 0.15s;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 10px 100%, 0 calc(100% - 10px));
+}
+.ws-cmd-back:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-back:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-crest {
+  width: 50px; height: 50px; flex: 0 0 auto; display: grid; place-items: center;
+  border: 1px solid var(--ws-line-bright); color: var(--ws-faction);
+  background: radial-gradient(circle at 50% 30%, rgba(70, 211, 154, 0.18), transparent 70%);
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+}
+.ws-cmd-title { flex: 1 1 auto; min-width: 0; }
+.ws-cmd-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
+.ws-cmd-title .ws-dot { width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg); }
+.ws-cmd-title h2 {
+  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eafff5;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ws-cmd-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
+
+.ws-cmd-readout { display: flex; gap: 10px; flex: 0 0 auto; }
+.ws-cmd-stat {
+  min-width: 84px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
+}
+.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eafff5; line-height: 1; }
+.ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
+
+/* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
+.ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
+.ws-cmd-garrison, .ws-cmd-rail {
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); min-height: 200px;
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
+  box-shadow: var(--ws-glow);
+}
+.ws-cmd-soon {
+  display: grid; place-items: center; min-height: 200px; padding: 24px;
+  font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;
+}
+
+@media (max-width: 900px) {
+  .ws-cmd-layout { grid-template-columns: 1fr; }
+}

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -144,11 +144,147 @@ export class WorkspaceCommandView {
       '</div>' +
       '</header>' +
       '<div class="ws-cmd-layout">' +
-      '<section class="ws-cmd-garrison"><div class="ws-cmd-soon">Garrison arrives in the next update</div></section>' +
+      '<section class="ws-cmd-garrison">' + this.renderGarrison() + '</section>' +
       '<aside class="ws-cmd-rail"><div class="ws-cmd-soon">Intel · orders · comms arrive soon</div></aside>' +
       '</div>';
 
     const back = this.container.querySelector('[data-ws-cmd-detailed]');
     if (back) back.addEventListener('click', () => this.deactivate());
+    this.bindGarrison();
+  }
+
+  // ---------- garrison (agents as unit cards) ----------
+
+  statusTone(statusKey, statusLabel) {
+    const s = (String(statusKey || '') + ' ' + String(statusLabel || '')).toLowerCase();
+    if (/work|run|busy|active|progress/.test(s)) return 'working';
+    if (/error|fail|blocked/.test(s)) return 'alert';
+    return 'idle';
+  }
+
+  taskTone(status) {
+    switch (String(status || '').toLowerCase()) {
+      case 'in_progress': return 'working';
+      case 'failed': case 'cancelled': return 'alert';
+      case 'completed': case 'done': return 'done';
+      default: return 'pending';
+    }
+  }
+
+  unitCardHTML(group) {
+    const page = this.page;
+    const name = String(group.name || 'Agent');
+    const encoded = encodeURIComponent(name);
+    const keeper = !group.isUnassigned && page.isWorkspaceEntryAgent
+      ? page.isWorkspaceEntryAgent(name) : false;
+
+    const avatar = page.getAgentAvatarPresentation
+      ? page.getAgentAvatarPresentation(name)
+      : { initials: name.slice(0, 2).toUpperCase(), style: '' };
+    const status = !group.isUnassigned && page.getAgentRosterStatus
+      ? page.getAgentRosterStatus(name)
+      : { key: 'idle', label: 'Unassigned' };
+    const tone = this.statusTone(status.key, status.label);
+
+    let modelLabel = '';
+    if (!group.isUnassigned && page.getAgentProfile && page.getAgentModelPresentation) {
+      const m = page.getAgentModelPresentation(page.getAgentProfile(name));
+      modelLabel = m && !m.empty ? m.model : '';
+    }
+    let skillCount = 0;
+    if (!group.isUnassigned && page.getAgentSkillSummary) {
+      const sk = page.getAgentSkillSummary(name);
+      skillCount = (sk && sk.count) || 0;
+    }
+
+    const roleBadge = group.isUnassigned
+      ? '<span class="ws-cmd-badge">Unassigned</span>'
+      : (keeper
+          ? '<span class="ws-cmd-badge is-keeper">★ Keeper</span>'
+          : '<span class="ws-cmd-badge">Field Unit</span>');
+
+    const ctl = group.isUnassigned
+      ? ''
+      : (keeper
+          ? '<span class="ws-cmd-lock" title="Entry agent — locked, can\'t be removed">🔒</span>'
+          : '') +
+        '<button type="button" class="ws-cmd-icon-btn" data-cmd-add-task="' + escapeHtml(encoded) +
+        '" title="Add a task for ' + escapeHtml(name) + '" aria-label="Add a task for ' + escapeHtml(name) + '">＋</button>';
+
+    const rows = group.isUnassigned ? '' :
+      '<div class="ws-cmd-unit-rows">' +
+      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Class</span><span class="ws-cmd-rv">' +
+      escapeHtml(modelLabel || '—') + '</span></div>' +
+      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Skills</span><span class="ws-cmd-rv">' +
+      skillCount + '</span></div>' +
+      '</div>';
+
+    return (
+      '<article class="ws-cmd-unit' + (keeper ? ' is-keeper' : '') + '">' +
+      '<div class="ws-cmd-unit-top">' +
+      '<span class="ws-cmd-av" style="' + escapeHtml(avatar.style || '') + '">' + escapeHtml(avatar.initials) + '</span>' +
+      '<div class="ws-cmd-unit-id"><div class="ws-cmd-unit-name">' + escapeHtml(name) + '</div>' +
+      '<div class="ws-cmd-unit-role">' + roleBadge +
+      '<span class="ws-cmd-state"><span class="ws-cmd-led ' + tone + '"></span>' + escapeHtml(status.label || 'Idle') + '</span>' +
+      '</div></div>' +
+      '<div class="ws-cmd-unit-ctl">' + ctl + '</div>' +
+      '</div>' +
+      rows +
+      this.questLogHTML(group, encoded) +
+      '</article>'
+    );
+  }
+
+  questLogHTML(group, encoded) {
+    const tasks = Array.isArray(group.tasks) ? group.tasks : [];
+    const add = group.isUnassigned ? '' :
+      '<button type="button" class="ws-cmd-icon-btn sm" data-cmd-add-task="' + escapeHtml(encoded) +
+      '" aria-label="Add task">＋</button>';
+    const head = '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Quest Log · ' + tasks.length + '</span>' + add + '</div>';
+    if (!tasks.length) {
+      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">— no orders issued —</div></div>';
+    }
+    const items = tasks.map((t) => {
+      const label = String(t.description || t.name || t.title || 'Task');
+      const tone = this.taskTone(t.status);
+      const statusText = String(t.status || 'pending').replace('_', ' ');
+      return (
+        '<div class="ws-cmd-quest">' +
+        '<span class="ws-cmd-q-glyph">✦</span>' +
+        '<span class="ws-cmd-q-name">' + escapeHtml(label) + '</span>' +
+        '<span class="ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
+        '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' + escapeHtml(String(t.id || '')) +
+        '" title="Deploy" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
+        '</div>'
+      );
+    }).join('');
+    return '<div class="ws-cmd-questlog">' + head + items + '</div>';
+  }
+
+  renderGarrison() {
+    const page = this.page;
+    let groups = [];
+    try { groups = page.buildAgentGroups() || []; } catch (err) { groups = []; }
+    const units = groups.filter((g) => g && (g.isWorkspaceAgent || (g.isUnassigned && (g.tasks || []).length)));
+    if (!units.length) {
+      return '<div class="ws-cmd-soon">No agents garrisoned yet.</div>';
+    }
+    return '<div class="ws-cmd-garrison-grid">' + units.map((g) => this.unitCardHTML(g)).join('') + '</div>';
+  }
+
+  bindGarrison() {
+    const root = this.container && this.container.querySelector('.ws-cmd-garrison');
+    if (!root) return;
+    root.addEventListener('click', (event) => {
+      const addBtn = event.target.closest('[data-cmd-add-task]');
+      if (addBtn && window.workspaceDetail && window.workspaceDetail.showAddTaskModalForAgent) {
+        window.workspaceDetail.showAddTaskModalForAgent(addBtn.getAttribute('data-cmd-add-task'));
+        return;
+      }
+      const runBtn = event.target.closest('[data-cmd-run-task]');
+      if (runBtn && window.workspaceDetail && window.workspaceDetail.executeTask) {
+        window.workspaceDetail.executeTask(runBtn.getAttribute('data-cmd-run-task'));
+      }
+    });
   }
 }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -6,9 +6,22 @@
  * like buildAgentGroups / isWorkspaceEntryAgent) and renders into
  * #workspaceCommandView — no backend, no rewrite of the detailed page.
  *
- * Phase 0.0 = inert scaffolding. mount()/unmount() are safe no-ops; the command
- * bar, garrison, quest logs, and right rail land in Phase 1-3.
+ * Phase 1 = command bar (name, ops mode, stats) + the Detailed/Command toggle
+ * with persistence. Garrison, quest logs, and the right rail land in Phase 2-3.
  */
+const STORAGE_KEY = 'oriWorkspaceDetailView';
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+
+function statBox(value, label) {
+  return '<div class="ws-cmd-stat"><div class="ws-v">' + escapeHtml(value) +
+    '</div><div class="ws-l">' + escapeHtml(label) + '</div></div>';
+}
+
 export class WorkspaceCommandView {
   /**
    * @param {object} page - the live WorkspaceDetailPage instance (window.workspaceDetail).
@@ -17,17 +30,125 @@ export class WorkspaceCommandView {
     this.page = page || null;
     this.container = document.getElementById('workspaceCommandView');
     this.detailedView = document.getElementById('workspace-detail-view');
+    this.toggleBtn = document.getElementById('workspace-command-toggle');
     this.active = false;
+    this.setup();
   }
 
-  /** Render/refresh the command view into its container. Inert until Phase 1. */
-  mount() {
-    if (!this.container) return;
-    // Intentionally renders nothing yet.
+  setup() {
+    if (!this.container || !this.toggleBtn) return;
+    this.toggleBtn.hidden = false; // reveal (Phase 1)
+    this.toggleBtn.addEventListener('click', () => this.toggle());
+    let pref = '';
+    try { pref = localStorage.getItem(STORAGE_KEY) || ''; } catch (err) { pref = ''; }
+    if (pref === 'command') this.activate();
+    else this.deactivate();
   }
 
-  /** Tear down the command view. Inert until Phase 1. */
-  unmount() {
+  persist(view) {
+    try { localStorage.setItem(STORAGE_KEY, view); } catch (err) { /* storage may be unavailable */ }
+  }
+
+  toggle() {
+    if (this.active) this.deactivate();
+    else this.activate();
+  }
+
+  activate() {
+    this.active = true;
+    this.render();
+    if (this.container) this.container.hidden = false;
+    if (this.detailedView) this.detailedView.hidden = true;
+    this.updateToggle();
+    this.persist('command');
+  }
+
+  deactivate() {
+    this.active = false;
+    if (this.container) this.container.hidden = true;
+    if (this.detailedView) this.detailedView.hidden = false;
+    this.updateToggle();
+    this.persist('detailed');
+  }
+
+  updateToggle() {
+    if (!this.toggleBtn) return;
+    this.toggleBtn.setAttribute('aria-pressed', this.active ? 'true' : 'false');
+    this.toggleBtn.classList.toggle('modern-btn-primary', this.active);
+    this.toggleBtn.classList.toggle('modern-btn-secondary', !this.active);
+  }
+
+  /** Re-render if active — called by the page after its data loads/refreshes. */
+  refresh() {
+    if (this.active) this.render();
+  }
+
+  computeStats() {
+    const page = this.page || {};
+    const ws = page.workspace || {};
+    let agents = 0;
+    try {
+      agents = (page.buildAgentGroups() || []).filter(
+        (g) => g.isWorkspaceAgent && !g.isUnassigned
+      ).length;
+    } catch (err) {
+      agents = Array.isArray(ws.agent_instances) ? ws.agent_instances.length : 0;
+    }
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    const openTasks = tasks.filter((t) => {
+      const s = String((t && t.status) || '').toLowerCase();
+      return s === 'pending' || s === 'in_progress' || s === 'assigned';
+    }).length;
+    const mcp = Array.isArray(ws.mcp_bindings) ? ws.mcp_bindings.length : 0;
+    const skills = Array.isArray(ws.skill_bindings) ? ws.skill_bindings.length : 0;
+    return { agents, openTasks, mcp, skills };
+  }
+
+  opsModeLabel() {
+    const ws = (this.page && this.page.workspace) || {};
+    const settings = ws.workspace_settings || {};
+    const mode = String((settings.workflow && settings.workflow.mode) || '').toLowerCase();
+    switch (mode) {
+      case 'guided': return 'Guided';
+      case 'direct': return 'Direct';
+      case 'plan_then_execute': return 'Autonomous';
+      case '': return '';
+      default: return mode.charAt(0).toUpperCase() + mode.slice(1);
+    }
+  }
+
+  render() {
     if (!this.container) return;
+    const ws = (this.page && this.page.workspace) || {};
+    const name = String(ws.name || 'Workspace');
+    const mode = this.opsModeLabel();
+    const stats = this.computeStats();
+
+    this.container.innerHTML =
+      '<header class="ws-cmd-topbar">' +
+      '<button type="button" class="ws-cmd-back" data-ws-cmd-detailed aria-label="Back to detailed view">◂ Detailed</button>' +
+      '<div class="ws-cmd-crest">' +
+      '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">' +
+      '<path d="M3 21V9l9-6 9 6v12"/><path d="M9 21v-6h6v6"/><path d="M3 21h18"/></svg>' +
+      '</div>' +
+      '<div class="ws-cmd-title">' +
+      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">Outpost · Command</span></div>' +
+      '<h2>' + escapeHtml(name) + '</h2>' +
+      (mode ? '<div class="ws-sub">Ops mode · ' + escapeHtml(mode) + '</div>' : '') +
+      '</div>' +
+      '<div class="ws-cmd-readout">' +
+      statBox(stats.agents, 'Agents') +
+      statBox(stats.openTasks, 'Open Tasks') +
+      statBox(stats.mcp, 'Tools · MCP') +
+      statBox(stats.skills, 'Skills') +
+      '</div>' +
+      '</header>' +
+      '<div class="ws-cmd-layout">' +
+      '<section class="ws-cmd-garrison"><div class="ws-cmd-soon">Garrison arrives in the next update</div></section>' +
+      '<aside class="ws-cmd-rail"><div class="ws-cmd-soon">Intel · orders · comms arrive soon</div></aside>' +
+      '</div>';
+
+    const back = this.container.querySelector('[data-ws-cmd-detailed]');
+    if (back) back.addEventListener('click', () => this.deactivate());
   }
 }

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceCommandView } from './workspace-command.js';
+
+// The constructor only reads the DOM (getElementById) and returns early from
+// setup() when there's no container — a null-returning stub is enough to build
+// an instance whose pure format helpers we can exercise.
+globalThis.document = { getElementById: () => null };
+const view = new WorkspaceCommandView(null);
+
+test('statusTone maps an agent status to a visual tone', () => {
+  assert.equal(view.statusTone('working', ''), 'working');
+  assert.equal(view.statusTone('', 'running a task'), 'working');
+  assert.equal(view.statusTone('busy', ''), 'working');
+  assert.equal(view.statusTone('error', ''), 'alert');
+  assert.equal(view.statusTone('failed', ''), 'alert');
+  assert.equal(view.statusTone('idle', ''), 'idle');
+  assert.equal(view.statusTone('', ''), 'idle');
+});
+
+test('taskTone maps a task status to a visual tone', () => {
+  assert.equal(view.taskTone('pending'), 'pending');
+  assert.equal(view.taskTone('in_progress'), 'working');
+  assert.equal(view.taskTone('completed'), 'done');
+  assert.equal(view.taskTone('done'), 'done');
+  assert.equal(view.taskTone('failed'), 'alert');
+  assert.equal(view.taskTone('cancelled'), 'alert');
+  assert.equal(view.taskTone('anything-else'), 'pending');
+});
+
+test('opsModeLabel maps workflow modes to friendly labels', () => {
+  const withMode = (mode) => {
+    view.page = { workspace: { workspace_settings: { workflow: { mode } } } };
+    return view.opsModeLabel();
+  };
+  assert.equal(withMode('guided'), 'Guided');
+  assert.equal(withMode('direct'), 'Direct');
+  assert.equal(withMode('plan_then_execute'), 'Autonomous');
+  assert.equal(withMode(''), '');
+});

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -2140,6 +2140,8 @@ export class WorkspaceDetailPage {
       this.refreshHomeAssistantQuickPrompts();
       this.renderWorkspaceHealth();
       await this.membersPanel.syncWorkspace(this.workspace);
+      // Keep the opt-in Command view in sync once data is loaded/refreshed.
+      window.workspaceCommand?.refresh();
     } catch (error) {
       console.error('Failed to load workspace:', error);
       if (window.Toast) window.Toast.error('Failed to load workspace');


### PR DESCRIPTION
## What

Second seam-PR (**PR B**, Groups 1.0 + 2.0) of the Workspace Command view epic. Turns
the inert scaffolding from #130 into a **usable opt-in tactical view** on the workspace
detail page: a command bar and a garrison of agent unit cards, rendered from the data
the page already loads. The detailed page stays untouched behind a Detailed ⇄ Command
toggle. No backend, no rewrite of the ~25k-line detailed page.

## 1.0 — command bar + toggle

- Command bar from the live `WorkspaceDetailPage` instance: outpost name, ops-mode chip
  (from `workspace_settings`), and a stat readout (agents / open tasks / tools·MCP / skills).
- **Detailed ⇄ Command toggle**: the header "Command" button + a "◂ Detailed" control
  hide/show `#workspaceCommandView` vs `#workspace-detail-view`. Choice persists in
  localStorage (`oriWorkspaceDetailView`) and is honored on load (so arriving from the
  Map's Open Workspace respects the preference). The page calls
  `window.workspaceCommand?.refresh()` after its post-load render to stay in sync.

## 2.0 — garrison + quest logs

- Unit cards from `buildAgentGroups()`: hex avatar (reusing the page's avatar hue),
  name, class/model, skills count, and a roster status LED. The entry agent renders as
  the **locked Keeper** (`isWorkspaceEntryAgent` + a lock, matching the shipped
  non-deletable rule); others are Field Units; unassigned tasks get their own card.
- Per-agent **quest log**: tasks with status chips + a Deploy (run) button. Add-task
  and run reuse the existing detail handlers (`showAddTaskModalForAgent` / `executeTask`)
  via event delegation — no duplicated logic.
- Pure helpers (`statusTone` / `taskTone` / `opsModeLabel`) covered by
  `workspace-command.test.js` (node:test).

## Verification

Smoke server: the toggle activates the command bar with correct name/ops-mode/stats and
persists; with a roster + tasks, the garrison shows unit cards, the Keeper badge + lock,
and quest logs with correct statuses; add/run controls wired. No console errors; 3 unit
tests pass; ESLint clean; **no `ui-refresh.css` edits, no `!important`**; the detailed
page is unchanged behind the toggle.

## Not in this PR

The right rail — Intel (notes) / Standing Orders (schedules) / Comms (sessions) / Supply
(linked folders) — lands in PR C (3.0); polish/a11y in PR D (4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)