### PR TITLE
feat(workspace-command): command view right rail

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -97,11 +97,45 @@
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
 .ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
-.ws-cmd-garrison, .ws-cmd-rail {
+.ws-cmd-garrison {
   border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); min-height: 200px;
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
   box-shadow: var(--ws-glow);
 }
+.ws-cmd-rail { display: flex; flex-direction: column; gap: 16px; }
+
+/* rail panels */
+.ws-cmd-panel {
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213);
+  clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+  box-shadow: var(--ws-glow);
+}
+.ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-panel-title { display: flex; align-items: center; gap: 9px; }
+.ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #dff5ec; }
+.ws-cmd-panel-count { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-faint); }
+.ws-cmd-panel-more {
+  width: 26px; height: 24px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; transition: 0.15s;
+}
+.ws-cmd-panel-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-panel-more:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-panel-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
+.ws-cmd-rail-empty { padding: 16px 6px; text-align: center; font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-rail-item {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 2px; width: 100%; text-align: left;
+  padding: 8px 9px; border: 1px solid transparent; background: none; color: var(--ws-ink); cursor: pointer; text-decoration: none; transition: 0.13s;
+}
+.ws-cmd-rail-item.is-static { cursor: default; }
+.ws-cmd-rail-item:hover:not(.is-static) { border-color: var(--ws-line-bright); background: var(--ws-bg-2); }
+.ws-cmd-rail-item:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
+.ws-cmd-rail-t { font-size: 13px; color: #eafff5; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-rail-m { font-family: var(--ws-font-mono); font-size: 9.5px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-rail-more {
+  margin-top: 4px; padding: 7px; border: 1px dashed var(--ws-line-bright); background: none; color: var(--ws-ink-dim); cursor: pointer;
+  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-rail-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
 .ws-cmd-soon {
   display: grid; place-items: center; min-height: 200px; padding: 24px;
   font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -145,12 +145,13 @@ export class WorkspaceCommandView {
       '</header>' +
       '<div class="ws-cmd-layout">' +
       '<section class="ws-cmd-garrison">' + this.renderGarrison() + '</section>' +
-      '<aside class="ws-cmd-rail"><div class="ws-cmd-soon">Intel · orders · comms arrive soon</div></aside>' +
+      '<aside class="ws-cmd-rail">' + this.renderRail() + '</aside>' +
       '</div>';
 
     const back = this.container.querySelector('[data-ws-cmd-detailed]');
     if (back) back.addEventListener('click', () => this.deactivate());
     this.bindGarrison();
+    this.bindRail();
   }
 
   // ---------- garrison (agents as unit cards) ----------
@@ -284,6 +285,96 @@ export class WorkspaceCommandView {
       const runBtn = event.target.closest('[data-cmd-run-task]');
       if (runBtn && window.workspaceDetail && window.workspaceDetail.executeTask) {
         window.workspaceDetail.executeTask(runBtn.getAttribute('data-cmd-run-task'));
+      }
+    });
+  }
+
+  // ---------- right rail ----------
+
+  railPanelHTML(ix, title, items, count, emptyText) {
+    const body = items.length
+      ? items.join('')
+      : '<div class="ws-cmd-rail-empty">' + escapeHtml(emptyText) + '</div>';
+    return (
+      '<section class="ws-cmd-panel">' +
+      '<div class="ws-cmd-panel-head">' +
+      '<div class="ws-cmd-panel-title"><span class="ws-cmd-ix">' + escapeHtml(ix) + '</span>' +
+      '<h4>' + escapeHtml(title) + '</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<button type="button" class="ws-cmd-panel-more" data-ws-cmd-detailed title="Manage in detailed view" aria-label="Manage ' +
+      escapeHtml(title) + ' in the detailed view">▸</button>' +
+      '</div>' +
+      '<div class="ws-cmd-panel-body">' + body + '</div>' +
+      '</section>'
+    );
+  }
+
+  railItems(list, labelOf, opts) {
+    const arr = Array.isArray(list) ? list : [];
+    const shown = arr.slice(0, 5);
+    const attr = opts || {};
+    const items = shown.map((it) => {
+      const label = escapeHtml(labelOf(it));
+      const meta = attr.metaOf ? escapeHtml(attr.metaOf(it)) : '';
+      const inner = '<span class="ws-cmd-rail-t">' + label + '</span>' +
+        (meta ? '<span class="ws-cmd-rail-m">' + meta + '</span>' : '');
+      if (attr.href) {
+        return '<a class="ws-cmd-rail-item" href="' + escapeHtml(attr.href(it)) + '">' + inner + '</a>';
+      }
+      if (attr.action) {
+        return '<button type="button" class="ws-cmd-rail-item" ' + attr.action(it) + '>' + inner + '</button>';
+      }
+      return '<div class="ws-cmd-rail-item is-static">' + inner + '</div>';
+    });
+    if (arr.length > shown.length) {
+      items.push('<button type="button" class="ws-cmd-rail-more" data-ws-cmd-detailed>+ ' +
+        (arr.length - shown.length) + ' more · detailed view</button>');
+    }
+    return items;
+  }
+
+  renderRail() {
+    const page = this.page || {};
+    const notes = Array.isArray(page.notes) ? page.notes : [];
+    const schedules = Array.isArray(page.schedules) ? page.schedules : [];
+    const sessions = Array.isArray(page.sessions) ? page.sessions : [];
+    const dirs = Array.isArray(page.directories) ? page.directories : [];
+
+    const intel = this.railItems(notes, (n) => n.name || n.title || 'Untitled Note', {
+      href: (n) => '/notes/' + encodeURIComponent(n.id || '')
+    });
+    const orders = this.railItems(schedules, (s) => s.name || s.task_description || 'Unnamed Schedule', {
+      action: (s) => 'data-cmd-schedule="' + escapeHtml(String(s.id || '')) + '"'
+    });
+    const comms = this.railItems(sessions, (s) => s.title || s.name || 'Untitled Session', {
+      action: (s) => 'data-cmd-session="' + escapeHtml(String(s.id || '')) + '"',
+      metaOf: (s) => s.agent_name || ''
+    });
+    const supply = this.railItems(dirs, (d) => d.title || d.name || d.path || 'Unnamed Directory', {
+      metaOf: (d) => d.path || ''
+    });
+
+    return (
+      this.railPanelHTML('INT', 'Intel', intel, notes.length, 'No intel logged yet.') +
+      this.railPanelHTML('ORD', 'Standing Orders', orders, schedules.length, 'No scheduled orders.') +
+      this.railPanelHTML('COM', 'Comms', comms, sessions.length, 'No active sessions.') +
+      this.railPanelHTML('SUP', 'Supply Lines', supply, dirs.length, 'No linked folders.')
+    );
+  }
+
+  bindRail() {
+    const root = this.container && this.container.querySelector('.ws-cmd-rail');
+    if (!root) return;
+    root.addEventListener('click', (event) => {
+      const detailedBtn = event.target.closest('[data-ws-cmd-detailed]');
+      if (detailedBtn) { this.deactivate(); return; }
+      const sess = event.target.closest('[data-cmd-session]');
+      if (sess && window.workspaceDetail && window.workspaceDetail.openSession) {
+        window.workspaceDetail.openSession(sess.getAttribute('data-cmd-session'));
+        return;
+      }
+      const sched = event.target.closest('[data-cmd-schedule]');
+      if (sched && window.workspaceDetail && window.workspaceDetail.openSchedule) {
+        window.workspaceDetail.openSchedule(sched.getAttribute('data-cmd-schedule'));
       }
     });
   }


### PR DESCRIPTION
## What

Third seam-PR (**PR C**, Group 3.0) of the Workspace Command view epic. Adds the right
rail to the opt-in command view, rendered from the data the detail page already loads.
Pure frontend, no backend.

## Changes (2 files, +127 / −2)

Four rail panels:
- **Intel** = notes (link to `/notes/{id}`)
- **Standing Orders** = schedules (reuse `openSchedule`)
- **Comms** = sessions (reuse `openSession`, with agent meta)
- **Supply Lines** = linked folders (with path)

Each panel shows a count and up to five items, an empty state, a `+N more · detailed
view` overflow, and a per-panel `▸` that switches back to the detailed view for deep
management. Interactions reuse the existing detail handlers via event delegation.

## Verification

Smoke server with injected notes/schedules/sessions/folders: all four panels render with
correct counts, items, links, and empty states; the per-panel Detailed control works; no
console errors. 3 unit tests pass; ESLint clean; **no `ui-refresh.css` edits, no
`!important`**; the detailed page is unchanged behind the toggle.

## Not in this PR

Motion + reduced-motion, accessibility (focusable labeled controls, keyboard nav), and
re-render-on-refresh coverage land in PR D (Group 4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)