### PR TITLE
feat(workspace-command): polish, accessibility, and tests

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -206,3 +206,12 @@
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
 }
+
+/* Auto-playing motion is opt-in via the OS "reduce motion" preference. */
+@keyframes ws-cmd-rise { from { opacity: 0; transform: translateY(8px); } }
+@keyframes ws-cmd-pulse { 50% { opacity: 0.35; } }
+@media (prefers-reduced-motion: no-preference) {
+  .ws-cmd-topbar { animation: ws-cmd-rise 0.35s ease both; }
+  .ws-cmd-garrison, .ws-cmd-rail { animation: ws-cmd-rise 0.4s ease both; animation-delay: 0.05s; }
+  .ws-cmd-led.working { animation: ws-cmd-pulse 1.5s ease-in-out infinite; }
+}

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -38,3 +38,16 @@ test('opsModeLabel maps workflow modes to friendly labels', () => {
   assert.equal(withMode('plan_then_execute'), 'Autonomous');
   assert.equal(withMode(''), '');
 });
+
+test('computeStats reads counts from the page instance', () => {
+  view.page = {
+    buildAgentGroups: () => [
+      { isWorkspaceAgent: true, isUnassigned: false },
+      { isWorkspaceAgent: true, isUnassigned: false },
+      { isWorkspaceAgent: false, isUnassigned: true } // unassigned bucket, not an agent
+    ],
+    tasks: [{ status: 'pending' }, { status: 'in_progress' }, { status: 'completed' }],
+    workspace: { mcp_bindings: [{}, {}], skill_bindings: [{}] }
+  };
+  assert.deepEqual(view.computeStats(), { agents: 2, openTasks: 2, mcp: 2, skills: 1 });
+});

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -11,8 +11,8 @@
 
     <div class="main-content">
       <div class="container-fluid py-4">
-        <!-- Command view mount point — inert scaffolding (Phase 0.0); populated by workspace-command.js in Phase 1. -->
-        <div id="workspaceCommandView" class="ws-cmd" hidden></div>
+        <!-- Command view mount point — populated by workspace-command.js when the Command view is active. -->
+        <div id="workspaceCommandView" class="ws-cmd" role="region" aria-label="Workspace command view" hidden></div>
         <!-- Workspace Detail View -->
         <div id="workspace-detail-view">
           <!-- Header Card -->


### PR DESCRIPTION
## What

Final seam-PR (**PR D**, Group 4.0) of the Workspace Command view epic — the production
polish pass. Frontend + a test.

## Changes (3 files, +24 / −2)

- **Motion** (`workspace-command.css`): a subtle load-in for the command bar / garrison /
  rail and the working-status LED pulse, all gated behind
  `prefers-reduced-motion: no-preference` (reduce motion → none). No `!important`.
- **Accessibility**: the command view container is a labeled region (`role="region"`,
  `aria-label`); interactive controls are focusable labeled buttons/links with visible
  focus outlines; status is text, not color alone; the toggle exposes `aria-pressed`.
- **Tests** (`workspace-command.test.js`): a `computeStats` case alongside the existing
  tone/label tests (4 pass).

## Verification

Smoke + DOM checks: container `role="region"` + label, 9 focusable controls (first
labeled "Back to detailed view"), reduced-motion keyframes scoped to `no-preference`,
`aria-pressed` reflects toggle state, no console errors. 4 unit tests pass; ESLint +
`go vet` clean.

## Epic complete

Scaffolding (#130) → command bar + garrison (#131) → right rail (#132) → this
polish/a11y pass. The opt-in tactical Command view ships end to end on the workspace
detail page, with the detailed view untouched behind the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)