### PR TITLE
feat(workspace-construct): tactical reskin of the create-workspace modal

### DIFF
--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -1,0 +1,135 @@
+/*
+ * workspace-construct.css — tactical reskin of the create-workspace modal.
+ *
+ * Everything is scoped under `.workspace-create-modal` (the #addFolderModal root)
+ * so it cannot leak to other modals or pages. A dark tactical surface that mirrors
+ * the Map's `.ws-map` / Command view's `.ws-cmd` visual system; the self-hosted
+ * @font-face declarations are already provided globally by workspace-map.css.
+ *
+ * Styling only — the form logic, template picker, submission, and intake are
+ * untouched. No ui-refresh.css edits, no `!important`.
+ *
+ * Approach: the template's inline styles use app theme vars (var(--bg-primary),
+ * var(--text-secondary), ...), so we redefine those vars locally to re-theme the
+ * chrome + labels without editing the template, and add scoped rules (higher
+ * specificity than the base .modern-* classes) for inputs / buttons / cards.
+ */
+
+.workspace-create-modal {
+  /* tactical tokens */
+  --wc-bg: #070b0c;
+  --wc-bg-2: #0b1113;
+  --wc-panel: #0e1618;
+  --wc-panel-2: #101e1f;
+  --wc-line: #1c2e2c;
+  --wc-line-bright: #28413c;
+  --wc-ink: #cfe8df;
+  --wc-ink-dim: #7f998f;
+  --wc-ink-faint: #4d655d;
+  --wc-faction: #46d39a;
+  --wc-faction-deep: #0f3b30;
+  --wc-keeper: #e8b54b;
+  --wc-idle: #4ec5e6;
+  --wc-alert: #e2654d;
+  --wc-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+  --wc-font-display: 'Chakra Petch', system-ui, sans-serif;
+  --wc-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* redefine app theme vars locally → the modal's inline var() usages go tactical */
+  --bg-primary: var(--wc-panel);
+  --text-primary: #eafff5;
+  --text-secondary: var(--wc-ink-dim);
+  --border-color: var(--wc-line);
+
+  font-family: var(--wc-font-display);
+}
+
+/* ---------- chrome ---------- */
+.workspace-create-modal .modal-content {
+  color: var(--wc-ink);
+  box-shadow: var(--wc-glow);
+  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+}
+.workspace-create-modal .modal-header { background: linear-gradient(180deg, var(--wc-panel-2), var(--wc-panel)); }
+.workspace-create-modal .modal-title {
+  font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; color: #eafff5;
+}
+.workspace-create-modal .btn-close { filter: invert(1) grayscale(1) brightness(1.4); opacity: 0.7; }
+.workspace-create-modal .btn-close:hover { opacity: 1; }
+.workspace-create-modal .modal-footer { background: linear-gradient(0deg, var(--wc-panel-2), var(--wc-panel)); }
+
+/* kicker line under the title area */
+.workspace-create-modal .modal-title::after {
+  content: 'Construct'; display: inline-block; margin-left: 10px;
+  font-family: var(--wc-font-mono); font-size: 9px; letter-spacing: 2px; color: var(--wc-faction);
+  border: 1px solid var(--wc-faction-deep); padding: 2px 6px; vertical-align: middle;
+}
+
+/* ---------- inputs ---------- */
+.workspace-create-modal .modern-input {
+  background: var(--wc-bg-2); border: 1px solid var(--wc-line-bright); color: var(--wc-ink);
+  font-family: var(--wc-font-mono);
+}
+.workspace-create-modal .modern-input::placeholder { color: var(--wc-ink-faint); }
+.workspace-create-modal .modern-input:focus {
+  border-color: var(--wc-faction-deep); box-shadow: 0 0 0 1px var(--wc-faction-deep); outline: none;
+}
+.workspace-create-modal select.modern-input option { background: var(--wc-panel); color: var(--wc-ink); }
+
+/* ---------- buttons ---------- */
+.workspace-create-modal .modern-btn-primary {
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.18), rgba(70, 211, 154, 0.05));
+  border: 1px solid var(--wc-faction-deep); color: var(--wc-faction);
+  font-family: var(--wc-font-display); letter-spacing: 1px; text-transform: uppercase; font-weight: 700;
+}
+.workspace-create-modal .modern-btn-primary:hover { background: var(--wc-faction); color: #04110c; }
+.workspace-create-modal .modern-btn-secondary {
+  background: var(--wc-bg-2); border: 1px solid var(--wc-line-bright); color: var(--wc-ink-dim);
+}
+.workspace-create-modal .modern-btn-secondary:hover { color: var(--wc-faction); border-color: var(--wc-faction-deep); }
+.workspace-create-modal .modern-btn:focus-visible { outline: 2px solid var(--wc-faction); outline-offset: 2px; }
+
+/* ---------- setup / advanced cards ---------- */
+.workspace-create-modal .workspace-setup-card,
+.workspace-create-modal .workspace-advanced-details {
+  background: rgba(0, 0, 0, 0.22); border: 1px solid var(--wc-line);
+}
+.workspace-create-modal .workspace-setup-title,
+.workspace-create-modal .workspace-advanced-summary-title { color: #eafff5; }
+.workspace-create-modal .workspace-setup-help,
+.workspace-create-modal .workspace-advanced-summary-hint { color: var(--wc-ink-faint); }
+.workspace-create-modal .workspace-template-list-heading {
+  font-family: var(--wc-font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--wc-ink-faint);
+}
+
+/* ---------- template blueprint cards ---------- */
+.workspace-create-modal .workspace-template-card,
+.workspace-create-modal .workspace-template-row {
+  border: 1px solid var(--wc-line); background: var(--wc-panel-2); color: var(--wc-ink);
+  clip-path: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+.workspace-create-modal .workspace-template-card:hover,
+.workspace-create-modal .workspace-template-row:hover { border-color: var(--wc-line-bright); transform: translateY(-2px); }
+.workspace-create-modal .workspace-template-card.is-selected,
+.workspace-create-modal .workspace-template-row.is-selected {
+  border-color: var(--wc-faction-deep); background: rgba(70, 211, 154, 0.08);
+}
+.workspace-create-modal .workspace-template-card:focus-visible,
+.workspace-create-modal .workspace-template-row:focus-visible { outline: 2px solid var(--wc-faction); outline-offset: 2px; }
+.workspace-create-modal .workspace-template-card-icon { color: var(--wc-faction); }
+.workspace-create-modal .workspace-template-card-label {
+  color: #f1fff8; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase;
+}
+.workspace-create-modal .workspace-template-card-desc { color: var(--wc-ink-faint); }
+
+/* color picker: keep the swatch colors, tactical active ring */
+.workspace-create-modal .folder-color-btn.active { box-shadow: 0 0 0 2px var(--wc-faction); }
+
+/* honor the OS reduce-motion preference (drop the hover lift/transition) */
+@media (prefers-reduced-motion: reduce) {
+  .workspace-create-modal .workspace-template-card,
+  .workspace-create-modal .workspace-template-row { transition: none; }
+  .workspace-create-modal .workspace-template-card:hover,
+  .workspace-create-modal .workspace-template-row:hover { transform: none; }
+}

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -59,6 +59,7 @@
   <link href="/css/workspace-hub.css" rel="stylesheet">
   <link href="/css/workspace-map.css" rel="stylesheet">
   <link href="/css/workspace-command.css" rel="stylesheet">
+  <link href="/css/workspace-construct.css" rel="stylesheet">
   <link href="/css/settings.css" rel="stylesheet">
   <link href="/css/ui-refresh.css" rel="stylesheet">
   <link href="/css/tag-input.css" rel="stylesheet">


### PR DESCRIPTION
## What

Give the create-workspace modal (`#addFolderModal`) the command-center look, matching
the Map and Command view — from **every** entry point (user-chosen global restyle).
**Styling only:** the template picker, form logic, submission, and intake are untouched,
and the vocabulary stays real (Create Workspace / Template / Workspace name). Closes the
last "later phase" of the tactical-UI initiative.

## Changes (2 files, +136)

- **`static/css/workspace-construct.css`** *(new)* — everything scoped under
  `.workspace-create-modal`. It re-themes the modal's inline
  `var(--bg-primary)`/`var(--text-secondary)`/… usages by **redefining those app theme
  vars locally** (so no template edits are needed), and adds scoped tactical rules
  (higher specificity than the base `.modern-*` classes) for the chrome, inputs, buttons,
  and — the centerpiece — the template cards as clipped **blueprint cards** with hover +
  selected states. A "CONSTRUCT" kicker chip on the title; faction-green Create button;
  focus-visible outlines; hover lift gated behind `prefers-reduced-motion`. Fonts reused
  from `workspace-map.css`. **No `ui-refresh.css` edits, no `!important`.**
- **`layout/head.tmpl`** — link the new stylesheet.

## Verification

Smoke server: the modal renders fully tactical (8 blueprint cards, tactical
inputs/buttons, CONSTRUCT chip, faction Create button); template selection still moves
`is-selected` + `aria-checked`; the name input accepts text; create stays enabled; cards
are keyboard-focusable (`role="radio"`) with focus outlines; no console errors. Scoped so
nothing leaks outside the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)