### PR TITLE
feat(workspace-command): in-place manager modals for readout stats

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -90,8 +90,11 @@
 .ws-cmd-readout { display: flex; gap: 10px; flex: 0 0 auto; }
 .ws-cmd-stat {
   min-width: 84px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
+  color: inherit; font: inherit; cursor: pointer; transition: 0.15s;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
+.ws-cmd-stat:hover { border-color: var(--ws-line-bright); background: rgba(70, 211, 154, 0.06); }
+.ws-cmd-stat:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eafff5; line-height: 1; }
 .ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
 
@@ -110,6 +113,7 @@
   clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
   box-shadow: var(--ws-glow);
 }
+.ws-cmd-panel.is-managing { border-color: var(--ws-line-bright); background: linear-gradient(180deg, #102022, #0b1213); }
 .ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
 .ws-cmd-panel-title { display: flex; align-items: center; gap: 9px; }
 .ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #dff5ec; }
@@ -121,6 +125,13 @@
 .ws-cmd-panel-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
 .ws-cmd-panel-more:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-panel-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
+.ws-cmd-panel-actions { padding: 2px 0 8px; border-bottom: 1px solid var(--ws-line); margin-bottom: 5px; }
+.ws-cmd-panel-action {
+  width: 100%; padding: 8px 9px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction); cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-panel-action:hover { background: rgba(70, 211, 154, 0.14); border-color: var(--ws-faction); }
+.ws-cmd-panel-action:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-rail-empty { padding: 16px 6px; text-align: center; font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
 .ws-cmd-rail-item {
   display: flex; flex-direction: column; align-items: flex-start; gap: 2px; width: 100%; text-align: left;
@@ -202,6 +213,75 @@
 .ws-cmd-q-run:hover { background: var(--ws-faction); color: #04110c; }
 .ws-cmd-q-run:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 
+/* ---------- stat manager modal (agents / tasks / mcp / skills) ---------- */
+/* Lives inside the .ws-cmd container so it inherits the tactical tokens, but is
+   position:fixed so it overlays the viewport regardless of scroll position. */
+.ws-cmd-modal {
+  position: fixed; inset: 0; z-index: 1050; display: flex; align-items: center; justify-content: center; padding: 24px;
+}
+.ws-cmd-modal[hidden] { display: none; }
+.ws-cmd-modal-backdrop { position: absolute; inset: 0; background: rgba(3, 7, 8, 0.72); }
+.ws-cmd-modal-panel {
+  position: relative; z-index: 1; width: 100%; max-width: 560px; max-height: 82vh; display: flex; flex-direction: column;
+  border: 1px solid var(--ws-line-bright); background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
+  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  box-shadow: var(--ws-glow); outline: none;
+}
+.ws-cmd-modal-panel:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-head { display: flex; align-items: center; gap: 12px; padding: 14px 16px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-modal-title { margin: 0; font-size: 15px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: #eafff5; }
+.ws-cmd-modal-count { font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); }
+.ws-cmd-modal-head-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.ws-cmd-modal-add {
+  padding: 7px 12px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.09); color: var(--ws-faction);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
+}
+.ws-cmd-modal-add:hover { background: rgba(70, 211, 154, 0.16); border-color: var(--ws-faction); }
+.ws-cmd-modal-add:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-close {
+  width: 30px; height: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-size: 16px; line-height: 1; transition: 0.13s;
+}
+.ws-cmd-modal-close:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
+.ws-cmd-modal-close:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-body { padding: 12px 14px; overflow-y: auto; display: flex; flex-direction: column; gap: 8px; }
+.ws-cmd-modal-empty { padding: 28px 12px; text-align: center; font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 0.8px; color: var(--ws-ink-faint); }
+.ws-cmd-modal-foot { padding: 11px 14px; border-top: 1px solid var(--ws-line); display: flex; justify-content: flex-end; }
+.ws-cmd-modal-detailed {
+  border: none; background: none; color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono);
+  font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-modal-detailed:hover { color: var(--ws-faction); }
+.ws-cmd-modal-detailed:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+
+/* rows */
+.ws-cmd-mrow { display: flex; align-items: center; gap: 12px; padding: 11px 12px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
+.ws-cmd-mrow-av {
+  width: 34px; height: 34px; flex: 0 0 auto; display: grid; place-items: center; font-family: var(--ws-font-mono);
+  font-weight: 700; font-size: 11px; color: #04110c; background: hsl(var(--agent-avatar-hue, 160) 52% 48%);
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+}
+.ws-cmd-mrow-main { flex: 1 1 auto; min-width: 0; }
+.ws-cmd-mrow-name { display: flex; align-items: center; gap: 7px; font-size: 14px; color: #eafff5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-mrow-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.ws-cmd-mchip {
+  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 0.8px; text-transform: uppercase; padding: 2px 7px;
+  border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim);
+}
+.ws-cmd-mchip.is-on { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-mchip.is-disabled { color: var(--ws-ink-faint); }
+.ws-cmd-mchip.is-keeper { color: var(--ws-keeper); border-color: rgba(232, 181, 75, 0.4); background: rgba(232, 181, 75, 0.08); }
+.ws-cmd-mrow-actions { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+.ws-cmd-mrow-btn {
+  padding: 5px 9px; min-width: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono);
+  font-size: 10px; letter-spacing: 0.8px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-mrow-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.07); }
+.ws-cmd-mrow-btn.is-danger:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); background: rgba(226, 101, 77, 0.07); }
+.ws-cmd-mrow-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+
 @media (max-width: 1100px) { .ws-cmd-garrison-grid { grid-template-columns: 1fr; } }
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
@@ -214,4 +294,5 @@
   .ws-cmd-topbar { animation: ws-cmd-rise 0.35s ease both; }
   .ws-cmd-garrison, .ws-cmd-rail { animation: ws-cmd-rise 0.4s ease both; animation-delay: 0.05s; }
   .ws-cmd-led.working { animation: ws-cmd-pulse 1.5s ease-in-out infinite; }
+  .ws-cmd-modal-panel { animation: ws-cmd-rise 0.22s ease both; }
 }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -17,9 +17,10 @@ function escapeHtml(value) {
   });
 }
 
-function statBox(value, label) {
-  return '<div class="ws-cmd-stat"><div class="ws-v">' + escapeHtml(value) +
-    '</div><div class="ws-l">' + escapeHtml(label) + '</div></div>';
+function statBox(value, label, sectionKey, ariaLabel) {
+  return '<button type="button" class="ws-cmd-stat" data-cmd-section="' + escapeHtml(sectionKey) +
+    '" aria-label="' + escapeHtml(ariaLabel) + '"><div class="ws-v">' + escapeHtml(value) +
+    '</div><div class="ws-l">' + escapeHtml(label) + '</div></button>';
 }
 
 export class WorkspaceCommandView {
@@ -32,6 +33,10 @@ export class WorkspaceCommandView {
     this.detailedView = document.getElementById('workspace-detail-view');
     this.toggleBtn = document.getElementById('workspace-command-toggle');
     this.active = false;
+    this.activeRailSection = '';
+    this.statModalSection = '';
+    this.statModalEl = null;
+    this.statModalTrigger = null;
     this.setup();
   }
 
@@ -63,12 +68,13 @@ export class WorkspaceCommandView {
     this.persist('command');
   }
 
-  deactivate() {
+  deactivate({ persist = true } = {}) {
     this.active = false;
+    this.closeStatModal();
     if (this.container) this.container.hidden = true;
     if (this.detailedView) this.detailedView.hidden = false;
     this.updateToggle();
-    this.persist('detailed');
+    if (persist) this.persist('detailed');
   }
 
   updateToggle() {
@@ -81,6 +87,7 @@ export class WorkspaceCommandView {
   /** Re-render if active — called by the page after its data loads/refreshes. */
   refresh() {
     if (this.active) this.render();
+    else if (this.statModalSection) this.renderStatModalBody();
   }
 
   computeStats() {
@@ -134,13 +141,13 @@ export class WorkspaceCommandView {
       '<div class="ws-cmd-title">' +
       '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">Outpost · Command</span></div>' +
       '<h2>' + escapeHtml(name) + '</h2>' +
-      (mode ? '<div class="ws-sub">Ops mode · ' + escapeHtml(mode) + '</div>' : '') +
+      (mode ? '<div class="ws-sub">Workflow · ' + escapeHtml(mode) + '</div>' : '') +
       '</div>' +
       '<div class="ws-cmd-readout">' +
-      statBox(stats.agents, 'Agents') +
-      statBox(stats.openTasks, 'Open Tasks') +
-      statBox(stats.mcp, 'Tools · MCP') +
-      statBox(stats.skills, 'Skills') +
+      statBox(stats.agents, 'Agents', 'agents', 'View agents') +
+      statBox(stats.openTasks, 'Tasks', 'tasks', 'View tasks') +
+      statBox(stats.mcp, 'MCP', 'mcp', 'Open MCP settings') +
+      statBox(stats.skills, 'Skills', 'skills', 'Open Skills settings') +
       '</div>' +
       '</header>' +
       '<div class="ws-cmd-layout">' +
@@ -150,8 +157,418 @@ export class WorkspaceCommandView {
 
     const back = this.container.querySelector('[data-ws-cmd-detailed]');
     if (back) back.addEventListener('click', () => this.deactivate());
+    this.bindReadout();
     this.bindGarrison();
     this.bindRail();
+
+    // The stat manager modal lives inside the .ws-cmd container (so it inherits
+    // the tactical tokens) but survives full re-renders: re-attach + repaint it.
+    if (this.statModalEl && this.container && this.container.appendChild) {
+      this.container.appendChild(this.statModalEl);
+      if (this.statModalSection) this.renderStatModalBody();
+    }
+  }
+
+  bindReadout() {
+    const root = this.container && this.container.querySelector('.ws-cmd-readout');
+    if (!root) return;
+    root.addEventListener('click', (event) => {
+      const sectionBtn = event.target.closest('[data-cmd-section]');
+      if (!sectionBtn) return;
+      this.openStatModal(sectionBtn.getAttribute('data-cmd-section'), sectionBtn);
+    });
+  }
+
+  /** Escape hatch: leave the Command view for the full detailed section. */
+  openDetailedSection(sectionKey) {
+    const section = String(sectionKey || '').trim();
+    if (!section) return;
+    this.deactivate({ persist: false });
+    if (this.page && typeof this.page.focusSection === 'function') {
+      this.page.focusSection(section);
+    }
+  }
+
+  // ---------- stat manager modal (agents / tasks / mcp / skills) ----------
+
+  statSectionMeta(section) {
+    switch (String(section || '')) {
+      case 'agents': return { title: 'Agents', addLabel: '＋ Add Agent' };
+      case 'tasks': return { title: 'Tasks', addLabel: '＋ Add Task' };
+      case 'mcp': return { title: 'MCP Servers', addLabel: '＋ Add MCP' };
+      case 'skills': return { title: 'Skills', addLabel: '＋ Add Skill' };
+      default: return null;
+    }
+  }
+
+  openStatModal(sectionKey, trigger) {
+    const section = String(sectionKey || '').trim();
+    if (!this.statSectionMeta(section)) return;
+    this.statModalSection = section;
+    this.statModalTrigger = trigger || null;
+    const el = this.ensureStatModal();
+    if (!el) return;
+    this.renderStatModalBody();
+    el.hidden = false;
+    const panel = el.querySelector('.ws-cmd-modal-panel');
+    if (panel && typeof panel.focus === 'function') {
+      try { panel.focus({ preventScroll: true }); } catch (err) { panel.focus(); }
+    }
+  }
+
+  closeStatModal() {
+    const trigger = this.statModalTrigger;
+    this.statModalSection = '';
+    this.statModalTrigger = null;
+    if (this.statModalEl) this.statModalEl.hidden = true;
+    if (trigger && typeof trigger.focus === 'function') trigger.focus();
+  }
+
+  ensureStatModal() {
+    if (this.statModalEl) return this.statModalEl;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    const el = document.createElement('div');
+    el.className = 'ws-cmd-modal';
+    el.hidden = true;
+    el.innerHTML =
+      '<div class="ws-cmd-modal-backdrop" data-cmd-modal-action="close"></div>' +
+      '<div class="ws-cmd-modal-panel" role="dialog" aria-modal="true" tabindex="-1"></div>';
+    el.addEventListener('click', (event) => {
+      const btn = event.target.closest('[data-cmd-modal-action]');
+      if (!btn) return;
+      this.handleStatModalAction(btn.getAttribute('data-cmd-modal-action'), btn.getAttribute('data-cmd-id'));
+    });
+    el.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        this.closeStatModal();
+      }
+    });
+    this.statModalEl = el;
+    if (this.container && this.container.appendChild) this.container.appendChild(el);
+    return el;
+  }
+
+  renderStatModalBody() {
+    const el = this.statModalEl;
+    if (!el || typeof el.querySelector !== 'function') return;
+    const panel = el.querySelector('.ws-cmd-modal-panel');
+    if (!panel) return;
+    const meta = this.statSectionMeta(this.statModalSection);
+    if (meta) panel.setAttribute('aria-label', meta.title);
+    panel.innerHTML = this.statModalHTML(this.statModalSection);
+  }
+
+  statModalHTML(section) {
+    const meta = this.statSectionMeta(section);
+    if (!meta) return '';
+    return (
+      '<header class="ws-cmd-modal-head">' +
+      '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
+      '<span class="ws-cmd-modal-count">' + this.statModalCount(section) + '</span>' +
+      '<div class="ws-cmd-modal-head-actions">' +
+      '<button type="button" class="ws-cmd-modal-add" data-cmd-modal-action="add">' + escapeHtml(meta.addLabel) + '</button>' +
+      '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
+      '</div>' +
+      '</header>' +
+      '<div class="ws-cmd-modal-body">' + this.statModalRows(section) + '</div>' +
+      '<footer class="ws-cmd-modal-foot">' +
+      '<button type="button" class="ws-cmd-modal-detailed" data-cmd-modal-action="detailed">Open in detailed view ▸</button>' +
+      '</footer>'
+    );
+  }
+
+  statModalCount(section) {
+    switch (String(section || '')) {
+      case 'agents': return this.agentRowData().length;
+      case 'tasks': return this.taskRowData().length;
+      case 'mcp': return this.mcpRowData().length;
+      case 'skills': return this.skillRowData().length;
+      default: return 0;
+    }
+  }
+
+  statModalRows(section) {
+    switch (String(section || '')) {
+      case 'agents': return this.agentRowsHTML();
+      case 'tasks': return this.taskRowsHTML();
+      case 'mcp': return this.mcpRowsHTML();
+      case 'skills': return this.skillRowsHTML();
+      default: return '';
+    }
+  }
+
+  modalEmptyHTML(text) {
+    return '<div class="ws-cmd-modal-empty">' + escapeHtml(text) + '</div>';
+  }
+
+  agentRowData() {
+    const page = this.page || {};
+    let groups = [];
+    try { groups = page.buildAgentGroups() || []; } catch (err) { groups = []; }
+    return groups.filter((g) => g && g.isWorkspaceAgent && !g.isUnassigned);
+  }
+
+  agentRowsHTML() {
+    const page = this.page || {};
+    const groups = this.agentRowData();
+    if (!groups.length) return this.modalEmptyHTML('No agents yet. Add one to build the roster.');
+    return groups.map((group) => {
+      const name = String(group.name || 'Agent');
+      const encoded = encodeURIComponent(name);
+      const keeper = page.isWorkspaceEntryAgent ? page.isWorkspaceEntryAgent(name) : false;
+      const avatar = page.getAgentAvatarPresentation
+        ? page.getAgentAvatarPresentation(name)
+        : { initials: name.slice(0, 2).toUpperCase(), style: '' };
+      const status = page.getAgentRosterStatus
+        ? page.getAgentRosterStatus(name)
+        : { key: 'idle', label: 'Idle' };
+      const tone = this.statusTone(status.key, status.label);
+      let modelLabel = '';
+      if (page.getAgentProfile && page.getAgentModelPresentation) {
+        const m = page.getAgentModelPresentation(page.getAgentProfile(name));
+        modelLabel = m && !m.empty ? m.model : '';
+      }
+      let skillCount = 0;
+      if (page.getAgentSkillSummary) {
+        const sk = page.getAgentSkillSummary(name);
+        skillCount = (sk && sk.count) || 0;
+      }
+      const chips =
+        (keeper ? '<span class="ws-cmd-mchip is-keeper">★ Entry Agent</span>' : '') +
+        '<span class="ws-cmd-mchip">' + escapeHtml(modelLabel || '—') + '</span>' +
+        '<span class="ws-cmd-mchip">Skills · ' + skillCount + '</span>';
+      const removeCtl = keeper
+        ? '<span class="ws-cmd-lock" title="Entry agent — can\'t be removed">🔒</span>'
+        : '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+          escapeHtml(encoded) + '" title="Remove agent" aria-label="Remove ' + escapeHtml(name) + '">✕</button>';
+      return (
+        '<div class="ws-cmd-mrow">' +
+        '<span class="ws-cmd-mrow-av" style="' + escapeHtml(avatar.style || '') + '">' + escapeHtml(avatar.initials) + '</span>' +
+        '<div class="ws-cmd-mrow-main">' +
+        '<div class="ws-cmd-mrow-name"><span class="ws-cmd-led ' + tone + '"></span>' + escapeHtml(name) + '</div>' +
+        '<div class="ws-cmd-mrow-chips">' + chips + '</div>' +
+        '</div>' +
+        '<div class="ws-cmd-mrow-actions">' +
+        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="edit" data-cmd-id="' +
+        escapeHtml(encoded) + '" title="Edit model" aria-label="Edit model for ' + escapeHtml(name) + '">Model</button>' +
+        removeCtl +
+        '</div>' +
+        '</div>'
+      );
+    }).join('');
+  }
+
+  taskRowData() {
+    const page = this.page || {};
+    return Array.isArray(page.tasks) ? page.tasks : [];
+  }
+
+  taskRowsHTML() {
+    const tasks = this.taskRowData();
+    if (!tasks.length) return this.modalEmptyHTML('No tasks yet. Add one to get started.');
+    return tasks.map((t) => {
+      const id = String(t.id || '');
+      const label = String(t.description || t.name || t.title || 'Task');
+      const assignee = String(t.to || t.agent_name || t.assigned_to || '');
+      const tone = this.taskTone(t.status);
+      const statusText = String(t.status || 'pending').replace('_', ' ');
+      return (
+        '<div class="ws-cmd-mrow">' +
+        '<div class="ws-cmd-mrow-main">' +
+        '<div class="ws-cmd-mrow-name">' + escapeHtml(label) + '</div>' +
+        '<div class="ws-cmd-mrow-chips">' +
+        '<span class="ws-cmd-mchip ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
+        (assignee ? '<span class="ws-cmd-mchip">' + escapeHtml(assignee) + '</span>' : '') +
+        '</div>' +
+        '</div>' +
+        '<div class="ws-cmd-mrow-actions">' +
+        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="run" data-cmd-id="' +
+        escapeHtml(id) + '" title="Run" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
+        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="open" data-cmd-id="' +
+        escapeHtml(id) + '" title="Open" aria-label="Open task ' + escapeHtml(label) + '">↗</button>' +
+        '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+        escapeHtml(id) + '" title="Delete" aria-label="Delete task ' + escapeHtml(label) + '">✕</button>' +
+        '</div>' +
+        '</div>'
+      );
+    }).join('');
+  }
+
+  mcpRowData() {
+    const page = this.page || {};
+    if (typeof page.getWorkspaceMCPBindings === 'function') {
+      try { return page.getWorkspaceMCPBindings({ includeDisabled: true }) || []; } catch (err) { /* fall through */ }
+    }
+    const ws = page.workspace || {};
+    return Array.isArray(ws.mcp_bindings) ? ws.mcp_bindings : [];
+  }
+
+  mcpRowsHTML() {
+    const bindings = this.mcpRowData();
+    if (!bindings.length) return this.modalEmptyHTML('No MCP servers bound yet.');
+    return bindings.map((b) => {
+      const id = String(b.id || '');
+      const serverName = String(b.serverName || b.server_name || 'unknown');
+      const alias = String(b.alias || '');
+      const isDisabled = b.enabled === false;
+      const isSynth = b.source === 'synthesized';
+      const canRemove = b.source === 'workspace';
+      const chips =
+        '<span class="ws-cmd-mchip ' + (isDisabled ? 'is-disabled' : 'is-on') + '">' +
+        (isDisabled ? 'Disabled' : 'Enabled') + '</span>' +
+        '<span class="ws-cmd-mchip">' + (isSynth ? 'Synthesized' : 'Explicit') + '</span>' +
+        (alias ? '<span class="ws-cmd-mchip">' + escapeHtml(alias) + '</span>' : '');
+      const removeBtn = canRemove
+        ? '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+          escapeHtml(id) + '" title="Remove" aria-label="Remove ' + escapeHtml(serverName) + '">✕</button>'
+        : '';
+      return (
+        '<div class="ws-cmd-mrow">' +
+        '<div class="ws-cmd-mrow-main">' +
+        '<div class="ws-cmd-mrow-name">' + escapeHtml(serverName) + '</div>' +
+        '<div class="ws-cmd-mrow-chips">' + chips + '</div>' +
+        '</div>' +
+        '<div class="ws-cmd-mrow-actions">' +
+        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="edit" data-cmd-id="' +
+        escapeHtml(id) + '" title="Edit binding" aria-label="Edit ' + escapeHtml(serverName) + '">Edit</button>' +
+        removeBtn +
+        '</div>' +
+        '</div>'
+      );
+    }).join('');
+  }
+
+  skillRowData() {
+    const page = this.page || {};
+    if (typeof page.getWorkspaceSkillBindings === 'function') {
+      try { return page.getWorkspaceSkillBindings({ includeDisabled: true }) || []; } catch (err) { /* fall through */ }
+    }
+    const ws = page.workspace || {};
+    return Array.isArray(ws.skill_bindings) ? ws.skill_bindings : [];
+  }
+
+  skillRowsHTML() {
+    const bindings = this.skillRowData();
+    if (!bindings.length) return this.modalEmptyHTML('No skills bound yet.');
+    return bindings.map((b) => {
+      const id = String(b.id || '');
+      const skillName = String(b.skillName || b.skill_name || 'unknown');
+      const isDisabled = b.enabled === false;
+      const isPlanning = b.planningProfile === true;
+      const isTrusted = b.trusted === true;
+      const chips =
+        '<span class="ws-cmd-mchip ' + (isDisabled ? 'is-disabled' : 'is-on') + '">' +
+        (isDisabled ? 'Disabled' : 'Enabled') + '</span>' +
+        (isPlanning ? '<span class="ws-cmd-mchip">Planning</span>' : '') +
+        (isTrusted ? '<span class="ws-cmd-mchip">Trusted</span>' : '');
+      return (
+        '<div class="ws-cmd-mrow">' +
+        '<div class="ws-cmd-mrow-main">' +
+        '<div class="ws-cmd-mrow-name">' + escapeHtml(skillName) + '</div>' +
+        '<div class="ws-cmd-mrow-chips">' + chips + '</div>' +
+        '</div>' +
+        '<div class="ws-cmd-mrow-actions">' +
+        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="edit" data-cmd-id="' +
+        escapeHtml(id) + '" title="Edit binding" aria-label="Edit ' + escapeHtml(skillName) + '">Edit</button>' +
+        '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+        escapeHtml(id) + '" title="Remove" aria-label="Remove ' + escapeHtml(skillName) + '">✕</button>' +
+        '</div>' +
+        '</div>'
+      );
+    }).join('');
+  }
+
+  handleStatModalAction(action, id) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null) || {};
+    const section = this.statModalSection;
+    const a = String(action || '');
+    if (a === 'close') { this.closeStatModal(); return; }
+    if (a === 'detailed') {
+      this.closeStatModal();
+      this.openDetailedSection(section);
+      return;
+    }
+    // Add/Edit hand off to an existing modal, so close ours first (avoids stacked
+    // overlays). Run/Delete stay in place; the page reload triggers refresh().
+    switch (section) {
+      case 'agents':
+        if (a === 'add') { this.closeStatModal(); if (typeof page.openAddAgentModal === 'function') page.openAddAgentModal(); }
+        else if (a === 'edit') { this.closeStatModal(); if (typeof page.openAgentModelModal === 'function') page.openAgentModelModal(id); }
+        else if (a === 'delete') { if (typeof page.removeAgentFromWorkspace === 'function') page.removeAgentFromWorkspace(id); }
+        break;
+      case 'tasks':
+        if (a === 'add') { this.closeStatModal(); if (typeof page.showAddTaskModal === 'function') page.showAddTaskModal(); }
+        else if (a === 'run') { if (typeof page.executeTask === 'function') page.executeTask(id); }
+        else if (a === 'open') { if (typeof page.openTask === 'function') page.openTask(id); }
+        else if (a === 'delete') { if (typeof page.deleteTask === 'function') page.deleteTask(id); }
+        break;
+      case 'mcp':
+        if (a === 'add') { this.closeStatModal(); if (typeof page.openWorkspaceMCPModal === 'function') page.openWorkspaceMCPModal(); }
+        else if (a === 'edit') { this.closeStatModal(); if (typeof page.openWorkspaceMCPModal === 'function') page.openWorkspaceMCPModal(id); }
+        else if (a === 'delete') { if (typeof page.deleteWorkspaceMCPBinding === 'function') page.deleteWorkspaceMCPBinding(id); }
+        break;
+      case 'skills':
+        if (a === 'add') { this.closeStatModal(); if (typeof page.openWorkspaceSkillModal === 'function') page.openWorkspaceSkillModal(); }
+        else if (a === 'edit') { this.closeStatModal(); if (typeof page.openWorkspaceSkillModal === 'function') page.openWorkspaceSkillModal(id); }
+        else if (a === 'delete') { if (typeof page.deleteWorkspaceSkillBinding === 'function') page.deleteWorkspaceSkillBinding(id); }
+        break;
+      default:
+        break;
+    }
+  }
+
+  toggleRailManager(sectionKey) {
+    const section = String(sectionKey || '').trim();
+    if (!section) return;
+    this.activeRailSection = this.activeRailSection === section ? '' : section;
+    this.render();
+  }
+
+  runRailPrimaryAction(sectionKey, triggerButton) {
+    const page = this.page || window.workspaceDetail;
+    switch (String(sectionKey || '')) {
+      case 'notes':
+        if (page && typeof page.showNoteModal === 'function') page.showNoteModal();
+        break;
+      case 'schedules':
+        if (page && typeof page.showSchedulesModal === 'function') page.showSchedulesModal();
+        break;
+      case 'sessions':
+        if (page && typeof page.createNewSession === 'function') page.createNewSession();
+        break;
+      case 'folders':
+        if (page && typeof page.showAddDirectoryModal === 'function') page.showAddDirectoryModal(triggerButton);
+        break;
+      default:
+        break;
+    }
+  }
+
+  openRailItem(sectionKey, id, source) {
+    const page = this.page || window.workspaceDetail;
+    if (!page || !id) return;
+
+    switch (String(sectionKey || '')) {
+      case 'notes': {
+        const note = (Array.isArray(page.notes) ? page.notes : []).find(item => String(item.id || '') === id);
+        if (note && typeof page.showNoteModal === 'function') page.showNoteModal(note);
+        break;
+      }
+      case 'schedules':
+        if (typeof page.openSchedule === 'function') page.openSchedule(id);
+        break;
+      case 'sessions':
+        if (typeof page.openSession === 'function') page.openSession(id);
+        break;
+      case 'folders':
+        if (typeof page.openDirectoryExplorer === 'function') {
+          page.openDirectoryExplorer(id, source || 'reference');
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   // ---------- garrison (agents as unit cards) ----------
@@ -201,8 +618,8 @@ export class WorkspaceCommandView {
     const roleBadge = group.isUnassigned
       ? '<span class="ws-cmd-badge">Unassigned</span>'
       : (keeper
-          ? '<span class="ws-cmd-badge is-keeper">★ Keeper</span>'
-          : '<span class="ws-cmd-badge">Field Unit</span>');
+          ? '<span class="ws-cmd-badge is-keeper">★ Entry Agent</span>'
+          : '');
 
     const ctl = group.isUnassigned
       ? ''
@@ -214,7 +631,7 @@ export class WorkspaceCommandView {
 
     const rows = group.isUnassigned ? '' :
       '<div class="ws-cmd-unit-rows">' +
-      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Class</span><span class="ws-cmd-rv">' +
+      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Model</span><span class="ws-cmd-rv">' +
       escapeHtml(modelLabel || '—') + '</span></div>' +
       '<div class="ws-cmd-row"><span class="ws-cmd-rk">Skills</span><span class="ws-cmd-rv">' +
       skillCount + '</span></div>' +
@@ -241,9 +658,9 @@ export class WorkspaceCommandView {
     const add = group.isUnassigned ? '' :
       '<button type="button" class="ws-cmd-icon-btn sm" data-cmd-add-task="' + escapeHtml(encoded) +
       '" aria-label="Add task">＋</button>';
-    const head = '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Quest Log · ' + tasks.length + '</span>' + add + '</div>';
+    const head = '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Tasks · ' + tasks.length + '</span>' + add + '</div>';
     if (!tasks.length) {
-      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">— no orders issued —</div></div>';
+      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">— no tasks yet —</div></div>';
     }
     const items = tasks.map((t) => {
       const label = String(t.description || t.name || t.title || 'Task');
@@ -251,11 +668,11 @@ export class WorkspaceCommandView {
       const statusText = String(t.status || 'pending').replace('_', ' ');
       return (
         '<div class="ws-cmd-quest">' +
-        '<span class="ws-cmd-q-glyph">✦</span>' +
+        '<span class="ws-cmd-q-glyph">&bull;</span>' +
         '<span class="ws-cmd-q-name">' + escapeHtml(label) + '</span>' +
         '<span class="ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
         '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' + escapeHtml(String(t.id || '')) +
-        '" title="Deploy" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
+        '" title="Run" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
         '</div>'
       );
     }).join('');
@@ -268,7 +685,7 @@ export class WorkspaceCommandView {
     try { groups = page.buildAgentGroups() || []; } catch (err) { groups = []; }
     const units = groups.filter((g) => g && (g.isWorkspaceAgent || (g.isUnassigned && (g.tasks || []).length)));
     if (!units.length) {
-      return '<div class="ws-cmd-soon">No agents garrisoned yet.</div>';
+      return '<div class="ws-cmd-soon">No agents yet.</div>';
     }
     return '<div class="ws-cmd-garrison-grid">' + units.map((g) => this.unitCardHTML(g)).join('') + '</div>';
   }
@@ -291,27 +708,35 @@ export class WorkspaceCommandView {
 
   // ---------- right rail ----------
 
-  railPanelHTML(ix, title, items, count, emptyText) {
+  railPanelHTML(sectionKey, title, items, count, emptyText, primaryLabel) {
+    const isManaging = this.activeRailSection === sectionKey;
     const body = items.length
       ? items.join('')
       : '<div class="ws-cmd-rail-empty">' + escapeHtml(emptyText) + '</div>';
+    const actions = isManaging
+      ? '<div class="ws-cmd-panel-actions"><button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="' +
+        escapeHtml(sectionKey) + '">' + escapeHtml(primaryLabel) + '</button></div>'
+      : '';
     return (
-      '<section class="ws-cmd-panel">' +
+      '<section class="ws-cmd-panel' + (isManaging ? ' is-managing' : '') + '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><span class="ws-cmd-ix">' + escapeHtml(ix) + '</span>' +
-      '<h4>' + escapeHtml(title) + '</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
-      '<button type="button" class="ws-cmd-panel-more" data-ws-cmd-detailed title="Manage in detailed view" aria-label="Manage ' +
-      escapeHtml(title) + ' in the detailed view">▸</button>' +
+      '<div class="ws-cmd-panel-title"><h4>' + escapeHtml(title) + '</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="' + escapeHtml(sectionKey) +
+      '" aria-expanded="' + (isManaging ? 'true' : 'false') +
+      '" title="' + (isManaging ? 'Close Command manager' : 'Manage in Command view') +
+      '" aria-label="' + (isManaging ? 'Close ' : 'Manage ') +
+      escapeHtml(title) + ' in Command view">' + (isManaging ? '×' : '▸') + '</button>' +
       '</div>' +
-      '<div class="ws-cmd-panel-body">' + body + '</div>' +
+      '<div class="ws-cmd-panel-body">' + actions + body + '</div>' +
       '</section>'
     );
   }
 
   railItems(list, labelOf, opts) {
     const arr = Array.isArray(list) ? list : [];
-    const shown = arr.slice(0, 5);
     const attr = opts || {};
+    const limit = attr.expanded ? arr.length : 5;
+    const shown = arr.slice(0, limit);
     const items = shown.map((it) => {
       const label = escapeHtml(labelOf(it));
       const meta = attr.metaOf ? escapeHtml(attr.metaOf(it)) : '';
@@ -326,8 +751,9 @@ export class WorkspaceCommandView {
       return '<div class="ws-cmd-rail-item is-static">' + inner + '</div>';
     });
     if (arr.length > shown.length) {
-      items.push('<button type="button" class="ws-cmd-rail-more" data-ws-cmd-detailed>+ ' +
-        (arr.length - shown.length) + ' more · detailed view</button>');
+      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="' +
+        escapeHtml(attr.sectionKey || '') + '">+ ' +
+        (arr.length - shown.length) + ' more</button>');
     }
     return items;
   }
@@ -339,25 +765,40 @@ export class WorkspaceCommandView {
     const sessions = Array.isArray(page.sessions) ? page.sessions : [];
     const dirs = Array.isArray(page.directories) ? page.directories : [];
 
-    const intel = this.railItems(notes, (n) => n.name || n.title || 'Untitled Note', {
-      href: (n) => '/notes/' + encodeURIComponent(n.id || '')
+    const notesExpanded = this.activeRailSection === 'notes';
+    const schedulesExpanded = this.activeRailSection === 'schedules';
+    const sessionsExpanded = this.activeRailSection === 'sessions';
+    const foldersExpanded = this.activeRailSection === 'folders';
+
+    const notesItems = this.railItems(notes, (n) => n.name || n.title || 'Untitled Note', {
+      sectionKey: 'notes',
+      expanded: notesExpanded,
+      action: (n) => 'data-cmd-open-section="notes" data-cmd-item-id="' + escapeHtml(String(n.id || '')) + '"'
     });
-    const orders = this.railItems(schedules, (s) => s.name || s.task_description || 'Unnamed Schedule', {
-      action: (s) => 'data-cmd-schedule="' + escapeHtml(String(s.id || '')) + '"'
+    const scheduleItems = this.railItems(schedules, (s) => s.name || s.task_description || 'Unnamed Schedule', {
+      sectionKey: 'schedules',
+      expanded: schedulesExpanded,
+      action: (s) => 'data-cmd-open-section="schedules" data-cmd-item-id="' + escapeHtml(String(s.id || '')) + '"'
     });
-    const comms = this.railItems(sessions, (s) => s.title || s.name || 'Untitled Session', {
-      action: (s) => 'data-cmd-session="' + escapeHtml(String(s.id || '')) + '"',
+    const sessionItems = this.railItems(sessions, (s) => s.title || s.name || 'Untitled Session', {
+      sectionKey: 'sessions',
+      expanded: sessionsExpanded,
+      action: (s) => 'data-cmd-open-section="sessions" data-cmd-item-id="' + escapeHtml(String(s.id || '')) + '"',
       metaOf: (s) => s.agent_name || ''
     });
-    const supply = this.railItems(dirs, (d) => d.title || d.name || d.path || 'Unnamed Directory', {
+    const folderItems = this.railItems(dirs, (d) => d.title || d.name || d.path || 'Unnamed Directory', {
+      sectionKey: 'folders',
+      expanded: foldersExpanded,
+      action: (d) => 'data-cmd-open-section="folders" data-cmd-item-id="' + escapeHtml(String(d.id || '')) +
+        '" data-cmd-item-source="' + escapeHtml(String(d.source || 'reference')) + '"',
       metaOf: (d) => d.path || ''
     });
 
     return (
-      this.railPanelHTML('INT', 'Intel', intel, notes.length, 'No intel logged yet.') +
-      this.railPanelHTML('ORD', 'Standing Orders', orders, schedules.length, 'No scheduled orders.') +
-      this.railPanelHTML('COM', 'Comms', comms, sessions.length, 'No active sessions.') +
-      this.railPanelHTML('SUP', 'Supply Lines', supply, dirs.length, 'No linked folders.')
+      this.railPanelHTML('notes', 'Notes', notesItems, notes.length, 'No notes yet.', 'New Note') +
+      this.railPanelHTML('schedules', 'Schedules', scheduleItems, schedules.length, 'No schedules yet.', 'Open Schedules') +
+      this.railPanelHTML('sessions', 'Sessions', sessionItems, sessions.length, 'No sessions yet.', 'New Session') +
+      this.railPanelHTML('folders', 'Linked Folders', folderItems, dirs.length, 'No linked folders yet.', 'Link Folder')
     );
   }
 
@@ -365,16 +806,23 @@ export class WorkspaceCommandView {
     const root = this.container && this.container.querySelector('.ws-cmd-rail');
     if (!root) return;
     root.addEventListener('click', (event) => {
-      const detailedBtn = event.target.closest('[data-ws-cmd-detailed]');
-      if (detailedBtn) { this.deactivate(); return; }
-      const sess = event.target.closest('[data-cmd-session]');
-      if (sess && window.workspaceDetail && window.workspaceDetail.openSession) {
-        window.workspaceDetail.openSession(sess.getAttribute('data-cmd-session'));
+      const primaryBtn = event.target.closest('[data-cmd-primary-section]');
+      if (primaryBtn) {
+        this.runRailPrimaryAction(primaryBtn.getAttribute('data-cmd-primary-section'), primaryBtn);
         return;
       }
-      const sched = event.target.closest('[data-cmd-schedule]');
-      if (sched && window.workspaceDetail && window.workspaceDetail.openSchedule) {
-        window.workspaceDetail.openSchedule(sched.getAttribute('data-cmd-schedule'));
+      const manageBtn = event.target.closest('[data-cmd-manage-section]');
+      if (manageBtn) {
+        this.toggleRailManager(manageBtn.getAttribute('data-cmd-manage-section'));
+        return;
+      }
+      const itemBtn = event.target.closest('[data-cmd-open-section][data-cmd-item-id]');
+      if (itemBtn) {
+        this.openRailItem(
+          itemBtn.getAttribute('data-cmd-open-section'),
+          itemBtn.getAttribute('data-cmd-item-id'),
+          itemBtn.getAttribute('data-cmd-item-source')
+        );
       }
     });
   }

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -8,6 +8,72 @@ import { WorkspaceCommandView } from './workspace-command.js';
 globalThis.document = { getElementById: () => null };
 const view = new WorkspaceCommandView(null);
 
+function makeToggleButton() {
+  return {
+    attrs: {},
+    classList: { toggle() {} },
+    setAttribute(name, value) {
+      this.attrs[name] = value;
+    }
+  };
+}
+
+function makeListenerRoot() {
+  return {
+    listener: null,
+    addEventListener(type, listener) {
+      if (type === 'click') this.listener = listener;
+    }
+  };
+}
+
+function makeSectionClickTarget(section) {
+  return {
+    closest(selector) {
+      if (selector !== '[data-cmd-section]') return null;
+      return {
+        getAttribute(name) {
+          return name === 'data-cmd-section' ? section : '';
+        }
+      };
+    }
+  };
+}
+
+function makeAttributeClickTarget(attrs) {
+  return {
+    closest(selector) {
+      if (selector.includes('data-cmd-primary-section') && attrs['data-cmd-primary-section']) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
+      if (selector.includes('data-cmd-manage-section') && attrs['data-cmd-manage-section']) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
+      if (
+        selector.includes('data-cmd-open-section') &&
+        selector.includes('data-cmd-item-id') &&
+        attrs['data-cmd-open-section'] &&
+        attrs['data-cmd-item-id']
+      ) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
+      return null;
+    }
+  };
+}
+
 test('statusTone maps an agent status to a visual tone', () => {
   assert.equal(view.statusTone('working', ''), 'working');
   assert.equal(view.statusTone('', 'running a task'), 'working');
@@ -50,4 +116,362 @@ test('computeStats reads counts from the page instance', () => {
     workspace: { mcp_bindings: [{}, {}], skill_bindings: [{}] }
   };
   assert.deepEqual(view.computeStats(), { agents: 2, openTasks: 2, mcp: 2, skills: 1 });
+});
+
+test('rendered command copy uses detailed-view vocabulary', () => {
+  const readoutRoot = makeListenerRoot();
+  const garrisonRoot = makeListenerRoot();
+  const railRoot = makeListenerRoot();
+  const backButton = makeListenerRoot();
+  const container = {
+    hidden: true,
+    innerHTML: '',
+    querySelector(selector) {
+      if (selector === '[data-ws-cmd-detailed]') return backButton;
+      if (selector === '.ws-cmd-readout') return readoutRoot;
+      if (selector === '.ws-cmd-garrison') return garrisonRoot;
+      if (selector === '.ws-cmd-rail') return railRoot;
+      return null;
+    }
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container,
+    detailedView: { hidden: false },
+    toggleBtn: makeToggleButton(),
+    active: true,
+    page: {
+      workspace: {
+        name: 'Demo Workspace',
+        workspace_settings: { workflow: { mode: 'guided' } },
+        mcp_bindings: [],
+        skill_bindings: []
+      },
+      tasks: [{ status: 'pending' }],
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      buildAgentGroups: () => [
+        {
+          name: 'Atlas',
+          isWorkspaceAgent: true,
+          isUnassigned: false,
+          tasks: [{ id: 'task-1', description: 'Draft plan', status: 'pending' }]
+        },
+        {
+          name: 'Builder',
+          isWorkspaceAgent: true,
+          isUnassigned: false,
+          tasks: []
+        }
+      ],
+      isWorkspaceEntryAgent: name => name === 'Atlas',
+      getAgentAvatarPresentation: name => ({ initials: name.slice(0, 2), style: '' }),
+      getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' }),
+      getAgentProfile: () => ({}),
+      getAgentModelPresentation: () => ({ empty: false, model: 'gpt-test' }),
+      getAgentSkillSummary: () => ({ count: 0 })
+    },
+    persist() {}
+  });
+
+  commandView.render();
+
+  assert.match(container.innerHTML, /Workflow · Guided/);
+  assert.match(container.innerHTML, /<div class="ws-l">Tasks<\/div>/);
+  assert.match(container.innerHTML, /<div class="ws-l">MCP<\/div>/);
+  assert.match(container.innerHTML, />Notes<\/h4>/);
+  assert.match(container.innerHTML, />Schedules<\/h4>/);
+  assert.match(container.innerHTML, />Sessions<\/h4>/);
+  assert.match(container.innerHTML, />Linked Folders<\/h4>/);
+  assert.match(container.innerHTML, /No notes yet\./);
+  assert.match(container.innerHTML, /No schedules yet\./);
+  assert.match(container.innerHTML, /No sessions yet\./);
+  assert.match(container.innerHTML, /No linked folders yet\./);
+  assert.match(container.innerHTML, /★ Entry Agent/);
+  assert.match(container.innerHTML, />Model<\/span>/);
+  assert.match(container.innerHTML, /Tasks · 1/);
+  assert.match(container.innerHTML, /title="Run"/);
+  assert.match(container.innerHTML, /Manage Notes in Command view/);
+  assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Open Tasks|Tools · MCP|Ops mode|Deploy|✦/);
+});
+
+test('stat clicks open the in-place manager modal without leaving Command view', () => {
+  const readoutRoot = makeListenerRoot();
+  const opened = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: true,
+    container: {
+      hidden: false,
+      querySelector(selector) {
+        return selector === '.ws-cmd-readout' ? readoutRoot : null;
+      }
+    },
+    detailedView: { hidden: true },
+    openStatModal(section) {
+      opened.push(section);
+    }
+  });
+
+  commandView.bindReadout();
+
+  ['agents', 'tasks', 'mcp', 'skills'].forEach(section => {
+    readoutRoot.listener({ target: makeSectionClickTarget(section) });
+  });
+
+  assert.deepEqual(opened, ['agents', 'tasks', 'mcp', 'skills']);
+  // The Command view stays put — no deactivate, no view switch.
+  assert.equal(commandView.container.hidden, false);
+  assert.equal(commandView.detailedView.hidden, true);
+});
+
+test('rail more toggles command-local management without leaving Command view', () => {
+  const railRoot = makeListenerRoot();
+  const renders = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    container: {
+      hidden: false,
+      querySelector(selector) {
+        return selector === '.ws-cmd-rail' ? railRoot : null;
+      }
+    },
+    detailedView: { hidden: true },
+    render() {
+      renders.push(this.activeRailSection);
+    }
+  });
+
+  commandView.bindRail();
+
+  railRoot.listener({ target: makeAttributeClickTarget({ 'data-cmd-manage-section': 'notes' }) });
+  railRoot.listener({ target: makeAttributeClickTarget({ 'data-cmd-manage-section': 'notes' }) });
+
+  assert.deepEqual(renders, ['notes', '']);
+  assert.equal(commandView.container.hidden, false);
+  assert.equal(commandView.detailedView.hidden, true);
+});
+
+test('rail primary actions use command-view management hooks', () => {
+  const railRoot = makeListenerRoot();
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-rail' ? railRoot : null;
+      }
+    },
+    page: {
+      showNoteModal() { calls.push('new-note'); },
+      showSchedulesModal() { calls.push('open-schedules'); },
+      createNewSession() { calls.push('new-session'); },
+      showAddDirectoryModal() { calls.push('link-folder'); }
+    }
+  });
+
+  commandView.bindRail();
+
+  ['notes', 'schedules', 'sessions', 'folders'].forEach(section => {
+    railRoot.listener({
+      target: makeAttributeClickTarget({ 'data-cmd-primary-section': section })
+    });
+  });
+
+  assert.deepEqual(calls, ['new-note', 'open-schedules', 'new-session', 'link-folder']);
+});
+
+test('rail item actions open existing management flows from Command view', () => {
+  const railRoot = makeListenerRoot();
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-rail' ? railRoot : null;
+      }
+    },
+    page: {
+      notes: [{ id: 'note-1', name: 'Launch note' }],
+      showNoteModal(note) { calls.push(['note', note.id]); },
+      openSchedule(id) { calls.push(['schedule', id]); },
+      openSession(id) { calls.push(['session', id]); },
+      openDirectoryExplorer(id, source) { calls.push(['folder', id, source]); }
+    }
+  });
+
+  commandView.bindRail();
+
+  [
+    { 'data-cmd-open-section': 'notes', 'data-cmd-item-id': 'note-1' },
+    { 'data-cmd-open-section': 'schedules', 'data-cmd-item-id': 'sched-1' },
+    { 'data-cmd-open-section': 'sessions', 'data-cmd-item-id': 'session-1' },
+    {
+      'data-cmd-open-section': 'folders',
+      'data-cmd-item-id': 'dir-1',
+      'data-cmd-item-source': 'owned'
+    }
+  ].forEach(attrs => {
+    railRoot.listener({ target: makeAttributeClickTarget(attrs) });
+  });
+
+  assert.deepEqual(calls, [
+    ['note', 'note-1'],
+    ['schedule', 'sched-1'],
+    ['session', 'session-1'],
+    ['folder', 'dir-1', 'owned']
+  ]);
+});
+
+test('mcp manager modal lists bindings with add and detailed-view escape hatch', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      getWorkspaceMCPBindings: () => [
+        { id: 'b1', serverName: 'filesystem', source: 'workspace', enabled: true },
+        { id: 'b2', serverName: 'gmail', source: 'synthesized', enabled: false }
+      ]
+    }
+  });
+
+  const html = commandView.statModalHTML('mcp');
+  assert.match(html, /MCP Servers/);
+  assert.match(html, /filesystem/);
+  assert.match(html, /gmail/);
+  assert.match(html, /Disabled/);
+  assert.match(html, /Synthesized/);
+  assert.match(html, /data-cmd-modal-action="add"/);
+  assert.match(html, /data-cmd-modal-action="edit" data-cmd-id="b1"/);
+  assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="b1"/);
+  assert.match(html, /data-cmd-modal-action="detailed"/);
+  // Synthesized bindings are not workspace-owned, so no remove control.
+  assert.doesNotMatch(html, /data-cmd-modal-action="delete" data-cmd-id="b2"/);
+});
+
+test('skills manager modal lists bindings and offers add', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      getWorkspaceSkillBindings: () => [{ id: 's1', skillName: 'summarize', enabled: true, trusted: true }]
+    }
+  });
+
+  const html = commandView.statModalHTML('skills');
+  assert.match(html, />Skills</);
+  assert.match(html, /summarize/);
+  assert.match(html, /Trusted/);
+  assert.match(html, /data-cmd-modal-action="edit" data-cmd-id="s1"/);
+  assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="s1"/);
+});
+
+test('agents manager modal locks the entry agent from removal', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      buildAgentGroups: () => [
+        { name: 'Atlas', isWorkspaceAgent: true, isUnassigned: false },
+        { name: 'Builder', isWorkspaceAgent: true, isUnassigned: false },
+        { name: 'Unassigned', isWorkspaceAgent: false, isUnassigned: true }
+      ],
+      isWorkspaceEntryAgent: name => name === 'Atlas',
+      getAgentAvatarPresentation: name => ({ initials: name.slice(0, 2), style: '' }),
+      getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' }),
+      getAgentProfile: () => ({}),
+      getAgentModelPresentation: () => ({ empty: false, model: 'gpt-test' }),
+      getAgentSkillSummary: () => ({ count: 2 })
+    }
+  });
+
+  const html = commandView.statModalHTML('agents');
+  assert.match(html, /Atlas/);
+  assert.match(html, /Builder/);
+  assert.match(html, /★ Entry Agent/);
+  // Builder is removable; Atlas (entry agent) shows a lock, not a delete button.
+  assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="Builder"/);
+  assert.doesNotMatch(html, /data-cmd-modal-action="delete" data-cmd-id="Atlas"/);
+  // The unassigned bucket is not a real agent and should be excluded.
+  assert.doesNotMatch(html, /Unassigned/);
+});
+
+test('tasks manager modal exposes run / open / delete controls', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: { tasks: [{ id: 't1', description: 'Draft plan', status: 'pending', to: 'Atlas' }] }
+  });
+
+  const html = commandView.statModalHTML('tasks');
+  assert.match(html, /Draft plan/);
+  assert.match(html, /Atlas/);
+  assert.match(html, /data-cmd-modal-action="run" data-cmd-id="t1"/);
+  assert.match(html, /data-cmd-modal-action="open" data-cmd-id="t1"/);
+  assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="t1"/);
+});
+
+test('modal add/edit hand off to page flows and close the modal; delete stays open', () => {
+  const calls = [];
+  let closed = 0;
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    statModalSection: 'mcp',
+    closeStatModal() {
+      closed += 1;
+      this.statModalSection = '';
+    },
+    page: {
+      openWorkspaceMCPModal(id) { calls.push(['open', id]); },
+      deleteWorkspaceMCPBinding(id) { calls.push(['delete', id]); }
+    }
+  });
+
+  commandView.handleStatModalAction('add');
+  commandView.statModalSection = 'mcp';
+  commandView.handleStatModalAction('edit', 'b1');
+  commandView.statModalSection = 'mcp';
+  commandView.handleStatModalAction('delete', 'b2');
+
+  assert.deepEqual(calls, [['open', undefined], ['open', 'b1'], ['delete', 'b2']]);
+  assert.equal(closed, 2); // add + edit close the modal; delete keeps it open
+});
+
+test('modal detailed action closes the modal and deep-links the detailed view', () => {
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    statModalSection: 'skills',
+    closeStatModal() {
+      calls.push(['close', this.statModalSection]);
+      this.statModalSection = '';
+    },
+    openDetailedSection(section) {
+      calls.push(['detailed', section]);
+    }
+  });
+
+  commandView.handleStatModalAction('detailed');
+
+  // Section is captured before close resets it, then forwarded to the deep-link.
+  assert.deepEqual(calls, [['close', 'skills'], ['detailed', 'skills']]);
+});
+
+test('default deactivate path still persists detailed preference', () => {
+  const persisted = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: true,
+    container: { hidden: false },
+    detailedView: { hidden: true },
+    toggleBtn: makeToggleButton(),
+    persist(value) {
+      persisted.push(value);
+    }
+  });
+
+  commandView.deactivate();
+
+  assert.deepEqual(persisted, ['detailed']);
+  assert.equal(commandView.container.hidden, true);
+  assert.equal(commandView.detailedView.hidden, false);
 });

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -2985,6 +2985,9 @@ export class WorkspaceDetailPage {
         this.elements.taskCount.setAttribute('aria-label', `${this.tasks.length} tasks`);
       }
       this.refreshHomeAssistantQuickPrompts();
+      // Keep the opt-in Command view (and its open stat manager) in sync after
+      // task mutations, which reload tasks without a full workspace reload.
+      window.workspaceCommand?.refresh();
     }
   }
 
@@ -10789,6 +10792,10 @@ export class WorkspaceDetailPage {
     return this.skillsManager.openWorkspaceSkillModal(bindingId);
   }
 
+  deleteWorkspaceSkillBinding(bindingId) {
+    return this.skillsManager.deleteWorkspaceSkillBinding(bindingId);
+  }
+
   loadAvailableSkills(force = false) {
     return this.skillsManager.loadAvailableSkills(force);
   }
@@ -11957,6 +11964,68 @@ export class WorkspaceDetailPage {
     };
 
     setTimeout(poll, intervalMs);
+  }
+
+  focusSection(sectionKey) {
+    const key = String(sectionKey || '').toLowerCase();
+    const targets = {
+      agents: 'workspace-detail-agents-panel',
+      tasks: 'workspace-detail-agents-panel',
+      notes: 'workspace-detail-notes-panel',
+      sessions: 'workspace-detail-sessions-panel',
+      folders: 'workspace-detail-directories-panel',
+      schedules: 'workspace-detail-schedules-panel',
+      mcp: 'workspace-detail-config-content',
+      skills: 'workspace-detail-config-content'
+    };
+    const targetId = targets[key];
+    if (!targetId) return;
+
+    if (key === 'agents') {
+      this.setView('list');
+    } else if (key === 'tasks') {
+      this.setView('board');
+    } else if (key === 'mcp' || key === 'skills') {
+      this.setWorkspaceConfigExpanded(true);
+      const tabId =
+        key === 'mcp'
+          ? 'workspace-detail-config-mcp-tab'
+          : 'workspace-detail-config-skills-tab';
+      this.activateWorkspaceConfigTab(tabId);
+    }
+
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    if (typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    this.focusDeepLinkTarget(target);
+  }
+
+  activateWorkspaceConfigTab(tabId) {
+    const tabBtn = document.getElementById(tabId);
+    if (!tabBtn) return;
+
+    if (typeof tabBtn.click === 'function') {
+      tabBtn.click();
+      return;
+    }
+    if (window.bootstrap?.Tab?.getOrCreateInstance) {
+      window.bootstrap.Tab.getOrCreateInstance(tabBtn).show();
+    }
+  }
+
+  focusDeepLinkTarget(target) {
+    if (!target || typeof target.focus !== 'function') return;
+    if (!target.hasAttribute('tabindex')) {
+      target.setAttribute('tabindex', '-1');
+    }
+    try {
+      target.focus({ preventScroll: true });
+    } catch {
+      target.focus();
+    }
   }
 
   /**

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -26,6 +26,124 @@ global.document = {
 
 const { WorkspaceDetailPage } = await import('./workspace-detail.js');
 
+function withDocumentElements(elements, fn) {
+  const previousDocument = global.document;
+  global.document = {
+    ...previousDocument,
+    getElementById(id) {
+      return elements[id] || null;
+    }
+  };
+  try {
+    fn();
+  } finally {
+    global.document = previousDocument;
+  }
+}
+
+function makeFocusTarget({ hasTabindex = false } = {}) {
+  const attributes = hasTabindex ? { tabindex: '0' } : {};
+  return {
+    attributes,
+    scrollCalls: [],
+    focusCalls: [],
+    hasAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(attributes, name);
+    },
+    setAttribute(name, value) {
+      attributes[name] = value;
+    },
+    scrollIntoView(options) {
+      this.scrollCalls.push(options);
+    },
+    focus(options) {
+      this.focusCalls.push(options);
+    }
+  };
+}
+
+function makeTabButton() {
+  return {
+    clickCount: 0,
+    click() {
+      this.clickCount += 1;
+    }
+  };
+}
+
+test('workspace detail focusSection routes agents and tasks to the correct sub-view', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  const target = makeFocusTarget();
+  const selectedViews = [];
+  page.setView = view => selectedViews.push(view);
+
+  withDocumentElements({ 'workspace-detail-agents-panel': target }, () => {
+    page.focusSection('agents');
+    page.focusSection('tasks');
+  });
+
+  assert.deepEqual(selectedViews, ['list', 'board']);
+  assert.deepEqual(target.scrollCalls, [
+    { behavior: 'smooth', block: 'start' },
+    { behavior: 'smooth', block: 'start' }
+  ]);
+  assert.equal(target.attributes.tabindex, '-1');
+  assert.deepEqual(target.focusCalls, [{ preventScroll: true }, { preventScroll: true }]);
+});
+
+test('workspace detail focusSection expands config and activates MCP and Skills tabs', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  const target = makeFocusTarget({ hasTabindex: true });
+  const mcpTab = makeTabButton();
+  const skillsTab = makeTabButton();
+  const expanded = [];
+  page.setWorkspaceConfigExpanded = value => expanded.push(value);
+
+  withDocumentElements(
+    {
+      'workspace-detail-config-content': target,
+      'workspace-detail-config-mcp-tab': mcpTab,
+      'workspace-detail-config-skills-tab': skillsTab
+    },
+    () => {
+      page.focusSection('mcp');
+      page.focusSection('skills');
+    }
+  );
+
+  assert.deepEqual(expanded, [true, true]);
+  assert.equal(mcpTab.clickCount, 1);
+  assert.equal(skillsTab.clickCount, 1);
+  assert.equal(target.attributes.tabindex, '0');
+  assert.deepEqual(target.scrollCalls, [
+    { behavior: 'smooth', block: 'start' },
+    { behavior: 'smooth', block: 'start' }
+  ]);
+  assert.deepEqual(target.focusCalls, [{ preventScroll: true }, { preventScroll: true }]);
+});
+
+test('workspace detail focusSection scrolls and focuses section targets', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  const target = makeFocusTarget();
+
+  withDocumentElements({ 'workspace-detail-notes-panel': target }, () => {
+    page.focusSection('notes');
+  });
+
+  assert.deepEqual(target.scrollCalls, [{ behavior: 'smooth', block: 'start' }]);
+  assert.equal(target.attributes.tabindex, '-1');
+  assert.deepEqual(target.focusCalls, [{ preventScroll: true }]);
+});
+
+test('workspace detail focusSection tolerates missing targets', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+
+  withDocumentElements({}, () => {
+    assert.doesNotThrow(() => page.focusSection('schedules'));
+    assert.doesNotThrow(() => page.focusSection('unknown'));
+  });
+});
+
 test('workspace detail renders reference URL task indicators', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   const indicator = page.renderTaskReferenceURLIndicator({


### PR DESCRIPTION
## Summary

Refines the interior **Command view** so the readout stats no longer yank you into the detailed settings panel. Clicking **Agents / Tasks / MCP / Skills** now opens a themed manager modal *in place* — you stay in the Command view for both quick checks and edits.

This was the specific pain point: clicking MCP/Skills switched to the detailed view and jumped to the settings tab. Now it's a modal, with full inline management for all four stats.

## What each modal does

- **MCP / Skills** — lists bindings with status chips (Enabled/Disabled, Synthesized/Explicit, alias, Trusted/Planning). `＋ Add`, `Edit`, and `Remove` reuse the existing workspace add/edit forms and delete flows — no duplicated logic.
- **Agents** — roster with avatar/status/model/skills; `＋ Add Agent`, `Model` (edit), `Remove`. The **entry agent is locked** (🔒) and can't be removed.
- **Tasks** — cross-agent list with `Run`, `Open`, `Delete`, `＋ Add Task`.
- Every modal has an **"Open in detailed view ▸"** escape hatch (reuses the existing `focusSection` deep-link).

## How the hand-off avoids stacking

Add/Edit **close the manager first**, then open the existing Bootstrap form — no stacked overlays. Run/Delete stay open; the page reload triggers `refresh()`, which live-repaints the open modal so counts/rows stay in sync.

## Changes

- `workspace-command.js` — modal subsystem (open/close/render, per-section rows, action dispatch); readout now opens the modal; rail panels manage in place with detailed-view vocabulary.
- `workspace-detail.js` — added a `deleteWorkspaceSkillBinding` page wrapper; `loadTasks()` now refreshes the Command view.
- `workspace-command.css` — modal styles scoped under `.ws-cmd` (no `!important`, inherits the tactical tokens).
- Tests — rewrote the deep-link test for the new behavior + new modal render/dispatch tests.

## Verification

- `node --test` → **455/455 pass**; ESLint clean on changed files; `go build` OK.
- Live browser smoke (isolated server, research-project workspace): all four modals render on the tactical theme; real readout click opens the modal; `Edit` cleanly closes the manager and opens the existing Bootstrap form (no stacking, Command view stays active); creating a task live-updated the open Tasks modal without closing it; backdrop-click and Esc both close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)