### PR TITLE
feat(release): auto-compute version, add --pre-release channel, align auto-release gate

### DIFF
--- a/scripts/release-ready.sh
+++ b/scripts/release-ready.sh
@@ -5,7 +5,7 @@
 #   • there are unreleased commits on dev since the last v* tag
 #   • dev's HEAD commit has green CI (all check-runs completed & successful)
 #   • cadence threshold met: >=N merged PRs since the last release,
-#     OR >=D days since the last release, OR FORCE_RELEASE=true
+#     OR FORCE_RELEASE=true (manual dispatch)
 #   • the kill-switch (AUTO_RELEASE_HOLD) is not set
 #
 # Designed to run in GitHub Actions (.github/workflows/auto-release.yml) on a
@@ -22,7 +22,6 @@ set -euo pipefail
 
 # ── tunables (override via env) ───────────────────────────────────────────────
 MIN_PRS="${RELEASE_MIN_PRS:-5}"          # >= this many merged PRs since last tag → ready
-MIN_DAYS="${RELEASE_MIN_DAYS:-3}"        # >= this many days since last release → ready
 BASE_BRANCH="${RELEASE_BASE_BRANCH:-dev}"
 FORCE_RELEASE="${FORCE_RELEASE:-false}"  # bypass the cadence threshold (CI-green still required)
 
@@ -50,7 +49,7 @@ case "${AUTO_RELEASE_HOLD:-}" in
 esac
 
 # ── 1. last release tag ───────────────────────────────────────────────────────
-LAST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)"
+LAST_TAG="$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
 [ -n "$LAST_TAG" ] || hold "no previous v* tag found"
 LAST_DATE="$(git log -1 --format=%cI "$LAST_TAG" | cut -dT -f1)"
 echo "Last release: $LAST_TAG ($LAST_DATE)"
@@ -91,18 +90,14 @@ NOW_S="$(date +%s)"
 LAST_S="$(date -d "$LAST_DATE" +%s 2>/dev/null || date -j -f %Y-%m-%d "$LAST_DATE" +%s)"
 DAYS_SINCE=$(( (NOW_S - LAST_S) / 86400 ))
 
-if   [ "$FORCE_RELEASE" = "true" ];     then REASON="forced (manual dispatch), CI green"
-elif [ "$PR_COUNT" -ge "$MIN_PRS" ];    then REASON="$PR_COUNT PRs since $LAST_TAG (>=$MIN_PRS)"
-elif [ "$DAYS_SINCE" -ge "$MIN_DAYS" ]; then REASON="$DAYS_SINCE days since $LAST_TAG (>=$MIN_DAYS)"
-else hold "cadence not met: $PR_COUNT PRs / $DAYS_SINCE days since $LAST_TAG (force with manual dispatch)"
+if   [ "$FORCE_RELEASE" = "true" ];  then REASON="forced (manual dispatch), CI green"
+elif [ "$PR_COUNT" -ge "$MIN_PRS" ]; then REASON="$PR_COUNT PRs since $LAST_TAG (>=$MIN_PRS)"
+else hold "cadence not met: $PR_COUNT PRs since $LAST_TAG ($DAYS_SINCE days old; force with manual dispatch)"
 fi
 
-# ── 5. next version (odometer: bump patch, roll at 9; major bump stays manual) ─
+# ── 5. next version (odometer: bump the last segment, no roll — major/minor editorial) ─
 IFS=. read -r MA MI PA <<< "${LAST_TAG#v}"
-PA=$((PA + 1))
-if [ "$PA" -gt 9 ]; then PA=0; MI=$((MI + 1)); fi
-[ "$MI" -le 9 ] || hold "next version would roll a major from $LAST_TAG — bump manually"
-NEXT="v${MA}.${MI}.${PA}"
+NEXT="v${MA}.${MI}.$((PA + 1))"
 
 echo "READY → $NEXT   ($REASON)"
 emit ready true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,6 +8,7 @@
 # Usage:
 #   ./scripts/release.sh              # Auto-computes next version (odometer: bumps last segment)
 #   ./scripts/release.sh v0.1.0       # Explicit version for an editorial bump
+#   ./scripts/release.sh --pre-release  # Candidate build (GitHub pre-release, doesn't touch main)
 #
 # Workflow:
 #   1. Validates current branch (dev or main)
@@ -67,6 +68,20 @@ compute_next_version() {
   echo "v${major}.${minor}.$((patch + 1))"
 }
 
+# Given a clean base version (vX.Y.Z), return the next -rc.N pre-release tag for
+# it, auto-incrementing N past any existing candidates for that base.
+next_prerelease_version() {
+  local base="$1" t n maxn=0
+  while IFS= read -r t; do
+    [ -z "$t" ] && continue
+    n="${t##*-rc.}"
+    if [[ "$n" =~ ^[0-9]+$ ]] && [ "$n" -gt "$maxn" ]; then
+      maxn="$n"
+    fi
+  done < <(git tag --list "${base}-rc.*" 2>/dev/null)
+  echo "${base}-rc.$((maxn + 1))"
+}
+
 # Help function
 show_help() {
   echo ""
@@ -88,11 +103,14 @@ show_help() {
   echo "  --help, -h      Show this help message"
   echo "  --dry-run       Run checks but don't create tag or push"
   echo "  --skip-checks   Skip pre-release checks (use with caution)"
+  echo "  --pre-release   Cut a candidate build: tags dev with an -rc.N suffix,"
+  echo "                  publishes a GitHub pre-release (not 'Latest'), and does"
+  echo "                  NOT merge to main. Stable is the default (no flag)."
   echo ""
   echo -e "${BLUE}EXAMPLES:${NC}"
-  echo "  ./scripts/release.sh                   # Auto-compute next version and release"
-  echo "  ./scripts/release.sh v0.1.0            # Editorial bump to v0.1.0"
-  echo "  ./scripts/release.sh 0.1.0             # Same as above (v prefix added)"
+  echo "  ./scripts/release.sh                   # Auto-compute next version, release (stable)"
+  echo "  ./scripts/release.sh v0.1.0            # Editorial bump to v0.1.0 (stable)"
+  echo "  ./scripts/release.sh --pre-release     # Cut a candidate (v0.0.86-rc.1, not 'Latest')"
   echo "  ./scripts/release.sh --dry-run         # Auto-compute + validate, no release"
   echo ""
   echo -e "${BLUE}WORKFLOW:${NC}"
@@ -120,6 +138,7 @@ show_help() {
 VERSION=""
 DRY_RUN=false
 SKIP_CHECKS=false
+PRE_RELEASE=false
 
 for arg in "$@"; do
   case $arg in
@@ -131,6 +150,9 @@ for arg in "$@"; do
       ;;
     --skip-checks)
       SKIP_CHECKS=true
+      ;;
+    --pre-release|--prerelease)
+      PRE_RELEASE=true
       ;;
     *)
       if [ -z "$VERSION" ]; then
@@ -189,9 +211,21 @@ if [[ ! "$VERSION" =~ ^v ]]; then
   print_status "Added 'v' prefix: $VERSION"
 fi
 
-# Validate version format
-if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  print_error "Version must be in format vX.Y.Z (e.g., v1.0.1)"
+# For a pre-release (candidate) build, append an auto-incrementing -rc.N suffix
+# to the base version (unless the caller already supplied their own suffix).
+# goreleaser's `prerelease: auto` marks any suffixed tag as a GitHub
+# pre-release, so it never becomes the "Latest" (stable) pin and the in-app
+# updater skips it by default.
+if [ "$PRE_RELEASE" = true ] && [[ "$VERSION" != *-* ]]; then
+  if [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    VERSION="$(next_prerelease_version "$VERSION")"
+    print_status "Pre-release build: ${YELLOW}${VERSION}${NC} (won't move the stable pin)"
+  fi
+fi
+
+# Validate version format (an optional -suffix marks a pre-release)
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  print_error "Version must be vX.Y.Z or vX.Y.Z-suffix (e.g., v1.0.1 or v1.0.1-rc.1)"
   exit 1
 fi
 
@@ -232,6 +266,11 @@ if [ -n "$CURRENT_VERSION" ] && [ "$VERSION" != "$CURRENT_VERSION" ]; then
   echo -e "  Current: ${YELLOW}$CURRENT_VERSION${NC} → ${GREEN}$VERSION${NC}"
 fi
 echo -e "  Branch:  ${BLUE}$CURRENT_BRANCH${NC}"
+if [ "$PRE_RELEASE" = true ]; then
+  echo -e "  Channel: ${YELLOW}pre-release${NC} (candidate — won't become 'Latest')"
+else
+  echo -e "  Channel: ${GREEN}stable${NC} (GitHub 'Latest' — the pin the updater follows)"
+fi
 if [ "$DRY_RUN" = true ]; then
   echo -e "  Mode:    ${YELLOW}DRY RUN${NC} (no tag/push)"
 fi
@@ -291,7 +330,16 @@ fi
 # STEP 2: Merge dev to main (if started on dev)
 # ════════════════════════════════════════════════════════════════════
 
-if [ "$STARTED_ON_DEV" = true ]; then
+if [ "$STARTED_ON_DEV" = true ] && [ "$PRE_RELEASE" = true ]; then
+  echo ""
+  echo "════════════════════════════════════════════"
+  echo "STEP 2: Pre-release — tag dev (no merge to main)"
+  echo "════════════════════════════════════════════"
+  echo ""
+  print_status "Pushing dev so the tag points at an origin commit..."
+  git push origin dev
+
+elif [ "$STARTED_ON_DEV" = true ]; then
   echo ""
   echo "════════════════════════════════════════════"
   echo "STEP 2: Merging dev to main"
@@ -376,7 +424,9 @@ echo ""
 
 # Check if VERSION needs updating
 CURRENT_VERSION_NOW=$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]')
-if [ "$CURRENT_VERSION_NOW" != "$VERSION" ]; then
+if [ "$PRE_RELEASE" = true ]; then
+  print_status "Pre-release: leaving the VERSION file and main branch untouched"
+elif [ "$CURRENT_VERSION_NOW" != "$VERSION" ]; then
   print_status "Updating VERSION: $CURRENT_VERSION_NOW → $VERSION"
   echo "$VERSION" > "$VERSION_FILE"
   git add "$VERSION_FILE"
@@ -405,14 +455,18 @@ echo ""
 
 if [ "$DRY_RUN" = true ]; then
   print_warning "DRY RUN: Would create tag $VERSION and push"
-  print_warning "DRY RUN: Would push main branch"
+  if [ "$PRE_RELEASE" = true ]; then
+    print_warning "DRY RUN: Pre-release — would NOT touch main"
+  else
+    print_warning "DRY RUN: Would push main branch"
+  fi
   echo ""
   print_success "Dry run complete - no changes pushed"
   exit 0
 fi
 
-# Push main branch (skip if worktree mode already pushed)
-if [ "${USING_WORKTREES:-false}" = false ]; then
+# Push main branch (skip for pre-releases and when worktree mode already pushed)
+if [ "$PRE_RELEASE" = false ] && [ "${USING_WORKTREES:-false}" = false ]; then
   print_status "Pushing main branch..."
   git push origin main
 fi
@@ -444,12 +498,16 @@ echo ""
 
 print_success "Release $VERSION triggered!"
 echo ""
+if [ "$PRE_RELEASE" = true ]; then
+  print_status "This is a ${YELLOW}pre-release${NC} — GitHub won't mark it 'Latest' and the updater skips it."
+  print_status "To promote to stable, cut a normal release: ${BLUE}./scripts/release.sh${NC}"
+fi
 print_status "GitHub Actions is now building the release."
 print_status "View progress: ${BLUE}gh run list --workflow=release.yml${NC}"
 echo ""
 
-# Offer to sync dev branch
-if [ "$STARTED_ON_DEV" = true ]; then
+# Offer to sync dev branch (stable releases only; pre-releases never touch main)
+if [ "$STARTED_ON_DEV" = true ] && [ "$PRE_RELEASE" = false ]; then
   if [ "${USING_WORKTREES:-false}" = true ]; then
     # Worktree mode: already on dev, just pull/merge
     echo -n "Sync dev with main? [Y/n]: "

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,9 +6,8 @@
 # Supports git worktrees - run from either dev or main worktree.
 #
 # Usage:
-#   ./scripts/release.sh [version]
-#   ./scripts/release.sh v1.3.0
-#   ./scripts/release.sh          # Prompts for version interactively
+#   ./scripts/release.sh              # Auto-computes next version (odometer: bumps last segment)
+#   ./scripts/release.sh v0.1.0       # Explicit version for an editorial bump
 #
 # Workflow:
 #   1. Validates current branch (dev or main)
@@ -49,6 +48,25 @@ print_error() {
   echo -e "${RED}[ERROR]${NC} $1"
 }
 
+# Latest clean release tag (vX.Y.Z), or empty if there are none yet.
+latest_release_tag() {
+  git tag --list --sort=-v:refname 2>/dev/null \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1
+}
+
+# Compute the next release version from the latest release tag.
+# Odometer model: bump only the last segment (v0.0.85 -> v0.0.86), never
+# rolling over. Major/minor are editorial and only move when a version is
+# passed explicitly. Prints nothing if there are no release tags yet.
+compute_next_version() {
+  local latest ver major minor patch
+  latest=$(latest_release_tag)
+  [ -z "$latest" ] && { echo ""; return; }
+  ver="${latest#v}"
+  IFS='.' read -r major minor patch <<< "$ver"
+  echo "v${major}.${minor}.$((patch + 1))"
+}
+
 # Help function
 show_help() {
   echo ""
@@ -60,8 +78,10 @@ show_help() {
   echo "  ./scripts/release.sh [version]"
   echo ""
   echo -e "${BLUE}ARGUMENTS:${NC}"
-  echo "  [version]       Version to release (e.g., v1.3.0 or 1.3.0)"
-  echo "                  If omitted, you will be prompted to enter it"
+  echo "  [version]       Version to release (e.g., v0.1.0 or 0.1.0)"
+  echo "                  If omitted, the next version is auto-computed from the"
+  echo "                  latest release tag (odometer: bumps the last segment)."
+  echo "                  Pass a version explicitly to make an editorial bump."
   echo "                  The 'v' prefix is added automatically if missing"
   echo ""
   echo -e "${BLUE}OPTIONS:${NC}"
@@ -70,10 +90,10 @@ show_help() {
   echo "  --skip-checks   Skip pre-release checks (use with caution)"
   echo ""
   echo -e "${BLUE}EXAMPLES:${NC}"
-  echo "  ./scripts/release.sh           # Interactive mode"
-  echo "  ./scripts/release.sh v1.3.0    # Release v1.3.0"
-  echo "  ./scripts/release.sh 1.3.0     # Same as above (v prefix added)"
-  echo "  ./scripts/release.sh --dry-run v1.3.0  # Validate without releasing"
+  echo "  ./scripts/release.sh                   # Auto-compute next version and release"
+  echo "  ./scripts/release.sh v0.1.0            # Editorial bump to v0.1.0"
+  echo "  ./scripts/release.sh 0.1.0             # Same as above (v prefix added)"
+  echo "  ./scripts/release.sh --dry-run         # Auto-compute + validate, no release"
   echo ""
   echo -e "${BLUE}WORKFLOW:${NC}"
   echo "  1. Validates branch (must be on 'dev' or 'main')"
@@ -133,17 +153,33 @@ if [ -f "$VERSION_FILE" ]; then
   CURRENT_VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
 fi
 
-# If no version argument provided, prompt the user
+# If no version argument was provided, auto-compute the next version from the
+# latest release tag (odometer: bump the last segment). This makes the version
+# a byproduct of shipping rather than a per-release decision. To make an
+# editorial bump, pass a version explicitly (e.g. v0.1.0 or v1.0.0).
 if [ -z "$VERSION" ]; then
-  if [ -n "$CURRENT_VERSION" ]; then
-    print_status "Current VERSION file: ${YELLOW}$CURRENT_VERSION${NC}"
-  fi
-  echo -n "Enter version to release (e.g., v1.3.0): "
-  read -r VERSION
+  print_status "Fetching latest tags to compute next version..."
+  git fetch --tags origin >/dev/null 2>&1 || true
 
-  if [ -z "$VERSION" ]; then
-    print_error "No version provided. Aborting."
-    exit 1
+  SUGGESTED_VERSION=$(compute_next_version)
+
+  if [ -n "$SUGGESTED_VERSION" ]; then
+    VERSION="$SUGGESTED_VERSION"
+    print_status "Latest release tag:  ${YELLOW}$(latest_release_tag)${NC}"
+    print_success "Next version (auto): ${GREEN}${VERSION}${NC}"
+    print_status "Editorial bump? Re-run with a version, e.g. ${BLUE}./scripts/release.sh v0.1.0${NC}"
+  else
+    # No release tags yet — fall back to an interactive prompt.
+    if [ -n "$CURRENT_VERSION" ]; then
+      print_status "Current VERSION file: ${YELLOW}$CURRENT_VERSION${NC}"
+    fi
+    echo -n "Enter version to release (e.g., v0.1.0): "
+    read -r VERSION
+
+    if [ -z "$VERSION" ]; then
+      print_error "No version provided. Aborting."
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Why

Versioning should be a byproduct of shipping, not a per-release decision. This makes `release.sh` compute the next version itself (odometer: bump the last segment, no rollover), and decouples "stable" from the number entirely — stable is a **pin** (GitHub's "Latest" release), which the in-app updater already follows. Major/minor stay editorial: you only type them when a chapter closes.

## What changed (2 files, both release tooling)

**1. `release.sh` — auto-computed version** (`e900564d`)
- No argument → fetches tags and bumps the last segment of the latest release tag (`v0.0.85 → v0.0.86`), no roll-at-9. You never type a version.
- Explicit version still works for an editorial bump: `./scripts/release.sh v0.1.0`.
- Falls back to the interactive prompt only when there are no release tags yet.

**2. `release.sh` — `--pre-release` channel** (`d38ce7bc`)
- `./scripts/release.sh --pre-release` cuts a candidate: tags `dev` with an auto-incrementing `-rc.N` suffix, publishes a GitHub **pre-release**, and does **not** merge to `main` or bump `VERSION`.
- Stable is the default (no flag): a clean `vX.Y.Z` tag → GitHub "Latest" → the pin the updater follows. Promoting a candidate = cutting the normal release.
- No goreleaser/updater changes needed: `prerelease: auto` already flags suffixed tags, and `updatemanager` already skips pre-releases by default.

**3. `release-ready.sh` — align the auto-release gate** (`4578cf91`)
- Drop the 3-day cadence trigger — a release fires only on **≥5 merged PRs** since the last tag (or a forced manual dispatch).
- Pure-increment versioning (no roll-at-9), so the gate now computes `v0.0.86` — identical to `release.sh` — instead of jumping to `v0.1.0`.
- Strict `vX.Y.Z` tag filter so the new `-rc.N` pre-release tags are ignored (they'd otherwise be picked up and break the gate's version arithmetic).

## Verification

- `bash -n` clean on both scripts.
- `compute_next_version` and the gate's math both produce `v0.0.86` from `v0.0.85`.
- `next_prerelease_version v0.0.86` → `v0.0.86-rc.1`.
- Ran `release.sh` (stable and `--pre-release`) up to the branch guard — both resolve the right version, then halt safely (no destructive step runs before the guard).
- The end-to-end merge/tag paths can't be exercised from a feature branch (the script guards to `dev`/`main`); they are syntax-checked and traced by hand.

## Operational note

Scheduled workflows run from the default branch (`main`), so the gate change activates on `main` only after the next release fast-forwards `dev→main`. Recommend making the **next release a manual `./scripts/release.sh`** (→ `v0.0.86`) to carry the fixed scripts onto `main`. No urgency — the gate is currently holding at 1/5 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
