### PR TITLE
fix: resolve macOS arm64 DMG build failure from hdiutil resource race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,15 @@ jobs:
           hdiutil info | grep -E "^/dev/" | awk '{print $1}' | while read dev; do
             hdiutil detach "$dev" -force 2>/dev/null || true
           done
-          sleep 3
+          # diskimages-help can keep holding the previous DMG's resources for a
+          # while after hdiutil create/detach return, which causes the next
+          # hdiutil create to fail with "Resource busy". Wait for it to clear
+          # instead of a fixed sleep (observed hanging past 3s on CI runners).
+          for i in $(seq 1 30); do
+            pgrep -x diskimages-help >/dev/null 2>&1 || break
+            sleep 1
+          done
+          sleep 2
 
           # Create DMG for Apple Silicon
           ./build/macos/create-dmg.sh "$SHORT_VERSION" darwin arm64 dist || echo "Warning: arm64 DMG creation failed"
@@ -120,6 +128,17 @@ jobs:
           files: dist/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify both DMG architectures were built
+        run: |
+          missing=0
+          for arch in amd64 arm64; do
+            if ! ls dist/*-${arch}.dmg >/dev/null 2>&1; then
+              echo "::error::Missing ${arch} DMG in dist/ — it was not created or failed to build"
+              missing=1
+            fi
+          done
+          exit $missing
 
   # Windows MSI build job
   build-msi:

--- a/build/macos/create-dmg.sh
+++ b/build/macos/create-dmg.sh
@@ -297,9 +297,9 @@ for attempt in 1 2 3; do
     echo "❌ hdiutil create failed after 3 attempts" >&2
     exit 1
   fi
-  echo "⚠️  hdiutil create failed (attempt ${attempt}/3); retrying after 10s..." >&2
+  echo "⚠️  hdiutil create failed (attempt ${attempt}/3); retrying after $((attempt * 15))s..." >&2
   rm -f "${DIST_DIR}/${DMG_NAME}"
-  sleep 10
+  sleep $((attempt * 15))
 done
 
 # Clean up


### PR DESCRIPTION
## Summary
- v0.0.86 shipped without the Apple Silicon (arm64) DMG — `hdiutil create` failed 3x with "Resource busy" because `diskimages-help` was still holding the previous (amd64) DMG's resources when the arm64 build started; the fixed `sleep 3` between builds wasn't long enough
- Replace the fixed sleep with a poll that waits (up to 30s) for `diskimages-help` to actually clear, and widen the script's own retry backoff (10s → 15s/30s) as defense in depth
- Add a post-upload verification step that fails the workflow if either architecture's DMG is missing, so this can't silently ship incomplete again (previously `|| echo "Warning..."` swallowed the failure entirely)

## Test plan
- [ ] Trigger a release (or manually dispatch `release.yml` against this branch) and confirm both `*-amd64.dmg` and `*-arm64.dmg` are uploaded
- [ ] Confirm the new "Verify both DMG architectures were built" step passes when both DMGs exist
- [ ] Confirm it fails loudly (red job) if one is deliberately removed before that step, so future breakage is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)