### PR TITLE
fix(workspace-hub): map-view data fix, reachability, and cross-view consistency

### DIFF
--- a/internal/orchestrationhttp/workspace_handler.go
+++ b/internal/orchestrationhttp/workspace_handler.go
@@ -52,26 +52,15 @@ func addWorkspaceMapFields(ws *workspace.Workspace, summary map[string]any) {
 	if ws == nil || summary == nil {
 		return
 	}
-	summary["entry_agent_name"] = ws.EntryAgentName()
+	fields := workspace.ComputeMapSummaryFields(ws)
+	summary["entry_agent_name"] = fields.EntryAgentName
 	summary["kind"] = ws.Kind
 	summary["parent_id"] = ws.ParentID
-	summary["mcp_count"] = len(ws.MCPBindings)
-	summary["skill_count"] = len(ws.SkillBindings)
-	summary["ops_mode"] = workspacesettings.Extract(ws.SharedData).Workflow.Mode
-
-	openTaskCount := 0
-	active := false
-	for _, t := range ws.Tasks {
-		switch t.Status {
-		case workspace.TaskStatusPending:
-			openTaskCount++
-		case workspace.TaskStatusInProgress:
-			openTaskCount++
-			active = true
-		}
-	}
-	summary["open_task_count"] = openTaskCount
-	summary["active"] = active
+	summary["mcp_count"] = fields.MCPCount
+	summary["skill_count"] = fields.SkillCount
+	summary["ops_mode"] = fields.OpsMode
+	summary["open_task_count"] = fields.OpenTaskCount
+	summary["active"] = fields.Active
 }
 
 // WorkspaceHandler handles workspace CRUD operations

--- a/internal/orchestrationhttp/workspace_handler.go
+++ b/internal/orchestrationhttp/workspace_handler.go
@@ -60,6 +60,7 @@ func addWorkspaceMapFields(ws *workspace.Workspace, summary map[string]any) {
 	summary["skill_count"] = fields.SkillCount
 	summary["ops_mode"] = fields.OpsMode
 	summary["open_task_count"] = fields.OpenTaskCount
+	summary["needs_attention_count"] = fields.NeedsAttentionCount
 	summary["active"] = fields.Active
 }
 

--- a/internal/orchestrationhttp/workspace_handler_test.go
+++ b/internal/orchestrationhttp/workspace_handler_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/johnjallday/ori-agent/internal/workspacesettings"
 )
 
+// TestAddWorkspaceMapFields covers the map-summary keys via addWorkspaceMapFields,
+// which now delegates to workspace.ComputeMapSummaryFields (see
+// TestComputeMapSummaryFields in internal/workspace for the field-derivation
+// logic itself); this test guards the summary-map wiring stays intact.
 func TestAddWorkspaceMapFields(t *testing.T) {
 	settings := workspacesettings.DefaultSettings()
 	settings.Workflow.Mode = "direct"

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -287,6 +287,19 @@ type Workspace struct {
 	// This is denormalized for efficient display.
 	SessionCount int `json:"session_count"`
 
+	// Map-view summary fields: computed at read time from the folder-store
+	// workspace by hydrateWorkspaceMetadataInto (sessionhttp), mirroring
+	// workspace.ComputeMapSummaryFields. No SQLite column backs these; they
+	// are display-only, same precedent as SessionCount above.
+	EntryAgentName string   `json:"entry_agent_name,omitempty"`
+	Agents         []string `json:"agents,omitempty"`
+	AgentCount     int      `json:"agent_count"`
+	OpenTaskCount  int      `json:"open_task_count"`
+	MCPCount       int      `json:"mcp_count"`
+	SkillCount     int      `json:"skill_count"`
+	OpsMode        string   `json:"ops_mode,omitempty"`
+	Active         bool     `json:"active"`
+
 	// CreatedAt is when the workspace was created.
 	CreatedAt time.Time `json:"created_at"`
 

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -291,14 +291,15 @@ type Workspace struct {
 	// workspace by hydrateWorkspaceMetadataInto (sessionhttp), mirroring
 	// workspace.ComputeMapSummaryFields. No SQLite column backs these; they
 	// are display-only, same precedent as SessionCount above.
-	EntryAgentName string   `json:"entry_agent_name,omitempty"`
-	Agents         []string `json:"agents,omitempty"`
-	AgentCount     int      `json:"agent_count"`
-	OpenTaskCount  int      `json:"open_task_count"`
-	MCPCount       int      `json:"mcp_count"`
-	SkillCount     int      `json:"skill_count"`
-	OpsMode        string   `json:"ops_mode,omitempty"`
-	Active         bool     `json:"active"`
+	EntryAgentName      string   `json:"entry_agent_name,omitempty"`
+	Agents              []string `json:"agents,omitempty"`
+	AgentCount          int      `json:"agent_count"`
+	OpenTaskCount       int      `json:"open_task_count"`
+	NeedsAttentionCount int      `json:"needs_attention_count"`
+	MCPCount            int      `json:"mcp_count"`
+	SkillCount          int      `json:"skill_count"`
+	OpsMode             string   `json:"ops_mode,omitempty"`
+	Active              bool     `json:"active"`
 
 	// CreatedAt is when the workspace was created.
 	CreatedAt time.Time `json:"created_at"`

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -983,6 +983,20 @@ func (h *Handler) hydrateWorkspaceMetadataInto(workspace *session.Workspace) {
 	mergeWorkspaceJSONField(&workspace.AgentMCPAccessJSON, fallback.AgentMCPAccessJSON)
 	mergeWorkspaceJSONField(&workspace.SkillBindingsJSON, fallback.SkillBindingsJSON)
 	mergeWorkspaceJSONField(&workspace.AgentSkillAccessJSON, fallback.AgentSkillAccessJSON)
+
+	// Map-view summary fields (agent roster, task/tool/skill counts, ops mode,
+	// active flag) are always recomputed from the disk workspace rather than
+	// filled-if-empty like the fields above — they're display-only derived
+	// state, not data that could already be populated from another source.
+	mapFields := agentworkspace.ComputeMapSummaryFields(diskWorkspace)
+	workspace.EntryAgentName = mapFields.EntryAgentName
+	workspace.Agents = mapFields.AgentNames
+	workspace.AgentCount = mapFields.AgentCount
+	workspace.OpenTaskCount = mapFields.OpenTaskCount
+	workspace.MCPCount = mapFields.MCPCount
+	workspace.SkillCount = mapFields.SkillCount
+	workspace.OpsMode = mapFields.OpsMode
+	workspace.Active = mapFields.Active
 }
 
 func mergeWorkspaceJSONField(target *json.RawMessage, fallback json.RawMessage) {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -993,6 +993,7 @@ func (h *Handler) hydrateWorkspaceMetadataInto(workspace *session.Workspace) {
 	workspace.Agents = mapFields.AgentNames
 	workspace.AgentCount = mapFields.AgentCount
 	workspace.OpenTaskCount = mapFields.OpenTaskCount
+	workspace.NeedsAttentionCount = mapFields.NeedsAttentionCount
 	workspace.MCPCount = mapFields.MCPCount
 	workspace.SkillCount = mapFields.SkillCount
 	workspace.OpsMode = mapFields.OpsMode

--- a/internal/sessionhttp/workspace_map_summary_test.go
+++ b/internal/sessionhttp/workspace_map_summary_test.go
@@ -1,0 +1,279 @@
+package sessionhttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+	"github.com/johnjallday/ori-agent/internal/workspacesettings"
+)
+
+// seedMapSummaryFixture loads the given workspace from the folder-based file
+// store, overwrites it with a fixed roster/tasks/tool-binding shape, and saves
+// it back. This is the enrichment source hydrateWorkspaceMetadataInto reads
+// from, independent of whatever the SQLite side already holds.
+func seedMapSummaryFixture(t *testing.T, fileStore *agentworkspace.FileStore, workspaceID string) {
+	t.Helper()
+
+	ws, err := fileStore.Get(workspaceID)
+	if err != nil {
+		t.Fatalf("failed to load workspace %q from file store: %v", workspaceID, err)
+	}
+
+	settings := workspacesettings.DefaultSettings()
+	settings.Workflow.Mode = "direct"
+
+	ws.AgentInstances = []agentworkspace.AgentInstance{
+		{Name: "Research Lead", EntryPoint: true},
+		{Name: "Source Scout"},
+	}
+	ws.Tasks = []agentworkspace.Task{
+		{ID: "t1", Status: agentworkspace.TaskStatusPending},
+		{ID: "t2", Status: agentworkspace.TaskStatusInProgress},
+		{ID: "t3", Status: agentworkspace.TaskStatusCompleted},
+	}
+	ws.MCPBindings = []agentworkspace.WorkspaceMCPBinding{{}, {}}
+	ws.SkillBindings = []agentworkspace.WorkspaceSkillBinding{{}}
+	ws.SharedData = workspacesettings.Store(map[string]any{}, settings)
+
+	if err := fileStore.Save(ws); err != nil {
+		t.Fatalf("failed to save fixture for workspace %q: %v", workspaceID, err)
+	}
+}
+
+func assertMapSummaryFields(t *testing.T, entry map[string]any) {
+	t.Helper()
+
+	if got := entry["entry_agent_name"]; got != "Research Lead" {
+		t.Errorf("entry_agent_name = %v, want %q", got, "Research Lead")
+	}
+	if got, ok := entry["agent_count"].(float64); !ok || got != 2 {
+		t.Errorf("agent_count = %v, want 2", entry["agent_count"])
+	}
+	agents, ok := entry["agents"].([]any)
+	if !ok || len(agents) != 2 {
+		t.Errorf("agents = %v, want 2 entries", entry["agents"])
+	}
+	if got, ok := entry["open_task_count"].(float64); !ok || got != 2 {
+		t.Errorf("open_task_count = %v, want 2 (pending + in_progress, excludes completed)", entry["open_task_count"])
+	}
+	if got, ok := entry["mcp_count"].(float64); !ok || got != 2 {
+		t.Errorf("mcp_count = %v, want 2", entry["mcp_count"])
+	}
+	if got, ok := entry["skill_count"].(float64); !ok || got != 1 {
+		t.Errorf("skill_count = %v, want 1", entry["skill_count"])
+	}
+	if got := entry["ops_mode"]; got != "direct" {
+		t.Errorf("ops_mode = %v, want %q", got, "direct")
+	}
+	if got, ok := entry["active"].(bool); !ok || !got {
+		t.Errorf("active = %v, want true (workspace has an in-progress task)", entry["active"])
+	}
+}
+
+func TestListWorkspacesFlatIncludesMapSummaryFields(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	workspaceID := createTestWorkspace(t, handler, "Flat Summary")
+	seedMapSummaryFixture(t, fileStore, workspaceID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Workspaces []map[string]any `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var found map[string]any
+	for _, entry := range resp.Workspaces {
+		if entry["id"] == workspaceID {
+			found = entry
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("workspace %q not found in flat list", workspaceID)
+	}
+	assertMapSummaryFields(t, found)
+}
+
+func TestListWorkspacesTreeIncludesMapSummaryFields(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	workspaceID := createTestWorkspace(t, handler, "Tree Summary")
+	seedMapSummaryFixture(t, fileStore, workspaceID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces?tree=true", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Workspaces []map[string]any `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var found map[string]any
+	for _, entry := range resp.Workspaces {
+		if entry["id"] == workspaceID {
+			found = entry
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("workspace %q not found in tree list", workspaceID)
+	}
+	assertMapSummaryFields(t, found)
+}
+
+func TestListWorkspacesGroupIncludesMapSummaryFields(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	groupID := createTestGroup(t, handler, "Group Summary")
+	seedMapSummaryFixture(t, fileStore, groupID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Workspaces []map[string]any `json:"workspaces"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var found map[string]any
+	for _, entry := range resp.Workspaces {
+		if entry["id"] == groupID {
+			found = entry
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("group %q not found in flat list", groupID)
+	}
+	if got := found["kind"]; got != "group" {
+		t.Fatalf("expected kind group, got %v", got)
+	}
+	assertMapSummaryFields(t, found)
+}
+
+func TestListWorkspacesTreeNestedChildIncludesMapSummaryFields(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	baseDir := t.TempDir()
+	fileStore, err := agentworkspace.NewFileStore(baseDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer func() { _ = fileStore.Close() }()
+	handler.SetWorkspaceStore(fileStore)
+
+	groupID := createTestGroup(t, handler, "Nested Parent")
+
+	childBody := `{"name":"Nested Child","parent_id":"` + groupID + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", bytes.NewBufferString(childBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("failed to create nested child: %d - %s", w.Code, w.Body.String())
+	}
+	var createResp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	childPayload := createResp["folder"].(map[string]any)
+	childID := childPayload["id"].(string)
+
+	seedMapSummaryFixture(t, fileStore, childID)
+
+	treeReq := httptest.NewRequest(http.MethodGet, "/api/workspaces?tree=true", nil)
+	treeW := httptest.NewRecorder()
+	handler.HandleWorkspaces(treeW, treeReq)
+	if treeW.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", treeW.Code, treeW.Body.String())
+	}
+
+	var treeResp struct {
+		Workspaces []map[string]any `json:"workspaces"`
+	}
+	if err := json.Unmarshal(treeW.Body.Bytes(), &treeResp); err != nil {
+		t.Fatalf("decode tree response: %v", err)
+	}
+
+	var parent map[string]any
+	for _, entry := range treeResp.Workspaces {
+		if entry["id"] == groupID {
+			parent = entry
+			break
+		}
+	}
+	if parent == nil {
+		t.Fatalf("parent group %q not found in tree", groupID)
+	}
+
+	children, ok := parent["children"].([]any)
+	if !ok {
+		t.Fatalf("expected children array on parent, got %#v", parent["children"])
+	}
+
+	var child map[string]any
+	for _, c := range children {
+		childMap, ok := c.(map[string]any)
+		if ok && childMap["id"] == childID {
+			child = childMap
+			break
+		}
+	}
+	if child == nil {
+		t.Fatalf("nested child %q not found under parent %q", childID, groupID)
+	}
+	assertMapSummaryFields(t, child)
+}

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -12,18 +12,19 @@
  */
 
 .ws-cmd {
-  /* surface */
-  --ws-bg: #070b0c;
-  --ws-bg-2: #0b1113;
-  --ws-panel: #0e1618;
-  --ws-panel-2: #101e1f;
-  --ws-line: #1c2e2c;
-  --ws-line-bright: #28413c;
+  /* surface — neutral charcoal, matching the app shell's dark theme family
+     (#0A0A0A → #1F2128 → #2A2C33); green stays an ACCENT, not a surface cast */
+  --ws-bg: #0c0d10;
+  --ws-bg-2: #121317;
+  --ws-panel: #16181d;
+  --ws-panel-2: #1a1d23;
+  --ws-line: #262931;
+  --ws-line-bright: #363a45;
 
   /* ink */
-  --ws-ink: #cfe8df;
-  --ws-ink-dim: #7f998f;
-  --ws-ink-faint: #4d655d;
+  --ws-ink: #d6d9de;
+  --ws-ink-dim: #8b909a;
+  --ws-ink-faint: #5a5f6a;
 
   /* semantic accents */
   --ws-faction: #46d39a;
@@ -37,7 +38,7 @@
   /* geometry */
   --ws-clip: 14px;
   --ws-clip-sm: 8px;
-  --ws-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+  --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
 
   /* type (families vendored globally by workspace-map.css) */
   --ws-font-display: 'Chakra Petch', system-ui, sans-serif;
@@ -82,7 +83,7 @@
 .ws-cmd-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
 .ws-cmd-title .ws-dot { width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg); }
 .ws-cmd-title h2 {
-  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eafff5;
+  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eef0f3;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .ws-cmd-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
@@ -95,13 +96,13 @@
 }
 .ws-cmd-stat:hover { border-color: var(--ws-line-bright); background: rgba(70, 211, 154, 0.06); }
 .ws-cmd-stat:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eafff5; line-height: 1; }
+.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; }
 .ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
 .ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
 .ws-cmd-garrison {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); min-height: 200px;
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014); min-height: 200px;
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
   box-shadow: var(--ws-glow);
 }
@@ -109,14 +110,14 @@
 
 /* rail panels */
 .ws-cmd-panel {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213);
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014);
   clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-panel.is-managing { border-color: var(--ws-line-bright); background: linear-gradient(180deg, #102022, #0b1213); }
+.ws-cmd-panel.is-managing { border-color: var(--ws-line-bright); background: linear-gradient(180deg, #1c1f26, #0f1014); }
 .ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
 .ws-cmd-panel-title { display: flex; align-items: center; gap: 9px; }
-.ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #dff5ec; }
+.ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #e3e6ea; }
 .ws-cmd-panel-count { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-faint); }
 .ws-cmd-panel-more {
   width: 26px; height: 24px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
@@ -140,7 +141,7 @@
 .ws-cmd-rail-item.is-static { cursor: default; }
 .ws-cmd-rail-item:hover:not(.is-static) { border-color: var(--ws-line-bright); background: var(--ws-bg-2); }
 .ws-cmd-rail-item:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
-.ws-cmd-rail-t { font-size: 13px; color: #eafff5; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-rail-t { font-size: 13px; color: #eef0f3; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ws-cmd-rail-m { font-family: var(--ws-font-mono); font-size: 9.5px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
 .ws-cmd-rail-more {
   margin-top: 4px; padding: 7px; border: 1px dashed var(--ws-line-bright); background: none; color: var(--ws-ink-dim); cursor: pointer;
@@ -157,7 +158,7 @@
 .ws-cmd-garrison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
 
 .ws-cmd-unit {
-  border: 1px solid var(--ws-line); background: linear-gradient(165deg, #0f1a1b, #0b1112); overflow: hidden;
+  border: 1px solid var(--ws-line); background: linear-gradient(165deg, #171a20, #0e0f13); overflow: hidden;
   clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
 }
 .ws-cmd-unit.is-keeper { border-color: rgba(232, 181, 75, 0.32); }
@@ -169,7 +170,7 @@
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
 .ws-cmd-unit-id { flex: 1 1 auto; min-width: 0; }
-.ws-cmd-unit-name { font-size: 15px; font-weight: 700; letter-spacing: 0.4px; text-transform: uppercase; color: #f1fff8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-unit-name { font-size: 15px; font-weight: 700; letter-spacing: 0.4px; text-transform: uppercase; color: #f3f5f8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ws-cmd-unit-role { display: flex; align-items: center; gap: 8px; margin-top: 5px; flex-wrap: wrap; }
 .ws-cmd-badge {
   font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase;
@@ -194,7 +195,7 @@
 .ws-cmd-unit-rows { padding: 11px 13px; display: flex; flex-direction: column; gap: 8px; }
 .ws-cmd-row { display: flex; justify-content: space-between; align-items: center; }
 .ws-cmd-rk { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-ink-faint); }
-.ws-cmd-rv { font-family: var(--ws-font-mono); font-size: 12px; color: #eafff5; }
+.ws-cmd-rv { font-family: var(--ws-font-mono); font-size: 12px; color: #eef0f3; }
 
 .ws-cmd-questlog { margin: 2px 13px 13px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
 .ws-cmd-ql-head { display: flex; justify-content: space-between; align-items: center; padding: 8px 11px; border-bottom: 1px solid var(--ws-line); }
@@ -203,7 +204,7 @@
 .ws-cmd-quest { display: flex; align-items: center; gap: 9px; padding: 9px 11px; }
 .ws-cmd-quest + .ws-cmd-quest { border-top: 1px solid var(--ws-line); }
 .ws-cmd-q-glyph { width: 22px; height: 22px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-keeper-deep); color: var(--ws-keeper); font-size: 11px; }
-.ws-cmd-q-name { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eafff5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-q-name { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ws-cmd-q-status { font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
 .ws-cmd-q-status.pending { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); }
 .ws-cmd-q-status.working { color: var(--ws-working); border-color: var(--ws-faction-deep); }
@@ -229,7 +230,7 @@
 }
 .ws-cmd-modal-panel:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-modal-head { display: flex; align-items: center; gap: 12px; padding: 14px 16px; border-bottom: 1px solid var(--ws-line); }
-.ws-cmd-modal-title { margin: 0; font-size: 15px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: #eafff5; }
+.ws-cmd-modal-title { margin: 0; font-size: 15px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: #eef0f3; }
 .ws-cmd-modal-count { font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); }
 .ws-cmd-modal-head-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 .ws-cmd-modal-add {
@@ -263,7 +264,7 @@
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
 .ws-cmd-mrow-main { flex: 1 1 auto; min-width: 0; }
-.ws-cmd-mrow-name { display: flex; align-items: center; gap: 7px; font-size: 14px; color: #eafff5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-mrow-name { display: flex; align-items: center; gap: 7px; font-size: 14px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ws-cmd-mrow-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 .ws-cmd-mchip {
   font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 0.8px; text-transform: uppercase; padding: 2px 7px;

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -96,7 +96,7 @@
 }
 .ws-cmd-stat:hover { border-color: var(--ws-line-bright); background: rgba(70, 211, 154, 0.06); }
 .ws-cmd-stat:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; }
+.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; font-variant-numeric: tabular-nums; }
 .ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -17,27 +17,27 @@
 
 .workspace-create-modal {
   /* tactical tokens */
-  --wc-bg: #070b0c;
-  --wc-bg-2: #0b1113;
-  --wc-panel: #0e1618;
-  --wc-panel-2: #101e1f;
-  --wc-line: #1c2e2c;
-  --wc-line-bright: #28413c;
-  --wc-ink: #cfe8df;
-  --wc-ink-dim: #7f998f;
-  --wc-ink-faint: #4d655d;
+  --wc-bg: #0c0d10;
+  --wc-bg-2: #121317;
+  --wc-panel: #16181d;
+  --wc-panel-2: #1a1d23;
+  --wc-line: #262931;
+  --wc-line-bright: #363a45;
+  --wc-ink: #d6d9de;
+  --wc-ink-dim: #8b909a;
+  --wc-ink-faint: #5a5f6a;
   --wc-faction: #46d39a;
   --wc-faction-deep: #0f3b30;
   --wc-keeper: #e8b54b;
   --wc-idle: #4ec5e6;
   --wc-alert: #e2654d;
-  --wc-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+  --wc-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
   --wc-font-display: 'Chakra Petch', system-ui, sans-serif;
   --wc-font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
   /* redefine app theme vars locally → the modal's inline var() usages go tactical */
   --bg-primary: var(--wc-panel);
-  --text-primary: #eafff5;
+  --text-primary: #eef0f3;
   --text-secondary: var(--wc-ink-dim);
   --border-color: var(--wc-line);
 
@@ -52,7 +52,7 @@
 }
 .workspace-create-modal .modal-header { background: linear-gradient(180deg, var(--wc-panel-2), var(--wc-panel)); }
 .workspace-create-modal .modal-title {
-  font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; color: #eafff5;
+  font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; color: #eef0f3;
 }
 .workspace-create-modal .btn-close { filter: invert(1) grayscale(1) brightness(1.4); opacity: 0.7; }
 .workspace-create-modal .btn-close:hover { opacity: 1; }
@@ -95,7 +95,7 @@
   background: rgba(0, 0, 0, 0.22); border: 1px solid var(--wc-line);
 }
 .workspace-create-modal .workspace-setup-title,
-.workspace-create-modal .workspace-advanced-summary-title { color: #eafff5; }
+.workspace-create-modal .workspace-advanced-summary-title { color: #eef0f3; }
 .workspace-create-modal .workspace-setup-help,
 .workspace-create-modal .workspace-advanced-summary-hint { color: var(--wc-ink-faint); }
 .workspace-create-modal .workspace-template-list-heading {
@@ -119,7 +119,7 @@
 .workspace-create-modal .workspace-template-row:focus-visible { outline: 2px solid var(--wc-faction); outline-offset: 2px; }
 .workspace-create-modal .workspace-template-card-icon { color: var(--wc-faction); }
 .workspace-create-modal .workspace-template-card-label {
-  color: #f1fff8; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase;
+  color: #f3f5f8; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase;
 }
 .workspace-create-modal .workspace-template-card-desc { color: var(--wc-ink-faint); }
 

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -22,6 +22,16 @@
   padding-top: 0.75rem;
 }
 
+/* The workspace hub scrolls the document root. Bootstrap Reboot applies
+   :root { scroll-behavior: smooth } under prefers-reduced-motion:no-preference;
+   its rAF-driven animation makes scrolling to the Map view's below-the-fold
+   Overview panel unreliable (wheel/programmatic scrolls fail to land). Instant
+   scrolling lands and holds here, so opt this page out. Scoped via :has() so it
+   only affects the hub, not the rest of the app. */
+html:has(body.home-hub) {
+  scroll-behavior: auto;
+}
+
 .workspace-hub {
   display: flex;
   flex-direction: column;

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -3040,6 +3040,19 @@ button.hub-stat[hidden] {
   margin-right: 0.35rem;
 }
 
+/* Canonical "N agents · M open tasks" summary — same shape as the Map tile
+   meta and the Cards summary, so switching views reprojects the same facts. */
+.launcher-tree-meta {
+  flex: 0 0 auto;
+  max-width: 11rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-right: 0.35rem;
+}
+
 .launcher-tag-chip--tree {
   min-height: 1.25rem;
   font-size: 0.63rem;
@@ -3626,25 +3639,43 @@ button.hub-stat[hidden] {
 }
 
 .launcher-task-badge {
-  min-width: 1.4rem;
-  height: 1.4rem;
-  padding: 0 0.38rem;
+  min-height: 1.4rem;
+  padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  border: 1px solid rgba(31, 107, 78, 0.35);
-  background: rgba(31, 107, 78, 0.16);
-  color: #c7dcff;
+  border: 1px solid rgba(31, 107, 78, 0.32);
+  background: rgba(31, 107, 78, 0.12);
+  color: #155039;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 0.72rem;
   font-weight: 700;
   line-height: 1;
+  white-space: nowrap;
   flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .launcher-task-badge.is-attention {
-  border-color: rgba(239, 68, 68, 0.38);
-  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+/* The badge went from a bare 1-2 digit number to visible "N open" text
+   (task 5.2): the original colors were only ever tuned against the dark
+   card background and were unreadable in light mode. */
+[data-bs-theme="dark"] .launcher-task-badge,
+.dark-mode .launcher-task-badge {
+  border-color: rgba(31, 107, 78, 0.38);
+  background: rgba(31, 107, 78, 0.2);
+  color: #c7dcff;
+}
+
+[data-bs-theme="dark"] .launcher-task-badge.is-attention,
+.dark-mode .launcher-task-badge.is-attention {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.22);
   color: #fca5a5;
 }
 
@@ -3676,15 +3707,44 @@ button.hub-stat[hidden] {
 
 .launcher-card-meta {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.35rem 0.75rem;
   font-size: 0.75rem;
   color: var(--text-muted);
 }
 
-.launcher-card-status {
+/* Idle/Working (task activity) — same vocabulary as the Map LED, replacing
+   the old workspace.Status chip that read "ACTIVE" for nearly every card. */
+.launcher-card-led-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.launcher-card-led {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.launcher-card-led-status.is-working {
+  color: var(--primary-color);
+}
+
+.launcher-card-led-status.is-working .launcher-card-led {
+  background: var(--primary-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 20%, transparent);
+}
+
+.launcher-card-summary {
+  color: var(--text-muted);
 }
 
 .launcher-empty {

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -2222,6 +2222,21 @@ button.hub-stat[hidden] {
   flex-wrap: wrap;
 }
 
+/* Map view: the map shell already carries identity, stats, and its own
+   ⊕ New Workspace affordance, so the legacy title/subtitle and the
+   duplicate green Create Workspace button collapse away — leaving one
+   create button in the chrome (the map pad tile) and a slim actions row
+   (Import Folder, view toggle, refresh/rescan/undo). */
+#workspaceHub[data-launcher-view="map"] .launcher-title,
+#workspaceHub[data-launcher-view="map"] .launcher-subtitle,
+#workspaceHub[data-launcher-view="map"] #launcherCreateWorkspaceBtn {
+  display: none;
+}
+
+#workspaceHub[data-launcher-view="map"] .launcher-workspace-root {
+  margin-top: 0;
+}
+
 .launcher-undo-btn {
   position: relative;
 }
@@ -2253,23 +2268,21 @@ button.hub-stat[hidden] {
 }
 
 .launcher-workspace-root {
-  margin-top: 1rem;
-  padding: 1rem 1.05rem;
-  border-radius: 18px;
-  border: 1px solid rgba(92, 92, 94, 0.22);
-  background:
-    radial-gradient(circle at top right, rgba(31, 107, 78, 0.12), transparent 42%),
-    linear-gradient(140deg, rgba(245, 246, 247, 0.97), rgba(201, 204, 209, 0.95));
-  box-shadow:
-    0 14px 28px rgba(79, 55, 32, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.52);
+  margin-top: 0.85rem;
+}
+
+/* Always-visible one-line summary: badge + truncated path + Edit. The full
+   card (kicker/summary/editor/footer) lives behind .launcher-workspace-root-editor
+   and only appears once Edit is clicked — this panel is persistent config UI
+   that shouldn't consume prime space on every visit. */
+.launcher-workspace-root-collapsed {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 }
 
 .launcher-workspace-root-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
+  margin-bottom: 0.9rem;
 }
 
 .launcher-workspace-root-kicker {
@@ -2291,8 +2304,7 @@ button.hub-stat[hidden] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 2rem;
-  padding: 0.32rem 0.72rem;
+  padding: 0.28rem 0.62rem;
   border-radius: 999px;
   border: 1px solid rgba(92, 92, 94, 0.2);
   background: rgba(255, 252, 247, 0.72);
@@ -2328,17 +2340,14 @@ button.hub-stat[hidden] {
 }
 
 .launcher-workspace-root-path {
-  margin-top: 0.85rem;
-  padding: 0.82rem 0.92rem;
-  border-radius: 14px;
-  background: rgba(255, 252, 247, 0.82);
-  border: 1px solid rgba(92, 92, 94, 0.16);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: "SFMono-Regular", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 0.9rem;
-  line-height: 1.45;
-  color: var(--text-primary);
-  word-break: break-word;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
 }
 
 .launcher-workspace-root-footer {
@@ -2347,19 +2356,12 @@ button.hub-stat[hidden] {
   align-items: center;
   gap: 0.75rem;
   flex-wrap: wrap;
-  margin-top: 0.75rem;
+  margin-top: 0.9rem;
 }
 
 .launcher-workspace-root-meta {
   font-size: 0.84rem;
   color: var(--text-secondary);
-}
-
-.launcher-workspace-root-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  flex-wrap: wrap;
 }
 
 .launcher-workspace-root-link {
@@ -2376,9 +2378,16 @@ button.hub-stat[hidden] {
 }
 
 .launcher-workspace-root-editor {
-  margin-top: 0.9rem;
-  padding-top: 0.9rem;
-  border-top: 1px solid rgba(92, 92, 94, 0.14);
+  margin-top: 0.75rem;
+  padding: 1rem 1.05rem;
+  border-radius: 18px;
+  border: 1px solid rgba(92, 92, 94, 0.22);
+  background:
+    radial-gradient(circle at top right, rgba(31, 107, 78, 0.12), transparent 42%),
+    linear-gradient(140deg, rgba(245, 246, 247, 0.97), rgba(201, 204, 209, 0.95));
+  box-shadow:
+    0 14px 28px rgba(79, 55, 32, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.52);
 }
 
 .launcher-workspace-root-editor[hidden] {
@@ -2419,8 +2428,8 @@ button.hub-stat[hidden] {
   padding: 0.08rem 0.34rem;
 }
 
-[data-bs-theme="dark"] .launcher-workspace-root,
-.dark-mode .launcher-workspace-root {
+[data-bs-theme="dark"] .launcher-workspace-root-editor,
+.dark-mode .launcher-workspace-root-editor {
   border: 1px solid rgba(138, 138, 138, 0.18);
   background:
     radial-gradient(circle at top right, rgba(31, 107, 78, 0.14), transparent 42%),
@@ -2476,10 +2485,7 @@ button.hub-stat[hidden] {
 
 [data-bs-theme="dark"] .launcher-workspace-root-path,
 .dark-mode .launcher-workspace-root-path {
-  background: rgba(10, 10, 10, 0.42);
-  border-color: rgba(255, 255, 255, 0.07);
-  box-shadow: none;
-  color: rgba(249, 246, 241, 0.94);
+  color: rgba(214, 214, 214, 0.82);
 }
 
 [data-bs-theme="dark"] .launcher-workspace-root-meta,
@@ -2497,11 +2503,6 @@ button.hub-stat[hidden] {
 .dark-mode .launcher-workspace-root-link:hover,
 .dark-mode .launcher-workspace-root-link:focus-visible {
   color: #3FA275;
-}
-
-[data-bs-theme="dark"] .launcher-workspace-root-editor,
-.dark-mode .launcher-workspace-root-editor {
-  border-top-color: rgba(255, 255, 255, 0.08);
 }
 
 [data-bs-theme="dark"] .launcher-workspace-root-label,
@@ -2766,20 +2767,15 @@ button.hub-stat[hidden] {
 }
 
 @media (max-width: 768px) {
-  .launcher-workspace-root {
+  .launcher-workspace-root-editor {
     padding: 0.95rem;
   }
 
-  .launcher-workspace-root-head,
   .launcher-workspace-root-footer,
   .launcher-workspace-root-editor-row,
   .launcher-workspace-root-editor-actions {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .launcher-workspace-root-actions {
-    width: 100%;
   }
 
   .launcher-workspace-root-input {

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -109,7 +109,7 @@
   min-width: 82px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
-.ws-map-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; }
+.ws-map-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; font-variant-numeric: tabular-nums; }
 .ws-map-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
 
 .ws-map-create {

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -28,18 +28,19 @@
 }
 
 .ws-map {
-  /* surface */
-  --ws-bg: #070b0c;
-  --ws-bg-2: #0b1113;
-  --ws-panel: #0e1618;
-  --ws-panel-2: #101e1f;
-  --ws-line: #1c2e2c;
-  --ws-line-bright: #28413c;
+  /* surface — neutral charcoal, matching the app shell's dark theme family
+     (#0A0A0A → #1F2128 → #2A2C33); green stays an ACCENT, not a surface cast */
+  --ws-bg: #0c0d10;
+  --ws-bg-2: #121317;
+  --ws-panel: #16181d;
+  --ws-panel-2: #1a1d23;
+  --ws-line: #262931;
+  --ws-line-bright: #363a45;
 
   /* ink */
-  --ws-ink: #cfe8df;
-  --ws-ink-dim: #7f998f;
-  --ws-ink-faint: #4d655d;
+  --ws-ink: #d6d9de;
+  --ws-ink-dim: #8b909a;
+  --ws-ink-faint: #5a5f6a;
 
   /* semantic accents */
   --ws-faction: #46d39a;
@@ -53,7 +54,7 @@
   /* geometry */
   --ws-clip: 14px;
   --ws-clip-sm: 8px;
-  --ws-glow: 0 0 0 1px rgba(70, 211, 154, 0.12), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+  --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
 
   /* type */
   --ws-font-display: 'Chakra Petch', system-ui, sans-serif;
@@ -99,7 +100,7 @@
   width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg);
 }
 .ws-map-title h2 {
-  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1.5px; text-transform: uppercase; color: #eafff5;
+  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1.5px; text-transform: uppercase; color: #eef0f3;
 }
 .ws-map-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
 
@@ -108,7 +109,7 @@
   min-width: 82px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
-.ws-map-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eafff5; line-height: 1; }
+.ws-map-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; }
 .ws-map-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
 
 .ws-map-create {
@@ -130,17 +131,17 @@
 .ws-map-theatre {
   position: relative; border: 1px solid var(--ws-line); min-height: 520px; overflow: hidden; padding: 44px 0 10px;
   background:
-    radial-gradient(120% 100% at 30% 20%, rgba(70, 211, 154, 0.05), transparent 55%),
-    radial-gradient(90% 90% at 85% 90%, rgba(123, 108, 240, 0.05), transparent 55%),
-    linear-gradient(180deg, #0a1213, #070d0e);
+    radial-gradient(120% 100% at 30% 20%, rgba(255, 255, 255, 0.025), transparent 55%),
+    radial-gradient(90% 90% at 85% 90%, rgba(123, 108, 240, 0.04), transparent 55%),
+    linear-gradient(180deg, #121419, #0d0e11);
   clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
   box-shadow: var(--ws-glow);
 }
 .ws-map-theatre::before {
   content: ""; position: absolute; inset: 0; opacity: 0.55;
   background-image:
-    linear-gradient(rgba(70, 211, 154, 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(70, 211, 154, 0.045) 1px, transparent 1px);
+    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.038) 1px, transparent 1px);
   background-size: 38px 38px;
   -webkit-mask-image: radial-gradient(120% 100% at 50% 40%, #000 30%, transparent 88%);
   mask-image: radial-gradient(120% 100% at 50% 40%, #000 30%, transparent 88%);
@@ -150,7 +151,7 @@
   font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-faction);
   border: 1px solid var(--ws-faction-deep); padding: 2px 6px;
 }
-.ws-map-theatre-tag h3 { margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #dff5ec; }
+.ws-map-theatre-tag h3 { margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #e3e6ea; }
 .ws-map-compass {
   position: absolute; top: 14px; right: 16px; z-index: 6; width: 40px; height: 40px; display: grid; place-items: center;
   border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
@@ -172,7 +173,7 @@
   background: rgba(232, 134, 77, 0.04); border-radius: 16px;
 }
 .ws-map-district-tag {
-  position: absolute; top: -11px; left: 16px; border: 1px solid rgba(232, 134, 77, 0.35); background: #0a1213;
+  position: absolute; top: -11px; left: 16px; border: 1px solid rgba(232, 134, 77, 0.35); background: var(--ws-bg-2);
   color: var(--ws-keeper); cursor: pointer;
   font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; padding: 2px 9px;
 }
@@ -211,7 +212,7 @@
   text-shadow: 0 0 3px var(--ws-keeper); pointer-events: none;
 }
 .ws-map-tile-name {
-  margin-top: 2px; font-size: 12.5px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #eafff5;
+  margin-top: 2px; font-size: 12.5px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #eef0f3;
   text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9); max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .ws-map-tile-type {
@@ -219,7 +220,7 @@
 }
 .ws-map-tile-meta {
   margin-top: 5px; font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-dim);
-  border: 1px solid var(--ws-line); background: rgba(7, 13, 14, 0.85); padding: 3px 9px;
+  border: 1px solid var(--ws-line); background: rgba(13, 14, 17, 0.85); padding: 3px 9px;
   clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
 }
 
@@ -251,7 +252,7 @@
    parent already sets align-items:start; sticky pins it below the app navbar and
    caps its height to the viewport, scrolling internally if the roster is long. */
 .ws-map-overview {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); min-height: 520px;
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014); min-height: 520px;
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
   box-shadow: var(--ws-glow);
   position: sticky;
@@ -264,7 +265,7 @@
   display: flex; align-items: center; justify-content: space-between; padding: 13px 16px; border-bottom: 1px solid var(--ws-line);
 }
 .ws-map-overview-head h3 {
-  margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #dff5ec; display: inline;
+  margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #e3e6ea; display: inline;
 }
 .ws-map-overview-body { padding: 16px; }
 .ws-map-overview-empty {
@@ -282,7 +283,7 @@
   background: linear-gradient(150deg, var(--av, var(--ws-faction)), color-mix(in srgb, var(--av, var(--ws-faction)) 55%, #000));
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-map-ov-name { font-size: 17px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #f1fff8; }
+.ws-map-ov-name { font-size: 17px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #f3f5f8; }
 .ws-map-ov-tag { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 3px; }
 
 .ws-map-ov-label {
@@ -292,7 +293,7 @@
 .ws-map-ov-none { font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); }
 
 .ws-map-ov-keeper { display: flex; align-items: center; gap: 10px; }
-.ws-map-ov-keeper-name { font-size: 13px; color: #eafff5; }
+.ws-map-ov-keeper-name { font-size: 13px; color: #eef0f3; }
 .ws-map-ov-keeper-badge { font-family: var(--ws-font-mono); font-size: 8.5px; letter-spacing: 1px; color: var(--ws-keeper); margin-top: 2px; }
 
 .ws-map-ov-roster { display: flex; flex-wrap: wrap; gap: 7px; }
@@ -310,7 +311,7 @@
 }
 .ws-map-ov-row:first-of-type { border-top: 1px solid var(--ws-line); }
 .ws-map-ov-k { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); }
-.ws-map-ov-v { font-family: var(--ws-font-mono); font-size: 12px; color: #dff5ec; }
+.ws-map-ov-v { font-family: var(--ws-font-mono); font-size: 12px; color: #e3e6ea; }
 
 /* Primary action lives in the hero row (top of the panel) so it stays reachable
    without scrolling to the bottom. */

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -77,6 +77,9 @@
 /* ---------- command bar ---------- */
 .ws-map-topbar {
   display: flex; align-items: center; gap: 18px;
+  /* Narrow windows: readout + create button wrap below the title instead of
+     overlapping it — the bar has no other width release valve. */
+  flex-wrap: wrap;
   border: 1px solid var(--ws-line);
   background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
   padding: 14px 18px; margin-bottom: 18px;
@@ -100,7 +103,7 @@
 }
 .ws-map-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
 
-.ws-map-readout { display: flex; gap: 10px; }
+.ws-map-readout { display: flex; gap: 10px; flex-wrap: wrap; }
 .ws-map-stat {
   min-width: 82px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
@@ -110,6 +113,7 @@
 
 .ws-map-create {
   align-self: stretch; display: flex; align-items: center; gap: 9px; padding: 0 18px;
+  min-height: 46px; /* keeps its height when flex-wrap puts it on its own row */
   border: 1px solid var(--ws-faction-deep);
   background: linear-gradient(180deg, rgba(70, 211, 154, 0.16), rgba(70, 211, 154, 0.04));
   color: var(--ws-faction); cursor: pointer;
@@ -229,20 +233,32 @@
   border: 1.4px dashed var(--ws-line-bright);
   background: repeating-linear-gradient(45deg, rgba(70, 211, 154, 0.04) 0 8px, transparent 8px 16px);
   clip-path: polygon(50% 4%, 96% 50%, 50% 96%, 4% 50%); transition: 0.15s;
+  /* Tile structs have ~28px of visual headroom above their floor diamond
+     (floor center ≈ 57px down the 92px SVG vs this plate's 30px center);
+     match it so the pad and its label sit on the tiles' baseline grid. */
+  margin-top: 28px;
 }
 .ws-map-pad:hover .ws-map-pad-plate { border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
 .ws-map-pad:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 4px; }
 .ws-map-pad-label {
   margin-top: 6px; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint);
 }
-.ws-map-pad--hero .ws-map-pad-plate { width: 120px; height: 76px; font-size: 30px; }
+.ws-map-pad--hero .ws-map-pad-plate { width: 120px; height: 76px; font-size: 30px; margin-top: 0; }
 .ws-map-pad--hero .ws-map-pad-label { font-size: 11px; }
 
-/* overview panel */
+/* overview panel — sticky so it (and its primary "Open" action) stays on screen
+   beside the map without depending on whole-page scrolling to reach it. The grid
+   parent already sets align-items:start; sticky pins it below the app navbar and
+   caps its height to the viewport, scrolling internally if the roster is long. */
 .ws-map-overview {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); position: relative; min-height: 520px;
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0b1213); min-height: 520px;
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
   box-shadow: var(--ws-glow);
+  position: sticky;
+  align-self: start;
+  top: calc(var(--navbar-offset, 76px) + 12px);
+  max-height: calc(100vh - var(--navbar-offset, 76px) - 24px);
+  overflow-y: auto;
 }
 .ws-map-overview-head {
   display: flex; align-items: center; justify-content: space-between; padding: 13px 16px; border-bottom: 1px solid var(--ws-line);
@@ -256,8 +272,10 @@
 }
 .ws-map-overview-empty .ws-big { display: block; font-size: 22px; color: var(--ws-ink-dim); margin-bottom: 10px; }
 
+
 /* populated overview */
 .ws-map-ov-hero { display: flex; gap: 12px; align-items: center; padding-bottom: 14px; border-bottom: 1px solid var(--ws-line); }
+.ws-map-ov-herometa { flex: 1 1 auto; min-width: 0; }
 .ws-map-ov-ic {
   width: 44px; height: 44px; flex: 0 0 auto; display: grid; place-items: center;
   font-family: var(--ws-font-mono); font-weight: 700; font-size: 13px; color: #04110c;
@@ -294,22 +312,28 @@
 .ws-map-ov-k { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); }
 .ws-map-ov-v { font-family: var(--ws-font-mono); font-size: 12px; color: #dff5ec; }
 
-.ws-map-ov-actions { display: flex; gap: 8px; margin-top: 16px; }
+/* Primary action lives in the hero row (top of the panel) so it stays reachable
+   without scrolling to the bottom. */
 .ws-map-ov-open {
-  flex: 1; text-align: center; padding: 12px; border: 1px solid var(--ws-faction-deep); cursor: pointer;
+  flex: 0 0 auto; align-self: center; text-align: center; padding: 9px 15px; border: 1px solid var(--ws-faction-deep); cursor: pointer;
   background: linear-gradient(180deg, rgba(70, 211, 154, 0.16), rgba(70, 211, 154, 0.04)); color: var(--ws-faction);
-  font-family: var(--ws-font-display); font-size: 12px; letter-spacing: 2px; text-transform: uppercase; font-weight: 700; transition: 0.15s;
+  font-family: var(--ws-font-display); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
   clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
 }
 .ws-map-ov-open:hover { background: var(--ws-faction); color: #04110c; }
-.ws-map-ov-cog {
-  width: 46px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
-  color: var(--ws-ink-dim); cursor: pointer; font-size: 15px;
-}
-.ws-map-ov-cog:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-map-ov-open:focus-visible, .ws-map-ov-cog:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-map-ov-open:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 
 @media (max-width: 900px) {
   .ws-map-layout { grid-template-columns: 1fr; }
-  .ws-map-overview { min-height: 0; }
+
+  /* Narrow windows: the overview stays in normal flow, stacked below the map,
+     so plain page scrolling reveals map tiles first and the panel after them.
+     (A fixed bottom-sheet variant was tried and reverted: it occluded the
+     tiles and could never be scrolled out of the way.) */
+  .ws-map-overview {
+    min-height: 0;
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+  }
 }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -44,14 +44,44 @@ export class WorkspaceCommandView {
     if (!this.container || !this.toggleBtn) return;
     this.toggleBtn.hidden = false; // reveal (Phase 1)
     this.toggleBtn.addEventListener('click', () => this.toggle());
+    // The URL wins over localStorage on load; a bare visit (no ?view=) falls
+    // back to the saved preference exactly as before. Bootstrap only reads
+    // the URL — it doesn't rewrite it, so a plain visit stays plain even if
+    // the saved preference is command.
+    const urlView = this.getViewFromURL();
     let pref = '';
     try { pref = localStorage.getItem(STORAGE_KEY) || ''; } catch (err) { pref = ''; }
-    if (pref === 'command') this.activate();
-    else this.deactivate();
+    const initialView = urlView || pref;
+    if (initialView === 'command') this.activate({ syncUrl: false });
+    else this.deactivate({ syncUrl: false });
   }
 
   persist(view) {
     try { localStorage.setItem(STORAGE_KEY, view); } catch (err) { /* storage may be unavailable */ }
+  }
+
+  getViewFromURL() {
+    try {
+      const raw = new URLSearchParams(window.location.search).get('view');
+      return raw === 'command' ? 'command' : '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  // Deep-linkable, non-spammy: detailed (the default) drops the param, and
+  // every toggle uses replaceState so switching views never grows history.
+  syncURL(view) {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (view === 'command') params.set('view', 'command');
+      else params.delete('view');
+      const query = params.toString();
+      const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+      window.history.replaceState(null, '', nextUrl);
+    } catch (err) {
+      // no-op: history API may be unavailable in some embedding contexts
+    }
   }
 
   toggle() {
@@ -59,22 +89,24 @@ export class WorkspaceCommandView {
     else this.activate();
   }
 
-  activate() {
+  activate({ syncUrl = true } = {}) {
     this.active = true;
     this.render();
     if (this.container) this.container.hidden = false;
     if (this.detailedView) this.detailedView.hidden = true;
     this.updateToggle();
     this.persist('command');
+    if (syncUrl) this.syncURL('command');
   }
 
-  deactivate({ persist = true } = {}) {
+  deactivate({ persist = true, syncUrl = true } = {}) {
     this.active = false;
     this.closeStatModal();
     if (this.container) this.container.hidden = true;
     if (this.detailedView) this.detailedView.hidden = false;
     this.updateToggle();
     if (persist) this.persist('detailed');
+    if (syncUrl) this.syncURL('detailed');
   }
 
   updateToggle() {

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -133,10 +133,12 @@ export class WorkspaceCommandView {
     } catch (err) {
       agents = Array.isArray(ws.agent_instances) ? ws.agent_instances.length : 0;
     }
+    // Canonical "open" = pending + in-progress, matching the server-side
+    // open_task_count Map/Cards/Tree all read (see workspace.ComputeMapSummaryFields).
     const tasks = Array.isArray(page.tasks) ? page.tasks : [];
     const openTasks = tasks.filter((t) => {
       const s = String((t && t.status) || '').toLowerCase();
-      return s === 'pending' || s === 'in_progress' || s === 'assigned';
+      return s === 'pending' || s === 'in_progress';
     }).length;
     const mcp = Array.isArray(ws.mcp_bindings) ? ws.mcp_bindings.length : 0;
     const skills = Array.isArray(ws.skill_bindings) ? ws.skill_bindings.length : 0;
@@ -177,7 +179,7 @@ export class WorkspaceCommandView {
       '</div>' +
       '<div class="ws-cmd-readout">' +
       statBox(stats.agents, 'Agents', 'agents', 'View agents') +
-      statBox(stats.openTasks, 'Tasks', 'tasks', 'View tasks') +
+      statBox(stats.openTasks, 'Open Tasks', 'tasks', 'View open tasks') +
       statBox(stats.mcp, 'MCP', 'mcp', 'Open MCP settings') +
       statBox(stats.skills, 'Skills', 'skills', 'Open Skills settings') +
       '</div>' +

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -179,7 +179,7 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   commandView.render();
 
   assert.match(container.innerHTML, /Workflow · Guided/);
-  assert.match(container.innerHTML, /<div class="ws-l">Tasks<\/div>/);
+  assert.match(container.innerHTML, /<div class="ws-l">Open Tasks<\/div>/);
   assert.match(container.innerHTML, /<div class="ws-l">MCP<\/div>/);
   assert.match(container.innerHTML, />Notes<\/h4>/);
   assert.match(container.innerHTML, />Schedules<\/h4>/);
@@ -194,7 +194,12 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   assert.match(container.innerHTML, /Tasks · 1/);
   assert.match(container.innerHTML, /title="Run"/);
   assert.match(container.innerHTML, /Manage Notes in Command view/);
-  assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Open Tasks|Tools · MCP|Ops mode|Deploy|✦/);
+  // "Open Tasks" is now the deliberate exception: the summary stat chip's
+  // label was unified with Map/Cards (see workspace-hub-ui-ux task 5.2). It
+  // reflects the filtered open-task count specifically — the modal title and
+  // per-agent quest-log header stay "Tasks" since those list every task
+  // regardless of status, so "Open Tasks" there would misdescribe them.
+  assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Tools · MCP|Ops mode|Deploy|✦/);
 });
 
 test('stat clicks open the in-place manager modal without leaving Command view', () => {

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -475,3 +475,90 @@ test('default deactivate path still persists detailed preference', () => {
   assert.equal(commandView.container.hidden, true);
   assert.equal(commandView.detailedView.hidden, false);
 });
+
+test('getViewFromURL only trusts an explicit ?view=command param', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  const originalWindow = globalThis.window;
+  try {
+    globalThis.window = { location: { search: '?view=command' } };
+    assert.equal(commandView.getViewFromURL(), 'command');
+
+    globalThis.window = { location: { search: '?view=detailed' } };
+    assert.equal(commandView.getViewFromURL(), '');
+
+    globalThis.window = { location: { search: '' } };
+    assert.equal(commandView.getViewFromURL(), '');
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('syncURL sets ?view=command and clears it back to a bare path via replaceState', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  const originalWindow = globalThis.window;
+  const replaceStateCalls = [];
+  globalThis.window = {
+    location: { search: '', pathname: '/workspaces/abc' },
+    history: {
+      replaceState(state, title, url) {
+        replaceStateCalls.push(url);
+      }
+    }
+  };
+
+  try {
+    commandView.syncURL('command');
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command']);
+
+    globalThis.window.location.search = '?view=command';
+    commandView.syncURL('detailed');
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command', '/workspaces/abc']);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('activate/deactivate sync the URL by default but bootstrap can opt out', () => {
+  const replaceStateCalls = [];
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    location: { search: '', pathname: '/workspaces/abc' },
+    history: {
+      replaceState(state, title, url) {
+        replaceStateCalls.push(url);
+      }
+    }
+  };
+  const persisted = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: false,
+    container: { hidden: true },
+    detailedView: { hidden: false },
+    toggleBtn: makeToggleButton(),
+    render() {},
+    persist(value) {
+      persisted.push(value);
+    }
+  });
+
+  try {
+    // Bootstrap path (setup()) passes syncUrl: false — a plain visit must
+    // not gain a ?view= param just because a preference is stored.
+    commandView.activate({ syncUrl: false });
+    assert.deepEqual(replaceStateCalls, []);
+    assert.deepEqual(persisted, ['command']);
+
+    commandView.deactivate({ syncUrl: false });
+    assert.deepEqual(replaceStateCalls, []);
+
+    // Real user toggles (default options) sync the URL via replaceState.
+    commandView.activate();
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command']);
+
+    commandView.deactivate();
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command', '/workspaces/abc']);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -787,13 +787,49 @@ console.log('[workspace-hub.js] FILE LOADED');
     renderLauncherActiveView(flattenWorkspaces(state.workspaces || []));
   }
 
+  // Reads ?view= from the URL, honoring only values normalizeLauncherView
+  // would return unchanged — anything else is silently ignored rather than
+  // falling back to cards (a typo'd param shouldn't override localStorage).
+  function getLauncherViewFromURL() {
+    try {
+      const raw = new URLSearchParams(window.location.search).get('view');
+      if (!raw) return null;
+      const normalized = normalizeLauncherView(raw);
+      return raw.trim().toLowerCase() === normalized ? normalized : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  // Deep-linkable, non-spammy: cards (the default) has no param at all, and
+  // every toggle uses replaceState so switching views never grows history.
+  function syncLauncherViewToURL(view) {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (view === LAUNCHER_VIEW_CARDS) {
+        params.delete('view');
+      } else {
+        params.set('view', view);
+      }
+      const query = params.toString();
+      const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+      window.history.replaceState(null, '', nextUrl);
+    } catch (err) {
+      // no-op: history API may be unavailable in some embedding contexts
+    }
+  }
+
   function setLauncherViewMode(view, options = {}) {
     const shouldPersist = options.persist !== false;
     const shouldRender = options.render !== false;
+    const shouldSyncUrl = options.syncUrl !== false;
     launcherActiveView = shouldPersist
       ? setLauncherViewPreference(view)
       : normalizeLauncherView(view);
     updateLauncherViewToggle(launcherActiveView);
+    if (shouldSyncUrl) {
+      syncLauncherViewToURL(launcherActiveView);
+    }
     if (shouldRender) {
       rerenderLauncherFromState();
     }
@@ -801,7 +837,13 @@ console.log('[workspace-hub.js] FILE LOADED');
   }
 
   function initLauncherViewState() {
-    setLauncherViewMode(getLauncherViewPreference(), { persist: false, render: false });
+    // The URL wins over localStorage on load; a bare visit (no ?view=) falls
+    // back to the saved preference exactly as before. Bootstrap only reads
+    // the URL here — it doesn't rewrite it, so a plain /workspaces visit
+    // stays plain even if the saved preference is tree/map.
+    const urlView = getLauncherViewFromURL();
+    const initialView = urlView || getLauncherViewPreference();
+    setLauncherViewMode(initialView, { persist: true, render: false, syncUrl: false });
   }
 
   function navigateToWorkspace(workspaceId) {
@@ -4546,6 +4588,8 @@ console.log('[workspace-hub.js] FILE LOADED');
     getLauncherCardDropIntent,
     getLauncherTreeDropIntent,
     getLauncherViewPreference,
+    getLauncherViewFromURL,
+    syncLauncherViewToURL,
     bindLauncherTreeKeyboardEvents,
     focusLauncherTreeRow,
     getVisibleLauncherTreeRows,

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -245,7 +245,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   const undoStack = []; // LIFO of { id, label }
   let launcherOverviewRequestSeq = 0;
   let launcherOverviewRefreshTimer = null;
-  let launcherTaskBadgeByWorkspace = new Map();
+  let workspaceListRefreshTimer = null;
   let launcherActiveTab = 'workspaces';
   let launcherActiveView = LAUNCHER_VIEW_CARDS;
   let launcherWorkspaceRootState = null;
@@ -343,20 +343,25 @@ console.log('[workspace-hub.js] FILE LOADED');
     if (elements.launcherOverviewOpenSessions) elements.launcherOverviewOpenSessions.textContent = String(metrics.openSessions || 0);
   }
 
-  function renderLauncherTaskBadge(workspaceID) {
-    if (!workspaceID) return '';
-    const counts = launcherTaskBadgeByWorkspace.get(workspaceID);
-    if (!counts || counts.open <= 0) return '';
+  // Reads counts straight off the workspace's own enriched summary fields
+  // (agent_count/open_task_count/needs_attention_count etc., populated
+  // server-side by hydrateWorkspaceMetadataInto) rather than a separately
+  // fetched per-workspace task list, so rendering a tile never triggers a
+  // network request.
+  function renderLauncherTaskBadge(workspace) {
+    if (!workspace) return '';
+    const open = Number(workspace.open_task_count) || 0;
+    if (open <= 0) return '';
+    const needsAttention = Number(workspace.needs_attention_count) || 0;
 
-    const titleParts = [`${counts.open} open task${counts.open === 1 ? '' : 's'}`];
-    if (counts.inProgress > 0) titleParts.push(`${counts.inProgress} in progress`);
-    if (counts.needsAttention > 0) titleParts.push(`${counts.needsAttention} need attention`);
+    const titleParts = [`${open} open task${open === 1 ? '' : 's'}`];
+    if (needsAttention > 0) titleParts.push(`${needsAttention} need attention`);
     const title = titleParts.join(' | ');
-    const badgeClass = counts.needsAttention > 0
+    const badgeClass = needsAttention > 0
       ? 'launcher-task-badge is-attention'
       : 'launcher-task-badge';
 
-    return `<span class="${badgeClass}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}">${escapeHtml(String(counts.open))}</span>`;
+    return `<span class="${badgeClass}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}">${escapeHtml(String(open))}</span>`;
   }
 
   function normalizeWorkspaceFolderPath(value) {
@@ -958,7 +963,6 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     const workspaces = (flattened || []).filter((workspace) => workspace && workspace.id);
     if (workspaces.length === 0) {
-      launcherTaskBadgeByWorkspace = new Map();
       updateLauncherOverviewMetrics({
         open: 0,
         pending: 0,
@@ -1137,16 +1141,6 @@ console.log('[workspace-hub.js] FILE LOADED');
       return a.name.localeCompare(b.name);
     });
 
-    launcherTaskBadgeByWorkspace = new Map(
-      workspaceSummaries.map((summary) => [summary.id, {
-        open: summary.open,
-        pending: summary.pending,
-        inProgress: summary.inProgress,
-        needsAttention: summary.needsAttention,
-        scheduled: summary.scheduled
-      }])
-    );
-
     aggregateTasks.sort((a, b) => {
       const statusDiff = statusPriorityForOverview(a.status) - statusPriorityForOverview(b.status);
       if (statusDiff !== 0) return statusDiff;
@@ -1286,6 +1280,42 @@ console.log('[workspace-hub.js] FILE LOADED');
       const flattened = flattenWorkspaces(state.workspaces || []).filter(isConcreteWorkspace);
       void refreshLauncherTaskOverview(flattened);
     }, delayMs);
+  }
+
+  // Cheap alternative to scheduleLauncherOverviewRefresh: a single
+  // /api/workspaces?tree=true refetch keeps Cards/Tree/Map badges (sourced
+  // from each workspace's own enriched summary fields) current after a task
+  // changes, without re-fetching every workspace's task/session list just to
+  // recount them. The heavier overview refresh above stays reserved for the
+  // Summary tab, which needs actual task/session content, not just counts.
+  function scheduleWorkspaceListRefresh(delayMs = 700) {
+    if (workspaceListRefreshTimer) {
+      clearTimeout(workspaceListRefreshTimer);
+    }
+    workspaceListRefreshTimer = setTimeout(() => {
+      workspaceListRefreshTimer = null;
+      void refreshWorkspaceListForBadges();
+    }, delayMs);
+  }
+
+  async function refreshWorkspaceListForBadges() {
+    const state = window.WorkspaceHubState.getState();
+    try {
+      const response = await fetch('/api/workspaces?tree=true');
+      if (!response.ok) throw new Error(`Failed to refresh workspaces (${response.status})`);
+      const data = await response.json();
+      state.workspaces = data.folders || [];
+
+      const flattened = flattenWorkspaces(state.workspaces);
+      state.workspaceMap = new Map(flattened.map((workspace) => [workspace.id, workspace]));
+
+      populateWorkspaceSelect(flattened);
+      if (hubEl.dataset.state === 'launcher') {
+        renderLauncherActiveView(flattened);
+      }
+    } catch (err) {
+      console.error('Failed to refresh workspace list for badge counts:', err);
+    }
   }
 
   /**
@@ -1497,7 +1527,7 @@ console.log('[workspace-hub.js] FILE LOADED');
       const accentStyle = row.color ? `style="border-color: ${escapeHtml(row.color)}"` : '';
       const hasChildren = Array.isArray(row.children) && row.children.length > 0;
       const deleteTitle = hasChildren ? 'Delete group' : 'Delete workspace';
-      const taskBadge = renderLauncherTaskBadge(row.id);
+      const taskBadge = renderLauncherTaskBadge(row);
       const folderDisplay = getWorkspaceFolderDisplay(row);
       const parentGroup = row.parent_id ? flattenedMap.get(row.parent_id) : null;
       const parentGroupChip = parentGroup && isGroupWorkspace(parentGroup)
@@ -3881,9 +3911,14 @@ console.log('[workspace-hub.js] FILE LOADED');
       elements.directoriesList.innerHTML = '<div class="hub-empty">Select a workspace to view directories.</div>';
     }
 
-    const flattened = flattenWorkspaces(state.workspaces || []).filter(isConcreteWorkspace);
     setLauncherTab(launcherActiveTab, { refreshSummary: false, force: true });
-    void refreshLauncherTaskOverview(flattened);
+    // Cards/Tree/Map badges already come from state.workspaces' enriched
+    // fields (no fetch needed); only the Summary tab needs a refresh here,
+    // and only when it's the tab actually being shown.
+    if (launcherActiveTab === 'summary') {
+      const flattened = flattenWorkspaces(state.workspaces || []).filter(isConcreteWorkspace);
+      void refreshLauncherTaskOverview(flattened);
+    }
   }
 
   /**
@@ -4134,7 +4169,12 @@ console.log('[workspace-hub.js] FILE LOADED');
     // Workspace selection via dropdown removed; use launcher cards instead.
 
     if (elements.workspaceBrowseBtn) {
-      elements.workspaceBrowseBtn.addEventListener('click', () => showLauncher());
+      elements.workspaceBrowseBtn.addEventListener('click', () => {
+        showLauncher();
+        // Badge counts may be stale after time spent on a workspace detail
+        // page (task events there don't refresh the hub's launcher state).
+        void refreshWorkspaceListForBadges();
+      });
     }
 
     if (elements.workspaceMoveBtn) {
@@ -4413,7 +4453,13 @@ console.log('[workspace-hub.js] FILE LOADED');
     EventBus.on('task:created', (data) => {
       const state = window.WorkspaceHubState.getState();
       if (hubEl.dataset.state === 'launcher') {
-        scheduleLauncherOverviewRefresh();
+        // Cheap list refetch keeps Cards/Tree/Map badges current; only
+        // re-run the expensive per-workspace fan-out if the Summary tab
+        // (which needs full task content, not just counts) is open.
+        scheduleWorkspaceListRefresh();
+        if (launcherActiveTab === 'summary') {
+          scheduleLauncherOverviewRefresh();
+        }
       }
       if (!state.selectedId) return;
       if (!data?.workspaceId || data.workspaceId === state.selectedId) {
@@ -4424,7 +4470,13 @@ console.log('[workspace-hub.js] FILE LOADED');
     EventBus.on('task:updated', (data) => {
       const state = window.WorkspaceHubState.getState();
       if (hubEl.dataset.state === 'launcher') {
-        scheduleLauncherOverviewRefresh();
+        // Cheap list refetch keeps Cards/Tree/Map badges current; only
+        // re-run the expensive per-workspace fan-out if the Summary tab
+        // (which needs full task content, not just counts) is open.
+        scheduleWorkspaceListRefresh();
+        if (launcherActiveTab === 'summary') {
+          scheduleLauncherOverviewRefresh();
+        }
       }
       if (!state.selectedId) return;
       if (!data?.workspaceId || data.workspaceId === state.selectedId) {
@@ -4506,6 +4558,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     removeWorkspaceTag,
     renderLauncherCards,
     renderLauncherActiveView,
+    renderLauncherTaskBadge,
     renderLauncherTree,
     renderWorkspaceSummary,
     toggleLauncherTagFilter,

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -343,6 +343,15 @@ console.log('[workspace-hub.js] FILE LOADED');
     if (elements.launcherOverviewOpenSessions) elements.launcherOverviewOpenSessions.textContent = String(metrics.openSessions || 0);
   }
 
+  // Canonical "N agents · M open tasks" summary, shared by Cards and Tree
+  // rows so switching views reprojects the same facts instead of changing
+  // the subject (Map already shows the same shape in its tile meta line).
+  function formatWorkspaceSummaryMeta(workspace) {
+    const agents = Number(workspace && workspace.agent_count) || 0;
+    const openTasks = Number(workspace && workspace.open_task_count) || 0;
+    return `${agents} ${agents === 1 ? 'agent' : 'agents'} · ${openTasks} open ${openTasks === 1 ? 'task' : 'tasks'}`;
+  }
+
   // Reads counts straight off the workspace's own enriched summary fields
   // (agent_count/open_task_count/needs_attention_count etc., populated
   // server-side by hydrateWorkspaceMetadataInto) rather than a separately
@@ -361,7 +370,10 @@ console.log('[workspace-hub.js] FILE LOADED');
       ? 'launcher-task-badge is-attention'
       : 'launcher-task-badge';
 
-    return `<span class="${badgeClass}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}">${escapeHtml(String(open))}</span>`;
+    // "N open" rather than a bare number: the count needs a visible unit
+    // label, not just a hover tooltip, to read the same way as the Map/
+    // Command "Open Tasks" stat chips.
+    return `<span class="${badgeClass}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}">${escapeHtml(String(open))} open</span>`;
   }
 
   function normalizeWorkspaceFolderPath(value) {
@@ -1564,8 +1576,12 @@ console.log('[workspace-hub.js] FILE LOADED');
     function renderWorkspaceCard(workspace) {
       const row = flattenedMap.get(workspace.id) || workspace;
       const description = row.description || 'No description yet.';
-      const status = row.status || 'active';
-      const statusLabel = escapeHtml(String(status).replace('_', ' '));
+      // Idle/Working (task activity) replaces the old workspace.Status chip,
+      // which read "ACTIVE" for nearly every workspace regardless of state
+      // and collided with the same word meaning "has a running task"
+      // everywhere else (Map LED, "Open Tasks" stat). Same vocabulary as Map.
+      const isActive = !!row.active;
+      const summaryMeta = formatWorkspaceSummaryMeta(row);
       const accentStyle = row.color ? `style="border-color: ${escapeHtml(row.color)}"` : '';
       const hasChildren = Array.isArray(row.children) && row.children.length > 0;
       const deleteTitle = hasChildren ? 'Delete group' : 'Delete workspace';
@@ -1623,7 +1639,10 @@ console.log('[workspace-hub.js] FILE LOADED');
           ${tagRow}
           <div class="launcher-card-description">${escapeHtml(description)}</div>
           <div class="launcher-card-meta">
-            <span class="launcher-card-status status-${escapeHtml(status)}">${statusLabel}</span>
+            <span class="launcher-card-led-status${isActive ? ' is-working' : ''}">
+              <span class="launcher-card-led" aria-hidden="true"></span>${isActive ? 'Working' : 'Idle'}
+            </span>
+            <span class="launcher-card-summary">${escapeHtml(summaryMeta)}</span>
             <span>${row.session_count || 0} sessions</span>
           </div>
         </div>
@@ -1784,6 +1803,9 @@ console.log('[workspace-hub.js] FILE LOADED');
       filterable: true,
       limit: 4
     });
+    // Same canonical summary as Cards/Map; groups aggregate their members'
+    // stats elsewhere (the group header) so this only applies to workspaces.
+    const treeMeta = isGroup ? '' : `<span class="launcher-tree-meta">${escapeHtml(formatWorkspaceSummaryMeta(row))}</span>`;
 
     const childHtml = children.map((child, index) => renderLauncherTreeNode(child, depth + 1, children, index, ctx)).join('');
     const emptyHint = isGroup && children.length === 0
@@ -1802,6 +1824,7 @@ console.log('[workspace-hub.js] FILE LOADED');
           ${caret}
           ${renderLauncherTreeIcon(isGroup ? 'group' : 'workspace')}
           <span class="launcher-tree-name" title="${safeName}">${safeName}</span>
+          ${treeMeta}
           ${tagRow}
           ${deleteButton}
         </div>
@@ -4273,7 +4296,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     if (elements.launcherWorkspaceRootBrowseBtn) {
       elements.launcherWorkspaceRootBrowseBtn.addEventListener('click', async () => {
-        setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootBrowseBtn, true, 'Selecting...');
+        setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootBrowseBtn, true, 'Selecting…');
         try {
           await browseLauncherWorkspaceRoot();
         } catch (error) {
@@ -4287,7 +4310,7 @@ console.log('[workspace-hub.js] FILE LOADED');
 
     const handleWorkspaceRootSave = async () => {
       const nextValue = String(elements.launcherWorkspaceRootInput?.value || '').trim();
-      setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootSaveBtn, true, 'Saving...');
+      setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootSaveBtn, true, 'Saving…');
       try {
         await saveLauncherWorkspaceRoot(nextValue);
         setLauncherWorkspaceRootEditorOpen(false);
@@ -4319,7 +4342,7 @@ console.log('[workspace-hub.js] FILE LOADED');
           return;
         }
 
-        setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootResetBtn, true, 'Clearing...');
+        setLauncherWorkspaceRootButtonLoading(elements.launcherWorkspaceRootResetBtn, true, 'Clearing…');
         try {
           await saveLauncherWorkspaceRoot('');
           setLauncherWorkspaceRootEditorOpen(false);

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -391,6 +391,35 @@ test('launcher cards render always-available workspace checkboxes without select
   assert.doesNotMatch(launcherGrid.innerHTML, /data-select-mode/);
 });
 
+test('renderLauncherTaskBadge reads counts straight off the workspace object', () => {
+  const { helpers } = loadWorkspaceHub();
+
+  assert.equal(helpers.renderLauncherTaskBadge(null), '');
+  assert.equal(helpers.renderLauncherTaskBadge({ open_task_count: 0 }), '');
+
+  const openOnly = helpers.renderLauncherTaskBadge({ open_task_count: 3, needs_attention_count: 0 });
+  assert.match(openOnly, /class="launcher-task-badge"/);
+  assert.doesNotMatch(openOnly, /is-attention/);
+  assert.match(openOnly, />3</);
+
+  const withAttention = helpers.renderLauncherTaskBadge({ open_task_count: 2, needs_attention_count: 1 });
+  assert.match(withAttention, /class="launcher-task-badge is-attention"/);
+  assert.match(withAttention, /1 need attention/);
+});
+
+test('launcher cards badge sources counts from enriched workspace fields, not a fetched map', () => {
+  const workspaces = [
+    { id: 'workspace-1', kind: 'workspace', name: 'API', open_task_count: 2, needs_attention_count: 1 },
+    { id: 'workspace-2', kind: 'workspace', name: 'UI', open_task_count: 0 }
+  ];
+  const flattened = flattenWorkspaces(workspaces);
+  const { helpers, launcherGrid } = loadWorkspaceHub({ state: { workspaces } });
+
+  helpers.renderLauncherCards(flattened);
+
+  assert.match(launcherGrid.innerHTML, /launcher-task-badge is-attention"[^>]*>2</);
+});
+
 test('launcher cards render tag chips with filter and remove controls', () => {
   const workspaces = [
     {

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -444,6 +444,44 @@ test('launcher cards render always-available workspace checkboxes without select
   assert.doesNotMatch(launcherGrid.innerHTML, /data-select-mode/);
 });
 
+test('launcher cards show the Idle/Working LED (from enriched active) instead of the workspace.Status chip', () => {
+  const workspaces = [
+    { id: 'workspace-1', kind: 'workspace', name: 'API', status: 'active', active: true, agent_count: 2, open_task_count: 1 },
+    { id: 'workspace-2', kind: 'workspace', name: 'UI', status: 'active', active: false, agent_count: 1, open_task_count: 0 }
+  ];
+  const flattened = flattenWorkspaces(workspaces);
+  const { helpers, launcherGrid } = loadWorkspaceHub({ state: { workspaces } });
+
+  helpers.renderLauncherCards(flattened);
+
+  assert.doesNotMatch(launcherGrid.innerHTML, /launcher-card-status/);
+  assert.match(launcherGrid.innerHTML, /launcher-card-led-status is-working"[^>]*>\s*<span class="launcher-card-led"[^>]*><\/span>Working/);
+  assert.match(launcherGrid.innerHTML, /launcher-card-led-status"[^>]*>\s*<span class="launcher-card-led"[^>]*><\/span>Idle/);
+  // Canonical "N agents · M open tasks" summary, same shape as the Map tile meta.
+  assert.match(launcherGrid.innerHTML, /launcher-card-summary">2 agents · 1 open task</);
+  assert.match(launcherGrid.innerHTML, /launcher-card-summary">1 agent · 0 open tasks</);
+});
+
+test('launcher tree rows carry the same canonical summary as Cards, but group rows do not', () => {
+  const workspaces = [
+    {
+      id: 'group-1',
+      kind: 'group',
+      name: 'Platform',
+      children: [{ id: 'workspace-1', kind: 'workspace', name: 'API', parent_id: 'group-1', agent_count: 3, open_task_count: 2 }]
+    }
+  ];
+  const flattened = flattenWorkspaces(workspaces);
+  const { helpers, launcherGrid } = loadWorkspaceHub({ state: { workspaces } });
+
+  helpers.renderLauncherTree(flattened);
+
+  assert.match(launcherGrid.innerHTML, /launcher-tree-meta">3 agents · 2 open tasks</);
+  // Only one tree-meta span should exist — the group row itself gets none.
+  const metaCount = (launcherGrid.innerHTML.match(/launcher-tree-meta"/g) || []).length;
+  assert.equal(metaCount, 1);
+});
+
 test('renderLauncherTaskBadge reads counts straight off the workspace object', () => {
   const { helpers } = loadWorkspaceHub();
 
@@ -453,7 +491,7 @@ test('renderLauncherTaskBadge reads counts straight off the workspace object', (
   const openOnly = helpers.renderLauncherTaskBadge({ open_task_count: 3, needs_attention_count: 0 });
   assert.match(openOnly, /class="launcher-task-badge"/);
   assert.doesNotMatch(openOnly, /is-attention/);
-  assert.match(openOnly, />3</);
+  assert.match(openOnly, />3 open</);
 
   const withAttention = helpers.renderLauncherTaskBadge({ open_task_count: 2, needs_attention_count: 1 });
   assert.match(withAttention, /class="launcher-task-badge is-attention"/);
@@ -470,7 +508,7 @@ test('launcher cards badge sources counts from enriched workspace fields, not a 
 
   helpers.renderLauncherCards(flattened);
 
-  assert.match(launcherGrid.innerHTML, /launcher-task-badge is-attention"[^>]*>2</);
+  assert.match(launcherGrid.innerHTML, /launcher-task-badge is-attention"[^>]*>2 open</);
 });
 
 test('launcher cards render tag chips with filter and remove controls', () => {

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -278,6 +278,7 @@ function loadWorkspaceHub(overrides = {}) {
     localStorage: window.localStorage,
     sessionStorage: window.sessionStorage,
     setTimeout,
+    URLSearchParams,
     window
   };
 
@@ -317,6 +318,58 @@ test('launcher view registers the map view and persists it', () => {
   assert.equal(helpers.normalizeLauncherView('MAP'), 'map');
   assert.equal(helpers.setLauncherViewPreference('map'), 'map');
   assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'map');
+});
+
+test('getLauncherViewFromURL only trusts an explicit, valid ?view= param', () => {
+  const { helpers, window } = loadWorkspaceHub();
+
+  window.location.search = '?view=map';
+  assert.equal(helpers.getLauncherViewFromURL(), 'map');
+
+  window.location.search = '?view=tree';
+  assert.equal(helpers.getLauncherViewFromURL(), 'tree');
+
+  // Garbage should not silently fall back to cards — that would let a typo'd
+  // param mask the user's saved localStorage preference.
+  window.location.search = '?view=bogus';
+  assert.equal(helpers.getLauncherViewFromURL(), null);
+
+  window.location.search = '';
+  assert.equal(helpers.getLauncherViewFromURL(), null);
+});
+
+test('syncLauncherViewToURL omits the param for cards and sets it otherwise, via replaceState', () => {
+  const { helpers, window } = loadWorkspaceHub();
+  window.location.pathname = '/workspaces';
+  window.location.search = '';
+  const calls = [];
+  window.history = { replaceState: (state, title, url) => calls.push(url) };
+
+  helpers.syncLauncherViewToURL('map');
+  assert.deepEqual(calls, ['/workspaces?view=map']);
+
+  window.location.search = '?view=map';
+  helpers.syncLauncherViewToURL('cards');
+  assert.deepEqual(calls, ['/workspaces?view=map', '/workspaces']);
+});
+
+test('setLauncherViewMode syncs the URL for real toggles but not for the initial bootstrap', () => {
+  const { helpers, window } = loadWorkspaceHub();
+  window.location.pathname = '/workspaces';
+  window.location.search = '';
+  const calls = [];
+  window.history = { replaceState: (state, title, url) => calls.push(url) };
+
+  // Bootstrap (initLauncherViewState's call shape): syncUrl:false, render:false.
+  helpers.setLauncherViewMode('map', { persist: false, render: false, syncUrl: false });
+  assert.deepEqual(calls, []);
+
+  // A real toggle-button click uses the defaults and should update the URL.
+  helpers.setLauncherViewMode('tree', { render: false });
+  assert.deepEqual(calls, ['/workspaces?view=tree']);
+
+  helpers.setLauncherViewMode('cards', { render: false });
+  assert.deepEqual(calls, ['/workspaces?view=tree', '/workspaces']);
 });
 
 test('launcher tree renders minimal hierarchy with always-available workspace checkboxes', () => {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -474,6 +474,9 @@
   window.OriWorkspaceMap = {
     mount: mount,
     unmount: unmount,
-    computeLayout: computeMapLayout
+    computeLayout: computeMapLayout,
+    computeStats: computeStats,
+    tileHTML: tileHTML,
+    overviewBodyHTML: overviewBodyHTML
   };
 })();

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -188,13 +188,13 @@
 
   function computeStats(workspaces) {
     var list = Array.isArray(workspaces) ? workspaces : [];
-    var agents = 0, activeTasks = 0, groups = 0;
+    var agents = 0, openTasks = 0, groups = 0;
     list.forEach(function (ws) {
       agents += Number((ws && ws.agent_count) || 0);
-      activeTasks += Number((ws && ws.open_task_count) || 0);
+      openTasks += Number((ws && ws.open_task_count) || 0);
       if (isGroup(ws)) groups += 1;
     });
-    return { workspaces: list.length, agents: agents, activeTasks: activeTasks, groups: groups };
+    return { workspaces: list.length, agents: agents, openTasks: openTasks, groups: groups };
   }
 
   function statBox(value, label) {
@@ -384,7 +384,7 @@
       '<div class="ws-map-readout">' +
       statBox(stats.workspaces, 'Workspaces') +
       statBox(stats.agents, 'Agents') +
-      statBox(stats.activeTasks, 'Active Tasks') +
+      statBox(stats.openTasks, 'Open Tasks') +
       statBox(stats.groups, 'Groups') +
       '</div>' +
       '<button type="button" class="ws-map-create" data-ws-map-create>⊕ New Workspace</button>' +

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -222,18 +222,24 @@
     var openTasks = Number(ws.open_task_count || 0);
     var mode = opsModeLabel(ws.ops_mode);
     var hasKeeper = String(ws.entry_agent_name || '').trim() !== '';
-    var selected = selectedId && ws.id === selectedId ? ' is-selected' : '';
+    var isSel = selectedId && ws.id === selectedId;
+    var selected = isSel ? ' is-selected' : '';
     var left = PAD + tile.col * CELL_W;
     var top = PAD + tile.row * CELL_H;
     var meta = agents + (agents === 1 ? ' agent' : ' agents') + ' · ' +
       openTasks + (openTasks === 1 ? ' task' : ' tasks');
+    // A single click selects; opening happens on double-click, or on a
+    // click/Enter when the tile is already selected — so the aria-label
+    // advertises the currently-available action.
+    var actionHint = isSel ? '. Selected — activate to open' : '. Activate to select, double-click to open';
 
     return (
       '<button type="button" class="ws-map-tile' + selected + '" ' +
       'data-ws-id="' + escapeHtml(ws.id) + '" ' +
+      'aria-pressed="' + (isSel ? 'true' : 'false') + '" ' +
       'style="left:' + left + 'px;top:' + top + 'px;--i:' + (index || 0) + '" ' +
       'aria-label="' + escapeHtml(ws.name || 'Workspace') + ', ' + meta + ', ' + statusText +
-      (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') + '">' +
+      (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') + actionHint + '">' +
       '<span class="ws-map-tile-flag"><span class="ws-map-led' + (active ? ' is-working' : '') + '"></span>' +
       escapeHtml(statusText) + '</span>' +
       (hasKeeper ? '<span class="ws-map-tile-crest" title="Entry agent (locked)">★</span>' : '') +
@@ -274,8 +280,9 @@
     );
   }
 
-  function canvasHTML(workspaces, selectedId) {
-    var layout = computeMapLayout(workspaces);
+  function canvasHTML(workspaces, selectedId, maxCols) {
+    var cols = Math.max(1, maxCols || MAX_COLS);
+    var layout = computeMapLayout(workspaces, { maxCols: cols });
     var parts = [];
     layout.districts.forEach(function (d) { parts.push(districtHTML(d)); });
     layout.tiles.forEach(function (t, i) { parts.push(tileHTML(t, selectedId, i)); });
@@ -285,7 +292,7 @@
     layout.tiles.forEach(function (t) { if (t.row > lastRow) lastRow = t.row; });
     var padCol = 0;
     layout.tiles.forEach(function (t) { if (t.row === lastRow && t.col >= padCol) padCol = t.col + 1; });
-    if (padCol >= MAX_COLS) { padCol = 0; lastRow += 1; }
+    if (padCol >= cols) { padCol = 0; lastRow += 1; }
     parts.push(padHTML(padCol, lastRow));
 
     var height = PAD * 2 + (lastRow + 1) * CELL_H;
@@ -340,9 +347,12 @@
     return (
       '<div class="ws-map-ov-hero">' +
       '<span class="ws-map-ov-ic" style="--av:' + pal.key + '">' + escapeHtml(initials(ws.name)) + '</span>' +
-      '<div><div class="ws-map-ov-name">' + escapeHtml(ws.name || 'Workspace') + '</div>' +
+      '<div class="ws-map-ov-herometa"><div class="ws-map-ov-name">' + escapeHtml(ws.name || 'Workspace') + '</div>' +
       (mode ? '<div class="ws-map-ov-tag">' + escapeHtml(mode) + '</div>' : '') +
-      '</div></div>' +
+      '</div>' +
+      '<button type="button" class="ws-map-ov-open" data-ws-open="' + escapeHtml(ws.id) +
+      '" aria-label="Open ' + escapeHtml(ws.name || 'workspace') + '">Open ▸</button>' +
+      '</div>' +
       '<div class="ws-map-ov-label">Entry agent</div>' +
       '<div class="ws-map-ov-keeperwrap">' + keeper + '</div>' +
       '<div class="ws-map-ov-label">Agents · ' + agents.length + '</div>' +
@@ -352,17 +362,13 @@
       '<div class="ws-map-ov-row"><span class="ws-map-ov-k">Tools · MCP</span>' +
       '<span class="ws-map-ov-v">' + mcp + '</span></div>' +
       '<div class="ws-map-ov-row"><span class="ws-map-ov-k">Skills</span>' +
-      '<span class="ws-map-ov-v">' + skills + '</span></div>' +
-      '<div class="ws-map-ov-actions">' +
-      '<button type="button" class="ws-map-ov-open" data-ws-open="' + escapeHtml(ws.id) + '">Open Workspace ▸</button>' +
-      '<button type="button" class="ws-map-ov-cog" data-ws-open="' + escapeHtml(ws.id) + '" aria-label="Open workspace">⚙</button>' +
-      '</div>'
+      '<span class="ws-map-ov-v">' + skills + '</span></div>'
     );
   }
 
-  function shellHTML(stats, workspaces, selectedId) {
+  function shellHTML(stats, workspaces, selectedId, maxCols) {
     var canvas = (Array.isArray(workspaces) && workspaces.length > 0)
-      ? canvasHTML(workspaces, selectedId).html
+      ? canvasHTML(workspaces, selectedId, maxCols).html
       : emptyCanvasHTML();
     return (
       '<header class="ws-map-topbar">' +
@@ -389,7 +395,7 @@
       '<div class="ws-map-compass">N<b>▲</b></div>' +
       canvas +
       '</section>' +
-      '<aside class="ws-map-overview">' +
+      '<aside class="ws-map-overview" role="region" aria-label="Workspace overview">' +
       '<div class="ws-map-overview-head"><div><span class="ws-map-ix">WS</span> <h3>Overview</h3></div></div>' +
       '<div class="ws-map-overview-body">' +
       overviewBodyHTML(findWs(workspaces, selectedId)) +
@@ -397,6 +403,51 @@
       '</aside>' +
       '</div>'
     );
+  }
+
+  // Below this width the layout stacks: theatre full-width, overview in flow
+  // beneath it (no overview column beside the map).
+  function isNarrowViewport() {
+    return typeof window.matchMedia === 'function' && window.matchMedia('(max-width: 900px)').matches;
+  }
+
+  // ---------- responsive columns ----------
+
+  // Grid column count from the theatre's usable width, capped at MAX_COLS so
+  // wide screens keep the compact command-table look. Unknown/zero width
+  // (e.g. measured while hidden) falls back to the cap. The theatre clips
+  // overflow, so tiles MUST wrap into rows that fit — a fixed column count
+  // cuts tiles off on narrow windows with no way to scroll to them.
+  function computeMaxCols(theatreWidth) {
+    if (!theatreWidth || theatreWidth <= 0) return MAX_COLS;
+    return Math.max(1, Math.min(MAX_COLS, Math.floor((theatreWidth - PAD * 2) / CELL_W)));
+  }
+
+  function measureMaxCols(container) {
+    var width = (container && container.clientWidth) || 0;
+    if (width <= 0) return MAX_COLS;
+    // Beside the theatre sits the 338px overview column + 18px grid gap,
+    // except in the stacked narrow layout where the theatre spans full width.
+    var theatre = isNarrowViewport() ? width : width - 338 - 18;
+    return computeMaxCols(theatre);
+  }
+
+  // Re-lay-out when a window resize changes how many columns fit. mount() is
+  // idempotent and preserves the selection, so a plain re-mount is safe.
+  var lastMount = null; // { container, state }
+  var lastMaxCols = 0;
+  var resizeTimer = null;
+  var resizeBound = false;
+  function handleResize() {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      resizeTimer = null;
+      if (!lastMount || !lastMount.container) return;
+      if (!lastMount.container.isConnected || lastMount.container.hidden) return;
+      if (measureMaxCols(lastMount.container) !== lastMaxCols) {
+        mount(lastMount.container, lastMount.state);
+      }
+    }, 150);
   }
 
   // Reuse the hub's existing create flow for every create affordance.
@@ -410,12 +461,15 @@
     });
   }
 
+  function openWorkspace(id) {
+    if (id) window.location.href = '/workspaces/' + encodeURIComponent(id);
+  }
+
   function bindOverviewActions(container) {
     var opens = container.querySelectorAll('[data-ws-open]');
     Array.prototype.forEach.call(opens, function (el) {
       el.addEventListener('click', function () {
-        var id = el.getAttribute('data-ws-open');
-        if (id) window.location.href = '/workspaces/' + encodeURIComponent(id);
+        openWorkspace(el.getAttribute('data-ws-open'));
       });
     });
   }
@@ -425,7 +479,9 @@
     selectedId = id;
     var tiles = container.querySelectorAll('.ws-map-tile');
     Array.prototype.forEach.call(tiles, function (el) {
-      el.classList.toggle('is-selected', el.getAttribute('data-ws-id') === id);
+      var sel = el.getAttribute('data-ws-id') === id;
+      el.classList.toggle('is-selected', sel);
+      el.setAttribute('aria-pressed', sel ? 'true' : 'false');
     });
     var body = container.querySelector('.ws-map-overview-body');
     if (body) {
@@ -439,8 +495,15 @@
       '.ws-map-tile[data-ws-id], .ws-map-district-tag[data-ws-id]'
     );
     Array.prototype.forEach.call(selectables, function (el) {
+      // Single click selects; clicking (or Enter, which fires click on a
+      // button) an already-selected tile opens it. Double-click always opens.
       el.addEventListener('click', function () {
-        applySelection(container, workspaces, el.getAttribute('data-ws-id'));
+        var id = el.getAttribute('data-ws-id');
+        if (id && id === selectedId) { openWorkspace(id); return; }
+        applySelection(container, workspaces, id);
+      });
+      el.addEventListener('dblclick', function () {
+        openWorkspace(el.getAttribute('data-ws-id'));
       });
     });
   }
@@ -459,16 +522,26 @@
     selectedId = findWs(workspaces, selectedId) ? selectedId
       : (findWs(workspaces, incoming) ? incoming : pickDefaultSelection(workspaces));
 
-    container.innerHTML = shellHTML(computeStats(workspaces), workspaces, selectedId);
+    var maxCols = measureMaxCols(container);
+    lastMount = { container: container, state: state };
+    lastMaxCols = maxCols;
+
+    container.innerHTML = shellHTML(computeStats(workspaces), workspaces, selectedId, maxCols);
     bindCreate(container);
     bindTiles(container, workspaces);
     bindOverviewActions(container);
+
+    if (!resizeBound && typeof window.addEventListener === 'function') {
+      window.addEventListener('resize', handleResize);
+      resizeBound = true;
+    }
   }
 
   /** Tear down the map view (called when switching away). */
   function unmount(container) {
     if (!container) return;
     container.innerHTML = '';
+    lastMount = null;
   }
 
   window.OriWorkspaceMap = {
@@ -476,6 +549,7 @@
     unmount: unmount,
     computeLayout: computeMapLayout,
     computeStats: computeStats,
+    computeMaxCols: computeMaxCols,
     tileHTML: tileHTML,
     overviewBodyHTML: overviewBodyHTML
   };

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -130,7 +130,7 @@ test('computeStats sums enriched agent/task counts and counts groups', () => {
   ]);
   assert.equal(stats.workspaces, 3);
   assert.equal(stats.agents, 3);
-  assert.equal(stats.activeTasks, 1);
+  assert.equal(stats.openTasks, 1);
   assert.equal(stats.groups, 1);
 });
 

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -12,6 +12,13 @@ function loadComputeLayout() {
   return window.OriWorkspaceMap.computeLayout;
 }
 
+// Load the IIFE and grab the full exposed API (used for meta-rendering tests).
+function loadOriWorkspaceMap() {
+  const window = {};
+  vm.runInNewContext(source, { window, document: {} }, { filename: 'workspace-map.js' });
+  return window.OriWorkspaceMap;
+}
+
 function posById(layout) {
   const map = {};
   layout.tiles.forEach((t) => {
@@ -92,4 +99,75 @@ test('a member whose parent is missing degrades to a standalone tile', () => {
   const layout = computeLayout([{ id: 'orphan', parent_id: 'ghost' }]);
   assert.equal(layout.tiles.length, 1);
   assert.equal(layout.tiles[0].groupId, '');
+});
+
+test('computeStats sums enriched agent/task counts and counts groups', () => {
+  const { computeStats } = loadOriWorkspaceMap();
+  const stats = computeStats([
+    { id: 'a', agent_count: 2, open_task_count: 1 },
+    { id: 'b', kind: 'group', agent_count: 1, open_task_count: 0 },
+    { id: 'c' } // missing fields degrade to 0, not NaN
+  ]);
+  assert.equal(stats.workspaces, 3);
+  assert.equal(stats.agents, 3);
+  assert.equal(stats.activeTasks, 1);
+  assert.equal(stats.groups, 1);
+});
+
+test('tileHTML meta line reflects enriched agent/task counts with correct pluralization', () => {
+  const { tileHTML } = loadOriWorkspaceMap();
+  const plural = tileHTML({ ws: { id: 'a', name: 'Deep Sea Research', agent_count: 2, open_task_count: 3 }, col: 0, row: 0 });
+  assert.match(plural, /ws-map-tile-meta">2 agents · 3 tasks</);
+
+  const singular = tileHTML({ ws: { id: 'b', name: 'Solo', agent_count: 1, open_task_count: 1 }, col: 0, row: 0 });
+  assert.match(singular, /ws-map-tile-meta">1 agent · 1 task</);
+});
+
+test('tileHTML LED and entry-agent crest reflect active state and entry_agent_name', () => {
+  const { tileHTML } = loadOriWorkspaceMap();
+  const working = tileHTML({ ws: { id: 'a', name: 'Deep Sea Research', active: true, entry_agent_name: 'Research Lead' }, col: 0, row: 0 });
+  assert.match(working, /ws-map-led is-working/);
+  assert.match(working, />Working</);
+  assert.match(working, /ws-map-tile-crest/);
+  assert.match(working, /entry agent Research Lead/);
+
+  const idle = tileHTML({ ws: { id: 'b', name: 'No Keeper' }, col: 0, row: 0 });
+  assert.doesNotMatch(idle, /ws-map-led is-working/);
+  assert.match(idle, />Idle</);
+  assert.doesNotMatch(idle, /ws-map-tile-crest/);
+});
+
+test('overviewBodyHTML renders entry agent, roster, and tool/skill counts from enriched fields', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML({
+    id: 'a',
+    name: 'Deep Sea Research',
+    ops_mode: 'guided',
+    entry_agent_name: 'Research Lead',
+    agents: ['Research Lead', 'Source Scout'],
+    open_task_count: 2,
+    mcp_count: 1,
+    skill_count: 3
+  });
+
+  assert.match(html, /Research Lead/);
+  assert.match(html, /Locked · can&#39;t remove/);
+  assert.match(html, /Agents · 2/);
+  assert.match(html, /ws-map-av/); // roster avatar chips rendered
+  assert.match(html, /2 open</);
+  assert.match(html, /ws-map-ov-k">Tools · MCP<\/span><span class="ws-map-ov-v">1</);
+  assert.match(html, /ws-map-ov-k">Skills<\/span><span class="ws-map-ov-v">3</);
+});
+
+test('overviewBodyHTML falls back to empty-state copy when a workspace has no entry agent or agents', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML({ id: 'a', name: 'Bare Workspace' });
+
+  assert.match(html, /No entry agent/);
+  assert.match(html, /No agents yet/);
+});
+
+test('overviewBodyHTML renders the select-a-workspace placeholder when nothing is selected', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  assert.match(overviewBodyHTML(null), /Select a workspace to see its agents, tasks, tools, and skills\./);
 });

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -101,6 +101,26 @@ test('a member whose parent is missing degrades to a standalone tile', () => {
   assert.equal(layout.tiles[0].groupId, '');
 });
 
+test('computeMaxCols derives the column count from the theatre width', () => {
+  const { computeMaxCols } = loadOriWorkspaceMap();
+  // cells are 176px wide with 26px padding each side (52 total)
+  assert.equal(computeMaxCols(1200), 5); // capped at the desktop max
+  assert.equal(computeMaxCols(930), 4);  // (930-52)/176 = 4.98 -> 4
+  assert.equal(computeMaxCols(700), 3);
+  assert.equal(computeMaxCols(400), 1);
+  assert.equal(computeMaxCols(100), 1);  // never below one column
+  assert.equal(computeMaxCols(0), 5);    // unmeasurable (hidden) -> default
+});
+
+test('narrow column counts wrap tiles into extra rows instead of overflowing', () => {
+  const computeLayout = loadComputeLayout();
+  const five = Array.from({ length: 5 }, (_, i) => ({ id: 'w' + i }));
+  const layout = computeLayout(five, { maxCols: 2 });
+  assert.equal(layout.tiles.length, 5);
+  layout.tiles.forEach((t) => assert.ok(t.col < 2, 'col stays inside the 2-wide grid'));
+  assert.ok(layout.rows >= 3, '5 tiles at 2 cols need at least 3 rows');
+});
+
 test('computeStats sums enriched agent/task counts and counts groups', () => {
   const { computeStats } = loadOriWorkspaceMap();
   const stats = computeStats([
@@ -137,6 +157,17 @@ test('tileHTML LED and entry-agent crest reflect active state and entry_agent_na
   assert.doesNotMatch(idle, /ws-map-tile-crest/);
 });
 
+test('tileHTML advertises select-vs-open affordance via aria-pressed and aria-label', () => {
+  const { tileHTML } = loadOriWorkspaceMap();
+  const unselected = tileHTML({ ws: { id: 'a', name: 'Deep Sea Research' }, col: 0, row: 0 }, '');
+  assert.match(unselected, /aria-pressed="false"/);
+  assert.match(unselected, /Activate to select, double-click to open/);
+
+  const selected = tileHTML({ ws: { id: 'a', name: 'Deep Sea Research' }, col: 0, row: 0 }, 'a');
+  assert.match(selected, /aria-pressed="true"/);
+  assert.match(selected, /Selected — activate to open/);
+});
+
 test('overviewBodyHTML renders entry agent, roster, and tool/skill counts from enriched fields', () => {
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   const html = overviewBodyHTML({
@@ -157,6 +188,18 @@ test('overviewBodyHTML renders entry agent, roster, and tool/skill counts from e
   assert.match(html, /2 open</);
   assert.match(html, /ws-map-ov-k">Tools · MCP<\/span><span class="ws-map-ov-v">1</);
   assert.match(html, /ws-map-ov-k">Skills<\/span><span class="ws-map-ov-v">3</);
+});
+
+test('overviewBodyHTML puts the primary Open action in the hero row and drops the duplicate cog', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML({ id: 'ws-42', name: 'Deep Sea Research', entry_agent_name: 'Research Lead', agents: ['Research Lead'] });
+
+  // Open button carries the id the click binding reads, and lives inside the hero row (before the first ov-label).
+  assert.match(html, /class="ws-map-ov-open" data-ws-open="ws-42"/);
+  const heroEnd = html.indexOf('ws-map-ov-label');
+  assert.ok(html.indexOf('ws-map-ov-open') < heroEnd, 'Open button should render in the hero row, above the detail rows');
+  // The redundant settings cog is gone.
+  assert.doesNotMatch(html, /ws-map-ov-cog/);
 });
 
 test('overviewBodyHTML falls back to empty-state copy when a workspace has no entry agent or agents', () => {

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -6,24 +6,18 @@
           <h2 class="launcher-title">Choose a workspace</h2>
           <p class="launcher-subtitle">Start with tasks and schedules, then open chat when needed.</p>
           <div id="launcherWorkspaceRootPanel" class="launcher-workspace-root" aria-live="polite">
-            <div class="launcher-workspace-root-head">
-              <div>
+            <div class="launcher-workspace-root-collapsed">
+              <span id="launcherWorkspaceRootBadge" class="launcher-workspace-root-badge is-loading">Loading</span>
+              <span id="launcherWorkspaceRootPath" class="launcher-workspace-root-path" title="">Fetching current workspace location...</span>
+              <button id="launcherWorkspaceRootEditBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button" aria-expanded="false" aria-controls="launcherWorkspaceRootEditor">
+                Edit
+              </button>
+            </div>
+            <div id="launcherWorkspaceRootEditor" class="launcher-workspace-root-editor" hidden>
+              <div class="launcher-workspace-root-head">
                 <div class="launcher-workspace-root-kicker">Default Workspace Directory</div>
                 <div id="launcherWorkspaceRootSummary" class="launcher-workspace-root-summary">Loading workspace directory...</div>
               </div>
-              <span id="launcherWorkspaceRootBadge" class="launcher-workspace-root-badge is-loading">Loading</span>
-            </div>
-            <div id="launcherWorkspaceRootPath" class="launcher-workspace-root-path">Fetching current workspace location...</div>
-            <div class="launcher-workspace-root-footer">
-              <span id="launcherWorkspaceRootMeta" class="launcher-workspace-root-meta">New workspaces will be created here.</span>
-              <div class="launcher-workspace-root-actions">
-                <button id="launcherWorkspaceRootEditBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button" aria-expanded="false" aria-controls="launcherWorkspaceRootEditor">
-                  Edit
-                </button>
-                <a href="/settings" class="launcher-workspace-root-link">Manage in Settings</a>
-              </div>
-            </div>
-            <div id="launcherWorkspaceRootEditor" class="launcher-workspace-root-editor" hidden>
               <label for="launcherWorkspaceRootInput" class="launcher-workspace-root-label">Workspace directory</label>
               <div class="launcher-workspace-root-editor-row">
                 <input id="launcherWorkspaceRootInput" class="modern-input launcher-workspace-root-input" type="text" placeholder="/absolute/path/to/workspaces" autocomplete="off" spellcheck="false">
@@ -31,6 +25,10 @@
               </div>
               <div class="launcher-workspace-root-editor-help">
                 This affects where new workspaces are created. Clearing the custom path falls back to <code>WORKSPACE_DIR</code> or the built-in default.
+              </div>
+              <div class="launcher-workspace-root-footer">
+                <span id="launcherWorkspaceRootMeta" class="launcher-workspace-root-meta">New workspaces will be created here.</span>
+                <a href="/settings" class="launcher-workspace-root-link">Manage in Settings</a>
               </div>
               <div class="launcher-workspace-root-editor-actions">
                 <button id="launcherWorkspaceRootCancelBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button">Cancel</button>

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -8,7 +8,7 @@
           <div id="launcherWorkspaceRootPanel" class="launcher-workspace-root" aria-live="polite">
             <div class="launcher-workspace-root-collapsed">
               <span id="launcherWorkspaceRootBadge" class="launcher-workspace-root-badge is-loading">Loading</span>
-              <span id="launcherWorkspaceRootPath" class="launcher-workspace-root-path" title="">Fetching current workspace location...</span>
+              <span id="launcherWorkspaceRootPath" class="launcher-workspace-root-path" title="">Fetching current workspace location…</span>
               <button id="launcherWorkspaceRootEditBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button" aria-expanded="false" aria-controls="launcherWorkspaceRootEditor">
                 Edit
               </button>
@@ -16,7 +16,7 @@
             <div id="launcherWorkspaceRootEditor" class="launcher-workspace-root-editor" hidden>
               <div class="launcher-workspace-root-head">
                 <div class="launcher-workspace-root-kicker">Default Workspace Directory</div>
-                <div id="launcherWorkspaceRootSummary" class="launcher-workspace-root-summary">Loading workspace directory...</div>
+                <div id="launcherWorkspaceRootSummary" class="launcher-workspace-root-summary">Loading workspace directory…</div>
               </div>
               <label for="launcherWorkspaceRootInput" class="launcher-workspace-root-label">Workspace directory</label>
               <div class="launcher-workspace-root-editor-row">
@@ -152,7 +152,7 @@
               <p class="launcher-overview-subtitle">Track ongoing work, scheduled runs, and open sessions across all workspaces.</p>
             </div>
             <div class="launcher-overview-header-actions">
-              <span class="launcher-overview-updated" id="launcherOverviewUpdatedAt">Loading...</span>
+              <span class="launcher-overview-updated" id="launcherOverviewUpdatedAt">Loading…</span>
               <button id="launcherOverviewToggleBtn" class="modern-btn modern-btn-secondary modern-btn-sm" type="button" aria-expanded="false" aria-controls="launcherOverviewDetails">
                 Show Details
               </button>
@@ -188,25 +188,25 @@
             <div class="launcher-overview-column">
               <h4 class="launcher-overview-column-title">By Workspace</h4>
               <div class="launcher-overview-list" id="launcherOverviewByWorkspace">
-                <div class="hub-loading">Loading overview...</div>
+                <div class="hub-loading">Loading overview…</div>
               </div>
             </div>
             <div class="launcher-overview-column">
               <h4 class="launcher-overview-column-title">Ongoing Tasks</h4>
               <div class="launcher-overview-list" id="launcherOverviewTopTasks">
-                <div class="hub-loading">Loading ongoing tasks...</div>
+                <div class="hub-loading">Loading ongoing tasks…</div>
               </div>
             </div>
             <div class="launcher-overview-column">
               <h4 class="launcher-overview-column-title">Scheduled Tasks</h4>
               <div class="launcher-overview-list" id="launcherOverviewScheduledTasks">
-                <div class="hub-loading">Loading scheduled tasks...</div>
+                <div class="hub-loading">Loading scheduled tasks…</div>
               </div>
             </div>
             <div class="launcher-overview-column">
               <h4 class="launcher-overview-column-title">Open Sessions</h4>
               <div class="launcher-overview-list" id="launcherOverviewOpenSessionsList">
-                <div class="hub-loading">Loading open sessions...</div>
+                <div class="hub-loading">Loading open sessions…</div>
               </div>
             </div>
           </div>
@@ -428,7 +428,7 @@
             <div class="hub-task-filter-chips" id="hubTaskFilterChips" role="group" aria-label="Filter tasks by status"></div>
           </div>
           <div id="hubTasksList" class="hub-task-list">
-            <div class="hub-loading">Loading tasks...</div>
+            <div class="hub-loading">Loading tasks…</div>
           </div>
         </div>
       </div>
@@ -626,14 +626,14 @@
       </div>
       <div class="hub-board-loading" id="hubBoardLoading" hidden>
         <div class="hub-loading-spinner"></div>
-        <span>Loading board...</span>
+        <span>Loading board…</span>
       </div>
     </div>
   </div>
 
   <div class="workspace-hub-loading" id="workspaceHubLoading">
     <div class="hub-loading-spinner"></div>
-    <span>Loading workspace data...</span>
+    <span>Loading workspace data…</span>
   </div>
 
   <!-- Panel expansion backdrop -->
@@ -650,7 +650,7 @@
           <div class="hub-progress-status">
             <div class="hub-loading-spinner" aria-hidden="true"></div>
             <div>
-              <div class="hub-progress-title" id="hubSmartInputProgressHeadline">Working...</div>
+              <div class="hub-progress-title" id="hubSmartInputProgressHeadline">Working…</div>
               <div class="hub-progress-subtitle" id="hubSmartInputProgressMessage">Analyzing your request.</div>
             </div>
           </div>
@@ -794,7 +794,7 @@
           <!-- Upload Progress -->
           <div id="hubFileUploadProgress" class="hub-file-upload-progress" style="display: none;">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <span style="color: var(--text-primary);">Uploading...</span>
+              <span style="color: var(--text-primary);">Uploading…</span>
               <span id="hubFileUploadPercent" style="color: var(--text-secondary);">0%</span>
             </div>
             <div class="progress">

--- a/internal/workspace/workspace_analytics.go
+++ b/internal/workspace/workspace_analytics.go
@@ -2,6 +2,8 @@ package workspace
 
 import (
 	"time"
+
+	"github.com/johnjallday/ori-agent/internal/workspacesettings"
 )
 
 // GetSummary returns a summary of the workspace
@@ -23,6 +25,55 @@ func (w *Workspace) GetSummary() map[string]any {
 		"created_at":    w.CreatedAt,
 		"updated_at":    w.UpdatedAt,
 	}
+}
+
+// MapSummaryFields holds the additional display fields the Workspace Map view
+// needs but GetSummary() omits: entry agent, roster, tool/skill counts, ops
+// mode, and open-task/active state. Shared by orchestrationhttp (GetSummary
+// callers) and sessionhttp (session.Workspace list/tree callers) so both
+// surfaces derive the same values from one place.
+type MapSummaryFields struct {
+	EntryAgentName string
+	AgentNames     []string
+	AgentCount     int
+	OpenTaskCount  int
+	MCPCount       int
+	SkillCount     int
+	OpsMode        string
+	Active         bool
+}
+
+// ComputeMapSummaryFields derives entry agent, roster, tool/skill counts, ops
+// mode, and open-task/active state from a workspace in a single locked pass.
+func ComputeMapSummaryFields(w *Workspace) MapSummaryFields {
+	if w == nil {
+		return MapSummaryFields{}
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	agentNames := w.agentNamesLocked()
+	fields := MapSummaryFields{
+		EntryAgentName: w.entryAgentNameLocked(),
+		AgentNames:     agentNames,
+		AgentCount:     len(agentNames),
+		MCPCount:       len(w.MCPBindings),
+		SkillCount:     len(w.SkillBindings),
+		OpsMode:        workspacesettings.Extract(w.SharedData).Workflow.Mode,
+	}
+
+	for _, t := range w.Tasks {
+		switch t.Status {
+		case TaskStatusPending:
+			fields.OpenTaskCount++
+		case TaskStatusInProgress:
+			fields.OpenTaskCount++
+			fields.Active = true
+		}
+	}
+
+	return fields
 }
 
 // GetAgentStats returns statistics for all agents in the workspace

--- a/internal/workspace/workspace_analytics.go
+++ b/internal/workspace/workspace_analytics.go
@@ -33,14 +33,15 @@ func (w *Workspace) GetSummary() map[string]any {
 // callers) and sessionhttp (session.Workspace list/tree callers) so both
 // surfaces derive the same values from one place.
 type MapSummaryFields struct {
-	EntryAgentName string
-	AgentNames     []string
-	AgentCount     int
-	OpenTaskCount  int
-	MCPCount       int
-	SkillCount     int
-	OpsMode        string
-	Active         bool
+	EntryAgentName      string
+	AgentNames          []string
+	AgentCount          int
+	OpenTaskCount       int
+	NeedsAttentionCount int
+	MCPCount            int
+	SkillCount          int
+	OpsMode             string
+	Active              bool
 }
 
 // ComputeMapSummaryFields derives entry agent, roster, tool/skill counts, ops
@@ -70,6 +71,8 @@ func ComputeMapSummaryFields(w *Workspace) MapSummaryFields {
 		case TaskStatusInProgress:
 			fields.OpenTaskCount++
 			fields.Active = true
+		case TaskStatusFailed, TaskStatusTimeout:
+			fields.NeedsAttentionCount++
 		}
 	}
 

--- a/internal/workspace/workspace_analytics_test.go
+++ b/internal/workspace/workspace_analytics_test.go
@@ -22,6 +22,8 @@ func TestComputeMapSummaryFields(t *testing.T) {
 			{Status: TaskStatusPending},
 			{Status: TaskStatusInProgress},
 			{Status: TaskStatusCompleted},
+			{Status: TaskStatusFailed},
+			{Status: TaskStatusTimeout},
 		},
 		SharedData: workspacesettings.Store(map[string]any{}, settings),
 	}
@@ -46,6 +48,9 @@ func TestComputeMapSummaryFields(t *testing.T) {
 	if fields.OpenTaskCount != 2 {
 		t.Errorf("OpenTaskCount = %d, want 2 (pending + in_progress, excludes completed)", fields.OpenTaskCount)
 	}
+	if fields.NeedsAttentionCount != 2 {
+		t.Errorf("NeedsAttentionCount = %d, want 2 (failed + timeout)", fields.NeedsAttentionCount)
+	}
 	if !fields.Active {
 		t.Error("Active = false, want true (workspace has an in-progress task)")
 	}
@@ -54,8 +59,8 @@ func TestComputeMapSummaryFields(t *testing.T) {
 func TestComputeMapSummaryFieldsNilWorkspace(t *testing.T) {
 	fields := ComputeMapSummaryFields(nil)
 	if fields.AgentNames != nil || fields.EntryAgentName != "" || fields.AgentCount != 0 ||
-		fields.OpenTaskCount != 0 || fields.MCPCount != 0 || fields.SkillCount != 0 ||
-		fields.OpsMode != "" || fields.Active {
+		fields.OpenTaskCount != 0 || fields.NeedsAttentionCount != 0 || fields.MCPCount != 0 ||
+		fields.SkillCount != 0 || fields.OpsMode != "" || fields.Active {
 		t.Errorf("ComputeMapSummaryFields(nil) = %+v, want zero value", fields)
 	}
 }

--- a/internal/workspace/workspace_analytics_test.go
+++ b/internal/workspace/workspace_analytics_test.go
@@ -1,0 +1,61 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/workspacesettings"
+)
+
+func TestComputeMapSummaryFields(t *testing.T) {
+	settings := workspacesettings.DefaultSettings()
+	settings.Workflow.Mode = "direct"
+
+	ws := &Workspace{
+		Kind: "group",
+		AgentInstances: []AgentInstance{
+			{Name: "Research Lead", EntryPoint: true},
+			{Name: "Source Scout"},
+		},
+		MCPBindings:   []WorkspaceMCPBinding{{}, {}},
+		SkillBindings: []WorkspaceSkillBinding{{}},
+		Tasks: []Task{
+			{Status: TaskStatusPending},
+			{Status: TaskStatusInProgress},
+			{Status: TaskStatusCompleted},
+		},
+		SharedData: workspacesettings.Store(map[string]any{}, settings),
+	}
+
+	fields := ComputeMapSummaryFields(ws)
+
+	if fields.EntryAgentName != "Research Lead" {
+		t.Errorf("EntryAgentName = %q, want %q", fields.EntryAgentName, "Research Lead")
+	}
+	if fields.AgentCount != 2 {
+		t.Errorf("AgentCount = %d, want 2", fields.AgentCount)
+	}
+	if fields.MCPCount != 2 {
+		t.Errorf("MCPCount = %d, want 2", fields.MCPCount)
+	}
+	if fields.SkillCount != 1 {
+		t.Errorf("SkillCount = %d, want 1", fields.SkillCount)
+	}
+	if fields.OpsMode != "direct" {
+		t.Errorf("OpsMode = %q, want %q", fields.OpsMode, "direct")
+	}
+	if fields.OpenTaskCount != 2 {
+		t.Errorf("OpenTaskCount = %d, want 2 (pending + in_progress, excludes completed)", fields.OpenTaskCount)
+	}
+	if !fields.Active {
+		t.Error("Active = false, want true (workspace has an in-progress task)")
+	}
+}
+
+func TestComputeMapSummaryFieldsNilWorkspace(t *testing.T) {
+	fields := ComputeMapSummaryFields(nil)
+	if fields.AgentNames != nil || fields.EntryAgentName != "" || fields.AgentCount != 0 ||
+		fields.OpenTaskCount != 0 || fields.MCPCount != 0 || fields.SkillCount != 0 ||
+		fields.OpsMode != "" || fields.Active {
+		t.Errorf("ComputeMapSummaryFields(nil) = %+v, want zero value", fields)
+	}
+}


### PR DESCRIPTION
## Summary

UI/UX review of the workspace hub (Map view) and workspace detail (Command view). Root cause: `workspace-map.js` needed enriched summary fields that only `/api/orchestration/workspace` produced, while the hub fed it `/api/workspaces` (sessionhttp), whose rows lacked them — so Map permanently rendered "0 agents · 0 tasks", "Idle", and "No entry agent". Fixing that opened the door to a broader consistency pass across Cards/Tree/Map/Command.

- **Backend**: shared `workspace.ComputeMapSummaryFields` helper; `sessionhttp` list/tree/GET now carry `agent_count`, `agents`, `entry_agent_name`, `open_task_count`, `needs_attention_count`, `mcp_count`, `skill_count`, `ops_mode`, `active` — computed at read time, no new SQLite columns.
- **Frontend data**: Map/Cards render real counts; dropped the per-workspace `fetchWorkspaceOverviewData` fan-out that used to feed the Cards badge (now reads the enriched fields directly; the fan-out is reserved for the Summary tab, which genuinely needs full task/session content).
- **Map reachability**: root-caused the scroll/reachability complaints (the original innerHTML-rebuild theory was disproven by instrumentation); made the Overview panel sticky with its primary action at the top, fixed tile open interactions (select vs. open), and replaced a fixed 5-column grid with a responsive column count that reflows on resize instead of clipping tiles on narrow windows.
- **Theming**: retheme Map/Command/Construct surfaces from green-tinted dark to neutral charcoal, matching the app shell; green/gold/cyan remain accents only.
- **Chrome consolidation**: Map view collapses the legacy launcher header (redundant title/Create button); the Default Workspace Directory panel collapses to a one-line summary with the full editor behind Edit, in every view; both the hub and Command view now support `?view=` deep links (URL wins over localStorage on load, `history.replaceState` on toggle — no history spam).
- **Vocabulary pass**: Idle/Working LED replaces Cards' misleading "ACTIVE" status chip everywhere; "Open Tasks" is now one label with one definition (pending + in-progress) across Map/Command/Cards; added a canonical "N agents · M open tasks" summary to Cards and Tree rows; fixed a real light-mode contrast bug found during the theme sweep.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] Backend package tests pass (`sessionhttp`, `orchestrationhttp`, `workspace`)
- [x] 475 JS unit tests pass (`npm run test:modules`), ESLint clean
- [x] Live-verified on an isolated smoke server: Cards/Tree/Map/Command views, light + dark theme, several viewport widths, real task-state transitions (pending → in-progress → failed), deep links from a fresh profile, history-spam check on view toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)