### PR TITLE
fix: repair structured-logging debris across backend

### DIFF
--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -59,7 +59,7 @@ func main() {
 	// Initialize LaunchAgent manager
 	launchAgentMgr, err := menubar.NewLaunchAgentManager()
 	if err != nil {
-		logger.Error("Failed to create LaunchAgent manager", logger.Fields{"agent": err})
+		logger.Error("Failed to create LaunchAgent manager", logger.Fields{"error": err})
 		log.Println("Auto-start feature will be disabled")
 	}
 
@@ -167,14 +167,14 @@ func setupMenuSystray(controller *menubar.Controller, settingsMgr *menubar.Setti
 				}
 				ctx := context.Background()
 				if err := controller.StartServer(ctx); err != nil {
-					logger.Error("Failed to start server", logger.Fields{"server": err})
+					logger.Error("Failed to start server", logger.Fields{"error": err})
 				}
 
 			case <-stopItem.ClickedCh:
 				log.Println("Stop Server clicked")
 				ctx := context.Background()
 				if err := controller.StopServer(ctx); err != nil {
-					logger.Error("Failed to stop server", logger.Fields{"server": err})
+					logger.Error("Failed to stop server", logger.Fields{"error": err})
 				}
 
 			case <-openBrowserItem.ClickedCh:
@@ -193,7 +193,7 @@ func setupMenuSystray(controller *menubar.Controller, settingsMgr *menubar.Setti
 					// Currently checked, so uncheck (disable auto-start)
 					log.Println("Disabling auto-start...")
 					if err := launchAgentMgr.Uninstall(); err != nil {
-						logger.Error("Failed to uninstall LaunchAgent", logger.Fields{"agent": err})
+						logger.Error("Failed to uninstall LaunchAgent", logger.Fields{"error": err})
 					} else {
 						if err := settingsMgr.SetAutoStartEnabled(false); err != nil {
 							logger.Error("Failed to save auto-start setting", logger.Fields{"err": err})
@@ -205,7 +205,7 @@ func setupMenuSystray(controller *menubar.Controller, settingsMgr *menubar.Setti
 					// Currently unchecked, so check (enable auto-start)
 					log.Println("Enabling auto-start...")
 					if err := launchAgentMgr.Install(); err != nil {
-						logger.Error("Failed to install LaunchAgent", logger.Fields{"agent": err})
+						logger.Error("Failed to install LaunchAgent", logger.Fields{"error": err})
 					} else {
 						if err := settingsMgr.SetAutoStartEnabled(true); err != nil {
 							logger.Error("Failed to save auto-start setting", logger.Fields{"err": err})

--- a/internal/agentcomm/communicator.go
+++ b/internal/agentcomm/communicator.go
@@ -49,7 +49,7 @@ func (c *Communicator) SendMessage(req MessageRequest) error {
 		return fmt.Errorf("failed to save workspace: %w", err)
 	}
 
-	logger.Debug("✉️ Message sent from to in workspace", logger.Fields{"workspaceid": req.WorkspaceID, "workspace_id": req.From, "to": req.To})
+	logger.Debug("✉️ Message sent", logger.Fields{"workspace_id": req.WorkspaceID, "from": req.From, "to": req.To})
 	return nil
 }
 
@@ -170,10 +170,10 @@ func (c *Communicator) DelegateTask(req DelegationRequest) (*workspace.Task, err
 			"context":  req.Context,
 		},
 	}); err != nil {
-		logger.Error("Failed to send task message", logger.Fields{"task_id": err})
+		logger.Error("Failed to send task message", logger.Fields{"task_id": addedTask.ID, "error": err})
 	}
 
-	logger.Debug("📋 Task delegated from to", logger.Fields{"description": req.Description, "task_id": addedTask.ID, "from": req.From, "to": req.To})
+	logger.Debug("📋 Task delegated", logger.Fields{"description": req.Description, "task_id": addedTask.ID, "from": req.From, "to": req.To})
 	return addedTask, nil
 }
 
@@ -310,7 +310,7 @@ func (c *Communicator) sendTaskResult(task *workspace.Task, result string, error
 			"duration": duration.String(),
 		},
 	}); err != nil {
-		logger.Error("Failed to send task result", logger.Fields{"task_id": err})
+		logger.Error("Failed to send task result", logger.Fields{"task_id": task.ID, "error": err})
 	}
 }
 
@@ -394,7 +394,7 @@ func (c *Communicator) CleanupCompletedTasks(olderThan time.Duration) int {
 	}
 
 	if removed > 0 {
-		logger.Info("🧹 Cleaned up completed tasks", logger.Fields{"task_id": removed})
+		logger.Info("🧹 Cleaned up completed tasks", logger.Fields{"removed_count": removed})
 	}
 
 	return removed
@@ -407,7 +407,7 @@ func (c *Communicator) CheckTimeouts() []workspace.Task {
 
 	workspaceIDs, err := c.workspaceStore.List()
 	if err != nil {
-		logger.Error("Failed to list workspaces for timeout check", logger.Fields{"duration": err})
+		logger.Error("Failed to list workspaces for timeout check", logger.Fields{"error": err})
 		return timedOut
 	}
 
@@ -430,7 +430,7 @@ func (c *Communicator) CheckTimeouts() []workspace.Task {
 					task.CompletedAt = &completedAt
 					timedOut = append(timedOut, *task)
 					modified = true
-					logger.Debug("⏰ Task timed out after", logger.Fields{"duration": task.ID, "timeout": task.Timeout})
+					logger.Debug("⏰ Task timed out", logger.Fields{"task_id": task.ID, "timeout": task.Timeout})
 				}
 			}
 		}

--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -472,7 +472,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if err := h.State.SetAgent(*req.Name, agent); err != nil {
-				logger.Error("Failed to save renamed agent", logger.Fields{"agent": err})
+				logger.Error("Failed to save renamed agent", logger.Fields{"agent": *req.Name, "error": err})
 				orihttp.RespondErrorWithErr(w, http.StatusInternalServerError, "Failed to update agent", err)
 				return
 			}
@@ -482,7 +482,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			newName = *req.Name
 		} else {
 			if err := h.State.SetAgent(agentName, agent); err != nil {
-				logger.Error("Failed to update agent metadata", logger.Fields{"agent": err})
+				logger.Error("Failed to update agent metadata", logger.Fields{"agent": agentName, "error": err})
 				orihttp.RespondErrorWithErr(w, http.StatusInternalServerError, "Failed to update agent", err)
 				return
 			}

--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -499,7 +499,7 @@ func (h *DashboardHandler) UpdateAgentStatus(w http.ResponseWriter, r *http.Requ
 						"source":     "cli",
 					}
 					if err := h.ActivityLogger.LogActivity(cliAgentDisplayName(backend), types.ActivityEventStatusChanged, details, ""); err != nil {
-						logger.Error("Failed to log CLI status change activity", logger.Fields{"status": err})
+						logger.Error("Failed to log CLI status change activity", logger.Fields{"error": err})
 					}
 				}
 
@@ -541,7 +541,7 @@ func (h *DashboardHandler) UpdateAgentStatus(w http.ResponseWriter, r *http.Requ
 		}
 		if err := h.ActivityLogger.LogActivity(agentName, types.ActivityEventStatusChanged, details, ""); err != nil {
 			// Log error but don't fail the request
-			logger.Error("Failed to log status change activity", logger.Fields{"status": err})
+			logger.Error("Failed to log status change activity", logger.Fields{"error": err})
 		}
 	}
 

--- a/internal/filehttp/handler.go
+++ b/internal/filehttp/handler.go
@@ -54,7 +54,7 @@ func (h *Handler) ParseFileHandler(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(ParseFileResponse{
 			Error: "Failed to decode file content: " + err.Error(),
 		}); err != nil {
-			logger.Error("Failed to encode response", logger.Fields{"response": err})
+			logger.Error("Failed to encode response", logger.Fields{"error": err})
 		}
 		return
 	}
@@ -64,7 +64,7 @@ func (h *Handler) ParseFileHandler(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(ParseFileResponse{
 			Error: err.Error(),
 		}); err != nil {
-			logger.Error("Failed to encode response", logger.Fields{"response": err})
+			logger.Error("Failed to encode response", logger.Fields{"error": err})
 		}
 		return
 	}
@@ -75,7 +75,7 @@ func (h *Handler) ParseFileHandler(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(ParseFileResponse{
 			Error: "Failed to parse file: " + err.Error(),
 		}); err != nil {
-			logger.Error("Failed to encode response", logger.Fields{"response": err})
+			logger.Error("Failed to encode response", logger.Fields{"error": err})
 		}
 		return
 	}
@@ -83,7 +83,7 @@ func (h *Handler) ParseFileHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(ParseFileResponse{
 		Text: text,
 	}); err != nil {
-		logger.Error("Failed to encode response", logger.Fields{"response": err})
+		logger.Error("Failed to encode response", logger.Fields{"error": err})
 	}
 }
 

--- a/internal/http/response.go
+++ b/internal/http/response.go
@@ -31,7 +31,7 @@ type ErrorResponse struct {
 // Usage:
 //
 //	if err := http.RespondJSON(w, http.StatusOK, data); err != nil {
-//		logger.Error("Failed to encode response", logger.Fields{"response": err})
+//		logger.Error("Failed to encode response", logger.Fields{"error": err})
 //	}
 func RespondJSON(w http.ResponseWriter, statusCode int, data any) error {
 	w.Header().Set("Content-Type", "application/json")
@@ -53,7 +53,7 @@ func RespondJSON(w http.ResponseWriter, statusCode int, data any) error {
 // Usage:
 //
 //	if err := http.RespondError(w, http.StatusNotFound, "Agent not found"); err != nil {
-//		logger.Error("Failed to write error response", logger.Fields{"response": err})
+//		logger.Error("Failed to write error response", logger.Fields{"error": err})
 //	}
 func RespondError(w http.ResponseWriter, statusCode int, message string) error {
 	return RespondJSON(w, statusCode, map[string]string{
@@ -66,7 +66,7 @@ func RespondError(w http.ResponseWriter, statusCode int, message string) error {
 // Usage:
 //
 //	if err := http.RespondSuccess(w, data); err != nil {
-//		logger.Error("Failed to encode success response", logger.Fields{"response": err})
+//		logger.Error("Failed to encode success response", logger.Fields{"error": err})
 //	}
 func RespondSuccess(w http.ResponseWriter, data any) error {
 	return RespondJSON(w, http.StatusOK, data)
@@ -78,7 +78,7 @@ func RespondSuccess(w http.ResponseWriter, data any) error {
 // Usage:
 //
 //	if err := http.RespondCreated(w, newAgent); err != nil {
-//		logger.Error("Failed to encode created response", logger.Fields{"response": err})
+//		logger.Error("Failed to encode created response", logger.Fields{"error": err})
 //	}
 func RespondCreated(w http.ResponseWriter, data any) error {
 	return RespondJSON(w, http.StatusCreated, data)

--- a/internal/location/manager.go
+++ b/internal/location/manager.go
@@ -130,7 +130,7 @@ func (m *Manager) detectAndUpdate() {
 			DetectionMethod:  method,
 		}
 		m.emitLocationChange(event)
-		logger.Debug("Location changed: -> (method: )", logger.Fields{"previousLocation": previousLocation, "zoneName": zoneName, "method": method})
+		logger.Debug("Location changed", logger.Fields{"previous_location": previousLocation, "zone_name": zoneName, "method": method})
 	}
 }
 

--- a/internal/mcphttp/handlers.go
+++ b/internal/mcphttp/handlers.go
@@ -64,7 +64,7 @@ func (h *Handler) AddServerHandler(w http.ResponseWriter, r *http.Request) {
 	// Add to config manager (persists to disk)
 
 	if err := h.configManager.AddServer(serverConfig); err != nil {
-		logger.Error("Failed to add MCP server to config", logger.Fields{"server": err})
+		logger.Error("Failed to add MCP server to config", logger.Fields{"server": serverConfig.Name, "error": err})
 		orihttp.InternalError(w, err.Error())
 		return
 	}
@@ -72,7 +72,7 @@ func (h *Handler) AddServerHandler(w http.ResponseWriter, r *http.Request) {
 	// Add to registry (runtime)
 
 	if err := h.registry.AddServer(serverConfig); err != nil {
-		logger.Error("Failed to add MCP server to registry", logger.Fields{"server": err})
+		logger.Error("Failed to add MCP server to registry", logger.Fields{"server": serverConfig.Name, "error": err})
 		orihttp.InternalError(w, err.Error())
 		return
 	}
@@ -94,7 +94,7 @@ func (h *Handler) RemoveServerHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Remove from registry (stops if running)
 	if err := h.registry.RemoveServer(serverName); err != nil {
-		logger.Error("Failed to remove MCP server from registry", logger.Fields{"server": err})
+		logger.Error("Failed to remove MCP server from registry", logger.Fields{"server": serverName, "error": err})
 		orihttp.InternalError(w, err.Error())
 		return
 	}
@@ -102,7 +102,7 @@ func (h *Handler) RemoveServerHandler(w http.ResponseWriter, r *http.Request) {
 	// Remove from config (persists)
 
 	if err := h.configManager.RemoveServer(serverName); err != nil {
-		logger.Error("Failed to remove MCP server from config", logger.Fields{"server": err})
+		logger.Error("Failed to remove MCP server from config", logger.Fields{"server": serverName, "error": err})
 		orihttp.InternalError(w, err.Error())
 		return
 	}

--- a/internal/menubar/controller.go
+++ b/internal/menubar/controller.go
@@ -228,7 +228,7 @@ func (c *Controller) isPortAvailable() bool {
 
 // runServer runs the HTTP server in a goroutine
 func (c *Controller) runServer() {
-	logger.Debug("Starting ori-agent server on port ...", logger.Fields{"server": c.port})
+	logger.Debug("Starting ori-agent server", logger.Fields{"port": c.port})
 
 	// Create server instance
 	srv, err := server.New()
@@ -238,7 +238,7 @@ func (c *Controller) runServer() {
 		c.errorMsg = fmt.Sprintf("Failed to create server: %v", err)
 		c.statusMu.Unlock()
 		c.notifyStatusChange(StatusError)
-		logger.Error("Failed to create server", logger.Fields{"server": err})
+		logger.Error("Failed to create server", logger.Fields{"error": err})
 		return
 	}
 
@@ -258,7 +258,7 @@ func (c *Controller) runServer() {
 	c.statusMu.Unlock()
 	c.notifyStatusChange(StatusRunning)
 
-	logger.Info("Server running on http://localhost", logger.Fields{"server": c.port})
+	logger.Info("Server running", logger.Fields{"port": c.port})
 
 	// Start HTTP server (blocks until shutdown)
 	if err := httpServer.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -73,7 +73,7 @@ func (n *Notifier) AddChannel(channel Channel) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.channels = append(n.channels, channel)
-	logger.Debug("Added notification channel", logger.Fields{"name()": channel.Name()})
+	logger.Debug("Added notification channel", logger.Fields{"channel": channel.Name()})
 }
 
 // RemoveChannel removes a notification channel by name
@@ -139,7 +139,7 @@ func (n *Notifier) deliverNotification(notification Notification) {
 	for _, channel := range channels {
 		go func(ch Channel) {
 			if err := ch.Send(notification); err != nil {
-				logger.Error("Failed to send notification via", logger.Fields{"name()": ch.Name(), "err": err})
+				logger.Error("Failed to send notification via channel", logger.Fields{"channel": ch.Name(), "error": err})
 			}
 		}(channel)
 	}
@@ -224,7 +224,7 @@ func (c *LogChannel) Send(notification Notification) error {
 		icon = "ℹ️ "
 	}
 
-	logger.Debug(": -", logger.Fields{"type": notification.Type, "icon": icon, "title": notification.Title, "message": notification.Message})
+	logger.Debug("Console notification", logger.Fields{"type": notification.Type, "icon": icon, "title": notification.Title, "message": notification.Message})
 	return nil
 }
 

--- a/internal/orchestration/orchestrator.go
+++ b/internal/orchestration/orchestrator.go
@@ -231,7 +231,7 @@ func (o *Orchestrator) ExecuteCollaborativeTask(ctx context.Context, mainAgent s
 		return nil, fmt.Errorf("failed to create workspace: %w", err)
 	}
 
-	logger.Info("📦 Created workspace: (ID: )", logger.Fields{"workspace_id": workspaceName, "id": ws.ID})
+	logger.Info("📦 Created workspace", logger.Fields{"workspace_name": workspaceName, "workspace_id": ws.ID})
 
 	// 2. Identify required agents based on roles
 	agents, err := o.findAgentsByRoles(task.RequiredRoles)
@@ -400,7 +400,7 @@ func (o *Orchestrator) executeResearchWorkflow(ws *workspace.Workspace, task Col
 		return nil, fmt.Errorf("failed to delegate research task: %w", err)
 	}
 
-	logger.Debug("📋 Delegated research to (task: )", logger.Fields{"task_id": researcherAgent, "id": delegateTask.ID})
+	logger.Debug("📋 Delegated research", logger.Fields{"agent": researcherAgent, "task_id": delegateTask.ID})
 
 	// Wait for completion (simplified - in production, this would be event-driven)
 	// For now, we'll return a status indicating the task is in progress
@@ -448,7 +448,7 @@ func (o *Orchestrator) executeParallelWorkflow(ws *workspace.Workspace, task Col
 
 		taskIDs = append(taskIDs, delegateTask.ID)
 		subResults[agentName] = delegateTask.ID
-		logger.Debug("📋 Delegated to (task: )", logger.Fields{"task_id": agentName, "id": delegateTask.ID})
+		logger.Debug("📋 Delegated task", logger.Fields{"agent": agentName, "task_id": delegateTask.ID})
 	}
 
 	return &CollaborativeResult{

--- a/internal/orchestration/workflow.go
+++ b/internal/orchestration/workflow.go
@@ -68,7 +68,7 @@ func (o *Orchestrator) executeResearchPipeline(ws *workspace.Workspace, task Col
 
 	subResults["research_task"] = researchTask.ID
 	subResults["researcher"] = researcherAgent
-	logger.Debug("📋 Research delegated to (task: )", logger.Fields{"task_id": researcherAgent, "id": researchTask.ID})
+	logger.Debug("📋 Research delegated", logger.Fields{"agent": researcherAgent, "task_id": researchTask.ID})
 
 	// Phase 2: Analysis
 	logger.Debug("🔍 Phase 2: Analysis", logger.Fields{})
@@ -90,7 +90,7 @@ func (o *Orchestrator) executeResearchPipeline(ws *workspace.Workspace, task Col
 	} else {
 		subResults["analysis_task"] = analysisTask.ID
 		subResults["analyzer"] = analyzerAgent
-		logger.Debug("📋 Analysis delegated to (task: )", logger.Fields{"task_id": analyzerAgent, "id": analysisTask.ID})
+		logger.Debug("📋 Analysis delegated", logger.Fields{"agent": analyzerAgent, "task_id": analysisTask.ID})
 	}
 
 	// Phase 3: Synthesis
@@ -114,7 +114,7 @@ func (o *Orchestrator) executeResearchPipeline(ws *workspace.Workspace, task Col
 	} else {
 		subResults["synthesis_task"] = synthesisTask.ID
 		subResults["synthesizer"] = synthesizerAgent
-		logger.Debug("📋 Synthesis delegated to (task: )", logger.Fields{"task_id": synthesizerAgent, "id": synthesisTask.ID})
+		logger.Debug("📋 Synthesis delegated", logger.Fields{"agent": synthesizerAgent, "task_id": synthesisTask.ID})
 	}
 
 	// Phase 4: Validation (optional)
@@ -138,7 +138,7 @@ func (o *Orchestrator) executeResearchPipeline(ws *workspace.Workspace, task Col
 		} else {
 			subResults["validation_task"] = validationTask.ID
 			subResults["validator"] = validatorAgent
-			logger.Debug("📋 Validation delegated to (task: )", logger.Fields{"task_id": validatorAgent, "id": validationTask.ID})
+			logger.Debug("📋 Validation delegated", logger.Fields{"agent": validatorAgent, "task_id": validationTask.ID})
 		}
 	}
 

--- a/internal/orchestrationhttp/scheduled_task_handler.go
+++ b/internal/orchestrationhttp/scheduled_task_handler.go
@@ -183,7 +183,7 @@ func (th *TaskHandler) handleCreateScheduledTask(w http.ResponseWriter, r *http.
 
 	// Add to workspace
 	if err := ws.AddScheduledTask(st); err != nil {
-		logger.Error("Failed to add scheduled task", logger.Fields{"task_id": err})
+		logger.Error("Failed to add scheduled task", logger.Fields{"task_id": st.ID, "error": err})
 		orihttp.RespondErrorWithErr(w, http.StatusBadRequest, "Failed to add scheduled task", err)
 		return
 	}
@@ -357,7 +357,7 @@ func (th *TaskHandler) handleUpdateScheduledTask(w http.ResponseWriter, r *http.
 		st.UpdatedAt = time.Now()
 
 		if err := ws.UpdateScheduledTask(*st); err != nil {
-			logger.Error("Failed to update scheduled task", logger.Fields{"task_id": err})
+			logger.Error("Failed to update scheduled task", logger.Fields{"task_id": st.ID, "error": err})
 			orihttp.RespondErrorWithErr(w, http.StatusInternalServerError, "Failed to update scheduled task", err)
 			return
 		}
@@ -448,7 +448,7 @@ func (th *TaskHandler) handleEnableScheduledTask(w http.ResponseWriter, r *http.
 		}
 
 		if err := ws.UpdateScheduledTask(*st); err != nil {
-			logger.Error("Failed to update scheduled task", logger.Fields{"task_id": err})
+			logger.Error("Failed to update scheduled task", logger.Fields{"task_id": st.ID, "error": err})
 			orihttp.RespondErrorWithErr(w, http.StatusInternalServerError, "Failed to update scheduled task", err)
 			return
 		}
@@ -516,7 +516,7 @@ func (th *TaskHandler) handleTriggerScheduledTask(w http.ResponseWriter, r *http
 		}
 
 		if err := ws.AddTask(task); err != nil {
-			logger.Error("Failed to create task from scheduled task", logger.Fields{"task_id": err})
+			logger.Error("Failed to create task from scheduled task", logger.Fields{"task_id": task.ID, "error": err})
 			orihttp.RespondErrorWithErr(w, http.StatusBadRequest, "Failed to create task", err)
 			return
 		}

--- a/internal/orchestrationhttp/streaming_handler.go
+++ b/internal/orchestrationhttp/streaming_handler.go
@@ -57,7 +57,7 @@ func (sh *StreamingHandler) WorkflowStatusHandler(w http.ResponseWriter, r *http
 	// Get workflow status from orchestrator
 	status, err := sh.orchestrator.GetWorkflowStatus(workspaceID)
 	if err != nil {
-		logger.Error("Failed to get workflow status", logger.Fields{"status": err})
+		logger.Error("Failed to get workflow status", logger.Fields{"error": err})
 		orihttp.NotFound(w, err.Error())
 		return
 	}
@@ -211,7 +211,7 @@ func (sh *StreamingHandler) streamEventsFromPolling(ctx context.Context, w http.
 			// Send status as JSON
 			data, err := json.Marshal(status)
 			if err != nil {
-				logger.Error("Failed to marshal status", logger.Fields{"status": err})
+				logger.Error("Failed to marshal status", logger.Fields{"error": err})
 				continue
 			}
 

--- a/internal/orchestrationhttp/task_execution.go
+++ b/internal/orchestrationhttp/task_execution.go
@@ -206,7 +206,7 @@ func (th *TaskHandler) ExecuteTaskHandler(w http.ResponseWriter, r *http.Request
 
 		// Save the reset task status
 		if err := foundWorkspace.UpdateTask(*foundTask); err != nil {
-			logger.Error("Failed to reset task status", logger.Fields{"status": err})
+			logger.Error("Failed to reset task status", logger.Fields{"task_id": foundTask.ID, "error": err})
 			orihttp.InternalError(w, "Failed to reset task for rerun")
 			return
 		}
@@ -783,13 +783,13 @@ func (th *TaskHandler) executeTaskWithDependencies(ws *workspace.Workspace, task
 	taskForExecution := *task
 	var inputResults []string
 	if len(task.InputTaskIDs) > 0 {
-		logger.Debug("Task has input task IDs", logger.Fields{"task_id": task.ID, "inputtaskids)": len(task.InputTaskIDs), "inputtaskids": task.InputTaskIDs})
+		logger.Debug("Task has input task IDs", logger.Fields{"task_id": task.ID, "input_task_count": len(task.InputTaskIDs), "input_task_ids": task.InputTaskIDs})
 
 		taskForExecution.RuntimeInputs = ws.BuildRuntimeInputs(task)
 
 		if taskForExecution.RuntimeInputs != nil && len(taskForExecution.RuntimeInputs.TaskResults) > 0 {
 			resultsMap := taskForExecution.RuntimeInputs.TaskResults
-			logger.Debug("Built runtime inputs for task", logger.Fields{"task_id": len(resultsMap), "id": task.ID})
+			logger.Debug("Built runtime inputs for task", logger.Fields{"task_id": task.ID, "input_result_count": len(resultsMap)})
 
 			for _, inputTaskID := range task.InputTaskIDs {
 				if result, exists := resultsMap[inputTaskID]; exists {

--- a/internal/orchestrationhttp/task_handler.go
+++ b/internal/orchestrationhttp/task_handler.go
@@ -946,7 +946,7 @@ func (th *TaskHandler) handleDeleteTask(w http.ResponseWriter, r *http.Request) 
 
 	// Fallback: search all workspaces
 	if err := th.communicator.DeleteTask(taskID); err != nil {
-		logger.Error("Failed to delete task", logger.Fields{"task_id": err})
+		logger.Error("Failed to delete task", logger.Fields{"task_id": taskID, "error": err})
 		orihttp.NotFound(w, err.Error())
 		return
 	}

--- a/internal/orchestrationhttp/template_handler.go
+++ b/internal/orchestrationhttp/template_handler.go
@@ -204,7 +204,7 @@ func (th *TemplateHandler) InstantiateTemplateHandler(w http.ResponseWriter, r *
 	// Execute collaborative task
 	result, err := th.orchestrator.ExecuteCollaborativeTask(r.Context(), req.AgentName, task)
 	if err != nil {
-		logger.Error("Failed to execute collaborative task", logger.Fields{"task_id": err})
+		logger.Error("Failed to execute collaborative task", logger.Fields{"error": err})
 		orihttp.InternalError(w, fmt.Sprintf("failed to execute workflow: %v", err))
 		return
 	}

--- a/internal/server/builder_mcp.go
+++ b/internal/server/builder_mcp.go
@@ -31,7 +31,7 @@ func (b *ServerBuilder) initializeMCP() {
 
 	if err := b.mcpConfigManager.InitializeDefaultServers(); err != nil {
 		if verbose {
-			logger.Error("failed to initialize default MCP servers", logger.Fields{"server": err})
+			logger.Error("failed to initialize default MCP servers", logger.Fields{"error": err})
 		}
 	}
 

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -548,7 +548,7 @@ func (b *ServerBuilder) initializeTemplateManager() {
 	}
 
 	if verbose {
-		logger.Info("Loaded workflow templates", logger.Fields{"listtemplates())": len(templateManager.ListTemplates())})
+		logger.Info("Loaded workflow templates", logger.Fields{"template_count": len(templateManager.ListTemplates())})
 	}
 
 	b.orchestrationHandler.SetTemplateManager(templateManager)

--- a/internal/server/initialization.go
+++ b/internal/server/initialization.go
@@ -147,7 +147,7 @@ func registerLLMProviders(factory *llm.Factory, configMgr *config.Manager) error
 	})
 	factory.Register("ollama", ollamaProvider)
 	if verbose {
-		logger.Debug("Ollama provider registered (base URL: )", logger.Fields{"ollamaBaseURL": ollamaBaseURL})
+		logger.Debug("Ollama provider registered", logger.Fields{"base_url": ollamaBaseURL})
 	}
 
 	// Register LM Studio provider (OpenAI-compatible local server)
@@ -194,7 +194,7 @@ func resolveAgentStorePath() string {
 
 	verbose := os.Getenv("ORI_VERBOSE") == "true"
 	if verbose {
-		logger.Debug("Using agent store", logger.Fields{"agent": agentStorePath})
+		logger.Debug("Using agent store", logger.Fields{"path": agentStorePath})
 	}
 
 	return agentStorePath
@@ -222,7 +222,7 @@ func loadLocationZones(zonesPath string) []location.Zone {
 	}
 
 	if verbose {
-		logger.Debug("📍 Loaded location zones", logger.Fields{"value1": len(zones)})
+		logger.Debug("📍 Loaded location zones", logger.Fields{"zone_count": len(zones)})
 	}
 
 	return zones
@@ -261,7 +261,7 @@ func resolveWorkspaceDir() string {
 
 	verbose := os.Getenv("ORI_VERBOSE") == "true"
 	if verbose {
-		logger.Debug("Using workspace directory", logger.Fields{"workspace_id": workspaceDir})
+		logger.Debug("Using workspace directory", logger.Fields{"path": workspaceDir})
 	}
 
 	return workspaceDir

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -130,7 +130,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		name := filepath.Base(path)
 		_, err = tmpl.New(name).Parse(string(content))
 		if err != nil {
-			logger.Error("Error parsing template", logger.Fields{"error": name, "err": err})
+			logger.Error("Error parsing template", logger.Fields{"template": name, "error": err})
 			return err
 		}
 		logger.Debug("Loaded template", logger.Fields{"name": name})
@@ -193,7 +193,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 
 	err := tmpl.ExecuteTemplate(&buf, templateName, data)
 	if err != nil {
-		logger.Error("Error executing template", logger.Fields{"error": name, "err": err})
+		logger.Error("Error executing template", logger.Fields{"template": name, "error": err})
 		return "", err
 	}
 

--- a/internal/workspace/executor.go
+++ b/internal/workspace/executor.go
@@ -290,11 +290,11 @@ func (te *TaskExecutor) executeTask(ws *Workspace, task Task) {
 	// task.Context is intentionally untouched — runtime data lives in
 	// RuntimeInputs so re-runs cannot accumulate stale injection.
 	if len(task.InputTaskIDs) > 0 {
-		logger.Debug("🔗 Task has input task IDs", logger.Fields{"task_id": task.ID, "inputtaskids)": len(task.InputTaskIDs), "inputtaskids": task.InputTaskIDs})
+		logger.Debug("🔗 Task has input task IDs", logger.Fields{"task_id": task.ID, "input_task_count": len(task.InputTaskIDs), "input_task_ids": task.InputTaskIDs})
 		task.RuntimeInputs = ws.BuildRuntimeInputs(&task)
 
 		if task.RuntimeInputs != nil && len(task.RuntimeInputs.TaskResults) > 0 {
-			logger.Debug("Built runtime inputs for task", logger.Fields{"result": len(task.RuntimeInputs.TaskResults), "id": task.ID})
+			logger.Debug("Built runtime inputs for task", logger.Fields{"task_id": task.ID, "input_result_count": len(task.RuntimeInputs.TaskResults)})
 			for taskID, result := range task.RuntimeInputs.TaskResults {
 				preview := result
 				if len(preview) > 100 {

--- a/internal/workspace/http_handlers.go
+++ b/internal/workspace/http_handlers.go
@@ -113,7 +113,7 @@ func (h *HTTPHandler) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	agentNames := workspace.AgentNames()
-	logger.Info("Created workspace: (ID: ) with agents", logger.Fields{"workspace_id": workspace.Name, "id": workspace.ID, "agents": agentNames})
+	logger.Info("Created workspace", logger.Fields{"workspace_name": workspace.Name, "workspace_id": workspace.ID, "agents": agentNames})
 
 	// Return created workspace
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/workspace/http_handlers_agent.go
+++ b/internal/workspace/http_handlers_agent.go
@@ -177,9 +177,9 @@ func (h *HTTPHandler) RemoveAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if instanceNumber > 0 {
-		logger.Debug("Removed agent instance from workspace", logger.Fields{"instanceNumber": instanceNumber, "workspaceID": workspaceID, "workspace_id": agentName})
+		logger.Debug("Removed agent instance from workspace", logger.Fields{"instance_number": instanceNumber, "workspace_id": workspaceID, "agent": agentName})
 	} else {
-		logger.Debug("Removed agent from workspace", logger.Fields{"agent": agentName, "workspaceID": workspaceID})
+		logger.Debug("Removed agent from workspace", logger.Fields{"agent": agentName, "workspace_id": workspaceID})
 	}
 
 	// Return success

--- a/internal/workspace/http_handlers_task.go
+++ b/internal/workspace/http_handlers_task.go
@@ -149,7 +149,7 @@ func (h *HTTPHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 
 	// Add task to workspace
 	if err := workspace.AddTask(task); err != nil {
-		logger.Error("[DEBUG] CreateTask - AddTask failed", logger.Fields{"task_id": err})
+		logger.Error("CreateTask - AddTask failed", logger.Fields{"task_id": task.ID, "error": err})
 		orihttp.InternalError(w, fmt.Sprintf("Failed to add task: %v", err))
 		return
 	}
@@ -402,7 +402,7 @@ func (h *HTTPHandler) DeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Debug("Deleted task from workspace", logger.Fields{"workspace_id": taskID, "workspaceID": workspaceID})
+	logger.Debug("Deleted task from workspace", logger.Fields{"task_id": taskID, "workspace_id": workspaceID})
 
 	// Return success
 	w.Header().Set("Content-Type", "application/json")
@@ -454,7 +454,7 @@ func (h *HTTPHandler) ExecuteTaskManually(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	logger.Debug("Manually executing task in workspace", logger.Fields{"workspaceID": workspaceID, "workspace_id": taskID})
+	logger.Debug("Manually executing task in workspace", logger.Fields{"workspace_id": workspaceID, "task_id": taskID})
 
 	// Execute task asynchronously
 	go func() {

--- a/internal/workspace/orchestrator.go
+++ b/internal/workspace/orchestrator.go
@@ -83,7 +83,7 @@ func (o *Orchestrator) ExecuteMission(ctx context.Context, workspaceID string, m
 		return fmt.Errorf("failed to analyze mission: %w", err)
 	}
 
-	logger.Info("[Orchestrator] Created tasks from mission", logger.Fields{"task_id": len(tasks)})
+	logger.Info("[Orchestrator] Created tasks from mission", logger.Fields{"task_count": len(tasks)})
 
 	// Step 1.5: Topologically sort so AddTask sees dependencies before
 	// dependents (graph validation in AddTask rejects forward references)
@@ -191,7 +191,7 @@ Return your response as a JSON array of tasks in this format:
 	}
 
 	if err := json.Unmarshal([]byte(content), &taskSpecs); err != nil {
-		logger.Error("[Orchestrator] Warning: Failed to parse LLM response as JSON: . Content", logger.Fields{"response": err, "content": content})
+		logger.Error("[Orchestrator] Failed to parse LLM response as JSON", logger.Fields{"error": err, "content": content})
 		// Fallback: create a single task
 		return []Task{
 			{
@@ -319,7 +319,7 @@ func (o *Orchestrator) ExecuteTasksSequentially(ctx context.Context, workspaceID
 // delegated to the LLMTaskHandler wired via SetTaskHandler; the orchestrator
 // owns workspace state, message events, and task lifecycle bookkeeping.
 func (o *Orchestrator) ExecuteTask(ctx context.Context, workspaceID string, task Task) error {
-	logger.Debug("[Orchestrator] Executing task : (assigned to: )", logger.Fields{"task_id": task.ID, "description": task.Description, "to": task.To})
+	logger.Debug("[Orchestrator] Executing task", logger.Fields{"task_id": task.ID, "description": task.Description, "assigned_to": task.To})
 
 	workspace, err := o.workspaceStore.Get(workspaceID)
 	if err != nil {
@@ -329,11 +329,11 @@ func (o *Orchestrator) ExecuteTask(ctx context.Context, workspaceID string, task
 	// Build runtime inputs for this execution. Persisted task.Context stays
 	// untouched; see Task.RuntimeInputs for the runtime-only data path.
 	if len(task.InputTaskIDs) > 0 {
-		logger.Debug("🔗 Task has input task IDs", logger.Fields{"task_id": task.ID, "inputtaskids)": len(task.InputTaskIDs), "inputtaskids": task.InputTaskIDs})
+		logger.Debug("🔗 Task has input task IDs", logger.Fields{"task_id": task.ID, "input_task_count": len(task.InputTaskIDs), "input_task_ids": task.InputTaskIDs})
 		task.RuntimeInputs = workspace.BuildRuntimeInputs(&task)
 
 		if task.RuntimeInputs != nil && len(task.RuntimeInputs.TaskResults) > 0 {
-			logger.Debug("Built runtime inputs for task", logger.Fields{"result": len(task.RuntimeInputs.TaskResults), "id": task.ID})
+			logger.Debug("Built runtime inputs for task", logger.Fields{"task_id": task.ID, "input_result_count": len(task.RuntimeInputs.TaskResults)})
 			for taskID, result := range task.RuntimeInputs.TaskResults {
 				preview := result
 				if len(preview) > 100 {

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -408,7 +408,7 @@ func (h *LLMTaskHandler) executeTaskConversation(
 			return "", buildToolOnlyBlockedError(lastToolSummary)
 		}
 
-		logger.Debug("Task triggered tool call(s)", logger.Fields{"task_id": task.ID, "toolcalls)": len(resp.ToolCalls), "round": round + 1})
+		logger.Debug("Task triggered tool call(s)", logger.Fields{"task_id": task.ID, "tool_call_count": len(resp.ToolCalls), "round": round + 1})
 		conversationToolCalls := make([]llm.ToolCall, len(resp.ToolCalls))
 		copy(conversationToolCalls, resp.ToolCalls)
 		for index := range conversationToolCalls {

--- a/internal/workspace/workspace_agents.go
+++ b/internal/workspace/workspace_agents.go
@@ -221,7 +221,7 @@ func (w *Workspace) RemoveAgentInstance(instanceID string) error {
 		w.UpdatedAt = time.Now()
 	}
 
-	logger.Debug("Removed agent instance ( #)", logger.Fields{"instancenumber": removedInstance.InstanceNumber, "agent": removedInstance.ID, "name": removedInstance.Name})
+	logger.Debug("Removed agent instance", logger.Fields{"instance_number": removedInstance.InstanceNumber, "instance_id": removedInstance.ID, "agent_name": removedInstance.Name})
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Mechanical sweep fixing leftover artifacts from the printf→structured-logger migration. Log messages and field keys only — **no behavior changes** (76 insertions / 76 deletions across 28 files).

Found during the full-backend readability review; these artifacts actively corrupt log search and aggregation (e.g. querying by `task_id` surfaces error strings).

### Broken message strings (dangling placeholder punctuation)
- `"Created workspace: (ID: ) with agents"` → `"Created workspace"` (name/ID fields were also swapped)
- `"Location changed: -> (method: )"`, `"[Orchestrator] Executing task : (assigned to: )"`, `"📋 Delegated research to (task: )"` (×6), `"✉️ Message sent from to in workspace"`, `"⏰ Task timed out after"`, `"Removed agent instance ( #)"`, notifier's literal `": -"`, and similar

### Malformed field keys (stray characters)
- `"toolcalls)"`, `"inputtaskids)"` (×3), `"listtemplates())"`, `"name()"` (×2), `"value1"`, `"instancenumber"`

### Error values bound to unrelated keys (~25 sites)
- `"task_id": err`, `"status": err`, `"server": err`, `"agent": err`, `"duration": err`, `"response": err` → all now `"error": err`, with the real ID/name added alongside where in scope (e.g. mcphttp now logs both the server name and the error)

### Swapped / mislabeled values
- `workspace_id` holding task IDs, agent names, or directory paths
- counts logged under ID keys (`"task_id": len(resultsMap)`, `"task_id": removed`)

Also fixed the doc-comment usage examples in `internal/http/response.go` that demonstrated the `"response": err` anti-pattern — the likely source of the copied mistakes.

## Verification
- `go build ./...` clean
- `go vet` clean on all 14 touched packages
- `go test` passes on all touched packages
- gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)