### PR TITLE
fix: resolve 18 defects found in backend readability review

### DIFF
--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/menubar"
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	portutil "github.com/johnjallday/ori-agent/internal/port"
+	"github.com/johnjallday/ori-agent/internal/version"
 )
 
 func main() {
@@ -221,7 +222,7 @@ func setupMenuSystray(controller *menubar.Controller, settingsMgr *menubar.Setti
 
 			case <-aboutItem.ClickedCh:
 				log.Println("About clicked")
-				showNotification("About Ori Agent", "Ori Agent - AI Agent Framework\\nVersion 0.0.13")
+				showNotification("About Ori Agent", fmt.Sprintf("Ori Agent - AI Agent Framework\nVersion %s", version.GetVersion()))
 
 			case <-quitItem.ClickedCh:
 				log.Println("Quit clicked")
@@ -381,7 +382,8 @@ func handlePortConfigurationSystray(controller *menubar.Controller, settingsMgr 
 }
 
 func showInputDialog(title, prompt, defaultValue string) (string, error) {
-	script := fmt.Sprintf(`display dialog "%s" default answer "%s" with title "%s"`, prompt, defaultValue, title)
+	script := fmt.Sprintf(`display dialog "%s" default answer "%s" with title "%s"`,
+		escapeAppleScriptString(prompt), escapeAppleScriptString(defaultValue), escapeAppleScriptString(title))
 	cmd := exec.Command("osascript", "-e", script)
 	output, err := cmd.Output()
 	if err != nil {
@@ -404,7 +406,8 @@ func showInputDialog(title, prompt, defaultValue string) (string, error) {
 
 func showNotification(title, message string) {
 	if runtime.GOOS == "darwin" {
-		script := fmt.Sprintf(`display notification "%s" with title "%s"`, message, title)
+		script := fmt.Sprintf(`display notification "%s" with title "%s"`,
+			escapeAppleScriptString(message), escapeAppleScriptString(title))
 		cmd := exec.Command("osascript", "-e", script)
 		if err := cmd.Run(); err != nil {
 			logger.Error("Failed to show notification", logger.Fields{"err": err})
@@ -482,5 +485,8 @@ func confirmStopProcessDialog(port int, summary string) (bool, error) {
 }
 
 func escapeAppleScriptString(value string) string {
+	// Backslashes must be escaped before quotes, or the quote escaping
+	// itself gets double-escaped.
+	value = strings.ReplaceAll(value, "\\", "\\\\")
 	return strings.ReplaceAll(value, "\"", "\\\"")
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -133,7 +135,7 @@ func main() {
 
 	// Start server in background
 	go func() {
-		if err := httpServer.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatalf("Server error: %v", err)
 		}
 	}()

--- a/internal/cliagent/registry.go
+++ b/internal/cliagent/registry.go
@@ -89,29 +89,31 @@ func (r *CLIAgentRegistry) List() []CLIAgentInfo {
 	return infos
 }
 
-// newClaudeAdapterFromPath creates a minimal ClaudeCLIAdapter for auto-detection.
+// newClaudeAdapterFromPath creates a ClaudeCLIAdapter for auto-detection.
+// The invoker must be set or the adapter can list models but never execute
+// a step (ExecuteStep rejects a nil invoker).
 func newClaudeAdapterFromPath(cliPath string) *ClaudeCLIAdapter {
 	resolved, err := exec.LookPath(cliPath)
 	if err != nil {
 		resolved = cliPath
 	}
-	return &ClaudeCLIAdapter{cliPath: resolved}
+	return &ClaudeCLIAdapter{cliPath: resolved, invoker: NewCLIInvoker()}
 }
 
-// newCodexAdapterFromPath creates a minimal CodexCLIAdapter for auto-detection.
+// newCodexAdapterFromPath creates a CodexCLIAdapter for auto-detection.
 func newCodexAdapterFromPath(cliPath string) *CodexCLIAdapter {
 	resolved, err := exec.LookPath(cliPath)
 	if err != nil {
 		resolved = cliPath
 	}
-	return &CodexCLIAdapter{cliPath: resolved}
+	return &CodexCLIAdapter{cliPath: resolved, invoker: NewCLIInvoker()}
 }
 
-// newGeminiAdapterFromPath creates a minimal GeminiCLIAdapter for auto-detection.
+// newGeminiAdapterFromPath creates a GeminiCLIAdapter for auto-detection.
 func newGeminiAdapterFromPath(cliPath string) *GeminiCLIAdapter {
 	resolved, err := exec.LookPath(cliPath)
 	if err != nil {
 		resolved = cliPath
 	}
-	return &GeminiCLIAdapter{cliPath: resolved}
+	return &GeminiCLIAdapter{cliPath: resolved, invoker: NewCLIInvoker()}
 }

--- a/internal/cliagenthttp/handlers.go
+++ b/internal/cliagenthttp/handlers.go
@@ -2,6 +2,7 @@
 package cliagenthttp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -78,9 +79,12 @@ func (h *Handler) HandleCreateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Launch task in background
+	// Launch task in background. The request context is canceled as soon as
+	// this handler returns, so the background task must not inherit its
+	// cancellation or it dies almost immediately.
+	taskCtx := context.WithoutCancel(r.Context())
 	go func() {
-		result, err := h.executor.Execute(r.Context(), config)
+		result, err := h.executor.Execute(taskCtx, config)
 		if err != nil {
 			result = &cliagent.TaskResult{
 				Status: cliagent.TaskFailed,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -393,14 +393,16 @@ func TemplatesRootSource(configured string) string {
 
 // Save writes current configuration to file
 func (m *Manager) Save() error {
-	m.mu.RLock()
+	// validate() normalizes (mutates) m.settings, so a write lock is required
+	// here even though Save reads more than it writes.
+	m.mu.Lock()
 	if err := m.validate(); err != nil {
-		m.mu.RUnlock()
+		m.mu.Unlock()
 		return fmt.Errorf("cannot save invalid configuration: %w", err)
 	}
 
 	settingsForDisk := m.settings
-	m.mu.RUnlock()
+	m.mu.Unlock()
 
 	if m.hasWritableSecretStore() {
 		sanitizeSecretsForDisk(&settingsForDisk)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1047,7 +1047,9 @@ func (db *DB) migration019WorkspaceRunContext(ctx context.Context) error {
 		`ALTER TABLE workspace_runs ADD COLUMN prepared_context_json TEXT`,
 	}
 	for _, stmt := range statements {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
+		// Tolerate duplicate columns so a partially-applied migration can
+		// re-run, matching every other ALTER TABLE migration in this file.
+		if _, err := db.ExecContext(ctx, stmt); err != nil && !isDuplicateColumnError(err) {
 			return fmt.Errorf("failed to extend workspace run context schema: %w", err)
 		}
 	}

--- a/internal/evolution/service.go
+++ b/internal/evolution/service.go
@@ -224,7 +224,9 @@ func (s *Service) GetSuggestions(agentName string) ([]Suggestion, error) {
 
 	ag, found := s.agentStore.GetAgent(agentName)
 	if !found || ag == nil {
-		return nil, fmt.Errorf("agent %q not found", agentName)
+		// Wrap the sentinel so the HTTP layer's errors.Is mapping can turn
+		// this into a 404 instead of a 500.
+		return nil, fmt.Errorf("agent %q: %w", agentName, ErrAgentNotFound)
 	}
 	ag.InitializeEvolution()
 	ag.InitializeStatistics()

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -247,11 +247,14 @@ func ParseFormData(w http.ResponseWriter, r *http.Request) bool {
 // ValidateUploadFilename sanitizes and validates an uploaded filename.
 // Returns the sanitized filename and true if valid, or sends an error response and returns false.
 //
-// Security checks performed:
+// Security handling:
 //   - Path traversal prevention (uses filepath.Base)
 //   - Empty/invalid filename rejection
 //   - Hidden file rejection (files starting with .)
-//   - Character validation (only alphanumeric, hyphens, underscores, dots allowed)
+//   - Character sanitization: alphanumeric, hyphens, underscores, dots,
+//     spaces, and parentheses pass through; every other character is
+//     REPLACED with an underscore (the name is never rejected for bad
+//     characters, only rewritten)
 //
 // Usage:
 //

--- a/internal/llm/claude_provider.go
+++ b/internal/llm/claude_provider.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -179,9 +180,23 @@ func (p *ClaudeProvider) convertMessages(messages []Message) []anthropic.Message
 			}
 
 		case RoleAssistant:
-			claudeMessages = append(claudeMessages, anthropic.NewAssistantMessage(
-				anthropic.NewTextBlock(msg.Content),
-			))
+			// Assistant turns must replay tool_use blocks alongside any text:
+			// a later tool_result referencing a tool_use the API never saw is
+			// rejected, which breaks every multi-turn tool conversation.
+			var assistantBlocks []anthropic.ContentBlockParamUnion
+			if msg.Content != "" {
+				assistantBlocks = append(assistantBlocks, anthropic.NewTextBlock(msg.Content))
+			}
+			for _, toolCall := range msg.ToolCalls {
+				input := json.RawMessage(toolCall.Arguments)
+				if len(input) == 0 {
+					input = json.RawMessage("{}")
+				}
+				assistantBlocks = append(assistantBlocks, anthropic.NewToolUseBlock(toolCall.ID, input, toolCall.Name))
+			}
+			if len(assistantBlocks) > 0 {
+				claudeMessages = append(claudeMessages, anthropic.NewAssistantMessage(assistantBlocks...))
+			}
 
 		case RoleTool:
 			// Claude uses tool_result content blocks in user messages

--- a/internal/llm/cost_tracker.go
+++ b/internal/llm/cost_tracker.go
@@ -346,7 +346,14 @@ func (ct *CostTracker) calculateCost(provider, model string, usage Usage) (float
 func (ct *CostTracker) GetStats(start, end time.Time) UsageStats {
 	ct.mu.RLock()
 	defer ct.mu.RUnlock()
+	return ct.getStatsLocked(start, end)
+}
 
+// getStatsLocked computes usage statistics for a time range. Callers must
+// hold ct.mu (read or write); it exists so lock-holding methods can reuse
+// the computation without recursively acquiring the RLock, which can
+// deadlock when a writer is queued between the two acquisitions.
+func (ct *CostTracker) getStatsLocked(start, end time.Time) UsageStats {
 	stats := UsageStats{
 		ByProvider:    make(map[string]ProviderStats),
 		ByAgent:       make(map[string]AgentStats),
@@ -438,7 +445,7 @@ func (ct *CostTracker) GetAllTimeStats() UsageStats {
 	start := ct.records[0].Timestamp
 	end := ct.records[len(ct.records)-1].Timestamp
 
-	return ct.GetStats(start, end.Add(time.Second))
+	return ct.getStatsLocked(start, end.Add(time.Second))
 }
 
 // GetTodayStats returns stats for today

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -212,10 +212,13 @@ func (s *Server) Restart() error {
 		return fmt.Errorf("failed to stop: %w", err)
 	}
 
-	// Create new context
+	// Create new context; s.ctx/s.cancel are read by Start and the health
+	// check loop, so the swap must happen under the lock.
 	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
 	s.ctx = ctx
 	s.cancel = cancel
+	s.mu.Unlock()
 
 	return s.Start()
 }

--- a/internal/menubar/controller.go
+++ b/internal/menubar/controller.go
@@ -2,8 +2,10 @@ package menubar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -47,7 +49,6 @@ type Controller struct {
 	port        int
 	server      *server.Server
 	httpServer  *server.HTTPServerWrapper // Wrapper for graceful shutdown
-	cancelFunc  context.CancelFunc
 	errorMsg    string
 	statusChan  chan ServerStatus
 	subscribers []func(ServerStatus)
@@ -87,11 +88,8 @@ func (c *Controller) StartServer(ctx context.Context) error {
 	c.statusMu.Unlock()
 	c.notifyStatusChange(StatusStarting)
 
-	// Create context for server lifecycle
-	_, cancel := context.WithCancel(ctx)
-	c.cancelFunc = cancel
-
-	// Start server in goroutine
+	// Start server in goroutine. Shutdown is driven by httpServer.Shutdown
+	// and server.Shutdown in StopServer, not by context cancellation.
 	go c.runServer()
 
 	// Wait for server to be running (with timeout)
@@ -141,11 +139,6 @@ func (c *Controller) StopServer(ctx context.Context) error {
 	c.statusMu.Unlock()
 	c.notifyStatusChange(StatusStopping)
 
-	// Cancel the server context
-	if c.cancelFunc != nil {
-		c.cancelFunc()
-	}
-
 	// Wait for shutdown with timeout
 	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -166,7 +159,6 @@ func (c *Controller) StopServer(ctx context.Context) error {
 	c.status = StatusStopped
 	c.httpServer = nil
 	c.server = nil
-	c.cancelFunc = nil
 	c.statusMu.Unlock()
 	c.notifyStatusChange(StatusStopped)
 
@@ -261,7 +253,7 @@ func (c *Controller) runServer() {
 	logger.Info("Server running", logger.Fields{"port": c.port})
 
 	// Start HTTP server (blocks until shutdown)
-	if err := httpServer.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
+	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		c.statusMu.Lock()
 		c.status = StatusError
 		c.errorMsg = fmt.Sprintf("Server error: %v", err)

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -60,11 +60,14 @@ func (r *Runner) StartReview(ctx context.Context, opts ReviewOptions) (string, e
 
 // GetStatus returns the current status of a review job.
 func (r *Runner) GetStatus(ctx context.Context, jobID string) (*ReviewRun, error) {
-	// First check in-memory running jobs
+	// First check in-memory running jobs. Return a snapshot, not the live
+	// pointer: executeReview keeps mutating the tracked run under r.mu, and
+	// callers read the result without holding the lock.
 	r.mu.RLock()
 	if run, ok := r.running[jobID]; ok {
+		snapshot := *run
 		r.mu.RUnlock()
-		return run, nil
+		return &snapshot, nil
 	}
 	r.mu.RUnlock()
 

--- a/internal/settingshttp/handlers.go
+++ b/internal/settingshttp/handlers.go
@@ -826,7 +826,7 @@ func maskUtilityAPIKey(apiKey string) string {
 	if apiKey == "" {
 		return ""
 	}
-	if len(apiKey) < 12 {
+	if len(apiKey) < 20 {
 		return "***"
 	}
 	return apiKey[:6] + "***..." + apiKey[len(apiKey)-4:]
@@ -838,7 +838,7 @@ func maskAnthropicAPIKey(apiKey string) string {
 		return ""
 	}
 
-	if len(apiKey) < 12 {
+	if len(apiKey) < 24 {
 		return "***"
 	}
 	return apiKey[:8] + "***..." + apiKey[len(apiKey)-4:]
@@ -848,7 +848,7 @@ func maskGeminiAPIKey(apiKey string) string {
 	if apiKey == "" {
 		return ""
 	}
-	if len(apiKey) < 12 {
+	if len(apiKey) < 20 {
 		return "***"
 	}
 	return apiKey[:6] + "***..." + apiKey[len(apiKey)-4:]
@@ -861,7 +861,7 @@ func maskAPIKey(apiKey string) string {
 	if apiKey == "" {
 		return ""
 	}
-	if len(apiKey) < 12 {
+	if len(apiKey) < 20 {
 		return "***"
 	}
 	return apiKey[:6] + "***..." + apiKey[len(apiKey)-4:]

--- a/internal/updatemanager/manager.go
+++ b/internal/updatemanager/manager.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -241,7 +242,45 @@ func (m *Manager) isNewerVersion(latest, current string) bool {
 	latestNormalized := strings.TrimPrefix(latest, "v")
 	currentNormalized := strings.TrimPrefix(current, "v")
 
-	// Simple version comparison - you might want to use a proper semver library
-	// This handles basic cases like v1.2.3 vs v1.2.4
-	return latestNormalized != currentNormalized && latestNormalized > currentNormalized
+	return compareVersions(latestNormalized, currentNormalized) > 0
+}
+
+// compareVersions compares two dot-separated numeric versions segment by
+// segment, returning -1/0/1. Plain string comparison is wrong here because
+// it sorts "0.0.10" before "0.0.9". Non-numeric segments (pre-release tags
+// etc.) fall back to string comparison; a missing segment counts as 0.
+func compareVersions(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	for i := 0; i < len(aParts) || i < len(bParts); i++ {
+		aSeg, bSeg := "0", "0"
+		if i < len(aParts) {
+			aSeg = aParts[i]
+		}
+		if i < len(bParts) {
+			bSeg = bParts[i]
+		}
+
+		aNum, aErr := strconv.Atoi(aSeg)
+		bNum, bErr := strconv.Atoi(bSeg)
+		if aErr == nil && bErr == nil {
+			if aNum != bNum {
+				if aNum > bNum {
+					return 1
+				}
+				return -1
+			}
+			continue
+		}
+
+		if aSeg != bSeg {
+			if aSeg > bSeg {
+				return 1
+			}
+			return -1
+		}
+	}
+
+	return 0
 }

--- a/internal/workspace/events.go
+++ b/internal/workspace/events.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"sync"
 	"time"
 
@@ -321,7 +322,7 @@ func generateEventID() string {
 	eventIDMutex.Lock()
 	defer eventIDMutex.Unlock()
 	eventIDCounter++
-	return time.Now().Format("20060102150405") + "-" + string(rune(eventIDCounter%10000))
+	return time.Now().Format("20060102150405") + "-" + strconv.FormatUint(eventIDCounter%10000, 10)
 }
 
 var subIDCounter uint64
@@ -331,7 +332,7 @@ func generateSubscriptionID() string {
 	subIDMutex.Lock()
 	defer subIDMutex.Unlock()
 	subIDCounter++
-	return "sub-" + time.Now().Format("20060102150405") + "-" + string(rune(subIDCounter%10000))
+	return "sub-" + time.Now().Format("20060102150405") + "-" + strconv.FormatUint(subIDCounter%10000, 10)
 }
 
 // Helper methods to create events

--- a/internal/workspace/workspace_scheduled.go
+++ b/internal/workspace/workspace_scheduled.go
@@ -30,14 +30,17 @@ func (w *Workspace) AddScheduledTask(st ScheduledTask) error {
 	return nil
 }
 
-// GetScheduledTask retrieves a scheduled task by ID
+// GetScheduledTask retrieves a scheduled task by ID. It returns a copy, not
+// a pointer into the workspace's slice: callers mutate the result and then
+// persist it via UpdateScheduledTask, which must not bypass the write lock.
 func (w *Workspace) GetScheduledTask(id string) (*ScheduledTask, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
 	for i := range w.ScheduledTasks {
 		if w.ScheduledTasks[i].ID == id {
-			return &w.ScheduledTasks[i], nil
+			st := w.ScheduledTasks[i]
+			return &st, nil
 		}
 	}
 

--- a/internal/workspacerun/report.go
+++ b/internal/workspacerun/report.go
@@ -77,9 +77,21 @@ func changedFilesFromArtifacts(artifacts []Artifact) []string {
 			continue
 		}
 		if artifact.Metadata != nil {
-			if values, ok := artifact.Metadata["files"].([]string); ok {
+			// In-memory artifacts carry []string, but after a JSON round-trip
+			// through SQLite the same field decodes as []any — handle both or
+			// persisted runs silently lose their changed-files list.
+			switch values := artifact.Metadata["files"].(type) {
+			case []string:
 				for _, value := range values {
 					if value != "" && !seen[value] {
+						seen[value] = true
+						files = append(files, value)
+					}
+				}
+			case []any:
+				for _, raw := range values {
+					value, ok := raw.(string)
+					if ok && value != "" && !seen[value] {
 						seen[value] = true
 						files = append(files, value)
 					}


### PR DESCRIPTION
## Summary

Fixes all 18 defects from the bug-triage table of the full-backend readability review (2026-07-02). Every finding was re-verified against the live codebase before fixing — all 18 were real. 18 files, +149/−51.

### Concurrency / data races (5)
- **`llm/cost_tracker.go`** — `GetAllTimeStats` acquired RLock then called `GetStats` (RLock again); recursive read-lock deadlocks when a writer is queued between the two acquisitions. Extracted `getStatsLocked` so lock-holding methods reuse the computation.
- **`config/config.go`** — `Save()` ran the *mutating* `validate()` (it normalizes settings) under `mu.RLock()`; now takes the write lock. The other two `validate()` callers already held it.
- **`mcp/server.go`** — `Restart` wrote `s.ctx`/`s.cancel` without holding `s.mu`, racing `Start` and the health-check loop.
- **`review/runner.go`** — `GetStatus` returned the live `*ReviewRun` that `executeReview` keeps mutating under the lock; callers read it unlocked (torn reads). Now returns a snapshot.
- **`workspace/workspace_scheduled.go`** — `GetScheduledTask` returned a pointer into the live slice under RLock while every caller mutates through it; now returns a copy (callers persist via `UpdateScheduledTask`, so behavior is unchanged).

### Functional bugs (8)
- **`updatemanager/manager.go`** — version comparison was lexicographic (`"0.0.10" < "0.0.9"`), so v0.0.9→v0.0.10 reported "no update". Now compares numeric segments.
- **`llm/claude_provider.go`** — `convertMessages` dropped assistant `ToolCalls`, so subsequent `tool_result` blocks referenced `tool_use` ids the API never saw — breaking every multi-turn tool conversation on the native Claude provider. Assistant turns now replay `tool_use` blocks.
- **`workspace/events.go`** — event/subscription IDs used `string(rune(counter))`, producing unprintable control characters instead of digits.
- **`cliagenthttp/handlers.go`** — the "background" task ran on `r.Context()`, which is canceled the moment the handler returns, killing the task almost immediately. Now `context.WithoutCancel`.
- **`cliagent/registry.go`** — auto-detected adapters were built without an invoker, so they could list models but `ExecuteStep` always failed.
- **`database/migrations.go`** — migration019 lacked the duplicate-column guard every other ALTER TABLE migration has; a partially-applied 019 could never re-run.
- **`evolution/service.go`** — agent-not-found returned an ad-hoc error instead of wrapping `ErrAgentNotFound`, so the HTTP layer's `errors.Is` → 404 mapping never fired (missing agents surfaced as 500s).
- **`workspacerun/report.go`** — changed-files metadata was type-asserted as `[]string` only; after a JSON round-trip through SQLite it decodes as `[]any`, so persisted runs silently lost their changed-files list.

### Hardening / polish (5)
- **`cmd/server/main.go` + `menubar/controller.go`** — `err.Error() != "http: Server closed"` → `errors.Is(err, http.ErrServerClosed)`.
- **`cmd/menubar/main.go`** — AppleScript dialogs interpolated unescaped strings (injection risk); now escaped everywhere, with backslashes escaped before quotes. About dialog hardcoded "Version 0.0.13" (actual: v0.0.86); now reads the version package.
- **`settingshttp/handlers.go`** — API-key masking revealed 10 of 12 characters for short keys; raised the reveal thresholds.
- **`orihttp/request.go`** — `ValidateUploadFilename` doc claimed it *rejects* invalid characters; it *replaces* them with underscores. Doc now matches behavior (behavior unchanged).
- **`menubar/controller.go`** — `StartServer` discarded the context it derived (`_, cancel := context.WithCancel(ctx)`), so `cancelFunc` cancelled nothing; removed the dead machinery (shutdown is driven by `httpServer.Shutdown`).

## Verification
- `go build ./...` clean; `go vet` clean on all touched packages
- `go test -race` passes on all 16 touched packages
- Known env failure only: `TestProviderIntegration` hits the live OpenAI API and fails with `insufficient_quota` on a clean checkout too (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)