### PR TITLE
refactor: consolidate drifted duplicate helpers from readability review

### DIFF
--- a/internal/chathttp/action_plan.go
+++ b/internal/chathttp/action_plan.go
@@ -33,14 +33,6 @@ func newActionPlanID() string {
 	return "plan_" + uuid.NewString()
 }
 
-func truncatePlanText(text string, max int) string {
-	trimmed := strings.TrimSpace(text)
-	if max <= 0 || len(trimmed) <= max {
-		return trimmed
-	}
-	return strings.TrimSpace(trimmed[:max]) + "..."
-}
-
 func buildDirectToolActionPlan(request string, cmd *DirectToolCommand) *ActionPlanPreview {
 	toolName := ""
 	args := ""
@@ -165,7 +157,7 @@ func (h *Handler) buildChatActionPlan(
 						steps = append(steps, ActionPlanStep{
 							Kind:    "planner_task",
 							Title:   fmt.Sprintf("Planner task %d", i+1),
-							Details: truncatePlanText(task.Description, 180),
+							Details: truncateRunes(strings.TrimSpace(task.Description), 180),
 						})
 					}
 				} else {

--- a/internal/chathttp/action_receipts.go
+++ b/internal/chathttp/action_receipts.go
@@ -77,18 +77,6 @@ func attachActionReceipts(payload map[string]any, receipts []ActionReceipt) map[
 	return payload
 }
 
-func truncateResultPreview(result string, max int) string {
-	compact := strings.TrimSpace(result)
-	if compact == "" {
-		return ""
-	}
-	compact = strings.Join(strings.Fields(compact), " ")
-	if max <= 0 || len(compact) <= max {
-		return compact
-	}
-	return strings.TrimSpace(compact[:max]) + "..."
-}
-
 func extractLocationHints(result string) []string {
 	if strings.TrimSpace(result) == "" {
 		return nil

--- a/internal/chathttp/handlers_claude.go
+++ b/internal/chathttp/handlers_claude.go
@@ -46,7 +46,7 @@ func (h *Handler) handleClaudeChat(w http.ResponseWriter, r *http.Request, ag *r
 		SystemPrompt: systemPrompt,
 		Tools:        tools,
 		Temperature:  ag.Settings.Temperature,
-		MaxTokens:    4000,
+		MaxTokens:    defaultChatMaxTokens,
 	})
 	if err != nil {
 		writeErrorResponse(w, err.Error())
@@ -126,7 +126,7 @@ func (h *Handler) handleClaudeToolCalls(
 					SystemPrompt: systemPrompt + "\n\n" + getFollowUpSystemPrompt(),
 					Tools:        tools,
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", nil, err
@@ -143,7 +143,7 @@ func (h *Handler) handleClaudeToolCalls(
 					Messages:     messages,
 					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", err

--- a/internal/chathttp/handlers_gemini.go
+++ b/internal/chathttp/handlers_gemini.go
@@ -49,7 +49,7 @@ func (h *Handler) handleGeminiChat(w http.ResponseWriter, r *http.Request, ag *r
 		SystemPrompt: systemPrompt,
 		Tools:        tools,
 		Temperature:  ag.Settings.Temperature,
-		MaxTokens:    4000,
+		MaxTokens:    defaultChatMaxTokens,
 	})
 	if err != nil {
 		writeErrorResponse(w, err.Error())
@@ -122,7 +122,7 @@ func (h *Handler) handleGeminiToolCalls(
 					SystemPrompt: systemPrompt,
 					Tools:        tools,
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", nil, err
@@ -139,7 +139,7 @@ func (h *Handler) handleGeminiToolCalls(
 					Messages:     messages,
 					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", err

--- a/internal/chathttp/handlers_ollama.go
+++ b/internal/chathttp/handlers_ollama.go
@@ -61,7 +61,7 @@ func (h *Handler) handleLocalProviderChat(w http.ResponseWriter, r *http.Request
 		SystemPrompt: systemPrompt,
 		Tools:        tools,
 		Temperature:  ag.Settings.Temperature,
-		MaxTokens:    4000,
+		MaxTokens:    defaultChatMaxTokens,
 	})
 	if err != nil {
 		writeErrorResponse(w, err.Error())
@@ -147,7 +147,7 @@ func (h *Handler) handleLocalProviderToolCalls(
 					SystemPrompt: systemPrompt,
 					Tools:        tools,
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", nil, err
@@ -164,7 +164,7 @@ func (h *Handler) handleLocalProviderToolCalls(
 					Messages:     messages,
 					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
 					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    4000,
+					MaxTokens:    defaultChatMaxTokens,
 				})
 				if err != nil {
 					return "", err

--- a/internal/chathttp/provider_common.go
+++ b/internal/chathttp/provider_common.go
@@ -38,6 +38,10 @@ type ExecuteToolCallsResult struct {
 const (
 	defaultToolLoopMaxTurns          = 4
 	defaultToolLoopMaxRepeatedFinger = 2
+
+	// defaultChatMaxTokens caps completion length for every provider chat
+	// request in this package (initial turn and tool-loop turns alike).
+	defaultChatMaxTokens = 4000
 )
 
 type boundedToolLoopConfig struct {

--- a/internal/chathttp/tool_file_executor.go
+++ b/internal/chathttp/tool_file_executor.go
@@ -29,39 +29,7 @@ func ExecuteToolWithFiles(
 	args string,
 	files []toolapi.FileAttachment,
 ) (result string, err error) {
-	// Check if the plugin supports file attachments and files are provided
-	if fileHandler, ok := tool.(toolapi.FileAttachmentHandler); ok && len(files) > 0 {
-		// Filter files to only those accepted by the plugin
-		acceptedTypes := fileHandler.AcceptsFiles()
-		filteredFiles := toolapi.FilterFilesByAcceptedTypes(files, acceptedTypes)
-
-		logger.Info("Tool supports file attachments", logger.Fields{
-			"tool":           toolName,
-			"accepted_types": len(acceptedTypes),
-			"filtered_files": len(filteredFiles),
-		})
-
-		if len(filteredFiles) > 0 {
-			logger.Info("Calling tool with files", logger.Fields{
-				"tool":       toolName,
-				"file_count": len(filteredFiles),
-			})
-			return fileHandler.CallWithFiles(ctx, args, filteredFiles)
-		}
-
-		// No matching files, fall back to regular call
-		logger.Info("No matching files, using regular call", logger.Fields{"tool": toolName})
-		return tool.Call(ctx, args)
-	}
-
-	// Regular call without files
-	_, isFileHandler := tool.(toolapi.FileAttachmentHandler)
-	logger.Info("Tool call (no file support or no files)", logger.Fields{
-		"tool":            toolName,
-		"is_file_handler": isFileHandler,
-		"files_available": len(files),
-	})
-	return tool.Call(ctx, args)
+	return executeToolWithFiles(ctx, tool, toolName, args, files, logger.Info)
 }
 
 // ExecuteToolWithFilesDebug is a variant of ExecuteToolWithFiles that uses Debug-level
@@ -74,14 +42,33 @@ func ExecuteToolWithFilesDebug(
 	args string,
 	files []toolapi.FileAttachment,
 ) (result string, err error) {
+	return executeToolWithFiles(ctx, tool, toolName, args, files, logger.Debug)
+}
+
+// executeToolWithFiles is the shared implementation behind both exported
+// variants; only the log level differs between them.
+func executeToolWithFiles(
+	ctx context.Context,
+	tool toolapi.Tool,
+	toolName string,
+	args string,
+	files []toolapi.FileAttachment,
+	log func(msg string, fields ...logger.Fields),
+) (result string, err error) {
 	// Check if the plugin supports file attachments and files are provided
 	if fileHandler, ok := tool.(toolapi.FileAttachmentHandler); ok && len(files) > 0 {
 		// Filter files to only those accepted by the plugin
 		acceptedTypes := fileHandler.AcceptsFiles()
 		filteredFiles := toolapi.FilterFilesByAcceptedTypes(files, acceptedTypes)
 
+		log("Tool supports file attachments", logger.Fields{
+			"tool":           toolName,
+			"accepted_types": len(acceptedTypes),
+			"filtered_files": len(filteredFiles),
+		})
+
 		if len(filteredFiles) > 0 {
-			logger.Debug("Tool execution with files", logger.Fields{
+			log("Calling tool with files", logger.Fields{
 				"tool":       toolName,
 				"file_count": len(filteredFiles),
 			})
@@ -89,9 +76,16 @@ func ExecuteToolWithFilesDebug(
 		}
 
 		// No matching files, fall back to regular call
+		log("No matching files, using regular call", logger.Fields{"tool": toolName})
 		return tool.Call(ctx, args)
 	}
 
 	// Regular call without files
+	_, isFileHandler := tool.(toolapi.FileAttachmentHandler)
+	log("Tool call (no file support or no files)", logger.Fields{
+		"tool":            toolName,
+		"is_file_handler": isFileHandler,
+		"files_available": len(files),
+	})
 	return tool.Call(ctx, args)
 }

--- a/internal/chathttp/truncate.go
+++ b/internal/chathttp/truncate.go
@@ -1,0 +1,26 @@
+package chathttp
+
+import "strings"
+
+// truncateRunes caps a display string at maxRunes, appending "..." when it
+// was cut. Slicing is rune-based so multi-byte characters are never split.
+// It is the package's single truncation helper — previously four near-copies
+// (truncate, truncateRunes, truncatePlanText, truncateResultPreview) existed,
+// two of which byte-sliced and could emit invalid UTF-8.
+func truncateRunes(input string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(input)
+	if len(runes) <= maxRunes {
+		return input
+	}
+	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
+}
+
+// truncateResultPreview collapses all whitespace runs to single spaces and
+// then truncates — used for one-line previews of multi-line tool results.
+func truncateResultPreview(result string, maxRunes int) string {
+	compact := strings.Join(strings.Fields(result), " ")
+	return truncateRunes(compact, maxRunes)
+}

--- a/internal/chathttp/utility_web_adapters.go
+++ b/internal/chathttp/utility_web_adapters.go
@@ -1216,17 +1216,6 @@ func summarizeText(input string, maxRunes int) string {
 	return truncateRunes(text, maxRunes)
 }
 
-func truncateRunes(input string, maxRunes int) string {
-	if maxRunes <= 0 {
-		return ""
-	}
-	runes := []rune(input)
-	if len(runes) <= maxRunes {
-		return input
-	}
-	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
-}
-
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/chathttp/workspace_tools.go
+++ b/internal/chathttp/workspace_tools.go
@@ -647,7 +647,7 @@ func (p *WorkspaceToolProvider) readTasksTool() toolapi.Tool {
 					"created_at":  t.CreatedAt.Format(time.RFC3339),
 				}
 				if t.Result != "" {
-					item["result_preview"] = truncate(t.Result, 300)
+					item["result_preview"] = truncateRunes(t.Result, 300)
 				}
 				if t.ParentTaskID != "" {
 					item["parent_task_id"] = t.ParentTaskID
@@ -950,14 +950,6 @@ func marshalToolResponse(v any) (string, error) {
 }
 
 // truncate shortens a string to maxLen runes, appending "..." if truncated.
-func truncate(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	return string(runes[:maxLen]) + "..."
-}
-
 // ============================================================
 // Phase 2: Management Tools
 // ============================================================
@@ -1295,7 +1287,7 @@ func (p *WorkspaceToolProvider) manageSkillsTool() toolapi.Tool {
 				for _, s := range allSkills {
 					available = append(available, map[string]any{
 						"name":             s.Name,
-						"description":      truncate(s.Description, 200),
+						"description":      truncateRunes(s.Description, 200),
 						"already_attached": boundMap[strings.ToLower(s.Name)],
 					})
 				}

--- a/internal/cliagent/planner.go
+++ b/internal/cliagent/planner.go
@@ -156,19 +156,7 @@ func parseCompletionEval(content string) (bool, string, error) {
 
 // stripCodeFences removes markdown code fence wrappers if present.
 func stripCodeFences(s string) string {
-	s = strings.TrimSpace(s)
-	if strings.HasPrefix(s, "```") {
-		// Remove opening fence line
-		if idx := strings.Index(s, "\n"); idx != -1 {
-			s = s[idx+1:]
-		}
-		// Remove closing fence
-		if idx := strings.LastIndex(s, "```"); idx != -1 {
-			s = s[:idx]
-		}
-		s = strings.TrimSpace(s)
-	}
-	return s
+	return llm.StripCodeFence(s)
 }
 
 // truncate limits a string to maxLen characters.

--- a/internal/llm/helpers.go
+++ b/internal/llm/helpers.go
@@ -1,6 +1,9 @@
 package llm
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // NewUserMessage creates a new user message
 func NewUserMessage(content string) Message {
@@ -66,4 +69,28 @@ func IsToolCallResponse(resp *ChatResponse) bool {
 // HasContent checks if the response has content
 func HasContent(resp *ChatResponse) bool {
 	return resp.Content != ""
+}
+
+// StripCodeFence returns the content inside a markdown code fence when the
+// text begins with one (e.g. "```json\n{...}\n```"); otherwise it returns
+// the trimmed input unchanged. Models routinely wrap JSON answers in fences
+// even when instructed not to, so callers should strip before unmarshaling.
+func StripCodeFence(text string) string {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "```") {
+		return text
+	}
+
+	var inner []string
+	inFence := false
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			inner = append(inner, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(inner, "\n"))
 }

--- a/internal/modelcategoryhttp/auto_categorize.go
+++ b/internal/modelcategoryhttp/auto_categorize.go
@@ -308,22 +308,8 @@ Use "" for category_id if unsure.`, categoryList.String())
 		return nil, fmt.Errorf("LLM returned empty response (finish_reason: %s) - the model may not support this task or the prompt format", resp.FinishReason)
 	}
 
-	// Try to extract JSON if wrapped in markdown code blocks
-	if strings.HasPrefix(responseText, "```") {
-		lines := strings.Split(responseText, "\n")
-		var jsonLines []string
-		inJSON := false
-		for _, line := range lines {
-			if strings.HasPrefix(line, "```") {
-				inJSON = !inJSON
-				continue
-			}
-			if inJSON {
-				jsonLines = append(jsonLines, line)
-			}
-		}
-		responseText = strings.Join(jsonLines, "\n")
-	}
+	// Extract JSON if wrapped in a markdown code fence
+	responseText = llm.StripCodeFence(responseText)
 
 	var aiSuggestions []aiSuggestion
 	if err := json.Unmarshal([]byte(responseText), &aiSuggestions); err != nil {

--- a/internal/sessionhttp/auto_classify.go
+++ b/internal/sessionhttp/auto_classify.go
@@ -281,24 +281,7 @@ Please analyze this conversation and suggest the best workspace and agent.`,
 
 	// Parse the JSON response
 	var classification AutoClassifyResponse
-	responseText := strings.TrimSpace(resp.Content)
-
-	// Try to extract JSON if wrapped in markdown code blocks
-	if strings.HasPrefix(responseText, "```") {
-		lines := strings.Split(responseText, "\n")
-		var jsonLines []string
-		inJSON := false
-		for _, line := range lines {
-			if strings.HasPrefix(line, "```") {
-				inJSON = !inJSON
-				continue
-			}
-			if inJSON {
-				jsonLines = append(jsonLines, line)
-			}
-		}
-		responseText = strings.Join(jsonLines, "\n")
-	}
+	responseText := llm.StripCodeFence(resp.Content)
 
 	if err := json.Unmarshal([]byte(responseText), &classification); err != nil {
 		return nil, fmt.Errorf("failed to parse LLM response as JSON: %w (response: %s)", err, responseText)

--- a/internal/sessionhttp/smart_input_llm.go
+++ b/internal/sessionhttp/smart_input_llm.go
@@ -49,22 +49,7 @@ Guidance:
 		return smartInputHeuristicResult{}, fmt.Errorf("LLM request failed: %w", err)
 	}
 
-	responseText := strings.TrimSpace(resp.Content)
-	if strings.HasPrefix(responseText, "```") {
-		lines := strings.Split(responseText, "\n")
-		var jsonLines []string
-		inJSON := false
-		for _, line := range lines {
-			if strings.HasPrefix(line, "```") {
-				inJSON = !inJSON
-				continue
-			}
-			if inJSON {
-				jsonLines = append(jsonLines, line)
-			}
-		}
-		responseText = strings.Join(jsonLines, "\n")
-	}
+	responseText := llm.StripCodeFence(resp.Content)
 
 	var parsed smartInputLLMResponse
 	if err := json.Unmarshal([]byte(responseText), &parsed); err != nil {

--- a/internal/vault/email_accounts.go
+++ b/internal/vault/email_accounts.go
@@ -228,7 +228,7 @@ func buildEmailAccountRecord(input EmailAccountInput) (*Record, error) {
 }
 
 func normalizeEmailAccountRecord(record Record, payload emailAccountPayload) (Record, emailAccountPayload, error) {
-	payload.Provider = normalizeEmailProvider(payload.Provider)
+	payload.Provider = NormalizeEmailProvider(payload.Provider)
 	payload.AuthType = normalizeEmailAuthType(payload.AuthType)
 	payload.EmailAddress = strings.TrimSpace(payload.EmailAddress)
 	payload.DisplayName = strings.TrimSpace(payload.DisplayName)
@@ -368,7 +368,10 @@ func decodeEmailAccountPayload(data json.RawMessage) (emailAccountPayload, error
 	return payload, nil
 }
 
-func normalizeEmailProvider(provider EmailProvider) EmailProvider {
+// NormalizeEmailProvider canonicalizes a provider label (case, separators,
+// aliases like "outlook") to one of the EmailProvider constants. Exported so
+// the HTTP layer normalizes with the exact same alias set.
+func NormalizeEmailProvider(provider EmailProvider) EmailProvider {
 	switch strings.ToLower(strings.TrimSpace(string(provider))) {
 	case "gmail":
 		return EmailProviderGmail

--- a/internal/vaulthttp/email_oauth.go
+++ b/internal/vaulthttp/email_oauth.go
@@ -3,7 +3,6 @@ package vaulthttp
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html"
 	"net/http"
@@ -333,7 +332,7 @@ func (h *Handler) handleEmailOAuthStart(w http.ResponseWriter, r *http.Request) 
 
 	status, err := h.store.Status(r.Context(), vaultID)
 	if err != nil {
-		writeEmailOAuthPopupResult(w, statusCodeForVaultError(err), emailOAuthPopupPayload{
+		writeEmailOAuthPopupResult(w, vaultErrorStatus(err), emailOAuthPopupPayload{
 			Type:  emailOAuthPopupEventType,
 			Error: err.Error(),
 		})
@@ -356,7 +355,7 @@ func (h *Handler) handleEmailOAuthStart(w http.ResponseWriter, r *http.Request) 
 
 	flow, err := h.buildPendingEmailOAuthFlow(r.Context(), r, provider, vaultID, cfg)
 	if err != nil {
-		writeEmailOAuthPopupResult(w, statusCodeForVaultError(err), emailOAuthPopupPayload{
+		writeEmailOAuthPopupResult(w, vaultErrorStatus(err), emailOAuthPopupPayload{
 			Type:  emailOAuthPopupEventType,
 			Error: err.Error(),
 		})
@@ -422,7 +421,7 @@ func (h *Handler) buildPendingEmailOAuthFlow(ctx context.Context, r *http.Reques
 	if strings.TrimSpace(account.VaultID) != vaultID {
 		return flow, fmt.Errorf("%w: selected email account does not belong to this vault", vault.ErrInvalidEmailAccount)
 	}
-	if normalizeEmailProvider(account.Provider) != normalizeEmailProvider(provider) {
+	if vault.NormalizeEmailProvider(account.Provider) != vault.NormalizeEmailProvider(provider) {
 		return flow, fmt.Errorf("%w: reconnecting an account cannot change providers", vault.ErrInvalidEmailAccount)
 	}
 
@@ -514,7 +513,7 @@ func (h *Handler) handleEmailOAuthCallback(w http.ResponseWriter, r *http.Reques
 
 	account, err := h.persistEmailOAuthAccount(r.Context(), flow, cfg, token)
 	if err != nil {
-		writeEmailOAuthPopupResult(w, statusCodeForVaultError(err), emailOAuthPopupPayload{
+		writeEmailOAuthPopupResult(w, vaultErrorStatus(err), emailOAuthPopupPayload{
 			Type:  emailOAuthPopupEventType,
 			Error: err.Error(),
 		})
@@ -584,19 +583,6 @@ func (h *Handler) persistEmailOAuthAccount(ctx context.Context, flow pendingEmai
 			TokenEndpoint: cfg.tokenURL,
 		},
 	})
-}
-
-func normalizeEmailProvider(provider vault.EmailProvider) vault.EmailProvider {
-	switch strings.ToLower(strings.TrimSpace(string(provider))) {
-	case "gmail":
-		return vault.EmailProviderGmail
-	case "microsoft", "microsoft_mail", "microsoft-mail", "outlook", "outlook_mail", "outlook-mail":
-		return vault.EmailProviderMicrosoft
-	case "imap_smtp", "imap-smtp", "imap", "smtp":
-		return vault.EmailProviderIMAPSMTP
-	default:
-		return vault.EmailProvider(strings.ToLower(strings.TrimSpace(string(provider))))
-	}
 }
 
 func normalizeTags(values []string) []string {
@@ -747,33 +733,6 @@ func writeEmailOAuthPopupResult(w http.ResponseWriter, status int, payload email
 		html.EscapeString(bodyCopy),
 		strings.ReplaceAll(string(data), "</", `<\/`),
 	))
-}
-
-func statusCodeForVaultError(err error) int {
-	switch {
-	case err == nil:
-		return http.StatusOK
-	case errors.Is(err, vault.ErrVaultNotFound), errors.Is(err, vault.ErrRecordNotFound), errors.Is(err, vault.ErrGrantNotFound):
-		return http.StatusNotFound
-	case errors.Is(err, vault.ErrVaultAlreadyExists):
-		return http.StatusConflict
-	case errors.Is(err, vault.ErrPermissionDenied):
-		return http.StatusForbidden
-	case errors.Is(err, vault.ErrVaultPasswordInvalid):
-		return http.StatusUnauthorized
-	case errors.Is(err, vault.ErrVaultLocked):
-		return http.StatusLocked
-	case errors.Is(err, vault.ErrVaultRequired), errors.Is(err, vault.ErrVaultNameRequired), errors.Is(err, vault.ErrVaultPasswordRequired), errors.Is(err, vault.ErrExportPasswordEmpty), errors.Is(err, vault.ErrImportPasswordRequired), errors.Is(err, vault.ErrImportBundleRequired), errors.Is(err, vault.ErrImportBundleInvalid), errors.Is(err, vault.ErrImportTargetRequired), errors.Is(err, vault.ErrInvalidEmailAccount):
-		return http.StatusBadRequest
-	case errors.Is(err, vault.ErrImportPasswordInvalid):
-		return http.StatusUnauthorized
-	case errors.Is(err, vault.ErrVaultKeyUnavailable), errors.Is(err, vault.ErrMalformedRecord):
-		return http.StatusInternalServerError
-	case errors.Is(err, vault.ErrSecretStoreUnavailable), errors.Is(err, vault.ErrSecretStoreLocked):
-		return http.StatusServiceUnavailable
-	default:
-		return http.StatusInternalServerError
-	}
 }
 
 func stringPointer(value string) *string {

--- a/internal/vaulthttp/handlers.go
+++ b/internal/vaulthttp/handlers.go
@@ -608,31 +608,38 @@ func vaultIDFromRequest(r *http.Request, values ...string) string {
 	return firstNonEmpty(values...)
 }
 
-func respondVaultError(w http.ResponseWriter, err error) {
+// vaultErrorStatus maps a vault sentinel error to its HTTP status code. It is
+// the single source of truth for vault error → status mapping: both the JSON
+// error responses (respondVaultError) and the email OAuth popup flow use it.
+// When adding a vault sentinel error, add its mapping here.
+func vaultErrorStatus(err error) int {
 	switch {
 	case err == nil:
-		return
+		return http.StatusOK
 	case errors.Is(err, vault.ErrVaultNotFound), errors.Is(err, vault.ErrRecordNotFound), errors.Is(err, vault.ErrGrantNotFound), errors.Is(err, vault.ErrRecordAttachmentNotFound):
-		_ = orihttp.RespondError(w, http.StatusNotFound, err.Error())
+		return http.StatusNotFound
 	case errors.Is(err, vault.ErrVaultAlreadyExists), errors.Is(err, vault.ErrFolderNotEmpty), errors.Is(err, vault.ErrVaultStoragePathConflict):
-		_ = orihttp.RespondError(w, http.StatusConflict, err.Error())
+		return http.StatusConflict
 	case errors.Is(err, vault.ErrPermissionDenied):
-		_ = orihttp.RespondError(w, http.StatusForbidden, err.Error())
-	case errors.Is(err, vault.ErrVaultPasswordInvalid):
-		_ = orihttp.RespondError(w, http.StatusUnauthorized, err.Error())
+		return http.StatusForbidden
+	case errors.Is(err, vault.ErrVaultPasswordInvalid), errors.Is(err, vault.ErrImportPasswordInvalid):
+		return http.StatusUnauthorized
 	case errors.Is(err, vault.ErrVaultLocked):
-		_ = orihttp.RespondError(w, http.StatusLocked, err.Error())
+		return http.StatusLocked
 	case errors.Is(err, vault.ErrRecordAttachmentTooLarge):
-		_ = orihttp.RespondError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return http.StatusRequestEntityTooLarge
 	case errors.Is(err, vault.ErrVaultRequired), errors.Is(err, vault.ErrVaultNameRequired), errors.Is(err, vault.ErrVaultPasswordRequired), errors.Is(err, vault.ErrExportPasswordEmpty), errors.Is(err, vault.ErrImportPasswordRequired), errors.Is(err, vault.ErrImportBundleRequired), errors.Is(err, vault.ErrImportBundleInvalid), errors.Is(err, vault.ErrImportTargetRequired), errors.Is(err, vault.ErrInvalidEmailAccount), errors.Is(err, vault.ErrFolderPathInvalid), errors.Is(err, vault.ErrRecordAttachmentRequired), errors.Is(err, vault.ErrVaultStorageModeInvalid), errors.Is(err, vault.ErrVaultStoragePathRequired), errors.Is(err, vault.ErrVaultStoragePathInvalid):
-		_ = orihttp.RespondError(w, http.StatusBadRequest, err.Error())
-	case errors.Is(err, vault.ErrImportPasswordInvalid):
-		_ = orihttp.RespondError(w, http.StatusUnauthorized, err.Error())
-	case errors.Is(err, vault.ErrVaultKeyUnavailable), errors.Is(err, vault.ErrMalformedRecord), errors.Is(err, vault.ErrVaultFileMissing), errors.Is(err, vault.ErrVaultFileCorrupt):
-		_ = orihttp.RespondError(w, http.StatusInternalServerError, err.Error())
+		return http.StatusBadRequest
 	case errors.Is(err, vault.ErrSecretStoreUnavailable), errors.Is(err, vault.ErrSecretStoreLocked):
-		_ = orihttp.RespondError(w, http.StatusServiceUnavailable, err.Error())
+		return http.StatusServiceUnavailable
 	default:
-		_ = orihttp.RespondError(w, http.StatusInternalServerError, err.Error())
+		return http.StatusInternalServerError
 	}
+}
+
+func respondVaultError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	_ = orihttp.RespondError(w, vaultErrorStatus(err), err.Error())
 }

--- a/internal/workspace/workspace_analytics.go
+++ b/internal/workspace/workspace_analytics.go
@@ -79,11 +79,23 @@ func ComputeMapSummaryFields(w *Workspace) MapSummaryFields {
 	return fields
 }
 
+// busyQueueThreshold is the queued-task count beyond which an agent is
+// reported "busy" regardless of its other activity.
+const busyQueueThreshold = 5
+
 // GetAgentStats returns statistics for all agents in the workspace
 func (w *Workspace) GetAgentStats() map[string]AgentStats {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	return w.agentStatsLocked()
+}
 
+// agentStatsLocked computes per-agent task statistics. Callers must hold
+// w.mu (read or write). Single implementation shared by GetAgentStats and
+// GetWorkspaceProgress so the status handling cannot drift between them
+// (a previous private copy switched on raw strings and silently missed
+// TaskStatusTimeout).
+func (w *Workspace) agentStatsLocked() map[string]AgentStats {
 	stats := make(map[string]AgentStats)
 
 	// Initialize stats for all agents
@@ -150,7 +162,7 @@ func (w *Workspace) GetAgentStats() map[string]AgentStats {
 
 	// Determine if agent is busy (multiple tasks queued)
 	for agentName, agentStat := range stats {
-		if len(agentStat.QueuedTasks) > 5 {
+		if len(agentStat.QueuedTasks) > busyQueueThreshold {
 			agentStat.Status = "busy"
 			stats[agentName] = agentStat
 		}
@@ -240,7 +252,7 @@ func (w *Workspace) GetWorkspaceProgress() WorkspaceProgress {
 	}
 
 	// Count active vs idle agents using agent stats
-	agentStats := w.getAgentStatsUnlocked() // Use unlocked version since we already have read lock
+	agentStats := w.agentStatsLocked() // already holding the read lock
 	for _, stats := range agentStats {
 		if stats.Status == "active" || stats.Status == "busy" {
 			progress.ActiveAgents++
@@ -250,88 +262,4 @@ func (w *Workspace) GetWorkspaceProgress() WorkspaceProgress {
 	}
 
 	return progress
-}
-
-// getAgentStatsUnlocked is the unlocked version of GetAgentStats for internal use
-func (w *Workspace) getAgentStatsUnlocked() map[string]AgentStats {
-	stats := make(map[string]AgentStats)
-
-	// Initialize stats for all agents
-	for _, agentName := range w.agentNamesLocked() {
-		stats[agentName] = AgentStats{
-			Name:            agentName,
-			Status:          "idle",
-			CurrentTasks:    []string{},
-			QueuedTasks:     []string{},
-			CompletedTasks:  0,
-			FailedTasks:     0,
-			TotalExecutions: 0,
-		}
-	}
-
-	// Analyze tasks to populate stats
-	for _, task := range w.Tasks {
-		// Skip unassigned tasks
-		if task.To == "unassigned" || task.To == "" {
-			continue
-		}
-
-		agentStat, exists := stats[task.To]
-		if !exists {
-			continue
-		}
-
-		switch task.Status {
-		case "in_progress":
-			agentStat.CurrentTasks = append(agentStat.CurrentTasks, task.ID)
-			agentStat.Status = "active"
-			if task.StartedAt != nil {
-				agentStat.LastActive = *task.StartedAt
-			}
-			agentStat.TotalExecutions++
-
-		case "pending", "assigned":
-			agentStat.QueuedTasks = append(agentStat.QueuedTasks, task.ID)
-			// Set status to queued if not already active
-			switch agentStat.Status {
-			case "idle":
-				agentStat.Status = "queued"
-			case "active":
-				agentStat.Status = "busy" // Active with queued tasks
-			}
-
-		case "waiting_for_choice":
-			agentStat.CurrentTasks = append(agentStat.CurrentTasks, task.ID)
-			if agentStat.Status == "idle" || agentStat.Status == "queued" {
-				agentStat.Status = "waiting"
-			}
-
-		case "completed":
-			agentStat.CompletedTasks++
-			agentStat.TotalExecutions++
-			if task.CompletedAt != nil && !task.CompletedAt.IsZero() && task.CompletedAt.After(agentStat.LastActive) {
-				agentStat.LastActive = *task.CompletedAt
-			}
-
-		case "failed":
-			agentStat.FailedTasks++
-			agentStat.TotalExecutions++
-			agentStat.Status = "error"
-			if task.CompletedAt != nil && !task.CompletedAt.IsZero() && task.CompletedAt.After(agentStat.LastActive) {
-				agentStat.LastActive = *task.CompletedAt
-			}
-		}
-
-		stats[task.To] = agentStat
-	}
-
-	// Determine if agent is busy (multiple tasks queued)
-	for agentName, agentStat := range stats {
-		if len(agentStat.QueuedTasks) > 5 {
-			agentStat.Status = "busy"
-			stats[agentName] = agentStat
-		}
-	}
-
-	return stats
 }


### PR DESCRIPTION
## Summary

Phase 3 of the readability-review fix order: consolidate duplicated helpers that had already drifted (or were one edit from it). 19 files, +149/−298.

### Behavior fix included
- **vaulthttp** — two hand-maintained error→HTTP-status maps (`respondVaultError`, `statusCodeForVaultError`) had drifted: the email OAuth copy was missing the folder/attachment/storage sentinels, so those errors surfaced as **500 instead of 404/409/413** on the OAuth path. Both now derive from a single `vaultErrorStatus` map.

### Consolidations (each was 2–4 independently-maintained copies)
- **vault** — exported `NormalizeEmailProvider`; deleted the verbatim vaulthttp copy so the alias set can't drift between layers.
- **workspace** — replaced the `GetAgentStats` / `getAgentStatsUnlocked` twins with one `agentStatsLocked` core. The private copy switched on raw strings and had silently missed `TaskStatusTimeout`; consolidated on the typed, timeout-aware semantics. Named the busy-queue threshold constant.
- **llm** — new `StripCodeFence` helper replaces four copies of markdown-fence stripping (sessionhttp `auto_classify` + `smart_input_llm`, modelcategoryhttp, cliagent/planner).
- **chathttp** — collapsed four truncate helpers into one rune-safe pair (`truncate.go`); two of the old copies byte-sliced and could emit invalid UTF-8 mid-rune. Named the `MaxTokens: 4000` magic number (`defaultChatMaxTokens`, 9 sites). Folded `ExecuteToolWithFiles`/`ExecuteToolWithFilesDebug` into one implementation parameterized by log level.

### Deliberately deferred
- sessionhttp import/sync reference-rewrite twins — same policy line-for-line, but consolidating requires verifying JSON-tag equivalence between the mirror structs; tracked as its own follow-up.
- task-output vs output-contract type validators — intentionally different vocabularies serve different features; merging would change validation behavior.

## Verification
- `go build ./...` clean; `go vet` clean on touched packages
- `go test -race` green on all seven touched packages (vault, vaulthttp, workspace, sessionhttp, modelcategoryhttp, cliagent, chathttp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)