### PR TITLE
refactor: stage ChatHandler pipeline and dedupe provider tool loops

### DIFF
--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -805,6 +805,25 @@ type UploadedFile struct {
 }
 
 // ChatHandler handles chat requests
+// chatRequest is the JSON body of POST /api/chat.
+type chatRequest struct {
+	Question             string                `json:"question"`
+	AgentName            string                `json:"agent_name,omitempty"` // Allow specifying target agent
+	Files                []UploadedFile        `json:"files,omitempty"`
+	RouteContext         *chatRouteContext     `json:"route_context,omitempty"`
+	WorkflowResponse     *WorkflowUserResponse `json:"workflow_response,omitempty"`
+	MultiAgentMode       string                `json:"multi_agent_mode,omitempty"`
+	MultiAgentThreshold  float64               `json:"multi_agent_threshold,omitempty"`
+	PlanBeforeAction     bool                  `json:"plan_before_action,omitempty"`
+	ApprovedActionPlanID string                `json:"approved_action_plan_id,omitempty"`
+}
+
+// ChatHandler serves POST /api/chat. It runs the chat turn as a pipeline of
+// stages, most of which can short-circuit by writing a response: parse and
+// resolve the question -> resolve the execution agent -> pre-routing rewrites
+// (slash commands, skills, direct tools) -> workspace routing and agent load
+// -> planning/approval intercepts -> planner orchestration -> tool aggregation
+// -> provider dispatch.
 func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if !orihttp.RequireMethod(w, r, http.MethodPost) {
@@ -815,17 +834,7 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req struct {
-		Question             string                `json:"question"`
-		AgentName            string                `json:"agent_name,omitempty"` // Allow specifying target agent
-		Files                []UploadedFile        `json:"files,omitempty"`
-		RouteContext         *chatRouteContext     `json:"route_context,omitempty"`
-		WorkflowResponse     *WorkflowUserResponse `json:"workflow_response,omitempty"`
-		MultiAgentMode       string                `json:"multi_agent_mode,omitempty"`
-		MultiAgentThreshold  float64               `json:"multi_agent_threshold,omitempty"`
-		PlanBeforeAction     bool                  `json:"plan_before_action,omitempty"`
-		ApprovedActionPlanID string                `json:"approved_action_plan_id,omitempty"`
-	}
+	var req chatRequest
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
@@ -918,71 +927,9 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if strings.HasPrefix(q, "/tool ") {
-		// Direct tool execution - bypass LLM decision-making
-		cmd, err := parseDirectToolCommand(q)
-		if err != nil {
-			// Return parsing error as response
-			orihttp.WriteJSON(w, attachRouteMetadata(map[string]any{
-				"response":         fmt.Sprintf("❌ **Invalid command**: %v\n\nFormat: `/tool <tool_name> {\"key\": \"value\"}`\nExample: `/tool math {\"operation\": \"add\", \"a\": 5, \"b\": 3}`", err),
-				"direct_tool_call": true,
-				"success":          false,
-			}, chatRouteMetadata{
-				Mode: routeModeDirectTool,
-			}))
-			return
-		}
-
-		// Attach files to the command if present
-		if len(req.Files) > 0 {
-			cmd.Files = ConvertUploadedFilesToAttachments(req.Files)
-		}
-
-		// Load agent - use session-bound agent if available
-		current := executionAgent.Name
-		if current == "" {
-			orihttp.InternalError(w, "no agent available for direct tool execution")
-			return
-		}
-		ag, err := h.resolveEffectiveAgent(current, normalizedRouteContext)
-		if err != nil {
-			if errors.Is(err, errAgentPaused) {
-				orihttp.Conflict(w, fmt.Sprintf("Agent %q is disabled. Turn Enabled on before starting a chat or running tools.", current))
-				return
-			}
-			orihttp.InternalError(w, fmt.Sprintf("agent '%s' not found", current))
-			return
-		}
-
-		if req.PlanBeforeAction && approvedActionPlanID == "" {
-			plan := buildDirectToolActionPlan(q, cmd)
-			response := attachRouteMetadata(map[string]any{
-				"response":           formatActionPlanMessage(plan),
-				"requires_approval":  true,
-				"approval_type":      "action_plan",
-				"action_plan_id":     plan.ID,
-				"action_plan":        plan,
-				"plan_before_action": true,
-			}, chatRouteMetadata{
-				Mode:   routeModeDirectTool,
-				Reason: "awaiting action plan approval",
-			})
-			writeJSONResponse(w, response)
-			return
-		}
-
-		result := h.executeDirectTool(r.Context(), ag, cmd)
-
-		// Add to conversation history for context
-		ag.Messages = append(ag.Messages, openai.UserMessage(q))
-		ag.Messages = append(ag.Messages, openai.AssistantMessage(result.Result))
-		_ = h.persistAgent(current, ag.Agent)
-
-		// Return formatted response
-		response := formatDirectToolResponse(result)
-		writeJSONResponse(w, response)
+		h.handleDirectToolCommand(w, r, req, q, executionAgent, normalizedRouteContext, approvedActionPlanID)
 		return
 	}
-
 	logger.Debug("Chat question received", logger.Fields{"question": q})
 	// Context with timeout per request (prevents indefinite hang)
 	base := r.Context()
@@ -1025,27 +972,7 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	// full context across page reloads and server restarts.
 	h.rehydrateSessionHistory(r.Context(), sessionID, ag)
 
-	if planningResp := maybeBuildWorkspacePlanningFormResponse(ag, originalQuery, normalizedRouteContext, h.workspaceStore, h.sessionStore); planningResp != nil && planningResp.Form != nil {
-		responseText := strings.TrimSpace(planningResp.ResponseText)
-		if responseText == "" {
-			responseText = "Complete the planning step below."
-		}
-
-		ag.Messages = append(ag.Messages, openai.UserMessage(originalQuery))
-		ag.Messages = append(ag.Messages, openai.AssistantMessage(responseText))
-		_ = h.persistAgent(current, ag.Agent)
-
-		h.storeMessageInSession(base, sessionID, "user", originalQuery)
-		h.storeMessageInSession(base, sessionID, "assistant", responseText)
-
-		writeJSONResponse(w, attachRouteMetadata(map[string]any{
-			"response":      responseText,
-			"planning_form": planningResp.Form,
-			"workflow_step": buildWorkflowStepFromPlanningForm(planningResp.Form, sessionID),
-		}, chatRouteMetadata{
-			Mode:   routeModeAssistantChat,
-			Reason: "workspace planning form required",
-		}))
+	if h.maybeHandleWorkspacePlanningForm(w, base, ag, current, originalQuery, sessionID, normalizedRouteContext) {
 		return
 	}
 
@@ -1095,38 +1022,8 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if invokedSkill != nil && len(invokedSkill.Skill.RequiredMCPServers) > 0 {
-		missing := missingMCPServers(ag.MCPServers, invokedSkill.Skill.RequiredMCPServers)
-		if len(missing) > 0 {
-			primaryServer := missing[0]
-			preferenceKey := ""
-			workspaceID := strings.TrimSpace(normalizedRouteContext.WorkspaceID)
-			if workspaceID != "" {
-				preferenceKey = workspace.DependencyPreferenceKey(dependencyTypeWorkspaceMCP, primaryServer)
-			}
-			writeJSONResponse(w, attachDependencyResolution(map[string]any{
-				"response": fmt.Sprintf("❌ Skill '%s' requires MCP connectors: %s. Bind them from the target workspace.", invokedSkill.Skill.Name, strings.Join(missing, ", ")),
-			}, &dependencyResolution{
-				Version:            1,
-				Title:              "Required MCP connectors are not enabled",
-				Summary:            fmt.Sprintf("Enable the required connector for skill \"%s\" before retrying.", invokedSkill.Skill.Name),
-				ReasonCode:         "skill_required_mcp_missing",
-				RecommendedSurface: dependencyResolutionSurfaceModal,
-				RetryContext:       buildDefaultRetryContext(workspaceID != ""),
-				Steps: []dependencyResolutionStep{
-					{
-						ID:           "skill-required-mcp",
-						Type:         dependencyTypeWorkspaceMCP,
-						DisplayName:  primaryServer,
-						Summary:      fmt.Sprintf("Enable %s in the current workspace to run \"%s\".", primaryServer, invokedSkill.Skill.Name),
-						RiskLevel:    "low",
-						Suppressible: workspaceID != "",
-						Actions:      buildSkillRequiredMCPActions(workspaceID, primaryServer, preferenceKey),
-					},
-				},
-			}))
-			return
-		}
+	if h.maybeRejectSkillMissingMCP(w, ag, invokedSkill, normalizedRouteContext) {
+		return
 	}
 
 	sessionQuery := originalQuery
@@ -1141,173 +1038,12 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Debug("Agent MCP servers loaded", logger.Fields{"agent": current, "server_count": len(ag.MCPServers), "servers": ag.MCPServers})
-
-	var plannerDecision *types.PlannerDecision
-
-	// Planner-first orchestration routing
-	if h.orchestrator != nil {
-		mode, threshold := h.orchestrator.GetMultiAgentDefaults()
-		if req.MultiAgentMode != "" {
-			if parsed, ok := types.ParseMultiAgentMode(strings.ToLower(strings.TrimSpace(req.MultiAgentMode))); ok {
-				mode = parsed
-			}
-		}
-		if req.MultiAgentThreshold > 0 {
-			threshold = req.MultiAgentThreshold
-		}
-
-		if mode != types.MultiAgentModeOff {
-			plan, err := h.orchestrator.PlanTask(ctx, q)
-			if err != nil {
-				logger.Error("Planner failed", logger.Fields{"error": err})
-			} else {
-				decision := h.orchestrator.DecideMultiAgent(plan, mode, threshold)
-				plannerDecision = &decision
-				logger.Info("Planner routing decision", logger.Fields{
-					"mode":        decision.Mode,
-					"complexity":  decision.ComplexityScore,
-					"threshold":   decision.Threshold,
-					"multi_agent": decision.MultiAgent,
-				})
-
-				if decision.MultiAgent {
-					result, err := h.orchestrator.ExecutePlannedTask(ctx, current, q, plan, decision, 10*time.Minute)
-					if err != nil {
-						logger.Error("Orchestration failed", logger.Fields{"error": err})
-					} else {
-						logger.Info("Orchestration completed successfully", logger.Fields{})
-						responseText := result.FinalOutput
-						if responseText == "" && result.Status == "pending_approval" {
-							responseText = "Dynamic agent approval required to continue."
-						}
-						if h.utilityTelemetry != nil {
-							h.utilityTelemetry.RecordDelegationEvent(routeModeSpecialistFlow, "planner selected multi-agent execution", current)
-						}
-						receipt := buildActionReceipt(
-							"orchestration",
-							"Executed multi-agent workflow",
-							"planner selected multi-agent execution",
-							"",
-							"",
-							responseText,
-							0,
-							result.Error == "",
-							result.Error,
-						)
-						orihttp.WriteJSON(w, attachActionReceipts(attachRouteMetadata(map[string]any{
-							"response":               responseText,
-							"orchestrated":           true,
-							"workspace_id":           result.WorkspaceID,
-							"status":                 result.Status,
-							"pending_plan_id":        result.PendingPlanID,
-							"planner_decision":       result.PlannerDecision,
-							"planner_plan":           plan,
-							"dynamic_agent_requests": result.DynamicAgentRequests,
-						}, chatRouteMetadata{
-							Mode:   routeModeSpecialistFlow,
-							Reason: "planner selected multi-agent execution",
-						}), []ActionReceipt{receipt}))
-						return
-					}
-				}
-			}
-		} else {
-			decision := types.PlannerDecision{
-				ComplexityScore: 0,
-				Threshold:       threshold,
-				Mode:            string(mode),
-				MultiAgent:      false,
-				Rationale:       "Multi-agent disabled",
-				CreatedAt:       time.Now(),
-			}
-			plannerDecision = &decision
-		}
+	plannerDecision, handled := h.maybeRunPlannerOrchestration(ctx, w, q, current, req.MultiAgentMode, req.MultiAgentThreshold)
+	if handled {
+		return
 	}
 
-	// Build tools - refresh definitions to get latest dynamic enums (e.g., script lists)
-	tools := []llm.Tool{}
-	toolIndex := make(map[string]int)
-	toolSource := make(map[string]string)
-	appendTool := func(def llm.Tool, source string) {
-		name := strings.TrimSpace(def.Name)
-		if name == "" {
-			return
-		}
-		if idx, exists := toolIndex[name]; exists {
-			if source == "mcp" && toolSource[name] == "utility" && shouldPreferMCPToolOverUtility(name) {
-				tools[idx] = def
-				toolSource[name] = source
-			}
-			return
-		}
-		toolIndex[name] = len(tools)
-		toolSource[name] = source
-		tools = append(tools, def)
-	}
-
-	// Add native utility tools first
-	if h.utilityRegistry != nil {
-		for _, def := range h.utilityRegistry.ListToolDefinitions() {
-			if !isUtilityToolAllowedForAgent(ag.Agent, def.Name) {
-				continue
-			}
-			if shouldSuppressUtilityToolForAgent(ag, def.Name) {
-				continue
-			}
-			appendTool(llm.Tool{
-				Name:        def.Name,
-				Description: def.Description,
-				Parameters:  def.Parameters,
-			}, "utility")
-		}
-	}
-
-	// Add workspace-scoped tools when in a workspace context
-	if ag.WorkspaceTools != nil {
-		wsTools := ag.WorkspaceTools.Tools()
-		logger.Info("Adding workspace tools to LLM request", logger.Fields{
-			"count": len(wsTools),
-		})
-		for _, wt := range wsTools {
-			def := wt.Definition()
-			logger.Debug("Registering workspace tool", logger.Fields{"name": def.Name})
-			appendTool(llm.Tool{
-				Name:        def.Name,
-				Description: def.Description,
-				Parameters:  def.Parameters,
-			}, "workspace")
-		}
-	} else {
-		logger.Debug("No workspace tools to add (WorkspaceTools is nil)")
-	}
-
-	// Add MCP tools for enabled servers
-	logger.Debug("Checking MCP servers for agent", logger.Fields{"agent": current, "server_count": len(ag.MCPServers), "servers": ag.MCPServers})
-	if h.mcpRegistry != nil && len(ag.MCPServers) > 0 {
-		logger.Debug("Loading MCP tools for agent", logger.Fields{"agent": current})
-		for _, serverName := range ag.MCPServers {
-			logger.Debug("Attempting to get tools for MCP server", logger.Fields{"server": serverName})
-			mcpTools, err := h.getMCPToolsForServer(serverName)
-			if err != nil {
-				logger.Warn("Failed to get MCP tools for server", logger.Fields{"server": serverName, "error": err})
-				continue
-			}
-			for _, mcpTool := range mcpTools {
-				mcpDef := mcpTool.Definition()
-				appendTool(llm.Tool{
-					Name:        mcpDef.Name,
-					Description: mcpDef.Description,
-					Parameters:  mcpDef.Parameters,
-				}, "mcp")
-			}
-			logger.Debug("Added MCP tools from server", logger.Fields{"count": len(mcpTools), "server": serverName})
-		}
-	}
-
-	if invokedSkill != nil {
-		tools = filterToolsForSkill(tools, invokedSkill.Skill)
-	}
-	tools = prioritizeToolsForPath(ag.Agent, tools)
+	tools := h.buildChatToolList(ag, current, invokedSkill)
 
 	if invokedSkill == nil {
 		if h.maybeHandleCapabilityRecovery(w, base, ag, current, originalQuery, sessionID, tools, plannerDecision) {
@@ -1401,6 +1137,325 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	// Handle OpenAI models
 	agentClient := h.getClientForAgent(ag.Agent)
 	h.handleOpenAIChat(w, r, ag, q, tools, current, base, fileAttachments, llmImages, agentClient, plannerDecision, toolRuntimeSystemPrompt)
+}
+
+// handleDirectToolCommand executes a "/tool <name> {json}" chat message
+// directly, bypassing LLM decision-making. It always writes the response.
+func (h *Handler) handleDirectToolCommand(w http.ResponseWriter, r *http.Request, req chatRequest, q string, executionAgent executionAgentResolution, normalizedRouteContext normalizedChatRouteContext, approvedActionPlanID string) {
+	// Direct tool execution - bypass LLM decision-making
+	cmd, err := parseDirectToolCommand(q)
+	if err != nil {
+		// Return parsing error as response
+		orihttp.WriteJSON(w, attachRouteMetadata(map[string]any{
+			"response":         fmt.Sprintf("❌ **Invalid command**: %v\n\nFormat: `/tool <tool_name> {\"key\": \"value\"}`\nExample: `/tool math {\"operation\": \"add\", \"a\": 5, \"b\": 3}`", err),
+			"direct_tool_call": true,
+			"success":          false,
+		}, chatRouteMetadata{
+			Mode: routeModeDirectTool,
+		}))
+		return
+	}
+
+	// Attach files to the command if present
+	if len(req.Files) > 0 {
+		cmd.Files = ConvertUploadedFilesToAttachments(req.Files)
+	}
+
+	// Load agent - use session-bound agent if available
+	current := executionAgent.Name
+	if current == "" {
+		orihttp.InternalError(w, "no agent available for direct tool execution")
+		return
+	}
+	ag, err := h.resolveEffectiveAgent(current, normalizedRouteContext)
+	if err != nil {
+		if errors.Is(err, errAgentPaused) {
+			orihttp.Conflict(w, fmt.Sprintf("Agent %q is disabled. Turn Enabled on before starting a chat or running tools.", current))
+			return
+		}
+		orihttp.InternalError(w, fmt.Sprintf("agent '%s' not found", current))
+		return
+	}
+
+	if req.PlanBeforeAction && approvedActionPlanID == "" {
+		plan := buildDirectToolActionPlan(q, cmd)
+		response := attachRouteMetadata(map[string]any{
+			"response":           formatActionPlanMessage(plan),
+			"requires_approval":  true,
+			"approval_type":      "action_plan",
+			"action_plan_id":     plan.ID,
+			"action_plan":        plan,
+			"plan_before_action": true,
+		}, chatRouteMetadata{
+			Mode:   routeModeDirectTool,
+			Reason: "awaiting action plan approval",
+		})
+		writeJSONResponse(w, response)
+		return
+	}
+
+	result := h.executeDirectTool(r.Context(), ag, cmd)
+
+	// Add to conversation history for context
+	ag.Messages = append(ag.Messages, openai.UserMessage(q))
+	ag.Messages = append(ag.Messages, openai.AssistantMessage(result.Result))
+	_ = h.persistAgent(current, ag.Agent)
+
+	// Return formatted response
+	response := formatDirectToolResponse(result)
+	writeJSONResponse(w, response)
+	return
+}
+
+// maybeHandleWorkspacePlanningForm intercepts prompts that require a
+// workspace planning form before any model call, returning true when it has
+// written the form response.
+func (h *Handler) maybeHandleWorkspacePlanningForm(w http.ResponseWriter, base context.Context, ag *resolvedChatAgent, current, originalQuery, sessionID string, normalizedRouteContext normalizedChatRouteContext) bool {
+	if planningResp := maybeBuildWorkspacePlanningFormResponse(ag, originalQuery, normalizedRouteContext, h.workspaceStore, h.sessionStore); planningResp != nil && planningResp.Form != nil {
+		responseText := strings.TrimSpace(planningResp.ResponseText)
+		if responseText == "" {
+			responseText = "Complete the planning step below."
+		}
+
+		ag.Messages = append(ag.Messages, openai.UserMessage(originalQuery))
+		ag.Messages = append(ag.Messages, openai.AssistantMessage(responseText))
+		_ = h.persistAgent(current, ag.Agent)
+
+		h.storeMessageInSession(base, sessionID, "user", originalQuery)
+		h.storeMessageInSession(base, sessionID, "assistant", responseText)
+
+		writeJSONResponse(w, attachRouteMetadata(map[string]any{
+			"response":      responseText,
+			"planning_form": planningResp.Form,
+			"workflow_step": buildWorkflowStepFromPlanningForm(planningResp.Form, sessionID),
+		}, chatRouteMetadata{
+			Mode:   routeModeAssistantChat,
+			Reason: "workspace planning form required",
+		}))
+		return true
+	}
+	return false
+}
+
+// maybeRejectSkillMissingMCP rejects an invoked skill whose required MCP
+// connectors are not enabled on the agent, returning true when it has written
+// the dependency-resolution response.
+func (h *Handler) maybeRejectSkillMissingMCP(w http.ResponseWriter, ag *resolvedChatAgent, invokedSkill *skillInvocation, normalizedRouteContext normalizedChatRouteContext) bool {
+	if invokedSkill != nil && len(invokedSkill.Skill.RequiredMCPServers) > 0 {
+		missing := missingMCPServers(ag.MCPServers, invokedSkill.Skill.RequiredMCPServers)
+		if len(missing) > 0 {
+			primaryServer := missing[0]
+			preferenceKey := ""
+			workspaceID := strings.TrimSpace(normalizedRouteContext.WorkspaceID)
+			if workspaceID != "" {
+				preferenceKey = workspace.DependencyPreferenceKey(dependencyTypeWorkspaceMCP, primaryServer)
+			}
+			writeJSONResponse(w, attachDependencyResolution(map[string]any{
+				"response": fmt.Sprintf("❌ Skill '%s' requires MCP connectors: %s. Bind them from the target workspace.", invokedSkill.Skill.Name, strings.Join(missing, ", ")),
+			}, &dependencyResolution{
+				Version:            1,
+				Title:              "Required MCP connectors are not enabled",
+				Summary:            fmt.Sprintf("Enable the required connector for skill \"%s\" before retrying.", invokedSkill.Skill.Name),
+				ReasonCode:         "skill_required_mcp_missing",
+				RecommendedSurface: dependencyResolutionSurfaceModal,
+				RetryContext:       buildDefaultRetryContext(workspaceID != ""),
+				Steps: []dependencyResolutionStep{
+					{
+						ID:           "skill-required-mcp",
+						Type:         dependencyTypeWorkspaceMCP,
+						DisplayName:  primaryServer,
+						Summary:      fmt.Sprintf("Enable %s in the current workspace to run \"%s\".", primaryServer, invokedSkill.Skill.Name),
+						RiskLevel:    "low",
+						Suppressible: workspaceID != "",
+						Actions:      buildSkillRequiredMCPActions(workspaceID, primaryServer, preferenceKey),
+					},
+				},
+			}))
+			return true
+		}
+	}
+	return false
+}
+
+// maybeRunPlannerOrchestration runs planner-first multi-agent routing. When
+// the planner selects (and successfully executes) a multi-agent plan it
+// writes the orchestration response and returns handled=true; otherwise it
+// returns the planner decision (which may be nil) for the single-agent path.
+func (h *Handler) maybeRunPlannerOrchestration(ctx context.Context, w http.ResponseWriter, q, current, requestedMode string, requestedThreshold float64) (*types.PlannerDecision, bool) {
+	var plannerDecision *types.PlannerDecision
+	if h.orchestrator == nil {
+		return nil, false
+	}
+
+	mode, threshold := h.orchestrator.GetMultiAgentDefaults()
+	if requestedMode != "" {
+		if parsed, ok := types.ParseMultiAgentMode(strings.ToLower(strings.TrimSpace(requestedMode))); ok {
+			mode = parsed
+		}
+	}
+	if requestedThreshold > 0 {
+		threshold = requestedThreshold
+	}
+
+	if mode != types.MultiAgentModeOff {
+		plan, err := h.orchestrator.PlanTask(ctx, q)
+		if err != nil {
+			logger.Error("Planner failed", logger.Fields{"error": err})
+		} else {
+			decision := h.orchestrator.DecideMultiAgent(plan, mode, threshold)
+			plannerDecision = &decision
+			logger.Info("Planner routing decision", logger.Fields{
+				"mode":        decision.Mode,
+				"complexity":  decision.ComplexityScore,
+				"threshold":   decision.Threshold,
+				"multi_agent": decision.MultiAgent,
+			})
+
+			if decision.MultiAgent {
+				result, err := h.orchestrator.ExecutePlannedTask(ctx, current, q, plan, decision, 10*time.Minute)
+				if err != nil {
+					logger.Error("Orchestration failed", logger.Fields{"error": err})
+				} else {
+					logger.Info("Orchestration completed successfully", logger.Fields{})
+					responseText := result.FinalOutput
+					if responseText == "" && result.Status == "pending_approval" {
+						responseText = "Dynamic agent approval required to continue."
+					}
+					if h.utilityTelemetry != nil {
+						h.utilityTelemetry.RecordDelegationEvent(routeModeSpecialistFlow, "planner selected multi-agent execution", current)
+					}
+					receipt := buildActionReceipt(
+						"orchestration",
+						"Executed multi-agent workflow",
+						"planner selected multi-agent execution",
+						"",
+						"",
+						responseText,
+						0,
+						result.Error == "",
+						result.Error,
+					)
+					orihttp.WriteJSON(w, attachActionReceipts(attachRouteMetadata(map[string]any{
+						"response":               responseText,
+						"orchestrated":           true,
+						"workspace_id":           result.WorkspaceID,
+						"status":                 result.Status,
+						"pending_plan_id":        result.PendingPlanID,
+						"planner_decision":       result.PlannerDecision,
+						"planner_plan":           plan,
+						"dynamic_agent_requests": result.DynamicAgentRequests,
+					}, chatRouteMetadata{
+						Mode:   routeModeSpecialistFlow,
+						Reason: "planner selected multi-agent execution",
+					}), []ActionReceipt{receipt}))
+					return plannerDecision, true
+				}
+			}
+		}
+	} else {
+		decision := types.PlannerDecision{
+			ComplexityScore: 0,
+			Threshold:       threshold,
+			Mode:            string(mode),
+			MultiAgent:      false,
+			Rationale:       "Multi-agent disabled",
+			CreatedAt:       time.Now(),
+		}
+		plannerDecision = &decision
+	}
+	return plannerDecision, false
+}
+
+// buildChatToolList aggregates the tool definitions offered to the model for
+// this turn: native utility tools, workspace-scoped tools, and MCP tools from
+// the agent's enabled servers. Duplicate names keep the first definition
+// except when an MCP tool should supersede a same-named utility tool. The
+// list is then filtered for an invoked skill and path-prioritized.
+func (h *Handler) buildChatToolList(ag *resolvedChatAgent, current string, invokedSkill *skillInvocation) []llm.Tool {
+	tools := []llm.Tool{}
+	toolIndex := make(map[string]int)
+	toolSource := make(map[string]string)
+	appendTool := func(def llm.Tool, source string) {
+		name := strings.TrimSpace(def.Name)
+		if name == "" {
+			return
+		}
+		if idx, exists := toolIndex[name]; exists {
+			if source == "mcp" && toolSource[name] == "utility" && shouldPreferMCPToolOverUtility(name) {
+				tools[idx] = def
+				toolSource[name] = source
+			}
+			return
+		}
+		toolIndex[name] = len(tools)
+		toolSource[name] = source
+		tools = append(tools, def)
+	}
+
+	// Add native utility tools first
+	if h.utilityRegistry != nil {
+		for _, def := range h.utilityRegistry.ListToolDefinitions() {
+			if !isUtilityToolAllowedForAgent(ag.Agent, def.Name) {
+				continue
+			}
+			if shouldSuppressUtilityToolForAgent(ag, def.Name) {
+				continue
+			}
+			appendTool(llm.Tool{
+				Name:        def.Name,
+				Description: def.Description,
+				Parameters:  def.Parameters,
+			}, "utility")
+		}
+	}
+
+	// Add workspace-scoped tools when in a workspace context
+	if ag.WorkspaceTools != nil {
+		wsTools := ag.WorkspaceTools.Tools()
+		logger.Info("Adding workspace tools to LLM request", logger.Fields{
+			"count": len(wsTools),
+		})
+		for _, wt := range wsTools {
+			def := wt.Definition()
+			logger.Debug("Registering workspace tool", logger.Fields{"name": def.Name})
+			appendTool(llm.Tool{
+				Name:        def.Name,
+				Description: def.Description,
+				Parameters:  def.Parameters,
+			}, "workspace")
+		}
+	} else {
+		logger.Debug("No workspace tools to add (WorkspaceTools is nil)")
+	}
+
+	// Add MCP tools for enabled servers
+	logger.Debug("Checking MCP servers for agent", logger.Fields{"agent": current, "server_count": len(ag.MCPServers), "servers": ag.MCPServers})
+	if h.mcpRegistry != nil && len(ag.MCPServers) > 0 {
+		logger.Debug("Loading MCP tools for agent", logger.Fields{"agent": current})
+		for _, serverName := range ag.MCPServers {
+			logger.Debug("Attempting to get tools for MCP server", logger.Fields{"server": serverName})
+			mcpTools, err := h.getMCPToolsForServer(serverName)
+			if err != nil {
+				logger.Warn("Failed to get MCP tools for server", logger.Fields{"server": serverName, "error": err})
+				continue
+			}
+			for _, mcpTool := range mcpTools {
+				mcpDef := mcpTool.Definition()
+				appendTool(llm.Tool{
+					Name:        mcpDef.Name,
+					Description: mcpDef.Description,
+					Parameters:  mcpDef.Parameters,
+				}, "mcp")
+			}
+			logger.Debug("Added MCP tools from server", logger.Fields{"count": len(mcpTools), "server": serverName})
+		}
+	}
+
+	if invokedSkill != nil {
+		tools = filterToolsForSkill(tools, invokedSkill.Skill)
+	}
+	tools = prioritizeToolsForPath(ag.Agent, tools)
+	return tools
 }
 
 // isImageMimeType checks if a MIME type represents an image

--- a/internal/chathttp/handlers_claude.go
+++ b/internal/chathttp/handlers_claude.go
@@ -78,7 +78,9 @@ func (h *Handler) handleClaudeChat(w http.ResponseWriter, r *http.Request, ag *r
 	}), plannerDecision))
 }
 
-// handleClaudeToolCalls handles tool execution for Claude
+// handleClaudeToolCalls handles tool execution for Claude via the shared
+// provider tool loop. Claude follow-up turns append the follow-up guidance
+// prompt; the other providers use the base system prompt unchanged.
 func (h *Handler) handleClaudeToolCalls(
 	w http.ResponseWriter,
 	ctx context.Context,
@@ -97,82 +99,20 @@ func (h *Handler) handleClaudeToolCalls(
 	systemPrompt string,
 ) {
 	logger.Info("Claude requested tool calls", logger.Fields{"count": len(resp.ToolCalls)})
-
-	loopResult := h.runBoundedToolLoop(
-		resp.Content,
-		resp.ToolCalls,
-		boundedToolLoopConfig{},
-		boundedToolLoopCallbacks{
-			AppendAssistantTurn: func(content string, toolCalls []llm.ToolCall) {
-				assistantMsg := llm.NewAssistantMessage(content)
-				assistantMsg.ToolCalls = toolCalls
-				messages = append(messages, assistantMsg)
-			},
-			ExecuteToolCalls: func(toolCalls []llm.ToolCall) ExecuteToolCallsResult {
-				return h.executeToolCallsCommonWithSession(baseCtx, ag, toolCalls, files, sessionID)
-			},
-			AppendToolResults: func(toolCalls []llm.ToolCall, execResult ExecuteToolCallsResult) {
-				for i, tc := range toolCalls {
-					if i >= len(execResult.Results) {
-						break
-					}
-					messages = append(messages, llm.NewToolMessage(tc.ID, execResult.Results[i].Result))
-				}
-			},
-			RequestNextResponse: func() (string, []llm.ToolCall, error) {
-				resp2, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt + "\n\n" + getFollowUpSystemPrompt(),
-					Tools:        tools,
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", nil, err
-				}
-				if resp2 == nil {
-					return "", nil, fmt.Errorf("claude follow-up returned no response")
-				}
-				h.trackUsageCommon("claude", ag.Settings.Model, agentName, resp2.Usage, ag.Agent, userMessage)
-				return resp2.Content, resp2.ToolCalls, nil
-			},
-			RequestFinalResponse: func() (string, error) {
-				resp2, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", err
-				}
-				if resp2 == nil {
-					return "", fmt.Errorf("claude final synthesis returned no response")
-				}
-				h.trackUsageCommon("claude", ag.Settings.Model, agentName, resp2.Usage, ag.Agent, userMessage)
-				return resp2.Content, nil
-			},
-		},
-	)
-
-	finalText := getResponseText(loopResult.FinalContent)
-	if loopResult.HasStructuredResult {
-		finalText = loopResult.FinalContent
-	}
-
-	logger.Debug("Claude chat with tool completed", logger.Fields{"duration": time.Since(start)})
-	_ = h.persistAgent(agentName, ag.Agent)
-
-	// Store assistant response in session
-	h.storeMessageInSession(baseCtx, sessionID, "assistant", finalText)
-
-	writeJSONResponse(w, attachPlannerDecision(attachActionReceipts(attachRouteMetadata(map[string]any{
-		"response":  finalText,
-		"toolCalls": loopResult.ToolCalls,
-	}, chatRouteMetadata{
-		Mode:      routeModeAssistantChat,
-		ToolCount: len(loopResult.ToolCalls),
-	}), loopResult.Receipts), plannerDecision))
+	_ = start
+	h.runProviderToolLoop(w, ctx, baseCtx, providerToolLoopRun{
+		Agent:                ag,
+		AgentName:            agentName,
+		Messages:             messages,
+		InitialResponse:      resp,
+		Tools:                tools,
+		Files:                files,
+		Provider:             provider,
+		SessionID:            sessionID,
+		UserMessage:          userMessage,
+		PlannerDecision:      plannerDecision,
+		ProviderLabel:        "claude",
+		FollowUpSystemPrompt: systemPrompt + "\n\n" + getFollowUpSystemPrompt(),
+		FinalSystemPrompt:    systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
+	})
 }

--- a/internal/chathttp/handlers_gemini.go
+++ b/internal/chathttp/handlers_gemini.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/toolapi"
@@ -75,7 +74,8 @@ func (h *Handler) handleGeminiChat(w http.ResponseWriter, r *http.Request, ag *r
 	}), plannerDecision))
 }
 
-// handleGeminiToolCalls handles tool execution for Gemini.
+// handleGeminiToolCalls handles tool execution for Gemini via the shared
+// provider tool loop.
 func (h *Handler) handleGeminiToolCalls(
 	w http.ResponseWriter,
 	ctx context.Context,
@@ -93,79 +93,19 @@ func (h *Handler) handleGeminiToolCalls(
 	systemPrompt string,
 ) {
 	logger.Info("Gemini requested tool calls", logger.Fields{"count": len(resp.ToolCalls)})
-
-	loopResult := h.runBoundedToolLoop(
-		resp.Content,
-		resp.ToolCalls,
-		boundedToolLoopConfig{},
-		boundedToolLoopCallbacks{
-			AppendAssistantTurn: func(content string, toolCalls []llm.ToolCall) {
-				assistantMsg := llm.NewAssistantMessage(content)
-				assistantMsg.ToolCalls = toolCalls
-				messages = append(messages, assistantMsg)
-			},
-			ExecuteToolCalls: func(toolCalls []llm.ToolCall) ExecuteToolCallsResult {
-				return h.executeToolCallsCommonWithSession(baseCtx, ag, toolCalls, files, sessionID)
-			},
-			AppendToolResults: func(toolCalls []llm.ToolCall, execResult ExecuteToolCallsResult) {
-				for i, tc := range toolCalls {
-					if i >= len(execResult.Results) {
-						break
-					}
-					messages = append(messages, llm.NewToolMessage(tc.ID, execResult.Results[i].Result))
-				}
-			},
-			RequestNextResponse: func() (string, []llm.ToolCall, error) {
-				finalResp, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt,
-					Tools:        tools,
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", nil, err
-				}
-				if finalResp == nil {
-					return "", nil, fmt.Errorf("gemini follow-up returned no response")
-				}
-				h.trackUsageCommon("gemini", ag.Settings.Model, agentName, finalResp.Usage, ag.Agent, userMessage)
-				return finalResp.Content, finalResp.ToolCalls, nil
-			},
-			RequestFinalResponse: func() (string, error) {
-				finalResp, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", err
-				}
-				if finalResp == nil {
-					return "", fmt.Errorf("gemini final synthesis returned no response")
-				}
-				h.trackUsageCommon("gemini", ag.Settings.Model, agentName, finalResp.Usage, ag.Agent, userMessage)
-				return finalResp.Content, nil
-			},
-		},
-	)
-
-	finalText := getResponseText(loopResult.FinalContent)
-	if loopResult.HasStructuredResult {
-		finalText = loopResult.FinalContent
-	}
-	_ = h.persistAgent(agentName, ag.Agent)
-
-	h.storeMessageInSession(baseCtx, sessionID, "assistant", finalText)
-
-	orihttp.WriteJSON(w, attachPlannerDecision(attachActionReceipts(attachRouteMetadata(map[string]any{
-		"response":  finalText,
-		"toolCalls": loopResult.ToolCalls,
-	}, chatRouteMetadata{
-		Mode:      routeModeAssistantChat,
-		ToolCount: len(loopResult.ToolCalls),
-	}), loopResult.Receipts), plannerDecision))
+	h.runProviderToolLoop(w, ctx, baseCtx, providerToolLoopRun{
+		Agent:                ag,
+		AgentName:            agentName,
+		Messages:             messages,
+		InitialResponse:      resp,
+		Tools:                tools,
+		Files:                files,
+		Provider:             provider,
+		SessionID:            sessionID,
+		UserMessage:          userMessage,
+		PlannerDecision:      plannerDecision,
+		ProviderLabel:        "gemini",
+		FollowUpSystemPrompt: systemPrompt,
+		FinalSystemPrompt:    systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
+	})
 }

--- a/internal/chathttp/handlers_ollama.go
+++ b/internal/chathttp/handlers_ollama.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/toolapi"
@@ -92,7 +91,8 @@ func (h *Handler) handleLocalProviderChat(w http.ResponseWriter, r *http.Request
 	}), plannerDecision))
 }
 
-// handleLocalProviderToolCalls handles tool execution for local providers.
+// handleLocalProviderToolCalls handles tool execution for local providers
+// via the shared provider tool loop.
 func (h *Handler) handleLocalProviderToolCalls(
 	w http.ResponseWriter,
 	ctx context.Context,
@@ -114,88 +114,19 @@ func (h *Handler) handleLocalProviderToolCalls(
 		"count":    len(resp.ToolCalls),
 		"provider": providerName,
 	})
-
-	loopResult := h.runBoundedToolLoop(
-		resp.Content,
-		resp.ToolCalls,
-		boundedToolLoopConfig{},
-		boundedToolLoopCallbacks{
-			AppendAssistantTurn: func(content string, toolCalls []llm.ToolCall) {
-				assistantMsg := llm.NewAssistantMessage(content)
-				assistantMsg.ToolCalls = toolCalls
-				messages = append(messages, assistantMsg)
-			},
-			ExecuteToolCalls: func(toolCalls []llm.ToolCall) ExecuteToolCallsResult {
-				return h.executeToolCallsCommonWithSession(baseCtx, ag, toolCalls, files, sessionID)
-			},
-			AppendToolResults: func(toolCalls []llm.ToolCall, execResult ExecuteToolCallsResult) {
-				for i, tc := range toolCalls {
-					if i >= len(execResult.Results) {
-						break
-					}
-					messages = append(messages, llm.NewToolMessage(tc.ID, execResult.Results[i].Result))
-				}
-			},
-			RequestNextResponse: func() (string, []llm.ToolCall, error) {
-				logger.Debug("Sending tool results back to local provider", logger.Fields{
-					"message_count": len(messages),
-					"provider":      providerName,
-				})
-				finalResp, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt,
-					Tools:        tools,
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", nil, err
-				}
-				if finalResp == nil {
-					return "", nil, fmt.Errorf("%s follow-up returned no response", providerName)
-				}
-				h.trackUsageCommon(providerName, ag.Settings.Model, agentName, finalResp.Usage, ag.Agent, userMessage)
-				return finalResp.Content, finalResp.ToolCalls, nil
-			},
-			RequestFinalResponse: func() (string, error) {
-				finalResp, err := provider.Chat(ctx, llm.ChatRequest{
-					Model:        ag.Settings.Model,
-					Messages:     messages,
-					SystemPrompt: systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
-					Temperature:  ag.Settings.Temperature,
-					MaxTokens:    defaultChatMaxTokens,
-				})
-				if err != nil {
-					return "", err
-				}
-				if finalResp == nil {
-					return "", fmt.Errorf("%s final synthesis returned no response", providerName)
-				}
-				h.trackUsageCommon(providerName, ag.Settings.Model, agentName, finalResp.Usage, ag.Agent, userMessage)
-				return finalResp.Content, nil
-			},
-		},
-	)
-
-	finalText := getResponseText(loopResult.FinalContent)
-	if loopResult.HasStructuredResult {
-		finalText = loopResult.FinalContent
-	}
-
-	logger.Debug("Final response from local provider", logger.Fields{
-		"content":  finalText,
-		"provider": providerName,
+	h.runProviderToolLoop(w, ctx, baseCtx, providerToolLoopRun{
+		Agent:                ag,
+		AgentName:            agentName,
+		Messages:             messages,
+		InitialResponse:      resp,
+		Tools:                tools,
+		Files:                files,
+		Provider:             provider,
+		SessionID:            sessionID,
+		UserMessage:          userMessage,
+		PlannerDecision:      plannerDecision,
+		ProviderLabel:        providerName,
+		FollowUpSystemPrompt: systemPrompt,
+		FinalSystemPrompt:    systemPrompt + "\n\n" + getFinalToolLoopSynthesisPrompt(),
 	})
-
-	_ = h.persistAgent(agentName, ag.Agent)
-	h.storeMessageInSession(baseCtx, sessionID, "assistant", finalText)
-
-	orihttp.WriteJSON(w, attachPlannerDecision(attachActionReceipts(attachRouteMetadata(map[string]any{
-		"response":  finalText,
-		"toolCalls": loopResult.ToolCalls,
-	}, chatRouteMetadata{
-		Mode:      routeModeAssistantChat,
-		ToolCount: len(loopResult.ToolCalls),
-	}), loopResult.Receipts), plannerDecision))
 }

--- a/internal/chathttp/provider_common.go
+++ b/internal/chathttp/provider_common.go
@@ -194,6 +194,124 @@ func (h *Handler) runBoundedToolLoop(
 	}
 }
 
+// providerToolLoopRun bundles everything runProviderToolLoop needs to finish
+// a chat turn in which the model requested tool calls. Used by the Claude,
+// Gemini, and local-provider handlers, which previously each wired the same
+// callbacks around runBoundedToolLoop by hand. (The OpenAI handler keeps its
+// own wiring: it speaks the OpenAI SDK client, not llm.Provider.)
+type providerToolLoopRun struct {
+	Agent           *resolvedChatAgent
+	AgentName       string
+	Messages        []llm.Message
+	InitialResponse *llm.ChatResponse
+	Tools           []llm.Tool
+	Files           []toolapi.FileAttachment
+	Provider        llm.Provider
+	SessionID       string
+	UserMessage     string
+	PlannerDecision *types.PlannerDecision
+
+	// ProviderLabel is the usage-tracking / error-message name ("claude",
+	// "gemini", or the local provider's name).
+	ProviderLabel string
+	// FollowUpSystemPrompt is the system prompt for follow-up turns inside
+	// the loop; providers differ on whether they append follow-up guidance.
+	FollowUpSystemPrompt string
+	// FinalSystemPrompt is the system prompt for the last-resort synthesis
+	// request when the loop stops without a final answer.
+	FinalSystemPrompt string
+}
+
+// runProviderToolLoop drives the bounded tool loop for a generic
+// llm.Provider and writes the chat response: assistant turns and tool
+// results append to the conversation, follow-up/final-synthesis requests go
+// back to the same provider, and the final text is persisted to the agent,
+// stored in the session, and returned with receipts and route metadata.
+func (h *Handler) runProviderToolLoop(w http.ResponseWriter, ctx, baseCtx context.Context, run providerToolLoopRun) {
+	start := time.Now()
+	messages := run.Messages
+	ag := run.Agent
+
+	loopResult := h.runBoundedToolLoop(
+		run.InitialResponse.Content,
+		run.InitialResponse.ToolCalls,
+		boundedToolLoopConfig{},
+		boundedToolLoopCallbacks{
+			AppendAssistantTurn: func(content string, toolCalls []llm.ToolCall) {
+				assistantMsg := llm.NewAssistantMessage(content)
+				assistantMsg.ToolCalls = toolCalls
+				messages = append(messages, assistantMsg)
+			},
+			ExecuteToolCalls: func(toolCalls []llm.ToolCall) ExecuteToolCallsResult {
+				return h.executeToolCallsCommonWithSession(baseCtx, ag, toolCalls, run.Files, run.SessionID)
+			},
+			AppendToolResults: func(toolCalls []llm.ToolCall, execResult ExecuteToolCallsResult) {
+				for i, tc := range toolCalls {
+					if i >= len(execResult.Results) {
+						break
+					}
+					messages = append(messages, llm.NewToolMessage(tc.ID, execResult.Results[i].Result))
+				}
+			},
+			RequestNextResponse: func() (string, []llm.ToolCall, error) {
+				resp, err := run.Provider.Chat(ctx, llm.ChatRequest{
+					Model:        ag.Settings.Model,
+					Messages:     messages,
+					SystemPrompt: run.FollowUpSystemPrompt,
+					Tools:        run.Tools,
+					Temperature:  ag.Settings.Temperature,
+					MaxTokens:    defaultChatMaxTokens,
+				})
+				if err != nil {
+					return "", nil, err
+				}
+				if resp == nil {
+					return "", nil, fmt.Errorf("%s follow-up returned no response", run.ProviderLabel)
+				}
+				h.trackUsageCommon(run.ProviderLabel, ag.Settings.Model, run.AgentName, resp.Usage, ag.Agent, run.UserMessage)
+				return resp.Content, resp.ToolCalls, nil
+			},
+			RequestFinalResponse: func() (string, error) {
+				resp, err := run.Provider.Chat(ctx, llm.ChatRequest{
+					Model:        ag.Settings.Model,
+					Messages:     messages,
+					SystemPrompt: run.FinalSystemPrompt,
+					Temperature:  ag.Settings.Temperature,
+					MaxTokens:    defaultChatMaxTokens,
+				})
+				if err != nil {
+					return "", err
+				}
+				if resp == nil {
+					return "", fmt.Errorf("%s final synthesis returned no response", run.ProviderLabel)
+				}
+				h.trackUsageCommon(run.ProviderLabel, ag.Settings.Model, run.AgentName, resp.Usage, ag.Agent, run.UserMessage)
+				return resp.Content, nil
+			},
+		},
+	)
+
+	finalText := getResponseText(loopResult.FinalContent)
+	if loopResult.HasStructuredResult {
+		finalText = loopResult.FinalContent
+	}
+
+	logger.Debug("Provider tool loop completed", logger.Fields{
+		"provider": run.ProviderLabel,
+		"duration": time.Since(start),
+	})
+	_ = h.persistAgent(run.AgentName, ag.Agent)
+	h.storeMessageInSession(baseCtx, run.SessionID, "assistant", finalText)
+
+	writeJSONResponse(w, attachPlannerDecision(attachActionReceipts(attachRouteMetadata(map[string]any{
+		"response":  finalText,
+		"toolCalls": loopResult.ToolCalls,
+	}, chatRouteMetadata{
+		Mode:      routeModeAssistantChat,
+		ToolCount: len(loopResult.ToolCalls),
+	}), loopResult.Receipts), run.PlannerDecision))
+}
+
 func tryToolLoopFinalSynthesis(request func() (string, error)) (string, bool) {
 	if request == nil {
 		return "", false


### PR DESCRIPTION
## Summary

Final function split from the readability review, plus the provider tool-loop dedup.

### ChatHandler (~600 lines → staged pipeline)
The turn now reads as a sequence of named stages; sub-flows extracted verbatim:
- `chatRequest` — named request struct
- `handleDirectToolCommand` — the whole `/tool` direct-execution branch
- `maybeHandleWorkspacePlanningForm` — planning-form intercept
- `maybeRejectSkillMissingMCP` — skill dependency gate
- `maybeRunPlannerOrchestration` — planner-first multi-agent routing (returns the planner decision)
- `buildChatToolList` — utility + workspace + MCP tool aggregation with the dedupe/preference rules

Provider dispatch stays inline — that if-chain is the function's purpose.

### Provider tool-loop dedup
`handleClaudeToolCalls`, `handleGeminiToolCalls`, and `handleLocalProviderToolCalls` each hand-wired the same ~80 lines of `runBoundedToolLoop` callbacks (append turn → execute → append results → follow-up → final synthesis → persist → respond), differing only in provider label and follow-up system prompt. Now thin wrappers over a shared `runProviderToolLoop` + `providerToolLoopRun` struct (named fields). Claude's distinct follow-up-guidance prompt is preserved exactly. The OpenAI handler keeps its own wiring (OpenAI SDK client, not `llm.Provider`) with a pointer comment.

5 files, +500/−516. Rebased on dev including #144/#145.

## Verification
- gofmt/build/vet clean; `go test ./internal/chathttp/` green; full module builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)