### PR TITLE
refactor: de-stutter cliagent/review/mcp/console types and handler methods

### DIFF
--- a/internal/agenthttp/auto_config.go
+++ b/internal/agenthttp/auto_config.go
@@ -132,8 +132,8 @@ func unavailableLocalModelMessage(providerName string) string {
 	}
 }
 
-// AutoConfigHandler handles the auto-configuration request
-func (h *AutoConfigHandler) AutoConfigHandler(w http.ResponseWriter, r *http.Request) {
+// Handle serves the auto-configuration request.
+func (h *AutoConfigHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/internal/agenthttp/auto_config_test.go
+++ b/internal/agenthttp/auto_config_test.go
@@ -165,7 +165,7 @@ func TestAutoConfigHandler_AutoConfig_NoSystemModel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoConfigHandler(rr, req)
+	handler.Handle(rr, req)
 
 	// Should return service unavailable when no system model configured
 	if rr.Code != http.StatusServiceUnavailable {
@@ -188,7 +188,7 @@ func TestAutoConfigHandler_AutoConfig_ProviderNotAvailable(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoConfigHandler(rr, req)
+	handler.Handle(rr, req)
 
 	// Should return service unavailable when provider not available
 	if rr.Code != http.StatusServiceUnavailable {
@@ -212,7 +212,7 @@ func TestAutoConfigHandler_AutoConfig_EmptyDescription(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoConfigHandler(rr, req)
+	handler.Handle(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
@@ -234,7 +234,7 @@ func TestAutoConfigHandler_AutoConfig_SuccessIncludesGeneratedDescription(t *tes
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoConfigHandler(rr, req)
+	handler.Handle(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())
@@ -259,7 +259,7 @@ func TestAutoConfigHandler_AutoConfig_InvalidMethod(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/agents/auto-config", nil)
 	rr := httptest.NewRecorder()
 
-	handler.AutoConfigHandler(rr, req)
+	handler.Handle(rr, req)
 
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)

--- a/internal/agenthttp/dashboard_cli_status_test.go
+++ b/internal/agenthttp/dashboard_cli_status_test.go
@@ -26,8 +26,8 @@ func (a dashboardCLIStubAdapter) IsAvailable() bool {
 func (a dashboardCLIStubAdapter) AvailableModels() []string {
 	return a.models
 }
-func (a dashboardCLIStubAdapter) Capabilities() cliagent.CLIAgentCapabilities {
-	return cliagent.CLIAgentCapabilities{}
+func (a dashboardCLIStubAdapter) Capabilities() cliagent.Capabilities {
+	return cliagent.Capabilities{}
 }
 func (a dashboardCLIStubAdapter) ExecuteStep(context.Context, cliagent.StepRequest) (*cliagent.StepResult, error) {
 	return nil, nil

--- a/internal/cliagent/adapter.go
+++ b/internal/cliagent/adapter.go
@@ -2,15 +2,15 @@ package cliagent
 
 import "context"
 
-// CLIAgentAdapter is the interface that CLI agent backends must implement.
+// Adapter is the interface that CLI agent backends must implement.
 // Each adapter wraps a specific CLI tool (Claude CLI, Codex CLI) and translates
 // step requests into CLI invocations.
-type CLIAgentAdapter interface {
+type Adapter interface {
 	// ExecuteStep runs a single micro-step via the CLI and returns the result.
 	ExecuteStep(ctx context.Context, req StepRequest) (*StepResult, error)
 
 	// Capabilities reports what this CLI backend can do.
-	Capabilities() CLIAgentCapabilities
+	Capabilities() Capabilities
 
 	// AvailableModels returns the list of models this backend supports.
 	AvailableModels() []string

--- a/internal/cliagent/claude_adapter.go
+++ b/internal/cliagent/claude_adapter.go
@@ -34,8 +34,8 @@ func (a *ClaudeCLIAdapter) IsAvailable() bool {
 }
 
 // Capabilities returns Claude CLI capabilities.
-func (a *ClaudeCLIAdapter) Capabilities() CLIAgentCapabilities {
-	return CLIAgentCapabilities{
+func (a *ClaudeCLIAdapter) Capabilities() Capabilities {
+	return Capabilities{
 		SupportsTools:     true,
 		SupportsStreaming: true,
 		MaxContextWindow:  200000,

--- a/internal/cliagent/codex_adapter.go
+++ b/internal/cliagent/codex_adapter.go
@@ -37,8 +37,8 @@ func (a *CodexCLIAdapter) IsAvailable() bool {
 }
 
 // Capabilities returns Codex CLI capabilities.
-func (a *CodexCLIAdapter) Capabilities() CLIAgentCapabilities {
-	return CLIAgentCapabilities{
+func (a *CodexCLIAdapter) Capabilities() Capabilities {
+	return Capabilities{
 		SupportsTools:     true,
 		SupportsStreaming: true,
 		MaxContextWindow:  128000,

--- a/internal/cliagent/executor_test.go
+++ b/internal/cliagent/executor_test.go
@@ -13,10 +13,10 @@ type testAdapter struct {
 	callIdx int
 }
 
-func (a *testAdapter) Backend() string                    { return BackendClaude }
-func (a *testAdapter) IsAvailable() bool                  { return true }
-func (a *testAdapter) AvailableModels() []string          { return []string{"test"} }
-func (a *testAdapter) Capabilities() CLIAgentCapabilities { return CLIAgentCapabilities{} }
+func (a *testAdapter) Backend() string            { return BackendClaude }
+func (a *testAdapter) IsAvailable() bool          { return true }
+func (a *testAdapter) AvailableModels() []string  { return []string{"test"} }
+func (a *testAdapter) Capabilities() Capabilities { return Capabilities{} }
 
 func (a *testAdapter) ExecuteStep(_ context.Context, req StepRequest) (*StepResult, error) {
 	if a.callIdx < len(a.results) {

--- a/internal/cliagent/gemini_adapter.go
+++ b/internal/cliagent/gemini_adapter.go
@@ -34,8 +34,8 @@ func (a *GeminiCLIAdapter) IsAvailable() bool {
 }
 
 // Capabilities returns Gemini CLI capabilities.
-func (a *GeminiCLIAdapter) Capabilities() CLIAgentCapabilities {
-	return CLIAgentCapabilities{
+func (a *GeminiCLIAdapter) Capabilities() Capabilities {
+	return Capabilities{
 		SupportsTools:     true,
 		SupportsStreaming: true,
 		MaxContextWindow:  1000000,

--- a/internal/cliagent/registry.go
+++ b/internal/cliagent/registry.go
@@ -8,16 +8,16 @@ import (
 
 // CLIAgentRegistry manages available CLI agent backends.
 type CLIAgentRegistry struct {
-	adapters map[string]CLIAgentAdapter
+	adapters map[string]Adapter
 	mu       sync.RWMutex
 }
 
 // NewRegistry creates a CLIAgentRegistry and auto-detects installed CLIs.
 // Pass nil for adapters to use default auto-detection; pass explicit adapters
 // for testing.
-func NewRegistry(adapters ...CLIAgentAdapter) *CLIAgentRegistry {
+func NewRegistry(adapters ...Adapter) *CLIAgentRegistry {
 	r := &CLIAgentRegistry{
-		adapters: make(map[string]CLIAgentAdapter),
+		adapters: make(map[string]Adapter),
 	}
 	for _, a := range adapters {
 		r.adapters[a.Backend()] = a
@@ -42,14 +42,14 @@ func (r *CLIAgentRegistry) AutoDetect() {
 }
 
 // Register adds or replaces an adapter in the registry.
-func (r *CLIAgentRegistry) Register(adapter CLIAgentAdapter) {
+func (r *CLIAgentRegistry) Register(adapter Adapter) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.adapters[adapter.Backend()] = adapter
 }
 
 // Get returns the adapter for the given backend name.
-func (r *CLIAgentRegistry) Get(backend string) (CLIAgentAdapter, error) {
+func (r *CLIAgentRegistry) Get(backend string) (Adapter, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -73,13 +73,13 @@ func (r *CLIAgentRegistry) IsAvailable(backend string) bool {
 }
 
 // List returns information about all registered CLI agent backends.
-func (r *CLIAgentRegistry) List() []CLIAgentInfo {
+func (r *CLIAgentRegistry) List() []Info {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	infos := make([]CLIAgentInfo, 0, len(r.adapters))
+	infos := make([]Info, 0, len(r.adapters))
 	for _, a := range r.adapters {
-		infos = append(infos, CLIAgentInfo{
+		infos = append(infos, Info{
 			Backend:      a.Backend(),
 			Available:    a.IsAvailable(),
 			Models:       a.AvailableModels(),

--- a/internal/cliagent/registry_test.go
+++ b/internal/cliagent/registry_test.go
@@ -12,10 +12,10 @@ type stubAdapter struct {
 	models    []string
 }
 
-func (s *stubAdapter) Backend() string                    { return s.backend }
-func (s *stubAdapter) IsAvailable() bool                  { return s.available }
-func (s *stubAdapter) AvailableModels() []string          { return s.models }
-func (s *stubAdapter) Capabilities() CLIAgentCapabilities { return CLIAgentCapabilities{} }
+func (s *stubAdapter) Backend() string            { return s.backend }
+func (s *stubAdapter) IsAvailable() bool          { return s.available }
+func (s *stubAdapter) AvailableModels() []string  { return s.models }
+func (s *stubAdapter) Capabilities() Capabilities { return Capabilities{} }
 func (s *stubAdapter) ExecuteStep(_ context.Context, _ StepRequest) (*StepResult, error) {
 	return nil, nil
 }

--- a/internal/cliagent/types.go
+++ b/internal/cliagent/types.go
@@ -184,18 +184,18 @@ type TaskResult struct {
 	Error         string        `json:"error,omitempty"`
 }
 
-// CLIAgentCapabilities describes what a CLI backend can do.
-type CLIAgentCapabilities struct {
+// Capabilities describes what a CLI backend can do.
+type Capabilities struct {
 	SupportsTools     bool     `json:"supports_tools"`
 	SupportsStreaming bool     `json:"supports_streaming"`
 	MaxContextWindow  int      `json:"max_context_window"`
 	SupportedFormats  []string `json:"supported_formats"`
 }
 
-// CLIAgentInfo provides metadata about a registered CLI agent backend.
-type CLIAgentInfo struct {
-	Backend      string               `json:"backend"`
-	Available    bool                 `json:"available"`
-	Models       []string             `json:"models,omitempty"`
-	Capabilities CLIAgentCapabilities `json:"capabilities"`
+// Info provides metadata about a registered CLI agent backend.
+type Info struct {
+	Backend      string       `json:"backend"`
+	Available    bool         `json:"available"`
+	Models       []string     `json:"models,omitempty"`
+	Capabilities Capabilities `json:"capabilities"`
 }

--- a/internal/gateway/channels/console/console.go
+++ b/internal/gateway/channels/console/console.go
@@ -12,29 +12,29 @@ import (
 	"github.com/johnjallday/ori-agent/internal/logger"
 )
 
-// ConsoleChannel implements gateway.Channel for terminal interaction
-type ConsoleChannel struct {
+// Channel implements gateway.Channel for terminal interaction
+type Channel struct {
 	id     string
 	logger *logger.Logger
 	cancel context.CancelFunc
 }
 
 // NewConsoleChannel creates a new console channel
-func NewConsoleChannel(id string, l *logger.Logger) *ConsoleChannel {
-	return &ConsoleChannel{
+func NewConsoleChannel(id string, l *logger.Logger) *Channel {
+	return &Channel{
 		id:     id,
 		logger: l,
 	}
 }
 
 // ID returns the channel ID
-func (c *ConsoleChannel) ID() string { return c.id }
+func (c *Channel) ID() string { return c.id }
 
 // Type returns the channel type
-func (c *ConsoleChannel) Type() string { return "console" }
+func (c *Channel) Type() string { return "console" }
 
 // Start begins listening for input from os.Stdin
-func (c *ConsoleChannel) Start(ctx context.Context, handler gateway.Handler) error {
+func (c *Channel) Start(ctx context.Context, handler gateway.Handler) error {
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
 
@@ -85,7 +85,7 @@ func (c *ConsoleChannel) Start(ctx context.Context, handler gateway.Handler) err
 }
 
 // Stop stops the console channel
-func (c *ConsoleChannel) Stop(ctx context.Context) error {
+func (c *Channel) Stop(ctx context.Context) error {
 	if c.cancel != nil {
 		c.cancel()
 	}
@@ -93,7 +93,7 @@ func (c *ConsoleChannel) Stop(ctx context.Context) error {
 }
 
 // Send outputs a message to os.Stdout
-func (c *ConsoleChannel) Send(ctx context.Context, msg gateway.Message) error {
+func (c *Channel) Send(ctx context.Context, msg gateway.Message) error {
 	fmt.Printf("\n[ORI]: %s\n> ", msg.Content)
 	return nil
 }

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -13,9 +13,9 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// MCPAdapter adapts an MCP server to the toolapi.Tool interface
+// Adapter adapts an MCP server to the toolapi.Tool interface
 // This allows MCP tools to be used seamlessly alongside native tools
-type MCPAdapter struct {
+type Adapter struct {
 	server      *Server
 	tool        Tool
 	agentCtx    toolapi.AgentContext
@@ -23,8 +23,8 @@ type MCPAdapter struct {
 }
 
 // NewMCPAdapter creates a new adapter for an MCP tool
-func NewMCPAdapter(server *Server, tool Tool) *MCPAdapter {
-	return &MCPAdapter{
+func NewMCPAdapter(server *Server, tool Tool) *Adapter {
+	return &Adapter{
 		server: server,
 		tool:   tool,
 	}
@@ -32,7 +32,7 @@ func NewMCPAdapter(server *Server, tool Tool) *MCPAdapter {
 
 // Definition converts MCP tool schema to generic tool definition
 // This is the bridge that makes MCP tools compatible with any LLM provider
-func (a *MCPAdapter) Definition() toolapi.ToolDefinition {
+func (a *Adapter) Definition() toolapi.ToolDefinition {
 	// Convert MCP inputSchema to generic parameters format
 	parameters := map[string]any(nil)
 	switch schema := a.tool.InputSchema.(type) {
@@ -63,7 +63,7 @@ func (a *MCPAdapter) Definition() toolapi.ToolDefinition {
 }
 
 // Call executes the MCP tool and returns the result
-func (a *MCPAdapter) Call(ctx context.Context, args string) (string, error) {
+func (a *Adapter) Call(ctx context.Context, args string) (string, error) {
 	// Parse arguments
 	var arguments map[string]any
 	if len(args) > 0 {
@@ -99,7 +99,7 @@ func (a *MCPAdapter) Call(ctx context.Context, args string) (string, error) {
 }
 
 // formatResult converts MCP tool result content to a string
-func (a *MCPAdapter) formatResult(result *ToolCallResult) (string, error) {
+func (a *Adapter) formatResult(result *ToolCallResult) (string, error) {
 	if len(result.Content) == 0 {
 		return "", nil
 	}
@@ -170,20 +170,20 @@ func (a *MCPAdapter) formatResult(result *ToolCallResult) (string, error) {
 }
 
 // SetAgentContext implements AgentAwareTool interface
-func (a *MCPAdapter) SetAgentContext(ctx toolapi.AgentContext) {
+func (a *Adapter) SetAgentContext(ctx toolapi.AgentContext) {
 	a.agentCtx = ctx
 	a.hasAgentCtx = true
 }
 
 // Version returns the adapter version (implements VersionedTool)
-func (a *MCPAdapter) Version() string {
+func (a *Adapter) Version() string {
 	return "mcp-adapter-0.1.0"
 }
 
 // Ensure MCPAdapter implements required interfaces
-var _ toolapi.Tool = (*MCPAdapter)(nil)
-var _ toolapi.AgentAwareTool = (*MCPAdapter)(nil)
-var _ toolapi.VersionedTool = (*MCPAdapter)(nil)
+var _ toolapi.Tool = (*Adapter)(nil)
+var _ toolapi.AgentAwareTool = (*Adapter)(nil)
+var _ toolapi.VersionedTool = (*Adapter)(nil)
 
 func normalizeFilesystemArguments(toolName string, arguments map[string]any, serverConfig ServerConfig) map[string]any {
 	if len(arguments) == 0 || !isFilesystemTool(toolName) {

--- a/internal/modelcategoryhttp/auto_categorize.go
+++ b/internal/modelcategoryhttp/auto_categorize.go
@@ -108,9 +108,9 @@ func (h *AutoCategorizeHandler) CheckAvailabilityHandler(w http.ResponseWriter, 
 	orihttp.WriteJSON(w, response)
 }
 
-// AutoCategorizeHandler handles the auto-categorization request
+// Suggest serves the auto-categorization request.
 // POST /api/models/auto-categorize
-func (h *AutoCategorizeHandler) AutoCategorizeHandler(w http.ResponseWriter, r *http.Request) {
+func (h *AutoCategorizeHandler) Suggest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		_ = orihttp.RespondMethodNotAllowed(w)
 		return

--- a/internal/modelcategoryhttp/auto_categorize_test.go
+++ b/internal/modelcategoryhttp/auto_categorize_test.go
@@ -167,7 +167,7 @@ func TestAutoCategorizeHandler_AutoCategorize_WrongMethod(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/models/auto-categorize", nil)
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
@@ -188,7 +188,7 @@ func TestAutoCategorizeHandler_AutoCategorize_EmptyModelIDs(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
@@ -215,7 +215,7 @@ func TestAutoCategorizeHandler_AutoCategorize_TooManyModels(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
@@ -236,7 +236,7 @@ func TestAutoCategorizeHandler_AutoCategorize_NoSystemModel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusServiceUnavailable, rr.Code, rr.Body.String())
@@ -263,7 +263,7 @@ func TestAutoCategorizeHandler_AutoCategorize_NoCategories(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
@@ -285,7 +285,7 @@ func TestAutoCategorizeHandler_AutoCategorize_Success(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
-	handler.AutoCategorizeHandler(rr, req)
+	handler.Suggest(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d. Body: %s", http.StatusOK, rr.Code, rr.Body.String())

--- a/internal/review/models.go
+++ b/internal/review/models.go
@@ -59,17 +59,17 @@ type Issue struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// ReviewRunStatus indicates the state of a review job.
-type ReviewRunStatus string
+// RunStatus indicates the state of a review job.
+type RunStatus string
 
 const (
-	ReviewRunStatusRunning   ReviewRunStatus = "running"
-	ReviewRunStatusCompleted ReviewRunStatus = "completed"
-	ReviewRunStatusFailed    ReviewRunStatus = "failed"
+	ReviewRunStatusRunning   RunStatus = "running"
+	ReviewRunStatusCompleted RunStatus = "completed"
+	ReviewRunStatusFailed    RunStatus = "failed"
 )
 
-// ReviewRun tracks the execution of a review job.
-type ReviewRun struct {
+// Run tracks the execution of a review job.
+type Run struct {
 	// ID is a unique identifier for the run (UUID format).
 	ID string `json:"id"`
 
@@ -86,7 +86,7 @@ type ReviewRun struct {
 	IssuesFound int `json:"issues_found"`
 
 	// Status indicates the current state of the run.
-	Status ReviewRunStatus `json:"status"`
+	Status RunStatus `json:"status"`
 
 	// ErrorMessage contains error details if the run failed.
 	ErrorMessage string `json:"error_message,omitempty"`
@@ -105,8 +105,8 @@ type SessionReviewStatus struct {
 	LastMessageID string `json:"last_message_id,omitempty"`
 }
 
-// ReviewOptions configures what sessions to review.
-type ReviewOptions struct {
+// Options configures what sessions to review.
+type Options struct {
 	// AgentName filters to sessions for a specific agent.
 	AgentName string `json:"agent_name,omitempty"`
 

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -19,7 +19,7 @@ type Runner struct {
 	detector     *Detector
 
 	mu      sync.RWMutex
-	running map[string]*ReviewRun // Active runs by ID
+	running map[string]*Run // Active runs by ID
 }
 
 // NewRunner creates a new review runner.
@@ -30,7 +30,7 @@ func NewRunner(reviewStore Store, sessionStore session.SessionStore, toolStore s
 		toolStore:    toolStore,
 		config:       config,
 		detector:     NewDetector(config),
-		running:      make(map[string]*ReviewRun),
+		running:      make(map[string]*Run),
 	}
 }
 
@@ -40,7 +40,7 @@ func (r *Runner) SetAgentStore(agentStore store.Store) {
 }
 
 // StartReview begins a new review job asynchronously and returns the job ID.
-func (r *Runner) StartReview(ctx context.Context, opts ReviewOptions) (string, error) {
+func (r *Runner) StartReview(ctx context.Context, opts Options) (string, error) {
 	// Create the review run record
 	run, err := r.store.CreateReviewRun(ctx)
 	if err != nil {
@@ -59,7 +59,7 @@ func (r *Runner) StartReview(ctx context.Context, opts ReviewOptions) (string, e
 }
 
 // GetStatus returns the current status of a review job.
-func (r *Runner) GetStatus(ctx context.Context, jobID string) (*ReviewRun, error) {
+func (r *Runner) GetStatus(ctx context.Context, jobID string) (*Run, error) {
 	// First check in-memory running jobs. Return a snapshot, not the live
 	// pointer: executeReview keeps mutating the tracked run under r.mu, and
 	// callers read the result without holding the lock.
@@ -76,7 +76,7 @@ func (r *Runner) GetStatus(ctx context.Context, jobID string) (*ReviewRun, error
 }
 
 // executeReview performs the actual review work.
-func (r *Runner) executeReview(runID string, opts ReviewOptions) {
+func (r *Runner) executeReview(runID string, opts Options) {
 	ctx := context.Background()
 
 	// Get the run from our tracking map
@@ -166,7 +166,7 @@ func (r *Runner) executeReview(runID string, opts ReviewOptions) {
 }
 
 // getSessionsToReview retrieves sessions matching the review options.
-func (r *Runner) getSessionsToReview(ctx context.Context, opts ReviewOptions) ([]session.SessionListItem, error) {
+func (r *Runner) getSessionsToReview(ctx context.Context, opts Options) ([]session.SessionListItem, error) {
 	// If specific session requested, just get that one
 	if opts.SessionID != "" {
 		sess, err := r.sessionStore.GetSession(ctx, opts.SessionID)
@@ -210,7 +210,7 @@ func (r *Runner) getSessionsToReview(ctx context.Context, opts ReviewOptions) ([
 }
 
 // shouldReviewSession determines if a session needs review (incremental).
-func (r *Runner) shouldReviewSession(ctx context.Context, sess session.SessionListItem, opts ReviewOptions) bool {
+func (r *Runner) shouldReviewSession(ctx context.Context, sess session.SessionListItem, opts Options) bool {
 	// If Since is specified, check session activity
 	if opts.Since != nil && sess.UpdatedAt.Before(*opts.Since) {
 		return false
@@ -234,7 +234,7 @@ func (r *Runner) shouldReviewSession(ctx context.Context, sess session.SessionLi
 }
 
 // failRun marks a run as failed with an error.
-func (r *Runner) failRun(ctx context.Context, run *ReviewRun, err error) {
+func (r *Runner) failRun(ctx context.Context, run *Run, err error) {
 	r.mu.Lock()
 	run.Status = ReviewRunStatusFailed
 	run.CompletedAt = time.Now()

--- a/internal/review/store.go
+++ b/internal/review/store.go
@@ -17,10 +17,10 @@ type Store interface {
 	GetIssueByHash(ctx context.Context, sessionID, contentHash string) (*Issue, error)
 
 	// ReviewRun operations
-	CreateReviewRun(ctx context.Context) (*ReviewRun, error)
-	UpdateReviewRun(ctx context.Context, run *ReviewRun) error
-	GetReviewRun(ctx context.Context, id string) (*ReviewRun, error)
-	GetReviewRuns(ctx context.Context, limit int) ([]ReviewRun, error)
+	CreateReviewRun(ctx context.Context) (*Run, error)
+	UpdateReviewRun(ctx context.Context, run *Run) error
+	GetReviewRun(ctx context.Context, id string) (*Run, error)
+	GetReviewRuns(ctx context.Context, limit int) ([]Run, error)
 
 	// SessionReviewStatus operations
 	GetSessionReviewStatus(ctx context.Context, sessionID string) (*SessionReviewStatus, error)
@@ -184,8 +184,8 @@ func (s *SQLiteStore) GetIssueByHash(ctx context.Context, sessionID, contentHash
 }
 
 // CreateReviewRun creates a new review run and returns it.
-func (s *SQLiteStore) CreateReviewRun(ctx context.Context) (*ReviewRun, error) {
-	run := &ReviewRun{
+func (s *SQLiteStore) CreateReviewRun(ctx context.Context) (*Run, error) {
+	run := &Run{
 		ID:        uuid.New().String(),
 		StartedAt: time.Now(),
 		Status:    ReviewRunStatusRunning,
@@ -204,7 +204,7 @@ func (s *SQLiteStore) CreateReviewRun(ctx context.Context) (*ReviewRun, error) {
 }
 
 // UpdateReviewRun updates an existing review run.
-func (s *SQLiteStore) UpdateReviewRun(ctx context.Context, run *ReviewRun) error {
+func (s *SQLiteStore) UpdateReviewRun(ctx context.Context, run *Run) error {
 	query := `
 		UPDATE review_runs
 		SET completed_at = ?, sessions_reviewed = ?, issues_found = ?, status = ?, error_message = ?
@@ -228,14 +228,14 @@ func (s *SQLiteStore) UpdateReviewRun(ctx context.Context, run *ReviewRun) error
 }
 
 // GetReviewRun retrieves a review run by ID.
-func (s *SQLiteStore) GetReviewRun(ctx context.Context, id string) (*ReviewRun, error) {
+func (s *SQLiteStore) GetReviewRun(ctx context.Context, id string) (*Run, error) {
 	query := `
 		SELECT id, started_at, completed_at, sessions_reviewed, issues_found, status, error_message
 		FROM review_runs
 		WHERE id = ?
 	`
 
-	var run ReviewRun
+	var run Run
 	var completedAt sql.NullTime
 	var status string
 
@@ -258,12 +258,12 @@ func (s *SQLiteStore) GetReviewRun(ctx context.Context, id string) (*ReviewRun, 
 	if completedAt.Valid {
 		run.CompletedAt = completedAt.Time
 	}
-	run.Status = ReviewRunStatus(status)
+	run.Status = RunStatus(status)
 	return &run, nil
 }
 
 // GetReviewRuns retrieves the most recent review runs.
-func (s *SQLiteStore) GetReviewRuns(ctx context.Context, limit int) ([]ReviewRun, error) {
+func (s *SQLiteStore) GetReviewRuns(ctx context.Context, limit int) ([]Run, error) {
 	query := `
 		SELECT id, started_at, completed_at, sessions_reviewed, issues_found, status, error_message
 		FROM review_runs
@@ -277,9 +277,9 @@ func (s *SQLiteStore) GetReviewRuns(ctx context.Context, limit int) ([]ReviewRun
 	}
 	defer func() { _ = rows.Close() }()
 
-	var runs []ReviewRun
+	var runs []Run
 	for rows.Next() {
-		var run ReviewRun
+		var run Run
 		var completedAt sql.NullTime
 		var status string
 
@@ -299,7 +299,7 @@ func (s *SQLiteStore) GetReviewRuns(ctx context.Context, limit int) ([]ReviewRun
 		if completedAt.Valid {
 			run.CompletedAt = completedAt.Time
 		}
-		run.Status = ReviewRunStatus(status)
+		run.Status = RunStatus(status)
 		runs = append(runs, run)
 	}
 

--- a/internal/reviewhttp/handler.go
+++ b/internal/reviewhttp/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) HandleTrigger(w http.ResponseWriter, r *http.Request) {
 		since = &t
 	}
 
-	opts := review.ReviewOptions{
+	opts := review.Options{
 		AgentName:   req.AgentName,
 		SessionID:   req.SessionID,
 		Since:       since,
@@ -284,7 +284,7 @@ func (h *Handler) HandleRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if runs == nil {
-		runs = []review.ReviewRun{}
+		runs = []review.Run{}
 	}
 
 	orihttp.WriteJSON(w, map[string]any{

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -203,7 +203,7 @@ func registerAgentRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("/api/agents/capabilities", s.Handlers.Orchestration.AgentCapabilitiesHandler)
 
 	// Agent auto-config endpoints
-	mux.HandleFunc("/api/agents/auto-config", s.Handlers.AutoConfig.AutoConfigHandler)
+	mux.HandleFunc("/api/agents/auto-config", s.Handlers.AutoConfig.Handle)
 	mux.HandleFunc("/api/agents/auto-config/availability", s.Handlers.AutoConfig.CheckLLMAvailabilityHandler)
 
 	// Home assistant task routing endpoint
@@ -408,7 +408,7 @@ func registerModelCategoryRoutes(mux *http.ServeMux, s *Server) {
 	// Auto-categorize endpoints (requires both category store and LLM)
 	if s.Handlers.AutoCategorize != nil {
 		mux.HandleFunc("/api/models/auto-categorize/availability", s.Handlers.AutoCategorize.CheckAvailabilityHandler)
-		mux.HandleFunc("/api/models/auto-categorize", s.Handlers.AutoCategorize.AutoCategorizeHandler)
+		mux.HandleFunc("/api/models/auto-categorize", s.Handlers.AutoCategorize.Suggest)
 	}
 }
 

--- a/internal/workspacerun/nativecli_test.go
+++ b/internal/workspacerun/nativecli_test.go
@@ -212,8 +212,8 @@ func (a *stubCLIAgentAdapter) ExecuteStep(_ context.Context, req cliagent.StepRe
 	return a.result, a.err
 }
 
-func (a *stubCLIAgentAdapter) Capabilities() cliagent.CLIAgentCapabilities {
-	return cliagent.CLIAgentCapabilities{SupportsStreaming: true}
+func (a *stubCLIAgentAdapter) Capabilities() cliagent.Capabilities {
+	return cliagent.Capabilities{SupportsStreaming: true}
 }
 
 func (a *stubCLIAgentAdapter) AvailableModels() []string {


### PR DESCRIPTION
## Summary

Second and final de-stutter pass, covering the remaining packages the review flagged.

**Types** (via `gofmt -r`, AST-safe; JSON tags unchanged):
| before | after |
|---|---|
| `cliagent.CLIAgentAdapter` | `cliagent.Adapter` |
| `cliagent.CLIAgentCapabilities` | `cliagent.Capabilities` |
| `cliagent.CLIAgentInfo` | `cliagent.Info` |
| `review.ReviewRun` | `review.Run` |
| `review.ReviewRunStatus` | `review.RunStatus` |
| `review.ReviewOptions` | `review.Options` |
| `mcp.MCPAdapter` | `mcp.Adapter` |
| `console.ConsoleChannel` | `console.Channel` |

**Method-on-type stutters** (renamed by hand — `X.AutoConfigHandler` is ambiguous between the method and the type reference `agenthttp.AutoConfigHandler`, so `gofmt -r` can't be used):
- `(*AutoConfigHandler).AutoConfigHandler` → `.Handle`
- `(*AutoCategorizeHandler).AutoCategorizeHandler` → `.Suggest`

**Deliberately NOT renamed: `cliagent.CLIAgentRegistry`.** Its short form `Registry` is ambiguous, it doubles as the `HandlerFacade` field name, and it would clash conceptually with the existing `mcp.Registry`. The qualifier earns its keep, so it stays.

21 files, +109/−109. Rebased on dev including #147.

## Verification
- `go build ./...`, `go vet` clean
- `go test` green: cliagent, cliagenthttp, review, mcp, agenthttp, modelcategoryhttp, server, externalagentshttp

🤖 Generated with [Claude Code](https://claude.com/claude-code)