### PR TITLE
refactor: unify the import/sync workspace reference-rebase twins

### DIFF
--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -1240,16 +1240,11 @@ type workspaceSyncLocateRequest struct {
 	Path string `json:"path"`
 }
 
-type workspaceDirectoryReference struct {
-	ID          string    `json:"id"`
-	WorkspaceID string    `json:"workspace_id"`
-	Name        string    `json:"name"`
-	Path        string    `json:"path"`
-	X           float64   `json:"x"`
-	Y           float64   `json:"y"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-}
+// workspaceDirectoryReference is the session-side JSON shape for a workspace
+// directory reference. It is an alias of agentworkspace.DirectoryReference —
+// the two are field-identical — so the import and folder-sync paths share a
+// single reference-rebase core (see workspace_reference_rebase.go).
+type workspaceDirectoryReference = agentworkspace.DirectoryReference
 
 type workspaceImportItem struct {
 	Workspace  *agentworkspace.Workspace

--- a/internal/sessionhttp/workspace_handler_import.go
+++ b/internal/sessionhttp/workspace_handler_import.go
@@ -563,124 +563,22 @@ func appendWorkspaceImportTree(result *[]workspaceImportItem, folderPath string,
 	return nil
 }
 
+// rebaseImportedWorkspaceFolderReferences rewrites an imported workspace's
+// directory references and MCP roots from the source path onto the local
+// folder path. An empty newPath is a silent no-op (nothing imported).
 func rebaseImportedWorkspaceFolderReferences(ws *agentworkspace.Workspace, oldPath string, newPath string) {
 	if ws == nil {
 		return
 	}
-
-	normalizedNew := cleanWorkspaceSyncPath(newPath)
-	if normalizedNew == "" {
-		return
+	id := folderRebaseIdentity{
+		workspaceID: ws.ID,
+		folderSlug:  ws.FolderSlug,
+		name:        ws.Name,
+		isGroup:     session.NormalizeWorkspaceKind(ws.Kind) == session.WorkspaceKindGroup,
 	}
-
-	now := time.Now()
-	normalizedOld := cleanWorkspaceSyncPath(oldPath)
-	folderSlug := strings.TrimSpace(ws.FolderSlug)
-	newBaseName := filepath.Base(normalizedNew)
-	isGroup := session.NormalizeWorkspaceKind(ws.Kind) == session.WorkspaceKindGroup
-	defaultRefPath := defaultWorkspaceReferencePath(isGroup, normalizedNew)
-	defaultRoots := defaultWorkspaceMCPRoots(isGroup, normalizedNew)
-	matchedReference := false
-
-	for i := range ws.DirectoryReferences {
-		refPath := cleanWorkspaceSyncPath(ws.DirectoryReferences[i].Path)
-		if refPath == "" {
-			continue
-		}
-		if rewritten, ok := rewriteWorkspaceContentPath(refPath, normalizedOld, normalizedNew); ok {
-			ws.DirectoryReferences[i].WorkspaceID = ws.ID
-			if strings.TrimSpace(ws.DirectoryReferences[i].Name) == "" {
-				ws.DirectoryReferences[i].Name = workspaceReferenceName(ws, normalizedNew)
-			}
-			ws.DirectoryReferences[i].Path = rewritten
-			ws.DirectoryReferences[i].UpdatedAt = now
-			matchedReference = true
-			continue
-		}
-		if _, ok := rewriteWorkspaceContentPath(refPath, normalizedNew, normalizedNew); ok {
-			matchedReference = true
-			continue
-		}
-		if (folderSlug != "" && strings.EqualFold(strings.TrimSpace(ws.DirectoryReferences[i].Name), folderSlug)) ||
-			(newBaseName != "" && strings.EqualFold(strings.TrimSpace(ws.DirectoryReferences[i].Name), newBaseName)) {
-			ws.DirectoryReferences[i].WorkspaceID = ws.ID
-			if strings.TrimSpace(ws.DirectoryReferences[i].Name) == "" {
-				ws.DirectoryReferences[i].Name = workspaceReferenceName(ws, normalizedNew)
-			}
-			ws.DirectoryReferences[i].Path = defaultRefPath
-			ws.DirectoryReferences[i].UpdatedAt = now
-			matchedReference = true
-		}
-	}
-
-	if !matchedReference {
-		ws.DirectoryReferences = append(ws.DirectoryReferences, agentworkspace.DirectoryReference{
-			ID:          uuid.New().String(),
-			WorkspaceID: ws.ID,
-			Name:        workspaceReferenceName(ws, normalizedNew),
-			Path:        defaultRefPath,
-			X:           400,
-			Y:           300,
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		})
-	}
-	ws.DirectoryReferences = compactAgentWorkspaceDirectoryReferences(ws.DirectoryReferences)
-
-	matchedBinding := false
-	for i := range ws.MCPBindings {
-		if strings.EqualFold(strings.TrimSpace(ws.MCPBindings[i].Alias), workspaceFilesMCPAlias) ||
-			workspaceBindingHasRoot(ws.MCPBindings[i].Config, normalizedOld) {
-			if ws.MCPBindings[i].Config == nil {
-				ws.MCPBindings[i].Config = make(map[string]any)
-			}
-			ws.MCPBindings[i].Config["roots"] = rewriteWorkspaceBindingRoots(ws.MCPBindings[i].Config["roots"], normalizedOld, normalizedNew, defaultRoots)
-			ws.MCPBindings[i].UpdatedAt = now
-			ws.MCPBindings[i].Enabled = true
-			matchedBinding = true
-		}
-	}
-
-	if !matchedBinding {
-		ws.MCPBindings = append(ws.MCPBindings, newWorkspaceFilesMCPBinding(defaultRoots, now))
-	}
-}
-
-func workspaceReferenceName(ws *agentworkspace.Workspace, path string) string {
-	if ws != nil {
-		if name := strings.TrimSpace(ws.FolderSlug); name != "" {
-			return name
-		}
-		if name := strings.TrimSpace(ws.Name); name != "" {
-			return name
-		}
-	}
-	return filepath.Base(path)
-}
-
-func compactAgentWorkspaceDirectoryReferences(refs []agentworkspace.DirectoryReference) []agentworkspace.DirectoryReference {
-	if len(refs) < 2 {
-		return refs
-	}
-
-	seen := make(map[string]int, len(refs))
-	compact := make([]agentworkspace.DirectoryReference, 0, len(refs))
-	for _, ref := range refs {
-		key := cleanWorkspaceSyncPath(ref.Path)
-		if key == "" {
-			compact = append(compact, ref)
-			continue
-		}
-		if existingIndex, ok := seen[key]; ok {
-			if strings.TrimSpace(compact[existingIndex].Name) == "" && strings.TrimSpace(ref.Name) != "" {
-				compact[existingIndex].Name = ref.Name
-			}
-			continue
-		}
-		seen[key] = len(compact)
-		compact = append(compact, ref)
-	}
-	return compact
+	refs, bindings, _ := rebaseWorkspaceFolderReferences(id, ws.DirectoryReferences, ws.MCPBindings, oldPath, newPath, time.Now())
+	ws.DirectoryReferences = refs
+	ws.MCPBindings = bindings
 }
 
 func ensureImportedWorkspaceEntryAgent(ws *agentworkspace.Workspace, agentName string) error {

--- a/internal/sessionhttp/workspace_handler_sync.go
+++ b/internal/sessionhttp/workspace_handler_sync.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
@@ -729,108 +728,40 @@ func (h *Handler) syncManagedWorkspacePath(ws session.Workspace) (string, bool) 
 	return "", false
 }
 
+// updateManagedWorkspaceReferences rebases a managed session workspace's
+// directory references and MCP roots after its folder moves from oldPath to
+// newPath, re-encoding the JSON mirror fields. An empty newPath is an error
+// (the sync path always has a concrete destination).
 func updateManagedWorkspaceReferences(workspace *session.Workspace, oldPath string, newPath string) error {
 	if workspace == nil {
 		return fmt.Errorf("workspace is required")
 	}
 
-	now := time.Now()
-	normalizedOld := cleanWorkspaceSyncPath(oldPath)
-	normalizedNew := cleanWorkspaceSyncPath(newPath)
-	if normalizedNew == "" {
-		return fmt.Errorf("new workspace folder path is required")
-	}
-	folderSlug := strings.TrimSpace(workspace.FolderSlug)
-	newBaseName := filepath.Base(normalizedNew)
-
-	// Groups keep their linked folder and MCP roots scoped to their own
-	// content directories; rewriting onto the folder root would expose member
-	// sub-workspaces.
-	isGroup := workspace.IsGroup()
-	defaultRefPath := defaultWorkspaceReferencePath(isGroup, normalizedNew)
-	defaultRoots := defaultWorkspaceMCPRoots(isGroup, normalizedNew)
-
 	refs, err := decodeDirectoryReferences(workspace.DirectoryReferencesJSON)
 	if err != nil {
 		return fmt.Errorf("failed to decode directory references: %w", err)
 	}
+	bindings, err := decodeWorkspaceMCPBindings(workspace.MCPBindingsJSON)
+	if err != nil {
+		return fmt.Errorf("failed to decode workspace MCP bindings: %w", err)
+	}
 
-	matchedReference := false
-	for i := range refs {
-		refPath := cleanWorkspaceSyncPath(refs[i].Path)
-		if refPath == "" {
-			continue
-		}
-		// References at or inside the moved folder keep their relative
-		// location (a group's files/ stays files/).
-		if rewritten, ok := rewriteWorkspaceContentPath(refPath, normalizedOld, normalizedNew); ok {
-			refs[i].WorkspaceID = workspace.ID
-			if strings.TrimSpace(refs[i].Name) == "" {
-				refs[i].Name = sessionWorkspaceReferenceName(workspace, normalizedNew)
-			}
-			refs[i].Path = rewritten
-			refs[i].UpdatedAt = now
-			matchedReference = true
-			continue
-		}
-		if _, ok := rewriteWorkspaceContentPath(refPath, normalizedNew, normalizedNew); ok {
-			// Already pointing into the new location.
-			matchedReference = true
-			continue
-		}
-		// Name-keyed rebind for stale references whose path matches neither
-		// location.
-		if (folderSlug != "" && strings.EqualFold(strings.TrimSpace(refs[i].Name), folderSlug)) ||
-			(newBaseName != "" && strings.EqualFold(strings.TrimSpace(refs[i].Name), newBaseName)) {
-			refs[i].WorkspaceID = workspace.ID
-			if strings.TrimSpace(refs[i].Name) == "" {
-				refs[i].Name = sessionWorkspaceReferenceName(workspace, normalizedNew)
-			}
-			refs[i].Path = defaultRefPath
-			refs[i].UpdatedAt = now
-			matchedReference = true
-		}
+	id := folderRebaseIdentity{
+		workspaceID: workspace.ID,
+		folderSlug:  workspace.FolderSlug,
+		name:        workspace.Name,
+		isGroup:     workspace.IsGroup(),
 	}
-	if !matchedReference {
-		refs = append(refs, workspaceDirectoryReference{
-			ID:          uuid.New().String(),
-			WorkspaceID: workspace.ID,
-			Name:        sessionWorkspaceReferenceName(workspace, normalizedNew),
-			Path:        defaultRefPath,
-			X:           400,
-			Y:           300,
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		})
+	refs, bindings, ok := rebaseWorkspaceFolderReferences(id, refs, bindings, oldPath, newPath, time.Now())
+	if !ok {
+		return fmt.Errorf("new workspace folder path is required")
 	}
-	refs = compactWorkspaceDirectoryReferences(refs)
 
 	refData, err := json.Marshal(refs)
 	if err != nil {
 		return fmt.Errorf("failed to encode directory references: %w", err)
 	}
 	workspace.DirectoryReferencesJSON = refData
-
-	bindings, err := decodeWorkspaceMCPBindings(workspace.MCPBindingsJSON)
-	if err != nil {
-		return fmt.Errorf("failed to decode workspace MCP bindings: %w", err)
-	}
-
-	matchedBinding := false
-	for i := range bindings {
-		if strings.EqualFold(strings.TrimSpace(bindings[i].Alias), workspaceFilesMCPAlias) || workspaceBindingHasRoot(bindings[i].Config, normalizedOld) {
-			if bindings[i].Config == nil {
-				bindings[i].Config = make(map[string]any)
-			}
-			bindings[i].Config["roots"] = rewriteWorkspaceBindingRoots(bindings[i].Config["roots"], normalizedOld, normalizedNew, defaultRoots)
-			bindings[i].UpdatedAt = now
-			bindings[i].Enabled = true
-			matchedBinding = true
-		}
-	}
-	if !matchedBinding {
-		bindings = append(bindings, newWorkspaceFilesMCPBinding(defaultRoots, now))
-	}
 
 	bindingData, err := json.Marshal(bindings)
 	if err != nil {
@@ -839,43 +770,6 @@ func updateManagedWorkspaceReferences(workspace *session.Workspace, oldPath stri
 	workspace.MCPBindingsJSON = bindingData
 
 	return nil
-}
-
-func sessionWorkspaceReferenceName(ws *session.Workspace, path string) string {
-	if ws != nil {
-		if name := strings.TrimSpace(ws.FolderSlug); name != "" {
-			return name
-		}
-		if name := strings.TrimSpace(ws.Name); name != "" {
-			return name
-		}
-	}
-	return filepath.Base(path)
-}
-
-func compactWorkspaceDirectoryReferences(refs []workspaceDirectoryReference) []workspaceDirectoryReference {
-	if len(refs) < 2 {
-		return refs
-	}
-
-	seen := make(map[string]int, len(refs))
-	compact := make([]workspaceDirectoryReference, 0, len(refs))
-	for _, ref := range refs {
-		key := cleanWorkspaceSyncPath(ref.Path)
-		if key == "" {
-			compact = append(compact, ref)
-			continue
-		}
-		if existingIndex, ok := seen[key]; ok {
-			if strings.TrimSpace(compact[existingIndex].Name) == "" && strings.TrimSpace(ref.Name) != "" {
-				compact[existingIndex].Name = ref.Name
-			}
-			continue
-		}
-		seen[key] = len(compact)
-		compact = append(compact, ref)
-	}
-	return compact
 }
 
 func (h *Handler) restoreWorkspaceNoteFiles(ctx context.Context, workspaceID string) error {

--- a/internal/sessionhttp/workspace_reference_rebase.go
+++ b/internal/sessionhttp/workspace_reference_rebase.go
@@ -1,0 +1,170 @@
+package sessionhttp
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// folderRebaseIdentity carries the workspace fields the reference-rebase core
+// needs to name and scope references, decoupling it from the two concrete
+// workspace types (agentworkspace.Workspace on the import path,
+// session.Workspace on the folder-sync path).
+type folderRebaseIdentity struct {
+	workspaceID string
+	folderSlug  string
+	name        string
+	isGroup     bool
+}
+
+// rebaseWorkspaceFolderReferences rewrites directory references and MCP binding
+// roots after a workspace folder moves from oldPath to newPath, returning the
+// updated slices. ok is false when newPath is empty (nothing to do); the caller
+// decides whether that is a silent no-op (import) or an error (folder sync).
+//
+// This is the single implementation shared by rebaseImportedWorkspaceFolderReferences
+// (typed agentworkspace.Workspace) and updateManagedWorkspaceReferences
+// (JSON-encoded session.Workspace mirror). Both store these as agentworkspace
+// types — workspaceDirectoryReference is an alias of agentworkspace.DirectoryReference,
+// and the session binding decoder already yields agentworkspace.MCPBinding.
+func rebaseWorkspaceFolderReferences(
+	id folderRebaseIdentity,
+	refs []agentworkspace.DirectoryReference,
+	bindings []agentworkspace.MCPBinding,
+	oldPath, newPath string,
+	now time.Time,
+) ([]agentworkspace.DirectoryReference, []agentworkspace.MCPBinding, bool) {
+	normalizedNew := cleanWorkspaceSyncPath(newPath)
+	if normalizedNew == "" {
+		return refs, bindings, false
+	}
+
+	normalizedOld := cleanWorkspaceSyncPath(oldPath)
+	folderSlug := strings.TrimSpace(id.folderSlug)
+	newBaseName := filepath.Base(normalizedNew)
+	// Groups keep their linked folder and MCP roots scoped to their own content
+	// directories; rewriting onto the folder root would expose member
+	// sub-workspaces.
+	defaultRefPath := defaultWorkspaceReferencePath(id.isGroup, normalizedNew)
+	defaultRoots := defaultWorkspaceMCPRoots(id.isGroup, normalizedNew)
+	refName := workspaceReferenceNameFor(id.folderSlug, id.name, normalizedNew)
+
+	matchedReference := false
+	for i := range refs {
+		refPath := cleanWorkspaceSyncPath(refs[i].Path)
+		if refPath == "" {
+			continue
+		}
+		// References at or inside the moved folder keep their relative location
+		// (a group's files/ stays files/).
+		if rewritten, ok := rewriteWorkspaceContentPath(refPath, normalizedOld, normalizedNew); ok {
+			refs[i].WorkspaceID = id.workspaceID
+			if strings.TrimSpace(refs[i].Name) == "" {
+				refs[i].Name = refName
+			}
+			refs[i].Path = rewritten
+			refs[i].UpdatedAt = now
+			matchedReference = true
+			continue
+		}
+		if _, ok := rewriteWorkspaceContentPath(refPath, normalizedNew, normalizedNew); ok {
+			// Already pointing into the new location.
+			matchedReference = true
+			continue
+		}
+		// Name-keyed rebind for stale references whose path matches neither
+		// location.
+		if (folderSlug != "" && strings.EqualFold(strings.TrimSpace(refs[i].Name), folderSlug)) ||
+			(newBaseName != "" && strings.EqualFold(strings.TrimSpace(refs[i].Name), newBaseName)) {
+			refs[i].WorkspaceID = id.workspaceID
+			if strings.TrimSpace(refs[i].Name) == "" {
+				refs[i].Name = refName
+			}
+			refs[i].Path = defaultRefPath
+			refs[i].UpdatedAt = now
+			matchedReference = true
+		}
+	}
+	if !matchedReference {
+		refs = append(refs, agentworkspace.DirectoryReference{
+			ID:          uuid.New().String(),
+			WorkspaceID: id.workspaceID,
+			Name:        refName,
+			Path:        defaultRefPath,
+			X:           defaultDirectoryReferenceX,
+			Y:           defaultDirectoryReferenceY,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+	}
+	refs = compactDirectoryReferences(refs)
+
+	matchedBinding := false
+	for i := range bindings {
+		if strings.EqualFold(strings.TrimSpace(bindings[i].Alias), workspaceFilesMCPAlias) ||
+			workspaceBindingHasRoot(bindings[i].Config, normalizedOld) {
+			if bindings[i].Config == nil {
+				bindings[i].Config = make(map[string]any)
+			}
+			bindings[i].Config["roots"] = rewriteWorkspaceBindingRoots(bindings[i].Config["roots"], normalizedOld, normalizedNew, defaultRoots)
+			bindings[i].UpdatedAt = now
+			bindings[i].Enabled = true
+			matchedBinding = true
+		}
+	}
+	if !matchedBinding {
+		bindings = append(bindings, newWorkspaceFilesMCPBinding(defaultRoots, now))
+	}
+
+	return refs, bindings, true
+}
+
+// workspaceReferenceNameFor picks the display name for a directory reference:
+// the folder slug, else the workspace name, else the path's base name.
+func workspaceReferenceNameFor(folderSlug, workspaceName, path string) string {
+	if name := strings.TrimSpace(folderSlug); name != "" {
+		return name
+	}
+	if name := strings.TrimSpace(workspaceName); name != "" {
+		return name
+	}
+	return filepath.Base(path)
+}
+
+// compactDirectoryReferences removes references that resolve to the same
+// filesystem path, keeping the first and backfilling a blank name from a later
+// duplicate.
+func compactDirectoryReferences(refs []agentworkspace.DirectoryReference) []agentworkspace.DirectoryReference {
+	if len(refs) < 2 {
+		return refs
+	}
+
+	seen := make(map[string]int, len(refs))
+	compact := make([]agentworkspace.DirectoryReference, 0, len(refs))
+	for _, ref := range refs {
+		key := cleanWorkspaceSyncPath(ref.Path)
+		if key == "" {
+			compact = append(compact, ref)
+			continue
+		}
+		if existingIndex, ok := seen[key]; ok {
+			if strings.TrimSpace(compact[existingIndex].Name) == "" && strings.TrimSpace(ref.Name) != "" {
+				compact[existingIndex].Name = ref.Name
+			}
+			continue
+		}
+		seen[key] = len(compact)
+		compact = append(compact, ref)
+	}
+	return compact
+}
+
+// defaultDirectoryReferenceX and defaultDirectoryReferenceY are the canvas
+// coordinates a freshly-created workspace directory reference is placed at.
+const (
+	defaultDirectoryReferenceX = 400
+	defaultDirectoryReferenceY = 300
+)


### PR DESCRIPTION
## Summary

The last consolidation from the readability review (deliberately deferred as the most regression-sensitive — import and folder-sync move workspaces on disk and rewrite MCP roots).

`rebaseImportedWorkspaceFolderReferences` (import path, typed `agentworkspace.Workspace`) and `updateManagedWorkspaceReferences` (folder-sync path, JSON-encoded `session.Workspace` mirror) carried the **same ~100-line folder-move rebase logic** — rewrite directory references into the new path, name-key rebind stale ones, append a default, compact, then rewrite MCP binding roots — implemented twice against two representations.

**Key finding (the JSON-tag equivalence check this task required):** the two representations are the same types. `workspaceDirectoryReference` is field-identical to `agentworkspace.DirectoryReference` (same 8 fields, tags, types), and the session binding decoder already returns `agentworkspace.MCPBinding`. So:

- Made `workspaceDirectoryReference` a **type alias** of `agentworkspace.DirectoryReference` — all ~10 existing uses compile unchanged (no methods were bound to it, no positional literals).
- Extracted one `rebaseWorkspaceFolderReferences` core (+ `folderRebaseIdentity`, `workspaceReferenceNameFor`, `compactDirectoryReferences`) in a new `workspace_reference_rebase.go`.
- Both entry points are now thin adapters: import calls the core in place and ignores the empty-path no-op; sync decodes JSON → core → re-encodes, mapping the core's `ok=false` to its existing "new folder path required" error.
- Named the previously-magic `400`/`300` canvas coordinates (`defaultDirectoryReferenceX/Y`).

Removed the duplicated `compactWorkspaceDirectoryReferences`/`compactAgentWorkspaceDirectoryReferences` pair and the `workspaceReferenceName`/`sessionWorkspaceReferenceName` pair. 4 files, +203/−246.

## Verification
- `go build ./...`, `go vet` clean
- **Full `internal/sessionhttp` suite passes under `-race`** (52s), including import, folder-sync, move-folder (into/out-of group, cycle/depth/slug-collision rejection, descendant-path rewrite), and group-backfill tests — the paths that exercise both twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)