### PR TITLE
fix(workspace-command): cross-view consistency fixes; Command becomes the default view

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -141,8 +141,15 @@
 .ws-cmd-rail-item.is-static { cursor: default; }
 .ws-cmd-rail-item:hover:not(.is-static) { border-color: var(--ws-line-bright); background: var(--ws-bg-2); }
 .ws-cmd-rail-item:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
-.ws-cmd-rail-t { font-size: 13px; color: #eef0f3; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-cmd-rail-m { font-family: var(--ws-font-mono); font-size: 9.5px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-rail-line { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; min-width: 0; }
+.ws-cmd-rail-t { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eef0f3; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-rail-m { width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--ws-font-mono); font-size: 9.5px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-rail-role {
+  flex: 0 0 auto; padding: 2px 6px; border: 1px solid var(--ws-line-bright);
+  font-family: var(--ws-font-mono); font-size: 8px; letter-spacing: 0.8px; text-transform: uppercase; color: var(--ws-ink-dim);
+}
+.ws-cmd-rail-role.is-project { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.08); }
+.ws-cmd-rail-role.is-reference { color: var(--ws-ink-dim); }
 .ws-cmd-rail-more {
   margin-top: 4px; padding: 7px; border: 1px dashed var(--ws-line-bright); background: none; color: var(--ws-ink-dim); cursor: pointer;
   font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
@@ -240,6 +247,13 @@
 }
 .ws-cmd-modal-add:hover { background: rgba(70, 211, 154, 0.16); border-color: var(--ws-faction); }
 .ws-cmd-modal-add:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-filter {
+  padding: 7px 10px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.1px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-modal-filter[aria-pressed="true"],
+.ws-cmd-modal-filter:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
+.ws-cmd-modal-filter:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-modal-close {
   width: 30px; height: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
   background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-size: 16px; line-height: 1; transition: 0.13s;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -37,6 +37,7 @@ export class WorkspaceCommandView {
     this.statModalSection = '';
     this.statModalEl = null;
     this.statModalTrigger = null;
+    this.taskModalShowAll = false;
     this.setup();
   }
 
@@ -44,14 +45,12 @@ export class WorkspaceCommandView {
     if (!this.container || !this.toggleBtn) return;
     this.toggleBtn.hidden = false; // reveal (Phase 1)
     this.toggleBtn.addEventListener('click', () => this.toggle());
-    // The URL wins over localStorage on load; a bare visit (no ?view=) falls
-    // back to the saved preference exactly as before. Bootstrap only reads
-    // the URL — it doesn't rewrite it, so a plain visit stays plain even if
-    // the saved preference is command.
+    // The URL wins over localStorage on load. Command is now the implicit
+    // default; only an explicit detailed URL/preference keeps the legacy view.
     const urlView = this.getViewFromURL();
     let pref = '';
     try { pref = localStorage.getItem(STORAGE_KEY) || ''; } catch (err) { pref = ''; }
-    const initialView = urlView || pref;
+    const initialView = urlView || pref || 'command';
     if (initialView === 'command') this.activate({ syncUrl: false });
     else this.deactivate({ syncUrl: false });
   }
@@ -63,18 +62,20 @@ export class WorkspaceCommandView {
   getViewFromURL() {
     try {
       const raw = new URLSearchParams(window.location.search).get('view');
-      return raw === 'command' ? 'command' : '';
+      if (raw === 'command') return 'command';
+      if (raw === 'detailed') return 'detailed';
+      return '';
     } catch (err) {
       return '';
     }
   }
 
-  // Deep-linkable, non-spammy: detailed (the default) drops the param, and
-  // every toggle uses replaceState so switching views never grows history.
+  // Deep-linkable, non-spammy: command (the default) drops the param, detailed
+  // writes ?view=detailed, and toggles use replaceState so history doesn't grow.
   syncURL(view) {
     try {
       const params = new URLSearchParams(window.location.search);
-      if (view === 'command') params.set('view', 'command');
+      if (view === 'detailed') params.set('view', 'detailed');
       else params.delete('view');
       const query = params.toString();
       const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
@@ -228,7 +229,7 @@ export class WorkspaceCommandView {
   statSectionMeta(section) {
     switch (String(section || '')) {
       case 'agents': return { title: 'Agents', addLabel: '＋ Add Agent' };
-      case 'tasks': return { title: 'Tasks', addLabel: '＋ Add Task' };
+      case 'tasks': return { title: this.taskModalShowAll ? 'Tasks' : 'Open Tasks', addLabel: '＋ Add Task' };
       case 'mcp': return { title: 'MCP Servers', addLabel: '＋ Add MCP' };
       case 'skills': return { title: 'Skills', addLabel: '＋ Add Skill' };
       default: return null;
@@ -239,6 +240,7 @@ export class WorkspaceCommandView {
     const section = String(sectionKey || '').trim();
     if (!this.statSectionMeta(section)) return;
     this.statModalSection = section;
+    if (section === 'tasks') this.taskModalShowAll = false;
     this.statModalTrigger = trigger || null;
     const el = this.ensureStatModal();
     if (!el) return;
@@ -301,6 +303,7 @@ export class WorkspaceCommandView {
       '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
       '<span class="ws-cmd-modal-count">' + this.statModalCount(section) + '</span>' +
       '<div class="ws-cmd-modal-head-actions">' +
+      this.statModalFilterToggleHTML(section) +
       '<button type="button" class="ws-cmd-modal-add" data-cmd-modal-action="add">' + escapeHtml(meta.addLabel) + '</button>' +
       '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
       '</div>' +
@@ -312,10 +315,18 @@ export class WorkspaceCommandView {
     );
   }
 
+  statModalFilterToggleHTML(section) {
+    if (String(section || '') !== 'tasks') return '';
+    const label = this.taskModalShowAll ? 'Show open' : 'Show all';
+    const pressed = this.taskModalShowAll ? 'true' : 'false';
+    return '<button type="button" class="ws-cmd-modal-filter" data-cmd-modal-action="toggle-task-filter" aria-pressed="' +
+      pressed + '">' + escapeHtml(label) + '</button>';
+  }
+
   statModalCount(section) {
     switch (String(section || '')) {
       case 'agents': return this.agentRowData().length;
-      case 'tasks': return this.taskRowData().length;
+      case 'tasks': return this.taskRowData({ includeAll: this.taskModalShowAll }).length;
       case 'mcp': return this.mcpRowData().length;
       case 'skills': return this.skillRowData().length;
       default: return 0;
@@ -393,14 +404,24 @@ export class WorkspaceCommandView {
     }).join('');
   }
 
-  taskRowData() {
+  isOpenTask(task) {
+    const status = String((task && task.status) || '').toLowerCase();
+    return status === 'pending' || status === 'in_progress';
+  }
+
+  taskRowData({ includeAll = false } = {}) {
     const page = this.page || {};
-    return Array.isArray(page.tasks) ? page.tasks : [];
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    return includeAll ? tasks : tasks.filter((task) => this.isOpenTask(task));
   }
 
   taskRowsHTML() {
-    const tasks = this.taskRowData();
-    if (!tasks.length) return this.modalEmptyHTML('No tasks yet. Add one to get started.');
+    const tasks = this.taskRowData({ includeAll: this.taskModalShowAll });
+    if (!tasks.length) {
+      return this.modalEmptyHTML(
+        this.taskModalShowAll ? 'No tasks yet. Add one to get started.' : 'No open tasks. Use Show all to view completed tasks.'
+      );
+    }
     return tasks.map((t) => {
       const id = String(t.id || '');
       const label = String(t.description || t.name || t.title || 'Task');
@@ -518,6 +539,11 @@ export class WorkspaceCommandView {
     const section = this.statModalSection;
     const a = String(action || '');
     if (a === 'close') { this.closeStatModal(); return; }
+    if (a === 'toggle-task-filter' && section === 'tasks') {
+      this.taskModalShowAll = !this.taskModalShowAll;
+      this.renderStatModalBody();
+      return;
+    }
     if (a === 'detailed') {
       this.closeStatModal();
       this.openDetailedSection(section);
@@ -792,12 +818,89 @@ export class WorkspaceCommandView {
     return items;
   }
 
+  getWorkspaceProjectPath() {
+    const page = this.page || {};
+    if (typeof page.getWorkspaceProjectPath === 'function') {
+      try { return String(page.getWorkspaceProjectPath() || '').trim(); } catch (err) { return ''; }
+    }
+    return String((page.workspace && page.workspace.project_path) || '').trim();
+  }
+
+  folderDisplayName(path) {
+    const normalized = String(path || '').replace(/[\\/]+$/, '');
+    const parts = normalized.split(/[\\/]/).filter(Boolean);
+    return parts[parts.length - 1] || normalized || 'Project Folder';
+  }
+
+  folderRowData() {
+    const page = this.page || {};
+    const dirs = Array.isArray(page.directories) ? page.directories : [];
+    if (dirs.length) return dirs;
+    const projectPath = this.getWorkspaceProjectPath();
+    if (!projectPath) return [];
+    return [{
+      id: '__project_path__',
+      name: this.folderDisplayName(projectPath),
+      path: projectPath,
+      source: 'project_path',
+      isProjectPathOnly: true
+    }];
+  }
+
+  folderRole(dir) {
+    const page = this.page || {};
+    if (dir && dir.isProjectPathOnly) return { label: 'Project Folder', className: 'is-project' };
+    let primaryDirectoryId = '';
+    try {
+      primaryDirectoryId = typeof page.getPrimaryDirectoryId === 'function' ? String(page.getPrimaryDirectoryId() || '') : '';
+    } catch (err) {
+      primaryDirectoryId = '';
+    }
+    let isProject = false;
+    try {
+      isProject = typeof page.isProjectDirectory === 'function' ? Boolean(page.isProjectDirectory(dir)) : false;
+    } catch (err) {
+      isProject = false;
+    }
+    if (isProject || (dir && primaryDirectoryId && String(dir.id || '') === primaryDirectoryId)) {
+      return { label: 'Project Folder', className: 'is-project' };
+    }
+    return { label: 'Reference', className: 'is-reference' };
+  }
+
+  folderRailItems(rows, expanded) {
+    const arr = Array.isArray(rows) ? rows : [];
+    const limit = expanded ? arr.length : 5;
+    const shown = arr.slice(0, limit);
+    const items = shown.map((dir) => {
+      const id = String(dir.id || '');
+      const role = this.folderRole(dir);
+      const name = dir.title || dir.name || dir.path || 'Unnamed Directory';
+      const path = String(dir.path || '');
+      const source = String(dir.source || 'reference');
+      const inner =
+        '<span class="ws-cmd-rail-line"><span class="ws-cmd-rail-t">' + escapeHtml(name) + '</span>' +
+        '<span class="ws-cmd-rail-role ' + escapeHtml(role.className) + '">' + escapeHtml(role.label) + '</span></span>' +
+        (path ? '<span class="ws-cmd-rail-m">' + escapeHtml(path) + '</span>' : '');
+      if (dir.isProjectPathOnly) {
+        return '<div class="ws-cmd-rail-item is-static">' + inner + '</div>';
+      }
+      return '<button type="button" class="ws-cmd-rail-item" data-cmd-open-section="folders" data-cmd-item-id="' +
+        escapeHtml(id) + '" data-cmd-item-source="' + escapeHtml(source) + '">' + inner + '</button>';
+    });
+    if (arr.length > shown.length) {
+      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="folders">+ ' +
+        (arr.length - shown.length) + ' more</button>');
+    }
+    return items;
+  }
+
   renderRail() {
     const page = this.page || {};
     const notes = Array.isArray(page.notes) ? page.notes : [];
     const schedules = Array.isArray(page.schedules) ? page.schedules : [];
     const sessions = Array.isArray(page.sessions) ? page.sessions : [];
-    const dirs = Array.isArray(page.directories) ? page.directories : [];
+    const dirs = this.folderRowData();
 
     const notesExpanded = this.activeRailSection === 'notes';
     const schedulesExpanded = this.activeRailSection === 'schedules';
@@ -820,13 +923,7 @@ export class WorkspaceCommandView {
       action: (s) => 'data-cmd-open-section="sessions" data-cmd-item-id="' + escapeHtml(String(s.id || '')) + '"',
       metaOf: (s) => s.agent_name || ''
     });
-    const folderItems = this.railItems(dirs, (d) => d.title || d.name || d.path || 'Unnamed Directory', {
-      sectionKey: 'folders',
-      expanded: foldersExpanded,
-      action: (d) => 'data-cmd-open-section="folders" data-cmd-item-id="' + escapeHtml(String(d.id || '')) +
-        '" data-cmd-item-source="' + escapeHtml(String(d.source || 'reference')) + '"',
-      metaOf: (d) => d.path || ''
-    });
+    const folderItems = this.folderRailItems(dirs, foldersExpanded);
 
     return (
       this.railPanelHTML('notes', 'Notes', notesItems, notes.length, 'No notes yet.', 'New Note') +

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -202,6 +202,52 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Tools · MCP|Ops mode|Deploy|✦/);
 });
 
+test('command rail renders project_path fallback when no directories are loaded', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      workspace: { project_path: '/tmp/smoke-song' }
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.match(html, /smoke-song/);
+  assert.match(html, /Project Folder/);
+  assert.match(html, /\/tmp\/smoke-song/);
+  assert.doesNotMatch(html, /No linked folders yet\./);
+});
+
+test('command rail badges project and reference directory roles', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [
+        { id: 'dir-project', name: 'Project', path: '/tmp/project', source: 'reference' },
+        { id: 'dir-ref', name: 'Reference', path: '/tmp/reference', source: 'reference' }
+      ],
+      getPrimaryDirectoryId: () => 'dir-project',
+      isProjectDirectory: (dir) => dir.id === 'dir-project'
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.match(html, /Project Folder/);
+  assert.match(html, /Reference/);
+  assert.match(html, /data-cmd-item-id="dir-project"/);
+  assert.match(html, /data-cmd-item-id="dir-ref"/);
+});
+
 test('stat clicks open the in-place manager modal without leaving Command view', () => {
   const readoutRoot = makeListenerRoot();
   const opened = [];
@@ -415,6 +461,54 @@ test('tasks manager modal exposes run / open / delete controls', () => {
   assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="t1"/);
 });
 
+test('tasks manager modal defaults to open tasks and can show all rows', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    taskModalShowAll: false,
+    page: {
+      tasks: [
+        { id: 't1', description: 'Pending task', status: 'pending' },
+        { id: 't2', description: 'Running task', status: 'in_progress' },
+        { id: 't3', description: 'Done task', status: 'completed' },
+        { id: 't4', description: 'Failed task', status: 'failed' }
+      ]
+    }
+  });
+
+  let html = commandView.statModalHTML('tasks');
+  assert.match(html, /Open Tasks/);
+  assert.match(html, /<span class="ws-cmd-modal-count">2<\/span>/);
+  assert.match(html, /Pending task/);
+  assert.match(html, /Running task/);
+  assert.doesNotMatch(html, /Done task/);
+  assert.doesNotMatch(html, /Failed task/);
+  assert.match(html, /Show all/);
+
+  commandView.taskModalShowAll = true;
+  html = commandView.statModalHTML('tasks');
+  assert.match(html, /<span class="ws-cmd-modal-count">4<\/span>/);
+  assert.match(html, /Done task/);
+  assert.match(html, /Failed task/);
+  assert.match(html, /Show open/);
+});
+
+test('tasks manager filter action refreshes visible row count', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    taskModalShowAll: false,
+    statModalSection: 'tasks',
+    renderCalls: 0,
+    renderStatModalBody() {
+      this.renderCalls += 1;
+    }
+  });
+
+  commandView.handleStatModalAction('toggle-task-filter');
+
+  assert.equal(commandView.taskModalShowAll, true);
+  assert.equal(commandView.renderCalls, 1);
+});
+
 test('modal add/edit hand off to page flows and close the modal; delete stays open', () => {
   const calls = [];
   let closed = 0;
@@ -481,7 +575,7 @@ test('default deactivate path still persists detailed preference', () => {
   assert.equal(commandView.detailedView.hidden, false);
 });
 
-test('getViewFromURL only trusts an explicit ?view=command param', () => {
+test('getViewFromURL trusts explicit command and detailed params', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   const originalWindow = globalThis.window;
   try {
@@ -489,7 +583,7 @@ test('getViewFromURL only trusts an explicit ?view=command param', () => {
     assert.equal(commandView.getViewFromURL(), 'command');
 
     globalThis.window = { location: { search: '?view=detailed' } };
-    assert.equal(commandView.getViewFromURL(), '');
+    assert.equal(commandView.getViewFromURL(), 'detailed');
 
     globalThis.window = { location: { search: '' } };
     assert.equal(commandView.getViewFromURL(), '');
@@ -498,7 +592,7 @@ test('getViewFromURL only trusts an explicit ?view=command param', () => {
   }
 });
 
-test('syncURL sets ?view=command and clears it back to a bare path via replaceState', () => {
+test('syncURL clears command default and marks detailed via replaceState', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   const originalWindow = globalThis.window;
   const replaceStateCalls = [];
@@ -513,13 +607,71 @@ test('syncURL sets ?view=command and clears it back to a bare path via replaceSt
 
   try {
     commandView.syncURL('command');
-    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command']);
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc']);
 
-    globalThis.window.location.search = '?view=command';
+    globalThis.window.location.search = '';
     commandView.syncURL('detailed');
-    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command', '/workspaces/abc']);
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc', '/workspaces/abc?view=detailed']);
   } finally {
     globalThis.window = originalWindow;
+  }
+});
+
+test('setup defaults to Command view without URL or saved preference', () => {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalLocalStorage = globalThis.localStorage;
+  const toggleBtn = {
+    hidden: true,
+    attrs: {},
+    classList: { toggle() {} },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this.attrs[name] = value;
+    }
+  };
+  const container = {
+    hidden: true,
+    innerHTML: '',
+    querySelector() { return null; },
+    appendChild() {}
+  };
+  const detailedView = { hidden: false };
+  const replaceStateCalls = [];
+
+  try {
+    globalThis.document = {
+      getElementById(id) {
+        if (id === 'workspaceCommandView') return container;
+        if (id === 'workspace-detail-view') return detailedView;
+        if (id === 'workspace-command-toggle') return toggleBtn;
+        return null;
+      }
+    };
+    globalThis.window = {
+      location: { search: '', pathname: '/workspaces/abc' },
+      history: { replaceState(state, title, url) { replaceStateCalls.push(url); } }
+    };
+    globalThis.localStorage = { getItem: () => '', setItem() {} };
+
+    const commandView = new WorkspaceCommandView({
+      workspace: { name: 'Default Command', mcp_bindings: [], skill_bindings: [] },
+      tasks: [],
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      buildAgentGroups: () => []
+    });
+
+    assert.equal(commandView.active, true);
+    assert.equal(container.hidden, false);
+    assert.equal(detailedView.hidden, true);
+    assert.deepEqual(replaceStateCalls, []);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.window = originalWindow;
+    globalThis.localStorage = originalLocalStorage;
   }
 });
 
@@ -559,10 +711,10 @@ test('activate/deactivate sync the URL by default but bootstrap can opt out', ()
 
     // Real user toggles (default options) sync the URL via replaceState.
     commandView.activate();
-    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command']);
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc']);
 
     commandView.deactivate();
-    assert.deepEqual(replaceStateCalls, ['/workspaces/abc?view=command', '/workspaces/abc']);
+    assert.deepEqual(replaceStateCalls, ['/workspaces/abc', '/workspaces/abc?view=detailed']);
   } finally {
     globalThis.window = originalWindow;
   }

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -13107,6 +13107,7 @@ export class WorkspaceDetailPage {
         this.elements.sessionCount.setAttribute('aria-label', `${this.sessions.length} sessions`);
       }
       this.refreshHomeAssistantQuickPrompts();
+      window.workspaceCommand?.refresh();
     }
   }
 
@@ -13554,6 +13555,8 @@ export class WorkspaceDetailPage {
       this.notes = [];
       this.renderNotes();
       this.refreshHomeAssistantQuickPrompts();
+    } finally {
+      window.workspaceCommand?.refresh();
     }
   }
 
@@ -14069,6 +14072,8 @@ export class WorkspaceDetailPage {
       this.renderDirectories();
       this.syncProjectActionState();
       this.refreshHomeAssistantQuickPrompts();
+    } finally {
+      window.workspaceCommand?.refresh();
     }
   }
 
@@ -14548,6 +14553,8 @@ export class WorkspaceDetailPage {
       console.error('Failed to load schedules:', error);
       this.schedules = [];
       this.renderSchedules();
+    } finally {
+      window.workspaceCommand?.refresh();
     }
   }
 

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -265,6 +265,73 @@ test('workspace detail renders project_path fallback instead of unlinked empty s
   assert.doesNotMatch(list.innerHTML, /No project folder linked yet/);
 });
 
+test('workspace detail entity loaders refresh Command view after completion', async () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {};
+  page.elements = {};
+  page.renderSessions = () => {};
+  page.renderNotes = () => {};
+  page.renderDirectories = () => {};
+  page.renderSchedules = () => {};
+  page.refreshHomeAssistantQuickPrompts = () => {};
+  page.updateCopyNotesButtonState = () => {};
+  page.syncProjectActionState = () => {};
+  page.renderWorkspaceMCPBindings = () => {};
+  page.renderWorkspaceSkillBindings = () => {};
+  page.renderAgentGroups = () => {};
+
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+  let refreshCount = 0;
+  global.window = {
+    ...originalWindow,
+    workspaceCommand: {
+      refresh() {
+        refreshCount += 1;
+      }
+    }
+  };
+  global.fetch = async (url) => {
+    const href = String(url);
+    if (href.startsWith('/api/sessions')) {
+      return { ok: true, json: async () => ({ sessions: [{ id: 's1' }] }) };
+    }
+    if (href.endsWith('/notes')) {
+      return { ok: true, json: async () => ({ notes: [{ id: 'n1' }] }) };
+    }
+    if (href.startsWith('/api/orchestration/tasks')) {
+      return {
+        ok: true,
+        json: async () => ({
+          tasks: [{ id: 'sched-1', description: 'Scheduled', schedule: '* * * * *' }]
+        })
+      };
+    }
+    if (href.startsWith('/api/workspaces/')) {
+      return {
+        ok: true,
+        json: async () => ({
+          directory_references: [{ id: 'dir-1', name: 'Project', path: '/tmp/project' }],
+          attachments: []
+        })
+      };
+    }
+    throw new Error(`unexpected fetch: ${href}`);
+  };
+
+  try {
+    await page.loadSessions();
+    await page.loadNotes();
+    await page.loadDirectories();
+    await page.loadSchedules();
+  } finally {
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+  }
+
+  assert.equal(refreshCount, 4);
+});
+
 test('workspace detail protects the managed project directory row', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   const list = { innerHTML: '' };

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -13,6 +13,12 @@
       <div class="container-fluid py-4">
         <!-- Command view mount point — populated by workspace-command.js when the Command view is active. -->
         <div id="workspaceCommandView" class="ws-cmd" role="region" aria-label="Workspace command view" hidden></div>
+        <section
+          class="modern-card template-onboarding-panel mb-4"
+          id="workspace-template-onboarding"
+          aria-live="polite"
+          hidden>
+        </section>
         <!-- Workspace Detail View -->
         <div id="workspace-detail-view">
           <!-- Header Card -->
@@ -213,13 +219,6 @@
           </div>
 
           <!-- Workspace Health moved to /workspaces/{id}/diagnostics -->
-
-          <section
-            class="modern-card template-onboarding-panel mb-4"
-            id="workspace-template-onboarding"
-            aria-live="polite"
-            hidden>
-          </section>
 
           <!-- Workspace Goal -->
           <section class="modern-card workspace-detail-goal-card mb-4" id="workspace-detail-goal-card" aria-labelledby="workspace-detail-goal-title">


### PR DESCRIPTION
## Summary
- make Command the default workspace view while preserving detailed and command deep links
- refresh Command after Detailed loaders and render project-folder fallback/roles in the linked folders rail
- keep template onboarding visible in Command and filter Open Tasks by default

## Verification
- make test-js
- npm run lint
- go test ./internal/web/...
- ./scripts/build-server.sh
- isolated smoke: hub Open Workspace path, fresh workspace, ?view=detailed, ?view=command, folder fallback, Open Tasks modal, and template onboarding completion