### PR TITLE
feat(workspace-command): command bar identity, navigation, and baseline polish

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -58,21 +58,23 @@
 
 /* ---------- command bar ---------- */
 .ws-cmd-topbar {
-  display: flex; align-items: center; gap: 16px;
+  display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
   border: 1px solid var(--ws-line);
   background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
   padding: 14px 18px; margin-bottom: 18px;
   clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-back {
-  align-self: stretch; display: flex; align-items: center; padding: 0 14px; border: 1px solid var(--ws-line-bright);
+.ws-cmd-nav { flex: 1 0 100%; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ws-cmd-nav-btn {
+  min-height: 30px; display: inline-flex; align-items: center; padding: 7px 10px; border: 1px solid var(--ws-line-bright);
   background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer;
   font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; transition: 0.15s;
+  text-decoration: none;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 10px 100%, 0 calc(100% - 10px));
 }
-.ws-cmd-back:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-back:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-nav-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); text-decoration: none; }
+.ws-cmd-nav-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-crest {
   width: 50px; height: 50px; flex: 0 0 auto; display: grid; place-items: center;
   border: 1px solid var(--ws-line-bright); color: var(--ws-faction);
@@ -82,13 +84,54 @@
 .ws-cmd-title { flex: 1 1 auto; min-width: 0; }
 .ws-cmd-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
 .ws-cmd-title .ws-dot { width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg); }
+.ws-cmd-title-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .ws-cmd-title h2 {
-  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eef0f3;
+  flex: 1 1 auto; min-width: 0; margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eef0f3;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .ws-cmd-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
+.ws-cmd-description-row, .ws-cmd-tags-row { display: flex; align-items: flex-start; gap: 8px; margin-top: 8px; min-width: 0; }
+.ws-cmd-description {
+  flex: 1 1 auto; min-width: 0; margin: 0; color: var(--ws-ink-dim); font-size: 13px; line-height: 1.35;
+}
+.ws-cmd-description.is-empty { color: var(--ws-ink-faint); font-style: italic; }
+.ws-cmd-description.is-collapsed {
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.ws-cmd-mini-btn {
+  flex: 0 0 auto; padding: 4px 7px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
+  color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase;
+}
+.ws-cmd-mini-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-mini-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-tags { flex: 1 1 auto; min-width: 0; display: flex; flex-wrap: wrap; gap: 5px; }
+.ws-cmd-tag, .ws-cmd-tag-empty {
+  max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  border: 1px solid var(--ws-line-bright); padding: 2px 7px; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 0.8px; text-transform: uppercase;
+}
+.ws-cmd-tag { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.06); }
+.ws-cmd-tag.is-more { color: var(--ws-ink-dim); border-color: var(--ws-line-bright); background: transparent; }
+.ws-cmd-tag-empty { color: var(--ws-ink-faint); }
+.ws-cmd-identity-editor {
+  margin-top: 10px; padding: 10px; display: grid; gap: 8px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.2);
+}
+.ws-cmd-identity-field {
+  width: 100%; min-width: 0; border: 1px solid var(--ws-line-bright); background: var(--ws-bg); color: var(--ws-ink);
+  padding: 8px 10px; font: inherit; font-size: 13px; line-height: 1.35;
+}
+.ws-cmd-identity-field:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-tags-editor-mount .tag-input { border-color: var(--ws-line-bright); background: var(--ws-bg); color: var(--ws-ink); }
+.ws-cmd-identity-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.ws-cmd-identity-save, .ws-cmd-identity-cancel {
+  padding: 7px 10px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase;
+}
+.ws-cmd-identity-save { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
+.ws-cmd-identity-save:disabled { opacity: 0.55; cursor: wait; }
+.ws-cmd-identity-save:focus-visible, .ws-cmd-identity-cancel:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-identity-error { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-alert); }
 
-.ws-cmd-readout { display: flex; gap: 10px; flex: 0 0 auto; }
+.ws-cmd-readout { display: flex; gap: 10px; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; }
 .ws-cmd-stat {
   min-width: 84px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
   color: inherit; font: inherit; cursor: pointer; transition: 0.15s;
@@ -98,6 +141,8 @@
 .ws-cmd-stat:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; font-variant-numeric: tabular-nums; }
 .ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
+.ws-cmd-stat.is-alert { border-color: rgba(226, 101, 77, 0.55); background: rgba(226, 101, 77, 0.08); }
+.ws-cmd-stat.is-alert .ws-v, .ws-cmd-stat.is-alert .ws-l { color: var(--ws-alert); }
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
 .ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
@@ -115,10 +160,11 @@
   box-shadow: var(--ws-glow);
 }
 .ws-cmd-panel.is-managing { border-color: var(--ws-line-bright); background: linear-gradient(180deg, #1c1f26, #0f1014); }
-.ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
 .ws-cmd-panel-title { display: flex; align-items: center; gap: 9px; }
 .ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #e3e6ea; }
 .ws-cmd-panel-count { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-faint); }
+.ws-cmd-panel-tools { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
 .ws-cmd-panel-more {
   width: 26px; height: 24px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
   background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; transition: 0.15s;
@@ -126,9 +172,8 @@
 .ws-cmd-panel-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
 .ws-cmd-panel-more:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-panel-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
-.ws-cmd-panel-actions { padding: 2px 0 8px; border-bottom: 1px solid var(--ws-line); margin-bottom: 5px; }
 .ws-cmd-panel-action {
-  width: 100%; padding: 8px 9px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+  min-height: 24px; padding: 5px 7px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
   color: var(--ws-faction); cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
 }
 .ws-cmd-panel-action:hover { background: rgba(70, 211, 154, 0.14); border-color: var(--ws-faction); }
@@ -163,6 +208,7 @@
 /* ---------- garrison ---------- */
 .ws-cmd-garrison { padding: 14px; }
 .ws-cmd-garrison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child { grid-column: 1 / -1; }
 
 .ws-cmd-unit {
   border: 1px solid var(--ws-line); background: linear-gradient(165deg, #171a20, #0e0f13); overflow: hidden;
@@ -211,7 +257,12 @@
 .ws-cmd-quest { display: flex; align-items: center; gap: 9px; padding: 9px 11px; }
 .ws-cmd-quest + .ws-cmd-quest { border-top: 1px solid var(--ws-line); }
 .ws-cmd-q-glyph { width: 22px; height: 22px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-keeper-deep); color: var(--ws-keeper); font-size: 11px; }
-.ws-cmd-q-name { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ws-cmd-q-name {
+  flex: 1 1 auto; min-width: 0; padding: 0; border: 0; background: none; text-align: left;
+  font: inherit; font-size: 13px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer;
+}
+.ws-cmd-q-name:hover { color: var(--ws-faction); text-decoration: underline; text-underline-offset: 3px; }
+.ws-cmd-q-name:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-q-status { font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
 .ws-cmd-q-status.pending { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); }
 .ws-cmd-q-status.working { color: var(--ws-working); border-color: var(--ws-faction-deep); }
@@ -297,9 +348,23 @@
 .ws-cmd-mrow-btn.is-danger:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); background: rgba(226, 101, 77, 0.07); }
 .ws-cmd-mrow-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 
-@media (max-width: 1100px) { .ws-cmd-garrison-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) {
+  .ws-cmd-topbar { align-items: flex-start; }
+  .ws-cmd-title { flex-basis: calc(100% - 70px); }
+  .ws-cmd-readout { flex: 1 1 100%; justify-content: flex-start; }
+  .ws-cmd-garrison-grid { grid-template-columns: 1fr; }
+  .ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child { grid-column: auto; }
+}
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  .ws-cmd-nav-btn { flex: 1 1 calc(50% - 8px); justify-content: center; }
+  .ws-cmd-crest { width: 42px; height: 42px; }
+  .ws-cmd-title h2 { font-size: 20px; }
+  .ws-cmd-panel-head { align-items: flex-start; }
+  .ws-cmd-panel-tools { flex-wrap: wrap; justify-content: flex-end; }
+  .ws-cmd-readout .ws-cmd-stat { flex: 1 1 calc(50% - 10px); }
 }
 
 /* Auto-playing motion is opt-in via the OS "reduce motion" preference. */

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -17,12 +17,6 @@ function escapeHtml(value) {
   });
 }
 
-function statBox(value, label, sectionKey, ariaLabel) {
-  return '<button type="button" class="ws-cmd-stat" data-cmd-section="' + escapeHtml(sectionKey) +
-    '" aria-label="' + escapeHtml(ariaLabel) + '"><div class="ws-v">' + escapeHtml(value) +
-    '</div><div class="ws-l">' + escapeHtml(label) + '</div></button>';
-}
-
 export class WorkspaceCommandView {
   /**
    * @param {object} page - the live WorkspaceDetailPage instance (window.workspaceDetail).
@@ -38,6 +32,13 @@ export class WorkspaceCommandView {
     this.statModalEl = null;
     this.statModalTrigger = null;
     this.taskModalShowAll = false;
+    this.identityExpanded = false;
+    this.identityEditMode = '';
+    this.identitySaving = false;
+    this.commandTagInput = null;
+    this.commandTagDraft = [];
+    this.commandTagError = '';
+    this.boundGlobalKeydown = (event) => this.handleGlobalKeydown(event);
     this.setup();
   }
 
@@ -95,6 +96,9 @@ export class WorkspaceCommandView {
     this.render();
     if (this.container) this.container.hidden = false;
     if (this.detailedView) this.detailedView.hidden = true;
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+      document.addEventListener('keydown', this.boundGlobalKeydown);
+    }
     this.updateToggle();
     this.persist('command');
     if (syncUrl) this.syncURL('command');
@@ -102,7 +106,13 @@ export class WorkspaceCommandView {
 
   deactivate({ persist = true, syncUrl = true } = {}) {
     this.active = false;
+    this.activeRailSection = '';
+    this.identityEditMode = '';
+    this.destroyCommandTagInput();
     this.closeStatModal();
+    if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+      document.removeEventListener('keydown', this.boundGlobalKeydown);
+    }
     if (this.container) this.container.hidden = true;
     if (this.detailedView) this.detailedView.hidden = false;
     this.updateToggle();
@@ -121,6 +131,14 @@ export class WorkspaceCommandView {
   refresh() {
     if (this.active) this.render();
     else if (this.statModalSection) this.renderStatModalBody();
+  }
+
+  handleGlobalKeydown(event) {
+    if (!this.active || !event || event.key !== 'Escape') return;
+    if (this.statModalSection || this.identityEditMode) return;
+    if (!this.activeRailSection) return;
+    this.activeRailSection = '';
+    this.render();
   }
 
   computeStats() {
@@ -159,32 +177,166 @@ export class WorkspaceCommandView {
     }
   }
 
+  workspaceId() {
+    const page = this.page || {};
+    return String(page.workspaceId || (page.workspace && page.workspace.id) || '').trim();
+  }
+
+  workspaceTags() {
+    const page = this.page || {};
+    if (typeof page.getWorkspaceTags === 'function') {
+      try { return page.getWorkspaceTags(); } catch (err) { return []; }
+    }
+    const ws = page.workspace || {};
+    return Array.isArray(ws.tags) ? ws.tags.map(tag => String(tag || '').trim()).filter(Boolean) : [];
+  }
+
+  workflowHref() {
+    const page = this.page || {};
+    if (typeof page.collectWorkspaceWorkflowReferences === 'function' && typeof page.buildBehaviorStudioHref === 'function') {
+      try {
+        const refs = page.collectWorkspaceWorkflowReferences();
+        if (Array.isArray(refs) && refs.length === 1) {
+          return page.buildBehaviorStudioHref(refs[0].templateId);
+        }
+      } catch (err) {
+        return '/workflows';
+      }
+    }
+    return '/workflows';
+  }
+
+  workspaceRoute(suffix = '') {
+    const id = this.workspaceId();
+    return id ? '/workspaces/' + encodeURIComponent(id) + suffix : '#';
+  }
+
+  hasAttentionTasks() {
+    const page = this.page || {};
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    return tasks.some(task => {
+      const status = String((task && task.status) || '').toLowerCase();
+      return status === 'failed' || status === 'blocked';
+    });
+  }
+
+  statBoxHTML(value, label, sectionKey, ariaLabel, extraClass = '') {
+    const className = ('ws-cmd-stat ' + String(extraClass || '')).trim();
+    return '<button type="button" class="' + escapeHtml(className) + '" data-cmd-section="' + escapeHtml(sectionKey) +
+      '" aria-label="' + escapeHtml(ariaLabel) + '"><div class="ws-v">' + escapeHtml(value) +
+      '</div><div class="ws-l">' + escapeHtml(label) + '</div></button>';
+  }
+
+  commandBarHTML(ws, name, mode, stats) {
+    const description = String((ws && ws.description) || '').trim();
+    const tags = this.workspaceTags();
+    const isLongDescription = Array.from(description).length > 150;
+    const descriptionClass = 'ws-cmd-description' +
+      (!description ? ' is-empty' : '') +
+      (isLongDescription && !this.identityExpanded ? ' is-collapsed' : '');
+    const descriptionText = description || 'No description';
+    const workflowHref = this.workflowHref();
+
+    return (
+      '<header class="ws-cmd-topbar">' +
+      '<div class="ws-cmd-nav">' +
+      '<a class="ws-cmd-nav-btn" href="/workspaces" aria-label="Back to workspaces">Workspaces</a>' +
+      '<button type="button" class="ws-cmd-nav-btn" data-ws-cmd-detailed aria-label="Open detailed view">Detailed</button>' +
+      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(this.workspaceRoute('/canvas')) + '">Canvas</a>' +
+      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(this.workspaceRoute('/diagnostics')) + '">Diagnostics</a>' +
+      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(workflowHref) + '">Orchestration Skills</a>' +
+      '</div>' +
+      '<div class="ws-cmd-crest">' +
+      '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">' +
+      '<path d="M3 21V9l9-6 9 6v12"/><path d="M9 21v-6h6v6"/><path d="M3 21h18"/></svg>' +
+      '</div>' +
+      '<div class="ws-cmd-title">' +
+      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">Outpost · Command</span></div>' +
+      '<div class="ws-cmd-title-row">' +
+      '<h2>' + escapeHtml(name) + '</h2>' +
+      '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="name" aria-label="Edit workspace name">Edit</button>' +
+      '</div>' +
+      (mode ? '<div class="ws-sub">Workflow · ' + escapeHtml(mode) + '</div>' : '') +
+      '<div class="ws-cmd-description-row">' +
+      '<p class="' + descriptionClass + '">' + escapeHtml(descriptionText) + '</p>' +
+      '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="description" aria-label="Edit workspace description">Edit</button>' +
+      (isLongDescription
+        ? '<button type="button" class="ws-cmd-mini-btn" data-cmd-toggle-description aria-expanded="' +
+          (this.identityExpanded ? 'true' : 'false') + '">' + (this.identityExpanded ? 'Less' : 'More') + '</button>'
+        : '') +
+      '</div>' +
+      '<div class="ws-cmd-tags-row">' +
+      '<div class="ws-cmd-tags">' + this.commandTagsHTML(tags) + '</div>' +
+      '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="tags" aria-label="Edit workspace tags">Edit</button>' +
+      '</div>' +
+      this.identityEditorHTML(name, description) +
+      '</div>' +
+      '<div class="ws-cmd-readout">' +
+      this.statBoxHTML(stats.agents, 'Agents', 'agents', 'View agents') +
+      this.statBoxHTML(stats.openTasks, 'Open Tasks', 'tasks', 'View open tasks', this.hasAttentionTasks() ? 'is-alert' : '') +
+      this.statBoxHTML(stats.mcp, 'MCP', 'mcp', 'Open MCP settings') +
+      this.statBoxHTML(stats.skills, 'Skills', 'skills', 'Open Skills settings') +
+      '</div>' +
+      '</header>'
+    );
+  }
+
+  commandTagsHTML(tags) {
+    const arr = Array.isArray(tags) ? tags : [];
+    if (!arr.length) return '<span class="ws-cmd-tag-empty">No tags</span>';
+    const limit = 8;
+    const shown = arr.slice(0, limit).map(tag => '<span class="ws-cmd-tag">' + escapeHtml(tag) + '</span>').join('');
+    const more = arr.length > limit ? '<span class="ws-cmd-tag is-more">+' + (arr.length - limit) + '</span>' : '';
+    return shown + more;
+  }
+
+  identityEditorHTML(name, description) {
+    const mode = this.identityEditMode;
+    if (!mode) return '';
+    if (mode === 'name' || mode === 'description') {
+      const isDescription = mode === 'description';
+      const value = isDescription ? description : name;
+      const field = isDescription
+        ? '<textarea class="ws-cmd-identity-field" data-cmd-identity-input rows="2">' + escapeHtml(value) + '</textarea>'
+        : '<input class="ws-cmd-identity-field" data-cmd-identity-input type="text" value="' + escapeHtml(value) + '">';
+      return (
+        '<form class="ws-cmd-identity-editor" data-cmd-identity-form="' + escapeHtml(mode) + '">' +
+        field +
+        '<div class="ws-cmd-identity-actions">' +
+        '<button type="submit" class="ws-cmd-identity-save"' + (this.identitySaving ? ' disabled' : '') + '>Save</button>' +
+        '<button type="button" class="ws-cmd-identity-cancel" data-cmd-cancel-identity>Cancel</button>' +
+        '</div>' +
+        '</form>'
+      );
+    }
+    if (mode === 'tags') {
+      return (
+        '<div class="ws-cmd-identity-editor" data-cmd-identity-form="tags">' +
+        '<div class="ws-cmd-tags-editor-mount" data-cmd-tags-mount></div>' +
+        (this.commandTagError ? '<div class="ws-cmd-identity-error" role="alert">' + escapeHtml(this.commandTagError) + '</div>' : '') +
+        '<div class="ws-cmd-identity-actions">' +
+        '<button type="button" class="ws-cmd-identity-save" data-cmd-save-tags' + (this.identitySaving ? ' disabled' : '') + '>Save</button>' +
+        '<button type="button" class="ws-cmd-identity-cancel" data-cmd-cancel-identity>Cancel</button>' +
+        '</div>' +
+        '</div>'
+      );
+    }
+    return '';
+  }
+
   render() {
     if (!this.container) return;
+    if (this.commandTagInput) {
+      try { this.commandTagDraft = this.commandTagInput.getTags(); } catch (err) { /* keep existing draft */ }
+      this.destroyCommandTagInput();
+    }
     const ws = (this.page && this.page.workspace) || {};
     const name = String(ws.name || 'Workspace');
     const mode = this.opsModeLabel();
     const stats = this.computeStats();
 
     this.container.innerHTML =
-      '<header class="ws-cmd-topbar">' +
-      '<button type="button" class="ws-cmd-back" data-ws-cmd-detailed aria-label="Back to detailed view">◂ Detailed</button>' +
-      '<div class="ws-cmd-crest">' +
-      '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">' +
-      '<path d="M3 21V9l9-6 9 6v12"/><path d="M9 21v-6h6v6"/><path d="M3 21h18"/></svg>' +
-      '</div>' +
-      '<div class="ws-cmd-title">' +
-      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">Outpost · Command</span></div>' +
-      '<h2>' + escapeHtml(name) + '</h2>' +
-      (mode ? '<div class="ws-sub">Workflow · ' + escapeHtml(mode) + '</div>' : '') +
-      '</div>' +
-      '<div class="ws-cmd-readout">' +
-      statBox(stats.agents, 'Agents', 'agents', 'View agents') +
-      statBox(stats.openTasks, 'Open Tasks', 'tasks', 'View open tasks') +
-      statBox(stats.mcp, 'MCP', 'mcp', 'Open MCP settings') +
-      statBox(stats.skills, 'Skills', 'skills', 'Open Skills settings') +
-      '</div>' +
-      '</header>' +
+      this.commandBarHTML(ws, name, mode, stats) +
       '<div class="ws-cmd-layout">' +
       '<section class="ws-cmd-garrison">' + this.renderGarrison() + '</section>' +
       '<aside class="ws-cmd-rail">' + this.renderRail() + '</aside>' +
@@ -192,15 +344,153 @@ export class WorkspaceCommandView {
 
     const back = this.container.querySelector('[data-ws-cmd-detailed]');
     if (back) back.addEventListener('click', () => this.deactivate());
+    this.bindIdentityControls();
     this.bindReadout();
     this.bindGarrison();
     this.bindRail();
+    this.mountCommandTagInput();
 
     // The stat manager modal lives inside the .ws-cmd container (so it inherits
     // the tactical tokens) but survives full re-renders: re-attach + repaint it.
     if (this.statModalEl && this.container && this.container.appendChild) {
       this.container.appendChild(this.statModalEl);
-      if (this.statModalSection) this.renderStatModalBody();
+      if (this.statModalSection) {
+        this.renderStatModalBody();
+        this.setCommandBackgroundInert(true);
+      }
+    }
+  }
+
+  bindIdentityControls() {
+    const root = this.container && this.container.querySelector('.ws-cmd-topbar');
+    if (!root) return;
+
+    root.addEventListener('click', (event) => {
+      const editBtn = event.target.closest('[data-cmd-edit-identity]');
+      if (editBtn) {
+        this.startIdentityEdit(editBtn.getAttribute('data-cmd-edit-identity'));
+        return;
+      }
+      const toggleBtn = event.target.closest('[data-cmd-toggle-description]');
+      if (toggleBtn) {
+        this.identityExpanded = !this.identityExpanded;
+        this.render();
+        return;
+      }
+      const cancelBtn = event.target.closest('[data-cmd-cancel-identity]');
+      if (cancelBtn) {
+        this.cancelIdentityEdit();
+        return;
+      }
+      const saveTagsBtn = event.target.closest('[data-cmd-save-tags]');
+      if (saveTagsBtn) {
+        this.saveCommandTags();
+      }
+    });
+
+    root.addEventListener('submit', (event) => {
+      const form = event.target.closest('[data-cmd-identity-form]');
+      if (!form) return;
+      event.preventDefault();
+      const mode = form.getAttribute('data-cmd-identity-form');
+      if (mode === 'name' || mode === 'description') {
+        const input = form.querySelector('[data-cmd-identity-input]');
+        this.saveIdentityField(mode, input ? input.value : '');
+      }
+    });
+
+    root.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && event.target.closest('[data-cmd-identity-form]')) {
+        event.preventDefault();
+        this.cancelIdentityEdit();
+      }
+      if (
+        event.key === 'Enter' &&
+        event.target.matches('textarea[data-cmd-identity-input]') &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        this.saveIdentityField('description', event.target.value);
+      }
+    });
+  }
+
+  startIdentityEdit(mode) {
+    const nextMode = String(mode || '').trim();
+    if (!['name', 'description', 'tags'].includes(nextMode)) return;
+    this.identityEditMode = nextMode;
+    this.commandTagError = '';
+    if (nextMode === 'tags') this.commandTagDraft = this.workspaceTags();
+    this.render();
+    const input = this.container && this.container.querySelector('[data-cmd-identity-input]');
+    if (input && typeof input.focus === 'function') {
+      try { input.focus({ preventScroll: true }); } catch (err) { input.focus(); }
+      if (typeof input.select === 'function') input.select();
+    }
+  }
+
+  cancelIdentityEdit() {
+    this.identityEditMode = '';
+    this.identitySaving = false;
+    this.commandTagError = '';
+    this.commandTagDraft = [];
+    this.destroyCommandTagInput();
+    this.render();
+  }
+
+  async saveIdentityField(mode, value) {
+    const page = this.page || {};
+    if (typeof page.saveWorkspaceIdentityField !== 'function') return;
+    const ws = page.workspace || {};
+    const currentValue = mode === 'description' ? String(ws.description || '') : String(ws.name || '');
+    this.identitySaving = true;
+    const result = await page.saveWorkspaceIdentityField(mode, value, { currentValue });
+    this.identitySaving = false;
+    if (result && (result.error || result.invalid)) {
+      this.render();
+      return;
+    }
+    this.identityEditMode = '';
+    this.render();
+  }
+
+  mountCommandTagInput() {
+    if (this.identityEditMode !== 'tags' || this.commandTagInput) return;
+    const mount = this.container && this.container.querySelector('[data-cmd-tags-mount]');
+    if (!mount || !window.OriTagInput?.createTagInput) return;
+    this.commandTagInput = window.OriTagInput.createTagInput({
+      container: mount,
+      initialTags: this.commandTagDraft,
+      onChange: tags => {
+        this.commandTagDraft = tags;
+        this.commandTagError = '';
+      }
+    });
+    this.commandTagInput?.focus?.();
+  }
+
+  destroyCommandTagInput() {
+    if (!this.commandTagInput) return;
+    try { this.commandTagInput.destroy?.(); } catch (err) { /* no-op */ }
+    this.commandTagInput = null;
+  }
+
+  async saveCommandTags() {
+    const page = this.page || {};
+    if (typeof page.saveWorkspaceTagList !== 'function') return;
+    const tags = this.commandTagInput ? this.commandTagInput.getTags() : this.commandTagDraft;
+    this.identitySaving = true;
+    this.commandTagError = '';
+    try {
+      await page.saveWorkspaceTagList(tags);
+      this.identityEditMode = '';
+      this.commandTagDraft = [];
+      this.destroyCommandTagInput();
+    } catch (error) {
+      this.commandTagError = error.message || 'Failed to update tags';
+    } finally {
+      this.identitySaving = false;
+      this.render();
     }
   }
 
@@ -246,6 +536,7 @@ export class WorkspaceCommandView {
     if (!el) return;
     this.renderStatModalBody();
     el.hidden = false;
+    this.setCommandBackgroundInert(true);
     const panel = el.querySelector('.ws-cmd-modal-panel');
     if (panel && typeof panel.focus === 'function') {
       try { panel.focus({ preventScroll: true }); } catch (err) { panel.focus(); }
@@ -257,7 +548,51 @@ export class WorkspaceCommandView {
     this.statModalSection = '';
     this.statModalTrigger = null;
     if (this.statModalEl) this.statModalEl.hidden = true;
+    this.setCommandBackgroundInert(false);
     if (trigger && typeof trigger.focus === 'function') trigger.focus();
+  }
+
+  setCommandBackgroundInert(isInert) {
+    if (!this.container || !this.container.children) return;
+    Array.from(this.container.children).forEach(child => {
+      if (child === this.statModalEl) return;
+      if (isInert) {
+        child.setAttribute('aria-hidden', 'true');
+        try { child.inert = true; } catch (err) { /* inert may be readonly in tests */ }
+      } else {
+        child.removeAttribute('aria-hidden');
+        try { child.inert = false; } catch (err) { /* inert may be readonly in tests */ }
+      }
+    });
+  }
+
+  modalFocusableElements() {
+    const panel = this.statModalEl && this.statModalEl.querySelector('.ws-cmd-modal-panel');
+    if (!panel || typeof panel.querySelectorAll !== 'function') return [];
+    return Array.from(panel.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )).filter(el => el && !el.hidden && typeof el.focus === 'function');
+  }
+
+  trapStatModalFocus(event) {
+    if (!event || event.key !== 'Tab') return;
+    const focusable = this.modalFocusableElements();
+    if (!focusable.length) {
+      event.preventDefault();
+      const panel = this.statModalEl && this.statModalEl.querySelector('.ws-cmd-modal-panel');
+      if (panel && typeof panel.focus === 'function') panel.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const activeEl = typeof document !== 'undefined' ? document.activeElement : null;
+    if (event.shiftKey && activeEl === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && activeEl === last) {
+      event.preventDefault();
+      first.focus();
+    }
   }
 
   ensureStatModal() {
@@ -278,7 +613,9 @@ export class WorkspaceCommandView {
       if (event.key === 'Escape') {
         event.stopPropagation();
         this.closeStatModal();
+        return;
       }
+      this.trapStatModalFocus(event);
     });
     this.statModalEl = el;
     if (this.container && this.container.appendChild) this.container.appendChild(el);
@@ -726,12 +1063,14 @@ export class WorkspaceCommandView {
       const label = String(t.description || t.name || t.title || 'Task');
       const tone = this.taskTone(t.status);
       const statusText = String(t.status || 'pending').replace('_', ' ');
+      const taskId = String(t.id || '');
       return (
         '<div class="ws-cmd-quest">' +
         '<span class="ws-cmd-q-glyph">&bull;</span>' +
-        '<span class="ws-cmd-q-name">' + escapeHtml(label) + '</span>' +
+        '<button type="button" class="ws-cmd-q-name" data-cmd-open-task="' + escapeHtml(taskId) +
+        '" aria-label="Open task ' + escapeHtml(label) + '">' + escapeHtml(label) + '</button>' +
         '<span class="ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
-        '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' + escapeHtml(String(t.id || '')) +
+        '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' + escapeHtml(taskId) +
         '" title="Run" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
         '</div>'
       );
@@ -747,21 +1086,28 @@ export class WorkspaceCommandView {
     if (!units.length) {
       return '<div class="ws-cmd-soon">No agents yet.</div>';
     }
-    return '<div class="ws-cmd-garrison-grid">' + units.map((g) => this.unitCardHTML(g)).join('') + '</div>';
+    const gridClass = 'ws-cmd-garrison-grid' + (units.length > 1 && units.length % 2 === 1 ? ' is-odd' : '');
+    return '<div class="' + gridClass + '">' + units.map((g) => this.unitCardHTML(g)).join('') + '</div>';
   }
 
   bindGarrison() {
     const root = this.container && this.container.querySelector('.ws-cmd-garrison');
     if (!root) return;
     root.addEventListener('click', (event) => {
+      const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
       const addBtn = event.target.closest('[data-cmd-add-task]');
-      if (addBtn && window.workspaceDetail && window.workspaceDetail.showAddTaskModalForAgent) {
-        window.workspaceDetail.showAddTaskModalForAgent(addBtn.getAttribute('data-cmd-add-task'));
+      if (addBtn && page && page.showAddTaskModalForAgent) {
+        page.showAddTaskModalForAgent(addBtn.getAttribute('data-cmd-add-task'));
         return;
       }
       const runBtn = event.target.closest('[data-cmd-run-task]');
-      if (runBtn && window.workspaceDetail && window.workspaceDetail.executeTask) {
-        window.workspaceDetail.executeTask(runBtn.getAttribute('data-cmd-run-task'));
+      if (runBtn && page && page.executeTask) {
+        page.executeTask(runBtn.getAttribute('data-cmd-run-task'));
+        return;
+      }
+      const openBtn = event.target.closest('[data-cmd-open-task]');
+      if (openBtn && page && page.openTask) {
+        page.openTask(openBtn.getAttribute('data-cmd-open-task'));
       }
     });
   }
@@ -770,24 +1116,26 @@ export class WorkspaceCommandView {
 
   railPanelHTML(sectionKey, title, items, count, emptyText, primaryLabel) {
     const isManaging = this.activeRailSection === sectionKey;
-    const body = items.length
+    const hasItems = items.length > 0;
+    const shouldShowBody = hasItems || isManaging;
+    const body = hasItems
       ? items.join('')
       : '<div class="ws-cmd-rail-empty">' + escapeHtml(emptyText) + '</div>';
-    const actions = isManaging
-      ? '<div class="ws-cmd-panel-actions"><button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="' +
-        escapeHtml(sectionKey) + '">' + escapeHtml(primaryLabel) + '</button></div>'
-      : '';
     return (
-      '<section class="ws-cmd-panel' + (isManaging ? ' is-managing' : '') + '">' +
+      '<section class="ws-cmd-panel' + (isManaging ? ' is-managing' : '') + (!hasItems ? ' is-empty' : '') + '">' +
       '<div class="ws-cmd-panel-head">' +
       '<div class="ws-cmd-panel-title"><h4>' + escapeHtml(title) + '</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-tools">' +
+      '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="' +
+        escapeHtml(sectionKey) + '">' + escapeHtml(primaryLabel) + '</button>' +
       '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="' + escapeHtml(sectionKey) +
       '" aria-expanded="' + (isManaging ? 'true' : 'false') +
       '" title="' + (isManaging ? 'Close Command manager' : 'Manage in Command view') +
       '" aria-label="' + (isManaging ? 'Close ' : 'Manage ') +
       escapeHtml(title) + ' in Command view">' + (isManaging ? '×' : '▸') + '</button>' +
       '</div>' +
-      '<div class="ws-cmd-panel-body">' + actions + body + '</div>' +
+      '</div>' +
+      (shouldShowBody ? '<div class="ws-cmd-panel-body">' + body + '</div>' : '') +
       '</section>'
     );
   }

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -43,6 +43,13 @@ function makeSectionClickTarget(section) {
 function makeAttributeClickTarget(attrs) {
   return {
     closest(selector) {
+      if (selector.includes('data-cmd-open-task') && attrs['data-cmd-open-task']) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
       if (selector.includes('data-cmd-primary-section') && attrs['data-cmd-primary-section']) {
         return {
           getAttribute(name) {
@@ -141,8 +148,11 @@ test('rendered command copy uses detailed-view vocabulary', () => {
     toggleBtn: makeToggleButton(),
     active: true,
     page: {
+      workspaceId: 'workspace-1',
       workspace: {
         name: 'Demo Workspace',
+        description: 'A focused production workspace for launch planning and execution.',
+        tags: ['launch', 'ops'],
         workspace_settings: { workflow: { mode: 'guided' } },
         mcp_bindings: [],
         skill_bindings: []
@@ -179,16 +189,27 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   commandView.render();
 
   assert.match(container.innerHTML, /Workflow · Guided/);
+  assert.match(container.innerHTML, /A focused production workspace/);
+  assert.match(container.innerHTML, /launch/);
+  assert.match(container.innerHTML, /href="\/workspaces"/);
+  assert.match(container.innerHTML, /href="\/workspaces\/workspace-1\/canvas"/);
+  assert.match(container.innerHTML, /href="\/workspaces\/workspace-1\/diagnostics"/);
+  assert.match(container.innerHTML, /href="\/workflows"/);
+  assert.match(container.innerHTML, /data-cmd-edit-identity="name"/);
+  assert.match(container.innerHTML, /data-cmd-edit-identity="description"/);
+  assert.match(container.innerHTML, /data-cmd-edit-identity="tags"/);
   assert.match(container.innerHTML, /<div class="ws-l">Open Tasks<\/div>/);
   assert.match(container.innerHTML, /<div class="ws-l">MCP<\/div>/);
   assert.match(container.innerHTML, />Notes<\/h4>/);
   assert.match(container.innerHTML, />Schedules<\/h4>/);
   assert.match(container.innerHTML, />Sessions<\/h4>/);
   assert.match(container.innerHTML, />Linked Folders<\/h4>/);
-  assert.match(container.innerHTML, /No notes yet\./);
-  assert.match(container.innerHTML, /No schedules yet\./);
-  assert.match(container.innerHTML, /No sessions yet\./);
-  assert.match(container.innerHTML, /No linked folders yet\./);
+  assert.match(container.innerHTML, /data-cmd-primary-section="notes"/);
+  assert.match(container.innerHTML, /data-cmd-primary-section="folders"/);
+  assert.doesNotMatch(container.innerHTML, /No notes yet\./);
+  assert.doesNotMatch(container.innerHTML, /No schedules yet\./);
+  assert.doesNotMatch(container.innerHTML, /No sessions yet\./);
+  assert.doesNotMatch(container.innerHTML, /No linked folders yet\./);
   assert.match(container.innerHTML, /★ Entry Agent/);
   assert.match(container.innerHTML, />Model<\/span>/);
   assert.match(container.innerHTML, /Tasks · 1/);
@@ -246,6 +267,74 @@ test('command rail badges project and reference directory roles', () => {
   assert.match(html, /Reference/);
   assert.match(html, /data-cmd-item-id="dir-project"/);
   assert.match(html, /data-cmd-item-id="dir-ref"/);
+});
+
+test('empty rail panels collapse to the header but keep primary actions', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      workspace: {}
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.match(html, /data-cmd-primary-section="notes"/);
+  assert.match(html, /data-cmd-primary-section="schedules"/);
+  assert.match(html, /data-cmd-primary-section="sessions"/);
+  assert.match(html, /data-cmd-primary-section="folders"/);
+  assert.doesNotMatch(html, /No notes yet\./);
+
+  commandView.activeRailSection = 'notes';
+  const managingHtml = commandView.renderRail();
+  assert.match(managingHtml, /No notes yet\./);
+});
+
+test('escape closes the active rail manager without leaving Command', () => {
+  const renders = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: true,
+    activeRailSection: 'notes',
+    statModalSection: '',
+    identityEditMode: '',
+    render() {
+      renders.push(this.activeRailSection);
+    }
+  });
+
+  commandView.handleGlobalKeydown({ key: 'Escape' });
+
+  assert.equal(commandView.activeRailSection, '');
+  assert.deepEqual(renders, ['']);
+});
+
+test('Open Tasks stat is tinted when any task needs attention', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityExpanded: false,
+    identityEditMode: '',
+    page: {
+      workspaceId: 'workspace-1',
+      workspace: { name: 'Attention Workspace', mcp_bindings: [], skill_bindings: [] },
+      tasks: [{ status: 'blocked' }],
+      buildAgentGroups: () => []
+    }
+  });
+
+  const html = commandView.commandBarHTML(
+    commandView.page.workspace,
+    commandView.page.workspace.name,
+    '',
+    commandView.computeStats()
+  );
+
+  assert.match(html, /class="ws-cmd-stat is-alert" data-cmd-section="tasks"/);
 });
 
 test('stat clicks open the in-place manager modal without leaving Command view', () => {
@@ -375,6 +464,139 @@ test('rail item actions open existing management flows from Command view', () =>
     ['session', 'session-1'],
     ['folder', 'dir-1', 'owned']
   ]);
+});
+
+test('quest-log task name opens the existing task flow', () => {
+  const garrisonRoot = makeListenerRoot();
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-garrison' ? garrisonRoot : null;
+      }
+    },
+    page: {
+      openTask(id) { calls.push(['open', id]); },
+      executeTask(id) { calls.push(['run', id]); }
+    }
+  });
+
+  commandView.bindGarrison();
+
+  garrisonRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-open-task': 'task-1' })
+  });
+
+  assert.deepEqual(calls, [['open', 'task-1']]);
+});
+
+test('identity saves delegate to the workspace detail save helpers', async () => {
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityEditMode: 'name',
+    identitySaving: false,
+    renderCalls: 0,
+    render() {
+      this.renderCalls += 1;
+    },
+    page: {
+      workspace: { name: 'Old Name', description: 'Old description' },
+      async saveWorkspaceIdentityField(field, value, options) {
+        calls.push([field, value, options.currentValue]);
+        this.workspace.name = value;
+        return { changed: true, workspace: this.workspace };
+      }
+    }
+  });
+
+  await commandView.saveIdentityField('name', 'New Name');
+
+  assert.deepEqual(calls, [['name', 'New Name', 'Old Name']]);
+  assert.equal(commandView.identityEditMode, '');
+  assert.equal(commandView.identitySaving, false);
+  assert.equal(commandView.renderCalls, 1);
+});
+
+test('command tag saves use saveWorkspaceTagList and close the editor', async () => {
+  const saved = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityEditMode: 'tags',
+    identitySaving: false,
+    commandTagDraft: ['alpha', 'beta'],
+    commandTagInput: null,
+    renderCalls: 0,
+    render() {
+      this.renderCalls += 1;
+    },
+    destroyCommandTagInput() {},
+    page: {
+      async saveWorkspaceTagList(tags) {
+        saved.push(tags);
+      }
+    }
+  });
+
+  await commandView.saveCommandTags();
+
+  assert.deepEqual(saved, [['alpha', 'beta']]);
+  assert.equal(commandView.identityEditMode, '');
+  assert.equal(commandView.identitySaving, false);
+  assert.equal(commandView.renderCalls, 1);
+});
+
+test('stat modal inerts command background and traps tab focus', () => {
+  const topbar = {
+    attrs: {},
+    inert: false,
+    setAttribute(name, value) { this.attrs[name] = value; },
+    removeAttribute(name) { delete this.attrs[name]; }
+  };
+  const layout = {
+    attrs: {},
+    inert: false,
+    setAttribute(name, value) { this.attrs[name] = value; },
+    removeAttribute(name) { delete this.attrs[name]; }
+  };
+  const modal = {};
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: { children: [topbar, layout, modal] },
+    statModalEl: modal
+  });
+
+  commandView.setCommandBackgroundInert(true);
+  assert.equal(topbar.attrs['aria-hidden'], 'true');
+  assert.equal(layout.inert, true);
+
+  commandView.setCommandBackgroundInert(false);
+  assert.equal(topbar.attrs['aria-hidden'], undefined);
+  assert.equal(layout.inert, false);
+
+  const first = { hidden: false, focused: 0, focus() { this.focused += 1; } };
+  const last = { hidden: false, focused: 0, focus() { this.focused += 1; } };
+  const originalDocument = globalThis.document;
+  globalThis.document = { activeElement: last };
+  commandView.statModalEl = {
+    querySelector() {
+      return {
+        querySelectorAll() {
+          return [first, last];
+        }
+      };
+    }
+  };
+  let prevented = 0;
+  try {
+    commandView.trapStatModalFocus({ key: 'Tab', preventDefault() { prevented += 1; } });
+  } finally {
+    globalThis.document = originalDocument;
+  }
+
+  assert.equal(prevented, 1);
+  assert.equal(first.focused, 1);
 });
 
 test('mcp manager modal lists bindings with add and detailed-view escape hatch', () => {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -1828,6 +1828,77 @@ export class WorkspaceDetailPage {
     return result;
   }
 
+  async saveWorkspaceIdentityField(field, value, options = {}) {
+    const key = String(field || '').trim();
+    if (key !== 'name' && key !== 'description') return { changed: false };
+
+    const newValue = String(value || '').trim();
+    const hasCurrent = Object.prototype.hasOwnProperty.call(options, 'currentValue');
+    const currentValue = hasCurrent ? String(options.currentValue || '').trim() : null;
+    if (hasCurrent && newValue === currentValue) return { changed: false };
+
+    if (key === 'name' && !newValue) {
+      if (window.Toast) window.Toast.error('Name cannot be empty');
+      return { changed: false, invalid: true };
+    }
+
+    try {
+      let result;
+      if (key === 'name') {
+        result = await this.renameWorkspace(newValue);
+      } else {
+        result = await this.updateWorkspace({ [key]: newValue });
+      }
+
+      const updatedWorkspace = result?.folder || result?.workspace || null;
+      if (updatedWorkspace && typeof updatedWorkspace === 'object') {
+        this.workspace = {
+          ...(this.workspace || {}),
+          ...updatedWorkspace
+        };
+      } else if (this.workspace) {
+        this.workspace[key] = newValue;
+        if (key === 'description') {
+          this.workspace.shared_data =
+            this.workspace.shared_data && typeof this.workspace.shared_data === 'object'
+              ? this.workspace.shared_data
+              : {};
+          this.workspace.shared_data.workspace_bootstrap = {
+            ...(this.workspace.shared_data.workspace_bootstrap || {}),
+            goal: newValue
+          };
+        }
+      }
+
+      await this.renderWorkspaceInfo();
+      if (key === 'description') {
+        await this.loadNotes();
+      }
+
+      if (window.Toast) {
+        if (key === 'name') {
+          const appliedSlug = String(updatedWorkspace?.folder_slug || '').trim();
+          const expectedSlug = slugifyWorkspaceName(newValue);
+          window.Toast.success(
+            appliedSlug && expectedSlug && appliedSlug !== expectedSlug
+              ? `Workspace renamed. Folder saved as "${appliedSlug}".`
+              : 'Workspace renamed'
+          );
+        } else {
+          window.Toast.success('Description updated');
+        }
+      }
+
+      window.workspaceCommand?.refresh();
+      return { changed: true, workspace: this.workspace };
+    } catch (err) {
+      console.error(`Failed to update ${key}:`, err);
+      if (!err?.cancelled && window.Toast)
+        window.Toast.error(err.message || `Failed to update ${key}`);
+      return { changed: false, error: err };
+    }
+  }
+
   /**
    * Create inline editable element
    * @param {HTMLElement} element - The element to make editable
@@ -1874,63 +1945,7 @@ export class WorkspaceDetailPage {
 
         if (!save || newValue === currentValue) return;
 
-        // For name, don't allow empty
-        if (field === 'name' && !newValue) {
-          if (window.Toast) window.Toast.error('Name cannot be empty');
-          return;
-        }
-
-        try {
-          let result;
-          if (field === 'name') {
-            result = await this.renameWorkspace(newValue);
-          } else {
-            result = await this.updateWorkspace({ [field]: newValue });
-          }
-
-          const updatedWorkspace = result?.folder || result?.workspace || null;
-          if (updatedWorkspace && typeof updatedWorkspace === 'object') {
-            this.workspace = {
-              ...(this.workspace || {}),
-              ...updatedWorkspace
-            };
-          } else if (this.workspace) {
-            this.workspace[field] = newValue;
-            if (field === 'description') {
-              this.workspace.shared_data =
-                this.workspace.shared_data && typeof this.workspace.shared_data === 'object'
-                  ? this.workspace.shared_data
-                  : {};
-              this.workspace.shared_data.workspace_bootstrap = {
-                ...(this.workspace.shared_data.workspace_bootstrap || {}),
-                goal: newValue
-              };
-            }
-          }
-
-          await this.renderWorkspaceInfo();
-          if (field === 'description') {
-            await this.loadNotes();
-          }
-
-          if (window.Toast) {
-            if (field === 'name') {
-              const appliedSlug = String(updatedWorkspace?.folder_slug || '').trim();
-              const expectedSlug = slugifyWorkspaceName(newValue);
-              window.Toast.success(
-                appliedSlug && expectedSlug && appliedSlug !== expectedSlug
-                  ? `Workspace renamed. Folder saved as "${appliedSlug}".`
-                  : 'Workspace renamed'
-              );
-            } else {
-              window.Toast.success('Description updated');
-            }
-          }
-        } catch (err) {
-          console.error(`Failed to update ${field}:`, err);
-          if (!err?.cancelled && window.Toast)
-            window.Toast.error(err.message || `Failed to update ${field}`);
-        }
+        await this.saveWorkspaceIdentityField(field, newValue, { currentValue });
       };
 
       input.addEventListener('blur', () => finishEdit(true));
@@ -2051,15 +2066,34 @@ export class WorkspaceDetailPage {
     errorEl.hidden = text === '';
   }
 
+  async saveWorkspaceTagList(tags) {
+    const result = this.normalizeWorkspaceTagList(tags);
+    if (result.error) {
+      const validationError = new Error(result.error);
+      validationError.validation = true;
+      throw validationError;
+    }
+
+    const response = await this.updateWorkspace({ tags: result.tags });
+    const updatedWorkspace = response?.folder || response?.workspace || {};
+    const updatedTags = Array.isArray(updatedWorkspace.tags) ? updatedWorkspace.tags : result.tags;
+    this.workspace = {
+      ...(this.workspace || {}),
+      ...updatedWorkspace,
+      tags: updatedTags
+    };
+    this.renderWorkspaceTags();
+    // New tags should show up in suggestions everywhere right away.
+    window.OriTagInput?.clearTagPoolCache?.();
+    window.workspaceCommand?.refresh();
+    if (window.Toast) window.Toast.success('Tags updated');
+    return updatedTags;
+  }
+
   async saveWorkspaceTags() {
     if (this.workspaceTagsSaving) return;
 
     const draft = this.workspaceTagInput ? this.workspaceTagInput.getTags() : this.workspaceTagDraft;
-    const result = this.normalizeWorkspaceTagList(draft);
-    if (result.error) {
-      this.setWorkspaceTagsError(result.error);
-      return;
-    }
 
     this.workspaceTagsSaving = true;
     if (this.elements.workspaceTagsSaveBtn) {
@@ -2067,19 +2101,8 @@ export class WorkspaceDetailPage {
     }
 
     try {
-      const response = await this.updateWorkspace({ tags: result.tags });
-      const updatedWorkspace = response?.folder || response?.workspace || {};
-      const updatedTags = Array.isArray(updatedWorkspace.tags) ? updatedWorkspace.tags : result.tags;
-      this.workspace = {
-        ...(this.workspace || {}),
-        ...updatedWorkspace,
-        tags: updatedTags
-      };
+      await this.saveWorkspaceTagList(draft);
       this.closeWorkspaceTagsEditor();
-      this.renderWorkspaceTags();
-      // New tags should show up in suggestions everywhere right away.
-      window.OriTagInput?.clearTagPoolCache?.();
-      if (window.Toast) window.Toast.success('Tags updated');
     } catch (error) {
       console.error('Failed to update workspace tags:', error);
       this.setWorkspaceTagsError(error.message || 'Failed to update tags');

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -332,6 +332,53 @@ test('workspace detail entity loaders refresh Command view after completion', as
   assert.equal(refreshCount, 4);
 });
 
+test('workspace detail reusable identity and tag saves update workspace state', async () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = { id: 'workspace-1', name: 'Old Name', description: '', tags: ['old'] };
+  page.elements = {};
+  page.renderWorkspaceInfo = async () => {};
+  page.renderWorkspaceTags = () => {};
+  page.loadNotes = async () => {};
+
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+  const requests = [];
+  global.window = {
+    ...originalWindow,
+    Toast: { success() {}, error() {} },
+    OriTagInput: { clearTagPoolCache() {} },
+    workspaceCommand: { refresh() {} }
+  };
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url: String(url), body: options.body || '' });
+    if (String(url).endsWith('/rename')) {
+      return {
+        ok: true,
+        json: async () => ({ folder: { id: 'workspace-1', name: 'New Name', folder_slug: 'new-name' } })
+      };
+    }
+    return {
+      ok: true,
+      json: async () => ({ folder: { id: 'workspace-1', tags: ['alpha', 'beta'] } })
+    };
+  };
+
+  try {
+    await page.saveWorkspaceIdentityField('name', 'New Name', { currentValue: 'Old Name' });
+    const tags = await page.saveWorkspaceTagList(['Alpha', 'beta']);
+
+    assert.equal(page.workspace.name, 'New Name');
+    assert.deepEqual(tags, ['alpha', 'beta']);
+    assert.deepEqual(page.workspace.tags, ['alpha', 'beta']);
+    assert.match(requests[0].url, /\/api\/workspaces\/workspace-1\/rename$/);
+    assert.match(requests[1].url, /\/api\/workspaces\/workspace-1$/);
+    assert.match(requests[1].body, /"tags":\["alpha","beta"\]/);
+  } finally {
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+  }
+});
+
 test('workspace detail protects the managed project directory row', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   const list = { innerHTML: '' };


### PR DESCRIPTION
## Summary
- add Command-view workspace identity editing for name, description, and tags through the existing Detailed view save paths
- add Command topbar navigation links, responsive identity layout, rail header actions, and Escape behavior
- add Open Tasks alert tinting plus stat modal inert background and focus trapping

## Verification
- make test-js
- npm run lint
- git diff --check
- go test ./internal/web/...
- ./scripts/build-server.sh
- browser smoke for identity edits, tags, nav links, rail behavior, stat modal focus/inert behavior, and mobile overflow