### PR TITLE
feat(workspace-command): mission panel (goal, automation, run now, findings)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -146,6 +146,60 @@
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
 .ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
+.ws-cmd-main { min-width: 0; display: flex; flex-direction: column; gap: 18px; }
+.ws-cmd-mission {
+  display: flex; justify-content: space-between; align-items: stretch; gap: 16px; min-width: 0;
+  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014);
+  padding: 14px 16px;
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
+  box-shadow: var(--ws-glow);
+}
+.ws-cmd-mission-main { min-width: 0; display: flex; flex-direction: column; gap: 8px; }
+.ws-cmd-mission-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.ws-cmd-mission-kicker {
+  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-faction);
+}
+.ws-cmd-mission-status {
+  display: inline-flex; align-items: center; min-height: 21px; padding: 3px 8px; border: 1px solid var(--ws-line-bright);
+  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.1px; text-transform: uppercase; color: var(--ws-ink-dim);
+  background: rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-mission-status.is-enabled { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.07); }
+.ws-cmd-mission-status.is-paused,
+.ws-cmd-mission-status.is-manual { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.07); }
+.ws-cmd-mission-status.is-empty,
+.ws-cmd-mission-status.is-loading { color: var(--ws-ink-faint); }
+.ws-cmd-mission-title {
+  margin: 0; color: #eef0f3; font-size: 17px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase;
+}
+.ws-cmd-mission-text {
+  max-width: 88ch; margin: 0; color: var(--ws-ink); font-size: 13.5px; line-height: 1.45;
+}
+.ws-cmd-mission-text.is-empty { color: var(--ws-ink-faint); font-style: italic; }
+.ws-cmd-mission-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
+.ws-cmd-mission-meta span {
+  display: inline-flex; align-items: center; min-height: 22px; padding: 3px 8px; border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18); color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 0.7px; text-transform: uppercase;
+}
+.ws-cmd-mission-action-status {
+  min-height: 15px; color: var(--ws-ink-dim); font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 0.4px;
+}
+.ws-cmd-mission-action-status.is-error { color: var(--ws-alert); }
+.ws-cmd-mission-actions { display: flex; align-items: flex-start; justify-content: flex-end; gap: 8px; flex-wrap: wrap; flex: 0 0 auto; }
+.ws-cmd-mission-btn {
+  min-height: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase;
+  text-decoration: none; transition: 0.13s;
+}
+.ws-cmd-mission-btn.is-primary {
+  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-mission-btn.has-findings { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.08); }
+.ws-cmd-mission-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); text-decoration: none; }
+.ws-cmd-mission-btn:disabled { color: var(--ws-ink-faint); border-color: var(--ws-line); cursor: not-allowed; opacity: 0.72; }
+.ws-cmd-mission-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-cmd-garrison {
   border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014); min-height: 200px;
   clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
@@ -357,6 +411,8 @@
 }
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
+  .ws-cmd-mission { flex-direction: column; }
+  .ws-cmd-mission-actions { justify-content: flex-start; }
 }
 @media (max-width: 640px) {
   .ws-cmd-nav-btn { flex: 1 1 calc(50% - 8px); justify-content: center; }
@@ -365,6 +421,7 @@
   .ws-cmd-panel-head { align-items: flex-start; }
   .ws-cmd-panel-tools { flex-wrap: wrap; justify-content: flex-end; }
   .ws-cmd-readout .ws-cmd-stat { flex: 1 1 calc(50% - 10px); }
+  .ws-cmd-mission-actions .ws-cmd-mission-btn { flex: 1 1 calc(50% - 8px); }
 }
 
 /* Auto-playing motion is opt-in via the OS "reduce motion" preference. */
@@ -372,7 +429,7 @@
 @keyframes ws-cmd-pulse { 50% { opacity: 0.35; } }
 @media (prefers-reduced-motion: no-preference) {
   .ws-cmd-topbar { animation: ws-cmd-rise 0.35s ease both; }
-  .ws-cmd-garrison, .ws-cmd-rail { animation: ws-cmd-rise 0.4s ease both; animation-delay: 0.05s; }
+  .ws-cmd-mission, .ws-cmd-garrison, .ws-cmd-rail { animation: ws-cmd-rise 0.4s ease both; animation-delay: 0.05s; }
   .ws-cmd-led.working { animation: ws-cmd-pulse 1.5s ease-in-out infinite; }
   .ws-cmd-modal-panel { animation: ws-cmd-rise 0.22s ease both; }
 }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -177,6 +177,21 @@ export class WorkspaceCommandView {
     }
   }
 
+  missionSummary() {
+    const mission = typeof window !== 'undefined' ? window.workspaceMission : null;
+    if (mission && typeof mission.getSummary === 'function') {
+      try { return mission.getSummary() || {}; } catch (err) { return {}; }
+    }
+    return {};
+  }
+
+  commandSubtitle(mode) {
+    const workflow = mode ? 'Workflow · ' + mode : '';
+    const mission = this.missionSummary();
+    const missionLabel = mission && mission.label ? 'Mission · ' + mission.label : '';
+    return [workflow, missionLabel].filter(Boolean).join(' · ');
+  }
+
   workspaceId() {
     const page = this.page || {};
     return String(page.workspaceId || (page.workspace && page.workspace.id) || '').trim();
@@ -236,6 +251,8 @@ export class WorkspaceCommandView {
       (isLongDescription && !this.identityExpanded ? ' is-collapsed' : '');
     const descriptionText = description || 'No description';
     const workflowHref = this.workflowHref();
+    const workflowLabel = mode ? 'Workflow · ' + mode : '';
+    const subtitle = this.commandSubtitle(mode);
 
     return (
       '<header class="ws-cmd-topbar">' +
@@ -256,7 +273,8 @@ export class WorkspaceCommandView {
       '<h2>' + escapeHtml(name) + '</h2>' +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="name" aria-label="Edit workspace name">Edit</button>' +
       '</div>' +
-      (mode ? '<div class="ws-sub">Workflow · ' + escapeHtml(mode) + '</div>' : '') +
+      '<div class="ws-sub" id="workspace-command-subtitle" data-workflow-label="' +
+      escapeHtml(workflowLabel) + '"' + (subtitle ? '' : ' hidden') + '>' + escapeHtml(subtitle) + '</div>' +
       '<div class="ws-cmd-description-row">' +
       '<p class="' + descriptionClass + '">' + escapeHtml(descriptionText) + '</p>' +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="description" aria-label="Edit workspace description">Edit</button>' +
@@ -278,6 +296,54 @@ export class WorkspaceCommandView {
       this.statBoxHTML(stats.skills, 'Skills', 'skills', 'Open Skills settings') +
       '</div>' +
       '</header>'
+    );
+  }
+
+  renderMissionPanel() {
+    const summary = this.missionSummary();
+    const missionText = String(summary.mission || '').trim();
+    const title = summary.title || (missionText ? 'Current goal' : 'Workspace goal');
+    const text = summary.text || (missionText || 'Loading workspace goal...');
+    const statusLabel = summary.label || 'Loading';
+    const statusClass = summary.className || 'is-loading';
+    const cadence = summary.cadenceLabel || 'Cadence: loading';
+    const nextRun = summary.nextLabel || 'Next: loading';
+    const lastRun = summary.lastLabel || 'Last: loading';
+    const findingsHref = summary.findingsHref || (this.workspaceId()
+      ? '/action-center?workspace=' + encodeURIComponent(this.workspaceId())
+      : '/action-center');
+    const findingsLabel = summary.findingsLabel || 'Findings';
+    const runDisabled = summary.canRun === true ? '' : ' disabled';
+    const runTitle = summary.runTitle || 'Set a goal before running';
+    const actionStatus = summary.actionStatus || '';
+
+    return (
+      '<section class="ws-cmd-mission" id="workspace-command-mission-card" aria-labelledby="workspace-command-mission-title">' +
+      '<div class="ws-cmd-mission-main">' +
+      '<div class="ws-cmd-mission-head">' +
+      '<span class="ws-cmd-mission-kicker">Mission</span>' +
+      '<span class="ws-cmd-mission-status ' + escapeHtml(statusClass) + '" id="workspace-command-mission-status">' +
+      escapeHtml(statusLabel) + '</span>' +
+      '</div>' +
+      '<h3 id="workspace-command-mission-title" class="ws-cmd-mission-title">' + escapeHtml(title) + '</h3>' +
+      '<p id="workspace-command-mission-text" class="ws-cmd-mission-text' + (missionText ? '' : ' is-empty') + '">' +
+      escapeHtml(text) + '</p>' +
+      '<div class="ws-cmd-mission-meta" aria-label="Mission automation timing">' +
+      '<span id="workspace-command-mission-cadence">' + escapeHtml(cadence) + '</span>' +
+      '<span id="workspace-command-mission-next-run">' + escapeHtml(nextRun) + '</span>' +
+      '<span id="workspace-command-mission-last-run">' + escapeHtml(lastRun) + '</span>' +
+      '</div>' +
+      '<div class="ws-cmd-mission-action-status" id="workspace-command-mission-action-status" aria-live="polite">' +
+      escapeHtml(actionStatus) + '</div>' +
+      '</div>' +
+      '<div class="ws-cmd-mission-actions">' +
+      '<button type="button" class="ws-cmd-mission-btn" id="workspace-command-mission-edit" data-cmd-mission-action="edit">Set Goal</button>' +
+      '<button type="button" class="ws-cmd-mission-btn is-primary" id="workspace-command-mission-run" data-cmd-mission-action="run"' +
+      runDisabled + ' title="' + escapeHtml(runTitle) + '">Run now</button>' +
+      '<a class="ws-cmd-mission-btn" id="workspace-command-mission-findings" href="' + escapeHtml(findingsHref) + '">' +
+      escapeHtml(findingsLabel) + '</a>' +
+      '</div>' +
+      '</section>'
     );
   }
 
@@ -338,7 +404,10 @@ export class WorkspaceCommandView {
     this.container.innerHTML =
       this.commandBarHTML(ws, name, mode, stats) +
       '<div class="ws-cmd-layout">' +
+      '<main class="ws-cmd-main">' +
+      this.renderMissionPanel() +
       '<section class="ws-cmd-garrison">' + this.renderGarrison() + '</section>' +
+      '</main>' +
       '<aside class="ws-cmd-rail">' + this.renderRail() + '</aside>' +
       '</div>';
 
@@ -346,9 +415,11 @@ export class WorkspaceCommandView {
     if (back) back.addEventListener('click', () => this.deactivate());
     this.bindIdentityControls();
     this.bindReadout();
+    this.bindMissionPanel();
     this.bindGarrison();
     this.bindRail();
     this.mountCommandTagInput();
+    this.syncMissionPanel();
 
     // The stat manager modal lives inside the .ws-cmd container (so it inherits
     // the tactical tokens) but survives full re-renders: re-attach + repaint it.
@@ -502,6 +573,29 @@ export class WorkspaceCommandView {
       if (!sectionBtn) return;
       this.openStatModal(sectionBtn.getAttribute('data-cmd-section'), sectionBtn);
     });
+  }
+
+  bindMissionPanel() {
+    const root = this.container && this.container.querySelector('.ws-cmd-mission');
+    if (!root) return;
+    root.addEventListener('click', (event) => {
+      const btn = event.target.closest('[data-cmd-mission-action]');
+      if (!btn) return;
+      const action = btn.getAttribute('data-cmd-mission-action');
+      const mission = typeof window !== 'undefined' ? window.workspaceMission : null;
+      if (action === 'edit' && mission && typeof mission.openGoalModal === 'function') {
+        mission.openGoalModal();
+      } else if (action === 'run' && mission && typeof mission.runNow === 'function') {
+        mission.runNow(btn);
+      }
+    });
+  }
+
+  syncMissionPanel() {
+    const mission = typeof window !== 'undefined' ? window.workspaceMission : null;
+    if (mission && typeof mission.renderCommandSurfaces === 'function') {
+      mission.renderCommandSurfaces();
+    }
   }
 
   /** Escape hatch: leave the Command view for the full detailed section. */

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { WorkspaceCommandView } from './workspace-command.js';
 
 // The constructor only reads the DOM (getElementById) and returns early from
@@ -43,6 +44,13 @@ function makeSectionClickTarget(section) {
 function makeAttributeClickTarget(attrs) {
   return {
     closest(selector) {
+      if (selector.includes('data-cmd-mission-action') && attrs['data-cmd-mission-action']) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
       if (selector.includes('data-cmd-open-task') && attrs['data-cmd-open-task']) {
         return {
           getAttribute(name) {
@@ -189,6 +197,8 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   commandView.render();
 
   assert.match(container.innerHTML, /Workflow · Guided/);
+  assert.match(container.innerHTML, /workspace-command-mission-card/);
+  assert.match(container.innerHTML, /Mission/);
   assert.match(container.innerHTML, /A focused production workspace/);
   assert.match(container.innerHTML, /launch/);
   assert.match(container.innerHTML, /href="\/workspaces"/);
@@ -221,6 +231,163 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   // per-agent quest-log header stay "Tasks" since those list every task
   // regardless of status, so "Open Tasks" there would misdescribe them.
   assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Tools · MCP|Ops mode|Deploy|✦/);
+});
+
+test('command subtitle includes mission automation state when mission state is loaded', () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    workspaceMission: {
+      getSummary: () => ({ label: 'Enabled' })
+    }
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityExpanded: false,
+    identityEditMode: '',
+    page: {
+      workspaceId: 'workspace-1',
+      workspace: { name: 'Mission Workspace', description: '', mcp_bindings: [], skill_bindings: [] },
+      tasks: [],
+      buildAgentGroups: () => []
+    }
+  });
+
+  try {
+    const html = commandView.commandBarHTML(
+      commandView.page.workspace,
+      commandView.page.workspace.name,
+      'Guided',
+      commandView.computeStats()
+    );
+
+    assert.match(html, /Workflow · Guided · Mission · Enabled/);
+    assert.match(html, /id="workspace-command-subtitle"/);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('mission panel renders loaded goal state and findings link', () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    workspaceMission: {
+      getSummary: () => ({
+        mission: 'Keep launch readiness current.',
+        label: 'Enabled',
+        className: 'is-enabled',
+        title: 'Current goal',
+        text: 'Keep launch readiness current.',
+        cadenceLabel: 'Cadence: Daily at 09:00',
+        nextLabel: 'Next: in 2h',
+        lastLabel: 'Last: 1h ago',
+        canRun: true,
+        runTitle: 'Run this goal check now',
+        findingsHref: '/action-center?workspace=workspace-1',
+        findingsLabel: 'Findings (2)',
+        actionStatus: ''
+      })
+    }
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: { workspaceId: 'workspace-1', workspace: { id: 'workspace-1' } }
+  });
+
+  try {
+    const html = commandView.renderMissionPanel();
+
+    assert.match(html, /Keep launch readiness current\./);
+    assert.match(html, /ws-cmd-mission-status is-enabled/);
+    assert.match(html, /Cadence: Daily at 09:00/);
+    assert.match(html, /href="\/action-center\?workspace=workspace-1"/);
+    assert.match(html, />Findings \(2\)<\/a>/);
+    assert.doesNotMatch(html, /id="workspace-command-mission-run"[^>]* disabled/);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('mission panel disables Run Now when no saved goal is runnable', () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    workspaceMission: {
+      getSummary: () => ({
+        mission: '',
+        label: 'Not set',
+        className: 'is-empty',
+        title: 'No goal set',
+        text: 'No workspace goal yet.',
+        cadenceLabel: 'Cadence: Manual only',
+        nextLabel: 'Next: not scheduled',
+        lastLabel: 'Last: never',
+        canRun: false,
+        runTitle: 'Set a goal before running'
+      })
+    }
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: { workspaceId: 'workspace-1', workspace: { id: 'workspace-1' } }
+  });
+
+  try {
+    const html = commandView.renderMissionPanel();
+
+    assert.match(html, /No workspace goal yet\./);
+    assert.match(html, /id="workspace-command-mission-run"[^>]* disabled/);
+    assert.match(html, /title="Set a goal before running"/);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('mission panel actions delegate to workspace mission APIs', () => {
+  const missionRoot = makeListenerRoot();
+  const calls = [];
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    workspaceMission: {
+      openGoalModal() { calls.push('edit'); },
+      runNow(button) { calls.push(['run', button.getAttribute('data-cmd-mission-action')]); }
+    }
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-mission' ? missionRoot : null;
+      }
+    }
+  });
+
+  try {
+    commandView.bindMissionPanel();
+    missionRoot.listener({
+      target: makeAttributeClickTarget({ 'data-cmd-mission-action': 'edit' })
+    });
+    missionRoot.listener({
+      target: makeAttributeClickTarget({ 'data-cmd-mission-action': 'run' })
+    });
+
+    assert.deepEqual(calls, ['edit', ['run', 'run']]);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('goal modal is outside the hidden detailed view and keeps accessibility hooks', () => {
+  const template = readFileSync(new URL('../../../templates/pages/workspace-detail.tmpl', import.meta.url), 'utf8');
+  const detailStart = template.indexOf('id="workspace-detail-view"');
+  const detailEnd = template.indexOf('{{template "session-modals.tmpl" .}}');
+  const modalIndex = template.indexOf('id="workspace-detail-goal-modal"');
+  const addFileIndex = template.indexOf('id="hubAddFileModal"');
+
+  assert.ok(detailStart > -1);
+  assert.ok(detailEnd > detailStart);
+  assert.ok(modalIndex > detailEnd);
+  assert.ok(modalIndex < addFileIndex);
+  assert.match(template, /aria-labelledby="workspace-detail-goal-modal-title"/);
+  assert.match(template, /id="workspace-detail-goal-modal-form"/);
 });
 
 test('command rail renders project_path fallback when no directories are loaded', () => {

--- a/internal/web/static/js/modules/workspace-mission.js
+++ b/internal/web/static/js/modules/workspace-mission.js
@@ -77,6 +77,18 @@
     goalModalAutonomy: '#workspace-detail-goal-modal-autonomy',
     goalModalBindingsWarning: '#workspace-detail-goal-modal-bindings-warning',
     goalModalUnclassifiedList: '#workspace-detail-goal-modal-unclassified-list',
+    commandSubtitle: '#workspace-command-subtitle',
+    commandCard: '#workspace-command-mission-card',
+    commandStatus: '#workspace-command-mission-status',
+    commandTitle: '#workspace-command-mission-title',
+    commandText: '#workspace-command-mission-text',
+    commandCadence: '#workspace-command-mission-cadence',
+    commandNextRun: '#workspace-command-mission-next-run',
+    commandLastRun: '#workspace-command-mission-last-run',
+    commandActionStatus: '#workspace-command-mission-action-status',
+    commandEditBtn: '#workspace-command-mission-edit',
+    commandRunBtn: '#workspace-command-mission-run',
+    commandFindingsBtn: '#workspace-command-mission-findings',
   };
 
   // Plain-language summary of each autonomy policy. The quick-edit modal only
@@ -194,6 +206,13 @@
 
   function setGoalActionStatus(msg, kind) {
     const el = $(SELECTORS.goalActionStatus);
+    if (!el) return;
+    el.textContent = msg || '';
+    el.classList.toggle('is-error', kind === 'error');
+  }
+
+  function setCommandActionStatus(msg, kind) {
+    const el = $(SELECTORS.commandActionStatus);
     if (!el) return;
     el.textContent = msg || '';
     el.classList.toggle('is-error', kind === 'error');
@@ -362,6 +381,105 @@
     return { label: 'Manual only', className: 'is-manual' };
   }
 
+  function buildFindingsMeta(state) {
+    const wsId = getWorkspaceId();
+    const openFindings = Number(state.open_findings_count) || 0;
+    return {
+      href: wsId ? `/action-center?workspace=${encodeURIComponent(wsId)}` : '/action-center',
+      label: openFindings > 0 ? `Findings (${openFindings})` : 'Findings',
+      hasFindings: openFindings > 0,
+    };
+  }
+
+  function commandSummary(state) {
+    const current = state || latestState || {};
+    const mission = String(current.mission || '').trim();
+    const status = missionStatus(current);
+    const findings = buildFindingsMeta(current);
+    const mcp = Array.isArray(current.unclassified_mcp_ids) ? current.unclassified_mcp_ids : [];
+    const skills = Array.isArray(current.unclassified_skill_ids) ? current.unclassified_skill_ids : [];
+    const actionStatus = mission && mcp.length + skills.length > 0
+      ? 'Classify MCP or skill bindings before scheduled runs.'
+      : '';
+    return {
+      mission,
+      label: status.label,
+      className: status.className,
+      title: mission ? 'Current goal' : 'No goal set',
+      text: mission || 'No workspace goal yet.',
+      cadenceLabel: `Cadence: ${cadenceLabel(current.cadence)}`,
+      nextLabel: `Next: ${fmtNextRun(current.next_mission_run_at)}`,
+      lastLabel: `Last: ${fmtLastRun(current.last_mission_run_at)}`,
+      nextTitle: current.next_mission_run_at ? fmtTime(current.next_mission_run_at) : '',
+      lastTitle: current.last_mission_run_at ? fmtTime(current.last_mission_run_at) : '',
+      canRun: !!mission && !runInProgress,
+      runTitle: mission ? 'Run this goal check now' : 'Set a goal before running',
+      findingsHref: findings.href,
+      findingsLabel: findings.label,
+      hasFindings: findings.hasFindings,
+      actionStatus,
+    };
+  }
+
+  function renderCommandSubtitle(state) {
+    const el = $(SELECTORS.commandSubtitle);
+    if (!el) return;
+    const workflow = String(el.getAttribute('data-workflow-label') || '').trim();
+    const summary = commandSummary(state);
+    const missionPart = summary.label ? `Mission · ${summary.label}` : '';
+    const text = [workflow, missionPart].filter(Boolean).join(' · ');
+    el.textContent = text;
+    el.hidden = !text;
+  }
+
+  function renderCommandPanel(state) {
+    if (!$(SELECTORS.commandCard)) {
+      renderCommandSubtitle(state);
+      return;
+    }
+    const summary = commandSummary(state);
+    const statusEl = $(SELECTORS.commandStatus);
+    const titleEl = $(SELECTORS.commandTitle);
+    const textEl = $(SELECTORS.commandText);
+    const cadenceEl = $(SELECTORS.commandCadence);
+    const nextEl = $(SELECTORS.commandNextRun);
+    const lastEl = $(SELECTORS.commandLastRun);
+    const editBtn = $(SELECTORS.commandEditBtn);
+    const runBtn = $(SELECTORS.commandRunBtn);
+    const findingsBtn = $(SELECTORS.commandFindingsBtn);
+
+    if (statusEl) {
+      statusEl.textContent = summary.label;
+      statusEl.className = `ws-cmd-mission-status ${summary.className}`;
+    }
+    if (titleEl) titleEl.textContent = summary.title;
+    if (textEl) {
+      textEl.textContent = summary.text;
+      textEl.classList.toggle('is-empty', !summary.mission);
+    }
+    if (cadenceEl) cadenceEl.textContent = summary.cadenceLabel;
+    if (nextEl) {
+      nextEl.textContent = summary.nextLabel;
+      nextEl.title = summary.nextTitle;
+    }
+    if (lastEl) {
+      lastEl.textContent = summary.lastLabel;
+      lastEl.title = summary.lastTitle;
+    }
+    if (editBtn) editBtn.textContent = summary.mission ? 'Edit goal' : 'Set goal';
+    if (runBtn) {
+      runBtn.disabled = !summary.canRun;
+      runBtn.title = summary.runTitle;
+    }
+    if (findingsBtn) {
+      findingsBtn.href = summary.findingsHref;
+      findingsBtn.textContent = summary.findingsLabel;
+      findingsBtn.classList.toggle('has-findings', summary.hasFindings);
+    }
+    if (!runInProgress) setCommandActionStatus(summary.actionStatus, summary.actionStatus ? 'error' : null);
+    renderCommandSubtitle(state);
+  }
+
   function renderGoalCard(state) {
     if (!$(SELECTORS.goalCard)) return;
     const mission = String(state.mission || '').trim();
@@ -404,13 +522,10 @@
     // are open so the card reflects whether runs are producing anything.
     const findingsBtn = $(SELECTORS.goalFindingsBtn);
     if (findingsBtn) {
-      const wsId = getWorkspaceId();
-      findingsBtn.href = wsId
-        ? `/action-center?workspace=${encodeURIComponent(wsId)}`
-        : '/action-center';
-      const openFindings = Number(state.open_findings_count) || 0;
-      findingsBtn.textContent = openFindings > 0 ? `Findings (${openFindings})` : 'Findings';
-      findingsBtn.classList.toggle('has-findings', openFindings > 0);
+      const findings = buildFindingsMeta(state);
+      findingsBtn.href = findings.href;
+      findingsBtn.textContent = findings.label;
+      findingsBtn.classList.toggle('has-findings', findings.hasFindings);
     }
 
     // Don't touch the action-status line mid-run — handleRunClick owns it then
@@ -449,6 +564,33 @@
     if (lastEl) lastEl.textContent = 'Last: —';
     if (runBtn) runBtn.disabled = true;
     setGoalActionStatus(message || 'Could not load workspace goal.', 'error');
+    renderCommandPanelError(message);
+  }
+
+  function renderCommandPanelError(message) {
+    renderCommandSubtitle({});
+    if (!$(SELECTORS.commandCard)) return;
+    const statusEl = $(SELECTORS.commandStatus);
+    const titleEl = $(SELECTORS.commandTitle);
+    const textEl = $(SELECTORS.commandText);
+    const cadenceEl = $(SELECTORS.commandCadence);
+    const nextEl = $(SELECTORS.commandNextRun);
+    const lastEl = $(SELECTORS.commandLastRun);
+    const runBtn = $(SELECTORS.commandRunBtn);
+    if (statusEl) {
+      statusEl.textContent = 'Unavailable';
+      statusEl.className = 'ws-cmd-mission-status is-empty';
+    }
+    if (titleEl) titleEl.textContent = 'Goal unavailable';
+    if (textEl) {
+      textEl.textContent = message || 'Could not load workspace goal.';
+      textEl.classList.add('is-empty');
+    }
+    if (cadenceEl) cadenceEl.textContent = 'Cadence: unavailable';
+    if (nextEl) nextEl.textContent = 'Next: —';
+    if (lastEl) lastEl.textContent = 'Last: —';
+    if (runBtn) runBtn.disabled = true;
+    setCommandActionStatus(message || 'Could not load workspace goal.', 'error');
   }
 
   function renderStatus(state) {
@@ -636,6 +778,14 @@
 
   function openGoalSettings() {
     if (
+      window.workspaceCommand &&
+      window.workspaceCommand.active &&
+      typeof window.workspaceCommand.deactivate === 'function'
+    ) {
+      window.workspaceCommand.deactivate({ persist: false });
+    }
+
+    if (
       window.workspaceDetail &&
       typeof window.workspaceDetail.setWorkspaceConfigExpanded === 'function'
     ) {
@@ -673,6 +823,7 @@
   // mid-run never clobbers anything the user is typing.
   function renderReadOnly(state) {
     renderGoalCard(state);
+    renderCommandPanel(state);
     renderStatus(state);
     renderBindingsWarning(state);
     applyRunButtonModes(state);
@@ -902,6 +1053,27 @@
     }
   }
 
+  function runNowFromCommand(button) {
+    handleRunClick('trigger', button || $(SELECTORS.commandRunBtn), (msg, kind) => {
+      setGoalActionStatus(msg, kind);
+      setCommandActionStatus(msg, kind);
+    });
+  }
+
+  function exposeAPI() {
+    if (typeof window === 'undefined') return;
+    window.workspaceMission = Object.assign(window.workspaceMission || {}, {
+      getState: () => latestState,
+      getSummary: () => latestState ? commandSummary(latestState) : {},
+      renderCommandSurfaces: () => {
+        if (latestState) renderCommandPanel(latestState);
+      },
+      openGoalModal,
+      runNow: runNowFromCommand,
+      reload,
+    });
+  }
+
   function init() {
     // Bail only if neither the visible goal card nor the advanced settings tab
     // is present — the card must function on its own, without depending on the
@@ -935,4 +1107,5 @@
   } else {
     init();
   }
+  exposeAPI();
 })();

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -255,85 +255,6 @@
             <div id="workspace-tools-panel-host" hidden></div>
           </section>
 
-          <div class="modal fade" id="workspace-detail-goal-modal" tabindex="-1" aria-labelledby="workspace-detail-goal-modal-title" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered">
-              <form class="modal-content workspace-detail-goal-modal-content" id="workspace-detail-goal-modal-form">
-                <div class="modal-header workspace-detail-goal-modal-header">
-                  <div>
-                    <div class="workspace-detail-goal-kicker">Workspace Goal</div>
-                    <h2 class="modal-title workspace-detail-goal-modal-title" id="workspace-detail-goal-modal-title">Set goal</h2>
-                  </div>
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body workspace-detail-goal-modal-body">
-                  <div class="workspace-detail-goal-modal-warning" id="workspace-detail-goal-modal-bindings-warning" style="display: none;" role="status">
-                    <strong>Classify workspace bindings before this goal can run.</strong>
-                    <div class="workspace-detail-goal-modal-warning-list" id="workspace-detail-goal-modal-unclassified-list"></div>
-                    <div class="workspace-detail-goal-modal-warning-hint">Open <em>Advanced settings</em> → MCP or Workspace Skills to set each binding's side effect (read / write / external).</div>
-                  </div>
-
-                  <div class="workspace-detail-goal-modal-field">
-                    <label for="workspace-detail-goal-modal-text" class="form-label">Goal</label>
-                    <textarea id="workspace-detail-goal-modal-text" class="form-control" rows="4" placeholder="e.g. Keep brand voice and visuals consistent across all channels."></textarea>
-                  </div>
-
-                  <div class="workspace-detail-goal-modal-grid">
-                    <div class="workspace-detail-goal-modal-field">
-                      <label for="workspace-detail-goal-modal-cadence-type" class="form-label">Cadence</label>
-                      <select id="workspace-detail-goal-modal-cadence-type" class="form-select">
-                        <option value="">Manual only</option>
-                        <option value="daily">Daily</option>
-                        <option value="weekly">Weekly</option>
-                        <option value="monthly">Monthly</option>
-                        <option value="interval">Custom interval</option>
-                      </select>
-                    </div>
-
-                    <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-time-wrap" style="display: none;">
-                      <label for="workspace-detail-goal-modal-cadence-time" class="form-label">Time of day</label>
-                      <input id="workspace-detail-goal-modal-cadence-time" type="time" class="form-control" value="09:00">
-                    </div>
-                    <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-dow-wrap" style="display: none;">
-                      <label for="workspace-detail-goal-modal-cadence-dow" class="form-label">Day of week</label>
-                      <select id="workspace-detail-goal-modal-cadence-dow" class="form-select">
-                        <option value="1">Monday</option>
-                        <option value="2">Tuesday</option>
-                        <option value="3">Wednesday</option>
-                        <option value="4">Thursday</option>
-                        <option value="5">Friday</option>
-                        <option value="6">Saturday</option>
-                        <option value="0">Sunday</option>
-                      </select>
-                    </div>
-                    <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-dom-wrap" style="display: none;">
-                      <label for="workspace-detail-goal-modal-cadence-dom" class="form-label">Day of month</label>
-                      <input id="workspace-detail-goal-modal-cadence-dom" type="number" class="form-control" min="1" max="31" value="1">
-                    </div>
-                    <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-interval-wrap" style="display: none;">
-                      <label for="workspace-detail-goal-modal-cadence-interval" class="form-label">Interval (hours)</label>
-                      <input id="workspace-detail-goal-modal-cadence-interval" type="number" class="form-control" min="1" value="24">
-                    </div>
-                  </div>
-
-                  <div class="form-check form-switch workspace-detail-goal-modal-switch">
-                    <input class="form-check-input" type="checkbox" id="workspace-detail-goal-modal-enabled">
-                    <label class="form-check-label" for="workspace-detail-goal-modal-enabled">
-                      Enable goal automation
-                    </label>
-                  </div>
-                  <div class="workspace-detail-goal-modal-enabled-hint" id="workspace-detail-goal-modal-enabled-hint" style="display: none;">Pick a cadence above to enable automatic runs.</div>
-                  <div class="workspace-detail-goal-modal-autonomy" id="workspace-detail-goal-modal-autonomy"></div>
-                  <div class="workspace-detail-goal-modal-status" id="workspace-detail-goal-modal-status" aria-live="polite"></div>
-                </div>
-                <div class="modal-footer workspace-detail-goal-modal-footer">
-                  <button type="button" class="btn btn-link" id="workspace-detail-goal-modal-advanced">Advanced settings</button>
-                  <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-                  <button type="submit" class="btn btn-primary" id="workspace-detail-goal-modal-save">Save goal</button>
-                </div>
-              </form>
-            </div>
-          </div>
-
           <!-- Workspace Configuration -->
           <div class="modern-card workspace-detail-config-card is-collapsed mb-4" id="workspace-detail-settings-panel">
             <div class="workspace-detail-config-header">
@@ -1371,6 +1292,85 @@
 
   <!-- Shared modals (includes Add Agent modal used by Assistant) -->
   {{template "modals.tmpl" .}}
+
+  <div class="modal fade" id="workspace-detail-goal-modal" tabindex="-1" aria-labelledby="workspace-detail-goal-modal-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <form class="modal-content workspace-detail-goal-modal-content" id="workspace-detail-goal-modal-form">
+        <div class="modal-header workspace-detail-goal-modal-header">
+          <div>
+            <div class="workspace-detail-goal-kicker">Workspace Goal</div>
+            <h2 class="modal-title workspace-detail-goal-modal-title" id="workspace-detail-goal-modal-title">Set goal</h2>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body workspace-detail-goal-modal-body">
+          <div class="workspace-detail-goal-modal-warning" id="workspace-detail-goal-modal-bindings-warning" style="display: none;" role="status">
+            <strong>Classify workspace bindings before this goal can run.</strong>
+            <div class="workspace-detail-goal-modal-warning-list" id="workspace-detail-goal-modal-unclassified-list"></div>
+            <div class="workspace-detail-goal-modal-warning-hint">Open <em>Advanced settings</em> → MCP or Workspace Skills to set each binding's side effect (read / write / external).</div>
+          </div>
+
+          <div class="workspace-detail-goal-modal-field">
+            <label for="workspace-detail-goal-modal-text" class="form-label">Goal</label>
+            <textarea id="workspace-detail-goal-modal-text" class="form-control" rows="4" placeholder="e.g. Keep brand voice and visuals consistent across all channels."></textarea>
+          </div>
+
+          <div class="workspace-detail-goal-modal-grid">
+            <div class="workspace-detail-goal-modal-field">
+              <label for="workspace-detail-goal-modal-cadence-type" class="form-label">Cadence</label>
+              <select id="workspace-detail-goal-modal-cadence-type" class="form-select">
+                <option value="">Manual only</option>
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+                <option value="interval">Custom interval</option>
+              </select>
+            </div>
+
+            <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-time-wrap" style="display: none;">
+              <label for="workspace-detail-goal-modal-cadence-time" class="form-label">Time of day</label>
+              <input id="workspace-detail-goal-modal-cadence-time" type="time" class="form-control" value="09:00">
+            </div>
+            <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-dow-wrap" style="display: none;">
+              <label for="workspace-detail-goal-modal-cadence-dow" class="form-label">Day of week</label>
+              <select id="workspace-detail-goal-modal-cadence-dow" class="form-select">
+                <option value="1">Monday</option>
+                <option value="2">Tuesday</option>
+                <option value="3">Wednesday</option>
+                <option value="4">Thursday</option>
+                <option value="5">Friday</option>
+                <option value="6">Saturday</option>
+                <option value="0">Sunday</option>
+              </select>
+            </div>
+            <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-dom-wrap" style="display: none;">
+              <label for="workspace-detail-goal-modal-cadence-dom" class="form-label">Day of month</label>
+              <input id="workspace-detail-goal-modal-cadence-dom" type="number" class="form-control" min="1" max="31" value="1">
+            </div>
+            <div class="workspace-detail-goal-modal-field" id="workspace-detail-goal-modal-cadence-interval-wrap" style="display: none;">
+              <label for="workspace-detail-goal-modal-cadence-interval" class="form-label">Interval (hours)</label>
+              <input id="workspace-detail-goal-modal-cadence-interval" type="number" class="form-control" min="1" value="24">
+            </div>
+          </div>
+
+          <div class="form-check form-switch workspace-detail-goal-modal-switch">
+            <input class="form-check-input" type="checkbox" id="workspace-detail-goal-modal-enabled">
+            <label class="form-check-label" for="workspace-detail-goal-modal-enabled">
+              Enable goal automation
+            </label>
+          </div>
+          <div class="workspace-detail-goal-modal-enabled-hint" id="workspace-detail-goal-modal-enabled-hint" style="display: none;">Pick a cadence above to enable automatic runs.</div>
+          <div class="workspace-detail-goal-modal-autonomy" id="workspace-detail-goal-modal-autonomy"></div>
+          <div class="workspace-detail-goal-modal-status" id="workspace-detail-goal-modal-status" aria-live="polite"></div>
+        </div>
+        <div class="modal-footer workspace-detail-goal-modal-footer">
+          <button type="button" class="btn btn-link" id="workspace-detail-goal-modal-advanced">Advanced settings</button>
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary" id="workspace-detail-goal-modal-save">Save goal</button>
+        </div>
+      </form>
+    </div>
+  </div>
 
   <!-- Project Template Modal -->
   <div class="modal fade" id="workspace-detail-project-template-modal" tabindex="-1" aria-labelledby="workspace-detail-project-template-title" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add a Command Mission panel for goal text, automation status, cadence, next/last run, Run Now, and Findings
- reuse workspace-mission state, goal modal, save flow, and mission run path from Detailed view
- move the goal modal outside the hidden Detailed view so Command can open it, and switch Advanced settings back to Detailed config
- add Mission panel rendering/action tests plus template relocation coverage

## Verification
- make test-js
- npm run lint
- git diff --check
- go test ./internal/web/...
- ./scripts/build-server.sh
- browser smoke for Command Set Goal, Advanced settings, save, Run Now, and Findings