### PR TITLE
feat(workspace-command): files panel + config surfaces (plugins, memory, triggers, settings)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -254,6 +254,57 @@
   font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
 }
 .ws-cmd-rail-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-rail-item.is-missing .ws-cmd-rail-t { color: var(--ws-alert); }
+.ws-cmd-files-drop,
+.ws-cmd-files-browse {
+  width: 100%; min-height: 34px; margin-bottom: 6px; display: grid; place-items: center;
+  border: 1px dashed var(--ws-line-bright); background: rgba(0, 0, 0, 0.18); color: var(--ws-ink-dim);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase;
+  transition: 0.13s; text-align: center;
+}
+.ws-cmd-files-drop:hover,
+.ws-cmd-files-drop.is-active,
+.ws-cmd-files-browse:hover {
+  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-files-drop:focus-visible,
+.ws-cmd-files-browse:focus-visible {
+  outline: 2px solid var(--ws-faction); outline-offset: 2px;
+}
+.ws-cmd-systems-body { gap: 10px; }
+.ws-cmd-system-tabs {
+  display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 8px; border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-system-tab {
+  min-height: 28px; padding: 6px 8px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
+  color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono); font-size: 9.5px;
+  letter-spacing: 0.9px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-system-tab:hover,
+.ws-cmd-system-tab.is-active {
+  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-system-tab:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-system-host {
+  max-height: 72vh; overflow: auto; min-width: 0; padding-right: 2px;
+}
+.ws-cmd-system-host .workspace-detail-tools-card,
+.ws-cmd-system-host .workspace-detail-config-card {
+  margin: 0; border: 0; box-shadow: none; background: transparent; border-radius: 0; color: var(--text-primary);
+}
+.ws-cmd-system-host .workspace-detail-config-header,
+.ws-cmd-system-host .workspace-detail-config-nav {
+  display: none;
+}
+.ws-cmd-system-host .workspace-detail-config-content {
+  padding: 0; border: 0; background: transparent;
+}
+.ws-cmd-system-host .workspace-detail-config-body {
+  padding: 0;
+}
+.ws-cmd-system-host .workspace-detail-config-pane {
+  padding: 0;
+}
 .ws-cmd-soon {
   display: grid; place-items: center; min-height: 200px; padding: 24px;
   font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;
@@ -409,10 +460,16 @@
   .ws-cmd-garrison-grid { grid-template-columns: 1fr; }
   .ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child { grid-column: auto; }
 }
+@media (min-width: 1101px) {
+  .ws-cmd-layout:has(.ws-cmd-systems-panel.is-managing) {
+    grid-template-columns: minmax(0, 0.78fr) minmax(520px, 0.72fr);
+  }
+}
 @media (max-width: 900px) {
   .ws-cmd-layout { grid-template-columns: 1fr; }
   .ws-cmd-mission { flex-direction: column; }
   .ws-cmd-mission-actions { justify-content: flex-start; }
+  .ws-cmd-system-host { max-height: none; }
 }
 @media (max-width: 640px) {
   .ws-cmd-nav-btn { flex: 1 1 calc(50% - 8px); justify-content: center; }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -38,6 +38,8 @@ export class WorkspaceCommandView {
     this.commandTagInput = null;
     this.commandTagDraft = [];
     this.commandTagError = '';
+    this.activeSystemTab = 'mcp';
+    this.sharedSurfaceAnchors = {};
     this.boundGlobalKeydown = (event) => this.handleGlobalKeydown(event);
     this.setup();
   }
@@ -109,6 +111,7 @@ export class WorkspaceCommandView {
     this.activeRailSection = '';
     this.identityEditMode = '';
     this.destroyCommandTagInput();
+    this.restoreSharedSurfaces();
     this.closeStatModal();
     if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
       document.removeEventListener('keydown', this.boundGlobalKeydown);
@@ -420,6 +423,7 @@ export class WorkspaceCommandView {
     this.bindRail();
     this.mountCommandTagInput();
     this.syncMissionPanel();
+    this.syncSharedSurfaces();
 
     // The stat manager modal lives inside the .ws-cmd container (so it inherits
     // the tactical tokens) but survives full re-renders: re-attach + repaint it.
@@ -741,9 +745,17 @@ export class WorkspaceCommandView {
       '</header>' +
       '<div class="ws-cmd-modal-body">' + this.statModalRows(section) + '</div>' +
       '<footer class="ws-cmd-modal-foot">' +
-      '<button type="button" class="ws-cmd-modal-detailed" data-cmd-modal-action="detailed">Open in detailed view ▸</button>' +
+      '<button type="button" class="ws-cmd-modal-detailed" data-cmd-modal-action="detailed">' +
+      escapeHtml(this.statModalFooterLabel(section)) + '</button>' +
       '</footer>'
     );
+  }
+
+  statModalFooterLabel(section) {
+    const key = String(section || '');
+    if (key === 'mcp') return 'Open Systems: MCP ▸';
+    if (key === 'skills') return 'Open Systems: Skills ▸';
+    return 'Open in detailed view ▸';
   }
 
   statModalFilterToggleHTML(section) {
@@ -977,6 +989,10 @@ export class WorkspaceCommandView {
     }
     if (a === 'detailed') {
       this.closeStatModal();
+      if (section === 'mcp' || section === 'skills') {
+        this.openSystemTab(section);
+        return;
+      }
       this.openDetailedSection(section);
       return;
     }
@@ -1031,6 +1047,12 @@ export class WorkspaceCommandView {
       case 'folders':
         if (page && typeof page.showAddDirectoryModal === 'function') page.showAddDirectoryModal(triggerButton);
         break;
+      case 'files':
+        if (page && typeof page.showFileModal === 'function') page.showFileModal();
+        break;
+      case 'systems':
+        this.openSystemTab(this.activeSystemTab || 'mcp');
+        break;
       default:
         break;
     }
@@ -1055,6 +1077,11 @@ export class WorkspaceCommandView {
       case 'folders':
         if (typeof page.openDirectoryExplorer === 'function') {
           page.openDirectoryExplorer(id, source || 'reference');
+        }
+        break;
+      case 'files':
+        if (typeof page.openWorkspaceFilesExplorer === 'function') {
+          page.openWorkspaceFilesExplorer();
         }
         break;
       default:
@@ -1337,17 +1364,157 @@ export class WorkspaceCommandView {
     return items;
   }
 
+  fileRowData() {
+    const page = this.page || {};
+    return Array.isArray(page.files) ? page.files : [];
+  }
+
+  fileTitle(file) {
+    return String(file?.title || file?.file_meta?.name || file?.name || 'Untitled File');
+  }
+
+  formatFileDate(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return '';
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  fileMeta(file) {
+    const page = this.page || {};
+    const parts = [];
+    const size = Number(file?.file_meta?.size || file?.size || 0);
+    if (size > 0 && typeof page.formatFileSize === 'function') {
+      try { parts.push(page.formatFileSize(size)); } catch (err) { /* keep going */ }
+    }
+    const folder = String(file?.file_meta?.relative_path || file?.relative_path || '').trim();
+    if (folder) parts.push(folder);
+    const when = this.formatFileDate(file?.created_at || file?.updated_at);
+    if (when) parts.push(when);
+    if (file?.file_meta?.status === 'missing') parts.unshift('Missing');
+    return parts.join(' · ');
+  }
+
+  fileRailItems(files, expanded) {
+    const arr = Array.isArray(files) ? files : [];
+    const limit = expanded ? arr.length : 5;
+    const shown = arr.slice(0, limit);
+    const items = shown.map((file) => {
+      const id = String(file?.id || file?.file_meta?.name || this.fileTitle(file));
+      const title = this.fileTitle(file);
+      const meta = this.fileMeta(file);
+      const missingClass = file?.file_meta?.status === 'missing' ? ' is-missing' : '';
+      return (
+        '<button type="button" class="ws-cmd-rail-item' + missingClass +
+        '" data-cmd-open-section="files" data-cmd-item-id="' + escapeHtml(id) + '">' +
+        '<span class="ws-cmd-rail-t">' + escapeHtml(title) + '</span>' +
+        (meta ? '<span class="ws-cmd-rail-m">' + escapeHtml(meta) + '</span>' : '') +
+        '</button>'
+      );
+    });
+    if (arr.length > shown.length) {
+      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="files">+ ' +
+        (arr.length - shown.length) + ' more</button>');
+    }
+    return items;
+  }
+
+  renderFilesPanel(files, expanded) {
+    const items = this.fileRailItems(files, expanded);
+    const count = Array.isArray(files) ? files.length : 0;
+    const bodyRows = items.length
+      ? items.join('')
+      : '<div class="ws-cmd-rail-empty">No files yet.</div>';
+    return (
+      '<section class="ws-cmd-panel ws-cmd-files-panel' + (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') + '">' +
+      '<div class="ws-cmd-panel-head">' +
+      '<div class="ws-cmd-panel-title"><h4>Files</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-tools">' +
+      '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="files">Upload</button>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="files" aria-expanded="' +
+      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Files manager' : 'Manage Files in Command view') +
+      '" aria-label="' + (expanded ? 'Close Files manager' : 'Manage Files in Command view') + '">' +
+      (expanded ? '×' : '▸') + '</button>' +
+      '</div>' +
+      '</div>' +
+      '<div class="ws-cmd-panel-body">' +
+      (expanded
+        ? '<button type="button" class="ws-cmd-files-drop" data-cmd-file-drop>Drop files here or click Upload</button>' +
+          '<button type="button" class="ws-cmd-files-browse" data-cmd-open-section="files" data-cmd-item-id="__workspace_files__">Browse workspace files</button>'
+        : '') +
+      bodyRows +
+      '</div>' +
+      '</section>'
+    );
+  }
+
+  systemTabs() {
+    return [
+      { key: 'mcp', label: 'MCP', tabId: 'workspace-detail-config-mcp-tab', host: 'config' },
+      { key: 'skills', label: 'Skills', tabId: 'workspace-detail-config-skills-tab', host: 'config' },
+      { key: 'plugins', label: 'Plugins', tabId: 'workspace-detail-config-plugins-tab', host: 'config' },
+      { key: 'memory', label: 'Memory', tabId: 'workspace-detail-config-memory-tab', host: 'config' },
+      { key: 'triggers', label: 'Triggers', tabId: 'workspace-detail-config-triggers-tab', host: 'config' },
+      { key: 'settings', label: 'Manager Settings', tabId: 'workspace-detail-config-settings-tab', host: 'config' },
+      { key: 'intent', label: 'Intent & Setup', tabId: 'workspace-detail-config-intent-tab', host: 'config' },
+      { key: 'mission', label: 'Goal Settings', tabId: 'workspace-detail-config-mission-tab', host: 'config' },
+      { key: 'tools', label: 'Find Tools', tabId: '', host: 'tools' }
+    ];
+  }
+
+  systemTab(key) {
+    const normalized = String(key || '').trim();
+    return this.systemTabs().find(tab => tab.key === normalized) || this.systemTabs()[0];
+  }
+
+  renderSystemsPanel(expanded) {
+    const tabs = this.systemTabs();
+    const active = this.systemTab(this.activeSystemTab);
+    const tabButtons = tabs.map(tab => (
+      '<button type="button" class="ws-cmd-system-tab' + (tab.key === active.key ? ' is-active' : '') +
+      '" data-cmd-system-tab="' + escapeHtml(tab.key) + '" aria-selected="' +
+      (tab.key === active.key ? 'true' : 'false') + '">' + escapeHtml(tab.label) + '</button>'
+    )).join('');
+    return (
+      '<section class="ws-cmd-panel ws-cmd-systems-panel' + (expanded ? ' is-managing' : '') + '">' +
+      '<div class="ws-cmd-panel-head">' +
+      '<div class="ws-cmd-panel-title"><h4>Systems</h4><span class="ws-cmd-panel-count">' + tabs.length + '</span></div>' +
+      '<div class="ws-cmd-panel-tools">' +
+      '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="systems">Open</button>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="systems" aria-expanded="' +
+      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') +
+      '" aria-label="' + (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') + '">' +
+      (expanded ? '×' : '▸') + '</button>' +
+      '</div>' +
+      '</div>' +
+      (expanded
+        ? '<div class="ws-cmd-panel-body ws-cmd-systems-body">' +
+          '<div class="ws-cmd-system-tabs" role="tablist" aria-label="Workspace systems">' + tabButtons + '</div>' +
+          '<div class="ws-cmd-system-host" data-cmd-system-host>' +
+          '<div class="ws-cmd-rail-empty">Loading ' + escapeHtml(active.label) + '...</div>' +
+          '</div>' +
+          '</div>'
+        : '') +
+      '</section>'
+    );
+  }
+
   renderRail() {
     const page = this.page || {};
     const notes = Array.isArray(page.notes) ? page.notes : [];
     const schedules = Array.isArray(page.schedules) ? page.schedules : [];
     const sessions = Array.isArray(page.sessions) ? page.sessions : [];
     const dirs = this.folderRowData();
+    const files = this.fileRowData();
 
     const notesExpanded = this.activeRailSection === 'notes';
     const schedulesExpanded = this.activeRailSection === 'schedules';
     const sessionsExpanded = this.activeRailSection === 'sessions';
     const foldersExpanded = this.activeRailSection === 'folders';
+    const filesExpanded = this.activeRailSection === 'files';
+    const systemsExpanded = this.activeRailSection === 'systems';
 
     const notesItems = this.railItems(notes, (n) => n.name || n.title || 'Untitled Note', {
       sectionKey: 'notes',
@@ -1371,14 +1538,190 @@ export class WorkspaceCommandView {
       this.railPanelHTML('notes', 'Notes', notesItems, notes.length, 'No notes yet.', 'New Note') +
       this.railPanelHTML('schedules', 'Schedules', scheduleItems, schedules.length, 'No schedules yet.', 'Open Schedules') +
       this.railPanelHTML('sessions', 'Sessions', sessionItems, sessions.length, 'No sessions yet.', 'New Session') +
-      this.railPanelHTML('folders', 'Linked Folders', folderItems, dirs.length, 'No linked folders yet.', 'Link Folder')
+      this.railPanelHTML('folders', 'Linked Folders', folderItems, dirs.length, 'No linked folders yet.', 'Link Folder') +
+      this.renderFilesPanel(files, filesExpanded) +
+      this.renderSystemsPanel(systemsExpanded)
     );
+  }
+
+  normalizeSystemTab(key) {
+    return this.systemTab(key).key;
+  }
+
+  openSystemTab(key = 'mcp') {
+    this.activeRailSection = 'systems';
+    this.activeSystemTab = this.normalizeSystemTab(key);
+    this.render();
+  }
+
+  ensureSharedSurfaceAnchor(key, selector) {
+    if (!this.sharedSurfaceAnchors) this.sharedSurfaceAnchors = {};
+    const existing = this.sharedSurfaceAnchors[key];
+    if (existing && existing.node) return existing;
+    if (typeof document === 'undefined' || typeof document.getElementById !== 'function') return null;
+    const node = document.querySelector ? document.querySelector(selector) : null;
+    if (!node || !node.parentNode) return null;
+    const anchor = typeof document.createComment === 'function'
+      ? document.createComment('workspace-command-' + key + '-anchor')
+      : null;
+    if (anchor && node.parentNode) {
+      node.parentNode.insertBefore(anchor, node);
+    }
+    const record = { node, anchor, parent: node.parentNode };
+    this.sharedSurfaceAnchors[key] = record;
+    return record;
+  }
+
+  mountSharedSurface(key, selector, host) {
+    const record = this.ensureSharedSurfaceAnchor(key, selector);
+    if (!record || !record.node || !host || typeof host.appendChild !== 'function') return null;
+    host.innerHTML = '';
+    host.appendChild(record.node);
+    record.node.hidden = false;
+    return record.node;
+  }
+
+  restoreSharedSurface(key) {
+    const record = this.sharedSurfaceAnchors && this.sharedSurfaceAnchors[key];
+    if (!record || !record.node) return;
+    const parent = record.anchor && record.anchor.parentNode ? record.anchor.parentNode : record.parent;
+    if (!parent || typeof parent.insertBefore !== 'function') return;
+    if (record.node.parentNode === parent) return;
+    parent.insertBefore(record.node, record.anchor ? record.anchor.nextSibling : null);
+  }
+
+  restoreSharedSurfaces() {
+    this.restoreSharedSurface('config');
+    this.restoreSharedSurface('tools');
+  }
+
+  showConfigTab(tab) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (page && typeof page.setWorkspaceConfigExpanded === 'function') {
+      page.setWorkspaceConfigExpanded(true);
+    }
+    if (!tab || !tab.tabId) return;
+    const tabBtn = typeof document !== 'undefined' ? document.getElementById(tab.tabId) : null;
+    if (!tabBtn) return;
+
+    let usedBootstrap = false;
+    if (
+      typeof window !== 'undefined' &&
+      window.bootstrap &&
+      window.bootstrap.Tab &&
+      typeof window.bootstrap.Tab.getOrCreateInstance === 'function'
+    ) {
+      window.bootstrap.Tab.getOrCreateInstance(tabBtn).show();
+      usedBootstrap = true;
+    } else if (page && typeof page.activateWorkspaceConfigTab === 'function') {
+      page.activateWorkspaceConfigTab(tab.tabId);
+      usedBootstrap = true;
+    } else if (typeof tabBtn.click === 'function') {
+      tabBtn.click();
+    }
+
+    if (!usedBootstrap && typeof Event === 'function' && typeof tabBtn.dispatchEvent === 'function') {
+      tabBtn.dispatchEvent(new Event('shown.bs.tab', { bubbles: true }));
+    }
+  }
+
+  expandMountedConfig(configNode) {
+    if (!configNode || typeof configNode.querySelector !== 'function') return;
+    configNode.classList?.remove('is-collapsed');
+    const content = configNode.querySelector('#workspace-detail-config-content');
+    if (content) {
+      content.hidden = false;
+      if (typeof content.removeAttribute === 'function') content.removeAttribute('hidden');
+    }
+    const toggle = configNode.querySelector('#workspace-detail-config-toggle');
+    if (toggle && typeof toggle.setAttribute === 'function') {
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+    const label = configNode.querySelector('#workspace-detail-config-toggle-label');
+    if (label) label.textContent = 'Hide Configuration';
+  }
+
+  refreshSystemTabData(tab) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || !tab) return;
+    switch (tab.key) {
+      case 'mcp':
+        if (typeof page.renderWorkspaceMCPBindings === 'function') page.renderWorkspaceMCPBindings();
+        if (page.nativeMCPManager && typeof page.nativeMCPManager.load === 'function') {
+          page.nativeMCPManager.load();
+        }
+        break;
+      case 'skills':
+        if (typeof page.renderWorkspaceSkillBindings === 'function') page.renderWorkspaceSkillBindings();
+        break;
+      case 'plugins':
+        if (typeof page.renderWorkspacePluginBindings === 'function') page.renderWorkspacePluginBindings();
+        break;
+      case 'memory':
+        if (page.memoryManager && typeof page.memoryManager.load === 'function') page.memoryManager.load();
+        break;
+      case 'settings':
+        if (typeof page.renderWorkspaceSettings === 'function') page.renderWorkspaceSettings();
+        break;
+      default:
+        break;
+    }
+  }
+
+  syncSharedSurfaces() {
+    const host = this.container && this.container.querySelector('[data-cmd-system-host]');
+    if (!this.active || this.activeRailSection !== 'systems' || !host) {
+      this.restoreSharedSurfaces();
+      return;
+    }
+
+    const tab = this.systemTab(this.activeSystemTab);
+    if (tab.host === 'tools') {
+      this.restoreSharedSurface('config');
+      const tools = this.mountSharedSurface('tools', '#workspace-detail-tools-card', host);
+      if (!tools) host.innerHTML = '<div class="ws-cmd-rail-empty">Find Tools is unavailable.</div>';
+      return;
+    }
+
+    this.restoreSharedSurface('tools');
+    const config = this.mountSharedSurface('config', '#workspace-detail-settings-panel', host);
+    if (!config) {
+      host.innerHTML = '<div class="ws-cmd-rail-empty">Workspace configuration is unavailable.</div>';
+      return;
+    }
+    this.showConfigTab(tab);
+    this.refreshSystemTabData(tab);
+    this.expandMountedConfig(config);
+  }
+
+  setFileDropActive(dropZone, isActive) {
+    if (!dropZone || !dropZone.classList) return;
+    dropZone.classList.toggle('is-active', Boolean(isActive));
+  }
+
+  async uploadDroppedFiles(event) {
+    if (!event || !event.dataTransfer || !event.dataTransfer.files) return;
+    const files = event.dataTransfer.files;
+    if (!files.length) return;
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || typeof page.uploadFiles !== 'function') return;
+    await page.uploadFiles(files);
   }
 
   bindRail() {
     const root = this.container && this.container.querySelector('.ws-cmd-rail');
     if (!root) return;
     root.addEventListener('click', (event) => {
+      const systemTab = event.target.closest('[data-cmd-system-tab]');
+      if (systemTab) {
+        this.openSystemTab(systemTab.getAttribute('data-cmd-system-tab'));
+        return;
+      }
+      const fileDrop = event.target.closest('[data-cmd-file-drop]');
+      if (fileDrop) {
+        this.runRailPrimaryAction('files', fileDrop);
+        return;
+      }
       const primaryBtn = event.target.closest('[data-cmd-primary-section]');
       if (primaryBtn) {
         this.runRailPrimaryAction(primaryBtn.getAttribute('data-cmd-primary-section'), primaryBtn);
@@ -1397,6 +1740,25 @@ export class WorkspaceCommandView {
           itemBtn.getAttribute('data-cmd-item-source')
         );
       }
+    });
+    root.addEventListener('dragover', (event) => {
+      const dropZone = event.target.closest('[data-cmd-file-drop]');
+      if (!dropZone) return;
+      event.preventDefault();
+      this.setFileDropActive(dropZone, true);
+    });
+    root.addEventListener('dragleave', (event) => {
+      const dropZone = event.target.closest('[data-cmd-file-drop]');
+      if (!dropZone) return;
+      this.setFileDropActive(dropZone, false);
+    });
+    root.addEventListener('drop', (event) => {
+      const dropZone = event.target.closest('[data-cmd-file-drop]');
+      if (!dropZone) return;
+      event.preventDefault();
+      event.stopPropagation();
+      this.setFileDropActive(dropZone, false);
+      this.uploadDroppedFiles(event);
     });
   }
 }

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -166,6 +166,7 @@ test('rendered command copy uses detailed-view vocabulary', () => {
         skill_bindings: []
       },
       tasks: [{ status: 'pending' }],
+      files: [],
       notes: [],
       schedules: [],
       sessions: [],
@@ -214,8 +215,12 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   assert.match(container.innerHTML, />Schedules<\/h4>/);
   assert.match(container.innerHTML, />Sessions<\/h4>/);
   assert.match(container.innerHTML, />Linked Folders<\/h4>/);
+  assert.match(container.innerHTML, />Files<\/h4>/);
+  assert.match(container.innerHTML, />Systems<\/h4>/);
   assert.match(container.innerHTML, /data-cmd-primary-section="notes"/);
   assert.match(container.innerHTML, /data-cmd-primary-section="folders"/);
+  assert.match(container.innerHTML, /data-cmd-primary-section="files"/);
+  assert.match(container.innerHTML, /data-cmd-primary-section="systems"/);
   assert.doesNotMatch(container.innerHTML, /No notes yet\./);
   assert.doesNotMatch(container.innerHTML, /No schedules yet\./);
   assert.doesNotMatch(container.innerHTML, /No sessions yet\./);
@@ -460,6 +465,160 @@ test('empty rail panels collapse to the header but keep primary actions', () => 
   commandView.activeRailSection = 'notes';
   const managingHtml = commandView.renderRail();
   assert.match(managingHtml, /No notes yet\./);
+});
+
+test('files rail panel lists workspace files and exposes upload, browse, and drop target', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: 'files',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      files: [
+        {
+          id: 'file-1',
+          title: 'Launch Plan.pdf',
+          created_at: '2026-07-04T05:00:00Z',
+          file_meta: { size: 4096, relative_path: 'docs/Launch Plan.pdf' }
+        }
+      ],
+      workspace: {},
+      formatFileSize: size => `${size} B`
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.match(html, />Files<\/h4>/);
+  assert.match(html, /Launch Plan\.pdf/);
+  assert.match(html, /4096 B/);
+  assert.match(html, /docs\/Launch Plan\.pdf/);
+  assert.match(html, /data-cmd-file-drop/);
+  assert.match(html, /Browse workspace files/);
+  assert.match(html, /data-cmd-primary-section="files"/);
+  assert.match(html, /data-cmd-open-section="files" data-cmd-item-id="file-1"/);
+});
+
+test('files rail actions delegate to existing file modal and upload paths', async () => {
+  const calls = [];
+  const files = { length: 1, 0: { name: 'brief.txt' } };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      showFileModal() { calls.push(['modal']); },
+      async uploadFiles(fileList) { calls.push(['upload', fileList]); }
+    }
+  });
+
+  commandView.runRailPrimaryAction('files');
+  await commandView.uploadDroppedFiles({ dataTransfer: { files } });
+
+  assert.deepEqual(calls, [['modal'], ['upload', files]]);
+});
+
+test('files drop handler owns Command drop zones without duplicate page fallback', () => {
+  const listeners = {};
+  const files = { length: 1, 0: { name: 'brief.txt' } };
+  const dropZone = { classList: { toggle() {} } };
+  let prevented = false;
+  let stopped = false;
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-rail'
+          ? { addEventListener(type, listener) { listeners[type] = listener; } }
+          : null;
+      }
+    },
+    page: {
+      async uploadFiles(fileList) { calls.push(['upload', fileList]); }
+    }
+  });
+
+  commandView.bindRail();
+  listeners.drop({
+    target: { closest: selector => selector === '[data-cmd-file-drop]' ? dropZone : null },
+    dataTransfer: { files },
+    preventDefault() { prevented = true; },
+    stopPropagation() { stopped = true; }
+  });
+
+  assert.equal(prevented, true);
+  assert.equal(stopped, true);
+  assert.deepEqual(calls, [['upload', files]]);
+});
+
+test('systems rail panel renders Command-native tabs and a shared host', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeSystemTab: 'memory'
+  });
+
+  const html = commandView.renderSystemsPanel(true);
+
+  assert.match(html, />Systems<\/h4>/);
+  assert.match(html, /data-cmd-system-tab="mcp"/);
+  assert.match(html, /data-cmd-system-tab="plugins"/);
+  assert.match(html, /data-cmd-system-tab="memory" aria-selected="true"/);
+  assert.match(html, /data-cmd-system-tab="settings"/);
+  assert.match(html, /data-cmd-system-tab="intent"/);
+  assert.match(html, /data-cmd-system-tab="tools"/);
+  assert.match(html, /data-cmd-system-host/);
+});
+
+test('openSystemTab keeps Command active and selects the requested Systems tab', () => {
+  const renders = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    activeSystemTab: 'mcp',
+    render() { renders.push([this.activeRailSection, this.activeSystemTab]); }
+  });
+
+  commandView.openSystemTab('plugins');
+
+  assert.equal(commandView.activeRailSection, 'systems');
+  assert.equal(commandView.activeSystemTab, 'plugins');
+  assert.deepEqual(renders, [['systems', 'plugins']]);
+});
+
+test('systems shared surface mounts config or tools without cloning persistence logic', () => {
+  const calls = [];
+  const host = { innerHTML: '', appendChild() {} };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: true,
+    activeRailSection: 'systems',
+    activeSystemTab: 'plugins',
+    container: { querySelector: selector => selector === '[data-cmd-system-host]' ? host : null },
+    mountSharedSurface(key, selector) {
+      calls.push(['mount', key, selector]);
+      return { key };
+    },
+    restoreSharedSurface(key) { calls.push(['restore', key]); },
+    showConfigTab(tab) { calls.push(['tab', tab.key]); },
+    refreshSystemTabData(tab) { calls.push(['refresh', tab.key]); },
+    expandMountedConfig(node) { calls.push(['expand', node.key]); }
+  });
+
+  commandView.syncSharedSurfaces();
+
+  commandView.activeSystemTab = 'tools';
+  commandView.syncSharedSurfaces();
+
+  assert.deepEqual(calls, [
+    ['restore', 'tools'],
+    ['mount', 'config', '#workspace-detail-settings-panel'],
+    ['tab', 'plugins'],
+    ['refresh', 'plugins'],
+    ['expand', 'config'],
+    ['restore', 'config'],
+    ['mount', 'tools', '#workspace-detail-tools-card']
+  ]);
 });
 
 test('escape closes the active rail manager without leaving Command', () => {
@@ -766,7 +925,7 @@ test('stat modal inerts command background and traps tab focus', () => {
   assert.equal(first.focused, 1);
 });
 
-test('mcp manager modal lists bindings with add and detailed-view escape hatch', () => {
+test('mcp manager modal lists bindings with add and Systems escape hatch', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     page: {
@@ -787,6 +946,7 @@ test('mcp manager modal lists bindings with add and detailed-view escape hatch',
   assert.match(html, /data-cmd-modal-action="edit" data-cmd-id="b1"/);
   assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="b1"/);
   assert.match(html, /data-cmd-modal-action="detailed"/);
+  assert.match(html, /Open Systems: MCP/);
   // Synthesized bindings are not workspace-owned, so no remove control.
   assert.doesNotMatch(html, /data-cmd-modal-action="delete" data-cmd-id="b2"/);
 });
@@ -924,11 +1084,30 @@ test('modal add/edit hand off to page flows and close the modal; delete stays op
   assert.equal(closed, 2); // add + edit close the modal; delete keeps it open
 });
 
-test('modal detailed action closes the modal and deep-links the detailed view', () => {
+test('modal detailed action retargets mcp and skills to Systems', () => {
   const calls = [];
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     statModalSection: 'skills',
+    closeStatModal() {
+      calls.push(['close', this.statModalSection]);
+      this.statModalSection = '';
+    },
+    openSystemTab(section) {
+      calls.push(['systems', section]);
+    }
+  });
+
+  commandView.handleStatModalAction('detailed');
+
+  assert.deepEqual(calls, [['close', 'skills'], ['systems', 'skills']]);
+});
+
+test('modal detailed action still deep-links non-system sections', () => {
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    statModalSection: 'agents',
     closeStatModal() {
       calls.push(['close', this.statModalSection]);
       this.statModalSection = '';
@@ -940,8 +1119,7 @@ test('modal detailed action closes the modal and deep-links the detailed view', 
 
   commandView.handleStatModalAction('detailed');
 
-  // Section is captured before close resets it, then forwarded to the deep-link.
-  assert.deepEqual(calls, [['close', 'skills'], ['detailed', 'skills']]);
+  assert.deepEqual(calls, [['close', 'agents'], ['detailed', 'agents']]);
 });
 
 test('default deactivate path still persists detailed preference', () => {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -542,7 +542,11 @@ export class WorkspaceDetailPage {
     };
     const modalOpen = () => Boolean(document.querySelector('.modal.show'));
     const handledByDropZone = event =>
-      Boolean(event.target?.closest?.('.modal, #hubFileDropZone, .is-vault-drop-target'));
+      Boolean(
+        event.target?.closest?.(
+          '.modal, #hubFileDropZone, [data-cmd-file-drop], .is-vault-drop-target'
+        )
+      );
     const hideOverlay = () => {
       dragDepth = 0;
       overlay.classList.remove('is-active');
@@ -13187,6 +13191,7 @@ export class WorkspaceDetailPage {
         this.renderFiles();
         this.refreshHomeAssistantQuickPrompts();
         this.renderWorkspaceHealth();
+        window.workspaceCommand?.refresh();
         return;
       }
 
@@ -13200,6 +13205,7 @@ export class WorkspaceDetailPage {
       this.renderFiles();
       this.refreshHomeAssistantQuickPrompts();
       this.renderWorkspaceHealth();
+      window.workspaceCommand?.refresh();
     } catch (error) {
       console.error('Failed to load files:', error);
       this.files = [];
@@ -13208,6 +13214,7 @@ export class WorkspaceDetailPage {
       this.renderFiles();
       this.refreshHomeAssistantQuickPrompts();
       this.renderWorkspaceHealth();
+      window.workspaceCommand?.refresh();
     }
   }
 

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -324,12 +324,13 @@ test('workspace detail entity loaders refresh Command view after completion', as
     await page.loadNotes();
     await page.loadDirectories();
     await page.loadSchedules();
+    await page.loadFiles();
   } finally {
     global.fetch = originalFetch;
     global.window = originalWindow;
   }
 
-  assert.equal(refreshCount, 4);
+  assert.equal(refreshCount, 5);
 });
 
 test('workspace detail reusable identity and tag saves update workspace state', async () => {

--- a/internal/web/static/js/modules/workspace-mission.js
+++ b/internal/web/static/js/modules/workspace-mission.js
@@ -780,6 +780,12 @@
     if (
       window.workspaceCommand &&
       window.workspaceCommand.active &&
+      typeof window.workspaceCommand.openSystemTab === 'function'
+    ) {
+      window.workspaceCommand.openSystemTab('mission');
+    } else if (
+      window.workspaceCommand &&
+      window.workspaceCommand.active &&
       typeof window.workspaceCommand.deactivate === 'function'
     ) {
       window.workspaceCommand.deactivate({ persist: false });


### PR DESCRIPTION
## P3 — Command View Parity: Files panel + config surfaces

Adds the Files rail panel and a tabbed **Systems** panel to Command view, reaching parity with Detailed view for file management and all workspace configuration surfaces. Part of the Command View Parity epic (task group 4.0).

### Approach
Rather than forking any config UI, the Systems panel **mounts the live `#workspace-detail-settings-panel` node** (and `#workspace-detail-tools-card` for Find Tools) into the Command host via a comment-anchor swap, then restores it to its original DOM position on deactivate/tab-away. All config logic runs through existing detail-view code — no duplicated persistence.

### What's included
- **Files rail panel** — list (5 + "more"), Upload button, Browse workspace files, full drag-and-drop upload parity via `page.uploadFiles`, plus "Missing" status alert tinting.
- **Systems panel** — 9 tabs: MCP, Skills, Plugins, Memory, Triggers, Manager Settings, Intent & Setup, Goal Settings, Find Tools. Mounts the config/tools node, activates the right Bootstrap tab (with fallbacks), re-runs the tab's data refresh, and expands the mounted config.
- Stat-modal footers now route into the Systems tab ("Open Systems: MCP/Skills ▸") instead of "Open in detailed view".
- `workspace-mission.js` `openGoalSettings` routes to the Command `mission` system tab when Command is active.
- Shared surfaces restored on deactivate so P5's Detailed deletion won't strand them.

### Testing
- `make test-js`, `npm run lint`, relevant Go tests, rebuild, and isolated smoke of each P3 surface (tasks 4.11–4.15) all completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)