### PR TITLE
feat(workspace-command): group support + board view, tag filters, notes multi-select

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -85,6 +85,22 @@
 .ws-cmd-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
 .ws-cmd-title .ws-dot { width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg); }
 .ws-cmd-title-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.ws-cmd-group-badge {
+  flex: 0 0 auto; align-self: center; margin-top: 4px; padding: 3px 8px;
+  border: 1px solid var(--ws-group-accent-line, var(--ws-line-bright));
+  background: var(--ws-group-accent-soft, rgba(70, 211, 154, 0.08));
+  color: var(--ws-group-accent, var(--ws-faction));
+  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase;
+  clip-path: polygon(0 0, 100% 0, 100% 70%, calc(100% - 6px) 100%, 0 100%);
+}
+.ws-cmd-topbar.is-group .ws-dot {
+  background: var(--ws-group-accent, var(--ws-faction));
+  box-shadow: 0 0 8px var(--ws-group-accent, var(--ws-faction));
+}
+.ws-cmd-topbar.is-group .ws-cmd-crest {
+  color: var(--ws-group-accent, var(--ws-faction));
+  border-color: var(--ws-group-accent-line, var(--ws-line-bright));
+}
 .ws-cmd-title h2 {
   flex: 1 1 auto; min-width: 0; margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eef0f3;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -255,6 +271,23 @@
 }
 .ws-cmd-rail-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
 .ws-cmd-rail-item.is-missing .ws-cmd-rail-t { color: var(--ws-alert); }
+/* Notes multi-select rows: checkbox + open button on one line. */
+.ws-cmd-note-row { flex-direction: row; align-items: center; gap: 8px; padding: 4px 9px; }
+.ws-cmd-note-check { flex: 0 0 auto; width: 14px; height: 14px; accent-color: var(--ws-faction); cursor: pointer; }
+.ws-cmd-note-open {
+  flex: 1 1 auto; min-width: 0; display: flex; align-items: center; text-align: left;
+  padding: 4px 0; border: 0; background: none; color: var(--ws-ink); cursor: pointer;
+}
+.ws-cmd-note-open:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
+.ws-cmd-note-tools { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0 8px; }
+.ws-cmd-note-tool {
+  padding: 5px 9px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
+  cursor: pointer; text-decoration: none; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-note-tool:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
+.ws-cmd-note-tool.is-danger:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
+.ws-cmd-note-tool:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-note-filter, .ws-cmd-modal-note-filter { margin-bottom: 8px; }
 .ws-cmd-files-drop,
 .ws-cmd-files-browse {
   width: 100%; min-height: 34px; margin-bottom: 6px; display: grid; place-items: center;
@@ -305,6 +338,20 @@
 .ws-cmd-system-host .workspace-detail-config-pane {
   padding: 0;
 }
+.ws-cmd-members-host {
+  max-height: 72vh; overflow: auto; min-width: 0; padding-right: 2px;
+}
+/* Neutralize the mounted detail-view members bento card so it reads as a rail panel body. */
+.ws-cmd-members-host .workspace-detail-panel-members {
+  margin: 0; border: 0; box-shadow: none; background: transparent; border-radius: 0;
+  cursor: default; color: var(--text-primary); padding: 0;
+}
+.ws-cmd-members-host .workspace-detail-panel-members:hover {
+  box-shadow: none; border-color: transparent;
+}
+.ws-cmd-members-host .workspace-detail-panel-close { display: none; }
+.ws-cmd-members-host .workspace-detail-panel-header { padding: 0 0 8px; }
+.ws-cmd-members-host .workspace-detail-panel-body { padding: 0; max-height: none; }
 .ws-cmd-soon {
   display: grid; place-items: center; min-height: 200px; padding: 24px;
   font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;
@@ -410,6 +457,21 @@
 .ws-cmd-modal-filter[aria-pressed="true"],
 .ws-cmd-modal-filter:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
 .ws-cmd-modal-filter:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-viewtoggle { display: inline-flex; border: 1px solid var(--ws-line-bright); }
+.ws-cmd-modal-view {
+  padding: 7px 11px; border: 0; border-right: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
+  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.1px; text-transform: uppercase; transition: 0.13s;
+}
+.ws-cmd-modal-view:last-child { border-right: 0; }
+.ws-cmd-modal-view.is-active,
+.ws-cmd-modal-view:hover { color: var(--ws-faction); background: rgba(70, 211, 154, 0.08); }
+.ws-cmd-modal-view:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: -2px; }
+/* Board mode goes wide so status columns have room. */
+.ws-cmd-modal-panel.is-board { max-width: min(1240px, 96vw); }
+.ws-cmd-modal-board-body { flex: 1 1 auto; min-height: 0; padding: 12px 14px; }
+.ws-cmd-board-host { min-width: 0; height: 100%; overflow: auto; }
+/* Neutralize the mounted detail board wrapper chrome inside the modal host. */
+.ws-cmd-board-host .workspace-detail-board { display: block; margin: 0; }
 .ws-cmd-modal-close {
   width: 30px; height: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
   background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-size: 16px; line-height: 1; transition: 0.13s;
@@ -470,6 +532,7 @@
   .ws-cmd-mission { flex-direction: column; }
   .ws-cmd-mission-actions { justify-content: flex-start; }
   .ws-cmd-system-host { max-height: none; }
+  .ws-cmd-members-host { max-height: none; }
 }
 @media (max-width: 640px) {
   .ws-cmd-nav-btn { flex: 1 1 calc(50% - 8px); justify-content: center; }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -262,9 +262,17 @@ export class WorkspaceCommandView {
     return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
   }
 
+  groupColor(ws) {
+    // The detail workspace object carries no color; the tree node loaded by the
+    // members panel is the reliable source. Fall back to any color on ws.
+    const panelGroup = this.page && this.page.membersPanel && this.page.membersPanel.group;
+    const fromPanel = panelGroup ? panelGroup.color : '';
+    return String(fromPanel || (ws && ws.color) || '').trim();
+  }
+
   groupAccentStyle(ws) {
     if (!this.isGroupWorkspace()) return '';
-    const color = String((ws && ws.color) || '').trim();
+    const color = this.groupColor(ws);
     if (!color) return '';
     const soft = this.hexToRgba(color, 0.14);
     const line = this.hexToRgba(color, 0.5);

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -32,6 +32,7 @@ export class WorkspaceCommandView {
     this.statModalEl = null;
     this.statModalTrigger = null;
     this.taskModalShowAll = false;
+    this.taskModalBoardMode = false;
     this.identityExpanded = false;
     this.identityEditMode = '';
     this.identitySaving = false;
@@ -245,8 +246,41 @@ export class WorkspaceCommandView {
       '</div><div class="ws-l">' + escapeHtml(label) + '</div></button>';
   }
 
+  isGroupWorkspace() {
+    const ws = (this.page && this.page.workspace) || {};
+    return String(ws.kind || '').trim().toLowerCase() === 'group';
+  }
+
+  hexToRgba(hex, alpha) {
+    if (!hex || typeof hex !== 'string') return '';
+    const cleaned = hex.replace('#', '').trim();
+    if (cleaned.length !== 6) return '';
+    const r = parseInt(cleaned.slice(0, 2), 16);
+    const g = parseInt(cleaned.slice(2, 4), 16);
+    const b = parseInt(cleaned.slice(4, 6), 16);
+    if ([r, g, b].some(Number.isNaN)) return '';
+    return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+  }
+
+  groupAccentStyle(ws) {
+    if (!this.isGroupWorkspace()) return '';
+    const color = String((ws && ws.color) || '').trim();
+    if (!color) return '';
+    const soft = this.hexToRgba(color, 0.14);
+    const line = this.hexToRgba(color, 0.5);
+    const vars = ['--ws-group-accent: ' + color];
+    if (soft) vars.push('--ws-group-accent-soft: ' + soft);
+    if (line) vars.push('--ws-group-accent-line: ' + line);
+    return ' style="' + escapeHtml(vars.join('; ')) + '"';
+  }
+
   commandBarHTML(ws, name, mode, stats) {
     const description = String((ws && ws.description) || '').trim();
+    const isGroup = this.isGroupWorkspace();
+    const kicker = isGroup ? 'Detachment · Command' : 'Outpost · Command';
+    const groupBadge = isGroup
+      ? '<span class="ws-cmd-group-badge" title="Group workspace">Group</span>'
+      : '';
     const tags = this.workspaceTags();
     const isLongDescription = Array.from(description).length > 150;
     const descriptionClass = 'ws-cmd-description' +
@@ -258,7 +292,7 @@ export class WorkspaceCommandView {
     const subtitle = this.commandSubtitle(mode);
 
     return (
-      '<header class="ws-cmd-topbar">' +
+      '<header class="ws-cmd-topbar' + (isGroup ? ' is-group' : '') + '"' + this.groupAccentStyle(ws) + '>' +
       '<div class="ws-cmd-nav">' +
       '<a class="ws-cmd-nav-btn" href="/workspaces" aria-label="Back to workspaces">Workspaces</a>' +
       '<button type="button" class="ws-cmd-nav-btn" data-ws-cmd-detailed aria-label="Open detailed view">Detailed</button>' +
@@ -271,9 +305,10 @@ export class WorkspaceCommandView {
       '<path d="M3 21V9l9-6 9 6v12"/><path d="M9 21v-6h6v6"/><path d="M3 21h18"/></svg>' +
       '</div>' +
       '<div class="ws-cmd-title">' +
-      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">Outpost · Command</span></div>' +
+      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">' + escapeHtml(kicker) + '</span></div>' +
       '<div class="ws-cmd-title-row">' +
       '<h2>' + escapeHtml(name) + '</h2>' +
+      groupBadge +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="name" aria-label="Edit workspace name">Edit</button>' +
       '</div>' +
       '<div class="ws-sub" id="workspace-command-subtitle" data-workflow-label="' +
@@ -424,6 +459,7 @@ export class WorkspaceCommandView {
     this.mountCommandTagInput();
     this.syncMissionPanel();
     this.syncSharedSurfaces();
+    this.mountNoteFilterBar();
 
     // The stat manager modal lives inside the .ws-cmd container (so it inherits
     // the tactical tokens) but survives full re-renders: re-attach + repaint it.
@@ -628,7 +664,10 @@ export class WorkspaceCommandView {
     const section = String(sectionKey || '').trim();
     if (!this.statSectionMeta(section)) return;
     this.statModalSection = section;
-    if (section === 'tasks') this.taskModalShowAll = false;
+    if (section === 'tasks') {
+      this.taskModalShowAll = false;
+      this.taskModalBoardMode = false;
+    }
     this.statModalTrigger = trigger || null;
     const el = this.ensureStatModal();
     if (!el) return;
@@ -643,8 +682,16 @@ export class WorkspaceCommandView {
 
   closeStatModal() {
     const trigger = this.statModalTrigger;
+    const wasBoard = this.taskModalBoardMode;
     this.statModalSection = '';
     this.statModalTrigger = null;
+    this.taskModalBoardMode = false;
+    // Hand the live board node back to its Detailed home before hiding.
+    if (wasBoard) {
+      this.restoreSharedSurface('board');
+      const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      if (page && typeof page.setView === 'function') page.setView('list');
+    }
     if (this.statModalEl) this.statModalEl.hidden = true;
     this.setCommandBackgroundInert(false);
     if (trigger && typeof trigger.focus === 'function') trigger.focus();
@@ -727,27 +774,106 @@ export class WorkspaceCommandView {
     if (!panel) return;
     const meta = this.statSectionMeta(this.statModalSection);
     if (meta) panel.setAttribute('aria-label', meta.title);
+    const boardMode = this.statModalSection === 'tasks' && this.taskModalBoardMode;
+    if (panel.classList) panel.classList.toggle('is-board', boardMode);
     panel.innerHTML = this.statModalHTML(this.statModalSection);
+    this.syncBoardSurface();
+    this.mountTaskFilterBar();
+  }
+
+  ensureTaskFilterBar() {
+    if (this.taskFilterBar) return this.taskFilterBar;
+    const helper = this.tagFilterHelper();
+    if (!helper || typeof helper.createTagFilterBar !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    const holder = document.createElement('div');
+    this.taskFilterBar = helper.createTagFilterBar({
+      container: holder,
+      label: 'Tags',
+      onChange: () => this.renderStatModalBody()
+    });
+    return this.taskFilterBar;
+  }
+
+  mountTaskFilterBar() {
+    if (this.statModalSection !== 'tasks' || this.taskModalBoardMode) return;
+    const panel = this.statModalEl && this.statModalEl.querySelector('.ws-cmd-modal-panel');
+    const host = panel && panel.querySelector('[data-cmd-task-filter]');
+    if (!host) return;
+    const bar = this.ensureTaskFilterBar();
+    if (!bar || !bar.element) return;
+    const page = this.page || {};
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    const helper = this.tagFilterHelper();
+    if (helper && typeof helper.collectTags === 'function' && typeof bar.setAvailableTags === 'function') {
+      bar.setAvailableTags(helper.collectTags(tasks));
+    }
+    host.innerHTML = '';
+    host.appendChild(bar.element);
+  }
+
+  syncBoardSurface({ load = false } = {}) {
+    const inBoard = this.statModalSection === 'tasks' &&
+      this.taskModalBoardMode &&
+      this.statModalEl && !this.statModalEl.hidden;
+    if (!inBoard) {
+      this.restoreSharedSurface('board');
+      return;
+    }
+    const host = this.statModalEl.querySelector('[data-cmd-board-host]');
+    if (!host) return;
+    const board = this.mountSharedSurface('board', '#workspace-detail-tasks-board', host);
+    if (!board) {
+      host.innerHTML = '<div class="ws-cmd-modal-empty">Board is unavailable.</div>';
+      return;
+    }
+    if (board.style) board.style.display = '';
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (load && page && typeof page.setView === 'function') page.setView('board');
   }
 
   statModalHTML(section) {
     const meta = this.statSectionMeta(section);
     if (!meta) return '';
+    const boardMode = section === 'tasks' && this.taskModalBoardMode;
+    const taskFilterHost = section === 'tasks'
+      ? '<div class="ws-cmd-modal-note-filter" data-cmd-task-filter></div>'
+      : '';
+    const body = boardMode
+      ? '<div class="ws-cmd-modal-body ws-cmd-modal-board-body">' +
+        '<div class="ws-cmd-board-host" data-cmd-board-host>' +
+        '<div class="ws-cmd-modal-empty">Loading board...</div>' +
+        '</div></div>'
+      : '<div class="ws-cmd-modal-body">' + taskFilterHost + this.statModalRows(section) + '</div>';
     return (
       '<header class="ws-cmd-modal-head">' +
       '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
       '<span class="ws-cmd-modal-count">' + this.statModalCount(section) + '</span>' +
       '<div class="ws-cmd-modal-head-actions">' +
-      this.statModalFilterToggleHTML(section) +
+      this.taskViewToggleHTML(section) +
+      (boardMode ? '' : this.statModalFilterToggleHTML(section)) +
       '<button type="button" class="ws-cmd-modal-add" data-cmd-modal-action="add">' + escapeHtml(meta.addLabel) + '</button>' +
       '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
       '</div>' +
       '</header>' +
-      '<div class="ws-cmd-modal-body">' + this.statModalRows(section) + '</div>' +
+      body +
       '<footer class="ws-cmd-modal-foot">' +
       '<button type="button" class="ws-cmd-modal-detailed" data-cmd-modal-action="detailed">' +
       escapeHtml(this.statModalFooterLabel(section)) + '</button>' +
       '</footer>'
+    );
+  }
+
+  taskViewToggleHTML(section) {
+    if (String(section || '') !== 'tasks') return '';
+    const board = this.taskModalBoardMode;
+    return (
+      '<div class="ws-cmd-modal-viewtoggle" role="tablist" aria-label="Task view">' +
+      '<button type="button" class="ws-cmd-modal-view' + (board ? '' : ' is-active') +
+      '" data-cmd-modal-action="view-list" aria-pressed="' + (board ? 'false' : 'true') + '">List</button>' +
+      '<button type="button" class="ws-cmd-modal-view' + (board ? ' is-active' : '') +
+      '" data-cmd-modal-action="view-board" aria-pressed="' + (board ? 'true' : 'false') + '">Board</button>' +
+      '</div>'
     );
   }
 
@@ -852,10 +978,24 @@ export class WorkspaceCommandView {
     return status === 'pending' || status === 'in_progress';
   }
 
+  taskFilterActiveTags() {
+    const bar = this.taskFilterBar;
+    return bar && typeof bar.getActiveTags === 'function' ? bar.getActiveTags() : [];
+  }
+
+  applyTaskTagFilter(tasks) {
+    const all = Array.isArray(tasks) ? tasks : [];
+    const active = this.taskFilterActiveTags();
+    const helper = this.tagFilterHelper();
+    if (!active.length || !helper || typeof helper.filterItems !== 'function') return all;
+    return helper.filterItems(all, active);
+  }
+
   taskRowData({ includeAll = false } = {}) {
     const page = this.page || {};
     const tasks = Array.isArray(page.tasks) ? page.tasks : [];
-    return includeAll ? tasks : tasks.filter((task) => this.isOpenTask(task));
+    const base = includeAll ? tasks : tasks.filter((task) => this.isOpenTask(task));
+    return this.applyTaskTagFilter(base);
   }
 
   taskRowsHTML() {
@@ -987,6 +1127,20 @@ export class WorkspaceCommandView {
       this.renderStatModalBody();
       return;
     }
+    if ((a === 'view-board' || a === 'view-list') && section === 'tasks') {
+      const nextBoard = a === 'view-board';
+      if (this.taskModalBoardMode === nextBoard) return;
+      this.taskModalBoardMode = nextBoard;
+      if (!nextBoard) {
+        this.restoreSharedSurface('board');
+        if (typeof page.setView === 'function') page.setView('list');
+        this.renderStatModalBody();
+      } else {
+        this.renderStatModalBody();
+        this.syncBoardSurface({ load: true });
+      }
+      return;
+    }
     if (a === 'detailed') {
       this.closeStatModal();
       if (section === 'mcp' || section === 'skills') {
@@ -1032,6 +1186,25 @@ export class WorkspaceCommandView {
     this.render();
   }
 
+  handleNoteAction(action) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page) return;
+    switch (String(action || '')) {
+      case 'select-all':
+        if (typeof page.toggleSelectAllNotes === 'function') page.toggleSelectAllNotes();
+        this.render();
+        break;
+      case 'copy':
+        if (typeof page.copySelectedNotesToClipboard === 'function') page.copySelectedNotesToClipboard();
+        break;
+      case 'delete':
+        if (typeof page.deleteSelectedNotes === 'function') page.deleteSelectedNotes();
+        break;
+      default:
+        break;
+    }
+  }
+
   runRailPrimaryAction(sectionKey, triggerButton) {
     const page = this.page || window.workspaceDetail;
     switch (String(sectionKey || '')) {
@@ -1052,6 +1225,15 @@ export class WorkspaceCommandView {
         break;
       case 'systems':
         this.openSystemTab(this.activeSystemTab || 'mcp');
+        break;
+      case 'members':
+        if (this.activeRailSection !== 'members') {
+          this.activeRailSection = 'members';
+          this.render();
+        }
+        if (page && page.membersPanel && typeof page.membersPanel.openAddPicker === 'function') {
+          page.membersPanel.openAddPicker();
+        }
         break;
       default:
         break;
@@ -1172,13 +1354,14 @@ export class WorkspaceCommandView {
   }
 
   questLogHTML(group, encoded) {
-    const tasks = Array.isArray(group.tasks) ? group.tasks : [];
+    const tasks = this.applyTaskTagFilter(Array.isArray(group.tasks) ? group.tasks : []);
     const add = group.isUnassigned ? '' :
       '<button type="button" class="ws-cmd-icon-btn sm" data-cmd-add-task="' + escapeHtml(encoded) +
       '" aria-label="Add task">＋</button>';
     const head = '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Tasks · ' + tasks.length + '</span>' + add + '</div>';
     if (!tasks.length) {
-      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">— no tasks yet —</div></div>';
+      const emptyText = this.taskFilterActiveTags().length ? '— no tasks match the tag filter —' : '— no tasks yet —';
+      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">' + emptyText + '</div></div>';
     }
     const items = tasks.map((t) => {
       const label = String(t.description || t.name || t.title || 'Task');
@@ -1501,6 +1684,163 @@ export class WorkspaceCommandView {
     );
   }
 
+  detachmentMemberCount() {
+    const panel = this.page && this.page.membersPanel;
+    const group = panel && panel.group;
+    if (!group || !Array.isArray(group.children)) return 0;
+    return group.children.length;
+  }
+
+  renderDetachmentPanel(expanded) {
+    if (!this.isGroupWorkspace()) return '';
+    const count = this.detachmentMemberCount();
+    return (
+      '<section class="ws-cmd-panel ws-cmd-detachment-panel' + (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') + '">' +
+      '<div class="ws-cmd-panel-head">' +
+      '<div class="ws-cmd-panel-title"><h4>Detachment</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-tools">' +
+      '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="members">Add Member</button>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="members" aria-expanded="' +
+      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Detachment manager' : 'Manage members in Command view') +
+      '" aria-label="' + (expanded ? 'Close Detachment manager' : 'Manage members in Command view') + '">' +
+      (expanded ? '×' : '▸') + '</button>' +
+      '</div>' +
+      '</div>' +
+      (expanded
+        ? '<div class="ws-cmd-panel-body ws-cmd-detachment-body">' +
+          '<div class="ws-cmd-members-host" data-cmd-members-host>' +
+          '<div class="ws-cmd-rail-empty">Loading detachment...</div>' +
+          '</div>' +
+          '</div>'
+        : '') +
+      '</section>'
+    );
+  }
+
+  // ---------- notes panel (tag filter + multi-select) ----------
+
+  tagFilterHelper() {
+    return (typeof window !== 'undefined' && window.OriTagFilterBar) || null;
+  }
+
+  noteFilterActiveTags() {
+    const bar = this.noteFilterBar;
+    return bar && typeof bar.getActiveTags === 'function' ? bar.getActiveTags() : [];
+  }
+
+  visibleNotes(notes) {
+    const all = Array.isArray(notes) ? notes : [];
+    const active = this.noteFilterActiveTags();
+    const helper = this.tagFilterHelper();
+    if (!active.length || !helper || typeof helper.filterItems !== 'function') return all;
+    return helper.filterItems(all, active);
+  }
+
+  isNoteSelected(id) {
+    const set = this.page && this.page.selectedNoteIds;
+    return set && typeof set.has === 'function' ? set.has(String(id)) : false;
+  }
+
+  noteRowsHTML(list, expanded, total) {
+    const arr = Array.isArray(list) ? list : [];
+    const limit = expanded ? arr.length : 5;
+    const shown = arr.slice(0, limit);
+    const rows = shown.map((note) => {
+      const id = String(note.id || '');
+      const label = escapeHtml(note.name || note.title || 'Untitled Note');
+      const checkbox = expanded
+        ? '<input type="checkbox" class="ws-cmd-note-check" data-cmd-note-select="' + escapeHtml(id) + '"' +
+          (this.isNoteSelected(id) ? ' checked' : '') + ' aria-label="Select ' + label + '">'
+        : '';
+      return (
+        '<div class="ws-cmd-rail-item ws-cmd-note-row">' +
+        checkbox +
+        '<button type="button" class="ws-cmd-note-open" data-cmd-open-section="notes" data-cmd-item-id="' +
+        escapeHtml(id) + '"><span class="ws-cmd-rail-t">' + label + '</span></button>' +
+        '</div>'
+      );
+    });
+    if (arr.length > shown.length) {
+      rows.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="notes">+ ' +
+        (arr.length - shown.length) + ' more</button>');
+    }
+    if (expanded && !arr.length) {
+      rows.push('<div class="ws-cmd-rail-empty">' +
+        (total ? 'No notes match the active tag filter.' : 'No notes yet.') + '</div>');
+    }
+    return rows;
+  }
+
+  noteMultiSelectToolbarHTML() {
+    return (
+      '<div class="ws-cmd-note-tools" role="group" aria-label="Note bulk actions">' +
+      '<button type="button" class="ws-cmd-note-tool" data-cmd-note-action="select-all">Select all</button>' +
+      '<button type="button" class="ws-cmd-note-tool" data-cmd-note-action="copy">Copy</button>' +
+      '<button type="button" class="ws-cmd-note-tool is-danger" data-cmd-note-action="delete">Delete</button>' +
+      '<a class="ws-cmd-note-tool" href="' + escapeHtml(this.workspaceRoute('/notes')) + '">View all</a>' +
+      '</div>'
+    );
+  }
+
+  renderNotesPanel(notes, expanded) {
+    const all = Array.isArray(notes) ? notes : [];
+    const visible = this.visibleNotes(all);
+    const count = all.length;
+    const rows = this.noteRowsHTML(visible, expanded, count).join('');
+    const hasBody = expanded || visible.length > 0;
+    const body = expanded
+      ? '<div class="ws-cmd-note-filter" data-cmd-note-filter></div>' +
+        this.noteMultiSelectToolbarHTML() +
+        rows
+      : (visible.length ? rows : '<div class="ws-cmd-rail-empty">No notes yet.</div>');
+    return (
+      '<section class="ws-cmd-panel ws-cmd-notes-panel' + (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') + '">' +
+      '<div class="ws-cmd-panel-head">' +
+      '<div class="ws-cmd-panel-title"><h4>Notes</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-tools">' +
+      '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="notes">New Note</button>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="notes" aria-expanded="' +
+      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') +
+      '" aria-label="' + (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') + '">' +
+      (expanded ? '×' : '▸') + '</button>' +
+      '</div>' +
+      '</div>' +
+      (hasBody ? '<div class="ws-cmd-panel-body">' + body + '</div>' : '') +
+      '</section>'
+    );
+  }
+
+  ensureNoteFilterBar() {
+    if (this.noteFilterBar) return this.noteFilterBar;
+    const helper = this.tagFilterHelper();
+    if (!helper || typeof helper.createTagFilterBar !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    const holder = document.createElement('div');
+    this.noteFilterBar = helper.createTagFilterBar({
+      container: holder,
+      label: 'Tags',
+      onChange: () => this.render()
+    });
+    return this.noteFilterBar;
+  }
+
+  mountNoteFilterBar() {
+    if (!this.container) return;
+    const host = this.container.querySelector('[data-cmd-note-filter]');
+    if (!host) return;
+    const bar = this.ensureNoteFilterBar();
+    if (!bar || !bar.element) return;
+    const notes = Array.isArray(this.page && this.page.notes) ? this.page.notes : [];
+    const helper = this.tagFilterHelper();
+    if (helper && typeof helper.collectTags === 'function' && typeof bar.setAvailableTags === 'function') {
+      bar.setAvailableTags(helper.collectTags(notes));
+    }
+    host.innerHTML = '';
+    host.appendChild(bar.element);
+  }
+
   renderRail() {
     const page = this.page || {};
     const notes = Array.isArray(page.notes) ? page.notes : [];
@@ -1515,12 +1855,8 @@ export class WorkspaceCommandView {
     const foldersExpanded = this.activeRailSection === 'folders';
     const filesExpanded = this.activeRailSection === 'files';
     const systemsExpanded = this.activeRailSection === 'systems';
+    const detachmentExpanded = this.activeRailSection === 'members';
 
-    const notesItems = this.railItems(notes, (n) => n.name || n.title || 'Untitled Note', {
-      sectionKey: 'notes',
-      expanded: notesExpanded,
-      action: (n) => 'data-cmd-open-section="notes" data-cmd-item-id="' + escapeHtml(String(n.id || '')) + '"'
-    });
     const scheduleItems = this.railItems(schedules, (s) => s.name || s.task_description || 'Unnamed Schedule', {
       sectionKey: 'schedules',
       expanded: schedulesExpanded,
@@ -1535,10 +1871,11 @@ export class WorkspaceCommandView {
     const folderItems = this.folderRailItems(dirs, foldersExpanded);
 
     return (
-      this.railPanelHTML('notes', 'Notes', notesItems, notes.length, 'No notes yet.', 'New Note') +
+      this.renderNotesPanel(notes, notesExpanded) +
       this.railPanelHTML('schedules', 'Schedules', scheduleItems, schedules.length, 'No schedules yet.', 'Open Schedules') +
       this.railPanelHTML('sessions', 'Sessions', sessionItems, sessions.length, 'No sessions yet.', 'New Session') +
       this.railPanelHTML('folders', 'Linked Folders', folderItems, dirs.length, 'No linked folders yet.', 'Link Folder') +
+      this.renderDetachmentPanel(detachmentExpanded) +
       this.renderFilesPanel(files, filesExpanded) +
       this.renderSystemsPanel(systemsExpanded)
     );
@@ -1593,6 +1930,8 @@ export class WorkspaceCommandView {
   restoreSharedSurfaces() {
     this.restoreSharedSurface('config');
     this.restoreSharedSurface('tools');
+    this.restoreSharedSurface('members');
+    this.restoreSharedSurface('board');
   }
 
   showConfigTab(tab) {
@@ -1669,9 +2008,15 @@ export class WorkspaceCommandView {
   }
 
   syncSharedSurfaces() {
+    this.syncSystemsSurface();
+    this.syncDetachmentSurface();
+  }
+
+  syncSystemsSurface() {
     const host = this.container && this.container.querySelector('[data-cmd-system-host]');
     if (!this.active || this.activeRailSection !== 'systems' || !host) {
-      this.restoreSharedSurfaces();
+      this.restoreSharedSurface('config');
+      this.restoreSharedSurface('tools');
       return;
     }
 
@@ -1692,6 +2037,24 @@ export class WorkspaceCommandView {
     this.showConfigTab(tab);
     this.refreshSystemTabData(tab);
     this.expandMountedConfig(config);
+  }
+
+  async syncDetachmentSurface() {
+    if (!this.active || this.activeRailSection !== 'members') {
+      this.restoreSharedSurface('members');
+      return;
+    }
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (page && page.membersPanel && typeof page.membersPanel.syncWorkspace === 'function') {
+      try { await page.membersPanel.syncWorkspace(page.workspace); } catch (err) { /* keep going */ }
+    }
+    // Re-query after the await: a later render may have replaced the host.
+    const host = this.container && this.container.querySelector('[data-cmd-members-host]');
+    if (!host) return;
+    const members = this.mountSharedSurface('members', '#workspace-detail-members-panel', host);
+    if (!members) {
+      host.innerHTML = '<div class="ws-cmd-rail-empty">Members are unavailable.</div>';
+    }
   }
 
   setFileDropActive(dropZone, isActive) {
@@ -1732,6 +2095,11 @@ export class WorkspaceCommandView {
         this.toggleRailManager(manageBtn.getAttribute('data-cmd-manage-section'));
         return;
       }
+      const noteAction = event.target.closest('[data-cmd-note-action]');
+      if (noteAction) {
+        this.handleNoteAction(noteAction.getAttribute('data-cmd-note-action'));
+        return;
+      }
       const itemBtn = event.target.closest('[data-cmd-open-section][data-cmd-item-id]');
       if (itemBtn) {
         this.openRailItem(
@@ -1739,6 +2107,14 @@ export class WorkspaceCommandView {
           itemBtn.getAttribute('data-cmd-item-id'),
           itemBtn.getAttribute('data-cmd-item-source')
         );
+      }
+    });
+    root.addEventListener('change', (event) => {
+      const cb = event.target.closest('[data-cmd-note-select]');
+      if (!cb) return;
+      const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      if (page && typeof page.toggleNoteSelection === 'function') {
+        page.toggleNoteSelection(cb.getAttribute('data-cmd-note-select'), cb.checked);
       }
     });
     root.addEventListener('dragover', (event) => {

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -467,6 +467,31 @@ test('command bar shows group badge and color accent for group workspaces', () =
   assert.match(html, /Detachment · Command/);
 });
 
+test('group accent color is sourced from the members-panel group node (detail workspace has none)', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityExpanded: false,
+    identityEditMode: '',
+    page: {
+      workspaceId: 'grp-1',
+      // The detail workspace object carries no color; the tree node does.
+      workspace: { name: 'Alpha Group', kind: 'group', description: '', mcp_bindings: [], skill_bindings: [] },
+      membersPanel: { group: { color: '#8b5cf6' } },
+      tasks: [],
+      buildAgentGroups: () => []
+    }
+  });
+
+  const html = commandView.commandBarHTML(
+    commandView.page.workspace,
+    commandView.page.workspace.name,
+    'Guided',
+    commandView.computeStats()
+  );
+
+  assert.match(html, /--ws-group-accent: #8b5cf6/);
+});
+
 test('command bar omits group treatment for non-group workspaces', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -441,6 +441,221 @@ test('command rail badges project and reference directory roles', () => {
   assert.match(html, /data-cmd-item-id="dir-ref"/);
 });
 
+test('command bar shows group badge and color accent for group workspaces', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityExpanded: false,
+    identityEditMode: '',
+    page: {
+      workspaceId: 'grp-1',
+      workspace: { name: 'Alpha Group', kind: 'group', color: '#3b82f6', description: '', mcp_bindings: [], skill_bindings: [] },
+      tasks: [],
+      buildAgentGroups: () => []
+    }
+  });
+
+  const html = commandView.commandBarHTML(
+    commandView.page.workspace,
+    commandView.page.workspace.name,
+    'Guided',
+    commandView.computeStats()
+  );
+
+  assert.match(html, /ws-cmd-topbar is-group/);
+  assert.match(html, /ws-cmd-group-badge/);
+  assert.match(html, /--ws-group-accent: #3b82f6/);
+  assert.match(html, /Detachment · Command/);
+});
+
+test('command bar omits group treatment for non-group workspaces', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    identityExpanded: false,
+    identityEditMode: '',
+    page: {
+      workspaceId: 'ws-1',
+      workspace: { name: 'Solo Outpost', kind: 'workspace', description: '', mcp_bindings: [], skill_bindings: [] },
+      tasks: [],
+      buildAgentGroups: () => []
+    }
+  });
+
+  const html = commandView.commandBarHTML(
+    commandView.page.workspace,
+    commandView.page.workspace.name,
+    'Guided',
+    commandView.computeStats()
+  );
+
+  assert.doesNotMatch(html, /ws-cmd-group-badge/);
+  assert.doesNotMatch(html, /is-group/);
+  assert.match(html, /Outpost · Command/);
+});
+
+test('detachment rail panel renders only for group workspaces with member count', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: 'members',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      workspace: { name: 'Alpha Group', kind: 'group' },
+      membersPanel: { group: { children: [{ id: 'm1' }, { id: 'm2' }] } }
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.match(html, />Detachment<\/h4>/);
+  assert.match(html, /ws-cmd-panel-count">2</);
+  assert.match(html, /data-cmd-members-host/);
+  assert.match(html, /data-cmd-primary-section="members"/);
+});
+
+test('notes panel exposes tag filter host, multi-select toolbar, and per-note checkboxes when managing', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: 'notes',
+    noteFilterBar: null,
+    page: {
+      workspaceId: 'ws-1',
+      notes: [{ id: 'n1', name: 'Alpha' }, { id: 'n2', name: 'Beta' }],
+      selectedNoteIds: new Set(['n1'])
+    }
+  });
+
+  const html = commandView.renderNotesPanel(commandView.page.notes, true);
+
+  assert.match(html, /data-cmd-note-filter/);
+  assert.match(html, /data-cmd-note-action="select-all"/);
+  assert.match(html, /data-cmd-note-action="copy"/);
+  assert.match(html, /data-cmd-note-action="delete"/);
+  assert.match(html, /href="\/workspaces\/ws-1\/notes"/);
+  assert.match(html, /data-cmd-note-select="n1" checked/);
+  assert.match(html, /data-cmd-note-select="n2"/);
+  assert.doesNotMatch(html, /data-cmd-note-select="n2" checked/);
+});
+
+test('collapsed notes panel stays checkbox-free', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    noteFilterBar: null,
+    page: { notes: [{ id: 'n1', name: 'Alpha' }] }
+  });
+
+  const html = commandView.renderNotesPanel(commandView.page.notes, false);
+  assert.doesNotMatch(html, /data-cmd-note-select/);
+  assert.doesNotMatch(html, /data-cmd-note-action/);
+});
+
+test('handleNoteAction delegates bulk actions to the page', () => {
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    render() { calls.push('render'); },
+    page: {
+      toggleSelectAllNotes: () => calls.push('select-all'),
+      copySelectedNotesToClipboard: () => calls.push('copy'),
+      deleteSelectedNotes: () => calls.push('delete')
+    }
+  });
+
+  commandView.handleNoteAction('select-all');
+  commandView.handleNoteAction('copy');
+  commandView.handleNoteAction('delete');
+
+  assert.deepEqual(calls, ['select-all', 'render', 'copy', 'delete']);
+});
+
+test('note and task tag filters reuse OriTagFilterBar.filterItems on active tags', () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    OriTagFilterBar: {
+      filterItems: (items, active) => items.filter(i => (i.tags || []).some(t => active.includes(t)))
+    }
+  };
+  try {
+    const commandView = Object.create(WorkspaceCommandView.prototype);
+    Object.assign(commandView, {
+      noteFilterBar: { getActiveTags: () => ['urgent'] },
+      taskFilterBar: { getActiveTags: () => ['urgent'] },
+      taskModalShowAll: true,
+      page: {
+        notes: [{ id: 'n1', tags: ['urgent'] }, { id: 'n2', tags: ['later'] }],
+        tasks: [{ id: 't1', tags: ['urgent'] }, { id: 't2', tags: [] }]
+      }
+    });
+
+    assert.deepEqual(commandView.visibleNotes(commandView.page.notes).map(n => n.id), ['n1']);
+    assert.deepEqual(commandView.taskRowData({ includeAll: true }).map(t => t.id), ['t1']);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('tasks modal exposes a List/Board view toggle and renders the board host in board mode', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    taskModalShowAll: false,
+    taskModalBoardMode: false,
+    page: { tasks: [] }
+  });
+
+  const listHtml = commandView.statModalHTML('tasks');
+  assert.match(listHtml, /data-cmd-modal-action="view-list"/);
+  assert.match(listHtml, /data-cmd-modal-action="view-board"/);
+  assert.doesNotMatch(listHtml, /data-cmd-board-host/);
+
+  commandView.taskModalBoardMode = true;
+  const boardHtml = commandView.statModalHTML('tasks');
+  assert.match(boardHtml, /data-cmd-board-host/);
+  // The list-only "Show all" filter is hidden while the board is showing.
+  assert.doesNotMatch(boardHtml, /data-cmd-modal-action="toggle-task-filter"/);
+});
+
+test('view-board / view-list toggle flips board mode and hands the board node back on exit', () => {
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    statModalSection: 'tasks',
+    taskModalBoardMode: false,
+    page: { setView: (v) => calls.push(['setView', v]) },
+    renderStatModalBody() { calls.push(['render']); },
+    syncBoardSurface(opts) { calls.push(['sync', opts && opts.load === true]); },
+    restoreSharedSurface(key) { calls.push(['restore', key]); }
+  });
+
+  commandView.handleStatModalAction('view-board');
+  assert.equal(commandView.taskModalBoardMode, true);
+  assert.deepEqual(calls, [['render'], ['sync', true]]);
+
+  calls.length = 0;
+  commandView.handleStatModalAction('view-list');
+  assert.equal(commandView.taskModalBoardMode, false);
+  assert.deepEqual(calls, [['restore', 'board'], ['setView', 'list'], ['render']]);
+});
+
+test('detachment rail panel is absent for non-group workspaces', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeRailSection: '',
+    page: {
+      notes: [],
+      schedules: [],
+      sessions: [],
+      directories: [],
+      workspace: { name: 'Solo', kind: 'workspace' }
+    }
+  });
+
+  const html = commandView.renderRail();
+
+  assert.doesNotMatch(html, /Detachment/);
+});
+
 test('empty rail panels collapse to the header but keep primary actions', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
@@ -616,8 +831,10 @@ test('systems shared surface mounts config or tools without cloning persistence 
     ['tab', 'plugins'],
     ['refresh', 'plugins'],
     ['expand', 'config'],
+    ['restore', 'members'],
     ['restore', 'config'],
-    ['mount', 'tools', '#workspace-detail-tools-card']
+    ['mount', 'tools', '#workspace-detail-tools-card'],
+    ['restore', 'members']
   ]);
 });
 


### PR DESCRIPTION
## P4 — Command View Parity: Groups + power features

Adds group-workspace support, board view, tag filters, and notes multi-select to Command view, reaching parity with Detailed for the remaining power features. Part of the Command View Parity epic (task group 5.0). Branched from `dev` after P3 (#154) merged.

### What's included
- **Group identity** — `Group` badge + workspace-color accent (crest, dot, badge) in the command bar; kicker reads "Detachment · Command". Color is sourced from the members-panel tree node (the detail workspace object carries no color).
- **Detachment panel** — group-only rail panel that mounts the live `#workspace-detail-members-panel` via the P3 shared-surface pattern; member list, add-existing picker, create-member form, and rollups all come from the existing `WorkspaceMembersPanel` (no member logic duplicated).
- **Board view** — List ⇄ Board toggle in the Tasks stat modal; Board mode goes full-width and hosts the live `#workspace-detail-tasks-board` (columns, setup empty-state, cards, drag/drop). Zero board renderer copied; the node is handed back to Detailed on exit.
- **Tag filters** — `OriTagFilterBar` in the Tasks modal and Notes panel; garrison quest logs share the active task-tag filter. Bar instances persist across re-renders so filter state survives.
- **Notes multi-select** — per-note checkboxes, select-all / copy / delete, and a view-all link, all delegating to existing `WorkspaceDetailPage` methods (selection state lives on the page).

### Design
Everything reuses the P3 shared-surface mount (`mountSharedSurface`/`restoreSharedSurface`/anchors): the Detachment panel, the board, and config surfaces all mount live Detailed nodes and restore them on exit — so P5's deletion of Detailed is the only remaining step to make Command standalone.

### Testing
- `make test-js` 511 pass · `npm run lint` clean · `./scripts/build-server.sh` OK.
- 54 command-view unit tests (group badge/no-badge, accent-from-tree-node, detachment presence, board List/Board toggle + node hand-back, note filter/multiselect, task+note `OriTagFilterBar` reuse).
- **Interactive live smoke** on an isolated server (group workspace + member + 3 tagged notes + 3 tagged tasks): group badge + blue accent, Detachment mounts live members, notes filter narrows + state persists + multi-select toolbar, Tasks modal → full-width board (5 columns, card, setup empty-state) → clean hand-back, task filter narrows + count matches. No console errors. Smoke found and fixed a group-color source bug (see second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)