### PR TITLE
feat(local-models): context-window resolution + prompt/conversation token budgeting (WS1+WS2+WS7)

### DIFF
--- a/internal/llm/base_provider.go
+++ b/internal/llm/base_provider.go
@@ -2,8 +2,41 @@ package llm
 
 import (
 	"net/http"
+	"strings"
 	"time"
 )
+
+// defaultLocalContextWindow is the conservative fallback context window (in
+// tokens) for local models when no per-model or provider-level value is
+// configured (WS7.30 replaces the previously hardcoded literal).
+const defaultLocalContextWindow = 8192
+
+// resolveContextWindows extracts an optional provider-level default context
+// window and per-model overrides from provider config Options. Recognized keys:
+//
+//	"context_window":  number  — provider-level default (0 = unset)
+//	"context_windows": object  — {"<model>": number, ...} per-model overrides
+//
+// Model keys are lower-cased for case-insensitive lookup.
+func resolveContextWindows(config ProviderConfig) (defaultWindow int, perModel map[string]int) {
+	perModel = map[string]int{}
+	if config.Options == nil {
+		return 0, perModel
+	}
+	if v, ok := config.Options["context_window"]; ok {
+		defaultWindow = toInt(v)
+	}
+	if v, ok := config.Options["context_windows"]; ok {
+		if m, ok := v.(map[string]any); ok {
+			for model, raw := range m {
+				if w := toInt(raw); w > 0 {
+					perModel[strings.ToLower(strings.TrimSpace(model))] = w
+				}
+			}
+		}
+	}
+	return defaultWindow, perModel
+}
 
 // Common timeout constants for LLM providers
 const (

--- a/internal/llm/helpers.go
+++ b/internal/llm/helpers.go
@@ -2,8 +2,31 @@ package llm
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 )
+
+// toInt coerces a config value (which may arrive as int, float64 from JSON
+// decoding, or a numeric string) into an int. Returns 0 when the value is nil
+// or cannot be interpreted as a number.
+func toInt(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	case string:
+		i, _ := strconv.Atoi(strings.TrimSpace(n))
+		return i
+	default:
+		return 0
+	}
+}
 
 // NewUserMessage creates a new user message
 func NewUserMessage(content string) Message {

--- a/internal/llm/ollama_provider.go
+++ b/internal/llm/ollama_provider.go
@@ -9,13 +9,32 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
+// defaultMaxNumCtx caps the num_ctx we ask Ollama to allocate, so an optimistic
+// per-model context_window config cannot exhaust VRAM (WS1.4). Configurable per
+// provider via ProviderConfig.Options["max_num_ctx"].
+const defaultMaxNumCtx = 32768
+
+// modelListCacheTTL bounds how long a fetched /api/tags model list is reused so
+// HasModel / FindLocalProviderByModel do not issue a live HTTP request per task
+// (WS7.29).
+const modelListCacheTTL = 60 * time.Second
+
 // OllamaProvider implements the Provider interface for Ollama
 type OllamaProvider struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL              string
+	httpClient           *http.Client
+	maxNumCtx            int
+	defaultContextWindow int            // provider-level default (0 = use fallback)
+	contextWindows       map[string]int // per-model overrides, keyed lower-case
+
+	// modelCache memoizes /api/tags results for modelListCacheTTL.
+	modelCacheMu      sync.Mutex
+	modelCache        []string
+	modelCacheExpires time.Time
 }
 
 // NewOllamaProvider creates a new Ollama provider
@@ -25,10 +44,50 @@ func NewOllamaProvider(config ProviderConfig) *OllamaProvider {
 		baseURL = "http://localhost:11434"
 	}
 
+	defaultWindow, perModel := resolveContextWindows(config)
+
 	return &OllamaProvider{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		httpClient: NewHTTPClient(DefaultLocalTimeout),
+		baseURL:              strings.TrimRight(baseURL, "/"),
+		httpClient:           NewHTTPClient(DefaultLocalTimeout),
+		maxNumCtx:            resolveMaxNumCtx(config),
+		defaultContextWindow: defaultWindow,
+		contextWindows:       perModel,
 	}
+}
+
+// ModelContextWindow returns the configured context window for a specific model,
+// falling back to the provider-level default (or 0 if neither is set, letting
+// ResolveModelContextWindow fall back to Capabilities().MaxContextWindow).
+func (p *OllamaProvider) ModelContextWindow(model string) int {
+	if w, ok := p.contextWindows[strings.ToLower(strings.TrimSpace(model))]; ok && w > 0 {
+		return w
+	}
+	return p.defaultContextWindow
+}
+
+// resolveMaxNumCtx reads an optional per-provider num_ctx ceiling from config,
+// falling back to defaultMaxNumCtx.
+func resolveMaxNumCtx(config ProviderConfig) int {
+	if config.Options != nil {
+		if v, ok := config.Options["max_num_ctx"]; ok {
+			if n := toInt(v); n > 0 {
+				return n
+			}
+		}
+	}
+	return defaultMaxNumCtx
+}
+
+// clampNumCtx bounds a requested context window by the provider's ceiling.
+func (p *OllamaProvider) clampNumCtx(n int) int {
+	ceiling := p.maxNumCtx
+	if ceiling <= 0 {
+		ceiling = defaultMaxNumCtx
+	}
+	if n > ceiling {
+		return ceiling
+	}
+	return n
 }
 
 // Name returns the provider name
@@ -41,9 +100,15 @@ func (p *OllamaProvider) Type() ProviderType {
 	return ProviderTypeLocal
 }
 
-// Capabilities returns what this provider supports
+// Capabilities returns what this provider supports. The context window reflects
+// the configured provider-level default when set, else a conservative fallback;
+// per-model values are resolved via ModelContextWindow / ResolveModelContextWindow.
 func (p *OllamaProvider) Capabilities() ProviderCapabilities {
-	return LocalProviderCapabilities(8192) // Varies by model, using conservative default
+	window := p.defaultContextWindow
+	if window <= 0 {
+		window = defaultLocalContextWindow
+	}
+	return LocalProviderCapabilities(window)
 }
 
 // ValidateConfig validates the provider configuration
@@ -102,9 +167,36 @@ func (p *OllamaProvider) DefaultModels() []string {
 	return models
 }
 
-// fetchAvailableModels queries Ollama for installed models
+// fetchAvailableModels returns installed models, served from a short-lived
+// cache (modelListCacheTTL) so per-task HasModel / provider-inference lookups
+// do not each hit /api/tags (WS7.29). A failed refresh does not poison the
+// cache; the caller sees the error and any prior cached value is left intact.
 func (p *OllamaProvider) fetchAvailableModels() ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	p.modelCacheMu.Lock()
+	defer p.modelCacheMu.Unlock()
+
+	if p.modelCache != nil && time.Now().Before(p.modelCacheExpires) {
+		cached := make([]string, len(p.modelCache))
+		copy(cached, p.modelCache)
+		return cached, nil
+	}
+
+	models, err := p.fetchAvailableModelsUncached()
+	if err != nil {
+		return nil, err
+	}
+
+	p.modelCache = models
+	p.modelCacheExpires = time.Now().Add(modelListCacheTTL)
+
+	cached := make([]string, len(models))
+	copy(cached, models)
+	return cached, nil
+}
+
+// fetchAvailableModelsUncached performs the live /api/tags query.
+func (p *OllamaProvider) fetchAvailableModelsUncached() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultModelFetchTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", p.baseURL+"/api/tags", nil)
@@ -199,49 +291,53 @@ type ollamaRequest struct {
 	Tools    []ollamaTool    `json:"tools,omitempty"`
 }
 
-// ollamaOptions represents Ollama request options
+// ollamaOptions represents Ollama request options.
+// Temperature is a pointer so an explicit 0 (deterministic) is sent rather than
+// dropped by omitempty — the whole point of WS7.27.
 type ollamaOptions struct {
-	Temperature float64 `json:"temperature,omitempty"`
-	NumPredict  int     `json:"num_predict,omitempty"` // max tokens
+	Temperature *float64 `json:"temperature,omitempty"`
+	NumPredict  int      `json:"num_predict,omitempty"` // max tokens
+	NumCtx      int      `json:"num_ctx,omitempty"`     // context window (prompt+gen)
 }
 
-// ollamaResponse represents a response from Ollama
+// ollamaResponse represents a response from Ollama. The *_count fields carry
+// token usage on the final (done) message for both blocking and streaming
+// responses (WS7.28).
 type ollamaResponse struct {
-	Model     string        `json:"model"`
-	CreatedAt string        `json:"created_at"`
-	Message   ollamaMessage `json:"message"`
-	Done      bool          `json:"done"`
+	Model           string        `json:"model"`
+	CreatedAt       string        `json:"created_at"`
+	Message         ollamaMessage `json:"message"`
+	Done            bool          `json:"done"`
+	PromptEvalCount int           `json:"prompt_eval_count"`
+	EvalCount       int           `json:"eval_count"`
 }
 
-// Chat sends a chat request to Ollama
-func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
-	// Convert messages to Ollama format
-	messages := make([]ollamaMessage, 0, len(req.Messages))
-
-	// Add system prompt if provided
-	if req.SystemPrompt != "" {
-		messages = append(messages, ollamaMessage{
-			Role:    "system",
-			Content: req.SystemPrompt,
-		})
+// usage converts Ollama's eval counters into the unified Usage shape.
+func (r ollamaResponse) usage() Usage {
+	return Usage{
+		PromptTokens:     r.PromptEvalCount,
+		CompletionTokens: r.EvalCount,
+		TotalTokens:      r.PromptEvalCount + r.EvalCount,
 	}
+}
 
+// toOllamaMessages converts unified messages (plus an optional system prompt)
+// into Ollama's wire format. Shared by Chat and StreamChat so the two paths
+// cannot drift.
+func toOllamaMessages(req ChatRequest) []ollamaMessage {
+	messages := make([]ollamaMessage, 0, len(req.Messages)+1)
+	if req.SystemPrompt != "" {
+		messages = append(messages, ollamaMessage{Role: "system", Content: req.SystemPrompt})
+	}
 	for _, msg := range req.Messages {
-		ollamaMsg := ollamaMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
-		}
-
-		// Add images if present (for vision-capable models like llava)
+		ollamaMsg := ollamaMessage{Role: msg.Role, Content: msg.Content}
 		if len(msg.Images) > 0 {
 			ollamaMsg.Images = make([]string, len(msg.Images))
 			for i, img := range msg.Images {
-				// Ollama expects raw base64 data, not data URLs
+				// Ollama expects raw base64 data, not data URLs.
 				ollamaMsg.Images[i] = img.Base64Data
 			}
 		}
-
-		// Convert tool calls if present (for assistant messages)
 		if len(msg.ToolCalls) > 0 {
 			ollamaMsg.ToolCalls = make([]ollamaToolCall, len(msg.ToolCalls))
 			for i, tc := range msg.ToolCalls {
@@ -253,42 +349,62 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 				}
 			}
 		}
-
 		messages = append(messages, ollamaMsg)
 	}
+	return messages
+}
 
-	// Build request options
-	var options *ollamaOptions
-	if req.Temperature > 0 || req.MaxTokens > 0 {
-		options = &ollamaOptions{}
-		if req.Temperature > 0 {
-			options.Temperature = req.Temperature
-		}
-		if req.MaxTokens > 0 {
-			options.NumPredict = req.MaxTokens
-		}
+// toOllamaTools converts unified tool defs into Ollama's wire format.
+func toOllamaTools(tools []Tool) []ollamaTool {
+	if len(tools) == 0 {
+		return nil
 	}
-
-	// Convert tools to Ollama format
-	var tools []ollamaTool
-	if len(req.Tools) > 0 {
-		tools = make([]ollamaTool, len(req.Tools))
-		for i, tool := range req.Tools {
-			tools[i] = ollamaTool{
-				Type:     "function",
-				Function: ollamaFunctionDef(tool),
-			}
-		}
+	out := make([]ollamaTool, len(tools))
+	for i, tool := range tools {
+		out[i] = ollamaTool{Type: "function", Function: ollamaFunctionDef(tool)}
 	}
+	return out
+}
 
-	// Build Ollama request
-	ollamaReq := ollamaRequest{
+// buildOptions assembles Ollama's options block from the unified request,
+// applying the temperature sentinel (>= 0 is sent, including 0) and clamping
+// num_ctx. Returns nil when no option needs setting so the request stays lean.
+func (p *OllamaProvider) buildOptions(req ChatRequest) *ollamaOptions {
+	var opts ollamaOptions
+	set := false
+	if req.Temperature >= 0 {
+		t := req.Temperature
+		opts.Temperature = &t
+		set = true
+	}
+	if req.MaxTokens > 0 {
+		opts.NumPredict = req.MaxTokens
+		set = true
+	}
+	if req.ContextWindowTokens > 0 {
+		opts.NumCtx = p.clampNumCtx(req.ContextWindowTokens)
+		set = true
+	}
+	if !set {
+		return nil
+	}
+	return &opts
+}
+
+// buildRequest assembles a full Ollama chat request shared by both paths.
+func (p *OllamaProvider) buildRequest(req ChatRequest, stream bool) ollamaRequest {
+	return ollamaRequest{
 		Model:    req.Model,
-		Messages: messages,
-		Stream:   false,
-		Options:  options,
-		Tools:    tools,
+		Messages: toOllamaMessages(req),
+		Stream:   stream,
+		Options:  p.buildOptions(req),
+		Tools:    toOllamaTools(req.Tools),
 	}
+}
+
+// Chat sends a chat request to Ollama
+func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	ollamaReq := p.buildRequest(req, false)
 
 	// Marshal request
 	reqBody, err := json.Marshal(ollamaReq)
@@ -326,7 +442,10 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 
 	// Convert to common format
 	chatResp := &ChatResponse{
-		Content: ollamaResp.Message.Content,
+		Content:  ollamaResp.Message.Content,
+		Model:    ollamaResp.Model,
+		Provider: p.Name(),
+		Usage:    ollamaResp.usage(),
 	}
 
 	// Convert tool calls if present
@@ -373,6 +492,9 @@ func (r *ollamaStreamReader) Next() (*StreamChunk, error) {
 		Content: chunk.Message.Content,
 		Done:    chunk.Done,
 	}
+	if chunk.Done {
+		streamChunk.Usage = chunk.usage()
+	}
 
 	// Handle tool calls if present
 	if len(chunk.Message.ToolCalls) > 0 {
@@ -402,80 +524,7 @@ func (r *ollamaStreamReader) Close() error {
 
 // StreamChat sends a streaming chat request to Ollama
 func (p *OllamaProvider) StreamChat(ctx context.Context, req ChatRequest) (StreamReader, error) {
-	// Convert messages to Ollama format
-	messages := make([]ollamaMessage, 0, len(req.Messages))
-
-	// Add system prompt if provided
-	if req.SystemPrompt != "" {
-		messages = append(messages, ollamaMessage{
-			Role:    "system",
-			Content: req.SystemPrompt,
-		})
-	}
-
-	for _, msg := range req.Messages {
-		ollamaMsg := ollamaMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
-		}
-
-		// Add images if present (for vision-capable models like llava)
-		if len(msg.Images) > 0 {
-			ollamaMsg.Images = make([]string, len(msg.Images))
-			for i, img := range msg.Images {
-				// Ollama expects raw base64 data, not data URLs
-				ollamaMsg.Images[i] = img.Base64Data
-			}
-		}
-
-		// Convert tool calls if present (for assistant messages)
-		if len(msg.ToolCalls) > 0 {
-			ollamaMsg.ToolCalls = make([]ollamaToolCall, len(msg.ToolCalls))
-			for i, tc := range msg.ToolCalls {
-				ollamaMsg.ToolCalls[i] = ollamaToolCall{
-					Function: ollamaFunction{
-						Name:      tc.Name,
-						Arguments: json.RawMessage(tc.Arguments),
-					},
-				}
-			}
-		}
-
-		messages = append(messages, ollamaMsg)
-	}
-
-	// Build request options
-	var options *ollamaOptions
-	if req.Temperature > 0 || req.MaxTokens > 0 {
-		options = &ollamaOptions{}
-		if req.Temperature > 0 {
-			options.Temperature = req.Temperature
-		}
-		if req.MaxTokens > 0 {
-			options.NumPredict = req.MaxTokens
-		}
-	}
-
-	// Convert tools to Ollama format
-	var tools []ollamaTool
-	if len(req.Tools) > 0 {
-		tools = make([]ollamaTool, len(req.Tools))
-		for i, tool := range req.Tools {
-			tools[i] = ollamaTool{
-				Type:     "function",
-				Function: ollamaFunctionDef(tool),
-			}
-		}
-	}
-
-	// Build Ollama request with streaming enabled
-	ollamaReq := ollamaRequest{
-		Model:    req.Model,
-		Messages: messages,
-		Stream:   true,
-		Options:  options,
-		Tools:    tools,
-	}
+	ollamaReq := p.buildRequest(req, true)
 
 	// Marshal request
 	reqBody, err := json.Marshal(ollamaReq)

--- a/internal/llm/ollama_provider_test.go
+++ b/internal/llm/ollama_provider_test.go
@@ -1,0 +1,164 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestOllamaBuildOptions_TemperatureSentinel(t *testing.T) {
+	p := NewOllamaProvider(ProviderConfig{BaseURL: "http://localhost:11434"})
+
+	// Temperature 0 must be SENT (the WS7.27 bug: omitempty/>0 dropped it).
+	opts := p.buildOptions(ChatRequest{Temperature: 0})
+	if opts == nil || opts.Temperature == nil {
+		t.Fatalf("temperature 0 should be sent, got opts=%+v", opts)
+	}
+	if *opts.Temperature != 0 {
+		t.Fatalf("expected temperature 0, got %v", *opts.Temperature)
+	}
+
+	// A negative sentinel means "unset" — omit temperature entirely.
+	opts = p.buildOptions(ChatRequest{Temperature: -1})
+	if opts != nil && opts.Temperature != nil {
+		t.Fatalf("negative temperature should be omitted, got %v", *opts.Temperature)
+	}
+
+	// A positive temperature is passed through.
+	opts = p.buildOptions(ChatRequest{Temperature: 0.7})
+	if opts == nil || opts.Temperature == nil || *opts.Temperature != 0.7 {
+		t.Fatalf("expected temperature 0.7, got %+v", opts)
+	}
+}
+
+func TestOllamaBuildOptions_NumCtxClamp(t *testing.T) {
+	p := NewOllamaProvider(ProviderConfig{BaseURL: "http://localhost:11434"})
+
+	// Below the clamp: passed through.
+	opts := p.buildOptions(ChatRequest{ContextWindowTokens: 8192})
+	if opts == nil || opts.NumCtx != 8192 {
+		t.Fatalf("expected num_ctx 8192, got %+v", opts)
+	}
+
+	// Above the default clamp (32768): clamped.
+	opts = p.buildOptions(ChatRequest{ContextWindowTokens: 200000})
+	if opts == nil || opts.NumCtx != defaultMaxNumCtx {
+		t.Fatalf("expected num_ctx clamped to %d, got %+v", defaultMaxNumCtx, opts)
+	}
+
+	// Configurable ceiling honored.
+	p2 := NewOllamaProvider(ProviderConfig{
+		BaseURL: "http://localhost:11434",
+		Options: map[string]any{"max_num_ctx": 16384},
+	})
+	opts = p2.buildOptions(ChatRequest{ContextWindowTokens: 200000})
+	if opts == nil || opts.NumCtx != 16384 {
+		t.Fatalf("expected num_ctx clamped to configured 16384, got %+v", opts)
+	}
+
+	// No option-worthy fields → nil options block.
+	if got := p.buildOptions(ChatRequest{Temperature: -1}); got != nil {
+		t.Fatalf("expected nil options, got %+v", got)
+	}
+}
+
+func TestOllamaResponseUsage(t *testing.T) {
+	r := ollamaResponse{PromptEvalCount: 10, EvalCount: 5}
+	got := r.usage()
+	want := Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
+	if got != want {
+		t.Fatalf("usage() = %+v, want %+v", got, want)
+	}
+}
+
+func TestOllamaModelContextWindow(t *testing.T) {
+	p := NewOllamaProvider(ProviderConfig{
+		BaseURL: "http://localhost:11434",
+		Options: map[string]any{
+			"context_window":  4096,
+			"context_windows": map[string]any{"llama3.1:8b": 8192},
+		},
+	})
+
+	if got := p.ModelContextWindow("llama3.1:8b"); got != 8192 {
+		t.Fatalf("per-model window = %d, want 8192", got)
+	}
+	// Case-insensitive.
+	if got := p.ModelContextWindow("LLAMA3.1:8B"); got != 8192 {
+		t.Fatalf("case-insensitive per-model window = %d, want 8192", got)
+	}
+	// Unknown model → provider default.
+	if got := p.ModelContextWindow("mistral"); got != 4096 {
+		t.Fatalf("default window = %d, want 4096", got)
+	}
+	// Capabilities reflects the configured default.
+	if got := p.Capabilities().MaxContextWindow; got != 4096 {
+		t.Fatalf("Capabilities window = %d, want 4096", got)
+	}
+}
+
+func TestResolveModelContextWindow_Fallback(t *testing.T) {
+	// No config → ModelContextWindow returns 0 → fall back to Capabilities().
+	p := NewOllamaProvider(ProviderConfig{BaseURL: "http://localhost:11434"})
+	if got := ResolveModelContextWindow(p, "anything"); got != defaultLocalContextWindow {
+		t.Fatalf("fallback window = %d, want %d", got, defaultLocalContextWindow)
+	}
+}
+
+func TestOllamaChat_SendsNumCtxAndParsesUsage(t *testing.T) {
+	var captured ollamaRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"model":"llama3.1:8b","message":{"role":"assistant","content":"hi"},"done":true,"prompt_eval_count":12,"eval_count":7}`)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(ProviderConfig{BaseURL: srv.URL})
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:               "llama3.1:8b",
+		Messages:            []Message{NewUserMessage("hello")},
+		Temperature:         0,
+		ContextWindowTokens: 8192,
+	})
+	if err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+
+	// num_ctx and temperature 0 crossed the wire.
+	if captured.Options == nil || captured.Options.NumCtx != 8192 {
+		t.Fatalf("num_ctx not sent: %+v", captured.Options)
+	}
+	if captured.Options.Temperature == nil || *captured.Options.Temperature != 0 {
+		t.Fatalf("temperature 0 not sent: %+v", captured.Options)
+	}
+	// Usage parsed.
+	if resp.Usage.PromptTokens != 12 || resp.Usage.CompletionTokens != 7 || resp.Usage.TotalTokens != 19 {
+		t.Fatalf("usage not parsed: %+v", resp.Usage)
+	}
+}
+
+func TestOllamaModelListCache(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"models":[{"name":"llama3.1:8b"}]}`)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(ProviderConfig{BaseURL: srv.URL})
+	for i := 0; i < 5; i++ {
+		if !p.HasModel("llama3.1:8b") {
+			t.Fatalf("expected model present on call %d", i)
+		}
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 /api/tags fetch (cached), got %d", got)
+	}
+}

--- a/internal/llm/openai_compatible_local_provider.go
+++ b/internal/llm/openai_compatible_local_provider.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/openai/openai-go/v3"
@@ -27,11 +28,19 @@ type openAICompatibleModelsResponse struct {
 // OpenAICompatibleLocalProvider implements local providers that expose
 // OpenAI-compatible chat completion endpoints, such as LM Studio and MLX-LM.
 type OpenAICompatibleLocalProvider struct {
-	name           string
-	baseURL        string
-	client         openai.Client
-	httpClient     *http.Client
-	fallbackModels []string
+	name                 string
+	baseURL              string
+	client               openai.Client
+	httpClient           *http.Client
+	fallbackModels       []string
+	defaultContextWindow int            // provider-level default (0 = use fallback)
+	contextWindows       map[string]int // per-model overrides, keyed lower-case
+
+	// modelCache memoizes /models results for modelListCacheTTL so per-task
+	// HasModel lookups do not each hit the server (WS7.29).
+	modelCacheMu      sync.Mutex
+	modelCache        []string
+	modelCacheExpires time.Time
 }
 
 // NewLMStudioProvider creates a provider for LM Studio's OpenAI-compatible server.
@@ -63,13 +72,28 @@ func newOpenAICompatibleLocalProvider(name, defaultBaseURL string, config Provid
 		fallbackModels = append(fallbackModels, model)
 	}
 
+	defaultWindow, perModel := resolveContextWindows(config)
+
 	return &OpenAICompatibleLocalProvider{
-		name:           name,
-		baseURL:        baseURL,
-		client:         openai.NewClient(opts...),
-		httpClient:     httpClient,
-		fallbackModels: fallbackModels,
+		name:                 name,
+		baseURL:              baseURL,
+		client:               openai.NewClient(opts...),
+		httpClient:           httpClient,
+		fallbackModels:       fallbackModels,
+		defaultContextWindow: defaultWindow,
+		contextWindows:       perModel,
 	}
+}
+
+// ModelContextWindow returns the configured context window for a specific model,
+// falling back to the provider-level default (0 if neither is set). For these
+// providers the value is advisory — the server sizes its own context — and is
+// used for prompt budgeting only (WS1.1).
+func (p *OpenAICompatibleLocalProvider) ModelContextWindow(model string) int {
+	if w, ok := p.contextWindows[strings.ToLower(strings.TrimSpace(model))]; ok && w > 0 {
+		return w
+	}
+	return p.defaultContextWindow
 }
 
 func normalizeOpenAICompatibleBaseURL(baseURL, defaultBaseURL string) string {
@@ -94,7 +118,11 @@ func (p *OpenAICompatibleLocalProvider) Type() ProviderType {
 }
 
 func (p *OpenAICompatibleLocalProvider) Capabilities() ProviderCapabilities {
-	return LocalProviderCapabilities(8192)
+	window := p.defaultContextWindow
+	if window <= 0 {
+		window = defaultLocalContextWindow
+	}
+	return LocalProviderCapabilities(window)
 }
 
 func (p *OpenAICompatibleLocalProvider) ValidateConfig(config ProviderConfig) error {
@@ -154,6 +182,29 @@ func (p *OpenAICompatibleLocalProvider) HasModel(modelName string) bool {
 }
 
 func (p *OpenAICompatibleLocalProvider) fetchAvailableModels() ([]string, error) {
+	p.modelCacheMu.Lock()
+	defer p.modelCacheMu.Unlock()
+
+	if p.modelCache != nil && time.Now().Before(p.modelCacheExpires) {
+		cached := make([]string, len(p.modelCache))
+		copy(cached, p.modelCache)
+		return cached, nil
+	}
+
+	models, err := p.fetchAvailableModelsUncached()
+	if err != nil {
+		return nil, err
+	}
+
+	p.modelCache = models
+	p.modelCacheExpires = time.Now().Add(modelListCacheTTL)
+
+	cached := make([]string, len(models))
+	copy(cached, models)
+	return cached, nil
+}
+
+func (p *OpenAICompatibleLocalProvider) fetchAvailableModelsUncached() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultModelFetchTimeout)
 	defer cancel()
 

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -38,6 +38,29 @@ type StructuredOutputProvider interface {
 	ChatWithStructuredOutput(ctx context.Context, req StructuredOutputRequest) (*ChatResponse, error)
 }
 
+// ModelContextWindowResolver reports a model-specific context window (in tokens)
+// when a provider can resolve one (e.g. from per-model config). Return 0 to defer
+// to Capabilities().MaxContextWindow. Prefer ResolveModelContextWindow, which
+// applies that fallback.
+type ModelContextWindowResolver interface {
+	ModelContextWindow(model string) int
+}
+
+// ResolveModelContextWindow returns the best-known context window for a model:
+// a provider's per-model override (when it implements ModelContextWindowResolver
+// and returns a positive value), otherwise its Capabilities().MaxContextWindow.
+func ResolveModelContextWindow(provider Provider, model string) int {
+	if provider == nil {
+		return 0
+	}
+	if r, ok := provider.(ModelContextWindowResolver); ok {
+		if n := r.ModelContextWindow(model); n > 0 {
+			return n
+		}
+	}
+	return provider.Capabilities().MaxContextWindow
+}
+
 // StreamReader provides an interface for reading streamed responses
 type StreamReader interface {
 	// Next returns the next chunk of the response
@@ -52,6 +75,11 @@ type StreamChunk struct {
 	Content  string
 	ToolCall *ToolCall
 	Done     bool
+
+	// Usage carries token usage and is populated only on the final (Done)
+	// chunk by providers that report it (e.g. Ollama's eval counters). Zero on
+	// intermediate chunks.
+	Usage Usage
 }
 
 // ProviderType categorizes providers

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -20,6 +20,14 @@ type ChatRequest struct {
 	// MaxTokens is the maximum number of tokens to generate
 	MaxTokens int
 
+	// ContextWindowTokens is the effective context window (prompt + generation)
+	// the caller has resolved for this model, in tokens. 0 means "provider
+	// default". Local providers that own their context size (Ollama) map it to
+	// their runtime option (num_ctx); OpenAI-compatible local servers size their
+	// own context, so for them it is advisory (used for budgeting only). Cloud
+	// providers ignore it.
+	ContextWindowTokens int
+
 	// Stream indicates whether to stream the response
 	Stream bool
 

--- a/internal/server/initialization.go
+++ b/internal/server/initialization.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"os"
@@ -144,6 +145,7 @@ func registerLLMProviders(factory *llm.Factory, configMgr *config.Manager) error
 	}
 	ollamaProvider := llm.NewOllamaProvider(llm.ProviderConfig{
 		BaseURL: ollamaBaseURL,
+		Options: localProviderContextOptions("OLLAMA"),
 	})
 	factory.Register("ollama", ollamaProvider)
 	if verbose {
@@ -156,6 +158,7 @@ func registerLLMProviders(factory *llm.Factory, configMgr *config.Manager) error
 	lmStudioProvider := llm.NewLMStudioProvider(llm.ProviderConfig{
 		BaseURL: lmStudioBaseURL,
 		Model:   lmStudioModel,
+		Options: localProviderContextOptions("LM_STUDIO"),
 	})
 	factory.Register("lmstudio", lmStudioProvider)
 	if verbose {
@@ -171,6 +174,7 @@ func registerLLMProviders(factory *llm.Factory, configMgr *config.Manager) error
 	mlxLMProvider := llm.NewMLXLMProvider(llm.ProviderConfig{
 		BaseURL: mlxLMBaseURL,
 		Model:   mlxLMModel,
+		Options: localProviderContextOptions("MLX_LM"),
 	})
 	factory.Register("mlx_lm", mlxLMProvider)
 	if verbose {
@@ -181,6 +185,43 @@ func registerLLMProviders(factory *llm.Factory, configMgr *config.Manager) error
 	}
 
 	return nil
+}
+
+// localProviderContextOptions builds a ProviderConfig.Options map for a local
+// provider from environment variables, using the given prefix (e.g. "OLLAMA").
+// Recognized vars:
+//
+//	<PREFIX>_CONTEXT_WINDOW    provider-level default context window (tokens)
+//	<PREFIX>_MAX_NUM_CTX       ceiling for the requested num_ctx (Ollama)
+//	<PREFIX>_CONTEXT_WINDOWS   JSON object of per-model overrides, e.g.
+//	                          '{"llama3.1:8b":8192,"qwen2.5:7b":16384}'
+//
+// Returns nil when nothing is configured, so zero-config behavior is unchanged.
+// Long-term this config should move to provider settings (PRD Open Question 5);
+// env keeps parity with how local providers are configured today.
+func localProviderContextOptions(prefix string) map[string]any {
+	opts := map[string]any{}
+	if v := os.Getenv(prefix + "_CONTEXT_WINDOW"); v != "" {
+		opts["context_window"] = v
+	}
+	if v := os.Getenv(prefix + "_MAX_NUM_CTX"); v != "" {
+		opts["max_num_ctx"] = v
+	}
+	if v := os.Getenv(prefix + "_CONTEXT_WINDOWS"); v != "" {
+		var perModel map[string]any
+		if err := json.Unmarshal([]byte(v), &perModel); err == nil {
+			opts["context_windows"] = perModel
+		} else {
+			logger.Warn("Ignoring malformed per-model context window config", logger.Fields{
+				"env":   prefix + "_CONTEXT_WINDOWS",
+				"error": err.Error(),
+			})
+		}
+	}
+	if len(opts) == 0 {
+		return nil
+	}
+	return opts
 }
 
 // resolveAgentStorePath determines the agent store path from environment or default.

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -262,6 +262,11 @@ func (h *LLMTaskHandler) executeTaskConversation(
 	successfulToolCalls := map[string]bool{}
 	forceFinalAnswer := false
 
+	// Resolve the effective context window once and reuse it for every round, so
+	// the prompt is sized against a stable value (and, for Ollama, num_ctx is set
+	// from it). 0 = provider default; cloud providers ignore the field (WS1.3).
+	contextWindow := llm.ResolveModelContextWindow(provider, modelName)
+
 	for round := 0; round < maxTaskToolRounds; round++ {
 		requestTools := tools
 		if forceFinalAnswer {
@@ -281,11 +286,12 @@ func (h *LLMTaskHandler) executeTaskConversation(
 		}
 
 		chatReq := llm.ChatRequest{
-			Model:           modelName,
-			Messages:        conversation,
-			Temperature:     ag.Settings.Temperature,
-			ReasoningEffort: ag.Settings.EffectiveReasoningEffort(providerName),
-			Tools:           requestTools,
+			Model:               modelName,
+			Messages:            conversation,
+			Temperature:         ag.Settings.Temperature,
+			ReasoningEffort:     ag.Settings.EffectiveReasoningEffort(providerName),
+			Tools:               requestTools,
+			ContextWindowTokens: contextWindow,
 		}
 		// CLI agents (Claude Code / Codex), once opted in, run with an elevated
 		// sandboxed posture: workspace-write filesystem + localhost network +

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -217,29 +217,39 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 	}
 	modelName := h.normalizeModelForProvider(providerName, ag.Settings.Model)
 
-	// Build the prompt for the task
-	prompt := h.buildTaskPrompt(ctx, task)
-
-	// Prepare messages
-	messages := []llm.Message{
-		llm.NewUserMessage(prompt),
-	}
-
-	// Use a task-specific system prompt that's more conservative about tool use
-	// The agent's system prompt may encourage aggressive tool use which is inappropriate for workspace tasks
+	// Use a task-specific system prompt that's more conservative about tool use.
+	// The agent's system prompt may encourage aggressive tool use which is
+	// inappropriate for workspace tasks. Skills are injected so task/orchestration
+	// runs get skill instructions too, matching the chat path (skill-less agents
+	// add nothing).
 	taskSystemPrompt := h.buildTaskSystemPrompt()
-	// Inject the agent's resolved (enabled + bound) skills so task/orchestration
-	// runs get skill instructions too, matching the chat path. Skill-less agents
-	// add nothing (AppendSkillPromptsFromResolved returns the base unchanged).
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
 
-	messages = append([]llm.Message{llm.NewSystemMessage(taskSystemPrompt)}, messages...)
-
-	// Convert agent tools (MCP + workspace) to LLM format
+	// Convert agent tools (MCP + workspace) to LLM format. Needed before budgeting
+	// because tool schemas consume the context window too.
 	tools := h.convertAgentToolsToLLMTools(ag, task)
 
+	// Resolve the effective context window once and budget the assembled prompt
+	// against it, trimming the least-load-bearing sections in a fixed order (WS2).
+	// Cloud windows are large enough that nothing trims. If the prompt still
+	// overflows after all trims, block rather than let the server truncate it.
+	contextWindow := llm.ResolveModelContextWindow(provider, modelName)
+	segments := h.buildTaskPromptSegments(ctx, task)
+	trims, overflow := budgetPromptSegments(contextWindow, taskSystemPrompt, tools, segments)
+	if overflow {
+		return "", h.buildContextOverflowError(task, contextWindow, trimmableSegmentLabels(segments))
+	}
+	if len(trims) > 0 {
+		h.reportPromptTrims(task, agentName, contextWindow, trims)
+	}
+
+	messages := []llm.Message{
+		llm.NewSystemMessage(taskSystemPrompt),
+		llm.NewUserMessage(renderPromptSegments(segments)),
+	}
+
 	// Call the LLM
-	return h.executeTaskConversation(ctx, provider, providerName, modelName, ag, agentName, task, messages, tools)
+	return h.executeTaskConversation(ctx, provider, providerName, modelName, contextWindow, ag, agentName, task, messages, tools)
 }
 
 // resolveExecutionAgent and the rest of the agent-resolution helpers live
@@ -250,6 +260,7 @@ func (h *LLMTaskHandler) executeTaskConversation(
 	provider llm.Provider,
 	providerName string,
 	modelName string,
+	contextWindow int,
 	ag *resolvedTaskAgent,
 	agentName string,
 	task Task,
@@ -262,15 +273,25 @@ func (h *LLMTaskHandler) executeTaskConversation(
 	successfulToolCalls := map[string]bool{}
 	forceFinalAnswer := false
 
-	// Resolve the effective context window once and reuse it for every round, so
-	// the prompt is sized against a stable value (and, for Ollama, num_ctx is set
-	// from it). 0 = provider default; cloud providers ignore the field (WS1.3).
-	contextWindow := llm.ResolveModelContextWindow(provider, modelName)
+	// Tool-result messages appended to the conversation are capped tighter for
+	// local providers, whose context windows are small (WS2.9).
+	isLocal := provider.Type() == llm.ProviderTypeLocal
 
 	for round := 0; round < maxTaskToolRounds; round++ {
 		requestTools := tools
 		if forceFinalAnswer {
 			requestTools = nil
+		}
+
+		// The conversation grows every round; keep it within the window by
+		// compacting the oldest tool-result messages before sending (WS2.10a). If
+		// it still overflows after compaction, block instead of letting the server
+		// truncate mid-task.
+		if compacted, stillOver := evictConversationForContext(conversation, contextWindow, requestTools); compacted > 0 || stillOver {
+			h.reportConversationEviction(task, agentName, round+1, compacted, stillOver)
+			if stillOver {
+				return "", h.buildContextOverflowError(task, contextWindow, []string{"conversation_history"})
+			}
 		}
 
 		// Bracket the LLM call so the UI can show "awaiting LLM" instead of a
@@ -292,6 +313,18 @@ func (h *LLMTaskHandler) executeTaskConversation(
 			ReasoningEffort:     ag.Settings.EffectiveReasoningEffort(providerName),
 			Tools:               requestTools,
 			ContextWindowTokens: contextWindow,
+		}
+		// Keep generation from overrunning the context window: an explicit cap
+		// larger than the reserved output headroom is lowered so prompt+generation
+		// cannot exceed num_ctx and truncate the answer (WS2.5a). With no explicit
+		// cap (0 = provider default) this is a no-op.
+		if contextWindow > 0 {
+			if capped, lowered := reconcileGenerationCap(chatReq.MaxTokens, reservedOutputHeadroom(contextWindow)); lowered {
+				logger.Debug("Lowered generation cap to reserved output headroom", logger.Fields{
+					"task_id": task.ID, "from": chatReq.MaxTokens, "to": capped,
+				})
+				chatReq.MaxTokens = capped
+			}
 		}
 		// CLI agents (Claude Code / Codex), once opted in, run with an elevated
 		// sandboxed posture: workspace-write filesystem + localhost network +
@@ -438,6 +471,17 @@ func (h *LLMTaskHandler) executeTaskConversation(
 			toolContent := tr.Result
 			if tr.Error != nil {
 				toolContent = fmt.Sprintf("ERROR: %s", tr.Error.Error())
+			}
+
+			// Cap the copy appended to the conversation so one large tool result
+			// cannot dominate a small window. The full untruncated result stays in
+			// toolResults for event previews / result storage (WS2.9).
+			toolResultCap := maxToolResultBytesCloud
+			if isLocal {
+				toolResultCap = maxToolResultBytesLocal
+			}
+			if capped, cut := truncateHeadTailBytes(toolContent, toolResultCap); cut > 0 {
+				toolContent = capped
 			}
 
 			toolCallID := strings.TrimSpace(conversationToolCalls[index].ID)
@@ -653,6 +697,75 @@ func (h *LLMTaskHandler) cleanToolResult(result string) string {
 // looksLikeBrowserCapabilityRefusal helpers and their pattern data) lives
 // in task_handler_browser_intent.go.
 
+// buildContextOverflowError builds a blocked error for a prompt/conversation
+// that exceeds the model's context window even after all trims (WS2.10). The
+// offending sections are named so the user can act on them.
+func (h *LLMTaskHandler) buildContextOverflowError(task Task, window int, sections []string) error {
+	sectionList := strings.Join(sections, ", ")
+	logger.Warn("Task prompt exceeds model context window after trims", logger.Fields{
+		"workspace_id":   task.WorkspaceID,
+		"task_id":        task.ID,
+		"context_window": window,
+		"sections":       sectionList,
+	})
+	reason := fmt.Sprintf("The task prompt exceeds the model's %d-token context window even after trimming.", window)
+	if sectionList != "" {
+		reason = fmt.Sprintf("%s Largest sections: %s.", reason, sectionList)
+	}
+	return &TaskBlockedError{
+		ReasonCode:       "context_overflow",
+		Reason:           reason,
+		Question:         "The task is too large for this model's context window. Reduce attachments/inputs, assign a larger-context model, or switch agents?",
+		SuggestedActions: []string{"switch_agent_retry", "retry", "mark_failed"},
+	}
+}
+
+// reportPromptTrims logs and emits the prompt trims performed to fit the window
+// so they are observable on the execution trace (WS2 observability).
+func (h *LLMTaskHandler) reportPromptTrims(task Task, agentName string, window int, trims []budgetTrim) {
+	total := 0
+	parts := make([]string, 0, len(trims))
+	for _, t := range trims {
+		total += t.BytesCut
+		parts = append(parts, fmt.Sprintf("%s:%d", t.Label, t.BytesCut))
+	}
+	logger.Info("Trimmed task prompt to fit model context", logger.Fields{
+		"workspace_id":    task.WorkspaceID,
+		"task_id":         task.ID,
+		"context_window":  window,
+		"bytes_cut_total": total,
+		"trims":           strings.Join(parts, ","),
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":           "prompt_trimmed",
+			"context_window":  window,
+			"bytes_cut_total": total,
+			"sections":        parts,
+		}))
+	}
+}
+
+// reportConversationEviction logs and emits a per-round conversation compaction
+// (WS2.10a observability).
+func (h *LLMTaskHandler) reportConversationEviction(task Task, agentName string, round, compacted int, stillOver bool) {
+	logger.Info("Compacted task conversation to fit model context", logger.Fields{
+		"workspace_id":     task.WorkspaceID,
+		"task_id":          task.ID,
+		"round":            round,
+		"messages_compact": compacted,
+		"still_over":       stillOver,
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":              "conversation_compacted",
+			"round":              round,
+			"messages_compacted": compacted,
+			"still_over_budget":  stillOver,
+		}))
+	}
+}
+
 // buildTaskPrompt creates a prompt for the task
 // AttachmentContent holds attachment info and file contents
 type AttachmentContent struct {
@@ -676,6 +789,7 @@ func (h *LLMTaskHandler) getAttachedFileContents(task Task) []AttachmentContent 
 	}
 
 	var attachmentContents []AttachmentContent
+	totalInjected := 0 // bytes of attachment content injected so far (WS2.8)
 
 	// Find connections from attachments to this task
 	if workspace.Layout != nil && workspace.Layout.WorkflowConnections != nil {
@@ -701,7 +815,31 @@ func (h *LLMTaskHandler) getAttachedFileContents(task Task) []AttachmentContent 
 								logger.Warn("Failed to read attachment file", logger.Fields{"file": filePath, "error": err})
 								attContent.Content = fmt.Sprintf("[Failed to read file: %v]", err)
 							} else {
-								attContent.Content = string(content)
+								// Enforce per-file and total byte caps before injection so a
+								// large attachment cannot blow the context window ahead of the
+								// budget pass (WS2.8). Full content stays available via
+								// workspace_files tools.
+								remaining := maxAttachmentBytesTotal - totalInjected
+								if remaining <= 0 {
+									attContent.Content = fmt.Sprintf("…[attachment omitted: task attachment budget of %d bytes exhausted; read it with the workspace_files tool]…", maxAttachmentBytesTotal)
+								} else {
+									perFileCap := maxAttachmentBytesPerFile
+									if remaining < perFileCap {
+										perFileCap = remaining
+									}
+									capped, cut := truncateHeadTailBytes(string(content), perFileCap)
+									if cut > 0 {
+										logger.Warn("Capped oversized task attachment", logger.Fields{
+											"workspace_id": task.WorkspaceID,
+											"task_id":      task.ID,
+											"file":         filePath,
+											"bytes_cut":    cut,
+											"cap":          perFileCap,
+										})
+									}
+									attContent.Content = capped
+									totalInjected += len(capped)
+								}
 							}
 						}
 

--- a/internal/workspace/task_handler_native_mcp_test.go
+++ b/internal/workspace/task_handler_native_mcp_test.go
@@ -61,7 +61,7 @@ func TestExecuteTaskConversation_NativeMCPWiring(t *testing.T) {
 	ag := nativeMCPAgent(true)
 	ag.MCPServers = []string{runtime}
 
-	out, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", ag, "reaper",
+	out, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", 0, ag, "reaper",
 		Task{WorkspaceID: "ws-x"}, []llm.Message{llm.NewUserMessage("create project")}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -100,7 +100,7 @@ func TestExecuteTaskConversation_NativeMCPGatedOff(t *testing.T) {
 	ag := nativeMCPAgent(false) // agent NOT opted in
 	ag.MCPServers = []string{runtime}
 
-	if _, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", ag, "reaper",
+	if _, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", 0, ag, "reaper",
 		Task{WorkspaceID: "ws-y"}, []llm.Message{llm.NewUserMessage("x")}, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestExecuteTaskConversation_SkillOnlyElevated(t *testing.T) {
 	ag := nativeMCPAgent(true) // opted in
 	ag.MCPServers = nil        // skill-only: no MCP servers bound
 
-	if _, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", ag, "reaper",
+	if _, err := h.executeTaskConversation(context.Background(), prov, "codex", "gpt-5.5", 0, ag, "reaper",
 		Task{WorkspaceID: "ws-s"}, []llm.Message{llm.NewUserMessage("x")}, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/internal/workspace/task_prompt_context.go
+++ b/internal/workspace/task_prompt_context.go
@@ -665,114 +665,150 @@ func sanitizeTaskPromptText(value string, maxLen int) string {
 	return cleaned
 }
 
-// buildTaskPrompt creates a prompt for the task
+// buildTaskPrompt creates the rendered (unbudgeted) task user-prompt. Callers
+// that need token budgeting use buildTaskPromptSegments + budgetPromptSegments
+// and render the result themselves; this convenience wrapper keeps the previous
+// behavior for any caller that just wants the string.
 func (h *LLMTaskHandler) buildTaskPrompt(ctx context.Context, task Task) string {
-	var prompt strings.Builder
+	return renderPromptSegments(h.buildTaskPromptSegments(ctx, task))
+}
 
-	prompt.WriteString("# Task Assignment\n\n")
-	prompt.WriteString("You have been assigned a task in a collaborative workspace.\n\n")
-	fmt.Fprintf(&prompt, "**Task ID**: %s\n", task.ID)
-	fmt.Fprintf(&prompt, "**From**: %s\n", task.From)
-	fmt.Fprintf(&prompt, "**Priority**: %d/5\n\n", task.Priority)
+// buildTaskPromptSegments assembles the task user-prompt as ordered, labeled
+// segments. The task description, output-format instructions, and framing live
+// in protected segments (trimOrder 0); memory, workspace snapshot, attachments,
+// and upstream results carry trim ranks so the budget pass can shrink them in a
+// fixed order (WS2.6) without dropping load-bearing content. Concatenating the
+// segments in order reproduces the previous single-string prompt exactly when no
+// trimming occurs.
+func (h *LLMTaskHandler) buildTaskPromptSegments(ctx context.Context, task Task) []promptSegment {
+	segs := make([]promptSegment, 0, 6)
 
-	// Process task description with placeholder substitution
+	// Protected header: assignment framing, description, details, reference URL,
+	// user profile.
+	var header strings.Builder
+	header.WriteString("# Task Assignment\n\n")
+	header.WriteString("You have been assigned a task in a collaborative workspace.\n\n")
+	fmt.Fprintf(&header, "**Task ID**: %s\n", task.ID)
+	fmt.Fprintf(&header, "**From**: %s\n", task.From)
+	fmt.Fprintf(&header, "**Priority**: %d/5\n\n", task.Priority)
+
 	processedDescription := h.substitutePlaceholders(task)
-	fmt.Fprintf(&prompt, "## Task Description\n\n%s\n\n", processedDescription)
+	fmt.Fprintf(&header, "## Task Description\n\n%s\n\n", processedDescription)
 
 	if details := strings.TrimSpace(task.Details); details != "" {
-		prompt.WriteString("## Task Details\n\n")
-		prompt.WriteString(details)
-		prompt.WriteString("\n\n")
+		header.WriteString("## Task Details\n\n")
+		header.WriteString(details)
+		header.WriteString("\n\n")
 	}
 
 	if referenceURL := strings.TrimSpace(task.ReferenceURL); referenceURL != "" {
-		prompt.WriteString("## Reference URL\n\n")
-		prompt.WriteString(referenceURL)
-		prompt.WriteString("\n\n")
-		prompt.WriteString("Treat this URL as authoritative source material for this task. Inspect it with available fetch, browser, or web tools before making claims about its contents. If you cannot inspect it, state that limitation in your final response.\n\n")
+		header.WriteString("## Reference URL\n\n")
+		header.WriteString(referenceURL)
+		header.WriteString("\n\n")
+		header.WriteString("Treat this URL as authoritative source material for this task. Inspect it with available fetch, browser, or web tools before making claims about its contents. If you cannot inspect it, state that limitation in your final response.\n\n")
 	}
 
 	if userProfile := h.buildUserProfileSection(ctx, h.taskOwnerUserID(task)); userProfile != "" {
-		prompt.WriteString(userProfile)
-		prompt.WriteString("\n\n")
+		header.WriteString(userProfile)
+		header.WriteString("\n\n")
 	}
+	segs = append(segs, promptSegment{label: "header", text: header.String(), trimOrder: 0})
 
+	// Workspace memory — trimmed last (WS2.6 d).
 	if workspaceMemory := h.buildTaskMemorySection(task); workspaceMemory != "" {
-		prompt.WriteString(workspaceMemory)
-		prompt.WriteString("\n\n")
+		segs = append(segs, promptSegment{label: "memory", text: workspaceMemory + "\n\n", trimOrder: 4})
 	}
 
+	// Workspace snapshot (task/file/note/session lists) — WS2.6 c.
 	if workspaceSnapshot := h.buildTaskWorkspaceSnapshot(ctx, task); workspaceSnapshot != "" {
-		prompt.WriteString(workspaceSnapshot)
-		prompt.WriteString("\n\n")
+		segs = append(segs, promptSegment{label: "workspace_snapshot", text: workspaceSnapshot + "\n\n", trimOrder: 3})
 	}
 
-	// Include attachments if any are connected to this task
-	attachmentContents := h.getAttachedFileContents(task)
-	if len(attachmentContents) > 0 {
-		prompt.WriteString("## Attached Files\n\n")
-		prompt.WriteString("The following files are attached to this task:\n\n")
-		for _, att := range attachmentContents {
-			fmt.Fprintf(&prompt, "### %s\n\n", att.Title)
-			if att.FilePath != "" {
-				fmt.Fprintf(&prompt, "**File**: `%s`\n\n", att.FilePath)
-			}
-			if att.Body != "" {
-				fmt.Fprintf(&prompt, "**Note**: %s\n\n", att.Body)
-			}
-			if att.Content != "" {
-				prompt.WriteString("**Content**:\n```\n")
-				prompt.WriteString(att.Content)
-				prompt.WriteString("\n```\n\n")
-			}
-		}
+	// Attached file contents — trimmed first (WS2.6 a).
+	if attachmentSection := h.buildAttachmentsSection(task); attachmentSection != "" {
+		segs = append(segs, promptSegment{label: "attachments", text: attachmentSection, trimOrder: 1})
 	}
 
-	// Handle input task results specially for better formatting. Runtime inputs
-	// (rebuilt each execution) live on task.RuntimeInputs — never in Context.
-	// Structured outputs from upstream tasks with an OutputSchema get rendered
-	// as JSON alongside the raw text, so downstream tasks can consume either.
+	// Upstream task results / structured outputs — WS2.6 b. Runtime inputs
+	// (rebuilt each execution) live on task.RuntimeInputs; structured outputs from
+	// upstream tasks with an OutputSchema render as JSON alongside the raw text.
 	if task.RuntimeInputs != nil {
-		h.formatInputResults(&prompt, task.RuntimeInputs)
+		var inputs strings.Builder
+		h.formatInputResults(&inputs, task.RuntimeInputs)
+		if inputs.Len() > 0 {
+			segs = append(segs, promptSegment{label: "upstream_inputs", text: inputs.String(), trimOrder: 2})
+		}
 	}
 
-	// Include authored context fields. With runtime inputs no longer merged
-	// into Context, every key here is authored — no filtering needed.
+	// Protected tail: authored context, required output format, time limit, and
+	// the closing instructions.
+	var tail strings.Builder
 	if len(task.Context) > 0 {
-		prompt.WriteString("## Additional Context\n\n")
+		tail.WriteString("## Additional Context\n\n")
 		for key, value := range task.Context {
-			fmt.Fprintf(&prompt, "- **%s**: %v\n", key, value)
+			fmt.Fprintf(&tail, "- **%s**: %v\n", key, value)
 		}
-		prompt.WriteString("\n")
+		tail.WriteString("\n")
 	}
 
 	if outputInstructions := BuildTaskOutputSpecPrompt(ActiveTaskOutputSpec(&task)); outputInstructions != "" {
-		prompt.WriteString("## Required Output Format\n\n")
-		prompt.WriteString(outputInstructions)
-		prompt.WriteString("\n\n")
+		tail.WriteString("## Required Output Format\n\n")
+		tail.WriteString(outputInstructions)
+		tail.WriteString("\n\n")
 	} else if outputInstructions := BuildTaskOutputSchemaPrompt(task.OutputSchema); outputInstructions != "" {
-		prompt.WriteString("## Required Output Format\n\n")
-		prompt.WriteString(outputInstructions)
-		prompt.WriteString("\n\n")
+		tail.WriteString("## Required Output Format\n\n")
+		tail.WriteString(outputInstructions)
+		tail.WriteString("\n\n")
 	} else if outputInstructions := BuildTaskOutputContractPrompt(task.OutputContract); outputInstructions != "" {
-		prompt.WriteString("## Required Output Format\n\n")
-		prompt.WriteString(outputInstructions)
-		prompt.WriteString("\n\n")
+		tail.WriteString("## Required Output Format\n\n")
+		tail.WriteString(outputInstructions)
+		tail.WriteString("\n\n")
 	}
 
 	if task.Timeout > 0 {
-		fmt.Fprintf(&prompt, "**Time Limit**: %v\n\n", task.Timeout)
+		fmt.Fprintf(&tail, "**Time Limit**: %v\n\n", task.Timeout)
 	}
 
-	prompt.WriteString("Please complete this task to the best of your ability. ")
-	prompt.WriteString("**Important**: Only use tools when they are explicitly necessary to complete the task. ")
-	prompt.WriteString("For informational requests, meta-commands (like /tools, /help), or simple questions, ")
-	prompt.WriteString("respond directly without calling tools. ")
+	tail.WriteString("Please complete this task to the best of your ability. ")
+	tail.WriteString("**Important**: Only use tools when they are explicitly necessary to complete the task. ")
+	tail.WriteString("For informational requests, meta-commands (like /tools, /help), or simple questions, ")
+	tail.WriteString("respond directly without calling tools. ")
 	if ActiveTaskOutputSpec(&task) != nil || NormalizeTaskOutputSchema(task.OutputSchema) != nil || NormalizeTaskOutputContract(task.OutputContract) != nil {
-		prompt.WriteString("When you are done, your final answer must be the JSON object described above and nothing else.")
+		tail.WriteString("When you are done, your final answer must be the JSON object described above and nothing else.")
 	} else {
-		prompt.WriteString("Provide a clear, concise response with your findings or results.")
+		tail.WriteString("Provide a clear, concise response with your findings or results.")
+	}
+	segs = append(segs, promptSegment{label: "tail", text: tail.String(), trimOrder: 0})
+
+	return segs
+}
+
+// buildAttachmentsSection renders the "Attached Files" prompt block, or "" when
+// the task has no attachments. Attachment contents are capped (per-file and
+// total) before injection (WS2.8) so a large file cannot blow the context window
+// before budgeting even runs.
+func (h *LLMTaskHandler) buildAttachmentsSection(task Task) string {
+	attachmentContents := h.getAttachedFileContents(task)
+	if len(attachmentContents) == 0 {
+		return ""
 	}
 
+	var prompt strings.Builder
+	prompt.WriteString("## Attached Files\n\n")
+	prompt.WriteString("The following files are attached to this task:\n\n")
+	for _, att := range attachmentContents {
+		fmt.Fprintf(&prompt, "### %s\n\n", att.Title)
+		if att.FilePath != "" {
+			fmt.Fprintf(&prompt, "**File**: `%s`\n\n", att.FilePath)
+		}
+		if att.Body != "" {
+			fmt.Fprintf(&prompt, "**Note**: %s\n\n", att.Body)
+		}
+		if att.Content != "" {
+			prompt.WriteString("**Content**:\n```\n")
+			prompt.WriteString(att.Content)
+			prompt.WriteString("\n```\n\n")
+		}
+	}
 	return prompt.String()
 }

--- a/internal/workspace/token_budget.go
+++ b/internal/workspace/token_budget.go
@@ -1,0 +1,326 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+// Token budgeting for task prompts. Local models have small context windows and
+// silently truncate anything that overflows, so we estimate the assembled prompt
+// size and deterministically trim the least-load-bearing sections until it fits
+// (PRD WS2). Estimation is character-based (ceil(bytes/4)) — good enough for v1;
+// logged trims make estimation error observable (PRD Decision 3).
+const (
+	// bytesPerTokenEstimate divides byte length to approximate token count.
+	bytesPerTokenEstimate = 4
+
+	// outputHeadroomFraction reserves part of the window for generated tokens.
+	outputHeadroomFraction = 0.25
+	// minOutputHeadroomTokens floors the reserved output headroom.
+	minOutputHeadroomTokens = 1024
+
+	// imageTokenCost is the fixed nominal token cost charged per attached image;
+	// base64 bytes/4 would be wildly wrong, so images are charged flat (WS2.5).
+	imageTokenCost = 768
+
+	// Attachment injection caps (bytes), applied before budgeting (WS2.8).
+	maxAttachmentBytesPerFile = 64 * 1024
+	maxAttachmentBytesTotal   = 128 * 1024
+
+	// Tool-result message caps (bytes) appended to the conversation (WS2.9).
+	maxToolResultBytesLocal = 4 * 1024
+	maxToolResultBytesCloud = 16 * 1024
+
+	// minSegmentKeepBytes is the head+tail sliver a trimmable segment is reduced
+	// toward before the next segment is trimmed, so the model still sees a hint
+	// of what was cut.
+	minSegmentKeepBytes = 256
+)
+
+// estimateTokens approximates the token count of s as ceil(len(s)/4).
+func estimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	return int(math.Ceil(float64(len(s)) / float64(bytesPerTokenEstimate)))
+}
+
+// estimateToolTokens approximates the token cost of the tool schemas that are
+// serialized into the request (name + description + JSON parameters).
+func estimateToolTokens(tools []llm.Tool) int {
+	total := 0
+	for _, t := range tools {
+		total += estimateTokens(t.Name) + estimateTokens(t.Description)
+		if len(t.Parameters) > 0 {
+			if b, err := json.Marshal(t.Parameters); err == nil {
+				total += estimateTokens(string(b))
+			}
+		}
+	}
+	return total
+}
+
+// estimateMessageTokens approximates a conversation message's token cost,
+// including a flat charge per attached image (WS2.5).
+func estimateMessageTokens(msg llm.Message) int {
+	total := estimateTokens(msg.Content)
+	total += len(msg.Images) * imageTokenCost
+	for _, tc := range msg.ToolCalls {
+		total += estimateTokens(tc.Name) + estimateTokens(tc.Arguments)
+	}
+	return total
+}
+
+// estimateConversationTokens sums the token cost of a whole conversation.
+func estimateConversationTokens(messages []llm.Message) int {
+	total := 0
+	for _, m := range messages {
+		total += estimateMessageTokens(m)
+	}
+	return total
+}
+
+// reservedOutputHeadroom returns the tokens held back from the window for the
+// model's generation (WS2.5).
+func reservedOutputHeadroom(window int) int {
+	h := int(float64(window) * outputHeadroomFraction)
+	if h < minOutputHeadroomTokens {
+		h = minOutputHeadroomTokens
+	}
+	return h
+}
+
+// promptBudget returns the token budget available for the prompt (window minus
+// reserved output headroom). A non-positive window means "unknown" and disables
+// budgeting (returns 0).
+func promptBudget(window int) int {
+	if window <= 0 {
+		return 0
+	}
+	budget := window - reservedOutputHeadroom(window)
+	if budget <= 0 {
+		// Pathologically small window: keep a minimal positive budget so we still
+		// trim toward *something* rather than divide the prompt to nothing.
+		budget = window
+	}
+	return budget
+}
+
+// reconcileGenerationCap lowers an explicit generation cap to the reserved
+// headroom so generated output cannot overrun the context window (WS2.5a).
+// A cap of 0 (provider default) is left untouched. Returns the effective cap and
+// whether it was lowered.
+func reconcileGenerationCap(maxTokens, headroom int) (int, bool) {
+	if maxTokens > 0 && headroom > 0 && maxTokens > headroom {
+		return headroom, true
+	}
+	return maxTokens, false
+}
+
+// trimMarker renders the marker inserted where content was cut.
+func trimMarker(cutBytes int) string {
+	return fmt.Sprintf("\n…[trimmed %d bytes to fit model context]…\n", cutBytes)
+}
+
+// truncateHeadTailBytes shrinks s to roughly maxBytes, keeping a head and tail
+// slice around an inserted marker that reports how many bytes were removed
+// (WS2.7). Cuts fall on UTF-8 rune boundaries. Returns s unchanged (and cut 0)
+// when it already fits. The result may slightly exceed maxBytes by the marker
+// length — acceptable for estimate-based budgeting.
+func truncateHeadTailBytes(s string, maxBytes int) (string, int) {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s, 0
+	}
+
+	// First pass with an approximate marker to size the head/tail.
+	approxCut := len(s) - maxBytes
+	keep := maxBytes - len(trimMarker(approxCut))
+	if keep < 0 {
+		keep = 0
+	}
+	head := safePrefix(s, keep/2)
+	tail := safeSuffix(s, keep-len(head))
+
+	cut := len(s) - len(head) - len(tail)
+	if cut <= 0 {
+		return s, 0
+	}
+	return head + trimMarker(cut) + tail, cut
+}
+
+// safePrefix returns the longest prefix of s that is at most n bytes and ends on
+// a rune boundary.
+func safePrefix(s string, n int) string {
+	if n >= len(s) {
+		return s
+	}
+	if n <= 0 {
+		return ""
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+// safeSuffix returns the longest suffix of s that is at most n bytes and starts
+// on a rune boundary.
+func safeSuffix(s string, n int) string {
+	if n >= len(s) {
+		return s
+	}
+	if n <= 0 {
+		return ""
+	}
+	start := len(s) - n
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return s[start:]
+}
+
+// promptSegment is one region of the assembled task user-prompt. trimOrder 0
+// means protected (never trimmed — task description, output-format, headers);
+// segments with trimOrder > 0 are trimmed in ascending order until the prompt
+// fits (WS2.6): attachments (1), upstream results (2), workspace snapshot (3),
+// memory (4).
+type promptSegment struct {
+	label     string
+	text      string
+	trimOrder int
+}
+
+// budgetTrim records a single trim/eviction for logging and observability.
+type budgetTrim struct {
+	Label    string
+	BytesCut int
+}
+
+// renderPromptSegments concatenates segments in order.
+func renderPromptSegments(segs []promptSegment) string {
+	var b []byte
+	for _, s := range segs {
+		b = append(b, s.text...)
+	}
+	return string(b)
+}
+
+// budgetPromptSegments trims the trimmable segments in place until the assembled
+// prompt (system prompt + tool schemas + segments) fits the window's budget, in
+// the fixed WS2.6 order. It returns the trims performed and whether the prompt
+// still overflows after all trims (WS2.10). A non-positive window disables
+// budgeting.
+func budgetPromptSegments(window int, systemPrompt string, tools []llm.Tool, segs []promptSegment) (trims []budgetTrim, overflow bool) {
+	budget := promptBudget(window)
+	if budget <= 0 {
+		return nil, false
+	}
+
+	fixed := estimateTokens(systemPrompt) + estimateToolTokens(tools)
+	total := fixed + segmentsTokens(segs)
+	if total <= budget {
+		return nil, false
+	}
+
+	for _, idx := range trimmableOrder(segs) {
+		if total <= budget {
+			break
+		}
+		seg := &segs[idx]
+		cur := estimateTokens(seg.text)
+		minKeep := estimateTokens(safePrefix(seg.text, minSegmentKeepBytes))
+		reducible := cur - minKeep
+		if reducible <= 0 {
+			continue
+		}
+		reduce := min(reducible, total-budget)
+		targetBytes := (cur - reduce) * bytesPerTokenEstimate
+		newText, cut := truncateHeadTailBytes(seg.text, targetBytes)
+		if cut > 0 {
+			seg.text = newText
+			trims = append(trims, budgetTrim{Label: seg.label, BytesCut: cut})
+			total = fixed + segmentsTokens(segs)
+		}
+	}
+
+	return trims, total > budget
+}
+
+// segmentsTokens sums the estimated tokens of all segments.
+func segmentsTokens(segs []promptSegment) int {
+	total := 0
+	for _, s := range segs {
+		total += estimateTokens(s.text)
+	}
+	return total
+}
+
+// trimmableSegmentLabels returns the labels of trimmable segments, for naming
+// the offending sections in a context_overflow error (WS2.10).
+func trimmableSegmentLabels(segs []promptSegment) []string {
+	labels := make([]string, 0, len(segs))
+	for _, s := range segs {
+		if s.trimOrder > 0 {
+			labels = append(labels, s.label)
+		}
+	}
+	return labels
+}
+
+// evictConversationForContext keeps a growing tool-loop conversation within the
+// window budget by compacting the oldest tool-result messages (head+tail marker)
+// until it fits (WS2.10a). It mutates message content in place — never removing a
+// message, so assistant tool_call / tool_result pairing stays intact — and never
+// touches the system prompt (index 0), the initial task message (index 1), or the
+// most recent message. Returns how many messages were compacted and whether the
+// conversation still overflows after compacting every eligible one. A
+// non-positive window disables eviction.
+func evictConversationForContext(conversation []llm.Message, window int, tools []llm.Tool) (compacted int, overflow bool) {
+	budget := promptBudget(window)
+	if budget <= 0 {
+		return 0, false
+	}
+
+	total := estimateToolTokens(tools) + estimateConversationTokens(conversation)
+	if total <= budget {
+		return 0, false
+	}
+
+	const protectedHead = 2 // system prompt + initial task message
+	lastIdx := len(conversation) - 1
+	for i := protectedHead; i < lastIdx && total > budget; i++ {
+		if conversation[i].Role != llm.RoleTool {
+			continue
+		}
+		before := estimateMessageTokens(conversation[i])
+		newContent, cut := truncateHeadTailBytes(conversation[i].Content, minSegmentKeepBytes)
+		if cut <= 0 {
+			continue
+		}
+		conversation[i].Content = newContent
+		total -= before - estimateMessageTokens(conversation[i])
+		compacted++
+	}
+
+	return compacted, total > budget
+}
+
+// trimmableOrder returns segment indices with trimOrder > 0, sorted ascending by
+// trimOrder (stable on original position for ties).
+func trimmableOrder(segs []promptSegment) []int {
+	idx := make([]int, 0, len(segs))
+	for i := range segs {
+		if segs[i].trimOrder > 0 {
+			idx = append(idx, i)
+		}
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		return segs[idx[a]].trimOrder < segs[idx[b]].trimOrder
+	})
+	return idx
+}

--- a/internal/workspace/token_budget_test.go
+++ b/internal/workspace/token_budget_test.go
@@ -1,0 +1,184 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	if got := estimateTokens(""); got != 0 {
+		t.Fatalf("empty = %d, want 0", got)
+	}
+	// 8 bytes -> ceil(8/4) = 2.
+	if got := estimateTokens("abcdefgh"); got != 2 {
+		t.Fatalf("8 bytes = %d, want 2", got)
+	}
+	// 9 bytes -> ceil(9/4) = 3.
+	if got := estimateTokens("abcdefghi"); got != 3 {
+		t.Fatalf("9 bytes = %d, want 3", got)
+	}
+}
+
+func TestReservedOutputHeadroomAndBudget(t *testing.T) {
+	// Small window: floored at min headroom.
+	if got := reservedOutputHeadroom(2000); got != minOutputHeadroomTokens {
+		t.Fatalf("headroom(2000) = %d, want %d", got, minOutputHeadroomTokens)
+	}
+	// Large window: 25%.
+	if got := reservedOutputHeadroom(40000); got != 10000 {
+		t.Fatalf("headroom(40000) = %d, want 10000", got)
+	}
+	// Unknown window disables budgeting.
+	if got := promptBudget(0); got != 0 {
+		t.Fatalf("budget(0) = %d, want 0", got)
+	}
+	if got := promptBudget(40000); got != 30000 {
+		t.Fatalf("budget(40000) = %d, want 30000", got)
+	}
+}
+
+func TestReconcileGenerationCap(t *testing.T) {
+	// No explicit cap stays 0.
+	if got, lowered := reconcileGenerationCap(0, 1024); got != 0 || lowered {
+		t.Fatalf("cap(0,1024) = (%d,%v), want (0,false)", got, lowered)
+	}
+	// Cap below headroom untouched.
+	if got, lowered := reconcileGenerationCap(500, 1024); got != 500 || lowered {
+		t.Fatalf("cap(500,1024) = (%d,%v), want (500,false)", got, lowered)
+	}
+	// Cap above headroom lowered.
+	if got, lowered := reconcileGenerationCap(5000, 1024); got != 1024 || !lowered {
+		t.Fatalf("cap(5000,1024) = (%d,%v), want (1024,true)", got, lowered)
+	}
+}
+
+func TestTruncateHeadTailBytes(t *testing.T) {
+	// Fits: unchanged.
+	if got, cut := truncateHeadTailBytes("short", 100); got != "short" || cut != 0 {
+		t.Fatalf("fits = (%q,%d), want (short,0)", got, cut)
+	}
+
+	s := strings.Repeat("A", 500) + strings.Repeat("B", 500)
+	got, cut := truncateHeadTailBytes(s, 200)
+	if cut <= 0 {
+		t.Fatalf("expected a cut, got %d", cut)
+	}
+	if !strings.Contains(got, "trimmed") {
+		t.Fatalf("expected trim marker in %q", got)
+	}
+	// Keeps a head (A's) and a tail (B's).
+	if !strings.HasPrefix(got, "A") || !strings.HasSuffix(got, "B") {
+		t.Fatalf("expected head+tail preserved, got %q", got)
+	}
+}
+
+func TestTruncateHeadTailBytes_RuneSafe(t *testing.T) {
+	// Multibyte runes must not be split.
+	s := strings.Repeat("世", 400) // 3 bytes each = 1200 bytes
+	got, cut := truncateHeadTailBytes(s, 300)
+	if cut <= 0 {
+		t.Fatalf("expected a cut")
+	}
+	// The head+tail portions (excluding the ASCII marker) must be valid UTF-8.
+	if strings.ContainsRune(got, '�') {
+		t.Fatalf("result contains replacement char (split rune): %q", got)
+	}
+}
+
+func makeSeg(label string, order, bytes int) promptSegment {
+	return promptSegment{label: label, text: strings.Repeat("x", bytes), trimOrder: order}
+}
+
+func TestBudgetPromptSegments_TrimsAttachmentsFirst(t *testing.T) {
+	segs := []promptSegment{
+		makeSeg("header", 0, 400),
+		makeSeg("memory", 4, 4000),
+		makeSeg("workspace_snapshot", 3, 4000),
+		makeSeg("attachments", 1, 400000), // the outlier (~100k tokens, over budget)
+		makeSeg("upstream_inputs", 2, 4000),
+		makeSeg("tail", 0, 400),
+	}
+	// window 40000 -> budget 30000 tokens. Everything but attachments is small;
+	// trimming attachments alone should suffice.
+	trims, overflow := budgetPromptSegments(40000, "sys", nil, segs)
+	if overflow {
+		t.Fatalf("did not expect overflow")
+	}
+	if len(trims) != 1 || trims[0].Label != "attachments" {
+		t.Fatalf("expected only attachments trimmed, got %+v", trims)
+	}
+	// Protected + untouched segments keep their original size.
+	if len(segs[0].text) != 400 || len(segs[5].text) != 400 {
+		t.Fatalf("protected header/tail were modified")
+	}
+	if len(segs[1].text) != 4000 || len(segs[2].text) != 4000 || len(segs[4].text) != 4000 {
+		t.Fatalf("non-attachment trimmables were touched before needed")
+	}
+}
+
+func TestBudgetPromptSegments_CloudWindowNoTrim(t *testing.T) {
+	segs := []promptSegment{makeSeg("attachments", 1, 200000)}
+	// A 200k-token cloud window easily holds a 50k-token attachment.
+	trims, overflow := budgetPromptSegments(200000, "sys", nil, segs)
+	if overflow || len(trims) != 0 {
+		t.Fatalf("cloud window should not trim: trims=%+v overflow=%v", trims, overflow)
+	}
+	if len(segs[0].text) != 200000 {
+		t.Fatalf("segment modified on a large window")
+	}
+}
+
+func TestBudgetPromptSegments_OverflowWhenProtectedTooBig(t *testing.T) {
+	segs := []promptSegment{
+		makeSeg("header", 0, 200000), // protected + alone exceeds budget
+		makeSeg("attachments", 1, 8000),
+	}
+	trims, overflow := budgetPromptSegments(40000, "sys", nil, segs)
+	if !overflow {
+		t.Fatalf("expected overflow when protected content exceeds budget")
+	}
+	// Attachments should still have been trimmed toward the floor while trying.
+	_ = trims
+}
+
+func TestEvictConversationForContext(t *testing.T) {
+	big := strings.Repeat("T", 160000) // ~40000 tokens each, together over budget
+	conversation := []llm.Message{
+		llm.NewSystemMessage("system"),                // 0 protected
+		llm.NewUserMessage("do the task"),             // 1 protected
+		{Role: llm.RoleAssistant, Content: "calling"}, // 2
+		llm.NewToolMessage("t1", big),                 // 3 evictable
+		llm.NewToolMessage("t2", big),                 // 4 evictable
+		llm.NewUserMessage("continue"),                // 5 (most recent, protected)
+	}
+	compacted, overflow := evictConversationForContext(conversation, 40000, nil)
+	if compacted == 0 {
+		t.Fatalf("expected at least one message compacted")
+	}
+	if overflow {
+		t.Fatalf("did not expect overflow after compaction")
+	}
+	// System + task message untouched.
+	if conversation[0].Content != "system" || conversation[1].Content != "do the task" {
+		t.Fatalf("protected head messages were modified")
+	}
+	// At least one tool message shrank and carries a marker.
+	if len(conversation[3].Content) >= 40000 && len(conversation[4].Content) >= 40000 {
+		t.Fatalf("no tool message was compacted")
+	}
+}
+
+func TestEvictConversationForContext_UnknownWindowDisabled(t *testing.T) {
+	conversation := []llm.Message{
+		llm.NewSystemMessage("system"),
+		llm.NewUserMessage("task"),
+		llm.NewToolMessage("t1", strings.Repeat("X", 100000)),
+		llm.NewUserMessage("last"),
+	}
+	compacted, overflow := evictConversationForContext(conversation, 0, nil)
+	if compacted != 0 || overflow {
+		t.Fatalf("window 0 should disable eviction, got compacted=%d overflow=%v", compacted, overflow)
+	}
+}


### PR DESCRIPTION
First two groups of the **Reliable Workspace Task Execution on Local Models** epic (`tasks/prd-local-model-task-execution.md`). Both are inert for cloud providers — large windows never trip trims and every new field defaults to a no-op.

## Group 1 — Provider plumbing + context-window resolution (WS7 + WS1) — `33732fbd`
- **Ollama temp-0 bug**: send `temperature` when `>= 0` (was `> 0`, which dropped an explicit 0); `ollamaOptions.Temperature` is now `*float64` so `omitempty` no longer eats a 0.
- **Usage parsing**: `prompt_eval_count`/`eval_count` → `Usage` on both blocking (`Chat`) and streaming (`StreamChat`, via new `StreamChunk.Usage`).
- **`num_ctx`**: mapped from new `ChatRequest.ContextWindowTokens`, clamped by a configurable ceiling (default 32768). `Chat`/`StreamChat` refactored onto a shared `buildRequest`/`buildOptions` so the two paths can't diverge.
- **60s TTL model-list cache** on both local providers — no more per-task `/api/tags`.
- **Context-window resolution**: optional `ModelContextWindowResolver` + `ResolveModelContextWindow` (per-model → provider default → `MaxContextWindow`); resolved once per task. Config wired via env (`OLLAMA_/LM_STUDIO_/MLX_LM_ CONTEXT_WINDOW`, `_MAX_NUM_CTX`, `_CONTEXT_WINDOWS`) pending the settings-home decision (PRD OQ5).

## Group 2 — Prompt + cross-round conversation token budgeting (WS2) — `ae4a0c86`
- New pure `internal/workspace/token_budget.go`: `ceil(bytes/4)` estimator, 25%/min-1024 output headroom, `reconcileGenerationCap`, rune-safe head+tail truncation with markers.
- `budgetPromptSegments`: trims the least-load-bearing prompt sections in a fixed order (attachments → upstream → snapshot → memory), never touching task description / output format / system prompt; blocks with `TaskBlockedError{context_overflow}` when it still can't fit.
- `evictConversationForContext`: re-budgets the growing tool-loop conversation **before every round**, compacting the oldest tool-result messages **in place** (keeps assistant `tool_call`/`tool_result` pairing intact) — never dropping system prompt, initial task message, or the most recent message.
- `getAttachedFileContents` capped (64KB/file, 128KB total); tool-result messages capped per message (4KB local / 16KB cloud) with the full result preserved for previews/storage.
- `buildTaskPrompt` refactored into labeled segments; **rendered output is byte-identical when nothing trims**, so cloud behavior is unchanged. Trims + evictions logged and emitted on the event bus.

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, and `staticcheck ./internal/...` all clean. 19 new unit tests (Ollama plumbing + token budgeting) pass; `internal/llm`, `internal/server`, `internal/workspace` suites green. The only failing test is the pre-existing live-API `TestProviderIntegration` (OpenAI 429 quota), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)