### PR TITLE
feat(local-models): capability-aware tool exposure, degradation & pruning (WS4)

### DIFF
--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -229,6 +229,28 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 	// because tool schemas consume the context window too.
 	tools := h.convertAgentToolsToLLMTools(ag, task)
 
+	// Capability-aware tool exposure (WS4). A provider that supports neither the
+	// internal tool loop nor native MCP is offered no tools and told so; local
+	// providers get the toolset pruned to a manageable cap so a small model isn't
+	// swamped by a huge tool list it will mishandle.
+	if !provider.Capabilities().SupportsTools && !providerSupportsNativeMCP(provider) {
+		if len(tools) > 0 {
+			logger.Info("Provider does not support tools; running task tool-less", logger.Fields{
+				"workspace_id": task.WorkspaceID,
+				"task_id":      task.ID,
+				"provider":     providerName,
+				"dropped":      len(tools),
+			})
+		}
+		tools = nil
+		taskSystemPrompt += "\n\nTool calling is unavailable for this model. Answer directly from the information provided; do not attempt to call tools."
+	} else if provider.Type() == llm.ProviderTypeLocal {
+		if kept, dropped := pruneToolsForLocal(tools, task.Description, localToolCap); len(dropped) > 0 {
+			h.reportToolsPruned(task, agentName, dropped)
+			tools = kept
+		}
+	}
+
 	// Resolve the effective context window once and budget the assembled prompt
 	// against it, trimming the least-load-bearing sections in a fixed order (WS2).
 	// Cloud windows are large enough that nothing trims. If the prompt still
@@ -277,6 +299,12 @@ func (h *LLMTaskHandler) executeTaskConversation(
 	// local providers, whose context windows are small (WS2.9).
 	isLocal := provider.Type() == llm.ProviderTypeLocal
 
+	// Tool-support degradation (WS4). toolsRejected latches once a model rejects
+	// the tools parameter, so the rest of the task runs tool-less. textToolProtocol
+	// enables the feature-flagged prompt-based fallback (default off).
+	toolsRejected := false
+	textToolProtocol := isLocal && localTextToolProtocolEnabled()
+
 	// Constrained decoding for structured output: on rounds where tools are not
 	// offered (initial tool-less request or a forced final answer), enforce the
 	// task's output schema when the provider supports it (WS3.14). Tool rounds
@@ -289,7 +317,7 @@ func (h *LLMTaskHandler) executeTaskConversation(
 
 	for round := 0; round < maxTaskToolRounds; round++ {
 		requestTools := tools
-		if forceFinalAnswer {
+		if forceFinalAnswer || toolsRejected {
 			requestTools = nil
 		}
 
@@ -372,6 +400,23 @@ func (h *LLMTaskHandler) executeTaskConversation(
 		if cancelCall != nil {
 			cancelCall()
 		}
+		// Tools-rejected degradation (WS4.17): some local models reject the tools
+		// parameter outright. Retry this round once without tools and run tool-less
+		// for the remainder of the task rather than failing.
+		if err != nil && !nativeMCPActive && len(chatReq.Tools) > 0 && isToolsRejectedError(err) {
+			toolsRejected = true
+			h.reportToolSupportDegraded(task, agentName, err)
+			chatReq.Tools = nil
+			// Now that the round is tool-less, structured output can be enforced.
+			if taskResponseSchema != nil {
+				chatReq.ResponseSchema = taskResponseSchema
+			}
+			// Optionally switch the model to the prompt-based tool protocol.
+			if textToolProtocol && len(conversation) > 0 && conversation[0].Role == llm.RoleSystem {
+				conversation[0].Content += textToolProtocolInstruction
+			}
+			resp, err = provider.Chat(ctx, chatReq)
+		}
 		if err != nil {
 			// Surface the raw provider error (CLI stderr/stdout) before it is
 			// replaced by a friendly message, so MCP connection / permission /
@@ -396,6 +441,29 @@ func (h *LLMTaskHandler) executeTaskConversation(
 				"round":           round + 1,
 				"tool_call_count": len(resp.ToolCalls),
 			}))
+		}
+
+		// Feature-flagged prompt-based tool protocol (WS4.19): once native tools
+		// were rejected, a tool-less response may still carry a fenced
+		// {"tool_call": …} block. Parse and execute it as a tool round.
+		if textToolProtocol && toolsRejected && len(resp.ToolCalls) == 0 {
+			if name, args, ok := parseTextToolCall(resp.Content); ok {
+				textCall := llm.ToolCall{ID: fmt.Sprintf("txt_%d", round+1), Name: name, Arguments: args}
+				conversation = append(conversation, llm.Message{Role: llm.RoleAssistant, Content: resp.Content})
+				results := h.executeToolCalls(ctx, ag, agentName, task, []llm.ToolCall{textCall})
+				lastToolSummary = buildToolResultsSummary(resp.Content, results)
+				for _, tr := range results {
+					toolContent := tr.Result
+					if tr.Error != nil {
+						toolContent = fmt.Sprintf("ERROR: %s", tr.Error.Error())
+					}
+					if capped, cut := truncateHeadTailBytes(toolContent, maxToolResultBytesLocal); cut > 0 {
+						toolContent = capped
+					}
+					conversation = append(conversation, llm.NewToolMessage(textCall.ID, toolContent))
+				}
+				continue
+			}
 		}
 
 		if len(resp.ToolCalls) == 0 {
@@ -776,6 +844,41 @@ func (h *LLMTaskHandler) reportConversationEviction(task Task, agentName string,
 			"round":              round,
 			"messages_compacted": compacted,
 			"still_over_budget":  stillOver,
+		}))
+	}
+}
+
+// reportToolsPruned logs and emits the tools dropped when pruning the toolset
+// for a local provider, so a silently-missing capability is diagnosable (WS4.18).
+func (h *LLMTaskHandler) reportToolsPruned(task Task, agentName string, dropped []string) {
+	logger.Info("Pruned task toolset for local provider", logger.Fields{
+		"workspace_id":  task.WorkspaceID,
+		"task_id":       task.ID,
+		"dropped_count": len(dropped),
+		"dropped":       strings.Join(dropped, ","),
+		"cap":           localToolCap,
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":         "tools_pruned",
+			"dropped_tools": dropped,
+			"cap":           localToolCap,
+		}))
+	}
+}
+
+// reportToolSupportDegraded logs and emits that the model rejected the tools
+// parameter and the task is continuing tool-less (WS4.17).
+func (h *LLMTaskHandler) reportToolSupportDegraded(task Task, agentName string, cause error) {
+	logger.Warn("Model rejected tools; continuing tool-less", logger.Fields{
+		"workspace_id": task.WorkspaceID,
+		"task_id":      task.ID,
+		"error":        cause.Error(),
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":        "tool_support_degraded",
+			"tool_support": "rejected_by_model",
 		}))
 	}
 }

--- a/internal/workspace/task_handler_provider_test.go
+++ b/internal/workspace/task_handler_provider_test.go
@@ -32,7 +32,7 @@ func (p *providerStub) Type() llm.ProviderType {
 }
 
 func (p *providerStub) Capabilities() llm.ProviderCapabilities {
-	return llm.ProviderCapabilities{}
+	return llm.ProviderCapabilities{SupportsTools: true}
 }
 
 func (p *providerStub) ValidateConfig(_ llm.ProviderConfig) error {
@@ -68,7 +68,7 @@ func (p *scriptedProviderStub) Name() string { return p.name }
 func (p *scriptedProviderStub) Type() llm.ProviderType { return llm.ProviderTypeCloud }
 
 func (p *scriptedProviderStub) Capabilities() llm.ProviderCapabilities {
-	return llm.ProviderCapabilities{}
+	return llm.ProviderCapabilities{SupportsTools: true}
 }
 
 func (p *scriptedProviderStub) ValidateConfig(_ llm.ProviderConfig) error { return nil }

--- a/internal/workspace/task_tool_degradation.go
+++ b/internal/workspace/task_tool_degradation.go
@@ -1,0 +1,213 @@
+package workspace
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+// localToolCap is the default maximum number of tools offered to a local
+// provider per task; the full set is pruned to this when it exceeds it (WS4.18).
+const localToolCap = 12
+
+// workspaceCoreToolNames are always kept when pruning — an agent needs them to
+// read/update workspace state regardless of the task (WS4.18).
+var workspaceCoreToolNames = map[string]struct{}{
+	"workspace_notes":       {},
+	"workspace_tasks":       {},
+	"workspace_files":       {},
+	"workspace_directories": {},
+	"workspace_sessions":    {},
+}
+
+// toolKeywordStopwords are ignored when scoring tool relevance so common words
+// don't dominate the keyword overlap.
+var toolKeywordStopwords = map[string]struct{}{
+	"the": {}, "and": {}, "for": {}, "with": {}, "this": {}, "that": {},
+	"from": {}, "into": {}, "your": {}, "you": {}, "are": {}, "was": {},
+	"task": {}, "please": {}, "should": {}, "must": {}, "will": {},
+}
+
+// pruneToolsForLocal reduces tools to at most cap for local providers when the
+// full set exceeds it (WS4.18). Workspace core tools are always kept; the
+// remaining slots go to the tools whose name/description best overlap the task
+// description (ties broken by name for determinism). Returns the kept tools and
+// the sorted names of dropped tools. When tools already fit, it returns them
+// unchanged with no drops.
+func pruneToolsForLocal(tools []llm.Tool, taskDescription string, cap int) ([]llm.Tool, []string) {
+	if cap <= 0 || len(tools) <= cap {
+		return tools, nil
+	}
+
+	var kept, candidates []llm.Tool
+	for _, t := range tools {
+		if _, core := workspaceCoreToolNames[strings.ToLower(strings.TrimSpace(t.Name))]; core {
+			kept = append(kept, t)
+		} else {
+			candidates = append(candidates, t)
+		}
+	}
+
+	keywords := extractToolKeywords(taskDescription)
+	sort.SliceStable(candidates, func(i, j int) bool {
+		si, sj := toolRelevanceScore(candidates[i], keywords), toolRelevanceScore(candidates[j], keywords)
+		if si != sj {
+			return si > sj
+		}
+		return candidates[i].Name < candidates[j].Name
+	})
+
+	slots := cap - len(kept) // may be <= 0 if core alone exceeds cap; core is never dropped
+	var dropped []string
+	for idx, t := range candidates {
+		if idx < slots {
+			kept = append(kept, t)
+		} else {
+			dropped = append(dropped, t.Name)
+		}
+	}
+	sort.Strings(dropped)
+	return kept, dropped
+}
+
+// extractToolKeywords returns the distinct lowercase words (length >= 3, minus
+// stopwords) of the task description.
+func extractToolKeywords(description string) map[string]struct{} {
+	keywords := map[string]struct{}{}
+	for _, word := range strings.FieldsFunc(strings.ToLower(description), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	}) {
+		if len(word) < 3 {
+			continue
+		}
+		if _, stop := toolKeywordStopwords[word]; stop {
+			continue
+		}
+		keywords[word] = struct{}{}
+	}
+	return keywords
+}
+
+// toolRelevanceScore counts how many distinct task keywords appear in the tool's
+// name or description.
+func toolRelevanceScore(tool llm.Tool, keywords map[string]struct{}) int {
+	haystack := strings.ToLower(tool.Name + " " + tool.Description)
+	score := 0
+	for kw := range keywords {
+		if strings.Contains(haystack, kw) {
+			score++
+		}
+	}
+	return score
+}
+
+// isToolsRejectedError reports whether a provider error indicates the model
+// rejected the tools parameter (e.g. Ollama "<model> does not support tools"),
+// so the handler can retry the round without tools (WS4.17).
+func isToolsRejectedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "does not support tools"):
+		return true
+	case strings.Contains(s, "does not support tool"):
+		return true
+	case strings.Contains(s, "tools are not supported"):
+		return true
+	case strings.Contains(s, "tool") && strings.Contains(s, "not support"):
+		return true
+	default:
+		return false
+	}
+}
+
+// localTextToolProtocolEnabled reports whether the feature-flagged prompt-based
+// tool protocol is on (default off), read from ORI_LOCAL_TEXT_TOOL_PROTOCOL
+// (WS4.19).
+func localTextToolProtocolEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ORI_LOCAL_TEXT_TOOL_PROTOCOL"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// textToolProtocolInstruction is appended to the system prompt (when the flag is
+// on and native tool calling was rejected) telling the model how to request a
+// tool via a fenced JSON block the handler can parse (WS4.19).
+const textToolProtocolInstruction = "\n\nThis model cannot call tools natively. When you need a tool, respond with ONLY a single fenced JSON block of the form ```json\n{\"tool_call\": {\"name\": \"<tool_name>\", \"arguments\": { ... }}}\n``` and nothing else. When you have the final answer, respond normally without a tool_call block."
+
+// textToolCallEnvelope is the wire shape the model emits under the text protocol.
+type textToolCallEnvelope struct {
+	ToolCall struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"tool_call"`
+}
+
+// parseTextToolCall extracts a text-protocol tool call from a model response
+// (WS4.19). Returns the tool name, its arguments as a JSON string, and whether a
+// well-formed call was found. Tolerates code fences and surrounding prose.
+func parseTextToolCall(content string) (name string, arguments string, ok bool) {
+	candidate := strings.TrimSpace(llm.StripCodeFence(content))
+
+	var env textToolCallEnvelope
+	if err := json.Unmarshal([]byte(candidate), &env); err != nil {
+		sub, found := extractFirstJSONObject(candidate)
+		if !found {
+			return "", "", false
+		}
+		if err := json.Unmarshal([]byte(sub), &env); err != nil {
+			return "", "", false
+		}
+	}
+
+	name = strings.TrimSpace(env.ToolCall.Name)
+	if name == "" {
+		return "", "", false
+	}
+	arguments = strings.TrimSpace(string(env.ToolCall.Arguments))
+	if arguments == "" || arguments == "null" {
+		arguments = "{}"
+	}
+	return name, arguments, true
+}
+
+// extractFirstJSONObject returns the substring from the first '{' to its matching
+// closing '}' (brace-balanced, string-aware), or false if none.
+func extractFirstJSONObject(s string) (string, bool) {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+			// skip
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/workspace/task_tool_degradation_test.go
+++ b/internal/workspace/task_tool_degradation_test.go
@@ -1,0 +1,153 @@
+package workspace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+func coreTool(name string) llm.Tool { return llm.Tool{Name: name} }
+
+func TestPruneToolsForLocal_UnderCapUnchanged(t *testing.T) {
+	tools := []llm.Tool{coreTool("workspace_notes"), {Name: "web_search"}}
+	kept, dropped := pruneToolsForLocal(tools, "anything", localToolCap)
+	if len(dropped) != 0 || len(kept) != 2 {
+		t.Fatalf("under cap should be unchanged, got kept=%d dropped=%v", len(kept), dropped)
+	}
+}
+
+func TestPruneToolsForLocal_KeepsCoreAndRanksByRelevance(t *testing.T) {
+	tools := []llm.Tool{
+		coreTool("workspace_notes"),
+		coreTool("workspace_tasks"),
+		coreTool("workspace_files"),
+		coreTool("workspace_directories"),
+		coreTool("workspace_sessions"),
+		{Name: "reaper_transport", Description: "control reaper transport and tempo"},
+		{Name: "reaper_tracks", Description: "list reaper tracks"},
+		{Name: "web_search", Description: "search the web"},
+		{Name: "calendar_create", Description: "create a calendar event"},
+		{Name: "email_send", Description: "send an email"},
+		{Name: "weather", Description: "get the weather"},
+		{Name: "air_quality", Description: "get air quality"},
+		{Name: "stock_price", Description: "get a stock price"},
+		{Name: "translate", Description: "translate text"},
+	}
+	// 14 tools, cap 12 -> drop 2. Task keywords favor the reaper tools.
+	kept, dropped := pruneToolsForLocal(tools, "control the reaper transport and adjust tempo on tracks", localToolCap)
+
+	if len(kept) != localToolCap {
+		t.Fatalf("expected %d kept, got %d", localToolCap, len(kept))
+	}
+	keptNames := map[string]bool{}
+	for _, k := range kept {
+		keptNames[k.Name] = true
+	}
+	// All five core tools survive.
+	for name := range workspaceCoreToolNames {
+		if !keptNames[name] {
+			t.Fatalf("core tool %q was dropped", name)
+		}
+	}
+	// The relevant reaper tools survive.
+	if !keptNames["reaper_transport"] || !keptNames["reaper_tracks"] {
+		t.Fatalf("relevant reaper tools were dropped: kept=%v", keptNames)
+	}
+	if len(dropped) != 2 {
+		t.Fatalf("expected 2 dropped, got %v", dropped)
+	}
+	// Dropped list is sorted (deterministic).
+	for i := 1; i < len(dropped); i++ {
+		if dropped[i-1] > dropped[i] {
+			t.Fatalf("dropped not sorted: %v", dropped)
+		}
+	}
+}
+
+func TestPruneToolsForLocal_CoreNeverDroppedEvenOverCap(t *testing.T) {
+	// 5 core + 10 irrelevant, cap 3: core (5) exceeds cap but is never dropped;
+	// all non-core are dropped.
+	tools := []llm.Tool{
+		coreTool("workspace_notes"), coreTool("workspace_tasks"), coreTool("workspace_files"),
+		coreTool("workspace_directories"), coreTool("workspace_sessions"),
+	}
+	for _, n := range []string{"a_tool", "b_tool", "c_tool"} {
+		tools = append(tools, llm.Tool{Name: n})
+	}
+	kept, dropped := pruneToolsForLocal(tools, "unrelated task", 3)
+	if len(kept) != 5 {
+		t.Fatalf("all 5 core tools should be kept, got %d", len(kept))
+	}
+	if len(dropped) != 3 {
+		t.Fatalf("all 3 non-core should be dropped, got %v", dropped)
+	}
+}
+
+func TestIsToolsRejectedError(t *testing.T) {
+	cases := map[string]bool{
+		"registry.ollama.ai/library/llama2 does not support tools":          true,
+		"model does not support tool use":                                   true,
+		"tools are not supported by this model":                             true,
+		"the model does not support this and does not support tools things": true,
+		"connection refused":                                                false,
+		"context deadline exceeded":                                         false,
+		"":                                                                  false,
+	}
+	for msg, want := range cases {
+		var err error
+		if msg != "" {
+			err = errors.New(msg)
+		}
+		if got := isToolsRejectedError(err); got != want {
+			t.Fatalf("isToolsRejectedError(%q) = %v, want %v", msg, got, want)
+		}
+	}
+}
+
+func TestParseTextToolCall(t *testing.T) {
+	// Fenced.
+	name, args, ok := parseTextToolCall("```json\n{\"tool_call\": {\"name\": \"workspace_notes\", \"arguments\": {\"id\": \"n1\"}}}\n```")
+	if !ok || name != "workspace_notes" {
+		t.Fatalf("fenced parse failed: name=%q ok=%v", name, ok)
+	}
+	if args != `{"id": "n1"}` {
+		t.Fatalf("args = %q", args)
+	}
+
+	// Surrounded by prose.
+	name, _, ok = parseTextToolCall("Sure, let me look: {\"tool_call\": {\"name\": \"web_search\", \"arguments\": {}}} done")
+	if !ok || name != "web_search" {
+		t.Fatalf("prose parse failed: name=%q ok=%v", name, ok)
+	}
+
+	// Missing arguments -> defaults to {}.
+	name, args, ok = parseTextToolCall(`{"tool_call": {"name": "weather"}}`)
+	if !ok || name != "weather" || args != "{}" {
+		t.Fatalf("missing-args parse: name=%q args=%q ok=%v", name, args, ok)
+	}
+
+	// Not a tool call.
+	if _, _, ok := parseTextToolCall("Here is the final answer, no tools needed."); ok {
+		t.Fatal("plain answer should not parse as a tool call")
+	}
+	// Empty name.
+	if _, _, ok := parseTextToolCall(`{"tool_call": {"name": "", "arguments": {}}}`); ok {
+		t.Fatal("empty name should not parse")
+	}
+}
+
+func TestLocalTextToolProtocolEnabled(t *testing.T) {
+	t.Setenv("ORI_LOCAL_TEXT_TOOL_PROTOCOL", "")
+	if localTextToolProtocolEnabled() {
+		t.Fatal("unset should be disabled")
+	}
+	t.Setenv("ORI_LOCAL_TEXT_TOOL_PROTOCOL", "true")
+	if !localTextToolProtocolEnabled() {
+		t.Fatal("true should be enabled")
+	}
+	t.Setenv("ORI_LOCAL_TEXT_TOOL_PROTOCOL", "off")
+	if localTextToolProtocolEnabled() {
+		t.Fatal("off should be disabled")
+	}
+}


### PR DESCRIPTION
Group 4 of the **Reliable Workspace Task Execution on Local Models** epic (`tasks/prd-local-model-task-execution.md`), stacked on the merged WS1–WS3 foundation (#157, #158). Local models handle tools poorly — many reject the `tools` parameter outright, and a long tool list swamps a small model. This makes tool exposure **degrade gracefully instead of failing the task**, keyed off provider capabilities (not provider names).

## What's here (WS4)
- **Tool gating (WS4.16)** — a provider supporting neither the internal tool loop nor native MCP is offered no tools and told so in the system prompt. Guard is `!SupportsTools && !SupportsNativeMCP`, so native-MCP CLIs (Claude Code / Codex) are unaffected.
- **Tools-rejected retry (WS4.17)** — when a model rejects the `tools` parameter (e.g. Ollama `"<model> does not support tools"`), retry the same round once without tools (no extra round consumed), record `tool_support: rejected_by_model` on the trace, and run tool-less for the rest of the task. The retried tool-less round can then enforce the output schema (WS3) that the tool round could not.
- **Local pruning (WS4.18)** — for local providers, prune the toolset to a cap (default 12) when exceeded: the five workspace core tools are always kept; the rest are ranked by keyword overlap with the task description (deterministic tie-break by name). Dropped tool names land on the execution trace so a silently-missing capability is diagnosable.
- **Feature-flagged text tool protocol (WS4.19, default off** via `ORI_LOCAL_TEXT_TOOL_PROTOCOL`**)** — once native tools were rejected, the model is told to emit a fenced `{"tool_call": {name, arguments}}` block, which the handler parses (brace-balanced, fence/prose-tolerant) and executes as a tool round.

New pure `internal/workspace/task_tool_degradation.go` holds the helpers (pruning, tools-rejected classification, text-protocol parser), unit-tested.

## Note on the test change
The WS4.16 gate correctly stripped tools from two existing provider stubs that returned **zero-value** capabilities while asserting tools are passed. Those stubs now advertise `SupportsTools:true` — an honest fix (they're tool-handling fakes), and a legitimate consequence of moving from "always pass tools" to capability-driven exposure.

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, and `staticcheck ./internal/...` all clean. 6 new WS4 unit tests pass (pruning keeps core + ranks + deterministic tie-break, tools-rejected classification, text-protocol parser, flag on/off). Full `internal/workspace` suite green; the only failing test across the module is the pre-existing live-API `TestProviderIntegration` (OpenAI 429 quota), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)