### PR TITLE
feat(local-models): compact task system-prompt tier for local providers (WS5)

### DIFF
--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -219,11 +219,14 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 
 	// Use a task-specific system prompt that's more conservative about tool use.
 	// The agent's system prompt may encourage aggressive tool use which is
-	// inappropriate for workspace tasks. Skills are injected so task/orchestration
-	// runs get skill instructions too, matching the chat path (skill-less agents
-	// add nothing).
-	taskSystemPrompt := h.buildTaskSystemPrompt()
+	// inappropriate for workspace tasks. Local providers get the compact tier,
+	// sized for small-model instruction following (WS5). Skills are injected so
+	// task/orchestration runs get skill instructions too, matching the chat path
+	// (skill-less agents add nothing).
+	compactPrompt := provider.Type() == llm.ProviderTypeLocal
+	taskSystemPrompt := h.buildTaskSystemPrompt(compactPrompt)
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
+	h.reportPromptTier(task, agentName, compactPrompt)
 
 	// Convert agent tools (MCP + workspace) to LLM format. Needed before budgeting
 	// because tool schemas consume the context window too.
@@ -844,6 +847,21 @@ func (h *LLMTaskHandler) reportConversationEviction(task Task, agentName string,
 			"round":              round,
 			"messages_compacted": compacted,
 			"still_over_budget":  stillOver,
+		}))
+	}
+}
+
+// reportPromptTier records which task system-prompt tier was used so prompt-tier
+// selection is observable on the execution trace (WS5.22).
+func (h *LLMTaskHandler) reportPromptTier(task Task, agentName string, compact bool) {
+	tier := "full"
+	if compact {
+		tier = "compact"
+	}
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":       "prompt_tier",
+			"prompt_tier": tier,
 		}))
 	}
 }

--- a/internal/workspace/task_prompt_context.go
+++ b/internal/workspace/task_prompt_context.go
@@ -55,7 +55,26 @@ const (
 	taskPromptPathLimit      = 180
 )
 
-func (h *LLMTaskHandler) buildTaskSystemPrompt() string {
+// compactTaskSystemPrompt is a small-model-sized variant of the task system
+// prompt (WS5.20): imperative bullets, task-first, ordered rules/output-last,
+// preserving the load-bearing semantics of the full prompt (use tools only when
+// needed; read full notes/files via workspace tools rather than previews; never
+// fabricate URL/filesystem contents; synthesize tool results into a final answer;
+// state blockers explicitly).
+const compactTaskSystemPrompt = "You are completing one task in a shared workspace. Rules:\n" +
+	"- Do the task described in the prompt. Use tools only when they are needed; answer simple questions directly.\n" +
+	"- The workspace snapshot shows truncated previews. To use a full note, file, session, or directory, call the matching workspace_* tool with its id instead of relying on the preview.\n" +
+	"- Never invent file, folder, or URL contents. If a tool is unavailable or a target is unreachable, say so plainly.\n" +
+	"- After using tools, synthesize the results into a clear final answer. Never return raw tool output as your answer.\n" +
+	"- If you cannot finish, state exactly what is blocking you."
+
+// buildTaskSystemPrompt returns the task system prompt. The compact variant is
+// used for local providers, whose smaller models follow a short imperative prompt
+// better than the long cloud-tuned one (WS5.20); both preserve the same rules.
+func (h *LLMTaskHandler) buildTaskSystemPrompt(compact bool) string {
+	if compact {
+		return compactTaskSystemPrompt
+	}
 	var prompt strings.Builder
 	prompt.WriteString("You are a helpful AI assistant completing a task in a collaborative workspace. ")
 	prompt.WriteString("You have access to tools, but only use them when they are clearly necessary to complete the specific task. ")

--- a/internal/workspace/task_prompt_context_test.go
+++ b/internal/workspace/task_prompt_context_test.go
@@ -413,9 +413,31 @@ func TestPrepareTaskContext_IncludesReferenceURLSurface(t *testing.T) {
 	}
 }
 
+func TestBuildTaskSystemPrompt_CompactVariant(t *testing.T) {
+	handler := &LLMTaskHandler{}
+	full := handler.buildTaskSystemPrompt(false)
+	compact := handler.buildTaskSystemPrompt(true)
+
+	if compact == full {
+		t.Fatal("compact variant should differ from the full prompt")
+	}
+	if words := len(strings.Fields(compact)); words > 160 {
+		t.Fatalf("compact prompt too long: %d words", words)
+	}
+	if len(strings.Fields(full)) <= len(strings.Fields(compact)) {
+		t.Fatal("full prompt should be longer than the compact one")
+	}
+	// The compact variant preserves the load-bearing semantics.
+	for _, want := range []string{"workspace_", "Never invent", "synthesize", "blocking"} {
+		if !strings.Contains(compact, want) {
+			t.Fatalf("compact prompt missing semantic %q:\n%s", want, compact)
+		}
+	}
+}
+
 func TestBuildTaskSystemPrompt_DisambiguatesWorkspaceFromRepository(t *testing.T) {
 	handler := &LLMTaskHandler{}
-	prompt := handler.buildTaskSystemPrompt()
+	prompt := handler.buildTaskSystemPrompt(false)
 
 	for _, want := range []string{
 		"workspace as the collaborative workspace data provided in the prompt",


### PR DESCRIPTION
Group 5 of the **Reliable Workspace Task Execution on Local Models** epic (`tasks/prd-local-model-task-execution.md`), stacked on the merged WS1–WS4 foundation (#157, #158, #159). Small local models follow a short imperative prompt better than the long cloud-tuned system prompt.

## What's here (WS5)
- `buildTaskSystemPrompt(compact bool)` returns a **compact ~100-word variant** (imperative bullets, task-first) for local providers, preserving the same load-bearing rules as the full prompt: use tools only when needed; read full notes/files via `workspace_*` tools rather than previews; never fabricate URL/filesystem contents; synthesize tool results into a final answer (never return raw tool output); state blockers explicitly. Cloud providers keep the full prompt.
- Skill injection (`AppendSkillPromptsFromResolved`) applies to both tiers unchanged.
- The selected tier (`compact` | `full`) is emitted on the execution trace so prompt-tier selection is observable.

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, and `staticcheck ./internal/...` all clean. New compact-variant unit test (asserts it differs from full, stays under the word budget, and preserves the key semantics) plus the existing full-prompt test pass. Full `internal/workspace` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)