### PR TITLE
feat(local-models): local-aware scheduling, timeouts & cold-load retry (WS6)

### DIFF
--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -310,6 +310,10 @@ func (b *ServerBuilder) initializeTaskExecution() {
 		MaxConcurrent: 5,
 	})
 	b.taskExecutor.SetEventBus(b.eventBus)
+	// The execution handler may be a run bridge that does not itself resolve
+	// provider profiles, so wire the LLM task handler directly for scheduling
+	// decisions (per-provider concurrency, local timeouts) — WS6.
+	b.taskExecutor.SetProviderResolver(b.taskHandler)
 
 	b.stepExecutor = workspace.NewStepExecutor(b.workspaceStore, taskExecutionHandler, workspace.StepExecutorConfig{
 		PollInterval: 5 * time.Second,

--- a/internal/workspace/executor.go
+++ b/internal/workspace/executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -17,16 +18,64 @@ import (
 
 // TaskExecutor handles automatic execution of workspace tasks
 type TaskExecutor struct {
-	workspaceStore Store
-	taskHandler    TaskHandler
-	pollInterval   time.Duration
-	maxConcurrent  int
-	eventBus       *EventBus // Optional event bus for publishing events
+	workspaceStore         Store
+	taskHandler            TaskHandler
+	pollInterval           time.Duration
+	maxConcurrent          int
+	localTimeoutMultiplier int
+	eventBus               *EventBus // Optional event bus for publishing events
+
+	providerResolver TaskProviderResolver // optional; overrides taskHandler assertion
 
 	mu           sync.RWMutex
 	runningTasks map[string]*taskExecution
+	runningByKey map[string]int // per concurrency-key running counts (WS6.23)
 	stopChan     chan struct{}
 	wg           sync.WaitGroup
+}
+
+// SetProviderResolver wires provider-profile resolution for scheduling (WS6).
+// This is needed when the execution handler is a wrapper (e.g. a run bridge) that
+// does not itself implement TaskProviderResolver; without it the executor falls
+// back to type-asserting the task handler.
+func (te *TaskExecutor) SetProviderResolver(resolver TaskProviderResolver) {
+	te.providerResolver = resolver
+}
+
+// resolveProviderProfile resolves a task's provider profile, preferring an
+// explicitly wired resolver over a type-asserted handler.
+func (te *TaskExecutor) resolveProviderProfile(task Task) TaskProviderProfile {
+	resolver := te.providerResolver
+	if resolver == nil {
+		resolver, _ = te.taskHandler.(TaskProviderResolver)
+	}
+	if resolver == nil {
+		return TaskProviderProfile{}
+	}
+	return resolver.ResolveTaskProviderProfile(task)
+}
+
+// TaskProviderProfile describes a task's resolved provider for scheduling
+// decisions, so the executor can respect local hardware without coupling to the
+// LLM layer (WS6).
+type TaskProviderProfile struct {
+	// ConcurrencyKey scopes a per-instance concurrency limit ("" = global pool
+	// only, i.e. cloud providers).
+	ConcurrencyKey string
+	// Limit is the max concurrent tasks for ConcurrencyKey (<= 0 = unlimited).
+	Limit int
+	// IsLocal reports whether the task runs on a local provider.
+	IsLocal bool
+	// OrderKey groups identical provider+model tasks consecutively within a poll
+	// cycle to reduce model-swap churn (empty for cloud).
+	OrderKey string
+}
+
+// TaskProviderResolver lets the executor learn a task's provider profile. It is
+// an optional capability of the task handler; when absent the executor falls
+// back to the global concurrency pool and default timeout (cloud behavior).
+type TaskProviderResolver interface {
+	ResolveTaskProviderProfile(task Task) TaskProviderProfile
 }
 
 var errSkipOrphanCleanup = errors.New("skip orphan cleanup")
@@ -40,16 +89,39 @@ type TaskHandler interface {
 
 // taskExecution tracks a running task
 type taskExecution struct {
-	Task      Task
-	StartedAt time.Time
-	Context   context.Context
-	Cancel    context.CancelFunc
+	Task           Task
+	StartedAt      time.Time
+	Context        context.Context
+	Cancel         context.CancelFunc
+	ConcurrencyKey string // per-instance key held for the duration (WS6.23)
+}
+
+// defaultTaskTimeout is the fallback per-task timeout when a task sets none.
+const defaultTaskTimeout = 5 * time.Minute
+
+// defaultLocalTimeoutMultiplier scales the default timeout for local providers to
+// absorb cold model loads (WS6.25).
+const defaultLocalTimeoutMultiplier = 2
+
+// effectiveTaskTimeout returns the timeout for a task: an explicit task timeout is
+// honored as-is; otherwise the default is scaled by the local multiplier for
+// local-provider tasks (WS6.25).
+func effectiveTaskTimeout(taskTimeout time.Duration, isLocal bool, multiplier int) time.Duration {
+	if taskTimeout != 0 {
+		return taskTimeout
+	}
+	timeout := defaultTaskTimeout
+	if isLocal && multiplier > 1 {
+		timeout *= time.Duration(multiplier)
+	}
+	return timeout
 }
 
 // ExecutorConfig contains configuration for the task executor
 type ExecutorConfig struct {
-	PollInterval  time.Duration // How often to check for new tasks
-	MaxConcurrent int           // Max number of concurrent task executions
+	PollInterval           time.Duration // How often to check for new tasks
+	MaxConcurrent          int           // Max number of concurrent task executions
+	LocalTimeoutMultiplier int           // Multiplies the default timeout for local providers (0 = default)
 }
 
 // NewTaskExecutor creates a new task executor
@@ -60,14 +132,19 @@ func NewTaskExecutor(store Store, handler TaskHandler, config ExecutorConfig) *T
 	if config.MaxConcurrent == 0 {
 		config.MaxConcurrent = 5
 	}
+	if config.LocalTimeoutMultiplier <= 0 {
+		config.LocalTimeoutMultiplier = defaultLocalTimeoutMultiplier
+	}
 
 	return &TaskExecutor{
-		workspaceStore: store,
-		taskHandler:    handler,
-		pollInterval:   config.PollInterval,
-		maxConcurrent:  config.MaxConcurrent,
-		runningTasks:   make(map[string]*taskExecution),
-		stopChan:       make(chan struct{}),
+		workspaceStore:         store,
+		taskHandler:            handler,
+		pollInterval:           config.PollInterval,
+		maxConcurrent:          config.MaxConcurrent,
+		localTimeoutMultiplier: config.LocalTimeoutMultiplier,
+		runningTasks:           make(map[string]*taskExecution),
+		runningByKey:           make(map[string]int),
+		stopChan:               make(chan struct{}),
 	}
 }
 
@@ -201,73 +278,91 @@ func (te *TaskExecutor) pollLoop() {
 	}
 }
 
-// checkAndExecuteTasks checks for pending tasks and executes them
+// taskCandidate is a claimable task plus its workspace and resolved provider
+// profile, collected before ordering/claiming within a poll cycle.
+type taskCandidate struct {
+	ws      *Workspace
+	task    Task
+	profile TaskProviderProfile
+}
+
+// checkAndExecuteTasks checks for assigned tasks and executes those that fit the
+// global and per-provider concurrency limits.
 func (te *TaskExecutor) checkAndExecuteTasks() {
-	// Get all workspaces
 	workspaceIDs, err := te.workspaceStore.List()
 	if err != nil {
 		logger.Error("Failed to list workspaces", logger.Fields{"error": err})
 		return
 	}
 
+	// Collect all claimable candidates across active workspaces first, so they can
+	// be ordered before claiming.
+	var candidates []taskCandidate
 	for _, wsID := range workspaceIDs {
 		ws, err := te.workspaceStore.Get(wsID)
-		if err != nil {
+		if err != nil || ws.Status != StatusActive {
 			continue
 		}
-
-		// Only process active workspaces
-		if ws.Status != StatusActive {
-			continue
-		}
-
-		// Find tasks ready for execution
 		for i := range ws.Tasks {
-			task := &ws.Tasks[i]
-
-			// Only auto-execute tasks with "assigned" status
-			// Pending tasks require manual execution via the UI (click RUN button)
-			if task.Status != TaskStatusAssigned {
+			// Only auto-execute "assigned" tasks; "pending" requires the UI RUN button.
+			if ws.Tasks[i].Status != TaskStatusAssigned {
 				continue
 			}
-
-			// Check if already running and claim the task atomically
-			// Use write lock to prevent race condition between check and insert
-			te.mu.Lock()
-			_, isRunning := te.runningTasks[task.ID]
-			if isRunning {
-				te.mu.Unlock()
-				continue
-			}
-
-			// Check if we have capacity
-			if len(te.runningTasks) >= te.maxConcurrent {
-				te.mu.Unlock()
-				logger.Warn("Max concurrent tasks reached, deferring task", logger.Fields{"max_concurrent": te.maxConcurrent, "task_id": task.ID})
-				continue
-			}
-
-			// Mark task as claimed immediately to prevent double execution
-			// Create a placeholder execution entry that will be replaced by executeTask
-			te.runningTasks[task.ID] = &taskExecution{
-				Task:      *task,
-				StartedAt: time.Now(),
-			}
-			te.mu.Unlock()
-
-			// Execute the task (it will update the runningTasks entry with full context)
-			te.executeTask(ws, *task)
+			task := ws.Tasks[i]
+			candidates = append(candidates, taskCandidate{ws: ws, task: task, profile: te.resolveProviderProfile(task)})
 		}
+	}
+
+	// Group identical provider+model tasks consecutively to cut model-swap churn
+	// on a single local server (WS6.24). A stable sort preserves the original
+	// (FIFO) order within a group and among cloud tasks (OrderKey ""), so no task
+	// is starved by reordering (WS6.23).
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].profile.OrderKey < candidates[j].profile.OrderKey
+	})
+
+	for _, c := range candidates {
+		te.mu.Lock()
+		if _, running := te.runningTasks[c.task.ID]; running {
+			te.mu.Unlock()
+			continue
+		}
+		// Global capacity.
+		if len(te.runningTasks) >= te.maxConcurrent {
+			te.mu.Unlock()
+			logger.Warn("Max concurrent tasks reached, deferring task", logger.Fields{"max_concurrent": te.maxConcurrent, "task_id": c.task.ID})
+			continue
+		}
+		// Per-provider-instance capacity: a task whose provider is at its limit is
+		// deferred (not failed) and consumes no global slot (WS6.23).
+		key := c.profile.ConcurrencyKey
+		if key != "" && c.profile.Limit > 0 && te.runningByKey[key] >= c.profile.Limit {
+			te.mu.Unlock()
+			logger.Debug("Provider at concurrency limit, deferring task", logger.Fields{"provider_key": key, "limit": c.profile.Limit, "task_id": c.task.ID})
+			continue
+		}
+
+		// Claim: placeholder entry (replaced by executeTask with full context) and
+		// hold a per-key slot for the duration.
+		te.runningTasks[c.task.ID] = &taskExecution{
+			Task:           c.task,
+			StartedAt:      time.Now(),
+			ConcurrencyKey: key,
+		}
+		if key != "" {
+			te.runningByKey[key]++
+		}
+		te.mu.Unlock()
+
+		te.executeTask(c.ws, c.task, c.profile)
 	}
 }
 
 // executeTask executes a single task asynchronously
-func (te *TaskExecutor) executeTask(ws *Workspace, task Task) {
-	// Create context with timeout
-	timeout := task.Timeout
-	if timeout == 0 {
-		timeout = 5 * time.Minute // Default timeout
-	}
+func (te *TaskExecutor) executeTask(ws *Workspace, task Task, profile TaskProviderProfile) {
+	// Create context with timeout. Local providers get a scaled default to absorb
+	// cold model loads when the task set no explicit timeout (WS6.25).
+	timeout := effectiveTaskTimeout(task.Timeout, profile.IsLocal, te.localTimeoutMultiplier)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	// NOTE: Don't defer cancel() here because we launch a goroutine below
@@ -276,10 +371,11 @@ func (te *TaskExecutor) executeTask(ws *Workspace, task Task) {
 	// Track running task
 	te.mu.Lock()
 	te.runningTasks[task.ID] = &taskExecution{
-		Task:      task,
-		StartedAt: time.Now(),
-		Context:   ctx,
-		Cancel:    cancel,
+		Task:           task,
+		StartedAt:      time.Now(),
+		Context:        ctx,
+		Cancel:         cancel,
+		ConcurrencyKey: profile.ConcurrencyKey,
 	}
 	te.mu.Unlock()
 
@@ -343,6 +439,12 @@ func (te *TaskExecutor) executeTask(ws *Workspace, task Task) {
 		defer cancel()
 		defer func() {
 			te.mu.Lock()
+			if exec, ok := te.runningTasks[task.ID]; ok && exec.ConcurrencyKey != "" {
+				te.runningByKey[exec.ConcurrencyKey]--
+				if te.runningByKey[exec.ConcurrencyKey] <= 0 {
+					delete(te.runningByKey, exec.ConcurrencyKey)
+				}
+			}
 			delete(te.runningTasks, task.ID)
 			te.mu.Unlock()
 		}()

--- a/internal/workspace/local_error_classifier.go
+++ b/internal/workspace/local_error_classifier.go
@@ -1,0 +1,71 @@
+package workspace
+
+import "strings"
+
+// localErrorClass categorizes a local-provider failure so scheduling and offline
+// handling can react differently to the same error surface (WS6.26a). The two
+// actionable classes prescribe opposite responses — cold-load is retried, offline
+// is blocked — so the discriminator is explicit and table-driven rather than
+// ad-hoc string matching.
+type localErrorClass int
+
+const (
+	// localErrorOther is a failure that is neither a cold load nor an offline
+	// server (e.g. a model-quality or validation error): no special handling.
+	localErrorOther localErrorClass = iota
+	// localErrorColdLoad is a transient failure consistent with the server being
+	// reachable but slow to respond (model loading, connection reset mid-request,
+	// read timeout): retry once (WS6.26).
+	localErrorColdLoad
+	// localErrorOffline is a failure consistent with the server being unreachable
+	// (connection refused, DNS failure, no listener): block as offline (WS8.31).
+	localErrorOffline
+)
+
+// offlineErrorPatterns indicate the server is unreachable (checked first, since a
+// connect-phase refusal must classify as offline even though it also "times out").
+var offlineErrorPatterns = []string{
+	"connection refused",
+	"no such host",
+	"network is unreachable",
+	"no route to host",
+	"dial tcp",           // connect-phase failure (host down / wrong port)
+	"connect: ",          // generic connect failure
+	"server misbehaving", // DNS resolver failure
+}
+
+// coldLoadErrorPatterns indicate the server is reachable but was slow or dropped
+// the request (model still loading, reset, read timeout).
+var coldLoadErrorPatterns = []string{
+	"connection reset",
+	"reset by peer",
+	"unexpected eof",
+	"i/o timeout",
+	"context deadline exceeded",
+	"timeout",
+	"timed out",
+	"loading model",
+	"model is loading",
+	"model requires more system memory", // load-time failure, worth one retry
+}
+
+// classifyLocalError maps a provider error to a localErrorClass. Offline patterns
+// win over cold-load so a connection-refused during a cold-load retry is not
+// re-classified as a transient load (WS6.26a).
+func classifyLocalError(err error) localErrorClass {
+	if err == nil {
+		return localErrorOther
+	}
+	s := strings.ToLower(err.Error())
+	for _, p := range offlineErrorPatterns {
+		if strings.Contains(s, p) {
+			return localErrorOffline
+		}
+	}
+	for _, p := range coldLoadErrorPatterns {
+		if strings.Contains(s, p) {
+			return localErrorColdLoad
+		}
+	}
+	return localErrorOther
+}

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -280,6 +281,53 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 // resolveExecutionAgent and the rest of the agent-resolution helpers live
 // in task_handler_agent_resolver.go.
 
+// localProviderConcurrency is the per-instance concurrency limit for local
+// providers (default 1 — one task at a time protects a single GPU), configurable
+// via ORI_LOCAL_PROVIDER_CONCURRENCY (WS6.23).
+func localProviderConcurrency() int {
+	if v := strings.TrimSpace(os.Getenv("ORI_LOCAL_PROVIDER_CONCURRENCY")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 1
+}
+
+// ResolveTaskProviderProfile resolves a task's provider profile for the executor's
+// scheduling decisions (WS6). Cloud tasks (and any task that can't be resolved)
+// return the zero profile — global pool, default timeout. Local tasks get a
+// per-provider-instance concurrency key/limit, IsLocal, and an order key that
+// groups identical provider+model pairs within a poll cycle.
+//
+// The key is currently the resolved provider name, which for the built-in local
+// providers is one instance each; distinguishing multiple configs at the same
+// base URL would require exposing the URL on the provider interface (follow-up).
+func (h *LLMTaskHandler) ResolveTaskProviderProfile(task Task) TaskProviderProfile {
+	if h == nil || h.llmFactory == nil {
+		return TaskProviderProfile{}
+	}
+	agentName := strings.TrimSpace(task.To)
+	if agentName == "" {
+		return TaskProviderProfile{}
+	}
+	ag, err := h.resolveExecutionAgent(agentName, task)
+	if err != nil {
+		return TaskProviderProfile{}
+	}
+	providerName := h.getProviderForAgent(ag.Settings.Provider, ag.Settings.Model)
+	provider, err := h.llmFactory.GetProvider(providerName)
+	if err != nil || provider.Type() != llm.ProviderTypeLocal {
+		return TaskProviderProfile{}
+	}
+	modelName := h.normalizeModelForProvider(providerName, ag.Settings.Model)
+	return TaskProviderProfile{
+		ConcurrencyKey: "local:" + providerName,
+		Limit:          localProviderConcurrency(),
+		IsLocal:        true,
+		OrderKey:       providerName + "|" + modelName,
+	}
+}
+
 func (h *LLMTaskHandler) executeTaskConversation(
 	ctx context.Context,
 	provider llm.Provider,
@@ -307,6 +355,10 @@ func (h *LLMTaskHandler) executeTaskConversation(
 	// enables the feature-flagged prompt-based fallback (default off).
 	toolsRejected := false
 	textToolProtocol := isLocal && localTextToolProtocolEnabled()
+
+	// Cold-load retry (WS6.26): a first-round local failure that looks like the
+	// model still loading gets one retry after a short delay before failing.
+	coldLoadRetried := false
 
 	// Constrained decoding for structured output: on rounds where tools are not
 	// offered (initial tool-less request or a forced final answer), enforce the
@@ -417,6 +469,20 @@ func (h *LLMTaskHandler) executeTaskConversation(
 			// Optionally switch the model to the prompt-based tool protocol.
 			if textToolProtocol && len(conversation) > 0 && conversation[0].Role == llm.RoleSystem {
 				conversation[0].Content += textToolProtocolInstruction
+			}
+			resp, err = provider.Chat(ctx, chatReq)
+		}
+		// Cold-load retry (WS6.26): a first-round local failure that looks like the
+		// model still loading (or a dropped/timed-out connection to a reachable
+		// server) is retried once after a short delay. Offline/unreachable errors
+		// are NOT retried here — they surface for offline handling (WS8).
+		if err != nil && isLocal && round == 0 && !coldLoadRetried && classifyLocalError(err) == localErrorColdLoad {
+			coldLoadRetried = true
+			h.reportColdLoadRetry(task, agentName, err)
+			select {
+			case <-time.After(coldLoadRetryDelay):
+			case <-ctx.Done():
+				return "", ctx.Err()
 			}
 			resp, err = provider.Chat(ctx, chatReq)
 		}
@@ -847,6 +913,27 @@ func (h *LLMTaskHandler) reportConversationEviction(task Task, agentName string,
 			"round":              round,
 			"messages_compacted": compacted,
 			"still_over_budget":  stillOver,
+		}))
+	}
+}
+
+// coldLoadRetryDelay is how long to wait before retrying a first-round local
+// failure that looks like the model still loading (WS6.26).
+const coldLoadRetryDelay = 5 * time.Second
+
+// reportColdLoadRetry logs and emits a cold-load retry so the wait is visible on
+// the execution trace rather than looking like a stall (WS6.26).
+func (h *LLMTaskHandler) reportColdLoadRetry(task Task, agentName string, cause error) {
+	logger.Warn("Local model call failed on first round; retrying after cold-load delay", logger.Fields{
+		"workspace_id": task.WorkspaceID,
+		"task_id":      task.ID,
+		"delay":        coldLoadRetryDelay.String(),
+		"error":        cause.Error(),
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":    "cold_load_retry",
+			"delay_ms": coldLoadRetryDelay.Milliseconds(),
 		}))
 	}
 }

--- a/internal/workspace/task_scheduling_test.go
+++ b/internal/workspace/task_scheduling_test.go
@@ -1,0 +1,157 @@
+package workspace
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClassifyLocalError(t *testing.T) {
+	cases := map[string]localErrorClass{
+		"dial tcp 127.0.0.1:11434: connect: connection refused": localErrorOffline,
+		"lookup localhost: no such host":                        localErrorOffline,
+		"connect: network is unreachable":                       localErrorOffline,
+		"read tcp: connection reset by peer":                    localErrorColdLoad,
+		"Post \"...\": context deadline exceeded":               localErrorColdLoad,
+		"model is loading, please wait":                         localErrorColdLoad,
+		"i/o timeout":                                           localErrorColdLoad,
+		"invalid JSON in response":                              localErrorOther,
+		"":                                                      localErrorOther,
+	}
+	for msg, want := range cases {
+		var err error
+		if msg != "" {
+			err = errors.New(msg)
+		}
+		if got := classifyLocalError(err); got != want {
+			t.Errorf("classifyLocalError(%q) = %d, want %d", msg, got, want)
+		}
+	}
+}
+
+func TestClassifyLocalError_OfflineWinsOverColdLoad(t *testing.T) {
+	// A message with both a connect refusal and a timeout must classify offline.
+	err := errors.New("dial tcp: connect: connection refused (i/o timeout)")
+	if got := classifyLocalError(err); got != localErrorOffline {
+		t.Fatalf("expected offline to win, got %d", got)
+	}
+}
+
+func TestEffectiveTaskTimeout(t *testing.T) {
+	// Explicit timeout honored regardless of provider.
+	if got := effectiveTaskTimeout(90*time.Second, true, 2); got != 90*time.Second {
+		t.Fatalf("explicit timeout = %v, want 90s", got)
+	}
+	// Cloud default unscaled.
+	if got := effectiveTaskTimeout(0, false, 2); got != defaultTaskTimeout {
+		t.Fatalf("cloud default = %v, want %v", got, defaultTaskTimeout)
+	}
+	// Local default scaled by the multiplier.
+	if got := effectiveTaskTimeout(0, true, 2); got != 2*defaultTaskTimeout {
+		t.Fatalf("local default = %v, want %v", got, 2*defaultTaskTimeout)
+	}
+	// Multiplier <= 1 leaves the default alone.
+	if got := effectiveTaskTimeout(0, true, 1); got != defaultTaskTimeout {
+		t.Fatalf("multiplier 1 = %v, want %v", got, defaultTaskTimeout)
+	}
+}
+
+func TestLocalProviderConcurrency(t *testing.T) {
+	t.Setenv("ORI_LOCAL_PROVIDER_CONCURRENCY", "")
+	if got := localProviderConcurrency(); got != 1 {
+		t.Fatalf("default = %d, want 1", got)
+	}
+	t.Setenv("ORI_LOCAL_PROVIDER_CONCURRENCY", "3")
+	if got := localProviderConcurrency(); got != 3 {
+		t.Fatalf("configured = %d, want 3", got)
+	}
+	t.Setenv("ORI_LOCAL_PROVIDER_CONCURRENCY", "bogus")
+	if got := localProviderConcurrency(); got != 1 {
+		t.Fatalf("invalid should fall back to 1, got %d", got)
+	}
+}
+
+// localSchedFakeHandler is a fake task handler that also resolves a fixed
+// provider profile, so the executor's per-provider concurrency can be exercised.
+type localSchedFakeHandler struct {
+	*fakeTaskHandler
+	profile TaskProviderProfile
+}
+
+func (h *localSchedFakeHandler) ResolveTaskProviderProfile(_ Task) TaskProviderProfile {
+	return h.profile
+}
+
+func TestCheckAndExecuteTasks_PerProviderConcurrencyLimit(t *testing.T) {
+	store := newExecutorTestStore(t)
+	tasks := make([]Task, 0, 3)
+	for i := 0; i < 3; i++ {
+		tasks = append(tasks, Task{
+			ID:     "task-" + string(rune('a'+i)),
+			To:     "agent-a",
+			Status: TaskStatusAssigned,
+		})
+	}
+	ws := newWorkspaceWithTasks(t, tasks)
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	release := make(chan struct{})
+	handler := &localSchedFakeHandler{
+		fakeTaskHandler: &fakeTaskHandler{block: release},
+		profile: TaskProviderProfile{
+			ConcurrencyKey: "local:ollama",
+			Limit:          1,
+			IsLocal:        true,
+			OrderKey:       "ollama|m",
+		},
+	}
+
+	// Global capacity is generous; the per-provider limit of 1 is the constraint.
+	te := NewTaskExecutor(store, handler, ExecutorConfig{
+		PollInterval:  time.Hour,
+		MaxConcurrent: 5,
+	})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		te.Stop()
+	})
+
+	te.checkAndExecuteTasks()
+
+	// Exactly one task should be running; the other two are deferred by the
+	// per-provider limit, not failed.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt64(&handler.calls) < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&handler.calls); got != 1 {
+		t.Fatalf("running tasks = %d, want 1 (per-provider limit)", got)
+	}
+	// Confirm it stays at 1 (limit holds) rather than draining all three.
+	time.Sleep(150 * time.Millisecond)
+	if got := atomic.LoadInt64(&handler.calls); got != 1 {
+		t.Fatalf("per-provider limit breached: running = %d, want 1", got)
+	}
+
+	// The deferred tasks are still assigned (not failed/cancelled).
+	fresh, err := store.Get(ws.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	assigned := 0
+	for _, task := range fresh.Tasks {
+		if task.Status == TaskStatusAssigned {
+			assigned++
+		}
+	}
+	if assigned != 2 {
+		t.Fatalf("deferred tasks assigned = %d, want 2", assigned)
+	}
+}


### PR DESCRIPTION
Group 6 of the **Reliable Workspace Task Execution on Local Models** epic (`tasks/prd-local-model-task-execution.md`), stacked on the merged WS1–WS5 foundation (#157–#160). Task scheduling was tuned for cheap concurrent cloud requests; on a single local server, running several tasks at once thrashes the GPU with model swaps and a cold model load can blow the fixed 5-minute timeout. This makes scheduling respect local hardware, keyed off provider capabilities.

## What's here (WS6)
- **Shared cold-load-vs-offline classifier** (`local_error_classifier.go`) — a table-driven discriminator mapping a provider error to cold-load (server reachable but loading / connection reset / read timeout) vs offline (connection refused / DNS failure / no listener). Offline patterns win over cold-load so a connect refusal during a retry isn't mistaken for a transient load. Reused by WS8.
- **Per-provider concurrency** (executor) — tasks are collected, ordered, then claimed. A task whose provider instance is at its limit (default **1** for local, env `ORI_LOCAL_PROVIDER_CONCURRENCY`) is **deferred, not failed**, and consumes no global slot. A stable sort groups identical provider+model tasks consecutively to cut model-swap churn while preserving FIFO within a group (anti-starvation).
- **Local timeout multiplier** — the default per-task timeout is scaled (default 2×) for local-provider tasks that set no explicit timeout, to absorb cold loads.
- **Cold-load retry** (task handler) — a first-round local failure classified as cold-load is retried once after a 5s delay before failing; offline errors are left to surface for WS8.

Provider profiles are resolved by `LLMTaskHandler.ResolveTaskProviderProfile` via a new optional `TaskProviderResolver`, wired explicitly onto the executor (`SetProviderResolver`) because the execution handler is often a run bridge that doesn't implement it (type-assertion fallback kept for other setups).

## Scope notes
- Concurrency key is the **resolved provider name**, not base URL. Base-URL keying (distinguishing multiple configs at one URL) needs a `BaseURL()` method on the provider interface — deferred as a follow-up; for the built-in local providers it's equivalent in practice.

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, and `staticcheck ./internal/...` all clean. 5 new WS6 unit tests pass (classifier table + offline-priority, timeout multiplier, env concurrency, and a real executor test proving the per-provider limit defers 2 of 3 same-provider tasks while leaving them `assigned`). Full `internal/workspace` + `internal/server` suites green; the only failing test across the module is the pre-existing live-API `TestProviderIntegration` (OpenAI 429 quota), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)