### PR TITLE
feat(local-models): offline handling & opt-in provider fallback (WS8) — epic complete

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,6 +20,15 @@ type Settings struct {
 	// per-tool confirmation gate. Security-sensitive, so it defaults OFF (nil or
 	// false). Requires the workspace to also opt in.
 	AllowNativeMCPTools *bool `json:"allow_native_mcp_tools,omitempty"`
+
+	// FallbackProvider/FallbackModel opt a task into an alternative provider when
+	// the primary is unreachable (WS8.32). Empty = no fallback. FallbackModel
+	// falls back to Model when empty.
+	FallbackProvider string `json:"fallback_provider,omitempty"`
+	FallbackModel    string `json:"fallback_model,omitempty"`
+	// FallbackAllowCloud permits a local->cloud fallback to run without a one-time
+	// confirmation (spend guard). Nil/false = confirm first (WS8.33b).
+	FallbackAllowCloud *bool `json:"fallback_allow_cloud,omitempty"`
 }
 
 // IsNativeMCPToolsAllowed reports whether this agent may run native-MCP CLI

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -210,20 +210,45 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 		}
 	}
 
-	// Determine which provider to use based on explicit agent provider + model fallback.
-	providerName := h.getProviderForAgent(ag.Settings.Provider, ag.Settings.Model)
+	// Run on the agent's configured provider. If that provider is a local server
+	// that turns out to be offline and the agent has a configured fallback, re-run
+	// the whole task on the fallback provider — which re-resolves the context
+	// window, re-budgets the prompt, re-selects the prompt tier, and re-checks
+	// tool/structured-output support for that backend (WS8.33a).
+	primaryProviderName := h.getProviderForAgent(ag.Settings.Provider, ag.Settings.Model)
+	result, err := h.runTaskOnProvider(ctx, primaryProviderName, ag.Settings.Model, ag, agentName, task)
+	if err == nil || !isLocalProviderOfflineError(err) {
+		return result, err
+	}
+
+	fallbackProvider, fallbackModel, hasFallback := resolveAgentFallback(ag)
+	if !hasFallback {
+		return result, err // the offline block stands (WS8.32)
+	}
+	// Gate a local->cloud fallback behind explicit opt-in to avoid silent spend
+	// (WS8.33b); a local->local fallback proceeds with just a trace note.
+	if gateErr := h.fallbackCloudSpendGate(ag, task, agentName, fallbackProvider); gateErr != nil {
+		return "", gateErr
+	}
+	h.reportProviderFallback(task, agentName, primaryProviderName, fallbackProvider)
+	return h.runTaskOnProvider(ctx, fallbackProvider, fallbackModel, ag, agentName, task)
+}
+
+// runTaskOnProvider resolves the named provider and runs the full task pipeline
+// on it: prompt tier, tool exposure, prompt budgeting, and the tool loop. It is
+// called once for the primary provider and, on an offline block with a configured
+// fallback, again for the fallback — so every provider-dependent decision is
+// re-made for whichever backend actually runs the task (WS8.33a).
+func (h *LLMTaskHandler) runTaskOnProvider(ctx context.Context, providerName, requestedModel string, ag *resolvedTaskAgent, agentName string, task Task) (string, error) {
 	provider, err := h.llmFactory.GetProvider(providerName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get LLM provider: %w", err)
 	}
-	modelName := h.normalizeModelForProvider(providerName, ag.Settings.Model)
+	modelName := h.normalizeModelForProvider(providerName, requestedModel)
 
-	// Use a task-specific system prompt that's more conservative about tool use.
-	// The agent's system prompt may encourage aggressive tool use which is
-	// inappropriate for workspace tasks. Local providers get the compact tier,
-	// sized for small-model instruction following (WS5). Skills are injected so
-	// task/orchestration runs get skill instructions too, matching the chat path
-	// (skill-less agents add nothing).
+	// Local providers get the compact system-prompt tier (WS5). Skills are injected
+	// so task/orchestration runs get skill instructions too (skill-less agents add
+	// nothing).
 	compactPrompt := provider.Type() == llm.ProviderTypeLocal
 	taskSystemPrompt := h.buildTaskSystemPrompt(compactPrompt)
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
@@ -274,7 +299,6 @@ func (h *LLMTaskHandler) ExecuteTask(ctx context.Context, agentName string, task
 		llm.NewUserMessage(renderPromptSegments(segments)),
 	}
 
-	// Call the LLM
 	return h.executeTaskConversation(ctx, provider, providerName, modelName, contextWindow, ag, agentName, task, messages, tools)
 }
 
@@ -485,6 +509,12 @@ func (h *LLMTaskHandler) executeTaskConversation(
 				return "", ctx.Err()
 			}
 			resp, err = provider.Chat(ctx, chatReq)
+		}
+		// Offline classification (WS8.31): a local provider that is unreachable
+		// surfaces as an actionable blocked state (which Execute may turn into a
+		// fallback) rather than a generic failure buried in logs.
+		if err != nil && isLocal && classifyLocalError(err) == localErrorOffline {
+			return "", h.buildOfflineBlockedError(task, providerName, err)
 		}
 		if err != nil {
 			// Surface the raw provider error (CLI stderr/stdout) before it is

--- a/internal/workspace/task_offline_fallback.go
+++ b/internal/workspace/task_offline_fallback.go
@@ -1,0 +1,107 @@
+package workspace
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/logger"
+)
+
+// Reason codes for offline/fallback blocked states (WS8).
+const (
+	reasonLocalProviderOffline = "local_provider_offline"
+	reasonFallbackNeedsCloudOK = "fallback_requires_cloud_confirmation"
+)
+
+// buildOfflineBlockedError converts an unreachable-local-provider failure into an
+// actionable blocked state instead of a generic error (WS8.31).
+func (h *LLMTaskHandler) buildOfflineBlockedError(task Task, providerName string, cause error) error {
+	logger.Warn("Local provider offline; blocking task", logger.Fields{
+		"workspace_id": task.WorkspaceID,
+		"task_id":      task.ID,
+		"provider":     providerName,
+		"error":        cause.Error(),
+	})
+	return &TaskBlockedError{
+		ReasonCode:       reasonLocalProviderOffline,
+		Reason:           fmt.Sprintf("The local provider %q is unreachable: %v", providerName, cause),
+		Question:         fmt.Sprintf("The local provider %q appears to be offline. Retry, switch to another agent, or mark the task failed?", providerName),
+		SuggestedActions: []string{"retry", "switch_agent_retry", "mark_failed"},
+	}
+}
+
+// isLocalProviderOfflineError reports whether an error is the offline blocked
+// state, so Execute can decide whether to fall back.
+func isLocalProviderOfflineError(err error) bool {
+	if be, ok := AsTaskBlockedError(err); ok {
+		return be.ReasonCode == reasonLocalProviderOffline
+	}
+	return false
+}
+
+// resolveAgentFallback returns the agent's opt-in fallback provider/model, if set
+// (WS8.32). FallbackModel defaults to the primary model when empty.
+func resolveAgentFallback(ag *resolvedTaskAgent) (provider string, model string, ok bool) {
+	if ag == nil {
+		return "", "", false
+	}
+	provider = strings.TrimSpace(ag.Settings.FallbackProvider)
+	if provider == "" {
+		return "", "", false
+	}
+	model = strings.TrimSpace(ag.Settings.FallbackModel)
+	if model == "" {
+		model = strings.TrimSpace(ag.Settings.Model)
+	}
+	return provider, model, true
+}
+
+// fallbackCloudSpendGate blocks a local->cloud fallback for confirmation unless
+// the agent has explicitly opted in, so a task cannot silently incur cloud spend
+// (WS8.33b). A local->local fallback (or an opted-in cloud one) returns nil.
+func (h *LLMTaskHandler) fallbackCloudSpendGate(ag *resolvedTaskAgent, task Task, agentName, fallbackProvider string) error {
+	provider, err := h.llmFactory.GetProvider(fallbackProvider)
+	if err != nil {
+		// Let runTaskOnProvider surface the resolution error with full context.
+		return nil
+	}
+	if provider.Type() != llm.ProviderTypeCloud {
+		return nil // local->local: no spend risk
+	}
+	if ag != nil && ag.Settings.FallbackAllowCloud != nil && *ag.Settings.FallbackAllowCloud {
+		return nil // explicitly allowed
+	}
+	logger.Info("Local->cloud fallback requires confirmation", logger.Fields{
+		"workspace_id":      task.WorkspaceID,
+		"task_id":           task.ID,
+		"fallback_provider": fallbackProvider,
+	})
+	return &TaskBlockedError{
+		ReasonCode:       reasonFallbackNeedsCloudOK,
+		Reason:           fmt.Sprintf("The local provider is offline and the configured fallback %q is a paid cloud provider.", fallbackProvider),
+		Question:         fmt.Sprintf("Allow this task to fall back to the paid cloud provider %q (incurs cost)?", fallbackProvider),
+		SuggestedActions: []string{"allow_cloud_fallback_retry", "retry", "mark_failed"},
+	}
+}
+
+// reportProviderFallback logs and emits a provider fallback (with the
+// re-resolution note) so it is visible on the execution trace (WS8.32/8.33a).
+func (h *LLMTaskHandler) reportProviderFallback(task Task, agentName, from, to string) {
+	logger.Warn("Falling back to alternative provider", logger.Fields{
+		"workspace_id": task.WorkspaceID,
+		"task_id":      task.ID,
+		"from":         from,
+		"to":           to,
+		"reason":       reasonLocalProviderOffline,
+	})
+	if h.eventBus != nil {
+		h.eventBus.Publish(NewTaskEvent(EventTaskThinking, task.WorkspaceID, task.ID, agentName, map[string]any{
+			"phase":       "provider_fallback",
+			"from":        from,
+			"to":          to,
+			"reason":      reasonLocalProviderOffline,
+			"re_resolved": true,
+		}))
+	}
+}

--- a/internal/workspace/task_offline_fallback_test.go
+++ b/internal/workspace/task_offline_fallback_test.go
@@ -1,0 +1,122 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// fakeLocalProvider is a local provider that always fails with a fixed error, to
+// exercise offline / cold-load classification in the tool loop.
+type fakeLocalProvider struct {
+	name string
+	err  error
+}
+
+func (p *fakeLocalProvider) Chat(context.Context, llm.ChatRequest) (*llm.ChatResponse, error) {
+	return nil, p.err
+}
+func (p *fakeLocalProvider) StreamChat(context.Context, llm.ChatRequest) (llm.StreamReader, error) {
+	return nil, nil
+}
+func (p *fakeLocalProvider) Name() string           { return p.name }
+func (p *fakeLocalProvider) Type() llm.ProviderType { return llm.ProviderTypeLocal }
+func (p *fakeLocalProvider) Capabilities() llm.ProviderCapabilities {
+	return llm.LocalProviderCapabilities(8192)
+}
+func (p *fakeLocalProvider) ValidateConfig(llm.ProviderConfig) error { return nil }
+func (p *fakeLocalProvider) DefaultModels() []string                 { return nil }
+
+func agentWithSettings(s types.Settings) *resolvedTaskAgent {
+	return &resolvedTaskAgent{Agent: &agent.Agent{Settings: s}}
+}
+
+func TestIsLocalProviderOfflineError(t *testing.T) {
+	offline := &TaskBlockedError{ReasonCode: reasonLocalProviderOffline}
+	if !isLocalProviderOfflineError(offline) {
+		t.Fatal("offline block should be recognized")
+	}
+	other := &TaskBlockedError{ReasonCode: "context_overflow"}
+	if isLocalProviderOfflineError(other) {
+		t.Fatal("a different blocked reason should not match")
+	}
+	if isLocalProviderOfflineError(errors.New("plain error")) {
+		t.Fatal("a plain error should not match")
+	}
+}
+
+func TestResolveAgentFallback(t *testing.T) {
+	// No fallback configured.
+	if _, _, ok := resolveAgentFallback(agentWithSettings(types.Settings{Model: "m"})); ok {
+		t.Fatal("no fallback should report ok=false")
+	}
+	// Fallback provider set; model defaults to primary model.
+	p, m, ok := resolveAgentFallback(agentWithSettings(types.Settings{
+		Model:            "llama3.1:8b",
+		FallbackProvider: "openai",
+	}))
+	if !ok || p != "openai" || m != "llama3.1:8b" {
+		t.Fatalf("fallback = (%q,%q,%v), want (openai, llama3.1:8b, true)", p, m, ok)
+	}
+	// Explicit fallback model honored.
+	p, m, ok = resolveAgentFallback(agentWithSettings(types.Settings{
+		Model:            "llama3.1:8b",
+		FallbackProvider: "openai",
+		FallbackModel:    "gpt-5",
+	}))
+	if !ok || p != "openai" || m != "gpt-5" {
+		t.Fatalf("fallback = (%q,%q,%v), want (openai, gpt-5, true)", p, m, ok)
+	}
+}
+
+func TestExecuteTaskConversation_OfflineBlocks(t *testing.T) {
+	h := &LLMTaskHandler{}
+	prov := &fakeLocalProvider{name: "ollama", err: errors.New("dial tcp 127.0.0.1:11434: connect: connection refused")}
+	ag := agentWithSettings(types.Settings{Model: "llama3.1:8b"})
+
+	_, err := h.executeTaskConversation(context.Background(), prov, "ollama", "llama3.1:8b", 8192, ag, "agent-a",
+		Task{WorkspaceID: "ws-x"}, []llm.Message{llm.NewSystemMessage("sys"), llm.NewUserMessage("do it")}, nil)
+	be, ok := AsTaskBlockedError(err)
+	if !ok || be.ReasonCode != reasonLocalProviderOffline {
+		t.Fatalf("expected local_provider_offline block, got %v", err)
+	}
+	// The blocked error carries actionable choices.
+	found := false
+	for _, a := range be.SuggestedActions {
+		if a == "switch_agent_retry" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("offline block missing switch_agent_retry choice: %+v", be.SuggestedActions)
+	}
+}
+
+func TestFallbackCloudSpendGate(t *testing.T) {
+	factory := llm.NewFactory()
+	factory.Register("openai", &fakeNativeProvider{caps: llm.ProviderCapabilities{}}) // cloud (Type()=cloud)
+	factory.Register("ollama-2", &fakeLocalProvider{name: "ollama-2"})
+	h := &LLMTaskHandler{llmFactory: factory}
+	task := Task{WorkspaceID: "ws-x"}
+
+	// Local->cloud without opt-in: gated with a confirmation block.
+	gate := h.fallbackCloudSpendGate(agentWithSettings(types.Settings{}), task, "agent-a", "openai")
+	if be, ok := AsTaskBlockedError(gate); !ok || be.ReasonCode != reasonFallbackNeedsCloudOK {
+		t.Fatalf("cloud fallback should be gated, got %v", gate)
+	}
+
+	// Local->cloud with explicit opt-in: allowed.
+	allow := true
+	if gate := h.fallbackCloudSpendGate(agentWithSettings(types.Settings{FallbackAllowCloud: &allow}), task, "agent-a", "openai"); gate != nil {
+		t.Fatalf("opted-in cloud fallback should not be gated, got %v", gate)
+	}
+
+	// Local->local: never gated.
+	if gate := h.fallbackCloudSpendGate(agentWithSettings(types.Settings{}), task, "agent-a", "ollama-2"); gate != nil {
+		t.Fatalf("local->local fallback should not be gated, got %v", gate)
+	}
+}


### PR DESCRIPTION
**Final group** of the **Reliable Workspace Task Execution on Local Models** epic (`tasks/prd-local-model-task-execution.md`), stacked on the merged WS1–WS6 foundation (#157–#161). A down local server previously produced a generic failure buried in logs; this classifies an unreachable local provider into an actionable blocked state and, when the agent opts in, falls back to an alternative provider.

## What's here (WS8)
- **Offline block (WS8.31)** — a local provider that is unreachable (connection refused / DNS failure / no listener, via the shared WS6 classifier) surfaces as `TaskBlockedError{reason_code: local_provider_offline}` with retry / switch_agent_retry / mark_failed choices, instead of a generic error.
- **Opt-in fallback (WS8.32)** — new agent settings `fallback_provider` / `fallback_model` (`types.Settings`). When the primary is offline and a fallback is configured, the task re-runs on the fallback and `provider_fallback` is recorded on the trace.
- **Full re-resolution (WS8.33a)** — `ExecuteTask`'s prep+loop is extracted into `runTaskOnProvider`, so the fallback path re-resolves the context window, re-budgets the prompt, re-selects the prompt tier, and re-checks tool/structured-output support for the fallback backend — not a replay of the local-sized request.
- **Cloud spend gate (WS8.33b)** — absent `fallback_allow_cloud`, a local→cloud fallback returns a confirmation block rather than silently incurring cost; local→local proceeds with a trace note.
- Fallback triggers **only** on the offline classification, never on model-quality failures (WS8.33).

New `internal/workspace/task_offline_fallback.go` holds the helpers; offline detection lives in `executeTaskConversation` (any round). This **completes the epic (WS1–WS9)**.

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, and `staticcheck ./internal/...` all clean. 4 new WS8 unit tests pass (offline block shape + choices via a fake offline provider, fallback resolution incl. model defaulting, cloud-gate in all three modes: gated / opted-in / local→local). Full `internal/workspace` + `internal/types` + `internal/server` suites green; the only failing test across the module is the pre-existing live-API `TestProviderIntegration` (OpenAI 429 quota), untouched here.

## Manual, hardware-gated follow-ups (documented, not blockers)
- WS3.2: capture the pre-WS3 structured-output baseline via `test/smoke/local-models` against real Ollama.
- WS8.7: offline/fallback smoke (stop Ollama mid-run → block; configure a fallback → executes).
- Base-URL concurrency/offline keying (WS6/WS8): needs a `BaseURL()` on the provider interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)