### PR TITLE
feat(agents): reusable template agents — Phase 1 (workspace membership, guards, UI)

### DIFF
--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -197,25 +197,34 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 	// Otherwise, return list of all agents
 	names := h.State.ListAgents()
 
-	// Map of lowercase agent name → workspace ID for agents that are
-	// designated entry agents for a workspace. Sidebar / selector UIs use
-	// the resulting scope annotation to hide workspace-scoped agents.
-	entryAgentWorkspaces := collectWorkspaceEntryAgentNames(h.workspaceStore)
+	// Per-agent workspace membership (lowercase agent name → attached
+	// workspaces), computed from the metadata-only cache. Every referenced
+	// definition is annotated with workspace_count + workspaces; scope is no
+	// longer used to hide workspace entry agents (PRD FR1/FR2).
+	memberships := workspace.AgentWorkspaceMemberships(h.workspaceStore)
 
 	// Build agent details list with name and type
 	type AgentInfo struct {
-		Name        string                `json:"name"`
-		Type        string                `json:"type"`
-		Source      string                `json:"source"`
-		Scope       string                `json:"scope,omitempty"`
-		WorkspaceID string                `json:"workspace_id,omitempty"`
-		Status      types.AgentStatus     `json:"status,omitempty"`
-		Evolution   *types.AgentEvolution `json:"evolution,omitempty"`
+		Name           string                   `json:"name"`
+		Type           string                   `json:"type"`
+		Source         string                   `json:"source"`
+		Scope          string                   `json:"scope,omitempty"`
+		WorkspaceID    string                   `json:"workspace_id,omitempty"`
+		WorkspaceCount int                      `json:"workspace_count"`
+		Workspaces     []workspace.WorkspaceRef `json:"workspaces,omitempty"`
+		Status         types.AgentStatus        `json:"status,omitempty"`
+		Evolution      *types.AgentEvolution    `json:"evolution,omitempty"`
 	}
 	annotate := func(info AgentInfo) AgentInfo {
-		if wsID, ok := entryAgentWorkspaces[strings.ToLower(strings.TrimSpace(info.Name))]; ok {
-			info.Scope = "workspace"
-			info.WorkspaceID = wsID
+		if m, ok := memberships[strings.ToLower(strings.TrimSpace(info.Name))]; ok {
+			info.WorkspaceCount = m.Count
+			info.Workspaces = m.Workspaces
+			for _, ref := range m.Workspaces {
+				if ref.EntryPoint {
+					info.WorkspaceID = ref.ID
+					break
+				}
+			}
 		}
 		return info
 	}
@@ -402,8 +411,39 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		AvatarColor    *string                    `json:"avatar_color,omitempty"`
 		Favorite       *bool                      `json:"favorite,omitempty"`
 		RoutingProfile *types.AgentRoutingProfile `json:"routing_profile,omitempty"`
+		// ConfirmSharedEdit acknowledges that this edit changes a definition
+		// shared by multiple workspaces (PRD FR9). Required when the agent is
+		// attached to >1 workspace and a shared-definition field is being
+		// changed; the server re-checks membership at write time so API callers
+		// cannot bypass the UI warning.
+		ConfirmSharedEdit *bool `json:"confirm_shared_edit,omitempty"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	// Workspace membership drives the shared-edit / rename guards (PRD FR9/FR10).
+	// The system assistant ("Ori") is exempt (PRD FR1). Computed once from the
+	// metadata-only cache.
+	membership := workspace.WorkspaceMembershipFor(h.workspaceStore, agentName)
+	guardsApply := !isSystemAssistantAgent(agentName)
+
+	// Shared-edit confirmation: changing a field that lives on the shared
+	// definition affects every attached workspace. When attached to more than
+	// one workspace, require explicit confirmation and re-check here so a direct
+	// PATCH cannot skip the warning.
+	touchesSharedDefinition := req.SystemPrompt != nil || req.Model != nil || req.LLMProvider != nil ||
+		req.Type != nil || req.Role != nil || req.Tags != nil || req.AvatarColor != nil ||
+		req.RoutingProfile != nil || req.Temperature != nil || req.ReasoningEffort != nil ||
+		req.MaxTokens != nil || req.AllowWebSearch != nil
+	confirmed := req.ConfirmSharedEdit != nil && *req.ConfirmSharedEdit
+	if guardsApply && membership.Count > 1 && touchesSharedDefinition && !confirmed {
+		_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+			"error":           "shared_agent_edit_requires_confirmation",
+			"message":         fmt.Sprintf("%q is attached to %d workspaces — this change affects all of them. Resend with confirm_shared_edit=true to proceed.", agentName, membership.Count),
+			"workspace_count": membership.Count,
+			"workspaces":      membership.Workspaces,
+		})
 		return
 	}
 
@@ -478,6 +518,19 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	if req.Name != nil && *req.Name != "" && *req.Name != agentName {
 		if isSystemAssistantAgent(agentName) || isSystemAssistantAgent(*req.Name) {
 			orihttp.BadRequest(w, "system assistant cannot be renamed")
+			return
+		}
+
+		// Agent identity is still the bare name, so renaming an attached
+		// definition would strand every workspace that references the old name
+		// (PRD FR10). Block it; users create a new definition instead.
+		if guardsApply && membership.Count > 0 {
+			_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+				"error":           "attached_agent_rename_blocked",
+				"message":         fmt.Sprintf("%q is attached to %d workspace(s) and cannot be renamed. Create a new agent and attach it instead.", agentName, membership.Count),
+				"workspace_count": membership.Count,
+				"workspaces":      membership.Workspaces,
+			})
 			return
 		}
 
@@ -582,6 +635,20 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		orihttp.BadRequest(w, "CLI agents are built-in and cannot be deleted")
 		return
 	}
+
+	// Deleting a definition still attached to a workspace would leave a stale
+	// reference (and a restored snapshot pointing at a missing definition).
+	// Only unattached/library definitions may be deleted (PRD FR11).
+	if membership := workspace.WorkspaceMembershipFor(h.workspaceStore, name); membership.Count > 0 {
+		_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+			"error":           "attached_agent_delete_blocked",
+			"message":         fmt.Sprintf("%q is attached to %d workspace(s) and cannot be deleted. Detach it from every workspace first.", name, membership.Count),
+			"workspace_count": membership.Count,
+			"workspaces":      membership.Workspaces,
+		})
+		return
+	}
+
 	if err := h.State.DeleteAgent(name); err != nil {
 		orihttp.BadRequest(w, err.Error())
 		return

--- a/internal/agenthttp/agents_guards_test.go
+++ b/internal/agenthttp/agents_guards_test.go
@@ -1,0 +1,149 @@
+package agenthttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// guardTestHandler builds an agent handler wired to a workspace store, plus the
+// named agents and workspaces (each workspace attaches the given agent names as
+// instances, first = entry).
+func guardTestHandler(t *testing.T, agents []string, wsAgents map[string][]string) *Handler {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	st, err := store.NewFileStore(filepath.Join(tmpDir, "agents_index.json"), types.Settings{Model: "gpt-4o-mini", Temperature: 1.0})
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	for _, name := range agents {
+		if err := st.CreateAgent(name, &store.CreateAgentConfig{Type: agent.TypeGeneral}); err != nil {
+			t.Fatalf("CreateAgent %s: %v", name, err)
+		}
+	}
+
+	wsPath := filepath.Join(tmpDir, "workspaces")
+	if err := os.MkdirAll(wsPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	wsStore, err := workspace.NewFileStore(wsPath)
+	if err != nil {
+		t.Fatalf("workspace NewFileStore: %v", err)
+	}
+	for wsID, names := range wsAgents {
+		insts := make([]workspace.AgentInstance, 0, len(names))
+		for i, n := range names {
+			insts = append(insts, workspace.AgentInstance{ID: wsID + "-" + n, Name: n, EntryPoint: i == 0})
+		}
+		shared := map[string]any{}
+		if len(names) > 0 {
+			shared["entry_agent_name"] = names[0]
+		}
+		if err := wsStore.Save(&workspace.Workspace{ID: wsID, Name: wsID, AgentInstances: insts, SharedData: shared}); err != nil {
+			t.Fatalf("save ws %s: %v", wsID, err)
+		}
+	}
+
+	h := New(st)
+	h.SetWorkspaceStore(wsStore)
+	return h
+}
+
+// TestSharedEditRequiresConfirmation verifies a definition attached to >1
+// workspace rejects a shared-field edit without confirmation and accepts it with
+// confirm_shared_edit=true (PRD FR9).
+func TestSharedEditRequiresConfirmation(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Shared"},
+		map[string][]string{"ws-a": {"Shared"}, "ws-b": {"Shared"}},
+	)
+
+	// Without confirmation → 409.
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Shared", strings.NewReader(`{"system_prompt":"new"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 without confirmation, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "shared_agent_edit_requires_confirmation") {
+		t.Errorf("expected shared-edit error code, got %s", rr.Body.String())
+	}
+
+	// With confirmation → 200.
+	req = httptest.NewRequest(http.MethodPatch, "/api/agents/Shared", strings.NewReader(`{"system_prompt":"new","confirm_shared_edit":true}`))
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with confirmation, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestSharedEditSingleWorkspaceNoConfirmation verifies a definition attached to
+// exactly one workspace does not require confirmation.
+func TestSharedEditSingleWorkspaceNoConfirmation(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Solo"},
+		map[string][]string{"ws-a": {"Solo"}},
+	)
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Solo", strings.NewReader(`{"system_prompt":"new"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (single-workspace, no confirmation needed), got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRenameAttachedDefinitionBlocked verifies renaming an attached definition
+// is rejected (PRD FR10).
+func TestRenameAttachedDefinitionBlocked(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Attached"},
+		map[string][]string{"ws-a": {"Attached"}},
+	)
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Attached", strings.NewReader(`{"name":"Renamed"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 renaming attached definition, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "attached_agent_rename_blocked") {
+		t.Errorf("expected rename-blocked error code, got %s", rr.Body.String())
+	}
+}
+
+// TestDeleteAttachedDefinitionBlocked verifies delete is blocked while attached
+// and allowed once unattached (PRD FR11).
+func TestDeleteAttachedDefinitionBlocked(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Attached", "Loose"},
+		map[string][]string{"ws-a": {"Attached"}},
+	)
+
+	// Attached → 409.
+	req := httptest.NewRequest(http.MethodDelete, "/api/agents?name=Attached", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 deleting attached definition, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "attached_agent_delete_blocked") {
+		t.Errorf("expected delete-blocked error code, got %s", rr.Body.String())
+	}
+
+	// Unattached → 200.
+	req = httptest.NewRequest(http.MethodDelete, "/api/agents?name=Loose", nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 deleting unattached definition, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/agenthttp/agents_scope_test.go
+++ b/internal/agenthttp/agents_scope_test.go
@@ -14,22 +14,32 @@ import (
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
+// workspaceRefEntry mirrors workspace.WorkspaceRef for JSON decoding in tests.
+type workspaceRefEntry struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	EntryPoint bool   `json:"entry_point"`
+}
+
 // agentListEntry mirrors the inline AgentInfo struct returned by ServeHTTP so
 // tests can decode the response without exporting the internal type.
 type agentListEntry struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Source      string `json:"source"`
-	Scope       string `json:"scope,omitempty"`
-	WorkspaceID string `json:"workspace_id,omitempty"`
-	Status      string `json:"status,omitempty"`
+	Name           string              `json:"name"`
+	Type           string              `json:"type"`
+	Source         string              `json:"source"`
+	Scope          string              `json:"scope,omitempty"`
+	WorkspaceID    string              `json:"workspace_id,omitempty"`
+	WorkspaceCount int                 `json:"workspace_count"`
+	Workspaces     []workspaceRefEntry `json:"workspaces,omitempty"`
+	Status         string              `json:"status,omitempty"`
 }
 
-// TestListAgents_AnnotatesWorkspaceEntryAgents verifies that GET /api/agents
-// returns scope="workspace" and the workspace_id for agents that are
-// designated entry agents — clients such as the sidebar rely on this to
-// hide workspace-scoped agents from global pickers.
-func TestListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
+// TestListAgents_AnnotatesWorkspaceMembership verifies that GET /api/agents
+// annotates every referenced definition — entry agent AND specialists — with
+// workspace_count and the attached workspaces, and that the entry agent's
+// workspace ref carries entry_point=true. The Agents page uses this to group
+// definitions by their attached workspaces (PRD FR1/FR2).
+func TestListAgents_AnnotatesWorkspaceMembership(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	st, err := store.NewFileStore(filepath.Join(tmpDir, "agents_index.json"), types.Settings{
@@ -46,6 +56,9 @@ func TestListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 	if err := st.CreateAgent("Workspace Manager", &store.CreateAgentConfig{Type: "orchestration"}); err != nil {
 		t.Fatalf("CreateAgent workspace manager failed: %v", err)
 	}
+	if err := st.CreateAgent("Specialist", &store.CreateAgentConfig{Type: agent.TypeGeneral}); err != nil {
+		t.Fatalf("CreateAgent specialist failed: %v", err)
+	}
 
 	wsPath := filepath.Join(tmpDir, "workspaces")
 	if err := os.MkdirAll(wsPath, 0o755); err != nil {
@@ -61,6 +74,7 @@ func TestListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 		Name: "Test Workspace",
 		AgentInstances: []workspace.AgentInstance{
 			{ID: "inst-1", Name: "Workspace Manager", EntryPoint: true},
+			{ID: "inst-2", Name: "Specialist"},
 		},
 		SharedData: map[string]any{
 			"entry_agent_name": "Workspace Manager",
@@ -97,11 +111,11 @@ func TestListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected 'Regular Agent' in response, got %+v", body.Agents)
 	}
-	if regular.Scope != "" {
-		t.Errorf("expected Regular Agent to have empty scope, got %q", regular.Scope)
+	if regular.WorkspaceCount != 0 {
+		t.Errorf("expected Regular Agent workspace_count=0, got %d", regular.WorkspaceCount)
 	}
-	if regular.WorkspaceID != "" {
-		t.Errorf("expected Regular Agent to have empty workspace_id, got %q", regular.WorkspaceID)
+	if len(regular.Workspaces) != 0 {
+		t.Errorf("expected Regular Agent to have no workspaces, got %+v", regular.Workspaces)
 	}
 	if regular.Status != string(types.AgentStatusActive) {
 		t.Errorf("expected Regular Agent status=%q, got %q", types.AgentStatusActive, regular.Status)
@@ -111,18 +125,37 @@ func TestListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected 'Workspace Manager' in response, got %+v", body.Agents)
 	}
-	if entry.Scope != "workspace" {
-		t.Errorf("expected Workspace Manager scope='workspace', got %q", entry.Scope)
+	if entry.WorkspaceCount != 1 || len(entry.Workspaces) != 1 {
+		t.Fatalf("expected Workspace Manager attached to 1 workspace, got count=%d refs=%+v", entry.WorkspaceCount, entry.Workspaces)
+	}
+	if entry.Workspaces[0].ID != "ws-agents-1" || !entry.Workspaces[0].EntryPoint {
+		t.Errorf("expected Workspace Manager ref {ws-agents-1, entry_point:true}, got %+v", entry.Workspaces[0])
 	}
 	if entry.WorkspaceID != "ws-agents-1" {
 		t.Errorf("expected Workspace Manager workspace_id='ws-agents-1', got %q", entry.WorkspaceID)
 	}
+
+	// The specialist is a non-entry roster member — it must ALSO be annotated
+	// with membership (this is the behavior change: specialists are no longer
+	// loose, unscoped agents), but its ref is not an entry point.
+	spec, ok := byName["Specialist"]
+	if !ok {
+		t.Fatalf("expected 'Specialist' in response, got %+v", body.Agents)
+	}
+	if spec.WorkspaceCount != 1 || len(spec.Workspaces) != 1 {
+		t.Fatalf("expected Specialist attached to 1 workspace, got count=%d refs=%+v", spec.WorkspaceCount, spec.Workspaces)
+	}
+	if spec.Workspaces[0].ID != "ws-agents-1" || spec.Workspaces[0].EntryPoint {
+		t.Errorf("expected Specialist ref {ws-agents-1, entry_point:false}, got %+v", spec.Workspaces[0])
+	}
+	if spec.WorkspaceID != "" {
+		t.Errorf("expected Specialist to have empty workspace_id (not an entry agent), got %q", spec.WorkspaceID)
+	}
 }
 
-// TestListAgents_NoWorkspaceStore_NoScope verifies that when the workspace
-// store isn't wired, agents are returned without any scope annotation
-// (backwards-compatible behavior).
-func TestListAgents_NoWorkspaceStore_NoScope(t *testing.T) {
+// TestListAgents_NoWorkspaceStore_NoMembership verifies that when the workspace
+// store isn't wired, agents are returned without any membership annotation.
+func TestListAgents_NoWorkspaceStore_NoMembership(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	st, err := store.NewFileStore(filepath.Join(tmpDir, "agents_index.json"), types.Settings{
@@ -158,7 +191,8 @@ func TestListAgents_NoWorkspaceStore_NoScope(t *testing.T) {
 	if len(body.Agents) != 1 {
 		t.Fatalf("expected 1 agent, got %d", len(body.Agents))
 	}
-	if body.Agents[0].Scope != "" {
-		t.Errorf("expected empty scope when workspace store is unwired, got %q", body.Agents[0].Scope)
+	if body.Agents[0].WorkspaceCount != 0 || len(body.Agents[0].Workspaces) != 0 {
+		t.Errorf("expected no membership when workspace store is unwired, got count=%d refs=%+v",
+			body.Agents[0].WorkspaceCount, body.Agents[0].Workspaces)
 	}
 }

--- a/internal/agenthttp/dashboard_entry_scope_test.go
+++ b/internal/agenthttp/dashboard_entry_scope_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
-// TestDashboardListAgents_AnnotatesWorkspaceEntryAgents verifies that agents
-// designated as a workspace entry agent are returned with scope="workspace"
-// and a workspace_id, so the UI can choose to group or hide them.
-func TestDashboardListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
+// TestDashboardListAgents_AnnotatesWorkspaceMembership verifies that the
+// dashboard list annotates every referenced definition — entry agent AND
+// specialists — with workspace_count and the attached workspaces, with the
+// entry agent's ref flagged entry_point=true (PRD FR1/FR2).
+func TestDashboardListAgents_AnnotatesWorkspaceMembership(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create agent store with two agents
+	// Create agent store with three agents
 	st, err := store.NewFileStore(filepath.Join(tmpDir, "agents_index.json"), types.Settings{
 		Model:       "gpt-4o-mini",
 		Temperature: 1.0,
@@ -33,6 +34,9 @@ func TestDashboardListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 	}
 	if err := st.CreateAgent("Workspace Manager", &store.CreateAgentConfig{Type: "orchestration"}); err != nil {
 		t.Fatalf("CreateAgent workspace manager failed: %v", err)
+	}
+	if err := st.CreateAgent("Specialist", &store.CreateAgentConfig{Type: agent.TypeGeneral}); err != nil {
+		t.Fatalf("CreateAgent specialist failed: %v", err)
 	}
 
 	// Create workspace store with a workspace that designates "Workspace Manager" as entry
@@ -50,6 +54,7 @@ func TestDashboardListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 		Name: "Test Workspace",
 		AgentInstances: []workspace.AgentInstance{
 			{ID: "inst-1", Name: "Workspace Manager", EntryPoint: true},
+			{ID: "inst-2", Name: "Specialist"},
 		},
 		SharedData: map[string]any{
 			"entry_agent_name": "Workspace Manager",
@@ -80,8 +85,8 @@ func TestDashboardListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 		t.Fatalf("unmarshal response failed: %v", err)
 	}
 
-	if len(body.Agents) != 2 {
-		t.Fatalf("expected 2 agents to be returned, got %d", len(body.Agents))
+	if len(body.Agents) != 3 {
+		t.Fatalf("expected 3 agents to be returned, got %d", len(body.Agents))
 	}
 
 	byName := make(map[string]AgentListItem, len(body.Agents))
@@ -93,19 +98,33 @@ func TestDashboardListAgents_AnnotatesWorkspaceEntryAgents(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected 'Regular Agent' in response")
 	}
-	if regular.Scope != "" {
-		t.Errorf("expected Regular Agent to have empty scope, got %q", regular.Scope)
+	if regular.WorkspaceCount != 0 || len(regular.Workspaces) != 0 {
+		t.Errorf("expected Regular Agent to have no membership, got count=%d refs=%+v", regular.WorkspaceCount, regular.Workspaces)
 	}
 
 	entry, ok := byName["Workspace Manager"]
 	if !ok {
 		t.Fatalf("expected 'Workspace Manager' in response")
 	}
-	if entry.Scope != "workspace" {
-		t.Errorf("expected Workspace Manager scope='workspace', got %q", entry.Scope)
+	if entry.WorkspaceCount != 1 || len(entry.Workspaces) != 1 {
+		t.Fatalf("expected Workspace Manager attached to 1 workspace, got count=%d refs=%+v", entry.WorkspaceCount, entry.Workspaces)
+	}
+	if entry.Workspaces[0].ID != "ws-1" || !entry.Workspaces[0].EntryPoint {
+		t.Errorf("expected Workspace Manager ref {ws-1, entry_point:true}, got %+v", entry.Workspaces[0])
 	}
 	if entry.WorkspaceID != "ws-1" {
 		t.Errorf("expected Workspace Manager workspace_id='ws-1', got %q", entry.WorkspaceID)
+	}
+
+	spec, ok := byName["Specialist"]
+	if !ok {
+		t.Fatalf("expected 'Specialist' in response")
+	}
+	if spec.WorkspaceCount != 1 || len(spec.Workspaces) != 1 {
+		t.Fatalf("expected Specialist attached to 1 workspace, got count=%d refs=%+v", spec.WorkspaceCount, spec.Workspaces)
+	}
+	if spec.Workspaces[0].ID != "ws-1" || spec.Workspaces[0].EntryPoint {
+		t.Errorf("expected Specialist ref {ws-1, entry_point:false}, got %+v", spec.Workspaces[0])
 	}
 }
 

--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -44,8 +44,9 @@ func (h *DashboardHandler) SetCLIAgentRegistry(r *cliagent.CLIAgentRegistry) {
 	h.cliAgentRegistry = r
 }
 
-// SetWorkspaceStore wires the workspace store so dashboard can filter out
-// workspace entry agents from the top-level agents list.
+// SetWorkspaceStore wires the workspace store so the dashboard can annotate
+// each agent with the workspaces it is attached to (workspace_count +
+// workspaces).
 func (h *DashboardHandler) SetWorkspaceStore(s workspace.Store) {
 	h.workspaceStore = s
 }
@@ -64,19 +65,21 @@ func (h *DashboardHandler) SetCodexSyncProvider(provider func() any) {
 
 // AgentListItem represents an agent in the dashboard list view
 type AgentListItem struct {
-	Name           string                 `json:"name"`
-	Type           string                 `json:"type"`
-	Role           types.AgentRole        `json:"role"`
-	Source         string                 `json:"source"`
-	Scope          string                 `json:"scope,omitempty"`
-	WorkspaceID    string                 `json:"workspace_id,omitempty"`
-	Capabilities   []string               `json:"capabilities,omitempty"`
-	Status         types.AgentStatus      `json:"status"`
-	Statistics     *types.AgentStatistics `json:"statistics,omitempty"`
-	Metadata       *types.AgentMetadata   `json:"metadata,omitempty"`
-	Evolution      *types.AgentEvolution  `json:"evolution,omitempty"`
-	AllowWebSearch bool                   `json:"allow_web_search"`
-	Model          string                 `json:"model"`
+	Name           string                   `json:"name"`
+	Type           string                   `json:"type"`
+	Role           types.AgentRole          `json:"role"`
+	Source         string                   `json:"source"`
+	Scope          string                   `json:"scope,omitempty"`
+	WorkspaceID    string                   `json:"workspace_id,omitempty"`
+	WorkspaceCount int                      `json:"workspace_count"`
+	Workspaces     []workspace.WorkspaceRef `json:"workspaces,omitempty"`
+	Capabilities   []string                 `json:"capabilities,omitempty"`
+	Status         types.AgentStatus        `json:"status"`
+	Statistics     *types.AgentStatistics   `json:"statistics,omitempty"`
+	Metadata       *types.AgentMetadata     `json:"metadata,omitempty"`
+	Evolution      *types.AgentEvolution    `json:"evolution,omitempty"`
+	AllowWebSearch bool                     `json:"allow_web_search"`
+	Model          string                   `json:"model"`
 }
 
 // AgentDetailResponse represents detailed agent information
@@ -112,9 +115,11 @@ func (h *DashboardHandler) ListAgentsWithStats(w http.ResponseWriter, r *http.Re
 	tagFilter := r.URL.Query().Get("tag")
 	favoriteOnly := r.URL.Query().Get("favorite") == "true"
 
-	// Map of workspace entry agent name (lowercase) → workspace ID, so each
-	// agent can be annotated with scope="workspace" and its workspace link.
-	entryAgentWorkspaces := collectWorkspaceEntryAgentNames(h.workspaceStore)
+	// Per-agent workspace membership (lowercase agent name → attached
+	// workspaces), computed from the metadata-only cache. Every referenced
+	// definition is annotated with workspace_count + workspaces; scope is no
+	// longer used to hide workspace entry agents (PRD FR1/FR2).
+	memberships := workspace.AgentWorkspaceMemberships(h.workspaceStore)
 
 	// Get all agents
 	names := h.State.ListAgents()
@@ -167,10 +172,18 @@ func (h *DashboardHandler) ListAgentsWithStats(w http.ResponseWriter, r *http.Re
 			Model:          ag.Settings.Model,
 		}
 
-		// Annotate workspace entry agents so the UI can group / hide them.
-		if wsID, isEntry := entryAgentWorkspaces[strings.ToLower(strings.TrimSpace(name))]; isEntry {
-			item.Scope = "workspace"
-			item.WorkspaceID = wsID
+		// Annotate workspace membership so the UI can group definitions by the
+		// workspaces they're attached to (PRD FR1). The entry-agent workspace,
+		// when present, is carried as workspace_id for backward compatibility.
+		if m, ok := memberships[strings.ToLower(strings.TrimSpace(name))]; ok {
+			item.WorkspaceCount = m.Count
+			item.Workspaces = m.Workspaces
+			for _, ref := range m.Workspaces {
+				if ref.EntryPoint {
+					item.WorkspaceID = ref.ID
+					break
+				}
+			}
 		}
 
 		agents = append(agents, item)
@@ -316,35 +329,6 @@ func (h *DashboardHandler) GetAgentDetail(w http.ResponseWriter, r *http.Request
 	// Return JSON response
 	w.Header().Set("Content-Type", "application/json")
 	orihttp.WriteJSON(w, response)
-}
-
-// collectWorkspaceEntryAgentNames returns a map (lowercase agent name →
-// workspace ID) for every workspace that designates an entry agent. Returns
-// an empty map when the workspace store is nil or unreachable. Shared by the
-// dashboard and main agent list handlers so both can annotate workspace-scoped
-// entry agents consistently.
-func collectWorkspaceEntryAgentNames(wsStore workspace.Store) map[string]string {
-	names := make(map[string]string)
-	if wsStore == nil {
-		return names
-	}
-
-	ids, err := wsStore.List()
-	if err != nil {
-		return names
-	}
-
-	for _, id := range ids {
-		ws, err := wsStore.Get(id)
-		if err != nil || ws == nil {
-			continue
-		}
-		name := strings.ToLower(strings.TrimSpace(ws.EntryAgentName()))
-		if name != "" {
-			names[name] = ws.ID
-		}
-	}
-	return names
 }
 
 // Helper functions

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -27,7 +27,12 @@ type createdAgent struct {
 type seedAgentsResult struct {
 	Created  []createdAgent
 	Warnings []string
-	EntrySet bool
+	// ReuseNotices carries an informational message for each roster entry that
+	// matched an existing global agent by name and was attached as-is (its saved
+	// prompt/model/tools win over the template's). Surfaced to the user so the
+	// name-match reuse is visible rather than silent (PRD FR7).
+	ReuseNotices []string
+	EntrySet     bool
 }
 
 // validAgentTypes canonicalizes a template-declared agent type to the real
@@ -104,6 +109,14 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 					fmt.Sprintf("Specialist agent %q could not be created and was skipped.", spec.Name))
 				continue
 			}
+		}
+
+		if exists {
+			// Name-match reuse: the template's declared prompt/model/tools for
+			// this entry are ignored in favor of the existing definition. Make
+			// that visible (PRD FR7).
+			result.ReuseNotices = append(result.ReuseNotices,
+				fmt.Sprintf("Reusing existing agent %q — its saved prompt, model, and tools are used, not the template's.", spec.Name))
 		}
 
 		if isEntry {

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -88,6 +88,15 @@ func TestSeedTemplateAgents_ReuseOnNameMatchDoesNotMutate(t *testing.T) {
 	if _, ok := handler.agentStore.GetAgent("Fresh"); !ok {
 		t.Fatal("expected unmatched specialist to be created")
 	}
+
+	// The reused "Shared" agent must produce exactly one visible reuse notice;
+	// the freshly-created "Fresh" must not (PRD FR7).
+	if len(res.ReuseNotices) != 1 {
+		t.Fatalf("expected 1 reuse notice, got %d: %v", len(res.ReuseNotices), res.ReuseNotices)
+	}
+	if !strings.Contains(res.ReuseNotices[0], "Shared") {
+		t.Errorf("expected reuse notice to name 'Shared', got %q", res.ReuseNotices[0])
+	}
 }
 
 func TestSeedTemplateAgents_EmptyRosterNoop(t *testing.T) {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -303,6 +303,9 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	if len(agentSeedWarnings) > 0 {
 		response["agent_warnings"] = agentSeedWarnings
 	}
+	if len(seed.ReuseNotices) > 0 {
+		response["agent_reuse_notices"] = seed.ReuseNotices
+	}
 	if prov.onboardingSummary != nil {
 		response["onboarding"] = prov.onboardingSummary
 	}

--- a/internal/web/static/css/templates.css
+++ b/internal/web/static/css/templates.css
@@ -305,6 +305,21 @@
   grid-template-columns: 1fr 1fr;
 }
 
+#templatesPage .tpl-agent-reuse-hint {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #5b21b6;
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-reuse-hint {
+  color: #c4b5fd;
+}
+
+#templatesPage .tpl-agent-reuse-hint[hidden] {
+  display: none;
+}
+
 #templatesPage .tpl-agent-field {
   min-width: 0;
 }

--- a/internal/web/static/css/templates.css
+++ b/internal/web/static/css/templates.css
@@ -1,0 +1,380 @@
+#templatesPage .tpl-section-kicker {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+#templatesPage .tpl-section-title {
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 4px 0 2px;
+}
+
+#templatesPage .tpl-section-copy {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+  max-width: 66ch;
+}
+
+#templatesPage .tpl-agents-readonly {
+  align-items: center;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 10px;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+#templatesPage .tpl-agents-head {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+}
+
+#templatesPage .tpl-agents-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+#templatesPage .tpl-agents-empty {
+  background: var(--bg-tertiary);
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 22px 16px;
+  text-align: center;
+}
+
+#templatesPage .tpl-agents-empty-title {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+#templatesPage .tpl-agents-grid {
+  align-items: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 330px), 1fr));
+}
+
+#templatesPage .tpl-agent-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0)),
+    var(--bg-secondary);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+}
+
+#templatesPage .tpl-agent-card.is-entry {
+  border-color: rgba(245, 158, 11, 0.45);
+  box-shadow:
+    inset 3px 0 0 rgba(245, 158, 11, 0.84),
+    0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+#templatesPage .tpl-agent-card.is-dragging {
+  opacity: 0.55;
+}
+
+#templatesPage .tpl-agent-card-head {
+  align-items: flex-start;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+}
+
+#templatesPage .tpl-agent-card.is-readonly .tpl-agent-card-head {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+#templatesPage .tpl-agent-drag-handle {
+  align-self: center;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: grab;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  padding: 6px 5px;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+#templatesPage .tpl-agent-avatar {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.92), rgba(21, 94, 117, 0.96));
+  border: 1px solid rgba(8, 145, 178, 0.38);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  color: #fff;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 800;
+  height: 42px;
+  justify-content: center;
+  letter-spacing: 0.04em;
+  width: 42px;
+}
+
+#templatesPage .tpl-agent-card.is-entry .tpl-agent-avatar {
+  background: linear-gradient(135deg, rgba(180, 83, 9, 0.95), rgba(146, 64, 14, 0.98));
+  border-color: rgba(245, 158, 11, 0.56);
+}
+
+#templatesPage .tpl-agent-identity {
+  min-width: 0;
+}
+
+#templatesPage .tpl-agent-display-name {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#templatesPage .tpl-agent-subtitle {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.25;
+  margin-top: 2px;
+}
+
+#templatesPage .tpl-agent-remove {
+  color: #dc2626;
+  flex: 0 0 auto;
+}
+
+#templatesPage .tpl-agent-summary,
+#templatesPage .tpl-agent-chip-list {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+#templatesPage .tpl-agent-chip {
+  align-items: center;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  min-height: 22px;
+  padding: 5px 8px;
+}
+
+#templatesPage .tpl-agent-chip.is-entry {
+  background: rgba(245, 158, 11, 0.13);
+  border-color: rgba(245, 158, 11, 0.32);
+  color: #92400e;
+}
+
+#templatesPage .tpl-agent-chip.is-role,
+#templatesPage .tpl-agent-chip.is-type {
+  background: rgba(14, 165, 233, 0.1);
+  border-color: rgba(14, 165, 233, 0.23);
+  color: #0369a1;
+}
+
+#templatesPage .tpl-agent-chip.is-model {
+  background: rgba(22, 163, 74, 0.1);
+  border-color: rgba(22, 163, 74, 0.24);
+  color: #166534;
+}
+
+#templatesPage .tpl-agent-chip.is-skill {
+  background: rgba(79, 70, 229, 0.1);
+  border-color: rgba(79, 70, 229, 0.22);
+  color: #4338ca;
+}
+
+#templatesPage .tpl-agent-chip.is-mcp {
+  background: rgba(217, 119, 6, 0.1);
+  border-color: rgba(217, 119, 6, 0.23);
+  color: #a16207;
+}
+
+#templatesPage .tpl-agent-chip.is-empty,
+#templatesPage .tpl-agent-chip.is-count {
+  color: var(--text-secondary);
+}
+
+#templatesPage .tpl-agent-prompt-preview {
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+  min-height: 50px;
+  overflow: hidden;
+}
+
+#templatesPage .tpl-agent-tools {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+}
+
+#templatesPage .tpl-agent-tool-block {
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 9px;
+}
+
+#templatesPage .tpl-agent-tool-label {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin-bottom: 7px;
+  text-transform: uppercase;
+}
+
+#templatesPage .tpl-agent-editor {
+  border-top: 1px solid var(--border-color);
+  padding-top: 8px;
+}
+
+#templatesPage .tpl-agent-editor-summary {
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 800;
+  list-style-position: outside;
+  outline: none;
+}
+
+#templatesPage .tpl-agent-editor-summary:focus-visible {
+  border-radius: 6px;
+  box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.55);
+}
+
+#templatesPage .tpl-agent-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 10px;
+}
+
+#templatesPage .tpl-agent-form-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+#templatesPage .tpl-agent-field {
+  min-width: 0;
+}
+
+#templatesPage .tpl-agent-field-label {
+  color: var(--text-secondary);
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-bottom: 5px;
+  text-transform: uppercase;
+}
+
+#templatesPage .tpl-agent-prompt {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 13px;
+  resize: vertical;
+}
+
+@media (max-width: 720px) {
+  #templatesPage .tpl-agents-head {
+    flex-direction: column;
+  }
+
+  #templatesPage .tpl-agents-actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  #templatesPage .tpl-agent-card-head {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  #templatesPage .tpl-agent-drag-handle {
+    display: none;
+  }
+
+  #templatesPage .tpl-agent-tools,
+  #templatesPage .tpl-agent-form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0)),
+    var(--bg-secondary);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-entry {
+  color: #fcd34d;
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-role,
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-type {
+  color: #7dd3fc;
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-model {
+  color: #86efac;
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-skill {
+  color: #c4b5fd;
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-agent-chip.is-mcp {
+  color: #fcd34d;
+}

--- a/internal/web/static/js/agents-dashboard.js
+++ b/internal/web/static/js/agents-dashboard.js
@@ -188,11 +188,8 @@ function applyFiltersAndRender() {
   const searchTerm = rawSearchTerm.toLowerCase();
 
   dashboardFilteredAgents = dashboardAgents.filter((agent) => {
-    // Hide workspace-scoped entry agents from the top-level agents list —
-    // they're managed from their workspace detail page.
-    if (String(agent?.scope || '').toLowerCase() === 'workspace') {
-      return false;
-    }
+    // Every definition is shown — entry agents are no longer hidden; their
+    // workspace membership is rendered on the card instead (PRD FR1/FR3).
     const name = String(agent?.name || '').toLowerCase();
     const description = String(agent?.metadata?.description || '').toLowerCase();
     return name.includes(searchTerm) || description.includes(searchTerm);
@@ -337,6 +334,42 @@ function renderBucket(containerId, agents, emptyMessage) {
   });
 }
 
+// renderMembershipHtml renders the "attached to N workspaces" row for a
+// definition card: workspace chips (entry agent flagged) when attached, or a
+// "Library · unattached" pill when the definition belongs to no workspace
+// (PRD FR2/FR4/FR5).
+function renderMembershipHtml(agent) {
+  const count = Number(agent?.workspace_count || 0);
+  const workspaces = Array.isArray(agent?.workspaces) ? agent.workspaces : [];
+
+  if (count === 0) {
+    return `<div class="ops-agent-membership ops-agent-membership--library">`
+      + `<span class="ops-membership-pill library" title="Not attached to any workspace — a reusable library agent.">Library · unattached</span>`
+      + `</div>`;
+  }
+
+  const shown = workspaces.slice(0, 4);
+  const chips = shown.map((ws) => {
+    const rawName = String(ws?.name || 'Workspace');
+    const wsName = safeEscapeHtml(rawName);
+    const isEntry = !!ws?.entry_point;
+    const titleText = safeEscapeHtml(isEntry ? `Entry agent of ${rawName}` : `Attached to ${rawName}`);
+    const cls = isEntry ? 'ops-membership-chip entry' : 'ops-membership-chip';
+    if (ws?.id) {
+      return `<a class="${cls}" href="/workspaces/${encodeURIComponent(ws.id)}" title="${titleText}">${wsName}</a>`;
+    }
+    return `<span class="${cls}" title="${titleText}">${wsName}</span>`;
+  }).join('');
+  const overflow = workspaces.length > shown.length
+    ? `<span class="ops-membership-more" title="${workspaces.length - shown.length} more">+${workspaces.length - shown.length}</span>`
+    : '';
+  const label = safeEscapeHtml(`Attached to ${count} workspace${count === 1 ? '' : 's'}`);
+  return `<div class="ops-agent-membership">`
+    + `<span class="ops-membership-label">${label}</span>`
+    + `<span class="ops-membership-chips">${chips}${overflow}</span>`
+    + `</div>`;
+}
+
 function createAgentCard(agent) {
   const card = document.createElement('article');
   card.className = 'ops-agent-card';
@@ -357,9 +390,14 @@ function createAgentCard(agent) {
   const enabledCheckedAttr = isDisabled ? '' : 'checked';
   const isSystemAgent = isSystemAssistantAgentName(name);
   const isCLIAgent = isCLIAgentEntry(agent);
+  const workspaceCount = Number(agent?.workspace_count || 0);
+  const attachedBlockReason = workspaceCount > 0
+    ? `Attached to ${workspaceCount} workspace${workspaceCount === 1 ? '' : 's'} — detach it everywhere before deleting.`
+    : '';
   const deleteBlockedReason = isSystemAgent
     ? 'System assistant cannot be deleted.'
-    : (isCLIAgent ? 'Built-in CLI agent cannot be deleted.' : '');
+    : (isCLIAgent ? 'Built-in CLI agent cannot be deleted.' : attachedBlockReason);
+  const membershipHtml = isCLIAgent ? '' : renderMembershipHtml(agent);
   const deleteDisabledAttr = deleteBlockedReason
     ? `disabled title="${safeEscapeHtml(deleteBlockedReason)}" aria-disabled="true"`
     : 'title="Delete agent"';
@@ -384,6 +422,7 @@ function createAgentCard(agent) {
         </div>
         <p class="ops-agent-purpose" title="${safeEscapeHtml(description)}">${safeEscapeHtml(description)}</p>
         <div class="ops-agent-time">Last active: ${safeEscapeHtml(formatDate(agent?.statistics?.last_active || ''))}</div>
+        ${membershipHtml}
       </div>
       <div class="ops-card-controls">
         <label class="ops-enable-toggle" title="${safeEscapeHtml(enableToggleTitle)}">

--- a/internal/web/static/js/agents-detail.js
+++ b/internal/web/static/js/agents-detail.js
@@ -1075,11 +1075,11 @@ async function saveProfileChanges() {
     setProfileSavingState(true);
     setProfileStatus('Saving profile...');
 
-    const response = await fetch(`/api/agents/${encodeURIComponent(agentName)}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
+    const { response, cancelled } = await saveAgentPatch(agentName, payload);
+    if (cancelled) {
+      setProfileStatus('Change cancelled — shared agent not modified.');
+      return;
+    }
 
     if (!response.ok) {
       throw new Error(await readResponseError(response, 'Failed to save profile'));
@@ -1115,6 +1115,41 @@ async function saveProfileChanges() {
   }
 }
 
+// saveAgentPatch PATCHes an agent definition and transparently handles the
+// shared-edit confirmation gate (PRD FR9). On a 409 asking for confirmation it
+// shows a blast-radius warning naming every affected workspace and, if the user
+// confirms, retries with confirm_shared_edit=true. Rename/delete blocks (also
+// 409, different error codes) fall through as a normal non-ok response for the
+// caller's error handling. Returns { response, cancelled }.
+async function saveAgentPatch(name, payload) {
+  const doPatch = (body) => fetch(`/api/agents/${encodeURIComponent(name)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  let response = await doPatch(payload);
+  if (response.status === 409) {
+    const info = await response.clone().json().catch(() => ({}));
+    if (info && info.error === 'shared_agent_edit_requires_confirmation') {
+      const names = Array.isArray(info.workspaces)
+        ? info.workspaces.map((w) => w && w.name).filter(Boolean)
+        : [];
+      const count = Number(info.workspace_count || names.length || 0);
+      const list = names.length ? `\n\n• ${names.join('\n• ')}` : '';
+      const proceed = window.confirm(
+        `"${name}" is attached to ${count} workspace${count === 1 ? '' : 's'}. `
+        + `This change affects all of them:${list}\n\nApply the change everywhere?`
+      );
+      if (!proceed) {
+        return { response, cancelled: true };
+      }
+      response = await doPatch({ ...payload, confirm_shared_edit: true });
+    }
+  }
+  return { response, cancelled: false };
+}
+
 function setProfileSavingState(isSaving) {
   const saveButton = document.getElementById('profileSaveBtn');
   if (!saveButton) return;
@@ -1144,7 +1179,9 @@ function setProfileStatus(message, type = 'info') {
 async function readResponseError(response, fallback) {
   try {
     const data = await response.clone().json();
-    return data?.error || data?.message || fallback;
+    // Prefer the human-readable message; fall back to the (sometimes
+    // machine-code) error field, then the caller's fallback.
+    return data?.message || data?.error || fallback;
   } catch {
     const text = await response.text().catch(() => '');
     return text || fallback;
@@ -1267,17 +1304,14 @@ async function saveConfigChanges() {
     setConfigSavingState(true);
     setConfigStatus('Saving changes...');
 
-    const response = await fetch(`/api/agents/${encodeURIComponent(agentName)}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(payload)
-    });
+    const { response, cancelled } = await saveAgentPatch(agentName, payload);
+    if (cancelled) {
+      setConfigStatus('Change cancelled — shared agent not modified.');
+      return;
+    }
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(errorText || 'Failed to save changes');
+      throw new Error(await readResponseError(response, 'Failed to save changes'));
     }
 
     await refreshAgentDetails();
@@ -1370,17 +1404,14 @@ async function savePromptChanges() {
     setPromptSavingState(true);
     setPromptStatus('Saving system prompt...');
 
-    const response = await fetch(`/api/agents/${encodeURIComponent(agentName)}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ system_prompt: systemPrompt })
-    });
+    const { response, cancelled } = await saveAgentPatch(agentName, { system_prompt: systemPrompt });
+    if (cancelled) {
+      setPromptStatus('Change cancelled — shared agent not modified.');
+      return;
+    }
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(errorText || 'Failed to save system prompt');
+      throw new Error(await readResponseError(response, 'Failed to save system prompt'));
     }
 
     await refreshAgentDetails();

--- a/internal/web/static/js/modules/agents.js
+++ b/internal/web/static/js/modules/agents.js
@@ -1385,13 +1385,10 @@ async function loadAgentsForSidebar() {
   try {
     const data = await API.get('/api/agents');
     const all = Array.isArray(data.agents) ? data.agents : [];
-    // Hide workspace-scoped agents (workspace entry agents) from the
-    // global sidebar — they're bound to a specific workspace context.
-    const visible = all.filter((agent) => {
-      if (!agent) return false;
-      const scope = typeof agent === 'object' ? String(agent.scope || '').toLowerCase() : '';
-      return scope !== 'workspace';
-    });
+    // Every definition is listed — entry agents are no longer hidden from the
+    // global sidebar; their workspace membership is surfaced elsewhere
+    // (PRD FR6). Keep only well-formed entries.
+    const visible = all.filter((agent) => !!agent);
     agentsLog.debug('Received agents', { count: all.length, visible: visible.length });
     displayAgents(visible, resolveSidebarCurrentAgent());
 

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3479,6 +3479,13 @@ const sessionManager = {
           .filter((msg) => typeof msg === 'string' && msg)
           .forEach((msg) => this.showToast(msg, 'warning'));
       }
+      // A roster entry matched an existing agent by name; the existing
+      // definition was reused instead of the template's (PRD FR7).
+      if (Array.isArray(result.agent_reuse_notices)) {
+        result.agent_reuse_notices
+          .filter((msg) => typeof msg === 'string' && msg)
+          .forEach((msg) => this.showToast(msg, 'info'));
+      }
       if (window.ProjectTemplateCard) window.ProjectTemplateCard.reset();
       if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
       window.OriTagInput?.clearTagPoolCache?.();

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -355,6 +355,10 @@ function tplApplyReadOnly() {
   if (notice) notice.hidden = !builtin;
   const agentsNotice = tplEl('tplAgentsReadOnlyNotice');
   if (agentsNotice) agentsNotice.hidden = !builtin;
+  ['tplAgentsAddBtn', 'tplAgentsSaveBtn'].forEach((id) => {
+    const el = tplEl(id);
+    if (el) el.hidden = builtin;
+  });
   [
     'tplEditName', 'tplEditDescription', 'tplEditIcon', 'tplEditBehavior', 'tplEditStarterTasks',
     'tplSaveBtn', 'tplResetBtn', 'tplDeleteBtn',
@@ -1383,12 +1387,57 @@ function tplAgentsLoad() {
   tplAgentsRender(template.agents);
 }
 
+function tplAgentsDisplayName(agent, index) {
+  const name = String(agent?.name || '').trim();
+  if (name) return name;
+  return index === 0 ? 'Entry agent' : `Agent ${index + 1}`;
+}
+
+function tplAgentsInitials(name, index) {
+  const cleaned = String(name || '').trim();
+  const parts = cleaned.split(/\s+/).filter(Boolean);
+  const initials = parts.slice(0, 2).map((part) => part.charAt(0).toUpperCase()).join('');
+  return initials || String(index + 1).padStart(2, '0');
+}
+
+function tplAgentsRoleLabel(agent, index) {
+  if (index === 0) return 'Entry agent';
+  const role = String(agent?.role || '').trim();
+  if (!role) return 'Specialist';
+  return role.replace(/[_-]+/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function tplAgentsTypeLabel(type) {
+  const value = String(type || '').trim();
+  if (!value) return 'Default type';
+  return value.replace(/[_-]+/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function tplAgentsChip(text, kind = '') {
+  const chip = document.createElement('span');
+  chip.className = `tpl-agent-chip${kind ? ` is-${kind}` : ''}`;
+  chip.textContent = text;
+  return chip;
+}
+
+function tplAgentsChipList(values, emptyText, kind = '') {
+  const list = document.createElement('div');
+  list.className = 'tpl-agent-chip-list';
+  const items = (Array.isArray(values) ? values : []).map((item) => String(item || '').trim()).filter(Boolean);
+  if (items.length === 0) {
+    list.appendChild(tplAgentsChip(emptyText, 'empty'));
+    return list;
+  }
+  items.slice(0, 3).forEach((item) => list.appendChild(tplAgentsChip(item, kind)));
+  if (items.length > 3) list.appendChild(tplAgentsChip(`+${items.length - 3}`, 'count'));
+  return list;
+}
+
 function tplAgentsField(label, input) {
   const wrap = document.createElement('div');
-  wrap.className = 'mb-2';
+  wrap.className = 'tpl-agent-field';
   const lab = document.createElement('label');
-  lab.className = 'form-label';
-  lab.style.cssText = 'color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;';
+  lab.className = 'tpl-agent-field-label';
   lab.textContent = label;
   wrap.appendChild(lab);
   wrap.appendChild(input);
@@ -1397,7 +1446,7 @@ function tplAgentsField(label, input) {
 
 function tplAgentsCol(label, input) {
   const col = document.createElement('div');
-  col.className = 'col-6';
+  col.className = 'tpl-agent-form-col';
   col.appendChild(tplAgentsField(label, input));
   return col;
 }
@@ -1425,72 +1474,135 @@ function tplAgentsInput(cls, value, placeholder) {
 }
 
 function tplAgentsCard(agent, index) {
+  const readOnly = Boolean(tplSelected() && tplSelected().builtin);
   const card = document.createElement('div');
-  card.className = 'tpl-agent-card';
+  card.className = `tpl-agent-card${index === 0 ? ' is-entry' : ''}${readOnly ? ' is-readonly' : ''}`;
   card.dataset.index = String(index);
-  card.draggable = true;
-  card.style.cssText = 'border: 1px solid var(--border-color); border-radius: 8px; padding: 10px; background: var(--bg-tertiary);';
+  card.draggable = !readOnly;
+
+  const displayName = tplAgentsDisplayName(agent, index);
+  const skills = (agent.tools && agent.tools.skills ? agent.tools.skills : []);
+  const mcpServers = (agent.tools && agent.tools.mcp_servers ? agent.tools.mcp_servers : []);
 
   const header = document.createElement('div');
-  header.className = 'd-flex align-items-center gap-2 mb-2';
+  header.className = 'tpl-agent-card-head';
+
   const handle = document.createElement('span');
-  handle.textContent = '⠿';
+  handle.className = 'tpl-agent-drag-handle';
+  handle.textContent = 'Drag';
   handle.title = 'Drag to reorder';
-  handle.style.cssText = 'cursor: grab; color: var(--text-secondary); user-select: none;';
-  header.appendChild(handle);
-  const tag = document.createElement('span');
-  if (index === 0) {
-    tag.className = 'badge';
-    tag.textContent = 'Entry agent';
-    tag.style.cssText = 'background: #22c55e; color: #fff; font-size: 10px;';
-  } else {
-    tag.textContent = 'Specialist';
-    tag.style.cssText = 'font-size: 11px; color: var(--text-secondary);';
-  }
-  header.appendChild(tag);
+  if (!readOnly) header.appendChild(handle);
+
+  const avatar = document.createElement('span');
+  avatar.className = 'tpl-agent-avatar';
+  avatar.textContent = tplAgentsInitials(displayName, index);
+  header.appendChild(avatar);
+
+  const identity = document.createElement('div');
+  identity.className = 'tpl-agent-identity';
+  const name = document.createElement('div');
+  name.className = 'tpl-agent-display-name';
+  name.textContent = displayName;
+  identity.appendChild(name);
+  const subtitle = document.createElement('div');
+  subtitle.className = 'tpl-agent-subtitle';
+  subtitle.textContent = index === 0 ? 'Required workspace front door' : 'Seeded workspace specialist';
+  identity.appendChild(subtitle);
+  header.appendChild(identity);
+
   const remove = document.createElement('button');
   remove.type = 'button';
-  remove.className = 'modern-btn modern-btn-secondary btn-sm ms-auto';
+  remove.className = 'tpl-agent-remove modern-btn modern-btn-secondary btn-sm';
   remove.textContent = 'Remove';
-  remove.style.color = '#ef4444';
+  remove.setAttribute('aria-label', `Remove ${displayName}`);
   remove.addEventListener('click', () => tplAgentsRemove(index));
-  header.appendChild(remove);
+  if (!readOnly) header.appendChild(remove);
   card.appendChild(header);
 
-  card.appendChild(tplAgentsField('Name', tplAgentsInput('tpl-agent-name', agent.name, 'Agent name')));
+  const summary = document.createElement('div');
+  summary.className = 'tpl-agent-summary';
+  summary.appendChild(tplAgentsChip(tplAgentsRoleLabel(agent, index), index === 0 ? 'entry' : 'role'));
+  summary.appendChild(tplAgentsChip(tplAgentsTypeLabel(agent.type), 'type'));
+  summary.appendChild(tplAgentsChip(agent.model ? agent.model : 'Workspace model', agent.model ? 'model' : 'empty'));
+  card.appendChild(summary);
 
-  const rt = document.createElement('div');
-  rt.className = 'row g-2 mb-2';
-  rt.appendChild(tplAgentsCol('Role', tplAgentsSelect('tpl-agent-role', TPL_AGENT_ROLES, agent.role || '')));
-  rt.appendChild(tplAgentsCol('Type', tplAgentsSelect('tpl-agent-type', TPL_AGENT_TYPES, agent.type || '')));
-  card.appendChild(rt);
+  const promptPreview = document.createElement('p');
+  promptPreview.className = 'tpl-agent-prompt-preview';
+  promptPreview.textContent = agent.system_prompt || 'No system prompt yet.';
+  card.appendChild(promptPreview);
 
-  card.appendChild(tplAgentsField('Model', tplAgentsInput('tpl-agent-model', agent.model, 'Defaults to the workspace model')));
+  const tools = document.createElement('div');
+  tools.className = 'tpl-agent-tools';
+  const skillsBlock = document.createElement('div');
+  skillsBlock.className = 'tpl-agent-tool-block';
+  const skillsLabel = document.createElement('div');
+  skillsLabel.className = 'tpl-agent-tool-label';
+  skillsLabel.textContent = 'Skills';
+  skillsBlock.appendChild(skillsLabel);
+  skillsBlock.appendChild(tplAgentsChipList(skills, 'No skills', 'skill'));
+  tools.appendChild(skillsBlock);
 
-  const prompt = document.createElement('textarea');
-  prompt.className = 'form-control tpl-agent-prompt';
-  prompt.rows = 2;
-  prompt.style.cssText = 'background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.85em; resize: vertical;';
-  prompt.value = agent.system_prompt || '';
-  prompt.placeholder = "This agent's instructions";
-  card.appendChild(tplAgentsField('System prompt', prompt));
+  const mcpBlock = document.createElement('div');
+  mcpBlock.className = 'tpl-agent-tool-block';
+  const mcpLabel = document.createElement('div');
+  mcpLabel.className = 'tpl-agent-tool-label';
+  mcpLabel.textContent = 'MCP';
+  mcpBlock.appendChild(mcpLabel);
+  mcpBlock.appendChild(tplAgentsChipList(mcpServers, 'No MCP servers', 'mcp'));
+  tools.appendChild(mcpBlock);
+  card.appendChild(tools);
 
-  const sm = document.createElement('div');
-  sm.className = 'row g-2';
-  const skillsVal = (agent.tools && agent.tools.skills ? agent.tools.skills : []).join(', ');
-  const mcpVal = (agent.tools && agent.tools.mcp_servers ? agent.tools.mcp_servers : []).join(', ');
-  sm.appendChild(tplAgentsCol('Skills', tplAgentsInput('tpl-agent-skills', skillsVal, 'comma-separated')));
-  sm.appendChild(tplAgentsCol('MCP servers', tplAgentsInput('tpl-agent-mcp', mcpVal, 'comma-separated')));
-  card.appendChild(sm);
+  if (!readOnly) {
+    const details = document.createElement('details');
+    details.className = 'tpl-agent-editor';
+    details.open = !agent.name;
+    const summaryToggle = document.createElement('summary');
+    summaryToggle.className = 'tpl-agent-editor-summary';
+    summaryToggle.textContent = 'Edit agent';
+    details.appendChild(summaryToggle);
+
+    const form = document.createElement('div');
+    form.className = 'tpl-agent-form';
+    form.appendChild(tplAgentsField('Name', tplAgentsInput('tpl-agent-name', agent.name, 'Agent name')));
+
+    const rt = document.createElement('div');
+    rt.className = 'tpl-agent-form-row';
+    rt.appendChild(tplAgentsCol('Role', tplAgentsSelect('tpl-agent-role', TPL_AGENT_ROLES, agent.role || '')));
+    rt.appendChild(tplAgentsCol('Type', tplAgentsSelect('tpl-agent-type', TPL_AGENT_TYPES, agent.type || '')));
+    form.appendChild(rt);
+
+    form.appendChild(tplAgentsField('Model', tplAgentsInput('tpl-agent-model', agent.model, 'Defaults to the workspace model')));
+
+    const prompt = document.createElement('textarea');
+    prompt.className = 'form-control tpl-agent-prompt';
+    prompt.rows = 2;
+    prompt.value = agent.system_prompt || '';
+    prompt.placeholder = "This agent's instructions";
+    form.appendChild(tplAgentsField('System prompt', prompt));
+
+    const sm = document.createElement('div');
+    sm.className = 'tpl-agent-form-row';
+    const skillsVal = skills.join(', ');
+    const mcpVal = mcpServers.join(', ');
+    sm.appendChild(tplAgentsCol('Skills', tplAgentsInput('tpl-agent-skills', skillsVal, 'comma-separated')));
+    sm.appendChild(tplAgentsCol('MCP servers', tplAgentsInput('tpl-agent-mcp', mcpVal, 'comma-separated')));
+    form.appendChild(sm);
+    details.appendChild(form);
+    card.appendChild(details);
+  }
 
   card.addEventListener('dragstart', (event) => {
+    if (readOnly) return;
     tplAgents.dragIndex = index;
-    card.style.opacity = '0.5';
+    card.classList.add('is-dragging');
     if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
   });
-  card.addEventListener('dragend', () => { card.style.opacity = ''; });
-  card.addEventListener('dragover', (event) => event.preventDefault());
+  card.addEventListener('dragend', () => { card.classList.remove('is-dragging'); });
+  card.addEventListener('dragover', (event) => {
+    if (!readOnly) event.preventDefault();
+  });
   card.addEventListener('drop', (event) => {
+    if (readOnly) return;
     event.preventDefault();
     tplAgentsReorder(tplAgents.dragIndex, index);
   });

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -1357,7 +1357,7 @@ async function tplToolsSave() {
 const TPL_AGENT_ROLES = ['', 'orchestrator', 'specialist', 'researcher', 'analyzer', 'synthesizer', 'validator', 'general'];
 const TPL_AGENT_TYPES = ['', 'tool-calling', 'general', 'research'];
 
-const tplAgents = { templateId: '', dragIndex: -1 };
+const tplAgents = { templateId: '', dragIndex: -1, existingNames: [], existingLoaded: false };
 
 function tplAgentsBlank() {
   return { name: '', role: '', type: '', model: '', system_prompt: '', tools: { skills: [], mcp_servers: [] } };
@@ -1464,13 +1464,54 @@ function tplAgentsSelect(cls, values, selected) {
   return sel;
 }
 
-function tplAgentsInput(cls, value, placeholder) {
+function tplAgentsInput(cls, value, placeholder, listId) {
   const i = document.createElement('input');
   i.type = 'text';
   i.className = `modern-input w-100 ${cls}`;
   i.value = value || '';
   i.placeholder = placeholder || '';
+  if (listId) i.setAttribute('list', listId);
   return i;
+}
+
+// tplAgentsEnsureExistingNames lazily loads the global agent names once so the
+// roster name field can offer an "attach existing agent" picker (a datalist) and
+// flag when a typed name will reuse an existing definition (PRD FR7 / reuse
+// surfaces). Non-fatal: on failure the picker simply offers no suggestions.
+async function tplAgentsEnsureExistingNames() {
+  if (tplAgents.existingLoaded) return;
+  tplAgents.existingLoaded = true;
+  try {
+    const res = await fetch('/api/agents');
+    const data = await res.json().catch(() => ({}));
+    tplAgents.existingNames = Array.isArray(data.agents)
+      ? data.agents.map((a) => (a && typeof a === 'object' ? a.name : a)).filter(Boolean)
+      : [];
+  } catch {
+    tplAgents.existingNames = [];
+  }
+  tplAgentsPopulateDatalist();
+}
+
+function tplAgentsPopulateDatalist() {
+  let dl = document.getElementById('tpl-existing-agents');
+  if (!dl) {
+    dl = document.createElement('datalist');
+    dl.id = 'tpl-existing-agents';
+    document.body.appendChild(dl);
+  }
+  dl.innerHTML = '';
+  (tplAgents.existingNames || []).forEach((name) => {
+    const opt = document.createElement('option');
+    opt.value = String(name);
+    dl.appendChild(opt);
+  });
+}
+
+function tplAgentsNameMatchesExisting(value) {
+  const v = String(value || '').trim().toLowerCase();
+  if (!v) return false;
+  return (tplAgents.existingNames || []).some((n) => String(n).toLowerCase() === v);
 }
 
 function tplAgentsCard(agent, index) {
@@ -1563,7 +1604,16 @@ function tplAgentsCard(agent, index) {
 
     const form = document.createElement('div');
     form.className = 'tpl-agent-form';
-    form.appendChild(tplAgentsField('Name', tplAgentsInput('tpl-agent-name', agent.name, 'Agent name')));
+    const nameInput = tplAgentsInput('tpl-agent-name', agent.name, 'Agent name or pick an existing agent', 'tpl-existing-agents');
+    const nameField = tplAgentsField('Name', nameInput);
+    const reuseHint = document.createElement('div');
+    reuseHint.className = 'tpl-agent-reuse-hint';
+    reuseHint.textContent = 'Matches an existing agent — its saved prompt, model, and tools will be reused.';
+    const syncReuseHint = () => { reuseHint.hidden = !tplAgentsNameMatchesExisting(nameInput.value); };
+    nameInput.addEventListener('input', syncReuseHint);
+    syncReuseHint();
+    nameField.appendChild(reuseHint);
+    form.appendChild(nameField);
 
     const rt = document.createElement('div');
     rt.className = 'tpl-agent-form-row';
@@ -1614,6 +1664,13 @@ function tplAgentsRender(agents) {
   const list = tplEl('tplAgentsList');
   const empty = tplEl('tplAgentsEmpty');
   if (!list) return;
+  // Lazily load existing agent names so the roster name field can suggest /
+  // flag reuse; re-syncs hints once names arrive.
+  tplAgentsEnsureExistingNames().then(() => {
+    list.querySelectorAll('.tpl-agent-name').forEach((input) => {
+      input.dispatchEvent(new Event('input'));
+    });
+  });
   const items = tplAgentsNormalizeList(agents);
   list.innerHTML = '';
   items.forEach((agent, idx) => list.appendChild(tplAgentsCard(agent, idx)));

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -64,6 +64,7 @@
   <link href="/css/tag-input.css" rel="stylesheet">
   <link href="/css/keyboard-navigation.css" rel="stylesheet">
   <link href="/css/claude-sync.css" rel="stylesheet">
+  {{if eq .CurrentPage "templates"}}<link href="/css/templates.css" rel="stylesheet">{{end}}
   {{if eq .CurrentPage "vault"}}<link href="/css/vault-page.css" rel="stylesheet">{{end}}
   <!-- Shared tag input widget (deferred ES module; exposes window.OriTagInput) -->
   <script type="module" src="/js/modules/tag-input.js"></script>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1192,6 +1192,76 @@
         color: var(--text-muted);
     }
 
+    .ops-agent-membership {
+        margin-top: 8px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 4px 6px;
+    }
+
+    .ops-membership-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+    }
+
+    .ops-membership-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    .ops-membership-chip {
+        display: inline-block;
+        max-width: 140px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding: 1px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        line-height: 1.5;
+        text-decoration: none;
+        color: var(--text-secondary);
+        background: var(--surface-muted, rgba(148, 163, 184, 0.14));
+        border: 1px solid rgba(148, 163, 184, 0.28);
+    }
+
+    a.ops-membership-chip:hover {
+        border-color: rgba(99, 102, 241, 0.5);
+        color: var(--text-primary, inherit);
+    }
+
+    .ops-membership-chip.entry {
+        color: #5b21b6;
+        background: #ede9fe;
+        border-color: rgba(124, 58, 237, 0.25);
+        font-weight: 600;
+    }
+
+    [data-bs-theme="dark"] .ops-membership-chip.entry {
+        color: #c4b5fd;
+        background: rgba(139, 92, 246, 0.18);
+        border-color: rgba(139, 92, 246, 0.35);
+    }
+
+    .ops-membership-more {
+        font-size: 11px;
+        color: var(--text-muted);
+        align-self: center;
+    }
+
+    .ops-membership-pill.library {
+        padding: 1px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        background: transparent;
+        border: 1px dashed rgba(148, 163, 184, 0.45);
+    }
+
     .ops-card-actions {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -265,24 +265,28 @@
 
                   <!-- Agents: roster seeded when a workspace is created from this template -->
                   <div class="tab-pane fade" id="tplAgentsPane" role="tabpanel" aria-labelledby="tplTabAgents">
-                    <div id="tplAgentsReadOnlyNotice" hidden class="mb-3" style="padding: 10px 12px; border-radius: 8px; border: 1px solid var(--border-color); background: var(--bg-tertiary); font-size: 12px; color: var(--text-secondary);">
-                      This is a built-in template and is read-only.
-                      <button id="tplAgentsDuplicateBtn" class="modern-btn modern-btn-primary btn-sm ms-2">Duplicate to customize</button>
+                    <div id="tplAgentsReadOnlyNotice" hidden class="tpl-agents-readonly mb-3">
+                      <span>This is a built-in template and is read-only.</span>
+                      <button id="tplAgentsDuplicateBtn" class="modern-btn modern-btn-primary btn-sm">Duplicate to customize</button>
                     </div>
-                    <div style="font-size: 12px; color: var(--text-secondary);" class="mb-2">
-                      Agents are created when a workspace is made from this template. The
-                      <strong>first agent is the entry agent</strong> (the one required agent every workspace
-                      needs) — drag an agent to the top to make it the entry agent. The rest are specialist
-                      sub-agents. A name that already exists is reused as-is.
+                    <div class="tpl-agents-head">
+                      <div>
+                        <div class="tpl-section-kicker">Seeded roster</div>
+                        <h5 class="tpl-section-title">Agents</h5>
+                        <p class="tpl-section-copy">
+                          Agents are created when a workspace is made from this template. The first card becomes the entry agent; the rest seed specialist sub-agents.
+                        </p>
+                      </div>
+                      <div class="tpl-agents-actions">
+                        <button id="tplAgentsAddBtn" class="modern-btn modern-btn-secondary btn-sm">Add agent</button>
+                        <button id="tplAgentsSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save agents</button>
+                      </div>
                     </div>
-                    <div id="tplAgentsEmpty" class="text-center py-3" style="color: var(--text-secondary); font-size: 13px;" hidden>
-                      This template seeds no agents. Workspaces created from it will prompt for an entry agent.
+                    <div id="tplAgentsEmpty" class="tpl-agents-empty" hidden>
+                      <div class="tpl-agents-empty-title">No seeded agents</div>
+                      <div>Workspaces created from this template will prompt for an entry agent.</div>
                     </div>
-                    <div id="tplAgentsList" class="d-flex flex-column gap-2 mb-3"></div>
-                    <div class="d-flex gap-2">
-                      <button id="tplAgentsAddBtn" class="modern-btn modern-btn-secondary btn-sm">Add agent</button>
-                      <button id="tplAgentsSaveBtn" class="modern-btn modern-btn-primary btn-sm">Save agents</button>
-                    </div>
+                    <div id="tplAgentsList" class="tpl-agents-grid mb-3"></div>
                   </div>
                 </div>
               </div>

--- a/internal/workspace/agent_membership.go
+++ b/internal/workspace/agent_membership.go
@@ -1,0 +1,125 @@
+package workspace
+
+import (
+	"sort"
+	"strings"
+)
+
+// WorkspaceRef is a lightweight reference to a workspace that uses an agent
+// definition. It is serialized into the agents API membership annotation so the
+// Agents page can show which workspaces a definition is attached to.
+type WorkspaceRef struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	EntryPoint bool   `json:"entry_point"`
+}
+
+// AgentMembership records the workspaces that reference a single agent
+// definition (by name): the count plus a stable, name-sorted list of refs.
+type AgentMembership struct {
+	Count      int            `json:"workspace_count"`
+	Workspaces []WorkspaceRef `json:"workspaces"`
+}
+
+// AgentWorkspaceMemberships returns, keyed by lowercase agent name, the set of
+// non-trashed / non-missing workspaces that reference each agent definition —
+// via the workspace entry agent or any AgentInstance.
+//
+// It is computed from the metadata-only workspace cache when the store exposes
+// one (see eachWorkspaceMeta), so it never hydrates full workspaces:
+// /api/agents and /api/agents/dashboard/list are hot paths and an
+// O(workspaces) full-hydrate walk per request is prohibited (PRD FR2).
+//
+// A workspace is counted once per agent even when the agent is both the entry
+// agent and an instance (referencedAgentNames dedups names within a workspace,
+// and refs are deduped by workspace ID here). A group workspace and its nested
+// members are distinct workspaces, so members never double-count a shared
+// definition (PRD FR1).
+func AgentWorkspaceMemberships(workspaces Store) map[string]AgentMembership {
+	out := make(map[string]AgentMembership)
+	if workspaces == nil {
+		return out
+	}
+
+	// Per agent name → (workspace ID → ref), so duplicate references collapse.
+	refsByAgent := make(map[string]map[string]WorkspaceRef)
+
+	eachWorkspaceMeta(workspaces, func(ws *Workspace) {
+		if ws == nil {
+			return
+		}
+		if ws.Status == StatusTrashed || ws.Status == StatusMissing {
+			return
+		}
+		entry := strings.ToLower(strings.TrimSpace(ws.EntryAgentName()))
+		for _, name := range referencedAgentNames(ws) {
+			key := strings.ToLower(strings.TrimSpace(name))
+			if key == "" {
+				continue
+			}
+			refs := refsByAgent[key]
+			if refs == nil {
+				refs = make(map[string]WorkspaceRef)
+				refsByAgent[key] = refs
+			}
+			isEntry := key == entry
+			if existing, ok := refs[ws.ID]; ok {
+				// Keep entry_point sticky if any reference within the workspace
+				// is the entry agent.
+				isEntry = isEntry || existing.EntryPoint
+			}
+			refs[ws.ID] = WorkspaceRef{ID: ws.ID, Name: ws.Name, EntryPoint: isEntry}
+		}
+	})
+
+	for key, refs := range refsByAgent {
+		out[key] = AgentMembership{Count: len(refs), Workspaces: sortWorkspaceRefs(refs)}
+	}
+	return out
+}
+
+// WorkspaceMembershipFor returns the membership for a single agent name,
+// computed from the metadata-only cache. It is the mutation-path counterpart to
+// AgentWorkspaceMemberships, used by the shared-edit / rename / delete guards
+// that only need one definition's attachment set (PRD FR9–FR11).
+func WorkspaceMembershipFor(workspaces Store, agentName string) AgentMembership {
+	key := strings.ToLower(strings.TrimSpace(agentName))
+	if workspaces == nil || key == "" {
+		return AgentMembership{}
+	}
+	refs := make(map[string]WorkspaceRef)
+	eachWorkspaceMeta(workspaces, func(ws *Workspace) {
+		if ws == nil || ws.Status == StatusTrashed || ws.Status == StatusMissing {
+			return
+		}
+		entry := strings.ToLower(strings.TrimSpace(ws.EntryAgentName()))
+		for _, name := range referencedAgentNames(ws) {
+			if strings.ToLower(strings.TrimSpace(name)) != key {
+				continue
+			}
+			isEntry := key == entry
+			if existing, ok := refs[ws.ID]; ok {
+				isEntry = isEntry || existing.EntryPoint
+			}
+			refs[ws.ID] = WorkspaceRef{ID: ws.ID, Name: ws.Name, EntryPoint: isEntry}
+			break
+		}
+	})
+	return AgentMembership{Count: len(refs), Workspaces: sortWorkspaceRefs(refs)}
+}
+
+// sortWorkspaceRefs flattens a workspace-ID→ref map into a stable, name-sorted
+// slice.
+func sortWorkspaceRefs(refs map[string]WorkspaceRef) []WorkspaceRef {
+	list := make([]WorkspaceRef, 0, len(refs))
+	for _, r := range refs {
+		list = append(list, r)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].Name != list[j].Name {
+			return list[i].Name < list[j].Name
+		}
+		return list[i].ID < list[j].ID
+	})
+	return list
+}

--- a/internal/workspace/agent_membership_test.go
+++ b/internal/workspace/agent_membership_test.go
@@ -1,0 +1,93 @@
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestAgentWorkspaceMemberships covers shared definitions across multiple
+// workspaces, entry-point flagging, within-workspace dedup, and exclusion of
+// trashed/missing workspaces (PRD FR1/FR2).
+func TestAgentWorkspaceMemberships(t *testing.T) {
+	store, err := NewFileStore(filepath.Join(t.TempDir(), "workspaces"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	// "Shared" is the entry agent of two workspaces (and also listed as an
+	// instance in Alpha to exercise within-workspace dedup). "Solo" is a
+	// specialist in Alpha only.
+	alpha := &Workspace{
+		ID:   "ws-alpha",
+		Name: "Alpha",
+		AgentInstances: []AgentInstance{
+			{ID: "a1", Name: "Shared", EntryPoint: true},
+			{ID: "a2", Name: "Solo"},
+		},
+		SharedData: map[string]any{"entry_agent_name": "Shared"},
+	}
+	beta := &Workspace{
+		ID:   "ws-beta",
+		Name: "Beta",
+		AgentInstances: []AgentInstance{
+			{ID: "b1", Name: "Shared", EntryPoint: true},
+		},
+		SharedData: map[string]any{"entry_agent_name": "Shared"},
+	}
+	trashed := &Workspace{
+		ID:             "ws-trashed",
+		Name:           "Trashed",
+		Status:         StatusTrashed,
+		AgentInstances: []AgentInstance{{ID: "t1", Name: "Ghost"}},
+	}
+	missing := &Workspace{
+		ID:             "ws-missing",
+		Name:           "Missing",
+		Status:         StatusMissing,
+		AgentInstances: []AgentInstance{{ID: "m1", Name: "Ghost"}},
+	}
+	for _, ws := range []*Workspace{alpha, beta, trashed, missing} {
+		if err := store.Save(ws); err != nil {
+			t.Fatalf("Save %s: %v", ws.ID, err)
+		}
+	}
+
+	m := AgentWorkspaceMemberships(store)
+
+	shared, ok := m["shared"]
+	if !ok {
+		t.Fatalf("expected 'shared' membership, got %+v", m)
+	}
+	if shared.Count != 2 || len(shared.Workspaces) != 2 {
+		t.Fatalf("expected Shared in 2 workspaces, got count=%d refs=%+v", shared.Count, shared.Workspaces)
+	}
+	// Name-sorted: Alpha before Beta, both entry points.
+	if shared.Workspaces[0].ID != "ws-alpha" || shared.Workspaces[1].ID != "ws-beta" {
+		t.Errorf("expected name-sorted [ws-alpha, ws-beta], got %+v", shared.Workspaces)
+	}
+	for _, ref := range shared.Workspaces {
+		if !ref.EntryPoint {
+			t.Errorf("expected Shared to be entry_point in %s", ref.ID)
+		}
+	}
+
+	solo, ok := m["solo"]
+	if !ok {
+		t.Fatalf("expected 'solo' membership")
+	}
+	if solo.Count != 1 || solo.Workspaces[0].EntryPoint {
+		t.Errorf("expected Solo attached to 1 workspace as non-entry, got %+v", solo)
+	}
+
+	if _, ok := m["ghost"]; ok {
+		t.Errorf("expected 'ghost' to be excluded (trashed + missing workspaces), got %+v", m["ghost"])
+	}
+}
+
+// TestAgentWorkspaceMemberships_NilStore verifies a nil store yields an empty,
+// non-nil map.
+func TestAgentWorkspaceMemberships_NilStore(t *testing.T) {
+	if m := AgentWorkspaceMemberships(nil); m == nil || len(m) != 0 {
+		t.Fatalf("expected empty non-nil map, got %+v", m)
+	}
+}

--- a/internal/workspace/agent_snapshot_store.go
+++ b/internal/workspace/agent_snapshot_store.go
@@ -266,8 +266,15 @@ func WipeNonAllowlistedAgentSnapshots(workspaces Store, agents store.Store, allo
 		allowed := allowlist != nil && allowlist.Contains(ws.ID)
 		for _, name := range referenced {
 			key := strings.ToLower(name)
-			if _, ok, err := workspaces.GetWorkspaceAgent(ws.ID, name); err == nil && ok {
-				workspaceManagedAgents[key] = struct{}{}
+			if snap, ok, err := workspaces.GetWorkspaceAgent(ws.ID, name); err == nil && ok {
+				// Only a pure mirror of the workspace snapshot is a wipe
+				// candidate. A global definition the user has since edited
+				// (diverged from every snapshot) is user-owned and must be
+				// preserved — the boot-wipe must not do what the attached-delete
+				// guard forbids (PRD FR11).
+				if global, gok := agents.GetAgent(name); !gok || global == nil || agentDefinitionEquivalent(global, snap) {
+					workspaceManagedAgents[key] = struct{}{}
+				}
 			}
 			if allowed {
 				allowedReferencedAgents[key] = struct{}{}
@@ -314,6 +321,21 @@ func WipeNonAllowlistedAgentSnapshots(workspaces Store, agents store.Store, allo
 // changes.
 func isSystemAgentName(name string) bool {
 	return strings.EqualFold(strings.TrimSpace(name), "Ori")
+}
+
+// agentDefinitionEquivalent reports whether two agents share the same core
+// definition (type, role, model, system prompt). The boot-wipe uses it to tell
+// a pristine workspace-snapshot mirror (safe to reconcile away under the
+// allowlist gate) from a global definition the user has since edited, which is
+// user-owned and must be preserved (PRD FR11).
+func agentDefinitionEquivalent(a, b *agent.Agent) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Type == b.Type &&
+		a.Role == b.Role &&
+		a.Settings.Model == b.Settings.Model &&
+		a.Settings.SystemPrompt == b.Settings.SystemPrompt
 }
 
 func referencedAgentSnapshotCount(s Store, ws *Workspace) int {

--- a/internal/workspace/agent_snapshot_store_test.go
+++ b/internal/workspace/agent_snapshot_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/types"
 )
 
 func TestAgentSnapshotStore_SaveSnapshotsReferencedAgents(t *testing.T) {
@@ -306,12 +307,20 @@ func TestRestoreAllowlistedWorkspaceAgents_NilAllowlistRestoresNothing(t *testin
 func TestWipeNonAllowlistedAgentSnapshots_RemovesUnallowedKeepsAllowedAndSystem(t *testing.T) {
 	primary := NewInMemoryStore()
 
-	// One allowlisted workspace, one not. Both have workspace-local snapshots.
-	if err := primary.SaveWorkspaceAgent("ws-allow", "AllowedManager", &agent.Agent{}); err != nil {
+	// Snapshots mirror the global definition at snapshot time (as SaveWorkspaceAgent
+	// does in production). One allowlisted workspace, two not: one holding a pure
+	// mirror, one holding a *stale* snapshot of a since-edited global.
+	allowedDef := &agent.Agent{Type: agent.TypeGeneral}
+	deniedDef := &agent.Agent{Type: agent.TypeGeneral}
+	editedSnapshot := &agent.Agent{Type: agent.TypeGeneral, Settings: types.Settings{SystemPrompt: "OLD"}}
+	if err := primary.SaveWorkspaceAgent("ws-allow", "AllowedManager", allowedDef); err != nil {
 		t.Fatalf("seed allow snapshot: %v", err)
 	}
-	if err := primary.SaveWorkspaceAgent("ws-deny", "DeniedManager", &agent.Agent{}); err != nil {
+	if err := primary.SaveWorkspaceAgent("ws-deny", "DeniedManager", deniedDef); err != nil {
 		t.Fatalf("seed deny snapshot: %v", err)
+	}
+	if err := primary.SaveWorkspaceAgent("ws-deny-edited", "EditedManager", editedSnapshot); err != nil {
+		t.Fatalf("seed edited snapshot: %v", err)
 	}
 	if err := primary.Save(&Workspace{ID: "ws-allow", AgentInstances: AgentInstancesFromNames("AllowedManager")}); err != nil {
 		t.Fatalf("save allow ws: %v", err)
@@ -319,13 +328,18 @@ func TestWipeNonAllowlistedAgentSnapshots_RemovesUnallowedKeepsAllowedAndSystem(
 	if err := primary.Save(&Workspace{ID: "ws-deny", AgentInstances: AgentInstancesFromNames("DeniedManager")}); err != nil {
 		t.Fatalf("save deny ws: %v", err)
 	}
+	if err := primary.Save(&Workspace{ID: "ws-deny-edited", AgentInstances: AgentInstancesFromNames("EditedManager")}); err != nil {
+		t.Fatalf("save edited ws: %v", err)
+	}
 
-	// Global agent store has: the system agent (Ori), both workspace-managed
-	// agents, and a user-owned agent that no workspace knows about.
+	// Global agent store has: the system agent (Ori), the two mirror-managed
+	// agents, a user-owned agent no workspace knows about, and EditedManager
+	// whose global system prompt has since diverged from its stale snapshot.
 	agents := &resolverAgentStoreStub{agents: map[string]*agent.Agent{
 		"Ori":             {Type: agent.TypeToolCalling},
 		"AllowedManager":  {Type: agent.TypeGeneral},
 		"DeniedManager":   {Type: agent.TypeGeneral},
+		"EditedManager":   {Type: agent.TypeGeneral, Settings: types.Settings{SystemPrompt: "EDITED"}},
 		"UserOwnedHelper": {Type: agent.TypeGeneral},
 	}}
 	allowlist := NewAllowlist(filepath.Join(t.TempDir(), "wl.json"))
@@ -336,10 +350,13 @@ func TestWipeNonAllowlistedAgentSnapshots_RemovesUnallowedKeepsAllowedAndSystem(
 	WipeNonAllowlistedAgentSnapshots(primary, agents, allowlist)
 
 	if _, ok := agents.GetAgent("DeniedManager"); ok {
-		t.Fatal("DeniedManager should be wiped (workspace not in allowlist)")
+		t.Fatal("DeniedManager should be wiped (mirror of a non-allowlisted workspace snapshot)")
 	}
 	if _, ok := agents.GetAgent("AllowedManager"); !ok {
 		t.Fatal("AllowedManager should be preserved (workspace allowlisted)")
+	}
+	if _, ok := agents.GetAgent("EditedManager"); !ok {
+		t.Fatal("EditedManager must be preserved: user edited the global, so it is not a pure snapshot mirror (PRD FR11)")
 	}
 	if _, ok := agents.GetAgent("Ori"); !ok {
 		t.Fatal("system agent Ori must never be wiped")

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -22,13 +22,16 @@ async function openCreateModal(page: Page) {
     window.bootstrap.Modal.getOrCreateInstance(el).show();
   });
   await expect(page.locator('#addFolderModal')).toBeVisible();
-  // The show handler renders the Starting-point grid.
-  await expect(page.locator('#folderTemplateGrid .workspace-template-card')).toHaveCount(6);
+  // The show handler renders the unified Template picker.
+  await expect(cardByLabel(page, 'Blank')).toBeVisible();
+  await expect(cardByLabel(page, 'Research Project')).toBeVisible();
+  await expect(cardByLabel(page, 'Travels')).toBeVisible();
+  await expect(cardByLabel(page, 'Content Production')).toBeVisible();
 }
 
 function cardByLabel(page: Page, label: string) {
   return page
-    .locator('#folderTemplateGrid .workspace-template-card')
+    .locator('#templatePicker .workspace-template-card')
     .filter({ has: page.locator('.workspace-template-card-label', { hasText: new RegExp(`^${label}$`) }) });
 }
 

--- a/tests/find-tools.spec.ts
+++ b/tests/find-tools.spec.ts
@@ -29,20 +29,31 @@ async function createWorkspace(page: Page, name: string, description: string): P
 }
 
 // Concrete workspaces are created without an entry agent (by design), so the
-// page shows a "Create an entry agent?" prompt. Dismiss any open modal so it
-// doesn't intercept clicks on the Find tools card.
-async function dismissBlockingModals(page: Page) {
-  await page.evaluate(() => {
-    document.querySelectorAll('.modal.show').forEach((m) => {
-      // @ts-expect-error bootstrap is a page global
-      window.bootstrap?.Modal?.getInstance(m)?.hide();
-      (m as HTMLElement).classList.remove('show');
-      (m as HTMLElement).style.display = 'none';
-    });
-    document.querySelectorAll('.modal-backdrop').forEach((b) => b.remove());
-    document.body.classList.remove('modal-open');
-    document.body.style.removeProperty('overflow');
-  });
+// detail page would otherwise show a mandatory "Create an entry agent?" prompt.
+async function suppressEntryAgentPrompt(page: Page, workspaceId: string) {
+  await page.addInitScript((id) => {
+    window.sessionStorage.setItem(`workspace-detail-entry-agent-prompt-dismissed:${id}`, '1');
+  }, workspaceId);
+}
+
+async function gotoWorkspaceCommand(page: Page, workspaceId: string) {
+  await suppressEntryAgentPrompt(page, workspaceId);
+  await page.goto(`/workspaces/${workspaceId}`);
+  await expect(page.locator('#workspaceCommandView')).toBeVisible();
+}
+
+async function openFindToolsSurface(page: Page) {
+  const toolsStat = page.getByRole('button', { name: /Open tools: MCP, skills, plugins, and find tools/i });
+  await expect(toolsStat).toBeVisible();
+  await toolsStat.click();
+
+  const modal = page.locator('#workspaceCommandView .ws-cmd-modal:not([hidden])');
+  await expect(modal).toBeVisible();
+  await modal.getByRole('tab', { name: 'Find Tools' }).click();
+
+  await expect(page.locator('#workspace-detail-tools-card')).toBeVisible();
+  await expect(page.locator('#workspace-tools-find-btn')).toBeVisible();
+  return modal;
 }
 
 test.beforeEach(async ({ page }) => {
@@ -80,10 +91,10 @@ test('creating a workspace is non-blocking and makes no marketplace calls', asyn
 
 test('workspace page shows Find tools and not the old setup-review surface', async ({ page }) => {
   const wid = await createWorkspace(page, 'E2E ToolsCard', 'Plans and tracks trips.');
-  await page.goto(`/workspaces/${wid}`);
+  await gotoWorkspaceCommand(page, wid);
 
   // New surface present.
-  await expect(page.locator('#workspace-detail-tools-card')).toBeVisible();
+  await openFindToolsSurface(page);
   await expect(page.locator('#workspace-tools-find-btn')).toHaveText('Find tools');
 
   // Old Settings -> Intent setup-review surface removed.
@@ -104,9 +115,8 @@ test('Find tools searches and renders add-ons only with honest copy', async ({ p
     r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ servers: [], results: [] }) }));
 
   const wid = await createWorkspace(page, 'E2E Search', 'Plans and tracks trips.');
-  await page.goto(`/workspaces/${wid}`);
-  await page.waitForTimeout(800);
-  await dismissBlockingModals(page);
+  await gotoWorkspaceCommand(page, wid);
+  await openFindToolsSurface(page);
 
   await page.locator('#workspace-tools-find-btn').click();
   const host = page.locator('#workspace-tools-panel-host');

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -24,9 +24,6 @@ test.describe('Smoke Tests', () => {
       }
     });
 
-    // Wait for app initialization
-    await page.waitForLoadState('networkidle');
-
     // Filter out expected errors (add patterns as needed)
     const unexpectedErrors = errors.filter(e =>
       !e.includes('favicon') &&
@@ -38,7 +35,7 @@ test.describe('Smoke Tests', () => {
 
   test('theme toggle works', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('html')).toBeAttached();
 
     // Get initial theme
     const html = page.locator('html');
@@ -58,7 +55,6 @@ test.describe('Smoke Tests', () => {
 
   test('sidebar navigation is accessible', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
 
     // Check sidebar exists
     const sidebar = page.locator('.sidebar, [class*="sidebar"]').first();
@@ -189,7 +185,7 @@ test.describe('Home First Run', () => {
 test.describe('Agent Management', () => {
   test('can open create agent modal', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('body')).toBeVisible();
 
     // Look for create agent button (adjust selector based on your UI)
     const createBtn = page.locator('button:has-text("Create"), [data-bs-target="#addAgentModal"]').first();
@@ -209,7 +205,7 @@ test.describe('Agent Management', () => {
 
   test('agent form validation works', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('body')).toBeVisible();
 
     // Open create modal
     const createBtn = page.locator('[data-bs-target="#addAgentModal"]').first();
@@ -308,23 +304,19 @@ test.describe('Workspace Import Flow', () => {
     });
 
     await page.goto('/workspaces');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('#launcherCreateWorkspaceBtn')).toBeVisible();
     const modal = page.locator('#addFolderModal');
-    if (!await modal.isVisible()) {
-      await page.locator('#launcherCreateWorkspaceBtn').click();
-    }
+    await page.locator('#launcherImportFolderBtn').click();
     await expect(modal).toBeVisible();
 
     const importToggle = page.locator('#folderImportToggle');
-    if (!await importToggle.isChecked()) {
-      await importToggle.click();
-    }
     await expect(importToggle).toBeChecked();
     await expect(page.locator('#folderImportSection')).toBeVisible();
 
     await page.locator('#folderImportBrowseBtn').click();
     await expect(page.locator('#folderImportPathInput')).toHaveValue('/tmp/demo-project');
     await expect(page.locator('#folderImportDuplicateWarning')).toBeVisible();
+    await page.locator('#folderDescriptionInput').fill('Imported demo project for smoke coverage.');
 
     await page.locator('#folderImportProceedDuplicateBtn').click();
     await page.locator('#createFolderBtn').click();
@@ -336,20 +328,15 @@ test.describe('Workspace Import Flow', () => {
   test('import controls are keyboard and mobile friendly', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/workspaces');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('#launcherCreateWorkspaceBtn')).toBeVisible();
 
     const modal = page.locator('#addFolderModal');
-    if (!await modal.isVisible()) {
-      await page.locator('#launcherCreateWorkspaceBtn').click();
-    }
+    await page.locator('#launcherImportFolderBtn').focus();
+    await page.keyboard.press('Enter');
+    await expect(modal).toBeVisible();
 
     const importToggle = page.locator('#folderImportToggle');
-    if (await importToggle.isChecked()) {
-      await importToggle.focus();
-      await page.keyboard.press('Space');
-    }
-    await importToggle.focus();
-    await page.keyboard.press('Space');
+    await expect(importToggle).toBeChecked();
     await expect(page.locator('#folderImportSection')).toBeVisible();
 
     const pathBox = await page.locator('#folderImportPathInput').boundingBox();
@@ -364,7 +351,7 @@ test.describe('Workspace Import Flow', () => {
 
 test.describe('API Health', () => {
   test('health endpoint returns OK', async ({ request }) => {
-    const response = await request.get('/api/health');
+    const response = await request.get('/health');
     expect(response.ok()).toBeTruthy();
   });
 
@@ -566,7 +553,9 @@ test.describe('Task Output Contracts', () => {
       await expect(page.locator('#workspace-task-automation-storage')).toContainText('Storage destination');
       await expect(page.locator('#workspace-task-automation-columns')).toContainText('date, location, pollen_count');
 
-      await page.getByText('Advanced settings', { exact: true }).click();
+      await page.locator('.workspace-task-advanced-summary').click();
+      await expect(page.locator('#workspace-task-automation-storage [data-action="open-automation-storage-modal"]')).toBeVisible();
+      await page.locator('#workspace-task-automation-storage [data-action="open-automation-storage-modal"]').click();
       await expect(page.locator('#taskModalOutputContractSection')).toBeVisible();
       await expect(page.locator('#taskModalAutoSaveWriteMode')).toHaveValue('append');
       await expect(page.locator('#taskModalOutputContractRows [data-output-contract-name]').first()).toHaveValue('date');
@@ -626,13 +615,14 @@ test.describe('Task Output Contracts', () => {
       expect(taskId).toBeTruthy();
 
       await page.goto(`/workspaces/${workspaceId}/task/${taskId}`);
-      await expect(page.getByText('Store each run of this task to CSV')).toBeVisible();
+      await page.locator('.workspace-task-advanced-summary').click();
+      await expect(page.locator('#workspace-task-automation-columns')).toContainText('Save each run of this task to a dataset');
 
-      await page.locator('[data-action="toggle-csv-storage"]').check();
+      await page.locator('#workspace-task-automation-columns [data-action="toggle-csv-storage"]').check();
 
       await expect(page.locator('#workspace-task-automation-storage')).toContainText('Storage destination');
       await expect(page.locator('#workspace-task-automation-storage')).toContainText('Custom path');
-      await expect(page.locator('#workspace-task-automation-columns')).toContainText('Result format');
+      await expect(page.locator('#workspace-task-automation-columns')).toContainText('What each run returns');
       await expect(page.locator('#workspace-task-automation-columns')).toContainText('date');
     } finally {
       if (workspaceId) {
@@ -658,28 +648,14 @@ test.describe('Workspace File Folders', () => {
     workspaceId = workspaceData.workspace_id;
 
     try {
+      await page.addInitScript((id) => {
+        window.sessionStorage.setItem(`workspace-detail-entry-agent-prompt-dismissed:${id}`, '1');
+      }, workspaceId);
       await page.goto(`/workspaces/${workspaceId}`);
       await expect(page.locator('#workspaceCommandView .ws-cmd-files-panel')).toBeVisible();
       await page.waitForFunction(() =>
         Boolean((window as any).workspaceDetail?.fileModalManager?.fileModalElements?.modal)
       );
-      const entryAgentTitle = page.locator('#workspace-detail-task-confirm-title', {
-        hasText: 'Create an entry agent for this workspace?'
-      });
-      if (await entryAgentTitle.waitFor({ state: 'visible', timeout: 1500 }).then(() => true).catch(() => false)) {
-        await page.waitForTimeout(150);
-        await page.locator('#workspace-detail-task-confirm-cancel').click();
-        await page.waitForFunction(() => {
-          const modal = document.getElementById('workspace-detail-task-confirm-modal');
-          return !modal || !modal.classList.contains('show');
-        });
-        await page.waitForFunction(() => {
-          const modal = document.getElementById('workspace-detail-task-confirm-modal');
-          const settled = !modal || window.getComputedStyle(modal).display === 'none';
-          return settled && !(window as any).workspaceDetail?.pendingTaskConfirm;
-        });
-        await page.evaluate(() => window.Toast?.dismissAll?.());
-      }
 
       await page.locator('#workspaceCommandView .ws-cmd-files-panel [data-cmd-primary-section="files"]').click();
       await expect(page.locator('#hubAddFileModal')).toBeVisible();
@@ -783,24 +759,17 @@ test.describe('Floating Workspace Assistant', () => {
     });
   }
 
-  async function dismissEntryAgentDialogIfPresent(page) {
-    const entryAgentTitle = page.locator('#workspace-detail-task-confirm-title', {
-      hasText: 'Create an entry agent for this workspace?'
-    });
-    if (await entryAgentTitle.waitFor({ state: 'visible', timeout: 1500 }).then(() => true).catch(() => false)) {
-      await page.waitForTimeout(150);
-      await page.locator('#workspace-detail-task-confirm-cancel').click();
-      await page.waitForFunction(() => {
-        const modal = document.getElementById('workspace-detail-task-confirm-modal');
-        return !modal || !modal.classList.contains('show');
-      });
-      await page.waitForFunction(() => {
-        const modal = document.getElementById('workspace-detail-task-confirm-modal');
-        const settled = !modal || window.getComputedStyle(modal).display === 'none';
-        return settled && !(window as any).workspaceDetail?.pendingTaskConfirm;
-      });
-      await page.evaluate(() => window.Toast?.dismissAll?.());
-    }
+  async function suppressEntryAgentPrompt(page, workspaceId: string) {
+    await page.addInitScript((id) => {
+      window.sessionStorage.setItem(`workspace-detail-entry-agent-prompt-dismissed:${id}`, '1');
+    }, workspaceId);
+  }
+
+  async function gotoWorkspaceCommand(page, workspaceId: string) {
+    await suppressOnboarding(page);
+    await suppressEntryAgentPrompt(page, workspaceId);
+    await page.goto(`/workspaces/${workspaceId}`);
+    await expect(page.locator('#workspaceCommandView')).toBeVisible();
   }
 
   test('replaces the workspace-detail inline bar with a full floating assistant panel', async ({ page, request }) => {
@@ -808,10 +777,7 @@ test.describe('Floating Workspace Assistant', () => {
     workspaceId = await createTemporaryWorkspace(request, 'Playwright Floating Assistant');
 
     try {
-      await suppressOnboarding(page);
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
 
       await expect(page.locator('#homeAssistantCard.modern-card')).toHaveCount(0);
       await expect(page.locator('#hubSupportChatLauncher')).toBeVisible();
@@ -842,10 +808,7 @@ test.describe('Floating Workspace Assistant', () => {
     const taskTitle = `Write floating assistant smoke task ${Date.now()}`;
 
     try {
-      await suppressOnboarding(page);
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
       await page.waitForFunction(() => Boolean((window as any).workspaceDetail));
 
       await page.locator('#hubSupportChatLauncher').click();
@@ -871,10 +834,7 @@ test.describe('Floating Workspace Assistant', () => {
     const noteText = `Floating assistant note smoke ${Date.now()}`;
 
     try {
-      await suppressOnboarding(page);
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
       await page.waitForFunction(() => Boolean((window as any).workspaceDetail));
 
       await page.locator('#hubSupportChatLauncher').click();
@@ -897,18 +857,8 @@ test.describe('Floating Workspace Assistant', () => {
     let workspaceId = '';
     workspaceId = await createTemporaryWorkspace(request, 'Playwright Floating Quick Actions');
 
-    const getWorkspaceNoteCount = async () => {
-      const notesResp = await request.get(`/api/workspaces/${workspaceId}/notes`);
-      expect(notesResp.ok()).toBeTruthy();
-      const notesData = await notesResp.json();
-      return (notesData.notes || []).length;
-    };
-
     try {
-      await suppressOnboarding(page);
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
 
       await page.locator('#hubSupportChatLauncher').click();
       const panel = page.locator('#hubSupportChatPanel');
@@ -919,18 +869,16 @@ test.describe('Floating Workspace Assistant', () => {
       await expect(page.locator('#noteNameInput')).toHaveValue('Workspace Description');
       await expect(page.locator('#noteContentInput')).toHaveValue(/## Description/);
 
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
       await page.locator('#hubSupportChatLauncher').click();
       await page.locator('#hubSupportChatPanel').getByRole('button', { name: 'Note', exact: true }).click();
 
-      let expectedNotes = await getWorkspaceNoteCount();
       for (const selector of ['#homeAssistantQuickPlan', '#homeAssistantQuickTasks', '#homeAssistantQuickReview']) {
-        await page.locator('#hubSupportChatPanel').locator(selector).click();
-        expectedNotes += 1;
-        await expect(page.locator('#homeAssistantRoutingSummary')).toContainText('Note Created');
-        await expect.poll(getWorkspaceNoteCount).toBe(expectedNotes);
+        const button = page.locator('#hubSupportChatPanel').locator(selector);
+        const prompt = await button.getAttribute('data-home-prompt');
+        expect(prompt).toBeTruthy();
+        await button.click();
+        await expect(page.locator('#homeAssistantInput')).toHaveValue(prompt || '');
         await expect(page.locator('#homeAssistantSendBtn')).toBeEnabled();
       }
     } finally {
@@ -962,9 +910,7 @@ test.describe('Floating Workspace Assistant', () => {
         });
       });
 
-      await page.goto(`/workspaces/${workspaceId}`);
-      await expect(page.locator('#workspace-detail-files-panel')).toBeVisible();
-      await dismissEntryAgentDialogIfPresent(page);
+      await gotoWorkspaceCommand(page, workspaceId);
       await page.waitForFunction(() => Boolean((window as any).workspaceDetail));
 
       await page.locator('#hubSupportChatLauncher').click();


### PR DESCRIPTION
Phase 1 of the reusable-template-agents epic (PRD: tasks/prd-reusable-template-agents.md),
plus pre-existing templates-page UI polish carried on this branch.

## Reusable template agents — Phase 1 (honest grouping & visible reuse)
- `/api/agents` + dashboard list annotate every referenced definition (entry AND
  specialists) with `workspace_count` + `workspaces` ({id,name,entry_point}),
  computed from the metadata-only cache (no full hydration). `scope` no longer hides.
- Template roster reuse-by-name surfaces `agent_reuse_notices` instead of silently
  inheriting an existing definition.
- Guards: `confirm_shared_edit` required to edit a definition attached to >1 workspace
  (server re-checked); renaming/deleting an attached definition is blocked (409). Ori
  and CLI agents exempt. Boot-wipe preserves user-edited (diverged) definitions.
- Agents page: definition cards show "Attached to N workspaces" chips (entry accented)
  or a "Library · unattached" pill; delete disabled when attached; shared-edit shows a
  blast-radius confirm naming the affected workspaces. Sidebar stops hiding entry agents.
- Templates roster name field: datalist of existing agents + "will reuse" hint.

## Templates-page UI polish (pre-existing on branch)
- Earlier template-agents UI improvements + Playwright spec fixes.

## Testing
- Unit/API: membership annotation (entry/specialist/multi-ws/unattached/trashed-missing),
  shared-edit confirmation, rename/delete blocking, delete↔boot-wipe reconciliation.
- Live smoke: two workspaces from content-production → reuse notices, count:2 chips,
  409 guards verified, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)