### PR TITLE
feat(agents): per-workspace agent refinement (Phase 2 — dynamic prompts, part A)

### DIFF
--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -1074,6 +1074,9 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Carry the resolved agent so the runtime prompt can layer this agent's
+	// per-workspace refinement (PRD FR15/FR16/FR19).
+	normalizedRouteContext.AgentName = current
 	toolRuntimeSystemPrompt := h.buildRuntimeSystemPrompt(ctx, normalizedRouteContext)
 	providerName, providerErr := resolveChatProviderName(current, ag, h.llmFactory)
 	if providerErr != nil {

--- a/internal/chathttp/route_context_prompt.go
+++ b/internal/chathttp/route_context_prompt.go
@@ -19,6 +19,9 @@ type normalizedChatRouteContext struct {
 	WorkspaceID string
 	TaskID      string
 	Origin      string
+	// AgentName is the resolved responding agent, set after agent resolution so
+	// the runtime prompt can layer that agent's per-workspace refinement.
+	AgentName string
 }
 
 const (

--- a/internal/chathttp/workspace_context_prompt.go
+++ b/internal/chathttp/workspace_context_prompt.go
@@ -43,8 +43,9 @@ func (h *Handler) buildRuntimeSystemPromptForToolCapability(ctx context.Context,
 	base := buildWorkspaceRuntimeSystemPromptForToolCapability(ctx, routeCtx, h.workspaceStore, h.sessionStore, toolCallable)
 	profile := h.buildUserProfilePrompt(ctx, routeCtx)
 	memory := h.buildWorkspaceMemoryPrompt(routeCtx, toolCallable)
+	refinement := h.buildAgentRefinementPrompt(routeCtx)
 
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
 	if strings.TrimSpace(base) != "" {
 		parts = append(parts, base)
 	}
@@ -54,7 +55,29 @@ func (h *Handler) buildRuntimeSystemPromptForToolCapability(ctx context.Context,
 	if strings.TrimSpace(memory) != "" {
 		parts = append(parts, memory)
 	}
+	if strings.TrimSpace(refinement) != "" {
+		parts = append(parts, refinement)
+	}
 	return strings.Join(parts, "\n\n---\n")
+}
+
+// buildAgentRefinementPrompt renders the responding agent's per-workspace
+// refinement (role/description/custom_instructions) so it reaches the chat
+// prompt. Requires a workspace-scoped route with a resolved agent (PRD
+// FR16/FR19). Shares the renderer with the task path.
+func (h *Handler) buildAgentRefinementPrompt(routeCtx normalizedChatRouteContext) string {
+	if h == nil || h.workspaceStore == nil || !shouldAttachWorkspaceSnapshot(routeCtx) {
+		return ""
+	}
+	ws, err := h.workspaceStore.Get(routeCtx.WorkspaceID)
+	if err != nil || ws == nil {
+		return ""
+	}
+	inst, ok := workspace.AgentInstanceByName(ws, routeCtx.AgentName)
+	if !ok {
+		return ""
+	}
+	return workspace.RenderAgentRefinement(inst)
 }
 
 func (h *Handler) buildUserProfilePrompt(ctx context.Context, routeCtx normalizedChatRouteContext) string {

--- a/internal/chathttp/workspace_context_prompt_test.go
+++ b/internal/chathttp/workspace_context_prompt_test.go
@@ -184,6 +184,44 @@ func TestBuildRuntimeSystemPrompt_IncludesUserProfile(t *testing.T) {
 	}
 }
 
+func TestBuildRuntimeSystemPrompt_IncludesAgentRefinement(t *testing.T) {
+	wsStore := workspace.NewInMemoryStore()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Content", Agents: []string{"Copywriter"}})
+	ws.ID = "workspace-refine"
+	ws.AgentInstances = []workspace.AgentInstance{
+		{ID: "i1", Name: "Copywriter", InstanceNumber: 1, EntryPoint: true,
+			Role: "Voice keeper", CustomInstructions: "Favor short-form social copy."},
+	}
+	if err := wsStore.Save(ws); err != nil {
+		t.Fatalf("failed to save workspace: %v", err)
+	}
+
+	h := &Handler{workspaceStore: wsStore}
+
+	// With the responding agent set, its per-workspace refinement is layered in.
+	prompt := h.buildRuntimeSystemPrompt(context.Background(), normalizedChatRouteContext{
+		Surface:     "workspace_detail",
+		PagePath:    "/workspaces/" + ws.ID,
+		WorkspaceID: ws.ID,
+		AgentName:   "Copywriter",
+	})
+	for _, want := range []string{"Voice keeper", "Favor short-form social copy.", "only in this workspace"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("expected refinement %q in runtime prompt, got:\n%s", want, prompt)
+		}
+	}
+
+	// Without a resolved agent, no refinement section is added.
+	noAgent := h.buildRuntimeSystemPrompt(context.Background(), normalizedChatRouteContext{
+		Surface:     "workspace_detail",
+		PagePath:    "/workspaces/" + ws.ID,
+		WorkspaceID: ws.ID,
+	})
+	if strings.Contains(noAgent, "Favor short-form social copy.") {
+		t.Fatalf("expected no refinement without a resolved agent, got:\n%s", noAgent)
+	}
+}
+
 func TestBuildWorkspaceSnapshotPrompt_EmptyWorkspace(t *testing.T) {
 	wsStore := workspace.NewInMemoryStore()
 	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Empty"})

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -898,6 +898,8 @@ func registerWorkspaceRuntimeRoutes(mux *http.ServeMux, s *Server) {
 	// the workspace AgentInstances.
 	if s.Handlers.Session != nil {
 		mux.HandleFunc("PATCH /api/workspaces/{workspaceID}/agents/{name}/instance-settings", s.Handlers.Session.UpdateWorkspaceAgentInstanceSettings)
+		// Resolved effective prompt inspector (base + per-workspace refinement).
+		mux.HandleFunc("GET /api/workspaces/{workspaceID}/agents/{name}/effective-prompt", s.Handlers.Session.GetWorkspaceAgentEffectivePrompt)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -891,6 +891,14 @@ func registerWorkspaceRuntimeRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("GET /api/workspaces/{workspaceID}/native-mcp", s.Handlers.Workspace.GetNativeMCPSettings)
 	mux.HandleFunc("PATCH /api/workspaces/{workspaceID}/native-mcp", s.Handlers.Workspace.UpdateNativeMCPWorkspace)
 	mux.HandleFunc("PATCH /api/workspaces/{workspaceID}/agents/{name}/native-mcp", s.Handlers.Workspace.UpdateNativeMCPAgent)
+
+	// Per-instance refinement of a shared agent definition (role / description /
+	// custom_instructions) scoped to this workspace only; never mutates the
+	// global definition (PRD FR18). Handled by the session handler which owns
+	// the workspace AgentInstances.
+	if s.Handlers.Session != nil {
+		mux.HandleFunc("PATCH /api/workspaces/{workspaceID}/agents/{name}/instance-settings", s.Handlers.Session.UpdateWorkspaceAgentInstanceSettings)
+	}
 }
 
 // registerActionCenterRoutes registers cross-workspace Action Center triage endpoints.

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -201,6 +201,11 @@ type AgentInstance struct {
 	// Description is optional guidance about this instance's responsibility.
 	Description string `json:"description,omitempty"`
 
+	// CustomInstructions is the workspace owner's per-attachment refinement of a
+	// shared agent definition, layered onto the shared base prompt for this
+	// workspace only (never mutates the global definition). PRD FR16/FR17.
+	CustomInstructions string `json:"custom_instructions,omitempty"`
+
 	// EntryPoint marks the instance as the default workspace entry node.
 	EntryPoint bool `json:"entry_point,omitempty"`
 

--- a/internal/session/workspace_store_adapter.go
+++ b/internal/session/workspace_store_adapter.go
@@ -175,14 +175,15 @@ func (a *WorkspaceStoreAdapter) toSessionWorkspace(ws *workspace.Workspace) *Wor
 		sessionWS.AgentInstances = make([]AgentInstance, len(ws.AgentInstances))
 		for i, ai := range ws.AgentInstances {
 			sessionWS.AgentInstances[i] = AgentInstance{
-				ID:             ai.ID,
-				Name:           ai.Name,
-				InstanceNumber: ai.InstanceNumber,
-				NodeID:         ai.NodeID,
-				Role:           ai.Role,
-				Description:    ai.Description,
-				EntryPoint:     ai.EntryPoint,
-				CreatedAt:      ai.CreatedAt,
+				ID:                 ai.ID,
+				Name:               ai.Name,
+				InstanceNumber:     ai.InstanceNumber,
+				NodeID:             ai.NodeID,
+				Role:               ai.Role,
+				Description:        ai.Description,
+				CustomInstructions: ai.CustomInstructions,
+				EntryPoint:         ai.EntryPoint,
+				CreatedAt:          ai.CreatedAt,
 			}
 		}
 	}
@@ -319,14 +320,15 @@ func (a *WorkspaceStoreAdapter) toAgentWorkspace(ws *Workspace) *workspace.Works
 		agentWS.AgentInstances = make([]workspace.AgentInstance, len(ws.AgentInstances))
 		for i, ai := range ws.AgentInstances {
 			agentWS.AgentInstances[i] = workspace.AgentInstance{
-				ID:             ai.ID,
-				Name:           ai.Name,
-				InstanceNumber: ai.InstanceNumber,
-				NodeID:         ai.NodeID,
-				Role:           ai.Role,
-				Description:    ai.Description,
-				EntryPoint:     ai.EntryPoint,
-				CreatedAt:      ai.CreatedAt,
+				ID:                 ai.ID,
+				Name:               ai.Name,
+				InstanceNumber:     ai.InstanceNumber,
+				NodeID:             ai.NodeID,
+				Role:               ai.Role,
+				Description:        ai.Description,
+				CustomInstructions: ai.CustomInstructions,
+				EntryPoint:         ai.EntryPoint,
+				CreatedAt:          ai.CreatedAt,
 			}
 		}
 	}

--- a/internal/session/workspace_store_adapter_test.go
+++ b/internal/session/workspace_store_adapter_test.go
@@ -8,6 +8,59 @@ import (
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
+// TestWorkspaceStoreAdapter_AgentInstanceCustomInstructionsRoundTrip verifies the
+// per-instance custom_instructions field survives both adapter directions and the
+// SQLite JSON (de)serialization used for AgentInstances (PRD FR17).
+func TestWorkspaceStoreAdapter_AgentInstanceCustomInstructionsRoundTrip(t *testing.T) {
+	adapter := &WorkspaceStoreAdapter{}
+	now := time.Now().UTC().Round(time.Second)
+
+	const custom = "First line of guidance.\nSecond line — keep internal newlines."
+	input := &workspace.Workspace{
+		ID:        "ws-ci",
+		Name:      "CI Workspace",
+		CreatedAt: now,
+		UpdatedAt: now,
+		AgentInstances: []workspace.AgentInstance{
+			{
+				ID:                 "inst-1",
+				Name:               "Brand Copywriter",
+				InstanceNumber:     1,
+				NodeID:             "brand-node-1",
+				Role:               "Voice keeper",
+				Description:        "Owns tone",
+				CustomInstructions: custom,
+				EntryPoint:         true,
+				CreatedAt:          now,
+			},
+		},
+	}
+
+	// workspace -> session -> workspace preserves the field.
+	sessionWS := adapter.toSessionWorkspace(input)
+	if got := sessionWS.AgentInstances[0].CustomInstructions; got != custom {
+		t.Fatalf("session AgentInstance custom_instructions = %q, want %q", got, custom)
+	}
+	roundTripped := adapter.toAgentWorkspace(sessionWS)
+	if got := roundTripped.AgentInstances[0].CustomInstructions; got != custom {
+		t.Fatalf("round-tripped custom_instructions = %q, want %q", got, custom)
+	}
+
+	// The SQLite store serializes AgentInstances as a JSON blob; confirm the
+	// field marshals/unmarshals intact (internal newlines preserved).
+	data, err := json.Marshal(sessionWS.AgentInstances)
+	if err != nil {
+		t.Fatalf("marshal AgentInstances: %v", err)
+	}
+	var decoded []AgentInstance
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal AgentInstances: %v", err)
+	}
+	if got := decoded[0].CustomInstructions; got != custom {
+		t.Fatalf("JSON round-trip custom_instructions = %q, want %q", got, custom)
+	}
+}
+
 func TestWorkspaceStoreAdapter_MCPRoundTrip(t *testing.T) {
 	adapter := &WorkspaceStoreAdapter{}
 	now := time.Now().UTC().Round(time.Second)

--- a/internal/sessionhttp/workspace_agent_settings.go
+++ b/internal/sessionhttp/workspace_agent_settings.go
@@ -9,6 +9,7 @@ import (
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
+	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 // maxCustomInstructionsLen bounds a per-instance refinement string (PRD FR17).
@@ -101,5 +102,81 @@ func (h *Handler) UpdateWorkspaceAgentInstanceSettings(w http.ResponseWriter, r 
 		"agent":     agentName,
 		"instances": matched,
 		"workspace": workspace,
+	})
+}
+
+// GetWorkspaceAgentEffectivePrompt handles
+// GET /api/workspaces/{workspaceID}/agents/{name}/effective-prompt.
+//
+// It returns the shared base system prompt plus this workspace's per-instance
+// refinement and the layered result, so the workspace agent view can show what
+// the agent effectively sees here (PRD FR30). Live workspace context (notes,
+// memory, tools) is composed at run time and intentionally not resolved here —
+// that fuller inspector belongs to the composer work (4.0b).
+func (h *Handler) GetWorkspaceAgentEffectivePrompt(w http.ResponseWriter, r *http.Request) {
+	workspaceID := strings.TrimSpace(r.PathValue("workspaceID"))
+	agentName := strings.TrimSpace(r.PathValue("name"))
+	if workspaceID == "" || agentName == "" {
+		_ = orihttp.RespondBadRequest(w, "workspace id and agent name are required")
+		return
+	}
+
+	workspace, err := h.store.GetWorkspace(r.Context(), workspaceID)
+	if err == session.ErrWorkspaceNotFound {
+		_ = orihttp.RespondNotFound(w, "Workspace not found")
+		return
+	}
+	if err != nil {
+		logger.Error("Failed to get workspace", logger.Fields{"id": workspaceID, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to get workspace")
+		return
+	}
+
+	var inst *session.AgentInstance
+	for i := range workspace.AgentInstances {
+		if !strings.EqualFold(strings.TrimSpace(workspace.AgentInstances[i].Name), agentName) {
+			continue
+		}
+		inst = &workspace.AgentInstances[i]
+		if workspace.AgentInstances[i].EntryPoint {
+			break
+		}
+	}
+	if inst == nil {
+		_ = orihttp.RespondNotFound(w, fmt.Sprintf("Agent %q is not attached to this workspace", agentName))
+		return
+	}
+
+	basePrompt := ""
+	if h.agentStore != nil {
+		if ag, ok := h.agentStore.GetAgent(agentName); ok && ag != nil {
+			basePrompt = ag.Settings.SystemPrompt
+		}
+	}
+
+	// Share the renderer with the prompt paths so the inspector matches runtime.
+	refinement := agentworkspace.RenderAgentRefinement(agentworkspace.AgentInstance{
+		Role:               inst.Role,
+		Description:        inst.Description,
+		CustomInstructions: inst.CustomInstructions,
+	})
+	effective := basePrompt
+	if refinement != "" {
+		if strings.TrimSpace(effective) != "" {
+			effective += "\n\n---\n" + refinement
+		} else {
+			effective = refinement
+		}
+	}
+
+	_ = orihttp.RespondSuccess(w, map[string]any{
+		"agent":               agentName,
+		"base_system_prompt":  basePrompt,
+		"role":                inst.Role,
+		"description":         inst.Description,
+		"custom_instructions": inst.CustomInstructions,
+		"refinement":          refinement,
+		"effective_prompt":    effective,
+		"note":                "Live workspace context (notes, memory, tools) is added at run time and not shown here.",
 	})
 }

--- a/internal/sessionhttp/workspace_agent_settings.go
+++ b/internal/sessionhttp/workspace_agent_settings.go
@@ -1,0 +1,105 @@
+package sessionhttp
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// maxCustomInstructionsLen bounds a per-instance refinement string (PRD FR17).
+const maxCustomInstructionsLen = 2000
+
+// UpdateWorkspaceAgentInstanceSettings handles
+// PATCH /api/workspaces/{workspaceID}/agents/{name}/instance-settings.
+//
+// It updates the per-instance role, description, and custom_instructions on the
+// workspace's AgentInstance(s) for the named agent — the workspace owner's
+// refinement of a shared definition — WITHOUT touching the global agent
+// definition or the workspace-local agent snapshot (PRD FR16/FR17/FR18). Fields
+// are partial: only keys present in the body are changed.
+func (h *Handler) UpdateWorkspaceAgentInstanceSettings(w http.ResponseWriter, r *http.Request) {
+	// Go 1.22 ServeMux path values are already percent-decoded.
+	workspaceID := strings.TrimSpace(r.PathValue("workspaceID"))
+	agentName := strings.TrimSpace(r.PathValue("name"))
+	if workspaceID == "" || agentName == "" {
+		_ = orihttp.RespondBadRequest(w, "workspace id and agent name are required")
+		return
+	}
+
+	var req struct {
+		Role               *string `json:"role,omitempty"`
+		Description        *string `json:"description,omitempty"`
+		CustomInstructions *string `json:"custom_instructions,omitempty"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	// Trim outer whitespace (which also drops leading/trailing newlines) while
+	// preserving intentional internal newlines, and cap the length (PRD FR17).
+	var trimmedCustom string
+	if req.CustomInstructions != nil {
+		trimmedCustom = strings.TrimSpace(*req.CustomInstructions)
+		if len(trimmedCustom) > maxCustomInstructionsLen {
+			_ = orihttp.RespondBadRequest(w, fmt.Sprintf("custom_instructions exceeds %d characters", maxCustomInstructionsLen))
+			return
+		}
+	}
+
+	workspace, err := h.store.GetWorkspace(r.Context(), workspaceID)
+	if err == session.ErrWorkspaceNotFound {
+		_ = orihttp.RespondNotFound(w, "Workspace not found")
+		return
+	}
+	if err != nil {
+		logger.Error("Failed to get workspace", logger.Fields{"id": workspaceID, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to get workspace")
+		return
+	}
+
+	matched := 0
+	for i := range workspace.AgentInstances {
+		if !strings.EqualFold(strings.TrimSpace(workspace.AgentInstances[i].Name), agentName) {
+			continue
+		}
+		matched++
+		if req.Role != nil {
+			workspace.AgentInstances[i].Role = strings.TrimSpace(*req.Role)
+		}
+		if req.Description != nil {
+			workspace.AgentInstances[i].Description = strings.TrimSpace(*req.Description)
+		}
+		if req.CustomInstructions != nil {
+			workspace.AgentInstances[i].CustomInstructions = trimmedCustom
+		}
+	}
+	if matched == 0 {
+		_ = orihttp.RespondNotFound(w, fmt.Sprintf("Agent %q is not attached to this workspace", agentName))
+		return
+	}
+
+	workspace.UpdatedAt = time.Now()
+	if err := h.store.UpdateWorkspace(r.Context(), workspace); err != nil {
+		logger.Error("Failed to update workspace agent settings", logger.Fields{"id": workspaceID, "agent": agentName, "error": err})
+		_ = orihttp.RespondInternalError(w, "Failed to update agent settings")
+		return
+	}
+	if err := h.syncWorkspacePortableStateToFileStore(workspace); err != nil {
+		logger.Warn("Failed to sync workspace.json after updating agent settings", logger.Fields{"id": workspaceID, "error": err})
+	}
+
+	logger.Info("Updated workspace agent instance settings", logger.Fields{
+		"workspace_id": workspaceID, "agent": agentName, "instances": matched,
+	})
+	_ = orihttp.RespondSuccess(w, map[string]any{
+		"success":   true,
+		"agent":     agentName,
+		"instances": matched,
+		"workspace": workspace,
+	})
+}

--- a/internal/sessionhttp/workspace_agent_settings_test.go
+++ b/internal/sessionhttp/workspace_agent_settings_test.go
@@ -1,0 +1,104 @@
+package sessionhttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// patchInstanceSettings issues a PATCH to UpdateWorkspaceAgentInstanceSettings with
+// the given path values and JSON body. The URL path is escaped (agent names can
+// contain spaces) while SetPathValue carries the raw, already-decoded name that
+// the Go 1.22 mux would supply.
+func patchInstanceSettings(h *Handler, workspaceID, agentName, body string) *httptest.ResponseRecorder {
+	target := "/api/workspaces/" + url.PathEscape(workspaceID) + "/agents/" + url.PathEscape(agentName) + "/instance-settings"
+	req := httptest.NewRequest(http.MethodPatch, target, strings.NewReader(body))
+	req.SetPathValue("workspaceID", workspaceID)
+	req.SetPathValue("name", agentName)
+	rr := httptest.NewRecorder()
+	h.UpdateWorkspaceAgentInstanceSettings(rr, req)
+	return rr
+}
+
+func seedWorkspaceWithInstance(t *testing.T, h *Handler, wsID, agentName string) {
+	t.Helper()
+	ws := &session.Workspace{
+		ID:   wsID,
+		Name: wsID,
+		AgentInstances: []session.AgentInstance{
+			{ID: "inst-1", Name: agentName, InstanceNumber: 1, NodeID: agentName + "-node-1", EntryPoint: true},
+		},
+	}
+	if err := h.store.CreateWorkspace(context.Background(), ws); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+}
+
+// TestUpdateWorkspaceAgentInstanceSettings_UpdatesInstanceOnly verifies role,
+// description, and custom_instructions are persisted on the AgentInstance (and
+// survive a store reload), without touching the global agent definition (FR18).
+func TestUpdateWorkspaceAgentInstanceSettings_UpdatesInstanceOnly(t *testing.T) {
+	h, cleanup := createTestHandler(t)
+	defer cleanup()
+	seedWorkspaceWithInstance(t, h, "ws-1", "Brand Copywriter")
+
+	const custom = "Favor short-form social copy.\nKeep it punchy."
+	// Raw string literal so the JSON body contains an escaped \n and padded outer
+	// whitespace, which the handler trims (outer) while preserving the newline.
+	body := `{"role":"Voice keeper","description":"Owns tone","custom_instructions":"  Favor short-form social copy.\nKeep it punchy.  "}`
+	rr := patchInstanceSettings(h, "ws-1", "Brand Copywriter", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Reload from the store to prove persistence (real SQLite round-trip).
+	ws, err := h.store.GetWorkspace(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	inst := ws.AgentInstances[0]
+	if inst.Role != "Voice keeper" || inst.Description != "Owns tone" {
+		t.Errorf("role/description not persisted: %+v", inst)
+	}
+	// Outer whitespace trimmed, internal newline preserved.
+	if inst.CustomInstructions != custom {
+		t.Errorf("custom_instructions = %q, want %q", inst.CustomInstructions, custom)
+	}
+
+	// The global definition must not have been created/mutated by this call.
+	if _, ok := h.agentStore.GetAgent("Brand Copywriter"); ok {
+		t.Errorf("global agent definition should not be touched by instance settings")
+	}
+}
+
+// TestUpdateWorkspaceAgentInstanceSettings_RejectsOverlongCustom verifies the
+// 2000-char cap (FR17).
+func TestUpdateWorkspaceAgentInstanceSettings_RejectsOverlongCustom(t *testing.T) {
+	h, cleanup := createTestHandler(t)
+	defer cleanup()
+	seedWorkspaceWithInstance(t, h, "ws-1", "Editor")
+
+	long := strings.Repeat("x", maxCustomInstructionsLen+1)
+	rr := patchInstanceSettings(h, "ws-1", "Editor", `{"custom_instructions":"`+long+`"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for overlong custom_instructions, got %d", rr.Code)
+	}
+}
+
+// TestUpdateWorkspaceAgentInstanceSettings_UnattachedAgent404 verifies an agent
+// not attached to the workspace yields 404.
+func TestUpdateWorkspaceAgentInstanceSettings_UnattachedAgent404(t *testing.T) {
+	h, cleanup := createTestHandler(t)
+	defer cleanup()
+	seedWorkspaceWithInstance(t, h, "ws-1", "Editor")
+
+	rr := patchInstanceSettings(h, "ws-1", "Nonexistent", `{"role":"x"}`)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unattached agent, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/sessionhttp/workspace_agent_settings_test.go
+++ b/internal/sessionhttp/workspace_agent_settings_test.go
@@ -2,6 +2,7 @@ package sessionhttp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/session"
+	agentstore "github.com/johnjallday/ori-agent/internal/store"
 )
 
 // patchInstanceSettings issues a PATCH to UpdateWorkspaceAgentInstanceSettings with
@@ -100,5 +102,48 @@ func TestUpdateWorkspaceAgentInstanceSettings_UnattachedAgent404(t *testing.T) {
 	rr := patchInstanceSettings(h, "ws-1", "Nonexistent", `{"role":"x"}`)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for unattached agent, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestGetWorkspaceAgentEffectivePrompt verifies the inspector returns the shared
+// base prompt layered with the per-workspace refinement (PRD FR30).
+func TestGetWorkspaceAgentEffectivePrompt(t *testing.T) {
+	h, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	if err := h.agentStore.CreateAgent("Copywriter", &agentstore.CreateAgentConfig{SystemPrompt: "BASE PROMPT"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	seedWorkspaceWithInstance(t, h, "ws-1", "Copywriter")
+	if rr := patchInstanceSettings(h, "ws-1", "Copywriter", `{"custom_instructions":"Be concise."}`); rr.Code != http.StatusOK {
+		t.Fatalf("seed custom_instructions: %d", rr.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/ws-1/agents/Copywriter/effective-prompt", nil)
+	req.SetPathValue("workspaceID", "ws-1")
+	req.SetPathValue("name", "Copywriter")
+	rr := httptest.NewRecorder()
+	h.GetWorkspaceAgentEffectivePrompt(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		BaseSystemPrompt   string `json:"base_system_prompt"`
+		CustomInstructions string `json:"custom_instructions"`
+		Refinement         string `json:"refinement"`
+		EffectivePrompt    string `json:"effective_prompt"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+	}
+	if body.BaseSystemPrompt != "BASE PROMPT" {
+		t.Errorf("base_system_prompt = %q, want BASE PROMPT", body.BaseSystemPrompt)
+	}
+	if body.CustomInstructions != "Be concise." || !strings.Contains(body.Refinement, "Be concise.") {
+		t.Errorf("refinement not surfaced: %+v", body)
+	}
+	if !strings.Contains(body.EffectivePrompt, "BASE PROMPT") || !strings.Contains(body.EffectivePrompt, "Be concise.") {
+		t.Errorf("effective_prompt should layer base + refinement, got %q", body.EffectivePrompt)
 	}
 }

--- a/internal/sessionhttp/workspace_entry.go
+++ b/internal/sessionhttp/workspace_entry.go
@@ -264,14 +264,15 @@ func toWorkspaceAgentInstances(items []session.AgentInstance) []agentworkspace.A
 	out := make([]agentworkspace.AgentInstance, len(items))
 	for i, item := range items {
 		out[i] = agentworkspace.AgentInstance{
-			ID:             item.ID,
-			Name:           item.Name,
-			InstanceNumber: item.InstanceNumber,
-			NodeID:         item.NodeID,
-			Role:           item.Role,
-			Description:    item.Description,
-			EntryPoint:     item.EntryPoint,
-			CreatedAt:      item.CreatedAt,
+			ID:                 item.ID,
+			Name:               item.Name,
+			InstanceNumber:     item.InstanceNumber,
+			NodeID:             item.NodeID,
+			Role:               item.Role,
+			Description:        item.Description,
+			CustomInstructions: item.CustomInstructions,
+			EntryPoint:         item.EntryPoint,
+			CreatedAt:          item.CreatedAt,
 		}
 	}
 	return out

--- a/internal/sessionhttp/workspace_handler_agents.go
+++ b/internal/sessionhttp/workspace_handler_agents.go
@@ -312,14 +312,15 @@ func buildWorkspaceAnalyticsView(workspace *session.Workspace) *agentworkspace.W
 		analyticsWorkspace.AgentInstances = make([]agentworkspace.AgentInstance, len(workspace.AgentInstances))
 		for i, inst := range workspace.AgentInstances {
 			analyticsWorkspace.AgentInstances[i] = agentworkspace.AgentInstance{
-				ID:             inst.ID,
-				Name:           inst.Name,
-				InstanceNumber: inst.InstanceNumber,
-				NodeID:         inst.NodeID,
-				Role:           inst.Role,
-				Description:    inst.Description,
-				EntryPoint:     inst.EntryPoint,
-				CreatedAt:      inst.CreatedAt,
+				ID:                 inst.ID,
+				Name:               inst.Name,
+				InstanceNumber:     inst.InstanceNumber,
+				NodeID:             inst.NodeID,
+				Role:               inst.Role,
+				Description:        inst.Description,
+				CustomInstructions: inst.CustomInstructions,
+				EntryPoint:         inst.EntryPoint,
+				CreatedAt:          inst.CreatedAt,
 			}
 		}
 	}

--- a/internal/workspace/agent_refinement.go
+++ b/internal/workspace/agent_refinement.go
@@ -1,0 +1,91 @@
+package workspace
+
+import "strings"
+
+// AgentInstanceByName returns the workspace's AgentInstance for the given agent
+// name (case-insensitive). When several instances share the name, the
+// entry-point instance is preferred, else the first match. The bool is false
+// when the agent is not attached to the workspace.
+func AgentInstanceByName(ws *Workspace, name string) (AgentInstance, bool) {
+	if ws == nil {
+		return AgentInstance{}, false
+	}
+	target := strings.ToLower(strings.TrimSpace(name))
+	if target == "" {
+		return AgentInstance{}, false
+	}
+	var match AgentInstance
+	found := false
+	for _, inst := range ws.AgentInstances {
+		if strings.ToLower(strings.TrimSpace(inst.Name)) != target {
+			continue
+		}
+		if inst.EntryPoint {
+			return inst, true
+		}
+		if !found {
+			match, found = inst, true
+		}
+	}
+	return match, found
+}
+
+// RenderAgentRefinement renders a workspace instance's per-attachment refinement
+// of a shared agent definition — its role, description, and custom_instructions —
+// as a directive prompt section layered onto the shared base configuration. It
+// returns "" when the instance carries no refinement.
+//
+// Unlike notes/memory (untrusted data that is fenced as reference), refinement is
+// first-party guidance the workspace owner authored to steer the agent, so it is
+// rendered as directives. It is shared by the chat and task prompt paths so the
+// same refinement reaches both (PRD FR16/FR19).
+func RenderAgentRefinement(inst AgentInstance) string {
+	role := strings.TrimSpace(inst.Role)
+	desc := strings.TrimSpace(inst.Description)
+	custom := strings.TrimSpace(inst.CustomInstructions)
+	if role == "" && desc == "" && custom == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("Workspace-specific guidance (applies only in this workspace, layered on your base configuration):")
+	if role != "" {
+		b.WriteString("\n- Your role here: ")
+		b.WriteString(role)
+	}
+	if desc != "" {
+		b.WriteString("\n- ")
+		b.WriteString(desc)
+	}
+	if custom != "" {
+		b.WriteString("\n\n")
+		b.WriteString(custom)
+	}
+	return b.String()
+}
+
+// AppendAgentRefinement appends the named agent's refinement section (if any) to
+// base, resolving the instance from the workspace store. It is a no-op that
+// returns base unchanged when the store/workspace/instance is unavailable or the
+// instance carries no refinement. Convenience for prompt-assembly call sites.
+func AppendAgentRefinement(base string, store Store, workspaceID, agentName string) string {
+	if store == nil || strings.TrimSpace(workspaceID) == "" || strings.TrimSpace(agentName) == "" {
+		return base
+	}
+	ws, err := store.Get(workspaceID)
+	if err != nil || ws == nil {
+		return base
+	}
+	inst, ok := AgentInstanceByName(ws, agentName)
+	if !ok {
+		return base
+	}
+	section := RenderAgentRefinement(inst)
+	if section == "" {
+		return base
+	}
+	if strings.TrimSpace(base) == "" {
+		return section
+	}
+	return base + "\n\n---\n" + section
+}

--- a/internal/workspace/agent_refinement_test.go
+++ b/internal/workspace/agent_refinement_test.go
@@ -1,0 +1,87 @@
+package workspace
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderAgentRefinement(t *testing.T) {
+	if got := RenderAgentRefinement(AgentInstance{}); got != "" {
+		t.Errorf("empty instance should render nothing, got %q", got)
+	}
+
+	got := RenderAgentRefinement(AgentInstance{
+		Role:               "Voice keeper",
+		Description:        "Owns tone",
+		CustomInstructions: "Favor short-form social copy.\nKeep it punchy.",
+	})
+	for _, want := range []string{"Voice keeper", "Owns tone", "Favor short-form social copy.", "Keep it punchy.", "only in this workspace"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("refinement missing %q in:\n%s", want, got)
+		}
+	}
+
+	// custom_instructions alone still renders.
+	if got := RenderAgentRefinement(AgentInstance{CustomInstructions: "Just this."}); !strings.Contains(got, "Just this.") {
+		t.Errorf("custom-only refinement missing content: %q", got)
+	}
+}
+
+func TestAgentInstanceByName(t *testing.T) {
+	ws := &Workspace{
+		AgentInstances: []AgentInstance{
+			{Name: "Writer", InstanceNumber: 1},
+			{Name: "Writer", InstanceNumber: 2, EntryPoint: true, CustomInstructions: "entry"},
+			{Name: "Editor"},
+		},
+	}
+	// Entry-point instance is preferred among same-named matches.
+	inst, ok := AgentInstanceByName(ws, "writer")
+	if !ok || !inst.EntryPoint || inst.CustomInstructions != "entry" {
+		t.Fatalf("expected entry-point Writer, got %+v ok=%v", inst, ok)
+	}
+	if _, ok := AgentInstanceByName(ws, "Nonexistent"); ok {
+		t.Error("expected not-found for unattached agent")
+	}
+	if _, ok := AgentInstanceByName(nil, "x"); ok {
+		t.Error("nil workspace should be not-found")
+	}
+}
+
+func TestAppendAgentRefinement(t *testing.T) {
+	store, err := NewFileStore(filepath.Join(t.TempDir(), "workspaces"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	ws := &Workspace{
+		ID:   "ws-1",
+		Name: "WS",
+		AgentInstances: []AgentInstance{
+			{ID: "i1", Name: "Copywriter", EntryPoint: true, CustomInstructions: "Be concise."},
+			{ID: "i2", Name: "Plain"},
+		},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Agent with refinement: appended after the base.
+	out := AppendAgentRefinement("BASE", store, "ws-1", "Copywriter")
+	if !strings.Contains(out, "BASE") || !strings.Contains(out, "Be concise.") {
+		t.Errorf("expected base + refinement, got %q", out)
+	}
+
+	// Agent without refinement: base unchanged.
+	if out := AppendAgentRefinement("BASE", store, "ws-1", "Plain"); out != "BASE" {
+		t.Errorf("expected unchanged base for refinement-less agent, got %q", out)
+	}
+
+	// Missing pieces are no-ops returning base.
+	if out := AppendAgentRefinement("BASE", store, "ws-1", "Nonexistent"); out != "BASE" {
+		t.Errorf("unattached agent should return base, got %q", out)
+	}
+	if out := AppendAgentRefinement("BASE", nil, "ws-1", "Copywriter"); out != "BASE" {
+		t.Errorf("nil store should return base, got %q", out)
+	}
+}

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -252,6 +252,9 @@ func (h *LLMTaskHandler) runTaskOnProvider(ctx context.Context, providerName, re
 	compactPrompt := provider.Type() == llm.ProviderTypeLocal
 	taskSystemPrompt := h.buildTaskSystemPrompt(compactPrompt)
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
+	// Layer the workspace owner's per-instance refinement of this agent onto the
+	// task prompt so refinement reaches the task path too (PRD FR15/FR16/FR19).
+	taskSystemPrompt = AppendAgentRefinement(taskSystemPrompt, h.workspaceStore, task.WorkspaceID, agentName)
 	h.reportPromptTier(task, agentName, compactPrompt)
 
 	// Convert agent tools (MCP + workspace) to LLM format. Needed before budgeting

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -69,14 +69,18 @@ const (
 
 // AgentInstance represents a specific instance of an agent with a stable identifier
 type AgentInstance struct {
-	ID             string    `json:"id"`              // Stable UUID for this agent instance
-	Name           string    `json:"name"`            // Agent type name (e.g., "default", "writer")
-	InstanceNumber int       `json:"instance_number"` // Instance number for display (e.g., 1, 2, 3)
-	NodeID         string    `json:"node_id"`         // Stable node ID (e.g., "default-node-1")
-	Role           string    `json:"role,omitempty"`  // Workspace-specific responsibility label (e.g., "Project Manager")
-	Description    string    `json:"description,omitempty"`
-	EntryPoint     bool      `json:"entry_point,omitempty"` // Marks the default entry node for workspace-level requests
-	CreatedAt      time.Time `json:"created_at"`            // When this instance was added
+	ID             string `json:"id"`              // Stable UUID for this agent instance
+	Name           string `json:"name"`            // Agent type name (e.g., "default", "writer")
+	InstanceNumber int    `json:"instance_number"` // Instance number for display (e.g., 1, 2, 3)
+	NodeID         string `json:"node_id"`         // Stable node ID (e.g., "default-node-1")
+	Role           string `json:"role,omitempty"`  // Workspace-specific responsibility label (e.g., "Project Manager")
+	Description    string `json:"description,omitempty"`
+	// CustomInstructions is the workspace owner's per-attachment refinement of a
+	// shared agent definition, layered onto the shared base prompt for this
+	// workspace only (never mutates the global definition). PRD FR16/FR17.
+	CustomInstructions string    `json:"custom_instructions,omitempty"`
+	EntryPoint         bool      `json:"entry_point,omitempty"` // Marks the default entry node for workspace-level requests
+	CreatedAt          time.Time `json:"created_at"`            // When this instance was added
 }
 
 // Folder represents a managed folder under the workspace files root.


### PR DESCRIPTION
Phase 2 (value-first slice) of the reusable-template-agents epic
(PRD: tasks/prd-reusable-template-agents.md). A shared agent definition can now
be refined per workspace without forking: same base behavior everywhere, plus a
per-workspace layer.

## Persistence (group 3.0)
- Add CustomInstructions to workspace.AgentInstance and session.AgentInstance;
  carried through all adapter conversions and round-trips via SQLite (AgentInstances
  are a JSON blob) and workspace.json.
- New PATCH /api/workspaces/{id}/agents/{name}/instance-settings updates the
  per-instance role/description/custom_instructions without touching the global
  definition. Outer-trimmed, internal newlines preserved, capped at 2000 chars.

## Refinement in the prompt (group 4.0a)
- Shared workspace.RenderAgentRefinement turns an instance's role/description/
  custom_instructions into a directive section layered on the shared base.
- Chat path (route context + runtime prompt) and task path (runTaskOnProvider,
  guardrails untouched) both layer it in.
- Inspector: GET /api/workspaces/{id}/agents/{name}/effective-prompt returns
  base + refinement + the layered effective_prompt. Live workspace context is
  composed at run time and intentionally not resolved here.

## Deferred
- 4.0b: the pure composer-unification refactor (de-duplicating the parallel
  chat/task workspace-context builders) ships as its own PR — no user value, high
  blast radius.

## Testing
- Adapter + SQLite-JSON round-trip; settings handler (persist/reload, 2000-char
  reject, unattached 404, global untouched); shared renderer/lookup/append; chat
  prompt includes refinement (omitted without an agent); inspector layering.
- Live smoke: set custom_instructions on a template agent -> inspector returns the
  correctly composed base + refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)