### PR TITLE
feat(templates): variable inserter + resolved-prompt preview (Phase 3, part B)

### DIFF
--- a/internal/promptvars/promptvars.go
+++ b/internal/promptvars/promptvars.go
@@ -12,6 +12,7 @@ package promptvars
 import (
 	"regexp"
 	"strings"
+	"time"
 )
 
 // Kind distinguishes how a variable renders.
@@ -36,21 +37,61 @@ type Spec struct {
 	// authoritative instructions, for variables that carry untrusted content
 	// (notes, memory, task goal). Prevents prompt-injection via interpolated data.
 	Fenced bool
+	// Description is a short authoring-UI hint (what the variable resolves to).
+	Description string
 }
 
 // vocabulary is the complete closed set of variables (PRD Phase 3 table).
 var vocabulary = map[string]Spec{
-	"workspace.name":                {Name: "workspace.name", Kind: Scalar},
-	"workspace.description":         {Name: "workspace.description", Kind: Scalar},
-	"workspace.custom_instructions": {Name: "workspace.custom_instructions", Kind: Scalar},
-	"workspace.memory":              {Name: "workspace.memory", Kind: Block, Header: "Workspace memory", Fenced: true},
-	"workspace.notes.recent":        {Name: "workspace.notes.recent", Kind: Block, Header: "Recent notes", Fenced: true},
-	"workspace.tools":               {Name: "workspace.tools", Kind: Block, Header: "Available tools"},
-	"agent.name":                    {Name: "agent.name", Kind: Scalar},
-	"agent.role":                    {Name: "agent.role", Kind: Scalar},
-	"agent.description":             {Name: "agent.description", Kind: Scalar},
-	"task.goal":                     {Name: "task.goal", Kind: Block, Header: "Current task", Fenced: true},
-	"runtime.date":                  {Name: "runtime.date", Kind: Scalar},
+	"workspace.name":                {Name: "workspace.name", Kind: Scalar, Description: "The workspace's display name."},
+	"workspace.description":         {Name: "workspace.description", Kind: Scalar, Description: "The workspace's description / goal."},
+	"workspace.custom_instructions": {Name: "workspace.custom_instructions", Kind: Scalar, Description: "The workspace owner's per-agent refinement slot."},
+	"workspace.memory":              {Name: "workspace.memory", Kind: Block, Header: "Workspace memory", Fenced: true, Description: "The workspace's MEMORY.md (fenced as reference)."},
+	"workspace.notes.recent":        {Name: "workspace.notes.recent", Kind: Block, Header: "Recent notes", Fenced: true, Description: "Recent workspace notes (fenced as reference)."},
+	"workspace.tools":               {Name: "workspace.tools", Kind: Block, Header: "Available tools", Description: "The agent's effective tools in this workspace."},
+	"agent.name":                    {Name: "agent.name", Kind: Scalar, Description: "This agent's name."},
+	"agent.role":                    {Name: "agent.role", Kind: Scalar, Description: "The agent's workspace-specific role label."},
+	"agent.description":             {Name: "agent.description", Kind: Scalar, Description: "The agent's workspace-specific responsibility note."},
+	"task.goal":                     {Name: "task.goal", Kind: Block, Header: "Current task", Fenced: true, Description: "The current task's goal (task runs only; fenced)."},
+	"runtime.date":                  {Name: "runtime.date", Kind: Scalar, Description: "Today's date."},
+}
+
+// vocabularyOrder is the stable, author-facing ordering for the vocabulary
+// (grouped by namespace), used by Vocabulary().
+var vocabularyOrder = []string{
+	"workspace.name", "workspace.description", "workspace.custom_instructions",
+	"workspace.memory", "workspace.notes.recent", "workspace.tools",
+	"agent.name", "agent.role", "agent.description",
+	"task.goal", "runtime.date",
+}
+
+// Vocabulary returns the full vocabulary in a stable, author-facing order.
+// Intended for authoring UIs (the variable inserter / reference).
+func Vocabulary() []Spec {
+	out := make([]Spec, 0, len(vocabularyOrder))
+	for _, name := range vocabularyOrder {
+		out = append(out, vocabulary[name])
+	}
+	return out
+}
+
+// SampleValues returns deterministic placeholder values for every variable, for
+// previewing a prompt when no real workspace is selected. All values are
+// synthetic — no real workspace data or secrets are involved.
+func SampleValues() map[string]string {
+	return map[string]string{
+		"workspace.name":                "Acme Q3 Campaign",
+		"workspace.description":         "Launch the Q3 product campaign across social and email.",
+		"workspace.custom_instructions": "In this workspace, keep everything on-brand and short.",
+		"workspace.memory":              "- Brand voice: confident, warm, never salesy.\n- Primary audience: existing customers.",
+		"workspace.notes.recent":        "- Draft hero copy approved.\n- Waiting on final image assets.",
+		"workspace.tools":               "filesystem, web_search, notes",
+		"agent.name":                    "Brand Copywriter",
+		"agent.role":                    "Voice keeper",
+		"agent.description":             "Owns tone and consistency across all copy.",
+		"task.goal":                     "Write three launch-day social posts.",
+		"runtime.date":                  time.Now().Format("January 2, 2006"),
+	}
 }
 
 // placeholderRe matches a `{{ name }}` token, capturing the (trimmed) name.

--- a/internal/promptvars/promptvars_test.go
+++ b/internal/promptvars/promptvars_test.go
@@ -82,3 +82,25 @@ func TestResolve_NoWorkspaceGraceful(t *testing.T) {
 		t.Fatalf("empty blocks should omit their headers, got:\n%s", out)
 	}
 }
+
+func TestVocabularyAndSampleValues(t *testing.T) {
+	vocab := Vocabulary()
+	if len(vocab) != 11 {
+		t.Fatalf("expected 11 vocabulary entries, got %d", len(vocab))
+	}
+	for _, sp := range vocab {
+		if sp.Name == "" || sp.Description == "" {
+			t.Errorf("vocabulary entry missing name/description: %+v", sp)
+		}
+		if !Known(sp.Name) {
+			t.Errorf("Vocabulary returned unknown name %q", sp.Name)
+		}
+	}
+	// Every vocabulary variable has a sample value so previews never leave a
+	// literal token behind.
+	sample := SampleValues()
+	out := Resolve("{{workspace.name}} {{workspace.memory}} {{agent.role}} {{task.goal}} {{runtime.date}}", sample)
+	if strings.Contains(out, "{{") {
+		t.Errorf("sample values should resolve every variable, got: %s", out)
+	}
+}

--- a/internal/server/prompt_variables_routes.go
+++ b/internal/server/prompt_variables_routes.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/promptvars"
+)
+
+// handlePromptVariablesList serves GET /api/prompt-variables: the closed prompt
+// variable vocabulary in author-facing order, for the template authoring UI's
+// variable inserter / reference (PRD FR27).
+func (s *Server) handlePromptVariablesList(w http.ResponseWriter, r *http.Request) {
+	type variable struct {
+		Name        string `json:"name"`
+		Kind        string `json:"kind"`
+		Fenced      bool   `json:"fenced"`
+		Description string `json:"description"`
+	}
+	specs := promptvars.Vocabulary()
+	out := make([]variable, 0, len(specs))
+	for _, sp := range specs {
+		kind := "scalar"
+		if sp.Kind == promptvars.Block {
+			kind = "block"
+		}
+		out = append(out, variable{Name: sp.Name, Kind: kind, Fenced: sp.Fenced, Description: sp.Description})
+	}
+	_ = orihttp.RespondSuccess(w, map[string]any{"variables": out})
+}
+
+// handlePromptVariablesPreview serves POST /api/prompt-variables/preview: resolve
+// a prompt against a deterministic synthetic sample workspace so authors can see
+// what a variable-bearing prompt produces (PRD FR27/FR28).
+//
+// Preview safety: values are synthetic (no real workspace data, no vault secrets),
+// resolution reuses the same fences/self-omission as runtime, and the resolved
+// body is never written to application logs.
+func (s *Server) handlePromptVariablesPreview(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Prompt string `json:"prompt"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	unknown := promptvars.Unknown(req.Prompt)
+	if len(unknown) > 0 {
+		_ = orihttp.RespondBadRequest(w, "unknown prompt variable {{"+unknown[0]+"}} — only the documented variables are allowed")
+		return
+	}
+
+	resolved := promptvars.Resolve(req.Prompt, promptvars.SampleValues())
+	_ = orihttp.RespondSuccess(w, map[string]any{
+		"had_variables": promptvars.HasVariables(req.Prompt),
+		"resolved":      resolved,
+		"sample_source": "synthetic", // no real workspace was used
+		"note":          strings.TrimSpace("Preview uses a synthetic sample workspace; live runtime uses the real workspace's data and adds context at run time."),
+	})
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -679,6 +679,10 @@ func registerSessionRoutes(mux *http.ServeMux, s *Server) {
 			s.Handlers.TemplateOnboarding.RegisterRoutes(mux)
 		}
 
+		// Closed prompt-variable vocabulary + preview (template authoring UI)
+		mux.HandleFunc("GET /api/prompt-variables", s.handlePromptVariablesList)
+		mux.HandleFunc("POST /api/prompt-variables/preview", s.handlePromptVariablesPreview)
+
 		// Project template library (used by the workspace creation flow)
 		mux.HandleFunc("/api/project-templates", s.handleProjectTemplates)
 		mux.HandleFunc("POST /api/project-templates", s.handleProjectTemplateCreate)

--- a/internal/web/static/css/templates.css
+++ b/internal/web/static/css/templates.css
@@ -305,6 +305,71 @@
   grid-template-columns: 1fr 1fr;
 }
 
+#templatesPage .tpl-prompt-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#templatesPage .tpl-prompt-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+#templatesPage .tpl-prompt-toolbar-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+#templatesPage .tpl-prompt-var-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+#templatesPage .tpl-prompt-var-chip {
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-family: var(--font-mono, monospace);
+  color: #5b21b6;
+  background: #ede9fe;
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  cursor: pointer;
+}
+
+#templatesPage .tpl-prompt-var-chip:hover {
+  border-color: rgba(124, 58, 237, 0.55);
+}
+
+#templatesPage .tpl-prompt-preview-btn {
+  margin-left: auto;
+}
+
+#templatesPage .tpl-prompt-preview-panel {
+  margin: 0;
+  padding: 10px;
+  border-radius: 8px;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow: auto;
+  color: var(--text-secondary);
+  background: var(--surface-muted, rgba(148, 163, 184, 0.12));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+[data-bs-theme="dark"] #templatesPage .tpl-prompt-var-chip {
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.18);
+  border-color: rgba(139, 92, 246, 0.35);
+}
+
 #templatesPage .tpl-agent-reuse-hint {
   margin-top: 4px;
   font-size: 11px;

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -1357,7 +1357,7 @@ async function tplToolsSave() {
 const TPL_AGENT_ROLES = ['', 'orchestrator', 'specialist', 'researcher', 'analyzer', 'synthesizer', 'validator', 'general'];
 const TPL_AGENT_TYPES = ['', 'tool-calling', 'general', 'research'];
 
-const tplAgents = { templateId: '', dragIndex: -1, existingNames: [], existingLoaded: false };
+const tplAgents = { templateId: '', dragIndex: -1, existingNames: [], existingLoaded: false, promptVars: [], promptVarsLoaded: false };
 
 function tplAgentsBlank() {
   return { name: '', role: '', type: '', model: '', system_prompt: '', tools: { skills: [], mcp_servers: [] } };
@@ -1514,6 +1514,106 @@ function tplAgentsNameMatchesExisting(value) {
   return (tplAgents.existingNames || []).some((n) => String(n).toLowerCase() === v);
 }
 
+// tplAgentsEnsurePromptVars lazily loads the closed prompt-variable vocabulary
+// once, for the inserter chips (PRD FR27). Non-fatal: on failure the inserter
+// simply offers no chips.
+async function tplAgentsEnsurePromptVars() {
+  if (tplAgents.promptVarsLoaded) return tplAgents.promptVars;
+  tplAgents.promptVarsLoaded = true;
+  try {
+    const res = await fetch('/api/prompt-variables');
+    const data = await res.json().catch(() => ({}));
+    tplAgents.promptVars = Array.isArray(data.variables) ? data.variables : [];
+  } catch {
+    tplAgents.promptVars = [];
+  }
+  return tplAgents.promptVars;
+}
+
+// tplInsertAtCursor inserts text at the textarea's caret (or end), keeps focus,
+// and fires an input event so any dependent state updates.
+function tplInsertAtCursor(textarea, text) {
+  const start = Number.isInteger(textarea.selectionStart) ? textarea.selectionStart : textarea.value.length;
+  const end = Number.isInteger(textarea.selectionEnd) ? textarea.selectionEnd : textarea.value.length;
+  textarea.value = textarea.value.slice(0, start) + text + textarea.value.slice(end);
+  const pos = start + text.length;
+  textarea.selectionStart = pos;
+  textarea.selectionEnd = pos;
+  textarea.focus();
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// tplAgentsPromptTools wraps a system-prompt textarea with a variable inserter
+// (clickable vocabulary chips) and a live resolved-prompt preview against a
+// synthetic sample workspace (PRD FR27/FR28).
+function tplAgentsPromptTools(textarea) {
+  const wrap = document.createElement('div');
+  wrap.className = 'tpl-prompt-tools';
+  wrap.appendChild(textarea);
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'tpl-prompt-toolbar';
+
+  const label = document.createElement('span');
+  label.className = 'tpl-prompt-toolbar-label';
+  label.textContent = 'Insert:';
+  toolbar.appendChild(label);
+
+  const chips = document.createElement('span');
+  chips.className = 'tpl-prompt-var-chips';
+  toolbar.appendChild(chips);
+
+  const previewBtn = document.createElement('button');
+  previewBtn.type = 'button';
+  previewBtn.className = 'btn btn-sm btn-outline-secondary tpl-prompt-preview-btn';
+  previewBtn.textContent = 'Preview';
+  toolbar.appendChild(previewBtn);
+  wrap.appendChild(toolbar);
+
+  const panel = document.createElement('pre');
+  panel.className = 'tpl-prompt-preview-panel';
+  panel.hidden = true;
+  wrap.appendChild(panel);
+
+  tplAgentsEnsurePromptVars().then((vars) => {
+    chips.innerHTML = '';
+    vars.forEach((v) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'tpl-prompt-var-chip';
+      chip.textContent = v.name;
+      chip.title = v.description || v.name;
+      chip.addEventListener('click', () => tplInsertAtCursor(textarea, `{{${v.name}}}`));
+      chips.appendChild(chip);
+    });
+  });
+
+  previewBtn.addEventListener('click', async () => {
+    panel.hidden = false;
+    panel.textContent = 'Resolving preview…';
+    try {
+      const res = await fetch('/api/prompt-variables/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: textarea.value }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        panel.textContent = data.message || data.error || 'Preview failed.';
+        return;
+      }
+      const header = data.had_variables
+        ? '# Preview — synthetic sample workspace\n(Live runtime uses the real workspace and adds context automatically.)\n\n'
+        : '# Preview — this prompt has no variables\n\n';
+      panel.textContent = header + (data.resolved || '');
+    } catch {
+      panel.textContent = 'Preview failed.';
+    }
+  });
+
+  return wrap;
+}
+
 function tplAgentsCard(agent, index) {
   const readOnly = Boolean(tplSelected() && tplSelected().builtin);
   const card = document.createElement('div');
@@ -1627,8 +1727,8 @@ function tplAgentsCard(agent, index) {
     prompt.className = 'form-control tpl-agent-prompt';
     prompt.rows = 2;
     prompt.value = agent.system_prompt || '';
-    prompt.placeholder = "This agent's instructions";
-    form.appendChild(tplAgentsField('System prompt', prompt));
+    prompt.placeholder = "This agent's instructions. Use {{variables}} to weave in workspace context.";
+    form.appendChild(tplAgentsField('System prompt', tplAgentsPromptTools(prompt)));
 
     const sm = document.createElement('div');
     sm.className = 'tpl-agent-form-row';


### PR DESCRIPTION
Phase 3 (part B), completing the templated-variables work (part A = #168). Makes
the closed-vocabulary variable system discoverable in the /templates roster editor.

## Backend
- promptvars: per-variable Description, an ordered Vocabulary() for the authoring
  UI, and deterministic SampleValues() for preview.
- GET /api/prompt-variables — the closed vocabulary (name, kind, fenced,
  description) in author-facing order.
- POST /api/prompt-variables/preview — resolve a prompt against a synthetic
  sample workspace. Injection/secret-safe: synthetic values only, same fences as
  runtime, resolved body never logged; unknown variables -> 400.

## Frontend (roster editor)
- Each system-prompt field gains a variable inserter: clickable vocabulary chips
  that insert {{name}} at the caret, titled with each variable's description.
- A Preview button resolves the current prompt against the sample workspace and
  shows the composed result (block vars self-frame + fence, exactly as runtime).

## Testing
- Vocabulary/SampleValues resolve-all unit test. Endpoints smoke-verified (11
  vars; preview resolves with block self-framing + fencing). Visual browser check
  skipped (extension disconnected); JS is eslint-clean and reuses the existing
  roster-editor DOM patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)