### PR TITLE
feat(prompt): variables in task execution + notes/tools value-gathering

### DIFF
--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -1080,7 +1080,7 @@ func (h *Handler) ChatHandler(w http.ResponseWriter, r *http.Request) {
 	// Resolve any closed-vocabulary variables in the agent's base prompt. When it
 	// used variables, the author placed context explicitly, so the generic
 	// workspace-context layer is suppressed (PRD FR24).
-	basePromptHasVars := h.resolveAgentBasePromptVars(normalizedRouteContext, ag)
+	basePromptHasVars := h.resolveAgentBasePromptVars(ctx, normalizedRouteContext, ag)
 	toolRuntimeSystemPrompt := ""
 	if !basePromptHasVars {
 		toolRuntimeSystemPrompt = h.buildRuntimeSystemPrompt(ctx, normalizedRouteContext)

--- a/internal/chathttp/workspace_context_prompt.go
+++ b/internal/chathttp/workspace_context_prompt.go
@@ -67,7 +67,7 @@ func (h *Handler) buildRuntimeSystemPromptForToolCapability(ctx context.Context,
 // clone, so this never touches the stored definition). It returns true when the
 // base prompt contained variables — in which case the author has placed context
 // explicitly and the generic workspace-context layer is suppressed (PRD FR24).
-func (h *Handler) resolveAgentBasePromptVars(routeCtx normalizedChatRouteContext, ag *resolvedChatAgent) bool {
+func (h *Handler) resolveAgentBasePromptVars(ctx context.Context, routeCtx normalizedChatRouteContext, ag *resolvedChatAgent) bool {
 	if h == nil || ag == nil || ag.Agent == nil {
 		return false
 	}
@@ -89,11 +89,38 @@ func (h *Handler) resolveAgentBasePromptVars(routeCtx normalizedChatRouteContext
 		}
 	}
 
+	// Fetch notes / tools only when the prompt actually uses those variables, to
+	// avoid a note-store query on every variable-bearing prompt.
+	notes := ""
+	if h.sessionStore != nil && strings.Contains(prompt, "workspace.notes.recent") && strings.TrimSpace(routeCtx.WorkspaceID) != "" {
+		if items, err := h.sessionStore.ListNotesByWorkspace(ctx, routeCtx.WorkspaceID); err == nil {
+			lines := make([]string, 0, len(items))
+			for _, n := range limitWorkspaceNotes(items, workspaceSnapshotMaxNotes) {
+				line := "- " + strings.TrimSpace(n.Name)
+				if p := strings.TrimSpace(n.Preview); p != "" {
+					line += " — " + p
+				}
+				lines = append(lines, line)
+			}
+			notes = strings.Join(lines, "\n")
+		}
+	}
+	tools := ""
+	if strings.Contains(prompt, "workspace.tools") {
+		skillNames := make([]string, 0, len(ag.EffectiveSkills))
+		for _, s := range ag.EffectiveSkills {
+			skillNames = append(skillNames, s.Name)
+		}
+		tools = workspace.FormatToolNames(skillNames, ag.MCPServers)
+	}
+
 	resolved, hadVars := workspace.ResolveAgentBasePrompt(prompt, workspace.PromptVarInputs{
-		Workspace: ws,
-		Instance:  inst,
-		AgentName: routeCtx.AgentName,
-		Memory:    memory,
+		Workspace:   ws,
+		Instance:    inst,
+		AgentName:   routeCtx.AgentName,
+		Memory:      memory,
+		NotesRecent: notes,
+		Tools:       tools,
 	})
 	if hadVars {
 		ag.Agent.Settings.SystemPrompt = resolved

--- a/internal/chathttp/workspace_context_prompt_test.go
+++ b/internal/chathttp/workspace_context_prompt_test.go
@@ -244,7 +244,7 @@ func TestResolveAgentBasePromptVars(t *testing.T) {
 	ag := &resolvedChatAgent{Agent: &agent.Agent{Settings: types.Settings{
 		SystemPrompt: "You serve {{workspace.name}} ({{workspace.description}}). {{workspace.custom_instructions}}",
 	}}}
-	if !h.resolveAgentBasePromptVars(routeCtx, ag) {
+	if !h.resolveAgentBasePromptVars(context.Background(), routeCtx, ag) {
 		t.Fatal("expected hadVars=true for variable-bearing prompt")
 	}
 	got := ag.Agent.Settings.SystemPrompt
@@ -259,7 +259,7 @@ func TestResolveAgentBasePromptVars(t *testing.T) {
 
 	// Plain base prompt: unchanged, hadVars=false.
 	plain := &resolvedChatAgent{Agent: &agent.Agent{Settings: types.Settings{SystemPrompt: "Plain prompt."}}}
-	if h.resolveAgentBasePromptVars(routeCtx, plain) {
+	if h.resolveAgentBasePromptVars(context.Background(), routeCtx, plain) {
 		t.Error("expected hadVars=false for plain prompt")
 	}
 	if plain.Agent.Settings.SystemPrompt != "Plain prompt." {

--- a/internal/workspace/agent_prompt_vars.go
+++ b/internal/workspace/agent_prompt_vars.go
@@ -41,6 +41,28 @@ func BuildPromptVarValues(in PromptVarInputs) map[string]string {
 	return values
 }
 
+// FormatToolNames renders a compact, de-duplicated, comma-separated list of the
+// agent's effective tool/skill names for the workspace.tools variable.
+func FormatToolNames(skillNames, mcpNames []string) string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(skillNames)+len(mcpNames))
+	for _, group := range [][]string{skillNames, mcpNames} {
+		for _, n := range group {
+			n = strings.TrimSpace(n)
+			if n == "" {
+				continue
+			}
+			key := strings.ToLower(n)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, n)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
 // ResolveAgentBasePrompt resolves the closed prompt variables in prompt using
 // inputs. When prompt contains no variables it is returned unchanged with
 // hadVars=false, letting callers decide whether to suppress the generic

--- a/internal/workspace/agent_prompt_vars_test.go
+++ b/internal/workspace/agent_prompt_vars_test.go
@@ -38,3 +38,14 @@ func TestResolveAgentBasePrompt(t *testing.T) {
 		t.Errorf("empty block should self-omit, got %q", out)
 	}
 }
+
+func TestFormatToolNames(t *testing.T) {
+	// De-dupes (case-insensitive), trims, drops blanks, preserves order.
+	got := FormatToolNames([]string{"web_search", " notes ", "Web_Search"}, []string{"filesystem", "", "notes"})
+	if got != "web_search, notes, filesystem" {
+		t.Fatalf("FormatToolNames = %q", got)
+	}
+	if FormatToolNames(nil, nil) != "" {
+		t.Errorf("empty inputs should yield empty string")
+	}
+}

--- a/internal/workspace/task_agent_base_prompt_test.go
+++ b/internal/workspace/task_agent_base_prompt_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestResolveTaskAgentBasePrompt(t *testing.T) {
 	varsAgent := &resolvedTaskAgent{Agent: &agent.Agent{Settings: types.Settings{
 		SystemPrompt: "You are {{agent.role}} for {{workspace.name}}. Goal: {{task.goal}}",
 	}}}
-	resolved, hadVars := h.resolveTaskAgentBasePrompt(varsAgent, "Copywriter", task)
+	resolved, hadVars := h.resolveTaskAgentBasePrompt(context.Background(), varsAgent, "Copywriter", task)
 	if !hadVars {
 		t.Fatal("expected hadVars=true")
 	}
@@ -38,7 +39,7 @@ func TestResolveTaskAgentBasePrompt(t *testing.T) {
 
 	// Plain base prompt: hadVars=false, so task behavior is left unchanged.
 	plainAgent := &resolvedTaskAgent{Agent: &agent.Agent{Settings: types.Settings{SystemPrompt: "Plain persona."}}}
-	if _, hadVars := h.resolveTaskAgentBasePrompt(plainAgent, "Copywriter", task); hadVars {
+	if _, hadVars := h.resolveTaskAgentBasePrompt(context.Background(), plainAgent, "Copywriter", task); hadVars {
 		t.Error("expected hadVars=false for plain prompt (no task-behavior change)")
 	}
 }

--- a/internal/workspace/task_agent_base_prompt_test.go
+++ b/internal/workspace/task_agent_base_prompt_test.go
@@ -1,0 +1,44 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+func TestResolveTaskAgentBasePrompt(t *testing.T) {
+	ws := &Workspace{
+		ID:   "w1",
+		Name: "Acme Campaign",
+		AgentInstances: []AgentInstance{
+			{ID: "i1", Name: "Copywriter", EntryPoint: true, Role: "Voice keeper"},
+		},
+	}
+	h := &LLMTaskHandler{workspaceStore: newTestWorkspaceStore(t, ws)}
+	task := Task{WorkspaceID: "w1", Description: "Write three launch posts."}
+
+	// Variable-bearing base prompt resolves, reports hadVars=true.
+	varsAgent := &resolvedTaskAgent{Agent: &agent.Agent{Settings: types.Settings{
+		SystemPrompt: "You are {{agent.role}} for {{workspace.name}}. Goal: {{task.goal}}",
+	}}}
+	resolved, hadVars := h.resolveTaskAgentBasePrompt(varsAgent, "Copywriter", task)
+	if !hadVars {
+		t.Fatal("expected hadVars=true")
+	}
+	for _, want := range []string{"Voice keeper", "Acme Campaign", "Write three launch posts."} {
+		if !strings.Contains(resolved, want) {
+			t.Errorf("resolved task base prompt missing %q in:\n%s", want, resolved)
+		}
+	}
+	if strings.Contains(resolved, "{{") {
+		t.Errorf("no token should survive: %s", resolved)
+	}
+
+	// Plain base prompt: hadVars=false, so task behavior is left unchanged.
+	plainAgent := &resolvedTaskAgent{Agent: &agent.Agent{Settings: types.Settings{SystemPrompt: "Plain persona."}}}
+	if _, hadVars := h.resolveTaskAgentBasePrompt(plainAgent, "Copywriter", task); hadVars {
+		t.Error("expected hadVars=false for plain prompt (no task-behavior change)")
+	}
+}

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -252,9 +252,18 @@ func (h *LLMTaskHandler) runTaskOnProvider(ctx context.Context, providerName, re
 	compactPrompt := provider.Type() == llm.ProviderTypeLocal
 	taskSystemPrompt := h.buildTaskSystemPrompt(compactPrompt)
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
-	// Layer the workspace owner's per-instance refinement of this agent onto the
-	// task prompt so refinement reaches the task path too (PRD FR15/FR16/FR19).
-	taskSystemPrompt = AppendAgentRefinement(taskSystemPrompt, h.workspaceStore, task.WorkspaceID, agentName)
+	if resolvedBase, hadVars := h.resolveTaskAgentBasePrompt(ag, agentName, task); hadVars {
+		// The author wrote a variable-bearing base prompt, so a parametric persona
+		// is meant to apply here too: lead the task prompt with the resolved
+		// persona. The author placed context via variables, so the generic
+		// refinement layer is not also appended (mirrors chat FR24).
+		taskSystemPrompt = resolvedBase + "\n\n---\n" + taskSystemPrompt
+	} else {
+		// Plain prompt: task behavior is unchanged (the base persona is not
+		// injected), but the workspace owner's per-instance refinement still
+		// reaches the task path (PRD FR15/FR16/FR19).
+		taskSystemPrompt = AppendAgentRefinement(taskSystemPrompt, h.workspaceStore, task.WorkspaceID, agentName)
+	}
 	h.reportPromptTier(task, agentName, compactPrompt)
 
 	// Convert agent tools (MCP + workspace) to LLM format. Needed before budgeting

--- a/internal/workspace/task_handler.go
+++ b/internal/workspace/task_handler.go
@@ -252,7 +252,7 @@ func (h *LLMTaskHandler) runTaskOnProvider(ctx context.Context, providerName, re
 	compactPrompt := provider.Type() == llm.ProviderTypeLocal
 	taskSystemPrompt := h.buildTaskSystemPrompt(compactPrompt)
 	taskSystemPrompt = AppendSkillPromptsFromResolved(taskSystemPrompt, ag.EffectiveSkills)
-	if resolvedBase, hadVars := h.resolveTaskAgentBasePrompt(ag, agentName, task); hadVars {
+	if resolvedBase, hadVars := h.resolveTaskAgentBasePrompt(ctx, ag, agentName, task); hadVars {
 		// The author wrote a variable-bearing base prompt, so a parametric persona
 		// is meant to apply here too: lead the task prompt with the resolved
 		// persona. The author placed context via variables, so the generic

--- a/internal/workspace/task_prompt_context.go
+++ b/internal/workspace/task_prompt_context.go
@@ -111,7 +111,7 @@ func (h *LLMTaskHandler) buildTaskSystemPrompt(compact bool) string {
 // author used variables they clearly intend a parametric persona to apply, so we
 // resolve it and let the caller lead the task prompt with it (PRD FR24). Returns
 // hadVars=false (and "") for plain prompts, leaving task behavior untouched.
-func (h *LLMTaskHandler) resolveTaskAgentBasePrompt(ag *resolvedTaskAgent, agentName string, task Task) (string, bool) {
+func (h *LLMTaskHandler) resolveTaskAgentBasePrompt(ctx context.Context, ag *resolvedTaskAgent, agentName string, task Task) (string, bool) {
 	if h == nil || ag == nil || ag.Agent == nil {
 		return "", false
 	}
@@ -133,12 +133,38 @@ func (h *LLMTaskHandler) resolveTaskAgentBasePrompt(ag *resolvedTaskAgent, agent
 		}
 	}
 
+	// Fetch notes / tools only when the prompt actually uses those variables.
+	notes := ""
+	if h.contextStore != nil && strings.Contains(prompt, "workspace.notes.recent") && strings.TrimSpace(task.WorkspaceID) != "" {
+		if items, err := h.contextStore.ListNotesByWorkspace(ctx, task.WorkspaceID); err == nil {
+			lines := make([]string, 0, len(items))
+			for _, n := range limitTaskPromptNotes(items, taskPromptMaxNotes) {
+				line := "- " + strings.TrimSpace(n.Name)
+				if p := strings.TrimSpace(n.Preview); p != "" {
+					line += " — " + p
+				}
+				lines = append(lines, line)
+			}
+			notes = strings.Join(lines, "\n")
+		}
+	}
+	tools := ""
+	if strings.Contains(prompt, "workspace.tools") {
+		skillNames := make([]string, 0, len(ag.EffectiveSkills))
+		for _, s := range ag.EffectiveSkills {
+			skillNames = append(skillNames, s.Name)
+		}
+		tools = FormatToolNames(skillNames, ag.MCPServers)
+	}
+
 	return ResolveAgentBasePrompt(prompt, PromptVarInputs{
-		Workspace: ws,
-		Instance:  inst,
-		AgentName: agentName,
-		Memory:    memory,
-		TaskGoal:  task.Description,
+		Workspace:   ws,
+		Instance:    inst,
+		AgentName:   agentName,
+		Memory:      memory,
+		NotesRecent: notes,
+		Tools:       tools,
+		TaskGoal:    task.Description,
 	})
 }
 

--- a/internal/workspace/task_prompt_context.go
+++ b/internal/workspace/task_prompt_context.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/promptvars"
 	"github.com/johnjallday/ori-agent/internal/userprofile"
 )
 
@@ -103,6 +104,44 @@ func (h *LLMTaskHandler) buildTaskSystemPrompt(compact bool) string {
 // prompt. Memory tools are available during task execution, so tool guidance is
 // included. Returns "" when the store can't resolve a folder path (e.g. a
 // non-folder store) or memory is empty and there's nothing to guide.
+// resolveTaskAgentBasePrompt resolves the closed prompt-variable vocabulary in
+// the task agent's base system prompt, but ONLY when it actually uses variables
+// (opt-in): the task path otherwise ignores an agent's base prompt, so injecting
+// it unconditionally would change behavior for every existing agent. When the
+// author used variables they clearly intend a parametric persona to apply, so we
+// resolve it and let the caller lead the task prompt with it (PRD FR24). Returns
+// hadVars=false (and "") for plain prompts, leaving task behavior untouched.
+func (h *LLMTaskHandler) resolveTaskAgentBasePrompt(ag *resolvedTaskAgent, agentName string, task Task) (string, bool) {
+	if h == nil || ag == nil || ag.Agent == nil {
+		return "", false
+	}
+	prompt := ag.Settings.SystemPrompt
+	if !promptvars.HasVariables(prompt) {
+		return "", false
+	}
+
+	var ws *Workspace
+	if h.workspaceStore != nil && strings.TrimSpace(task.WorkspaceID) != "" {
+		ws, _ = h.workspaceStore.Get(task.WorkspaceID)
+	}
+	inst, _ := AgentInstanceByName(ws, agentName)
+
+	memory := ""
+	if resolver, ok := h.workspaceStore.(workspaceFolderStore); ok && strings.TrimSpace(task.WorkspaceID) != "" {
+		if raw, err := NewMemoryStore(resolver).ReadRaw(task.WorkspaceID); err == nil {
+			memory = raw
+		}
+	}
+
+	return ResolveAgentBasePrompt(prompt, PromptVarInputs{
+		Workspace: ws,
+		Instance:  inst,
+		AgentName: agentName,
+		Memory:    memory,
+		TaskGoal:  task.Description,
+	})
+}
+
 func (h *LLMTaskHandler) buildTaskMemorySection(task Task) string {
 	if h.workspaceStore == nil || strings.TrimSpace(task.WorkspaceID) == "" {
 		return ""


### PR DESCRIPTION
Two follow-ups closing the honest loose ends from the templated-prompts epic.

## Templated variables in task execution (opt-in)
The task path ignored an agent's base system prompt entirely, so template
variables in it never reached task runs. Now — ONLY when the base prompt uses
{{variables}} (opt-in, so existing plain-prompt agents are unaffected) — the task
path resolves it and leads the task prompt with the resolved persona. Mirrors
chat FR24: a variable-bearing prompt suppresses the generic refinement layer; a
plain prompt keeps current behavior and still gets per-instance refinement.

## notes.recent + tools value-gathering
The two block variables that previously always self-omitted now populate, but
only when a prompt actually references them (checked before any fetch):
- workspace.notes.recent — recent workspace notes ("- Name — Preview"); chat via
  sessionStore, task via contextStore.
- workspace.tools — the agent's effective tools (enabled skills + reachable MCP
  servers) via shared FormatToolNames.

## Not done: 4.0b (composer unification)
Inspection showed the chat/task context builders are intentionally divergent
(different note/session types, stores, formats, limits, sanitizers), so merging
them would change prompt content — not a safe no-value refactor. Deliberately
skipped; the duplication is the cost of two distinct context surfaces.

## Testing
- resolveTaskAgentBasePrompt (resolve + opt-in flag); FormatToolNames;
  ResolveAgentBasePrompt; chat/task resolvers build. All touched-package tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)