### PR TITLE
feat(map): delete, multi-select, and description in the Map view Overview

### DIFF
--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -211,6 +211,56 @@
   position: absolute; top: 30px; left: 50%; transform: translateX(-50%); z-index: 4; font-size: 13px; color: #04110c;
   text-shadow: 0 0 3px var(--ws-keeper); pointer-events: none;
 }
+
+/* Multi-select checkbox — subtle until the tile is hovered/focused or checked,
+   so it doesn't compete with the tile's status flag and crest at rest. */
+.ws-map-tile-check {
+  position: absolute; top: -2px; left: 20px; z-index: 6; width: 15px; height: 15px; box-sizing: border-box;
+  border: 1.5px solid var(--ws-line-bright); background: rgba(12, 13, 16, 0.9); cursor: pointer;
+  opacity: 0; transition: opacity 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+  clip-path: polygon(3px 0, 100% 0, 100% calc(100% - 3px), calc(100% - 3px) 100%, 0 100%, 0 3px);
+}
+.ws-map-tile:hover .ws-map-tile-check,
+.ws-map-tile:focus-visible .ws-map-tile-check,
+.ws-map-tile-check[aria-checked="true"] { opacity: 1; }
+.ws-map-tile-check[aria-checked="true"] {
+  background: var(--ws-faction); border-color: var(--ws-faction);
+}
+.ws-map-tile-check[aria-checked="true"]::after {
+  content: "✓"; position: absolute; inset: 0; display: grid; place-items: center;
+  font-size: 11px; font-weight: 700; line-height: 1; color: #04110c;
+}
+.ws-map-tile.is-multi .ws-map-struct { filter: drop-shadow(0 0 10px rgba(70, 211, 154, 0.55)); }
+.ws-map-tile.is-multi::after {
+  content: ""; position: absolute; top: 46px; left: 50%; width: 120px; height: 60px; transform: translate(-50%, -50%);
+  border: 1.5px dashed var(--ws-faction); border-radius: 50% / 40%; opacity: 0.8; pointer-events: none;
+}
+
+/* Contextual multi-select action bar — pinned to the bottom-center of the
+   viewport (like a mail client's selection bar) so it stays reachable no matter
+   how far the map has scrolled. */
+.ws-map-selbar {
+  position: fixed; left: 50%; bottom: 24px; transform: translateX(-50%); z-index: 1200;
+  display: flex; align-items: center; gap: 16px; padding: 9px 10px 9px 16px;
+  background: rgba(18, 19, 23, 0.96); border: 1px solid var(--ws-line-bright);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+}
+.ws-map-selbar[hidden] { display: none; }
+.ws-map-selbar-count {
+  font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #e3e6ea;
+}
+.ws-map-selbar-actions { display: flex; gap: 8px; }
+.ws-map-selbar-del, .ws-map-selbar-clear {
+  padding: 7px 13px; cursor: pointer; font-family: var(--ws-font-display); font-size: 11px;
+  letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
+  clip-path: polygon(7px 0, 100% 0, 100% calc(100% - 7px), calc(100% - 7px) 100%, 0 100%, 0 7px);
+}
+.ws-map-selbar-del { background: rgba(226, 96, 96, 0.1); border: 1px solid rgba(226, 96, 96, 0.45); color: #e78a8a; }
+.ws-map-selbar-del:hover { background: #c0392b; border-color: #c0392b; color: #fff; }
+.ws-map-selbar-clear { background: transparent; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
+.ws-map-selbar-clear:hover { border-color: var(--ws-faction); color: var(--ws-faction); }
+.ws-map-selbar-del:focus-visible, .ws-map-selbar-clear:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 .ws-map-tile-name {
   margin-top: 2px; font-size: 12.5px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #eef0f3;
   text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9); max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -324,6 +324,18 @@
 .ws-map-ov-open:hover { background: var(--ws-faction); color: #04110c; }
 .ws-map-ov-open:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
 
+/* Destructive action sits at the bottom of the panel, visually separated from
+   the read-only stats above it and de-emphasized versus the primary Open. */
+.ws-map-ov-actions { margin-top: 16px; display: flex; justify-content: flex-end; }
+.ws-map-ov-delete {
+  padding: 8px 14px; cursor: pointer;
+  background: rgba(226, 96, 96, 0.08); border: 1px solid rgba(226, 96, 96, 0.4); color: #e78a8a;
+  font-family: var(--ws-font-display); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
+  clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
+}
+.ws-map-ov-delete:hover { background: #c0392b; border-color: #c0392b; color: #fff; }
+.ws-map-ov-delete:focus-visible { outline: 2px solid #e78a8a; outline-offset: 2px; }
+
 @media (max-width: 900px) {
   .ws-map-layout { grid-template-columns: 1fr; }
 

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -336,6 +336,14 @@
 .ws-map-ov-name { font-size: 17px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #f3f5f8; }
 .ws-map-ov-tag { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 3px; }
 
+/* Workspace description — sits just under the hero. Clamped so a long blurb
+   doesn't push the roster/stats out of view; the full text is on hover. */
+.ws-map-ov-desc {
+  margin: 12px 0 0; font-size: 12.5px; line-height: 1.5; color: var(--ws-ink-dim);
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; line-clamp: 3; overflow: hidden;
+}
+.ws-map-ov-desc.is-empty { font-style: italic; color: var(--ws-ink-faint); }
+
 .ws-map-ov-label {
   font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint);
   margin: 14px 0 8px;

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -4607,6 +4607,10 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   window.WorkspaceHub = window.WorkspaceHub || {};
   window.WorkspaceHub.loadWorkspaces = loadWorkspaces;
+  // Single-item delete entry point reused by the Map view's Overview panel. It
+  // routes groups to the confirmed group-delete modal and plain workspaces to
+  // the trash confirm, then reloads (which re-mounts the map).
+  window.WorkspaceHub.deleteWorkspace = confirmDeleteWorkspace;
   window.WorkspaceHub.__test = {
     getLauncherCardDropIntent,
     getLauncherTreeDropIntent,

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -3390,6 +3390,15 @@ console.log('[workspace-hub.js] FILE LOADED');
     // Top-level ids only: a checked group is deleted as one branch, so its
     // selected descendants are deduped under it instead of deleted separately.
     const selected = getTopLevelSelectedIds();
+    await confirmAndDeleteWorkspaces(selected);
+  }
+
+  // Confirm-then-delete a batch of workspace ids. Shared by the launcher's
+  // "delete selected" toolbar and the Map view's multi-select action bar. A
+  // single id defers to the per-item confirm (which handles group modals); two
+  // or more show a batch confirm before moving everything to Trash.
+  async function confirmAndDeleteWorkspaces(ids) {
+    const selected = (Array.isArray(ids) ? ids : []).filter(Boolean);
     if (selected.length === 0) return;
 
     if (selected.length === 1) {
@@ -4611,6 +4620,9 @@ console.log('[workspace-hub.js] FILE LOADED');
   // routes groups to the confirmed group-delete modal and plain workspaces to
   // the trash confirm, then reloads (which re-mounts the map).
   window.WorkspaceHub.deleteWorkspace = confirmDeleteWorkspace;
+  // Batch delete (confirm + Trash + Undo) reused by the Map view's multi-select
+  // action bar; also reloads on success, which re-mounts the map.
+  window.WorkspaceHub.deleteWorkspaces = confirmAndDeleteWorkspaces;
   window.WorkspaceHub.__test = {
     getLauncherCardDropIntent,
     getLauncherTreeDropIntent,

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -333,6 +333,7 @@
     var openTasks = Number(ws.open_task_count || 0);
     var mcp = Number(ws.mcp_count || 0);
     var skills = Number(ws.skill_count || 0);
+    var delLabel = isGroup(ws) ? 'Delete group' : 'Delete workspace';
 
     var keeper = entry
       ? '<div class="ws-map-ov-keeper">' + avatarHTML(entry, 'is-keeper') +
@@ -362,7 +363,11 @@
       '<div class="ws-map-ov-row"><span class="ws-map-ov-k">Tools · MCP</span>' +
       '<span class="ws-map-ov-v">' + mcp + '</span></div>' +
       '<div class="ws-map-ov-row"><span class="ws-map-ov-k">Skills</span>' +
-      '<span class="ws-map-ov-v">' + skills + '</span></div>'
+      '<span class="ws-map-ov-v">' + skills + '</span></div>' +
+      '<div class="ws-map-ov-actions">' +
+      '<button type="button" class="ws-map-ov-delete" data-ws-delete="' + escapeHtml(ws.id) +
+      '" aria-label="' + escapeHtml(delLabel + ' ' + (ws.name || '')) + '">✕ ' + escapeHtml(delLabel) + '</button>' +
+      '</div>'
     );
   }
 
@@ -465,11 +470,26 @@
     if (id) window.location.href = '/workspaces/' + encodeURIComponent(id);
   }
 
+  function deleteWorkspace(id) {
+    if (!id) return;
+    // Reuse the hub's single-item delete flow (confirm modal, group handling,
+    // Trash + Undo, toasts). It reloads on success, which re-mounts the map.
+    if (window.WorkspaceHub && typeof window.WorkspaceHub.deleteWorkspace === 'function') {
+      window.WorkspaceHub.deleteWorkspace(id);
+    }
+  }
+
   function bindOverviewActions(container) {
     var opens = container.querySelectorAll('[data-ws-open]');
     Array.prototype.forEach.call(opens, function (el) {
       el.addEventListener('click', function () {
         openWorkspace(el.getAttribute('data-ws-open'));
+      });
+    });
+    var deletes = container.querySelectorAll('[data-ws-delete]');
+    Array.prototype.forEach.call(deletes, function (el) {
+      el.addEventListener('click', function () {
+        deleteWorkspace(el.getAttribute('data-ws-delete'));
       });
     });
   }

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -20,6 +20,19 @@
   // Currently-selected workspace id, remembered across re-mounts (data refreshes).
   var selectedId = '';
 
+  // Ids checked for a bulk operation (multi-select), remembered across re-mounts.
+  // Distinct from selectedId: selectedId drives the Overview preview, while this
+  // set drives the multi-select action bar. Only plain workspace tiles (not
+  // group districts) can be multi-selected.
+  var multiSelected = Object.create(null);
+
+  function multiIds() {
+    return Object.keys(multiSelected);
+  }
+  function multiCount() {
+    return multiIds().length;
+  }
+
   // curated, distinct building palettes (picked by stable id hash)
   var PALETTE = [
     { key: '#4f9bf0', floor: '#0c2238', top: '#2a5da0', l: '#16365e', r: '#0e2748' }, // blue
@@ -224,6 +237,8 @@
     var hasKeeper = String(ws.entry_agent_name || '').trim() !== '';
     var isSel = selectedId && ws.id === selectedId;
     var selected = isSel ? ' is-selected' : '';
+    var isMulti = !!multiSelected[ws.id];
+    var multiCls = isMulti ? ' is-multi' : '';
     var left = PAD + tile.col * CELL_W;
     var top = PAD + tile.row * CELL_H;
     var meta = agents + (agents === 1 ? ' agent' : ' agents') + ' · ' +
@@ -234,12 +249,15 @@
     var actionHint = isSel ? '. Selected — activate to open' : '. Activate to select, double-click to open';
 
     return (
-      '<button type="button" class="ws-map-tile' + selected + '" ' +
+      '<button type="button" class="ws-map-tile' + selected + multiCls + '" ' +
       'data-ws-id="' + escapeHtml(ws.id) + '" ' +
       'aria-pressed="' + (isSel ? 'true' : 'false') + '" ' +
       'style="left:' + left + 'px;top:' + top + 'px;--i:' + (index || 0) + '" ' +
       'aria-label="' + escapeHtml(ws.name || 'Workspace') + ', ' + meta + ', ' + statusText +
       (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') + actionHint + '">' +
+      '<span class="ws-map-tile-check" data-ws-check role="checkbox" tabindex="-1" ' +
+      'aria-checked="' + (isMulti ? 'true' : 'false') + '" ' +
+      'aria-label="Select for bulk action" title="Select"></span>' +
       '<span class="ws-map-tile-flag"><span class="ws-map-led' + (active ? ' is-working' : '') + '"></span>' +
       escapeHtml(statusText) + '</span>' +
       (hasKeeper ? '<span class="ws-map-tile-crest" title="Entry agent (locked)">★</span>' : '') +
@@ -311,6 +329,22 @@
       '<span class="ws-map-pad-plate">＋</span><span class="ws-map-pad-label">New workspace</span></button>' +
       '<div class="ws-map-empty-note">No workspaces yet — build your first one.</div>' +
       '</div></div>'
+    );
+  }
+
+  // Contextual action bar for the multi-select set. Rendered inside the theatre
+  // and shown only while at least one tile is checked. Count text is refreshed
+  // in place by updateSelBar so toggling selection never re-mounts the map.
+  function selBarHTML() {
+    var n = multiCount();
+    return (
+      '<div class="ws-map-selbar" data-ws-selbar' + (n ? '' : ' hidden') + '>' +
+      '<span class="ws-map-selbar-count" data-ws-selbar-count>' + n + ' selected</span>' +
+      '<div class="ws-map-selbar-actions">' +
+      '<button type="button" class="ws-map-selbar-del" data-ws-selbar-delete>✕ Delete</button>' +
+      '<button type="button" class="ws-map-selbar-clear" data-ws-selbar-clear>Clear</button>' +
+      '</div>' +
+      '</div>'
     );
   }
 
@@ -399,6 +433,7 @@
       '<div class="ws-map-theatre-tag"><span class="ws-map-ix">MAP</span><h3>All Workspaces</h3></div>' +
       '<div class="ws-map-compass">N<b>▲</b></div>' +
       canvas +
+      selBarHTML() +
       '</section>' +
       '<aside class="ws-map-overview" role="region" aria-label="Workspace overview">' +
       '<div class="ws-map-overview-head"><div><span class="ws-map-ix">WS</span> <h3>Overview</h3></div></div>' +
@@ -510,15 +545,73 @@
     }
   }
 
+  // Refresh the multi-select action bar and per-tile checked state in place
+  // (no re-mount) to keep toggling flicker-free.
+  function updateSelBar(container) {
+    var n = multiCount();
+    var bar = container.querySelector('[data-ws-selbar]');
+    if (bar) {
+      bar.hidden = n === 0;
+      var count = bar.querySelector('[data-ws-selbar-count]');
+      if (count) count.textContent = n + ' selected';
+    }
+    var tiles = container.querySelectorAll('.ws-map-tile[data-ws-id]');
+    Array.prototype.forEach.call(tiles, function (el) {
+      var on = !!multiSelected[el.getAttribute('data-ws-id')];
+      el.classList.toggle('is-multi', on);
+      var check = el.querySelector('[data-ws-check]');
+      if (check) check.setAttribute('aria-checked', on ? 'true' : 'false');
+    });
+  }
+
+  function toggleMulti(container, id) {
+    if (!id) return;
+    if (multiSelected[id]) delete multiSelected[id];
+    else multiSelected[id] = true;
+    updateSelBar(container);
+  }
+
+  function clearMulti(container) {
+    multiSelected = Object.create(null);
+    updateSelBar(container);
+  }
+
+  function deleteMulti() {
+    var ids = multiIds();
+    if (!ids.length) return;
+    // Reuse the hub's batch delete (confirm + Trash + Undo). On success it
+    // reloads and re-mounts the map, where mount() prunes the deleted ids.
+    if (window.WorkspaceHub && typeof window.WorkspaceHub.deleteWorkspaces === 'function') {
+      window.WorkspaceHub.deleteWorkspaces(ids);
+    }
+  }
+
+  function bindSelBar(container) {
+    var del = container.querySelector('[data-ws-selbar-delete]');
+    if (del) del.addEventListener('click', function () { deleteMulti(); });
+    var clr = container.querySelector('[data-ws-selbar-clear]');
+    if (clr) clr.addEventListener('click', function () { clearMulti(container); });
+  }
+
   function bindTiles(container, workspaces) {
     var selectables = container.querySelectorAll(
       '.ws-map-tile[data-ws-id], .ws-map-district-tag[data-ws-id]'
     );
     Array.prototype.forEach.call(selectables, function (el) {
+      var isTile = el.classList.contains('ws-map-tile');
       // Single click selects; clicking (or Enter, which fires click on a
       // button) an already-selected tile opens it. Double-click always opens.
-      el.addEventListener('click', function () {
+      // The corner checkbox — or a Cmd/Ctrl/Shift-click anywhere on a tile —
+      // toggles the tile into the multi-select set instead (group districts
+      // can't be multi-selected).
+      el.addEventListener('click', function (e) {
         var id = el.getAttribute('data-ws-id');
+        var onCheck = e.target && e.target.closest && e.target.closest('[data-ws-check]');
+        if (isTile && (onCheck || e.metaKey || e.ctrlKey || e.shiftKey)) {
+          e.preventDefault();
+          toggleMulti(container, id);
+          return;
+        }
         if (id && id === selectedId) { openWorkspace(id); return; }
         applySelection(container, workspaces, id);
       });
@@ -542,6 +635,12 @@
     selectedId = findWs(workspaces, selectedId) ? selectedId
       : (findWs(workspaces, incoming) ? incoming : pickDefaultSelection(workspaces));
 
+    // Drop any multi-selected ids that no longer exist (e.g. after a delete
+    // reload) so the action bar count stays truthful.
+    multiIds().forEach(function (id) {
+      if (!findWs(workspaces, id)) delete multiSelected[id];
+    });
+
     var maxCols = measureMaxCols(container);
     lastMount = { container: container, state: state };
     lastMaxCols = maxCols;
@@ -550,6 +649,7 @@
     bindCreate(container);
     bindTiles(container, workspaces);
     bindOverviewActions(container);
+    bindSelBar(container);
 
     if (!resizeBound && typeof window.addEventListener === 'function') {
       window.addEventListener('resize', handleResize);
@@ -562,6 +662,7 @@
     if (!container) return;
     container.innerHTML = '';
     lastMount = null;
+    multiSelected = Object.create(null);
   }
 
   window.OriWorkspaceMap = {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -367,6 +367,7 @@
     var openTasks = Number(ws.open_task_count || 0);
     var mcp = Number(ws.mcp_count || 0);
     var skills = Number(ws.skill_count || 0);
+    var description = String(ws.description || '').trim();
     var delLabel = isGroup(ws) ? 'Delete group' : 'Delete workspace';
 
     var keeper = entry
@@ -388,6 +389,9 @@
       '<button type="button" class="ws-map-ov-open" data-ws-open="' + escapeHtml(ws.id) +
       '" aria-label="Open ' + escapeHtml(ws.name || 'workspace') + '">Open ▸</button>' +
       '</div>' +
+      (description
+        ? '<p class="ws-map-ov-desc" title="' + escapeHtml(description) + '">' + escapeHtml(description) + '</p>'
+        : '<p class="ws-map-ov-desc is-empty">No description yet.</p>') +
       '<div class="ws-map-ov-label">Entry agent</div>' +
       '<div class="ws-map-ov-keeperwrap">' + keeper + '</div>' +
       '<div class="ws-map-ov-label">Agents · ' + agents.length + '</div>' +

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -215,6 +215,15 @@ test('overviewBodyHTML renders the select-a-workspace placeholder when nothing i
   assert.match(overviewBodyHTML(null), /Select a workspace to see its agents, tasks, tools, and skills\./);
 });
 
+test('tileHTML renders an (unchecked) multi-select checkbox affordance', () => {
+  const { tileHTML } = loadOriWorkspaceMap();
+  const html = tileHTML({ ws: { id: 'w1', name: 'Ops' }, col: 0, row: 0 }, '', 0);
+  assert.match(html, /class="ws-map-tile-check" data-ws-check role="checkbox"/);
+  assert.match(html, /aria-checked="false"/);
+  // Nothing is multi-selected by default, so the tile is not marked is-multi.
+  assert.doesNotMatch(html, /class="ws-map-tile[^"]*is-multi/);
+});
+
 test('overviewBodyHTML offers a delete action carrying the workspace id', () => {
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   const html = overviewBodyHTML({ id: 'ws-42', name: 'Deep Sea Research' });

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -214,3 +214,16 @@ test('overviewBodyHTML renders the select-a-workspace placeholder when nothing i
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   assert.match(overviewBodyHTML(null), /Select a workspace to see its agents, tasks, tools, and skills\./);
 });
+
+test('overviewBodyHTML offers a delete action carrying the workspace id', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML({ id: 'ws-42', name: 'Deep Sea Research' });
+  assert.match(html, /class="ws-map-ov-delete" data-ws-delete="ws-42"/);
+  assert.match(html, /Delete workspace/);
+});
+
+test('overviewBodyHTML labels the delete action "Delete group" for group workspaces', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML({ id: 'grp-1', name: 'Research Fleet', kind: 'group' });
+  assert.match(html, /data-ws-delete="grp-1"[^>]*>✕ Delete group</);
+});

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -224,6 +224,14 @@ test('tileHTML renders an (unchecked) multi-select checkbox affordance', () => {
   assert.doesNotMatch(html, /class="ws-map-tile[^"]*is-multi/);
 });
 
+test('overviewBodyHTML shows the workspace description, or an empty-state note', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const withDesc = overviewBodyHTML({ id: 'a', name: 'Ops', description: 'Coordinates field logistics.' });
+  assert.match(withDesc, /class="ws-map-ov-desc"[^>]*>Coordinates field logistics\./);
+  const noDesc = overviewBodyHTML({ id: 'b', name: 'Bare' });
+  assert.match(noDesc, /class="ws-map-ov-desc is-empty">No description yet\./);
+});
+
 test('overviewBodyHTML offers a delete action carrying the workspace id', () => {
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   const html = overviewBodyHTML({ id: 'ws-42', name: 'Deep Sea Research' });


### PR DESCRIPTION
## Summary

Three related enhancements to the Workspace **Map view**, all in the Overview panel / tile surface:

- **Delete a workspace** — a Delete action in the Overview panel (labeled *Delete workspace*, or *Delete group* for a group district). Reuses the hub's confirmed single-item delete flow (Trash + Undo + toasts + reload/re-mount) via a new `window.WorkspaceHub.deleteWorkspace`.
- **Multi-select for bulk delete** — each tile gains a corner checkbox (revealed on hover); Cmd/Ctrl/Shift-click on a tile also toggles it. A contextual action bar pinned to the bottom-center of the viewport shows the selected count with **Delete** and **Clear**. Bulk delete reuses a new `window.WorkspaceHub.deleteWorkspaces(ids)`, extracted from the hub's existing `deleteSelectedWorkspaces` (same batch-confirm + Trash + Undo). Group districts are excluded; stale ids are pruned on the post-delete reload.
- **Workspace description** — rendered under the Overview hero, clamped to 3 lines (full text on hover), with an italic "No description yet." empty state. Uses the same `description` field the Cards view shows.

## Design notes

- No new backend: deletes drive the existing `DELETE /api/workspaces/{id}?confirm=true` endpoint (verified live returns `{trashed:true}`); the map re-mounts automatically because the hub's delete flow calls `loadWorkspaces()`.
- The hub refactor (`confirmAndDeleteWorkspaces`) is behavior-preserving for the existing launcher toolbar — `deleteSelectedWorkspaces` now delegates to it.

## Testing

- Map unit tests 21/21, hub unit tests 26/26, ESLint clean on changed JS, `go build` succeeds (assets are embedded).
- Confirmed the delete endpoint end-to-end on an isolated smoke server.

## Not verified

- No live in-browser click-through (Claude Chrome extension wasn't connected this session) — rendering + API paths were verified instead. Worth an eyeball: the fixed action bar assumes no `#launcherMap` ancestor sets `transform`/`filter`; and the hover-reveal checkbox / modifier-click are desktop-only (no touch affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)