### PR TITLE
Deprecate workspace cards view

### DIFF
--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -3,7 +3,7 @@
  *
  * Everything is scoped under `.ws-map`. The map is an intentional DARK surface
  * regardless of the app's `data-bs-theme`, so its tokens are defined here.
- * Rules must NOT leak into Cards/Tree. No ui-refresh.css edits, no `!important`.
+ * Rules must NOT leak into the launcher shell or Tree. No ui-refresh.css edits, no `!important`.
  *
  * Phase 1 = command-bar + theatre chrome + empty Overview (the shell).
  * Building tiles / districts / populated Overview land in Phase 2–3.
@@ -343,6 +343,66 @@
   display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; line-clamp: 3; overflow: hidden;
 }
 .ws-map-ov-desc.is-empty { font-style: italic; color: var(--ws-ink-faint); }
+
+.ws-map-folder {
+  display: grid; gap: 7px; min-width: 0;
+}
+.ws-map-folder-badge {
+  justify-self: start; max-width: 100%; padding: 3px 9px;
+  border: 1px solid rgba(70, 211, 154, 0.26); background: rgba(70, 211, 154, 0.08); color: var(--ws-faction);
+  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
+}
+.ws-map-folder.is-unlinked .ws-map-folder-badge {
+  border-color: rgba(232, 181, 75, 0.35); background: rgba(232, 181, 75, 0.1); color: var(--ws-keeper);
+}
+.ws-map-folder-path {
+  display: block; min-width: 0;
+  font-family: var(--ws-font-mono); font-size: 10.5px; color: var(--ws-ink-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ws-map-folder.is-unlinked .ws-map-folder-path { color: var(--ws-ink-faint); }
+
+.ws-map-tags {
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.ws-map-tag {
+  display: inline-flex; align-items: stretch; max-width: 100%;
+  border: 1px solid rgba(70, 211, 154, 0.24); background: rgba(70, 211, 154, 0.08); color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 0.7px;
+  overflow: hidden;
+  clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
+}
+.ws-map-tag-label,
+.ws-map-tag-remove {
+  border: 0; background: transparent; color: inherit; font: inherit; cursor: pointer;
+}
+.ws-map-tag-label {
+  min-width: 0; padding: 4px 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ws-map-tag-remove {
+  flex: 0 0 auto; width: 24px; border-left: 1px solid rgba(70, 211, 154, 0.2);
+}
+.ws-map-tag-label:hover,
+.ws-map-tag-remove:hover {
+  background: rgba(70, 211, 154, 0.14); color: var(--ws-faction);
+}
+.ws-map-tag-more {
+  padding: 4px 8px; color: var(--ws-ink-faint);
+}
+
+.ws-map-group-preview {
+  display: grid; gap: 5px; padding: 9px 10px;
+  border: 1px dashed rgba(232, 134, 77, 0.28); background: rgba(232, 134, 77, 0.05);
+}
+.ws-map-group-count {
+  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-keeper);
+}
+.ws-map-group-names {
+  min-width: 0; font-size: 12px; line-height: 1.4; color: var(--ws-ink-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 .ws-map-ov-label {
   font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint);

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -27,6 +27,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   const LAUNCHER_VIEW_CARDS = 'cards';
   const LAUNCHER_VIEW_TREE = 'tree';
   const LAUNCHER_VIEW_MAP = 'map';
+  const LAUNCHER_DEFAULT_VIEW = LAUNCHER_VIEW_MAP;
   console.log('[workspace-hub] hubEl exists:', !!hubEl);
   if (!hubEl) return;
 
@@ -247,7 +248,7 @@ console.log('[workspace-hub.js] FILE LOADED');
   let launcherOverviewRefreshTimer = null;
   let workspaceListRefreshTimer = null;
   let launcherActiveTab = 'workspaces';
-  let launcherActiveView = LAUNCHER_VIEW_CARDS;
+  let launcherActiveView = LAUNCHER_DEFAULT_VIEW;
   let launcherWorkspaceRootState = null;
   let launcherWorkspaceRootEditorOpen = false;
   let launcherSuppressClickUntil = 0;
@@ -343,9 +344,10 @@ console.log('[workspace-hub.js] FILE LOADED');
     if (elements.launcherOverviewOpenSessions) elements.launcherOverviewOpenSessions.textContent = String(metrics.openSessions || 0);
   }
 
-  // Canonical "N agents · M open tasks" summary, shared by Cards and Tree
-  // rows so switching views reprojects the same facts instead of changing
-  // the subject (Map already shows the same shape in its tile meta line).
+  // Canonical "N agents · M open tasks" summary, shared by Tree rows and
+  // the deprecated Cards fallback so switching views reprojects the same facts
+  // instead of changing the subject (Map already shows the same shape in its
+  // tile meta line).
   function formatWorkspaceSummaryMeta(workspace) {
     const agents = Number(workspace && workspace.agent_count) || 0;
     const openTasks = Number(workspace && workspace.open_task_count) || 0;
@@ -450,6 +452,47 @@ console.log('[workspace-hub.js] FILE LOADED');
       detail: extraCount > 0 ? `${primaryPath} (+${extraCount} more)` : primaryPath,
       detailTitle: allPaths.join(' | ') || primaryPath,
       ariaLabel: directoryCount === 1 ? 'linked folder' : `${directoryCount} linked folders`
+    };
+  }
+
+  function buildLauncherMapMetadata(flattened, tree) {
+    const folderDisplayById = {};
+    const tagsById = {};
+    const groupPreviewById = {};
+
+    (Array.isArray(flattened) ? flattened : []).forEach((workspace) => {
+      if (!workspace || !workspace.id) return;
+      folderDisplayById[workspace.id] = getWorkspaceFolderDisplay(workspace);
+      tagsById[workspace.id] = getWorkspaceTags(workspace);
+    });
+
+    function visitGroups(nodes) {
+      (Array.isArray(nodes) ? nodes : []).forEach((workspace) => {
+        if (!workspace || !workspace.id) return;
+        const children = Array.isArray(workspace.children) ? workspace.children : [];
+        if (isGroupWorkspace(workspace)) {
+          const previewNames = children
+            .slice(0, 3)
+            .map((child) => String(child && (child.name || child.id) || 'Untitled Workspace').trim())
+            .filter(Boolean);
+          groupPreviewById[workspace.id] = {
+            childCount: children.length,
+            previewNames,
+            overflowCount: Math.max(0, children.length - previewNames.length)
+          };
+        }
+        if (children.length > 0) {
+          visitGroups(children);
+        }
+      });
+    }
+
+    visitGroups(tree);
+
+    return {
+      folderDisplayById,
+      tagsById,
+      groupPreviewById
     };
   }
 
@@ -742,28 +785,29 @@ console.log('[workspace-hub.js] FILE LOADED');
     setLauncherTab(saved === 'summary' ? 'summary' : 'workspaces', { force: true });
   }
 
-  function normalizeLauncherView(value) {
+  function normalizeLauncherView(value, options = {}) {
     const v = String(value || '').trim().toLowerCase();
     if (v === LAUNCHER_VIEW_TREE) return LAUNCHER_VIEW_TREE;
     if (v === LAUNCHER_VIEW_MAP) return LAUNCHER_VIEW_MAP;
-    return LAUNCHER_VIEW_CARDS;
+    if (v === LAUNCHER_VIEW_CARDS && options.allowDeprecatedCards !== false) return LAUNCHER_VIEW_CARDS;
+    return LAUNCHER_DEFAULT_VIEW;
   }
 
   function getLauncherViewPreference() {
     try {
       const saved = localStorage.getItem(LAUNCHER_VIEW_STORAGE_KEY);
-      const normalized = normalizeLauncherView(saved);
+      const normalized = normalizeLauncherView(saved, { allowDeprecatedCards: false });
       if (saved && saved !== normalized) {
         localStorage.setItem(LAUNCHER_VIEW_STORAGE_KEY, normalized);
       }
       return normalized;
     } catch (err) {
-      return LAUNCHER_VIEW_CARDS;
+      return LAUNCHER_DEFAULT_VIEW;
     }
   }
 
   function setLauncherViewPreference(view) {
-    const normalized = normalizeLauncherView(view);
+    const normalized = normalizeLauncherView(view, { allowDeprecatedCards: false });
     try {
       localStorage.setItem(LAUNCHER_VIEW_STORAGE_KEY, normalized);
     } catch (err) {
@@ -801,24 +845,24 @@ console.log('[workspace-hub.js] FILE LOADED');
 
   // Reads ?view= from the URL, honoring only values normalizeLauncherView
   // would return unchanged — anything else is silently ignored rather than
-  // falling back to cards (a typo'd param shouldn't override localStorage).
+  // falling back to the default (a typo'd param shouldn't override localStorage).
   function getLauncherViewFromURL() {
     try {
       const raw = new URLSearchParams(window.location.search).get('view');
       if (!raw) return null;
-      const normalized = normalizeLauncherView(raw);
+      const normalized = normalizeLauncherView(raw, { allowDeprecatedCards: true });
       return raw.trim().toLowerCase() === normalized ? normalized : null;
     } catch (err) {
       return null;
     }
   }
 
-  // Deep-linkable, non-spammy: cards (the default) has no param at all, and
+  // Deep-linkable, non-spammy: Map (the default) has no param at all, and
   // every toggle uses replaceState so switching views never grows history.
   function syncLauncherViewToURL(view) {
     try {
       const params = new URLSearchParams(window.location.search);
-      if (view === LAUNCHER_VIEW_CARDS) {
+      if (view === LAUNCHER_DEFAULT_VIEW) {
         params.delete('view');
       } else {
         params.set('view', view);
@@ -855,7 +899,7 @@ console.log('[workspace-hub.js] FILE LOADED');
     // stays plain even if the saved preference is tree/map.
     const urlView = getLauncherViewFromURL();
     const initialView = urlView || getLauncherViewPreference();
-    setLauncherViewMode(initialView, { persist: true, render: false, syncUrl: false });
+    setLauncherViewMode(initialView, { persist: !urlView, render: false, syncUrl: false });
   }
 
   function navigateToWorkspace(workspaceId) {
@@ -1337,11 +1381,12 @@ console.log('[workspace-hub.js] FILE LOADED');
   }
 
   // Cheap alternative to scheduleLauncherOverviewRefresh: a single
-  // /api/workspaces?tree=true refetch keeps Cards/Tree/Map badges (sourced
-  // from each workspace's own enriched summary fields) current after a task
-  // changes, without re-fetching every workspace's task/session list just to
-  // recount them. The heavier overview refresh above stays reserved for the
-  // Summary tab, which needs actual task/session content, not just counts.
+  // /api/workspaces?tree=true refetch keeps Map/Tree/deprecated Cards fallback
+  // badges (sourced from each workspace's own enriched summary fields) current
+  // after a task changes, without re-fetching every workspace's task/session
+  // list just to recount them. The heavier overview refresh above stays
+  // reserved for the Summary tab, which needs actual task/session content, not
+  // just counts.
   function scheduleWorkspaceListRefresh(delayMs = 700) {
     if (workspaceListRefreshTimer) {
       clearTimeout(workspaceListRefreshTimer);
@@ -1881,6 +1926,9 @@ console.log('[workspace-hub.js] FILE LOADED');
           workspaces: visibleFlattened,
           tree,
           selectedId: state.selectedId,
+          metadata: buildLauncherMapMetadata(visibleFlattened, tree),
+          onTagFilter: toggleLauncherTagFilter,
+          onTagRemove: removeWorkspaceTag,
         });
       }
       return;
@@ -3986,9 +4034,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
 
     setLauncherTab(launcherActiveTab, { refreshSummary: false, force: true });
-    // Cards/Tree/Map badges already come from state.workspaces' enriched
-    // fields (no fetch needed); only the Summary tab needs a refresh here,
-    // and only when it's the tab actually being shown.
+    // Map/Tree/deprecated Cards fallback badges already come from
+    // state.workspaces' enriched fields (no fetch needed); only the Summary tab
+    // needs a refresh here, and only when it's the tab actually being shown.
     if (launcherActiveTab === 'summary') {
       const flattened = flattenWorkspaces(state.workspaces || []).filter(isConcreteWorkspace);
       void refreshLauncherTaskOverview(flattened);
@@ -4527,9 +4575,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     EventBus.on('task:created', (data) => {
       const state = window.WorkspaceHubState.getState();
       if (hubEl.dataset.state === 'launcher') {
-        // Cheap list refetch keeps Cards/Tree/Map badges current; only
-        // re-run the expensive per-workspace fan-out if the Summary tab
-        // (which needs full task content, not just counts) is open.
+        // Cheap list refetch keeps Map/Tree/deprecated Cards fallback badges
+        // current; only re-run the expensive per-workspace fan-out if the
+        // Summary tab (which needs full task content, not just counts) is open.
         scheduleWorkspaceListRefresh();
         if (launcherActiveTab === 'summary') {
           scheduleLauncherOverviewRefresh();
@@ -4544,9 +4592,9 @@ console.log('[workspace-hub.js] FILE LOADED');
     EventBus.on('task:updated', (data) => {
       const state = window.WorkspaceHubState.getState();
       if (hubEl.dataset.state === 'launcher') {
-        // Cheap list refetch keeps Cards/Tree/Map badges current; only
-        // re-run the expensive per-workspace fan-out if the Summary tab
-        // (which needs full task content, not just counts) is open.
+        // Cheap list refetch keeps Map/Tree/deprecated Cards fallback badges
+        // current; only re-run the expensive per-workspace fan-out if the
+        // Summary tab (which needs full task content, not just counts) is open.
         scheduleWorkspaceListRefresh();
         if (launcherActiveTab === 'summary') {
           scheduleLauncherOverviewRefresh();

--- a/internal/web/static/js/modules/workspace-hub.test.js
+++ b/internal/web/static/js/modules/workspace-hub.test.js
@@ -157,9 +157,12 @@ function loadWorkspaceHub(overrides = {}) {
   const launcherTagFilterbar = createElement('launcherTagFilterbar');
   const launcherTagFilterChips = createElement('launcherTagFilterChips');
   const launcherTagFilterClear = createElement('launcherTagFilterClear');
-  const launcherViewCards = createElement('launcherViewCards');
+  const launcherViewCards = overrides.includeCardsToggle ? createElement('launcherViewCards') : null;
   const launcherViewTree = createElement('launcherViewTree');
+  const launcherViewMap = createElement('launcherViewMap');
+  const launcherMap = createElement('launcherMap');
   const workspaceTags = createElement('hubWorkspaceTags');
+  const mapMounts = [];
 
   elements.set('workspaceHub', hubEl);
   elements.set('launcherGrid', launcherGrid);
@@ -167,8 +170,10 @@ function loadWorkspaceHub(overrides = {}) {
   elements.set('launcherTagFilterbar', launcherTagFilterbar);
   elements.set('launcherTagFilterChips', launcherTagFilterChips);
   elements.set('launcherTagFilterClear', launcherTagFilterClear);
-  elements.set('launcherViewCards', launcherViewCards);
+  if (launcherViewCards) elements.set('launcherViewCards', launcherViewCards);
   elements.set('launcherViewTree', launcherViewTree);
+  elements.set('launcherViewMap', launcherViewMap);
+  elements.set('launcherMap', launcherMap);
   elements.set('hubWorkspaceTags', workspaceTags);
 
   const state = {
@@ -193,6 +198,12 @@ function loadWorkspaceHub(overrides = {}) {
       renderFiles: () => {}
     },
     WorkspaceHubModals: { bindModalEvents: () => {} },
+    OriWorkspaceMap: overrides.OriWorkspaceMap || {
+      mount: (container, mapState) => {
+        mapMounts.push({ container, state: mapState });
+      },
+      unmount: () => {}
+    },
     WorkspaceHubNotes: {
       createNewNote: () => {},
       loadNotes: async () => {},
@@ -288,11 +299,14 @@ function loadWorkspaceHub(overrides = {}) {
     helpers: window.WorkspaceHub.__test,
     launcherEmpty,
     launcherGrid,
+    launcherMap,
     launcherTagFilterbar,
     launcherTagFilterChips,
     launcherTagFilterClear,
     launcherViewCards,
+    launcherViewMap,
     launcherViewTree,
+    mapMounts,
     documentListeners,
     state,
     storage,
@@ -301,14 +315,24 @@ function loadWorkspaceHub(overrides = {}) {
   };
 }
 
-test('launcher view preference defaults to cards and persists valid values', () => {
+test('launcher view preference defaults to map and persists valid values', () => {
   const { helpers, storage } = loadWorkspaceHub();
 
   assert.equal(helpers.normalizeLauncherView('tree'), 'tree');
-  assert.equal(helpers.normalizeLauncherView('invalid'), 'cards');
-  assert.equal(helpers.getLauncherViewPreference(), 'cards');
+  assert.equal(helpers.normalizeLauncherView('invalid'), 'map');
+  assert.equal(helpers.getLauncherViewPreference(), 'map');
   assert.equal(helpers.setLauncherViewPreference('tree'), 'tree');
   assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'tree');
+});
+
+test('launcher view preference migrates saved cards to map', () => {
+  const { helpers, storage } = loadWorkspaceHub({
+    localStorage: { oriWorkspaceHubLauncherView: 'cards' }
+  });
+
+  assert.equal(helpers.getLauncherViewPreference(), 'map');
+  assert.equal(storage.get('oriWorkspaceHubLauncherView'), 'map');
+  assert.equal(helpers.setLauncherViewPreference('cards'), 'map');
 });
 
 test('launcher view registers the map view and persists it', () => {
@@ -329,7 +353,10 @@ test('getLauncherViewFromURL only trusts an explicit, valid ?view= param', () =>
   window.location.search = '?view=tree';
   assert.equal(helpers.getLauncherViewFromURL(), 'tree');
 
-  // Garbage should not silently fall back to cards — that would let a typo'd
+  window.location.search = '?view=cards';
+  assert.equal(helpers.getLauncherViewFromURL(), 'cards');
+
+  // Garbage should not silently fall back to the default — that would let a typo'd
   // param mask the user's saved localStorage preference.
   window.location.search = '?view=bogus';
   assert.equal(helpers.getLauncherViewFromURL(), null);
@@ -338,7 +365,7 @@ test('getLauncherViewFromURL only trusts an explicit, valid ?view= param', () =>
   assert.equal(helpers.getLauncherViewFromURL(), null);
 });
 
-test('syncLauncherViewToURL omits the param for cards and sets it otherwise, via replaceState', () => {
+test('syncLauncherViewToURL omits the param for map and sets non-default views via replaceState', () => {
   const { helpers, window } = loadWorkspaceHub();
   window.location.pathname = '/workspaces';
   window.location.search = '';
@@ -346,11 +373,15 @@ test('syncLauncherViewToURL omits the param for cards and sets it otherwise, via
   window.history = { replaceState: (state, title, url) => calls.push(url) };
 
   helpers.syncLauncherViewToURL('map');
-  assert.deepEqual(calls, ['/workspaces?view=map']);
+  assert.deepEqual(calls, ['/workspaces']);
 
-  window.location.search = '?view=map';
+  window.location.search = '';
+  helpers.syncLauncherViewToURL('tree');
+  assert.deepEqual(calls, ['/workspaces', '/workspaces?view=tree']);
+
+  window.location.search = '?view=tree';
   helpers.syncLauncherViewToURL('cards');
-  assert.deepEqual(calls, ['/workspaces?view=map', '/workspaces']);
+  assert.deepEqual(calls, ['/workspaces', '/workspaces?view=tree', '/workspaces?view=cards']);
 });
 
 test('setLauncherViewMode syncs the URL for real toggles but not for the initial bootstrap', () => {
@@ -368,8 +399,11 @@ test('setLauncherViewMode syncs the URL for real toggles but not for the initial
   helpers.setLauncherViewMode('tree', { render: false });
   assert.deepEqual(calls, ['/workspaces?view=tree']);
 
+  helpers.setLauncherViewMode('cards', { persist: false, render: false });
+  assert.deepEqual(calls, ['/workspaces?view=tree', '/workspaces?view=cards']);
+
   helpers.setLauncherViewMode('cards', { render: false });
-  assert.deepEqual(calls, ['/workspaces?view=tree', '/workspaces']);
+  assert.deepEqual(calls, ['/workspaces?view=tree', '/workspaces?view=cards', '/workspaces']);
 });
 
 test('launcher tree renders minimal hierarchy with always-available workspace checkboxes', () => {
@@ -462,7 +496,7 @@ test('launcher cards show the Idle/Working LED (from enriched active) instead of
   assert.match(launcherGrid.innerHTML, /launcher-card-summary">1 agent · 0 open tasks</);
 });
 
-test('launcher tree rows carry the same canonical summary as Cards, but group rows do not', () => {
+test('launcher tree rows carry the same canonical summary as the deprecated Cards fallback, but group rows do not', () => {
   const workspaces = [
     {
       id: 'group-1',
@@ -545,7 +579,7 @@ test('launcher tag filters use AND logic and retain matching groups', () => {
     },
     { id: 'client', kind: 'workspace', name: 'Client', tags: ['client:acme'] }
   ];
-  const { helpers, launcherGrid, state } = loadWorkspaceHub({
+  const { helpers, mapMounts, state } = loadWorkspaceHub({
     state: {
       launcherActiveTags: new Set(['music', 'reaper']),
       workspaces
@@ -555,10 +589,9 @@ test('launcher tag filters use AND logic and retain matching groups', () => {
   helpers.renderLauncherActiveView(flattenWorkspaces(workspaces));
 
   assert.equal(state.launcherActiveTags.has('music'), true);
-  assert.match(launcherGrid.innerHTML, /data-workspace-id="group-1"/);
-  assert.match(launcherGrid.innerHTML, /Song A/);
-  assert.doesNotMatch(launcherGrid.innerHTML, /Song B/);
-  assert.doesNotMatch(launcherGrid.innerHTML, /Client/);
+  const mounted = mapMounts[mapMounts.length - 1].state;
+  assert.deepEqual(mounted.workspaces.map((workspace) => workspace.id), ['group-1', 'song-a']);
+  assert.equal(mounted.metadata.groupPreviewById['group-1'].childCount, 1);
 });
 
 test('launcher tag filters drop stale active tags', () => {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -1,7 +1,8 @@
 /*
  * workspace-map.js — Workspace Map view ("tactical command-center")
  *
- * Opt-in third view on the /workspaces hub, beside Cards and Tree. Loaded as a
+ * Primary browse/open view on the /workspaces hub, beside the Tree management
+ * view. Loaded as a
  * plain deferred script (not an ES module); exposes itself on
  * window.OriWorkspaceMap, which workspace-hub.js calls when the "map" view is
  * active.
@@ -355,7 +356,118 @@
       escapeHtml(initials(name)) + '</span>';
   }
 
-  function overviewBodyHTML(ws) {
+  function mapMetadata(options) {
+    return options && options.metadata && typeof options.metadata === 'object'
+      ? options.metadata
+      : {};
+  }
+
+  function metadataValue(options, key, id) {
+    var metadata = mapMetadata(options);
+    var table = metadata && metadata[key];
+    return table && id ? table[id] : null;
+  }
+
+  function normalizeTags(tags) {
+    return (Array.isArray(tags) ? tags : [])
+      .map(function (tag) { return String(tag || '').trim(); })
+      .filter(Boolean);
+  }
+
+  function folderDisplayFor(ws, options) {
+    if (!ws || !ws.id) return null;
+    return metadataValue(options, 'folderDisplayById', ws.id) ||
+      ws.map_folder_display ||
+      ws.folder_display ||
+      null;
+  }
+
+  function tagsFor(ws, options) {
+    if (!ws || !ws.id) return [];
+    return normalizeTags(metadataValue(options, 'tagsById', ws.id) || ws.tags);
+  }
+
+  function groupPreviewFor(ws, options) {
+    if (!ws || !ws.id || !isGroup(ws)) return null;
+    var fromMetadata = metadataValue(options, 'groupPreviewById', ws.id);
+    if (fromMetadata) return fromMetadata;
+
+    var children = Array.isArray(ws.children) ? ws.children : [];
+    var names = children.slice(0, 3).map(function (child) {
+      return String(child && (child.name || child.id) || 'Untitled Workspace').trim();
+    }).filter(Boolean);
+    return {
+      childCount: children.length,
+      previewNames: names,
+      overflowCount: Math.max(0, children.length - names.length)
+    };
+  }
+
+  function folderOverviewHTML(ws, options) {
+    var folder = folderDisplayFor(ws, options);
+    if (!folder) return '';
+    var badgeClass = folder.badgeClass || (folder.linked ? 'is-linked' : 'is-unlinked');
+    var badge = folder.badgeLabel || (folder.linked ? 'Linked folder' : 'No folder linked');
+    var detail = folder.detail || (folder.linked ? 'Linked folder' : 'No local folder attached.');
+    var title = folder.detailTitle || detail;
+    return (
+      '<div class="ws-map-ov-label">Folder</div>' +
+      '<div class="ws-map-folder ' + escapeHtml(badgeClass) + '">' +
+      '<span class="ws-map-folder-badge">' + escapeHtml(badge) + '</span>' +
+      '<span class="ws-map-folder-path" title="' + escapeHtml(title) + '">' + escapeHtml(detail) + '</span>' +
+      '</div>'
+    );
+  }
+
+  function tagsOverviewHTML(ws, options) {
+    var tags = tagsFor(ws, options);
+    var workspaceId = ws && ws.id ? String(ws.id) : '';
+    var limit = 4;
+    var visible = tags.slice(0, limit);
+    var overflow = Math.max(0, tags.length - visible.length);
+    var body = '';
+
+    if (!tags.length) {
+      body = '<span class="ws-map-ov-none">No tags yet</span>';
+    } else {
+      body = '<div class="ws-map-tags">' + visible.map(function (tag) {
+        var safeTag = escapeHtml(tag);
+        return (
+          '<span class="ws-map-tag" title="' + safeTag + '">' +
+          '<button type="button" class="ws-map-tag-label" data-ws-tag-filter="' + safeTag + '" title="Filter by ' + safeTag + '">' + safeTag + '</button>' +
+          '<button type="button" class="ws-map-tag-remove" data-ws-tag-remove="' + escapeHtml(workspaceId) + '" data-ws-tag="' + safeTag + '" aria-label="Remove tag ' + safeTag + '" title="Remove tag">&times;</button>' +
+          '</span>'
+        );
+      }).join('') +
+        (overflow > 0
+          ? '<span class="ws-map-tag ws-map-tag-more" title="' + escapeHtml(tags.slice(limit).join(', ')) + '">+' + overflow + ' more</span>'
+          : '') +
+        '</div>';
+    }
+
+    return '<div class="ws-map-ov-label">Tags</div>' + body;
+  }
+
+  function groupPreviewHTML(ws, options) {
+    var preview = groupPreviewFor(ws, options);
+    if (!preview) return '';
+    var count = Number(preview.childCount || 0);
+    var names = normalizeTags(preview.previewNames);
+    var overflow = Number(preview.overflowCount || 0);
+    var summary = count + ' workspace' + (count === 1 ? '' : 's');
+    var body = names.length
+      ? names.join(' · ') + (overflow > 0 ? ' +' + overflow + ' more' : '')
+      : 'Drop workspaces here to organize related work.';
+    return (
+      '<div class="ws-map-ov-label">Group Preview</div>' +
+      '<div class="ws-map-group-preview">' +
+      '<span class="ws-map-group-count">' + escapeHtml(summary) + '</span>' +
+      '<span class="ws-map-group-names" title="' + escapeHtml(body) + '">' + escapeHtml(body) + '</span>' +
+      '</div>'
+    );
+  }
+
+  function overviewBodyHTML(ws, options) {
     if (!ws) {
       return '<div class="ws-map-overview-empty"><span class="ws-big">◈</span>' +
         'Select a workspace to see its agents, tasks, tools, and skills.</div>';
@@ -392,6 +504,9 @@
       (description
         ? '<p class="ws-map-ov-desc" title="' + escapeHtml(description) + '">' + escapeHtml(description) + '</p>'
         : '<p class="ws-map-ov-desc is-empty">No description yet.</p>') +
+      folderOverviewHTML(ws, options) +
+      tagsOverviewHTML(ws, options) +
+      groupPreviewHTML(ws, options) +
       '<div class="ws-map-ov-label">Entry agent</div>' +
       '<div class="ws-map-ov-keeperwrap">' + keeper + '</div>' +
       '<div class="ws-map-ov-label">Agents · ' + agents.length + '</div>' +
@@ -409,7 +524,7 @@
     );
   }
 
-  function shellHTML(stats, workspaces, selectedId, maxCols) {
+  function shellHTML(stats, workspaces, selectedId, maxCols, options) {
     var canvas = (Array.isArray(workspaces) && workspaces.length > 0)
       ? canvasHTML(workspaces, selectedId, maxCols).html
       : emptyCanvasHTML();
@@ -442,7 +557,7 @@
       '<aside class="ws-map-overview" role="region" aria-label="Workspace overview">' +
       '<div class="ws-map-overview-head"><div><span class="ws-map-ix">WS</span> <h3>Overview</h3></div></div>' +
       '<div class="ws-map-overview-body">' +
-      overviewBodyHTML(findWs(workspaces, selectedId)) +
+      overviewBodyHTML(findWs(workspaces, selectedId), options) +
       '</div>' +
       '</aside>' +
       '</div>'
@@ -518,7 +633,7 @@
     }
   }
 
-  function bindOverviewActions(container) {
+  function bindOverviewActions(container, options) {
     var opens = container.querySelectorAll('[data-ws-open]');
     Array.prototype.forEach.call(opens, function (el) {
       el.addEventListener('click', function () {
@@ -531,10 +646,30 @@
         deleteWorkspace(el.getAttribute('data-ws-delete'));
       });
     });
+    var tagFilters = container.querySelectorAll('[data-ws-tag-filter]');
+    Array.prototype.forEach.call(tagFilters, function (el) {
+      el.addEventListener('click', function (event) {
+        event.preventDefault();
+        var callback = options && options.onTagFilter;
+        if (typeof callback === 'function') {
+          callback(el.getAttribute('data-ws-tag-filter'));
+        }
+      });
+    });
+    var tagRemoves = container.querySelectorAll('[data-ws-tag-remove]');
+    Array.prototype.forEach.call(tagRemoves, function (el) {
+      el.addEventListener('click', function (event) {
+        event.preventDefault();
+        var callback = options && options.onTagRemove;
+        if (typeof callback === 'function') {
+          callback(el.getAttribute('data-ws-tag-remove'), el.getAttribute('data-ws-tag'));
+        }
+      });
+    });
   }
 
   // Update selection in place (no full re-mount) to avoid flicker.
-  function applySelection(container, workspaces, id) {
+  function applySelection(container, workspaces, id, options) {
     selectedId = id;
     var tiles = container.querySelectorAll('.ws-map-tile');
     Array.prototype.forEach.call(tiles, function (el) {
@@ -544,8 +679,8 @@
     });
     var body = container.querySelector('.ws-map-overview-body');
     if (body) {
-      body.innerHTML = overviewBodyHTML(findWs(workspaces, id));
-      bindOverviewActions(container);
+      body.innerHTML = overviewBodyHTML(findWs(workspaces, id), options);
+      bindOverviewActions(container, options);
     }
   }
 
@@ -597,7 +732,7 @@
     if (clr) clr.addEventListener('click', function () { clearMulti(container); });
   }
 
-  function bindTiles(container, workspaces) {
+  function bindTiles(container, workspaces, options) {
     var selectables = container.querySelectorAll(
       '.ws-map-tile[data-ws-id], .ws-map-district-tag[data-ws-id]'
     );
@@ -617,7 +752,7 @@
           return;
         }
         if (id && id === selectedId) { openWorkspace(id); return; }
-        applySelection(container, workspaces, id);
+        applySelection(container, workspaces, id, options);
       });
       el.addEventListener('dblclick', function () {
         openWorkspace(el.getAttribute('data-ws-id'));
@@ -649,10 +784,10 @@
     lastMount = { container: container, state: state };
     lastMaxCols = maxCols;
 
-    container.innerHTML = shellHTML(computeStats(workspaces), workspaces, selectedId, maxCols);
+    container.innerHTML = shellHTML(computeStats(workspaces), workspaces, selectedId, maxCols, state);
     bindCreate(container);
-    bindTiles(container, workspaces);
-    bindOverviewActions(container);
+    bindTiles(container, workspaces, state);
+    bindOverviewActions(container, state);
     bindSelBar(container);
 
     if (!resizeBound && typeof window.addEventListener === 'function') {

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -232,6 +232,96 @@ test('overviewBodyHTML shows the workspace description, or an empty-state note',
   assert.match(noDesc, /class="ws-map-ov-desc is-empty">No description yet\./);
 });
 
+test('overviewBodyHTML renders linked folder state from map metadata', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML(
+    { id: 'a', name: 'Ops' },
+    {
+      metadata: {
+        folderDisplayById: {
+          a: {
+            linked: true,
+            badgeLabel: '2 folders linked',
+            badgeClass: 'is-linked',
+            detail: '/tmp/ops (+1 more)',
+            detailTitle: '/tmp/ops | /tmp/ops-extra'
+          }
+        }
+      }
+    }
+  );
+
+  assert.match(html, /ws-map-folder is-linked/);
+  assert.match(html, />2 folders linked</);
+  assert.match(html, /\/tmp\/ops \(\+1 more\)/);
+  assert.match(html, /title="\/tmp\/ops \| \/tmp\/ops-extra"/);
+});
+
+test('overviewBodyHTML renders unlinked folder state from map metadata', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML(
+    { id: 'a', name: 'Ops' },
+    {
+      metadata: {
+        folderDisplayById: {
+          a: {
+            linked: false,
+            badgeLabel: 'No folder linked',
+            badgeClass: 'is-unlinked',
+            detail: 'No local folder attached.'
+          }
+        }
+      }
+    }
+  );
+
+  assert.match(html, /ws-map-folder is-unlinked/);
+  assert.match(html, /No folder linked/);
+  assert.match(html, /No local folder attached\./);
+});
+
+test('overviewBodyHTML renders filterable and removable tag chips from map metadata', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML(
+    { id: 'song', name: 'Song' },
+    {
+      metadata: {
+        tagsById: {
+          song: ['music', 'reaper', 'client:acme', 'archive', 'mix']
+        }
+      }
+    }
+  );
+
+  assert.match(html, /class="ws-map-tags"/);
+  assert.match(html, /data-ws-tag-filter="music"/);
+  assert.match(html, /data-ws-tag-remove="song"/);
+  assert.match(html, /data-ws-tag="reaper"/);
+  assert.match(html, /\+1 more/);
+});
+
+test('overviewBodyHTML renders group child previews from map metadata', () => {
+  const { overviewBodyHTML } = loadOriWorkspaceMap();
+  const html = overviewBodyHTML(
+    { id: 'grp-1', name: 'Research Fleet', kind: 'group' },
+    {
+      metadata: {
+        groupPreviewById: {
+          'grp-1': {
+            childCount: 4,
+            previewNames: ['Alpha', 'Beta', 'Gamma'],
+            overflowCount: 1
+          }
+        }
+      }
+    }
+  );
+
+  assert.match(html, /Group Preview/);
+  assert.match(html, /4 workspaces/);
+  assert.match(html, /Alpha · Beta · Gamma \+1 more/);
+});
+
 test('overviewBodyHTML offers a delete action carrying the workspace id', () => {
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   const html = overviewBodyHTML({ id: 'ws-42', name: 'Deep Sea Research' });

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -52,19 +52,14 @@
             Import Folder
           </button>
           <div class="hub-view-toggle launcher-view-toggle" role="tablist" aria-label="Launcher view mode">
-            <button id="launcherViewCards" class="modern-btn modern-btn-secondary hub-view-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="launcherGrid" aria-label="Cards view" title="Cards View" data-launcher-view="cards">
+            <button id="launcherViewMap" class="modern-btn modern-btn-secondary hub-view-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="launcherMap" aria-label="Map view" title="Map View" data-launcher-view="map">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M4,5H10V11H4V5M14,5H20V11H14V5M4,13H10V19H4V13M14,13H20V19H14V13Z"/>
+                <path d="M15,19L9,16.89V5L15,7.11M20.5,3C20.44,3 20.39,3 20.34,3L15,5.1L9,3L3.36,4.9C3.15,4.97 3,5.15 3,5.38V20.5A0.5,0.5 0 0,0 3.5,21C3.55,21 3.61,21 3.66,20.97L9,18.9L15,21L20.64,19.1C20.85,19 21,18.85 21,18.62V3.5A0.5,0.5 0 0,0 20.5,3Z"/>
               </svg>
             </button>
             <button id="launcherViewTree" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherGrid" aria-label="Tree view" title="Tree View" data-launcher-view="tree">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M3,5H9V7H5V17H9V19H3V5M11,5H21V9H11V5M11,10H21V14H11V10M11,15H21V19H11V15Z"/>
-              </svg>
-            </button>
-            <button id="launcherViewMap" class="modern-btn modern-btn-secondary hub-view-btn" type="button" role="tab" aria-selected="false" aria-controls="launcherMap" aria-label="Map view" title="Map View" data-launcher-view="map">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M15,19L9,16.89V5L15,7.11M20.5,3C20.44,3 20.39,3 20.34,3L15,5.1L9,3L3.36,4.9C3.15,4.97 3,5.15 3,5.38V20.5A0.5,0.5 0 0,0 3.5,21C3.55,21 3.61,21 3.66,20.97L9,18.9L15,21L20.64,19.1C20.85,19 21,18.85 21,18.62V3.5A0.5,0.5 0 0,0 20.5,3Z"/>
               </svg>
             </button>
           </div>
@@ -140,7 +135,7 @@
         </div>
         <div id="launcherGrid" class="launcher-grid"></div>
         <div id="launcherEmptyState" class="launcher-empty" style="display: none;">No workspaces yet. Create one to get started.</div>
-        <!-- Map view mount point — inert scaffolding (Phase 0.0); populated by workspace-map.js in Phase 1. -->
+        <!-- Map view mount point; populated by workspace-map.js. -->
         <div id="launcherMap" class="ws-map" hidden></div>
       </section>
 

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -71,8 +71,8 @@
   <script defer src="/js/modules/workspace-input-router.js"></script>
   <script defer src="/js/modules/workspace-hub-smart-input.js"></script>
   <script defer src="/js/modules/workspace-hub-panels.js"></script>
-  <script defer src="/js/modules/workspace-hub.js"></script>
   <script defer src="/js/modules/workspace-map.js"></script>
+  <script defer src="/js/modules/workspace-hub.js"></script>
   <script defer src="/js/modules/workspace-hub-board.js"></script>
   <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
   <script defer src="/js/modules/workspace-sync.js"></script>


### PR DESCRIPTION
## Summary
- make Map the default /workspaces launcher view and hide the Cards toggle
- keep Cards available only as a temporary ?view=cards fallback while migrating saved cards preferences to Map
- move Cards-only preview details into Map overview: folder/path state, removable/filterable tags, and group previews
- preserve Tree as the hierarchy, selection, delete, and reorder management surface

## Validation
- node --test internal/web/static/js/modules/workspace-map.test.js internal/web/static/js/modules/workspace-hub.test.js
- npm run test:modules
- npx eslint internal/web/static/js/modules/workspace-map.js internal/web/static/js/modules/workspace-hub.js
- git diff --check
- live browser check on localhost:32123 for Map default, Tree deep link, Cards fallback, and Map overview parity controls