### PR TITLE
Fix template agent model defaults and review roster

### DIFF
--- a/internal/projecttemplates/agents.go
+++ b/internal/projecttemplates/agents.go
@@ -24,10 +24,10 @@ const MaxTemplateAgents = 10
 
 // AgentSpec declares one agent a template seeds onto a workspace created from
 // it. Like ToolDefaults, this package carries the spec as data only — it never
-// creates or resolves agents. Role/Type/Model are trimmed and carried verbatim;
-// canonicalizing them against the real agent enums and resolving empty values to
-// defaults happens in the workspace-creation (seeding) layer, keeping this
-// file-copy engine domain-blind. The first surviving entry in a template's
+// creates or resolves agents. Role/Type/Model/Provider are trimmed and carried
+// verbatim; canonicalizing them against the real agent enums and resolving empty
+// values to defaults happens in the workspace-creation (seeding) layer, keeping
+// this file-copy engine domain-blind. The first surviving entry in a template's
 // roster is the workspace entry agent; the rest are specialist sub-agents.
 type AgentSpec struct {
 	Name         string       `json:"name"`
@@ -35,6 +35,7 @@ type AgentSpec struct {
 	Type         string       `json:"type,omitempty"`
 	SystemPrompt string       `json:"system_prompt,omitempty"`
 	Model        string       `json:"model,omitempty"`
+	Provider     string       `json:"provider,omitempty"`
 	Tools        ToolDefaults `json:"tools"`
 }
 
@@ -66,6 +67,7 @@ func normalizeAgentSpecs(specs []AgentSpec) []AgentSpec {
 			Type:         strings.TrimSpace(s.Type),
 			SystemPrompt: strings.TrimSpace(s.SystemPrompt),
 			Model:        strings.TrimSpace(s.Model),
+			Provider:     strings.TrimSpace(s.Provider),
 			Tools:        normalizeToolDefaults(s.Tools),
 		})
 		if len(out) >= MaxTemplateAgents {

--- a/internal/projecttemplates/agents_test.go
+++ b/internal/projecttemplates/agents_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNormalizeAgentSpecs_TrimDropDedupeOrder(t *testing.T) {
 	in := []AgentSpec{
-		{Name: "  Producer  ", Role: " orchestrator ", Type: " general ", SystemPrompt: "  lead  ", Model: " gpt-5.5 "},
+		{Name: "  Producer  ", Role: " orchestrator ", Type: " general ", SystemPrompt: "  lead  ", Model: " gpt-5.5 ", Provider: " codex "},
 		{Name: ""},    // blank name -> dropped
 		{Name: "   "}, // whitespace-only -> dropped
 		{Name: "Copywriter"},
@@ -36,7 +36,7 @@ func TestNormalizeAgentSpecs_TrimDropDedupeOrder(t *testing.T) {
 	}
 
 	first := out[0]
-	if first.Role != "orchestrator" || first.Type != "general" || first.SystemPrompt != "lead" || first.Model != "gpt-5.5" {
+	if first.Role != "orchestrator" || first.Type != "general" || first.SystemPrompt != "lead" || first.Model != "gpt-5.5" || first.Provider != "codex" {
 		t.Fatalf("fields not trimmed: %+v", first)
 	}
 }

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -153,6 +153,9 @@ func (b *ServerBuilder) initializeHandlers() {
 			return resolveTemplatesRoot(b.configManager)
 		})
 		b.sessionHandler.SetAgentStore(b.st)
+		if b.configManager != nil {
+			b.sessionHandler.SetSystemModelReader(b.configManager)
+		}
 		// Initialize auto-classify handler for session classification
 		b.autoClassifyHandler = sessionhttp.NewAutoClassifyHandler(sessionStore, b.st, b.llmFactory, b.configManager)
 		// Initialize smart input handler for Workspace Hub classification

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -32,6 +32,7 @@ type Handler struct {
 	workspaceRootResolver func() string
 	templatesRootResolver func() string // resolves the project templates library directory
 	agentStore            store.Store
+	systemModelReader     SystemModelReader
 	workspaceAllowlist    *workspace.Allowlist
 	eventBus              *workspace.EventBus // optional, for project.created events
 	templateOnboarding    *templateonboarding.Service
@@ -51,6 +52,13 @@ type Handler struct {
 	// walks; lastRescanAt backs the cooldown for background-initiated rescans.
 	rescanMu     sync.Mutex
 	lastRescanAt time.Time
+}
+
+// SystemModelReader exposes the configured system model used as the default
+// for workspace-created agents that do not declare a model of their own.
+type SystemModelReader interface {
+	GetSystemModel() (provider, model string)
+	GetSystemReasoningEffort() string
 }
 
 // New creates a new session handler.
@@ -82,6 +90,11 @@ func (h *Handler) SetWorkspaceRootResolver(fn func() string) {
 // SetAgentStore sets the agent store used for workspace entry-agent provisioning.
 func (h *Handler) SetAgentStore(agentStore store.Store) {
 	h.agentStore = agentStore
+}
+
+// SetSystemModelReader sets the source for the configured system model.
+func (h *Handler) SetSystemModelReader(reader SystemModelReader) {
+	h.systemModelReader = reader
 }
 
 // SetTemplateToolApplier injects the function that binds a template's declared

--- a/internal/sessionhttp/project_templates.go
+++ b/internal/sessionhttp/project_templates.go
@@ -47,6 +47,38 @@ func (h *Handler) resolveProjectTemplate(templateID, templatePath string) (proje
 	}
 }
 
+func (h *Handler) handleTemplateAgentPlan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+
+	var req struct {
+		TemplateID   string `json:"template_id,omitempty"`
+		TemplatePath string `json:"template_path,omitempty"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	if strings.TrimSpace(req.TemplateID) != "" && strings.TrimSpace(req.TemplatePath) != "" {
+		_ = orihttp.RespondBadRequest(w, "specify either template_id or template_path, not both")
+		return
+	}
+	if strings.TrimSpace(req.TemplateID) == "" && strings.TrimSpace(req.TemplatePath) == "" {
+		_ = orihttp.RespondSuccess(w, h.buildTemplateAgentPlan(projecttemplates.Template{}))
+		return
+	}
+
+	tpl, err := h.resolveProjectTemplate(req.TemplateID, req.TemplatePath)
+	if err != nil {
+		h.respondWorkspaceProjectError(w, err)
+		return
+	}
+
+	_ = orihttp.RespondSuccess(w, h.buildTemplateAgentPlan(tpl))
+}
+
 // instantiateWorkspaceProject creates a project folder from a template inside
 // the workspace's folder, persists ProjectPath in both the session store and
 // the folder store, and publishes project.created. On any failure after the

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -56,9 +56,19 @@ type templateAgentPlanItem struct {
 	Model           string                        `json:"model,omitempty"`
 	Provider        string                        `json:"provider,omitempty"`
 	ReasoningEffort string                        `json:"reasoning_effort,omitempty"`
+	SystemPrompt    string                        `json:"system_prompt,omitempty"`
 	ModelSource     string                        `json:"model_source,omitempty"`
 	Tools           projecttemplates.ToolDefaults `json:"tools,omitempty"`
 	Warning         string                        `json:"warning,omitempty"`
+}
+
+type templateAgentOverride struct {
+	Index        *int    `json:"index"`
+	Name         *string `json:"name,omitempty"`
+	Role         *string `json:"role,omitempty"`
+	Type         *string `json:"type,omitempty"`
+	Model        *string `json:"model,omitempty"`
+	SystemPrompt *string `json:"system_prompt,omitempty"`
 }
 
 // validAgentTypes canonicalizes a template-declared agent type to the real
@@ -89,6 +99,97 @@ func canonicalAgentType(s string) string {
 
 func canonicalAgentRole(s string) string {
 	return validAgentRoles[strings.ToLower(strings.TrimSpace(s))]
+}
+
+func applyTemplateAgentOverrides(tpl projecttemplates.Template, overrides []templateAgentOverride) (projecttemplates.Template, error) {
+	if len(overrides) == 0 {
+		return tpl, nil
+	}
+	if !tpl.HasAgents() {
+		return tpl, fmt.Errorf("template has no agents to customize")
+	}
+
+	next := tpl
+	next.Agents = append([]projecttemplates.AgentSpec(nil), tpl.Agents...)
+	seenIndexes := make(map[int]struct{}, len(overrides))
+	for _, override := range overrides {
+		if override.Index == nil {
+			return tpl, fmt.Errorf("template agent override is missing an index")
+		}
+		idx := *override.Index
+		if idx < 0 || idx >= len(next.Agents) {
+			return tpl, fmt.Errorf("template agent override index %d is out of range", idx)
+		}
+		if _, exists := seenIndexes[idx]; exists {
+			return tpl, fmt.Errorf("template agent override index %d is duplicated", idx)
+		}
+		seenIndexes[idx] = struct{}{}
+
+		spec := next.Agents[idx]
+		if override.Name != nil {
+			name := strings.TrimSpace(*override.Name)
+			if err := validateTemplateAgentOverrideName(name); err != nil {
+				return tpl, err
+			}
+			spec.Name = name
+		}
+		if override.Role != nil {
+			spec.Role = strings.TrimSpace(*override.Role)
+		}
+		if override.Type != nil {
+			spec.Type = strings.TrimSpace(*override.Type)
+		}
+		if override.Model != nil {
+			spec.Model = strings.TrimSpace(*override.Model)
+		}
+		if override.SystemPrompt != nil {
+			spec.SystemPrompt = strings.TrimSpace(*override.SystemPrompt)
+			if err := projecttemplates.ValidateAgentPrompts([]projecttemplates.AgentSpec{spec}); err != nil {
+				return tpl, err
+			}
+		}
+		next.Agents[idx] = spec
+	}
+	if err := validateTemplateAgentOverrideNames(next.Agents); err != nil {
+		return tpl, err
+	}
+	return next, nil
+}
+
+func validateTemplateAgentOverrideName(name string) error {
+	if name == "" {
+		return fmt.Errorf("template agent name cannot be empty")
+	}
+	if len(name) > 100 {
+		return fmt.Errorf("template agent name %q is too long (max 100 characters)", name)
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == ' ' || r == '_' || r == '-':
+		default:
+			return fmt.Errorf("template agent name %q contains invalid characters (only alphanumeric, spaces, underscores, and hyphens allowed)", name)
+		}
+	}
+	return nil
+}
+
+func validateTemplateAgentOverrideNames(specs []projecttemplates.AgentSpec) error {
+	seen := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		name := strings.TrimSpace(spec.Name)
+		if name == "" {
+			return fmt.Errorf("template agent name cannot be empty")
+		}
+		key := strings.ToLower(name)
+		if original, exists := seen[key]; exists {
+			return fmt.Errorf("template agent name %q duplicates %q", name, original)
+		}
+		seen[key] = name
+	}
+	return nil
 }
 
 func (h *Handler) templateAgentCreateConfig(spec projecttemplates.AgentSpec) (*store.CreateAgentConfig, string) {
@@ -236,6 +337,7 @@ func (h *Handler) buildTemplateAgentPlanItem(spec projecttemplates.AgentSpec, en
 			item.Model = strings.TrimSpace(ag.Settings.Model)
 			item.Provider = strings.TrimSpace(ag.Settings.Provider)
 			item.ReasoningEffort = strings.TrimSpace(ag.Settings.EffectiveReasoningEffort(ag.Settings.Provider))
+			item.SystemPrompt = strings.TrimSpace(ag.Settings.SystemPrompt)
 			item.ModelSource = "existing"
 			item.Tools = projecttemplates.ToolDefaults{}
 			item.Warning = fmt.Sprintf("Reusing existing agent %q - its saved prompt, model, and tools are used, not the template's.", name)
@@ -259,6 +361,7 @@ func (h *Handler) buildTemplateAgentPlanItem(spec projecttemplates.AgentSpec, en
 	item.Model = strings.TrimSpace(cfg.Model)
 	item.Provider = strings.TrimSpace(cfg.LLMProvider)
 	item.ReasoningEffort = strings.TrimSpace(cfg.ReasoningEffort)
+	item.SystemPrompt = strings.TrimSpace(cfg.SystemPrompt)
 	item.ModelSource = modelSource
 	if item.Model == "" {
 		item.Warning = fmt.Sprintf("Agent %q has no template or system model; it will use the app's default agent model.", name)

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -35,6 +35,32 @@ type seedAgentsResult struct {
 	EntrySet     bool
 }
 
+type templateAgentPlan struct {
+	HasAgents             bool                    `json:"has_agents"`
+	TemplateID            string                  `json:"template_id,omitempty"`
+	TemplateName          string                  `json:"template_name,omitempty"`
+	EntryAgentName        string                  `json:"entry_agent_name,omitempty"`
+	SystemModelConfigured bool                    `json:"system_model_configured"`
+	SystemProvider        string                  `json:"system_provider,omitempty"`
+	SystemModel           string                  `json:"system_model,omitempty"`
+	Agents                []templateAgentPlanItem `json:"agents"`
+	Warnings              []string                `json:"warnings,omitempty"`
+}
+
+type templateAgentPlanItem struct {
+	Name            string                        `json:"name"`
+	Action          string                        `json:"action"`
+	EntryPoint      bool                          `json:"entry_point"`
+	Role            string                        `json:"role,omitempty"`
+	Type            string                        `json:"type,omitempty"`
+	Model           string                        `json:"model,omitempty"`
+	Provider        string                        `json:"provider,omitempty"`
+	ReasoningEffort string                        `json:"reasoning_effort,omitempty"`
+	ModelSource     string                        `json:"model_source,omitempty"`
+	Tools           projecttemplates.ToolDefaults `json:"tools,omitempty"`
+	Warning         string                        `json:"warning,omitempty"`
+}
+
 // validAgentTypes canonicalizes a template-declared agent type to the real
 // vocabulary; an empty/unrecognized value maps to "" so the store applies its
 // own default (PRD FR8).
@@ -65,6 +91,18 @@ func canonicalAgentRole(s string) string {
 	return validAgentRoles[strings.ToLower(strings.TrimSpace(s))]
 }
 
+func (h *Handler) templateAgentCreateConfig(spec projecttemplates.AgentSpec) (*store.CreateAgentConfig, string) {
+	model, provider, reasoningEffort, modelSource := h.templateAgentModelDefaults(spec)
+	return &store.CreateAgentConfig{
+		Type:            canonicalAgentType(spec.Type),
+		Role:            types.AgentRole(canonicalAgentRole(spec.Role)),
+		Model:           model,
+		LLMProvider:     provider,
+		ReasoningEffort: reasoningEffort,
+		SystemPrompt:    spec.SystemPrompt,
+	}, modelSource
+}
+
 // seedTemplateAgents creates (or reuses) the agents a template declares and
 // attaches them to ws in roster order. The first declared agent becomes the
 // workspace entry agent; the rest are specialist sub-agents. It runs before the
@@ -89,21 +127,13 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 		isEntry := i == 0
 		_, exists := h.agentStore.GetAgent(spec.Name)
 		if !exists {
-			model, provider, reasoningEffort := h.templateAgentModelDefaults(spec)
-			cfg := &store.CreateAgentConfig{
-				Type:            canonicalAgentType(spec.Type),
-				Role:            types.AgentRole(canonicalAgentRole(spec.Role)),
-				Model:           model,
-				LLMProvider:     provider,
-				ReasoningEffort: reasoningEffort,
-				SystemPrompt:    spec.SystemPrompt,
-			}
+			cfg, _ := h.templateAgentCreateConfig(spec)
 			if err := h.agentStore.CreateAgent(spec.Name, cfg); err != nil {
 				if isEntry {
 					logger.Warn("Failed to seed template entry agent; falling back to entry-agent prompt",
 						logger.Fields{"workspace": ws.ID, "agent": spec.Name, "error": err})
 					result.Warnings = append(result.Warnings,
-						fmt.Sprintf("Entry agent %q could not be created — you'll be prompted to add one.", spec.Name))
+						fmt.Sprintf("Entry agent %q could not be created - you'll be prompted to add one.", spec.Name))
 					return result
 				}
 				logger.Warn("Failed to seed template specialist agent (skipped)",
@@ -119,7 +149,7 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 			// this entry are ignored in favor of the existing definition. Make
 			// that visible (PRD FR7).
 			result.ReuseNotices = append(result.ReuseNotices,
-				fmt.Sprintf("Reusing existing agent %q — its saved prompt, model, and tools are used, not the template's.", spec.Name))
+				fmt.Sprintf("Reusing existing agent %q - its saved prompt, model, and tools are used, not the template's.", spec.Name))
 		}
 
 		if isEntry {
@@ -138,22 +168,102 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 	return result
 }
 
-func (h *Handler) templateAgentModelDefaults(spec projecttemplates.AgentSpec) (model, provider, reasoningEffort string) {
+func (h *Handler) templateAgentModelDefaults(spec projecttemplates.AgentSpec) (model, provider, reasoningEffort, source string) {
 	model = strings.TrimSpace(spec.Model)
 	if model != "" || h == nil || h.systemModelReader == nil {
-		return model, "", ""
+		if model != "" {
+			return model, "", "", "template"
+		}
+		return "", "", "", "agent_default"
 	}
 
 	provider, model = h.systemModelReader.GetSystemModel()
 	provider = strings.TrimSpace(provider)
 	model = strings.TrimSpace(model)
 	if provider == "" || model == "" {
-		return "", "", ""
+		return "", "", "", "agent_default"
 	}
 	if strings.EqualFold(provider, "codex") {
 		reasoningEffort = h.systemModelReader.GetSystemReasoningEffort()
 	}
-	return model, provider, reasoningEffort
+	return model, provider, reasoningEffort, "system"
+}
+
+func (h *Handler) buildTemplateAgentPlan(tpl projecttemplates.Template) templateAgentPlan {
+	plan := templateAgentPlan{
+		HasAgents:    tpl.HasAgents(),
+		TemplateID:   tpl.ID,
+		TemplateName: tpl.Name,
+		Agents:       []templateAgentPlanItem{},
+	}
+	if h != nil && h.systemModelReader != nil {
+		provider, model := h.systemModelReader.GetSystemModel()
+		plan.SystemProvider = strings.TrimSpace(provider)
+		plan.SystemModel = strings.TrimSpace(model)
+		plan.SystemModelConfigured = plan.SystemProvider != "" && plan.SystemModel != ""
+	}
+	if !tpl.HasAgents() {
+		return plan
+	}
+
+	for i, spec := range tpl.Agents {
+		item := h.buildTemplateAgentPlanItem(spec, i == 0)
+		if item.EntryPoint {
+			plan.EntryAgentName = item.Name
+		}
+		if item.Warning != "" {
+			plan.Warnings = append(plan.Warnings, item.Warning)
+		}
+		plan.Agents = append(plan.Agents, item)
+	}
+	return plan
+}
+
+func (h *Handler) buildTemplateAgentPlanItem(spec projecttemplates.AgentSpec, entryPoint bool) templateAgentPlanItem {
+	name := strings.TrimSpace(spec.Name)
+	item := templateAgentPlanItem{
+		Name:       name,
+		Action:     "create",
+		EntryPoint: entryPoint,
+		Tools:      spec.Tools,
+	}
+
+	if h != nil && h.agentStore != nil {
+		if ag, exists := h.agentStore.GetAgent(name); exists && ag != nil {
+			item.Action = "reuse"
+			item.Type = strings.TrimSpace(ag.Type)
+			item.Role = strings.TrimSpace(string(ag.Role))
+			item.Model = strings.TrimSpace(ag.Settings.Model)
+			item.Provider = strings.TrimSpace(ag.Settings.Provider)
+			item.ReasoningEffort = strings.TrimSpace(ag.Settings.EffectiveReasoningEffort(ag.Settings.Provider))
+			item.ModelSource = "existing"
+			item.Tools = projecttemplates.ToolDefaults{}
+			item.Warning = fmt.Sprintf("Reusing existing agent %q - its saved prompt, model, and tools are used, not the template's.", name)
+			return item
+		}
+	}
+
+	cfg, modelSource := h.templateAgentCreateConfig(spec)
+	item.Type = strings.TrimSpace(cfg.Type)
+	if item.Type == "" {
+		if cfg.Model != "" {
+			item.Type = agent.GetTypeForModel(cfg.Model)
+		} else {
+			item.Type = agent.TypeToolCalling
+		}
+	}
+	item.Role = strings.TrimSpace(string(cfg.Role))
+	if item.Role == "" {
+		item.Role = string(types.RoleGeneral)
+	}
+	item.Model = strings.TrimSpace(cfg.Model)
+	item.Provider = strings.TrimSpace(cfg.LLMProvider)
+	item.ReasoningEffort = strings.TrimSpace(cfg.ReasoningEffort)
+	item.ModelSource = modelSource
+	if item.Model == "" {
+		item.Warning = fmt.Sprintf("Agent %q has no template or system model; it will use the app's default agent model.", name)
+	}
+	return item
 }
 
 // bindSeededAgentTools binds per-agent tools for the agents the seeder created,

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -68,6 +68,7 @@ type templateAgentOverride struct {
 	Role         *string `json:"role,omitempty"`
 	Type         *string `json:"type,omitempty"`
 	Model        *string `json:"model,omitempty"`
+	Provider     *string `json:"provider,omitempty"`
 	SystemPrompt *string `json:"system_prompt,omitempty"`
 }
 
@@ -141,6 +142,9 @@ func applyTemplateAgentOverrides(tpl projecttemplates.Template, overrides []temp
 		}
 		if override.Model != nil {
 			spec.Model = strings.TrimSpace(*override.Model)
+		}
+		if override.Provider != nil {
+			spec.Provider = strings.TrimSpace(*override.Provider)
 		}
 		if override.SystemPrompt != nil {
 			spec.SystemPrompt = strings.TrimSpace(*override.SystemPrompt)
@@ -271,9 +275,10 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 
 func (h *Handler) templateAgentModelDefaults(spec projecttemplates.AgentSpec) (model, provider, reasoningEffort, source string) {
 	model = strings.TrimSpace(spec.Model)
+	provider = strings.TrimSpace(spec.Provider)
 	if model != "" || h == nil || h.systemModelReader == nil {
 		if model != "" {
-			return model, "", "", "template"
+			return model, provider, "", "template"
 		}
 		return "", "", "", "agent_default"
 	}

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -89,11 +89,14 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 		isEntry := i == 0
 		_, exists := h.agentStore.GetAgent(spec.Name)
 		if !exists {
+			model, provider, reasoningEffort := h.templateAgentModelDefaults(spec)
 			cfg := &store.CreateAgentConfig{
-				Type:         canonicalAgentType(spec.Type),
-				Role:         types.AgentRole(canonicalAgentRole(spec.Role)),
-				Model:        spec.Model, // empty -> the store's global default model
-				SystemPrompt: spec.SystemPrompt,
+				Type:            canonicalAgentType(spec.Type),
+				Role:            types.AgentRole(canonicalAgentRole(spec.Role)),
+				Model:           model,
+				LLMProvider:     provider,
+				ReasoningEffort: reasoningEffort,
+				SystemPrompt:    spec.SystemPrompt,
 			}
 			if err := h.agentStore.CreateAgent(spec.Name, cfg); err != nil {
 				if isEntry {
@@ -133,6 +136,24 @@ func (h *Handler) seedTemplateAgents(ws *session.Workspace, tpl projecttemplates
 	}
 
 	return result
+}
+
+func (h *Handler) templateAgentModelDefaults(spec projecttemplates.AgentSpec) (model, provider, reasoningEffort string) {
+	model = strings.TrimSpace(spec.Model)
+	if model != "" || h == nil || h.systemModelReader == nil {
+		return model, "", ""
+	}
+
+	provider, model = h.systemModelReader.GetSystemModel()
+	provider = strings.TrimSpace(provider)
+	model = strings.TrimSpace(model)
+	if provider == "" || model == "" {
+		return "", "", ""
+	}
+	if strings.EqualFold(provider, "codex") {
+		reasoningEffort = h.systemModelReader.GetSystemReasoningEffort()
+	}
+	return model, provider, reasoningEffort
 }
 
 // bindSeededAgentTools binds per-agent tools for the agents the seeder created,

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -139,15 +139,16 @@ func TestBuildTemplateAgentPlan_CreateReuseAndSystemModel(t *testing.T) {
 		reasoningEffort: "high",
 	})
 	if err := handler.agentStore.CreateAgent("Shared", &agentstore.CreateAgentConfig{
-		Model:       "gpt-5-mini",
-		LLMProvider: "openai",
+		Model:        "gpt-5-mini",
+		LLMProvider:  "openai",
+		SystemPrompt: "saved shared prompt",
 	}); err != nil {
 		t.Fatalf("pre-create agent: %v", err)
 	}
 
 	tpl := rosterTemplate(
 		projecttemplates.AgentSpec{Name: "Shared", Model: "ignored-model"},
-		projecttemplates.AgentSpec{Name: "Fresh", Role: "orchestrator", Tools: projecttemplates.ToolDefaults{Skills: []string{"planning"}}},
+		projecttemplates.AgentSpec{Name: "Fresh", Role: "orchestrator", SystemPrompt: "fresh prompt", Tools: projecttemplates.ToolDefaults{Skills: []string{"planning"}}},
 	)
 	tpl.ID = "launch"
 	tpl.Name = "Launch"
@@ -166,14 +167,65 @@ func TestBuildTemplateAgentPlan_CreateReuseAndSystemModel(t *testing.T) {
 	if plan.Agents[0].Action != "reuse" || plan.Agents[0].Model != "gpt-5-mini" || plan.Agents[0].ModelSource != "existing" {
 		t.Fatalf("unexpected reused agent plan: %+v", plan.Agents[0])
 	}
+	if plan.Agents[0].SystemPrompt != "saved shared prompt" {
+		t.Fatalf("expected existing prompt to be surfaced, got %q", plan.Agents[0].SystemPrompt)
+	}
 	if plan.Agents[1].Action != "create" || plan.Agents[1].Model != "gpt-5.3-codex" || plan.Agents[1].Provider != "codex" || plan.Agents[1].ModelSource != "system" {
 		t.Fatalf("unexpected created agent plan: %+v", plan.Agents[1])
+	}
+	if plan.Agents[1].SystemPrompt != "fresh prompt" {
+		t.Fatalf("expected template prompt to be surfaced, got %q", plan.Agents[1].SystemPrompt)
 	}
 	if len(plan.Agents[1].Tools.Skills) != 1 || plan.Agents[1].Tools.Skills[0] != "planning" {
 		t.Fatalf("expected planned tools to be preserved, got %+v", plan.Agents[1].Tools)
 	}
 	if len(plan.Warnings) != 1 || !strings.Contains(plan.Warnings[0], "Shared") {
 		t.Fatalf("expected reuse warning for Shared, got %v", plan.Warnings)
+	}
+}
+
+func TestApplyTemplateAgentOverrides_UpdatesEditableFieldsAndPreservesTools(t *testing.T) {
+	name := "Edited Lead"
+	model := "gpt-5.7"
+	prompt := "Lead the workspace."
+	idx := 0
+	tpl := rosterTemplate(projecttemplates.AgentSpec{
+		Name:  "Lead",
+		Model: "gpt-5-mini",
+		Tools: projecttemplates.ToolDefaults{Skills: []string{"planning"}},
+	})
+
+	next, err := applyTemplateAgentOverrides(tpl, []templateAgentOverride{{
+		Index:        &idx,
+		Name:         &name,
+		Model:        &model,
+		SystemPrompt: &prompt,
+	}})
+	if err != nil {
+		t.Fatalf("apply overrides: %v", err)
+	}
+	got := next.Agents[0]
+	if got.Name != "Edited Lead" || got.Model != "gpt-5.7" || got.SystemPrompt != "Lead the workspace." {
+		t.Fatalf("editable fields not applied: %+v", got)
+	}
+	if len(got.Tools.Skills) != 1 || got.Tools.Skills[0] != "planning" {
+		t.Fatalf("tools should be preserved, got %+v", got.Tools)
+	}
+}
+
+func TestApplyTemplateAgentOverrides_RejectsDuplicateNames(t *testing.T) {
+	name := "Writer"
+	idx := 0
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Lead"},
+		projecttemplates.AgentSpec{Name: "Writer"},
+	)
+
+	if _, err := applyTemplateAgentOverrides(tpl, []templateAgentOverride{{
+		Index: &idx,
+		Name:  &name,
+	}}); err == nil {
+		t.Fatal("expected duplicate name error")
 	}
 }
 

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -130,6 +130,53 @@ func TestSeedTemplateAgents_ExplicitModelWinsOverSystemModel(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateAgentPlan_CreateReuseAndSystemModel(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+	handler.SetSystemModelReader(fakeSystemModelReader{
+		provider:        "codex",
+		model:           "gpt-5.3-codex",
+		reasoningEffort: "high",
+	})
+	if err := handler.agentStore.CreateAgent("Shared", &agentstore.CreateAgentConfig{
+		Model:       "gpt-5-mini",
+		LLMProvider: "openai",
+	}); err != nil {
+		t.Fatalf("pre-create agent: %v", err)
+	}
+
+	tpl := rosterTemplate(
+		projecttemplates.AgentSpec{Name: "Shared", Model: "ignored-model"},
+		projecttemplates.AgentSpec{Name: "Fresh", Role: "orchestrator", Tools: projecttemplates.ToolDefaults{Skills: []string{"planning"}}},
+	)
+	tpl.ID = "launch"
+	tpl.Name = "Launch"
+
+	plan := handler.buildTemplateAgentPlan(tpl)
+
+	if !plan.HasAgents || plan.EntryAgentName != "Shared" {
+		t.Fatalf("unexpected plan header: %+v", plan)
+	}
+	if !plan.SystemModelConfigured || plan.SystemProvider != "codex" || plan.SystemModel != "gpt-5.3-codex" {
+		t.Fatalf("unexpected system model fields: %+v", plan)
+	}
+	if len(plan.Agents) != 2 {
+		t.Fatalf("expected 2 planned agents, got %d", len(plan.Agents))
+	}
+	if plan.Agents[0].Action != "reuse" || plan.Agents[0].Model != "gpt-5-mini" || plan.Agents[0].ModelSource != "existing" {
+		t.Fatalf("unexpected reused agent plan: %+v", plan.Agents[0])
+	}
+	if plan.Agents[1].Action != "create" || plan.Agents[1].Model != "gpt-5.3-codex" || plan.Agents[1].Provider != "codex" || plan.Agents[1].ModelSource != "system" {
+		t.Fatalf("unexpected created agent plan: %+v", plan.Agents[1])
+	}
+	if len(plan.Agents[1].Tools.Skills) != 1 || plan.Agents[1].Tools.Skills[0] != "planning" {
+		t.Fatalf("expected planned tools to be preserved, got %+v", plan.Agents[1].Tools)
+	}
+	if len(plan.Warnings) != 1 || !strings.Contains(plan.Warnings[0], "Shared") {
+		t.Fatalf("expected reuse warning for Shared, got %v", plan.Warnings)
+	}
+}
+
 func TestSeedTemplateAgents_ReuseOnNameMatchDoesNotMutate(t *testing.T) {
 	handler, cleanup := createTestHandler(t)
 	defer cleanup()

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -24,6 +24,20 @@ func wsHasAgent(ws *session.Workspace, name string) bool {
 	return false
 }
 
+type fakeSystemModelReader struct {
+	provider        string
+	model           string
+	reasoningEffort string
+}
+
+func (f fakeSystemModelReader) GetSystemModel() (string, string) {
+	return f.provider, f.model
+}
+
+func (f fakeSystemModelReader) GetSystemReasoningEffort() string {
+	return f.reasoningEffort
+}
+
 func TestSeedTemplateAgents_CreatesRosterAndSetsEntry(t *testing.T) {
 	handler, cleanup := createTestHandler(t)
 	defer cleanup()
@@ -53,6 +67,66 @@ func TestSeedTemplateAgents_CreatesRosterAndSetsEntry(t *testing.T) {
 	}
 	if got := currentWorkspaceEntryAgentName(ws); got != "Lead" {
 		t.Fatalf("expected entry agent Lead, got %q", got)
+	}
+}
+
+func TestSeedTemplateAgents_BlankModelInheritsSystemModel(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+	handler.SetSystemModelReader(fakeSystemModelReader{
+		provider:        "codex",
+		model:           "gpt-5.3-codex",
+		reasoningEffort: "high",
+	})
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(projecttemplates.AgentSpec{Name: "Lead", Role: "orchestrator"})
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected EntrySet true")
+	}
+	created, ok := handler.agentStore.GetAgent("Lead")
+	if !ok {
+		t.Fatal("expected Lead agent to be created")
+	}
+	if created.Settings.Model != "gpt-5.3-codex" {
+		t.Fatalf("model = %q, want gpt-5.3-codex", created.Settings.Model)
+	}
+	if created.Settings.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", created.Settings.Provider)
+	}
+	if created.Settings.ReasoningEffort != "high" {
+		t.Fatalf("reasoning effort = %q, want high", created.Settings.ReasoningEffort)
+	}
+}
+
+func TestSeedTemplateAgents_ExplicitModelWinsOverSystemModel(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+	handler.SetSystemModelReader(fakeSystemModelReader{
+		provider: "codex",
+		model:    "gpt-5.3-codex",
+	})
+
+	ws := &session.Workspace{ID: "ws1", Name: "Campaign"}
+	tpl := rosterTemplate(projecttemplates.AgentSpec{Name: "Lead", Model: "gpt-5-mini"})
+
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected EntrySet true")
+	}
+	created, ok := handler.agentStore.GetAgent("Lead")
+	if !ok {
+		t.Fatal("expected Lead agent to be created")
+	}
+	if created.Settings.Model != "gpt-5-mini" {
+		t.Fatalf("model = %q, want explicit gpt-5-mini", created.Settings.Model)
+	}
+	if created.Settings.Provider != "" {
+		t.Fatalf("provider = %q, want empty provider for explicit model-only template", created.Settings.Provider)
 	}
 }
 

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -187,6 +187,7 @@ func TestBuildTemplateAgentPlan_CreateReuseAndSystemModel(t *testing.T) {
 func TestApplyTemplateAgentOverrides_UpdatesEditableFieldsAndPreservesTools(t *testing.T) {
 	name := "Edited Lead"
 	model := "gpt-5.7"
+	provider := "codex"
 	prompt := "Lead the workspace."
 	idx := 0
 	tpl := rosterTemplate(projecttemplates.AgentSpec{
@@ -199,13 +200,14 @@ func TestApplyTemplateAgentOverrides_UpdatesEditableFieldsAndPreservesTools(t *t
 		Index:        &idx,
 		Name:         &name,
 		Model:        &model,
+		Provider:     &provider,
 		SystemPrompt: &prompt,
 	}})
 	if err != nil {
 		t.Fatalf("apply overrides: %v", err)
 	}
 	got := next.Agents[0]
-	if got.Name != "Edited Lead" || got.Model != "gpt-5.7" || got.SystemPrompt != "Lead the workspace." {
+	if got.Name != "Edited Lead" || got.Model != "gpt-5.7" || got.Provider != "codex" || got.SystemPrompt != "Lead the workspace." {
 		t.Fatalf("editable fields not applied: %+v", got)
 	}
 	if len(got.Tools.Skills) != 1 || got.Tools.Skills[0] != "planning" {

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -385,7 +385,7 @@ func TestCreateWorkspaceAppliesTemplateAgentOverrides(t *testing.T) {
 		"name":"Launch",
 		"template_id":"roster-template",
 		"template_agent_overrides":[
-			{"index":0,"name":"Launch Lead","model":"gpt-5.7","system_prompt":"custom launch prompt"}
+			{"index":0,"name":"Launch Lead","model":"gpt-5.7","provider":"codex","system_prompt":"custom launch prompt"}
 		]
 	}`
 	w, resp := postCreateWorkspace(t, handler, body)
@@ -399,7 +399,7 @@ func TestCreateWorkspaceAppliesTemplateAgentOverrides(t *testing.T) {
 	if !ok {
 		t.Fatal("expected overridden agent name to be created")
 	}
-	if created.Settings.Model != "gpt-5.7" || created.Settings.SystemPrompt != "custom launch prompt" {
+	if created.Settings.Model != "gpt-5.7" || created.Settings.Provider != "codex" || created.Settings.SystemPrompt != "custom launch prompt" {
 		t.Fatalf("overridden settings not applied: %+v", created.Settings)
 	}
 	if len(appliedTools) != 1 || appliedTools[0] != "Launch Lead:planning" {

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -310,6 +310,82 @@ func TestCreateWorkspaceSeedsTemplateAgentRoster(t *testing.T) {
 	}
 }
 
+func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	handler.SetSystemModelReader(fakeSystemModelReader{provider: "codex", model: "gpt-5.3-codex"})
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator"},
+			{"name":"Copywriter","type":"general"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/template-agent-plan", bytes.NewBufferString(`{"template_id":"roster-template"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var plan templateAgentPlan
+	if err := json.Unmarshal(w.Body.Bytes(), &plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	if !plan.HasAgents || plan.EntryAgentName != "Campaign Lead" {
+		t.Fatalf("unexpected plan: %+v", plan)
+	}
+	if len(plan.Agents) != 2 || plan.Agents[0].Action != "create" || plan.Agents[0].Model != "gpt-5.3-codex" {
+		t.Fatalf("unexpected planned agents: %+v", plan.Agents)
+	}
+}
+
+func TestCreateWorkspaceCanSkipTemplateAgentRoster(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator"},
+			{"name":"Copywriter","type":"general"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := postCreateWorkspace(t, handler, `{"name":"Launch","template_id":"roster-template","create_template_agents":false}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, ok := handler.agentStore.GetAgent("Campaign Lead"); ok {
+		t.Fatal("entry agent should not be created when create_template_agents=false")
+	}
+	folder := resp["folder"].(map[string]any)
+	wsID := folder["id"].(string)
+	sessWS, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if len(sessWS.AgentInstances) != 0 || currentWorkspaceEntryAgentName(sessWS) != "" {
+		t.Fatalf("expected agentless workspace, got instances=%v entry=%q", sessWS.AgentInstances, currentWorkspaceEntryAgentName(sessWS))
+	}
+}
+
 func TestCreateWorkspaceWithOnboardingTemplateDefersProject(t *testing.T) {
 	handler, baseDir, events, cleanup := templateTestEnv(t)
 	defer cleanup()

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/session"
 	agentstore "github.com/johnjallday/ori-agent/internal/store"
 	"github.com/johnjallday/ori-agent/internal/templateonboarding"
@@ -322,7 +324,7 @@ func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
 	manifest := `{
 		"name":"Roster Template",
 		"agents":[
-			{"name":"Campaign Lead","role":"orchestrator"},
+			{"name":"Campaign Lead","role":"orchestrator","system_prompt":"lead it"},
 			{"name":"Copywriter","type":"general"}
 		]
 	}`
@@ -346,6 +348,104 @@ func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
 	}
 	if len(plan.Agents) != 2 || plan.Agents[0].Action != "create" || plan.Agents[0].Model != "gpt-5.3-codex" {
 		t.Fatalf("unexpected planned agents: %+v", plan.Agents)
+	}
+	if plan.Agents[0].SystemPrompt != "lead it" {
+		t.Fatalf("expected system prompt in plan, got %q", plan.Agents[0].SystemPrompt)
+	}
+}
+
+func TestCreateWorkspaceAppliesTemplateAgentOverrides(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	var appliedTools []string
+	handler.SetAgentToolApplier(func(_ string, agentName string, tools projecttemplates.ToolDefaults) ([]string, []string) {
+		if len(tools.Skills) > 0 {
+			appliedTools = append(appliedTools, agentName+":"+strings.Join(tools.Skills, ","))
+		}
+		return tools.Skills, nil
+	})
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator","model":"gpt-5-mini","system_prompt":"lead it","tools":{"skills":["planning"]}},
+			{"name":"Copywriter","type":"general"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{
+		"name":"Launch",
+		"template_id":"roster-template",
+		"template_agent_overrides":[
+			{"index":0,"name":"Launch Lead","model":"gpt-5.7","system_prompt":"custom launch prompt"}
+		]
+	}`
+	w, resp := postCreateWorkspace(t, handler, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, ok := handler.agentStore.GetAgent("Campaign Lead"); ok {
+		t.Fatal("original agent name should not be created after override")
+	}
+	created, ok := handler.agentStore.GetAgent("Launch Lead")
+	if !ok {
+		t.Fatal("expected overridden agent name to be created")
+	}
+	if created.Settings.Model != "gpt-5.7" || created.Settings.SystemPrompt != "custom launch prompt" {
+		t.Fatalf("overridden settings not applied: %+v", created.Settings)
+	}
+	if len(appliedTools) != 1 || appliedTools[0] != "Launch Lead:planning" {
+		t.Fatalf("expected original tools bound to renamed agent, got %v", appliedTools)
+	}
+
+	folder := resp["folder"].(map[string]any)
+	wsID := folder["id"].(string)
+	sessWS, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if got := currentWorkspaceEntryAgentName(sessWS); got != "Launch Lead" {
+		t.Fatalf("entry agent = %q, want Launch Lead", got)
+	}
+}
+
+func TestCreateWorkspaceRejectsDuplicateTemplateAgentOverrides(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator"},
+			{"name":"Copywriter","type":"general"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{
+		"name":"Launch",
+		"template_id":"roster-template",
+		"template_agent_overrides":[
+			{"index":0,"name":"Copywriter"}
+		]
+	}`
+	w, _ := postCreateWorkspace(t, handler, body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -194,23 +194,24 @@ func splitWorkspaceBootstrapValues(raw string) []string {
 
 // createWorkspaceRequest is the JSON body of POST /api/workspaces.
 type createWorkspaceRequest struct {
-	Name                 string                     `json:"name"`
-	Kind                 string                     `json:"kind,omitempty"`
-	WorkspacePreset      string                     `json:"workspace_preset,omitempty"`
-	Description          string                     `json:"description,omitempty"`
-	ParentID             string                     `json:"parent_id,omitempty"`
-	OrderIndex           *int                       `json:"order_index,omitempty"`
-	Color                string                     `json:"color,omitempty"`
-	ProjectPath          string                     `json:"project_path,omitempty"`
-	FolderSlug           string                     `json:"folder_slug,omitempty"`
-	Location             string                     `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
-	EntryAgentName       string                     `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
-	WorkspaceBootstrap   *workspaceBootstrapRequest `json:"workspace_bootstrap,omitempty"`
-	TemplateID           string                     `json:"template_id,omitempty"`   // Optional project template from the library
-	TemplatePath         string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
-	ProjectName          string                     `json:"project_name,omitempty"`  // Project name for template instantiation (defaults to the workspace name)
-	Tags                 []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
-	CreateTemplateAgents *bool                      `json:"create_template_agents,omitempty"`
+	Name                   string                     `json:"name"`
+	Kind                   string                     `json:"kind,omitempty"`
+	WorkspacePreset        string                     `json:"workspace_preset,omitempty"`
+	Description            string                     `json:"description,omitempty"`
+	ParentID               string                     `json:"parent_id,omitempty"`
+	OrderIndex             *int                       `json:"order_index,omitempty"`
+	Color                  string                     `json:"color,omitempty"`
+	ProjectPath            string                     `json:"project_path,omitempty"`
+	FolderSlug             string                     `json:"folder_slug,omitempty"`
+	Location               string                     `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
+	EntryAgentName         string                     `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
+	WorkspaceBootstrap     *workspaceBootstrapRequest `json:"workspace_bootstrap,omitempty"`
+	TemplateID             string                     `json:"template_id,omitempty"`   // Optional project template from the library
+	TemplatePath           string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
+	ProjectName            string                     `json:"project_name,omitempty"`  // Project name for template instantiation (defaults to the workspace name)
+	Tags                   []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
+	CreateTemplateAgents   *bool                      `json:"create_template_agents,omitempty"`
+	TemplateAgentOverrides []templateAgentOverride    `json:"template_agent_overrides,omitempty"`
 }
 
 // createWorkspace handles POST /api/workspaces. The flow is staged:
@@ -259,6 +260,14 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	if wantsProject {
 		resolvedTemplate, templateResolveErr = h.resolveProjectTemplate(req.TemplateID, req.TemplatePath)
 		templateResolved = templateResolveErr == nil
+	}
+	if templateResolved && createTemplateAgentsEnabled(req) && len(req.TemplateAgentOverrides) > 0 {
+		var err error
+		resolvedTemplate, err = applyTemplateAgentOverrides(resolvedTemplate, req.TemplateAgentOverrides)
+		if err != nil {
+			_ = orihttp.RespondBadRequest(w, err.Error())
+			return
+		}
 	}
 
 	ws := buildCreateWorkspace(req, kind, requestedTags, resolvedTemplate, templateResolved)

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -61,6 +61,9 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 	case "rescan":
 		h.handleWorkspaceRescan(w, r)
 		return
+	case "template-agent-plan":
+		h.handleTemplateAgentPlan(w, r)
+		return
 	}
 
 	// Handle sub-paths like {id}/agents, {id}/layout
@@ -191,22 +194,23 @@ func splitWorkspaceBootstrapValues(raw string) []string {
 
 // createWorkspaceRequest is the JSON body of POST /api/workspaces.
 type createWorkspaceRequest struct {
-	Name               string                     `json:"name"`
-	Kind               string                     `json:"kind,omitempty"`
-	WorkspacePreset    string                     `json:"workspace_preset,omitempty"`
-	Description        string                     `json:"description,omitempty"`
-	ParentID           string                     `json:"parent_id,omitempty"`
-	OrderIndex         *int                       `json:"order_index,omitempty"`
-	Color              string                     `json:"color,omitempty"`
-	ProjectPath        string                     `json:"project_path,omitempty"`
-	FolderSlug         string                     `json:"folder_slug,omitempty"`
-	Location           string                     `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
-	EntryAgentName     string                     `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
-	WorkspaceBootstrap *workspaceBootstrapRequest `json:"workspace_bootstrap,omitempty"`
-	TemplateID         string                     `json:"template_id,omitempty"`   // Optional project template from the library
-	TemplatePath       string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
-	ProjectName        string                     `json:"project_name,omitempty"`  // Project name for template instantiation (defaults to the workspace name)
-	Tags               []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
+	Name                 string                     `json:"name"`
+	Kind                 string                     `json:"kind,omitempty"`
+	WorkspacePreset      string                     `json:"workspace_preset,omitempty"`
+	Description          string                     `json:"description,omitempty"`
+	ParentID             string                     `json:"parent_id,omitempty"`
+	OrderIndex           *int                       `json:"order_index,omitempty"`
+	Color                string                     `json:"color,omitempty"`
+	ProjectPath          string                     `json:"project_path,omitempty"`
+	FolderSlug           string                     `json:"folder_slug,omitempty"`
+	Location             string                     `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
+	EntryAgentName       string                     `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
+	WorkspaceBootstrap   *workspaceBootstrapRequest `json:"workspace_bootstrap,omitempty"`
+	TemplateID           string                     `json:"template_id,omitempty"`   // Optional project template from the library
+	TemplatePath         string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
+	ProjectName          string                     `json:"project_name,omitempty"`  // Project name for template instantiation (defaults to the workspace name)
+	Tags                 []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
+	CreateTemplateAgents *bool                      `json:"create_template_agents,omitempty"`
 }
 
 // createWorkspace handles POST /api/workspaces. The flow is staged:
@@ -373,7 +377,7 @@ func (h *Handler) selectCreateWorkspaceEntryAgent(w http.ResponseWriter, ws *ses
 			setWorkspaceEntryAgent(ws, entryAgentName)
 			seed.EntrySet = true
 		}
-	case templateResolved && tmpl.HasAgents():
+	case templateResolved && tmpl.HasAgents() && createTemplateAgentsEnabled(req):
 		// The template declares an agent roster: seed it (first = entry agent,
 		// rest = specialists). A seeded entry agent suppresses the mandatory
 		// "create an entry agent" prompt; if it fails, the workspace is left
@@ -386,6 +390,10 @@ func (h *Handler) selectCreateWorkspaceEntryAgent(w http.ResponseWriter, ws *ses
 		}
 	}
 	return seed, true
+}
+
+func createTemplateAgentsEnabled(req createWorkspaceRequest) bool {
+	return req.CreateTemplateAgents == nil || *req.CreateTemplateAgents
 }
 
 // createTemplateContext bundles the template-resolution results that folder

--- a/internal/web/static/css/sessions.css
+++ b/internal/web/static/css/sessions.css
@@ -1215,15 +1215,36 @@ body.workspace-page .workspace-setup-card {
   min-width: 0;
 }
 
-.workspace-template-agent-name {
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  overflow-wrap: anywhere;
+.workspace-template-agent-fields {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.9fr) minmax(160px, 1.1fr);
+  gap: 0.5rem;
+}
+
+.workspace-template-agent-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0;
+  font-size: 0.66rem;
+  font-weight: 650;
+  color: var(--text-secondary);
+}
+
+.workspace-template-agent-field input {
+  min-height: 30px;
+  padding: 0.25rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.workspace-template-agent-row.is-edited {
+  border-color: color-mix(in srgb, var(--primary-color) 42%, var(--border-color));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary-color) 28%, transparent) inset;
 }
 
 .workspace-template-agent-meta {
-  margin-top: 0.28rem;
+  margin-top: 0.38rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem;
@@ -1277,6 +1298,45 @@ body.workspace-page .workspace-setup-card {
   font-size: 0.74rem;
 }
 
+.workspace-template-agent-note {
+  margin-top: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.workspace-template-agent-prompt {
+  margin-top: 0.45rem;
+  border-top: 1px dashed var(--border-color);
+  padding-top: 0.42rem;
+}
+
+.workspace-template-agent-prompt summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+  list-style: none;
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  font-weight: 650;
+}
+
+.workspace-template-agent-prompt summary::-webkit-details-marker {
+  display: none;
+}
+
+.workspace-template-agent-prompt textarea {
+  width: 100%;
+  min-height: 86px;
+  margin-top: 0.4rem;
+  padding: 0.45rem 0.5rem;
+  resize: vertical;
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
 .workspace-template-agent-warnings {
   margin-top: 0.55rem;
   padding-top: 0.5rem;
@@ -1290,8 +1350,16 @@ body.workspace-page .workspace-setup-card {
   opacity: 0.48;
 }
 
+.workspace-template-agent-review.is-disabled .workspace-template-agent-control {
+  pointer-events: none;
+}
+
 @media (max-width: 575.98px) {
   .workspace-template-agent-row {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-template-agent-fields {
     grid-template-columns: 1fr;
   }
 

--- a/internal/web/static/css/sessions.css
+++ b/internal/web/static/css/sessions.css
@@ -1146,6 +1146,162 @@ body.workspace-page .workspace-setup-card {
   color: var(--text-primary);
 }
 
+.workspace-template-agent-review {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.7rem;
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--primary-color) 12%);
+}
+
+.workspace-template-agent-review-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.workspace-template-agent-review-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.workspace-template-agent-review-summary,
+.workspace-template-agent-review-status {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
+.workspace-template-agent-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 28px;
+  padding: 0.22rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--bg-primary);
+}
+
+.workspace-template-agent-toggle input {
+  margin: 0;
+}
+
+.workspace-template-agent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: 0.6rem;
+}
+
+.workspace-template-agent-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.6rem;
+  align-items: start;
+  padding: 0.55rem 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+}
+
+.workspace-template-agent-main {
+  min-width: 0;
+}
+
+.workspace-template-agent-name {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.workspace-template-agent-meta {
+  margin-top: 0.28rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.workspace-template-agent-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-height: 20px;
+  padding: 0.12rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.66rem;
+  font-weight: 650;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.workspace-template-agent-chip.create {
+  color: #0f5132;
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.workspace-template-agent-chip.reuse {
+  color: #7c2d12;
+  background: rgba(245, 158, 11, 0.14);
+  border-color: rgba(245, 158, 11, 0.32);
+}
+
+.workspace-template-agent-chip.entry {
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.24);
+}
+
+.workspace-template-agent-model {
+  justify-self: end;
+  max-width: min(260px, 38vw);
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.workspace-template-agent-model strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: 0.74rem;
+}
+
+.workspace-template-agent-warnings {
+  margin-top: 0.55rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+}
+
+.workspace-template-agent-review.is-disabled .workspace-template-agent-list,
+.workspace-template-agent-review.is-disabled .workspace-template-agent-warnings {
+  opacity: 0.48;
+}
+
+@media (max-width: 575.98px) {
+  .workspace-template-agent-row {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-template-agent-model {
+    justify-self: start;
+    max-width: 100%;
+    text-align: left;
+  }
+}
+
 /* "Advanced" disclosure in the create-workspace modal (Agent behavior). */
 .workspace-advanced-details {
   border: 1px solid var(--border-color);

--- a/internal/web/static/css/sessions.css
+++ b/internal/web/static/css/sessions.css
@@ -1232,10 +1232,15 @@ body.workspace-page .workspace-setup-card {
   color: var(--text-secondary);
 }
 
-.workspace-template-agent-field input {
+.workspace-template-agent-field input,
+.workspace-template-agent-field select {
   min-height: 30px;
   padding: 0.25rem 0.45rem;
   font-size: 0.75rem;
+}
+
+.workspace-template-agent-field select {
+  cursor: pointer;
 }
 
 .workspace-template-agent-row.is-edited {

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -123,6 +123,55 @@
 }
 .workspace-create-modal .workspace-template-card-desc { color: var(--wc-ink-faint); }
 
+.workspace-create-modal .workspace-template-agent-review {
+  background: rgba(70, 211, 154, 0.06);
+  border-color: var(--wc-faction-deep);
+}
+.workspace-create-modal .workspace-template-agent-review-title {
+  color: #f3f5f8;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-template-agent-review-summary,
+.workspace-create-modal .workspace-template-agent-review-status,
+.workspace-create-modal .workspace-template-agent-warnings {
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-agent-toggle,
+.workspace-create-modal .workspace-template-agent-row {
+  background: var(--wc-panel-2);
+  border-color: var(--wc-line);
+}
+.workspace-create-modal .workspace-template-agent-toggle {
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-template-agent-name,
+.workspace-create-modal .workspace-template-agent-model strong {
+  color: #f3f5f8;
+}
+.workspace-create-modal .workspace-template-agent-model {
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-agent-chip {
+  border-color: var(--wc-line-bright);
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-agent-chip.create {
+  color: #9af2c5;
+  background: rgba(70, 211, 154, 0.1);
+  border-color: rgba(70, 211, 154, 0.26);
+}
+.workspace-create-modal .workspace-template-agent-chip.reuse {
+  color: #f7d27a;
+  background: rgba(232, 181, 75, 0.12);
+  border-color: rgba(232, 181, 75, 0.28);
+}
+.workspace-create-modal .workspace-template-agent-chip.entry {
+  color: #9be2f4;
+  background: rgba(78, 197, 230, 0.1);
+  border-color: rgba(78, 197, 230, 0.24);
+}
+
 /* color picker: keep the swatch colors, tactical active ring */
 .workspace-create-modal .folder-color-btn.active { box-shadow: 0 0 0 2px var(--wc-faction); }
 

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -145,12 +145,31 @@
 .workspace-create-modal .workspace-template-agent-toggle {
   color: var(--wc-faction);
 }
-.workspace-create-modal .workspace-template-agent-name,
 .workspace-create-modal .workspace-template-agent-model strong {
   color: #f3f5f8;
 }
 .workspace-create-modal .workspace-template-agent-model {
   color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-agent-field,
+.workspace-create-modal .workspace-template-agent-note,
+.workspace-create-modal .workspace-template-agent-prompt summary {
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-agent-control {
+  background: rgba(4, 8, 12, 0.48);
+  border-color: var(--wc-line);
+  color: #f3f5f8;
+}
+.workspace-create-modal .workspace-template-agent-control::placeholder {
+  color: rgba(198, 207, 216, 0.54);
+}
+.workspace-create-modal .workspace-template-agent-row.is-edited {
+  border-color: var(--wc-faction-deep);
+  box-shadow: 0 0 0 1px rgba(70, 211, 154, 0.22) inset;
+}
+.workspace-create-modal .workspace-template-agent-prompt {
+  border-top-color: var(--wc-line);
 }
 .workspace-create-modal .workspace-template-agent-chip {
   border-color: var(--wc-line-bright);

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -526,6 +526,7 @@ async function ptcBrowse() {
       ptcSelect(PTC_BLANK, ptcBlankCard());
       els.pathInput.value = picked.path;
       ptcUpdateUI();
+      els.pathInput.dispatchEvent(new Event('input', { bubbles: true }));
     }
   } catch (error) {
     ptmToast(error.message || 'Failed to open folder picker', 'error');
@@ -544,6 +545,7 @@ function ptcInit() {
       if (els.pathInput.value.trim()) {
         ptcSelected = PTC_BLANK;
         ptcMarkSelectedAcross(ptcBlankCard());
+        ptcEmitSelection();
       }
       ptcUpdateUI();
     });

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3307,6 +3307,8 @@ const sessionManager = {
         return;
       }
       this.templateAgentPlan = data;
+      await this.ensureEditAgentModelOptions();
+      if (requestId !== this.templateAgentPlanRequestId) return;
       this.renderTemplateAgentPlan(data);
     } catch (error) {
       if (requestId !== this.templateAgentPlanRequestId) return;
@@ -3410,9 +3412,11 @@ const sessionManager = {
     const name = String(agent?.name || '').trim();
     const systemPrompt = String(agent?.system_prompt || '').trim();
     const editableModel = ['template', 'existing'].includes(String(agent?.model_source || '').trim()) ? model : '';
+    const editableProvider = editableModel ? provider : '';
     const modelText = model
       ? `${provider ? `${provider} / ` : ''}${model}`
       : 'App default';
+    const modelOptions = this.renderTemplateAgentModelOptions(agent, editableModel, editableProvider, modelText);
     const promptState = systemPrompt ? 'Prompt set' : 'No prompt';
     const chips = [
       `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>`,
@@ -3431,6 +3435,7 @@ const sessionManager = {
            data-original-action="${this.escapeHtml(action)}"
            data-original-name="${this.escapeHtml(name)}"
            data-original-model="${this.escapeHtml(editableModel)}"
+           data-original-provider="${this.escapeHtml(editableProvider)}"
            data-original-system-prompt="${this.escapeHtml(systemPrompt)}">
         <div class="workspace-template-agent-main">
           <div class="workspace-template-agent-fields">
@@ -3443,10 +3448,9 @@ const sessionManager = {
             </label>
             <label class="workspace-template-agent-field">
               <span>Model</span>
-              <input type="text"
-                     class="modern-input workspace-template-agent-control workspace-template-agent-model-input"
-                     value="${this.escapeHtml(editableModel)}"
-                     placeholder="${this.escapeHtml(modelText)}">
+              <select class="modern-input workspace-template-agent-control workspace-template-agent-model-input">
+                ${modelOptions}
+              </select>
             </label>
           </div>
           <div class="workspace-template-agent-meta">${chips}</div>
@@ -3469,12 +3473,51 @@ const sessionManager = {
     `;
   },
 
+  renderTemplateAgentModelOptions(agent, currentModel, currentProvider, inheritedLabel) {
+    const source = String(agent?.model_source || '').trim();
+    const inheritedText = source === 'system'
+      ? `Use system model (${inheritedLabel})`
+      : `Use default (${inheritedLabel})`;
+    const options = [
+      `<option value="" data-provider=""${currentModel ? '' : ' selected'}>${this.escapeHtml(inheritedText)}</option>`
+    ];
+    let foundCurrent = !currentModel;
+    const providers = Array.isArray(this.editAgentProvidersData) ? this.editAgentProvidersData : [];
+    providers.forEach((provider) => {
+      const models = Array.isArray(provider?.models) ? provider.models : [];
+      if (models.length === 0) return;
+      const groupOptions = [];
+      models.forEach((model) => {
+        const value = String(model?.value || model?.id || '').trim();
+        if (!value) return;
+        const optionProvider = String(model?.provider || provider?.name || '').trim();
+        const label = String(model?.label || value).trim();
+        const selected = value === currentModel && optionProvider === currentProvider;
+        if (selected) foundCurrent = true;
+        groupOptions.push(
+          `<option value="${this.escapeHtml(value)}" data-provider="${this.escapeHtml(optionProvider)}"${selected ? ' selected' : ''}>${this.escapeHtml(label)}</option>`
+        );
+      });
+      if (groupOptions.length === 0) return;
+      options.push(
+        `<optgroup label="${this.escapeHtml(provider?.display_name || provider?.name || 'Provider')}">${groupOptions.join('')}</optgroup>`
+      );
+    });
+    if (currentModel && !foundCurrent) {
+      options.splice(1, 0,
+        `<option value="${this.escapeHtml(currentModel)}" data-provider="${this.escapeHtml(currentProvider)}" selected>${this.escapeHtml(currentModel)} (current)</option>`
+      );
+    }
+    return options.join('');
+  },
+
   bindTemplateAgentReviewInputs() {
     const list = document.getElementById('templateAgentReviewList');
     if (!list) return;
     list.querySelectorAll('.workspace-template-agent-row').forEach((row) => {
       row.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
         control.addEventListener('input', () => this.updateTemplateAgentReviewRowState(row));
+        control.addEventListener('change', () => this.updateTemplateAgentReviewRowState(row));
       });
       this.updateTemplateAgentReviewRowState(row);
     });
@@ -3490,11 +3533,13 @@ const sessionManager = {
     const promptState = row.querySelector('.workspace-template-agent-prompt-state');
     const originalName = row.dataset.originalName || '';
     const originalModel = row.dataset.originalModel || '';
+    const originalProvider = row.dataset.originalProvider || '';
     const originalPrompt = row.dataset.originalSystemPrompt || '';
     const name = String(nameInput?.value || '').trim();
     const model = String(modelInput?.value || '').trim();
+    const provider = String(modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || '').trim();
     const prompt = String(promptInput?.value || '').trim();
-    const dirty = name !== originalName || model !== originalModel || prompt !== originalPrompt;
+    const dirty = name !== originalName || model !== originalModel || provider !== originalProvider || prompt !== originalPrompt;
     row.classList.toggle('is-edited', dirty);
 
     if (actionChip && row.dataset.originalAction === 'reuse') {
@@ -3504,7 +3549,7 @@ const sessionManager = {
       actionChip.classList.toggle('reuse', !renamed);
     }
     if (sourceLabel && modelInput) {
-      sourceLabel.textContent = model !== originalModel
+      sourceLabel.textContent = model !== originalModel || provider !== originalProvider
         ? 'Custom model'
         : this.templateAgentModelSourceLabel(this.findTemplateAgentPlanItemSource(row));
     }
@@ -3514,9 +3559,13 @@ const sessionManager = {
   },
 
   findTemplateAgentPlanItemSource(row) {
+    return this.findTemplateAgentPlanItem(row)?.model_source || '';
+  },
+
+  findTemplateAgentPlanItem(row) {
     const index = Number.parseInt(row?.dataset?.templateAgentIndex || '', 10);
     const agents = Array.isArray(this.templateAgentPlan?.agents) ? this.templateAgentPlan.agents : [];
-    return Number.isInteger(index) && agents[index] ? agents[index].model_source : '';
+    return Number.isInteger(index) && agents[index] ? agents[index] : null;
   },
 
   collectTemplateAgentOverrides() {
@@ -3535,6 +3584,7 @@ const sessionManager = {
       const promptInput = row.querySelector('.workspace-template-agent-prompt-input');
       const name = String(nameInput?.value || '').trim();
       const model = String(modelInput?.value || '').trim();
+      const provider = String(modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || '').trim();
       const systemPrompt = String(promptInput?.value || '').trim();
       if (!name) {
         nameInput?.focus();
@@ -3551,10 +3601,35 @@ const sessionManager = {
       }
       names.set(duplicateKey, name);
 
+      const originalName = row.dataset.originalName || '';
+      const originalModel = row.dataset.originalModel || '';
+      const originalProvider = row.dataset.originalProvider || '';
+      const originalPrompt = row.dataset.originalSystemPrompt || '';
+      const renamed = name !== originalName;
+      const modelChanged = model !== originalModel || provider !== originalProvider;
+      const promptChanged = systemPrompt !== originalPrompt;
+      if (row.dataset.originalAction === 'reuse' && !renamed && (modelChanged || promptChanged)) {
+        nameInput?.focus();
+        throw new Error(`Rename "${name}" before changing its model or prompt. Existing shared agents are reused as-is.`);
+      }
+
       const override = { index };
-      if (name !== (row.dataset.originalName || '')) override.name = name;
-      if (model !== (row.dataset.originalModel || '')) override.model = model;
-      if (systemPrompt !== (row.dataset.originalSystemPrompt || '')) override.system_prompt = systemPrompt;
+      if (renamed) {
+        override.name = name;
+        if (row.dataset.originalAction === 'reuse') {
+          const planItem = this.findTemplateAgentPlanItem(row) || {};
+          override.model = model;
+          override.provider = provider;
+          override.system_prompt = systemPrompt;
+          if (planItem.role) override.role = String(planItem.role).trim();
+          if (planItem.type) override.type = String(planItem.type).trim();
+        }
+      }
+      if (modelChanged) {
+        override.model = model;
+        override.provider = provider;
+      }
+      if (promptChanged) override.system_prompt = systemPrompt;
       if (Object.keys(override).length > 1) {
         overrides.push(override);
       }

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3383,7 +3383,7 @@ const sessionManager = {
         : 'Blank template models use the app default because no system model is configured.';
     }
     if (list) {
-      list.innerHTML = agents.map((agent) => this.renderTemplateAgentPlanRow(agent)).join('');
+      list.innerHTML = agents.map((agent, index) => this.renderTemplateAgentPlanRow(agent, index)).join('');
     }
     const warningMessages = [
       ...(Array.isArray(plan.warnings) ? plan.warnings : [])
@@ -3394,10 +3394,11 @@ const sessionManager = {
         .map((msg) => `<div>${this.escapeHtml(msg)}</div>`)
         .join('');
     }
+    this.bindTemplateAgentReviewInputs();
     this.updateTemplateAgentReviewDisabledState();
   },
 
-  renderTemplateAgentPlanRow(agent) {
+  renderTemplateAgentPlanRow(agent, index) {
     const action = String(agent?.action || 'create').trim() === 'reuse' ? 'reuse' : 'create';
     const actionLabel = action === 'reuse' ? 'Reuse' : 'Create';
     const role = String(agent?.role || '').trim();
@@ -3406,29 +3407,159 @@ const sessionManager = {
     const provider = String(agent?.provider || '').trim();
     const source = this.templateAgentModelSourceLabel(agent?.model_source);
     const tools = this.templateAgentToolsLabel(agent?.tools);
+    const name = String(agent?.name || '').trim();
+    const systemPrompt = String(agent?.system_prompt || '').trim();
+    const editableModel = ['template', 'existing'].includes(String(agent?.model_source || '').trim()) ? model : '';
     const modelText = model
       ? `${provider ? `${provider} / ` : ''}${model}`
       : 'App default';
+    const promptState = systemPrompt ? 'Prompt set' : 'No prompt';
     const chips = [
-      `<span class="workspace-template-agent-chip ${action}">${actionLabel}</span>`,
+      `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>`,
       agent?.entry_point ? '<span class="workspace-template-agent-chip entry">Entry</span>' : '<span class="workspace-template-agent-chip">Specialist</span>',
       role ? `<span class="workspace-template-agent-chip">${this.escapeHtml(role)}</span>` : '',
       type ? `<span class="workspace-template-agent-chip">${this.escapeHtml(type)}</span>` : '',
       tools ? `<span class="workspace-template-agent-chip">${this.escapeHtml(tools)}</span>` : ''
     ].filter(Boolean).join('');
+    const reuseNote = action === 'reuse'
+      ? '<div class="workspace-template-agent-note">This name matches an existing agent. Saved settings are reused unless you rename it.</div>'
+      : '';
 
     return `
-      <div class="workspace-template-agent-row">
+      <div class="workspace-template-agent-row"
+           data-template-agent-index="${index}"
+           data-original-action="${this.escapeHtml(action)}"
+           data-original-name="${this.escapeHtml(name)}"
+           data-original-model="${this.escapeHtml(editableModel)}"
+           data-original-system-prompt="${this.escapeHtml(systemPrompt)}">
         <div class="workspace-template-agent-main">
-          <div class="workspace-template-agent-name">${this.escapeHtml(agent?.name || 'Unnamed agent')}</div>
+          <div class="workspace-template-agent-fields">
+            <label class="workspace-template-agent-field">
+              <span>Name</span>
+              <input type="text"
+                     class="modern-input workspace-template-agent-control workspace-template-agent-name-input"
+                     value="${this.escapeHtml(name)}"
+                     placeholder="Agent name">
+            </label>
+            <label class="workspace-template-agent-field">
+              <span>Model</span>
+              <input type="text"
+                     class="modern-input workspace-template-agent-control workspace-template-agent-model-input"
+                     value="${this.escapeHtml(editableModel)}"
+                     placeholder="${this.escapeHtml(modelText)}">
+            </label>
+          </div>
           <div class="workspace-template-agent-meta">${chips}</div>
+          ${reuseNote}
+          <details class="workspace-template-agent-prompt">
+            <summary>
+              <span>System prompt</span>
+              <span class="workspace-template-agent-prompt-state">${this.escapeHtml(promptState)}</span>
+            </summary>
+            <textarea class="modern-input workspace-template-agent-control workspace-template-agent-prompt-input"
+                      rows="4"
+                      placeholder="Optional system prompt">${this.escapeHtml(systemPrompt)}</textarea>
+          </details>
         </div>
         <div class="workspace-template-agent-model">
           <strong>${this.escapeHtml(modelText)}</strong>
-          <span>${this.escapeHtml(source)}</span>
+          <span class="workspace-template-agent-model-source">${this.escapeHtml(source)}</span>
         </div>
       </div>
     `;
+  },
+
+  bindTemplateAgentReviewInputs() {
+    const list = document.getElementById('templateAgentReviewList');
+    if (!list) return;
+    list.querySelectorAll('.workspace-template-agent-row').forEach((row) => {
+      row.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
+        control.addEventListener('input', () => this.updateTemplateAgentReviewRowState(row));
+      });
+      this.updateTemplateAgentReviewRowState(row);
+    });
+  },
+
+  updateTemplateAgentReviewRowState(row) {
+    if (!row) return;
+    const nameInput = row.querySelector('.workspace-template-agent-name-input');
+    const modelInput = row.querySelector('.workspace-template-agent-model-input');
+    const promptInput = row.querySelector('.workspace-template-agent-prompt-input');
+    const actionChip = row.querySelector('.workspace-template-agent-action');
+    const sourceLabel = row.querySelector('.workspace-template-agent-model-source');
+    const promptState = row.querySelector('.workspace-template-agent-prompt-state');
+    const originalName = row.dataset.originalName || '';
+    const originalModel = row.dataset.originalModel || '';
+    const originalPrompt = row.dataset.originalSystemPrompt || '';
+    const name = String(nameInput?.value || '').trim();
+    const model = String(modelInput?.value || '').trim();
+    const prompt = String(promptInput?.value || '').trim();
+    const dirty = name !== originalName || model !== originalModel || prompt !== originalPrompt;
+    row.classList.toggle('is-edited', dirty);
+
+    if (actionChip && row.dataset.originalAction === 'reuse') {
+      const renamed = name !== '' && name !== originalName;
+      actionChip.textContent = renamed ? 'Create' : 'Reuse';
+      actionChip.classList.toggle('create', renamed);
+      actionChip.classList.toggle('reuse', !renamed);
+    }
+    if (sourceLabel && modelInput) {
+      sourceLabel.textContent = model !== originalModel
+        ? 'Custom model'
+        : this.templateAgentModelSourceLabel(this.findTemplateAgentPlanItemSource(row));
+    }
+    if (promptState) {
+      promptState.textContent = prompt ? 'Prompt set' : 'No prompt';
+    }
+  },
+
+  findTemplateAgentPlanItemSource(row) {
+    const index = Number.parseInt(row?.dataset?.templateAgentIndex || '', 10);
+    const agents = Array.isArray(this.templateAgentPlan?.agents) ? this.templateAgentPlan.agents : [];
+    return Number.isInteger(index) && agents[index] ? agents[index].model_source : '';
+  },
+
+  collectTemplateAgentOverrides() {
+    const review = document.getElementById('templateAgentReview');
+    const toggle = document.getElementById('templateAgentReviewToggle');
+    if (!review || !toggle || !toggle.checked) return [];
+
+    const rows = Array.from(review.querySelectorAll('.workspace-template-agent-row'));
+    const overrides = [];
+    const names = new Map();
+    for (const row of rows) {
+      const index = Number.parseInt(row.dataset.templateAgentIndex || '', 10);
+      if (!Number.isInteger(index)) continue;
+      const nameInput = row.querySelector('.workspace-template-agent-name-input');
+      const modelInput = row.querySelector('.workspace-template-agent-model-input');
+      const promptInput = row.querySelector('.workspace-template-agent-prompt-input');
+      const name = String(nameInput?.value || '').trim();
+      const model = String(modelInput?.value || '').trim();
+      const systemPrompt = String(promptInput?.value || '').trim();
+      if (!name) {
+        nameInput?.focus();
+        throw new Error('Template agent name cannot be empty.');
+      }
+      if (!/^[a-zA-Z0-9_\- ]+$/.test(name)) {
+        nameInput?.focus();
+        throw new Error('Template agent names can use letters, numbers, spaces, underscores, and hyphens.');
+      }
+      const duplicateKey = name.toLowerCase();
+      if (names.has(duplicateKey)) {
+        nameInput?.focus();
+        throw new Error(`Template agent "${name}" duplicates "${names.get(duplicateKey)}".`);
+      }
+      names.set(duplicateKey, name);
+
+      const override = { index };
+      if (name !== (row.dataset.originalName || '')) override.name = name;
+      if (model !== (row.dataset.originalModel || '')) override.model = model;
+      if (systemPrompt !== (row.dataset.originalSystemPrompt || '')) override.system_prompt = systemPrompt;
+      if (Object.keys(override).length > 1) {
+        overrides.push(override);
+      }
+    }
+    return overrides;
   },
 
   templateAgentModelSourceLabel(source) {
@@ -3461,6 +3592,9 @@ const sessionManager = {
     const toggle = document.getElementById('templateAgentReviewToggle');
     if (!review || !toggle) return;
     review.classList.toggle('is-disabled', !toggle.checked);
+    review.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
+      control.disabled = !toggle.checked;
+    });
   },
 
   // Fills a create-modal input from a template default while tracking the
@@ -3655,6 +3789,12 @@ const sessionManager = {
         if (this.templateAgentPlan?.has_agents) {
           const createTemplateAgents = Boolean(document.getElementById('templateAgentReviewToggle')?.checked);
           payload.create_template_agents = createTemplateAgents;
+          if (createTemplateAgents) {
+            const templateAgentOverrides = this.collectTemplateAgentOverrides();
+            if (templateAgentOverrides.length > 0) {
+              payload.template_agent_overrides = templateAgentOverrides;
+            }
+          }
         }
         if (window.WorkspaceTagsCard) {
           Object.assign(payload, window.WorkspaceTagsCard.getPayloadFields());

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -37,6 +37,9 @@ const sessionManager = {
   // Create-workspace "Starting point" template currently picked in the modal.
   // Populated when the modal opens (defaults to the first/Blank template).
   workspaceTemplate: null,
+  templateAgentPlan: null,
+  templateAgentPlanRequestId: 0,
+  templateAgentPlanTimer: null,
   // True once the user manually changes "Agent behavior", so selecting a
   // Starting point no longer overwrites their choice. Reset on modal open.
   behaviorOverridden: false,
@@ -233,6 +236,15 @@ const sessionManager = {
       this.prefillTemplateValue(document.getElementById('folderNameInput'), template?.name || '', 'autofillName');
       this.prefillTemplateValue(document.getElementById('folderDescriptionInput'), template?.description || '', 'autofillDescription');
       this.applyTemplateBehavior(template);
+      void this.refreshTemplateAgentPlan();
+    });
+
+    document.getElementById('templateAgentReviewToggle')?.addEventListener('change', () => {
+      this.updateTemplateAgentReviewDisabledState();
+    });
+
+    document.getElementById('projectTemplatePathInput')?.addEventListener('input', () => {
+      this.scheduleTemplateAgentPlanRefresh();
     });
 
     const importToggle = document.getElementById('folderImportToggle');
@@ -3027,6 +3039,9 @@ const sessionManager = {
     if (!this.importModeEnabled) {
       this.importAllowDuplicate = false;
       this.clearImportDuplicateWarning();
+      this.scheduleTemplateAgentPlanRefresh();
+    } else {
+      this.resetTemplateAgentReview();
     }
   },
 
@@ -3223,7 +3238,229 @@ const sessionManager = {
     // where the picker module has not loaded yet.
     this.workspaceTemplate = null;
     window.ProjectTemplateCard?.reset?.();
+    this.resetTemplateAgentReview();
     this.updateBehaviorHint();
+  },
+
+  resetTemplateAgentReview() {
+    this.templateAgentPlan = null;
+    this.templateAgentPlanRequestId += 1;
+    if (this.templateAgentPlanTimer) {
+      clearTimeout(this.templateAgentPlanTimer);
+      this.templateAgentPlanTimer = null;
+    }
+    const review = document.getElementById('templateAgentReview');
+    const summary = document.getElementById('templateAgentReviewSummary');
+    const status = document.getElementById('templateAgentReviewStatus');
+    const list = document.getElementById('templateAgentReviewList');
+    const warnings = document.getElementById('templateAgentReviewWarnings');
+    const toggle = document.getElementById('templateAgentReviewToggle');
+    if (review) {
+      review.hidden = true;
+      review.classList.remove('is-disabled');
+    }
+    if (summary) summary.textContent = '';
+    if (status) status.textContent = '';
+    if (list) list.innerHTML = '';
+    if (warnings) {
+      warnings.hidden = true;
+      warnings.innerHTML = '';
+    }
+    if (toggle) toggle.checked = true;
+  },
+
+  scheduleTemplateAgentPlanRefresh() {
+    if (this.templateAgentPlanTimer) {
+      clearTimeout(this.templateAgentPlanTimer);
+    }
+    this.templateAgentPlanTimer = setTimeout(() => {
+      this.templateAgentPlanTimer = null;
+      void this.refreshTemplateAgentPlan();
+    }, 180);
+  },
+
+  async refreshTemplateAgentPlan() {
+    const fields = window.ProjectTemplateCard?.getPayloadFields?.() || {};
+    const templateId = String(fields.template_id || '').trim();
+    const templatePath = String(fields.template_path || '').trim();
+    const requestId = ++this.templateAgentPlanRequestId;
+
+    if (this.importModeEnabled || (!templateId && !templatePath)) {
+      this.resetTemplateAgentReview();
+      return;
+    }
+
+    this.setTemplateAgentReviewLoading();
+    try {
+      const response = await fetch('/api/workspaces/template-agent-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          template_id: templateId || undefined,
+          template_path: templatePath || undefined
+        })
+      });
+      const data = await response.json().catch(() => ({}));
+      if (requestId !== this.templateAgentPlanRequestId) return;
+      if (!response.ok || data.error) {
+        this.renderTemplateAgentPlanError(data.error || 'Could not load template agents.');
+        return;
+      }
+      this.templateAgentPlan = data;
+      this.renderTemplateAgentPlan(data);
+    } catch (error) {
+      if (requestId !== this.templateAgentPlanRequestId) return;
+      console.error('Failed to load template agent plan:', error);
+      this.renderTemplateAgentPlanError('Could not load template agents.');
+    }
+  },
+
+  setTemplateAgentReviewLoading() {
+    const review = document.getElementById('templateAgentReview');
+    const summary = document.getElementById('templateAgentReviewSummary');
+    const status = document.getElementById('templateAgentReviewStatus');
+    const list = document.getElementById('templateAgentReviewList');
+    const warnings = document.getElementById('templateAgentReviewWarnings');
+    if (review) {
+      review.hidden = false;
+      review.classList.remove('is-disabled');
+    }
+    if (summary) summary.textContent = 'Checking template roster...';
+    if (status) status.textContent = '';
+    if (list) list.innerHTML = '';
+    if (warnings) {
+      warnings.hidden = true;
+      warnings.innerHTML = '';
+    }
+  },
+
+  renderTemplateAgentPlanError(message) {
+    this.templateAgentPlan = null;
+    const review = document.getElementById('templateAgentReview');
+    const summary = document.getElementById('templateAgentReviewSummary');
+    const status = document.getElementById('templateAgentReviewStatus');
+    const list = document.getElementById('templateAgentReviewList');
+    const toggle = document.getElementById('templateAgentReviewToggle');
+    if (review) {
+      review.hidden = false;
+      review.classList.remove('is-disabled');
+    }
+    if (summary) summary.textContent = 'Template agents could not be checked.';
+    if (status) status.textContent = message || 'Could not load template agents.';
+    if (list) list.innerHTML = '';
+    if (toggle) toggle.checked = true;
+  },
+
+  renderTemplateAgentPlan(plan) {
+    const agents = Array.isArray(plan?.agents) ? plan.agents : [];
+    if (!plan?.has_agents || agents.length === 0) {
+      this.resetTemplateAgentReview();
+      return;
+    }
+
+    const review = document.getElementById('templateAgentReview');
+    const summary = document.getElementById('templateAgentReviewSummary');
+    const status = document.getElementById('templateAgentReviewStatus');
+    const list = document.getElementById('templateAgentReviewList');
+    const warnings = document.getElementById('templateAgentReviewWarnings');
+    const toggle = document.getElementById('templateAgentReviewToggle');
+    if (review) review.hidden = false;
+    if (toggle) toggle.checked = true;
+
+    const createCount = agents.filter((agent) => agent.action === 'create').length;
+    const reuseCount = agents.filter((agent) => agent.action === 'reuse').length;
+    const parts = [];
+    if (createCount) parts.push(`${createCount} new`);
+    if (reuseCount) parts.push(`${reuseCount} reused`);
+    if (summary) {
+      summary.textContent = `${parts.join(' / ')} agent${agents.length === 1 ? '' : 's'} will be attached to this workspace.`;
+    }
+    if (status) {
+      const provider = String(plan.system_provider || '').trim();
+      const model = String(plan.system_model || '').trim();
+      status.textContent = provider && model
+        ? `Blank template models resolve to ${provider} / ${model}.`
+        : 'Blank template models use the app default because no system model is configured.';
+    }
+    if (list) {
+      list.innerHTML = agents.map((agent) => this.renderTemplateAgentPlanRow(agent)).join('');
+    }
+    const warningMessages = [
+      ...(Array.isArray(plan.warnings) ? plan.warnings : [])
+    ].filter((msg) => typeof msg === 'string' && msg.trim());
+    if (warnings) {
+      warnings.hidden = warningMessages.length === 0;
+      warnings.innerHTML = warningMessages
+        .map((msg) => `<div>${this.escapeHtml(msg)}</div>`)
+        .join('');
+    }
+    this.updateTemplateAgentReviewDisabledState();
+  },
+
+  renderTemplateAgentPlanRow(agent) {
+    const action = String(agent?.action || 'create').trim() === 'reuse' ? 'reuse' : 'create';
+    const actionLabel = action === 'reuse' ? 'Reuse' : 'Create';
+    const role = String(agent?.role || '').trim();
+    const type = String(agent?.type || '').trim();
+    const model = String(agent?.model || '').trim();
+    const provider = String(agent?.provider || '').trim();
+    const source = this.templateAgentModelSourceLabel(agent?.model_source);
+    const tools = this.templateAgentToolsLabel(agent?.tools);
+    const modelText = model
+      ? `${provider ? `${provider} / ` : ''}${model}`
+      : 'App default';
+    const chips = [
+      `<span class="workspace-template-agent-chip ${action}">${actionLabel}</span>`,
+      agent?.entry_point ? '<span class="workspace-template-agent-chip entry">Entry</span>' : '<span class="workspace-template-agent-chip">Specialist</span>',
+      role ? `<span class="workspace-template-agent-chip">${this.escapeHtml(role)}</span>` : '',
+      type ? `<span class="workspace-template-agent-chip">${this.escapeHtml(type)}</span>` : '',
+      tools ? `<span class="workspace-template-agent-chip">${this.escapeHtml(tools)}</span>` : ''
+    ].filter(Boolean).join('');
+
+    return `
+      <div class="workspace-template-agent-row">
+        <div class="workspace-template-agent-main">
+          <div class="workspace-template-agent-name">${this.escapeHtml(agent?.name || 'Unnamed agent')}</div>
+          <div class="workspace-template-agent-meta">${chips}</div>
+        </div>
+        <div class="workspace-template-agent-model">
+          <strong>${this.escapeHtml(modelText)}</strong>
+          <span>${this.escapeHtml(source)}</span>
+        </div>
+      </div>
+    `;
+  },
+
+  templateAgentModelSourceLabel(source) {
+    switch (String(source || '').trim()) {
+      case 'system':
+        return 'System model';
+      case 'template':
+        return 'Template model';
+      case 'existing':
+        return 'Saved agent model';
+      case 'agent_default':
+      default:
+        return 'Default model';
+    }
+  },
+
+  templateAgentToolsLabel(tools) {
+    const parts = [];
+    const skills = Array.isArray(tools?.skills) ? tools.skills.length : 0;
+    const mcp = Array.isArray(tools?.mcp_servers) ? tools.mcp_servers.length : 0;
+    const plugins = Array.isArray(tools?.plugins) ? tools.plugins.length : 0;
+    if (skills) parts.push(`${skills} skill${skills === 1 ? '' : 's'}`);
+    if (mcp) parts.push(`${mcp} MCP`);
+    if (plugins) parts.push(`${plugins} plugin${plugins === 1 ? '' : 's'}`);
+    return parts.join(' / ');
+  },
+
+  updateTemplateAgentReviewDisabledState() {
+    const review = document.getElementById('templateAgentReview');
+    const toggle = document.getElementById('templateAgentReviewToggle');
+    if (!review || !toggle) return;
+    review.classList.toggle('is-disabled', !toggle.checked);
   },
 
   // Fills a create-modal input from a template default while tracking the
@@ -3414,6 +3651,10 @@ const sessionManager = {
           // (template_id/template_path). The scaffolded project folder name
           // defaults to the workspace name server-side.
           Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+        }
+        if (this.templateAgentPlan?.has_agents) {
+          const createTemplateAgents = Boolean(document.getElementById('templateAgentReviewToggle')?.checked);
+          payload.create_template_agents = createTemplateAgents;
         }
         if (window.WorkspaceTagsCard) {
           Object.assign(payload, window.WorkspaceTagsCard.getPayloadFields());

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3455,7 +3455,7 @@ const sessionManager = {
           </div>
           <div class="workspace-template-agent-meta">${chips}</div>
           ${reuseNote}
-          <details class="workspace-template-agent-prompt">
+          <details class="workspace-template-agent-prompt" open>
             <summary>
               <span>System prompt</span>
               <span class="workspace-template-agent-prompt-state">${this.escapeHtml(promptState)}</span>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -27,6 +27,22 @@
               Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
             </div>
 
+            <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
+              <div class="workspace-template-agent-review-head">
+                <div>
+                  <div class="workspace-template-agent-review-title">Template Agents</div>
+                  <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
+                </div>
+                <label class="workspace-template-agent-toggle">
+                  <input type="checkbox" id="templateAgentReviewToggle" checked>
+                  <span>Create</span>
+                </label>
+              </div>
+              <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>
+              <div id="templateAgentReviewList" class="workspace-template-agent-list"></div>
+              <div id="templateAgentReviewWarnings" class="workspace-template-agent-warnings" hidden></div>
+            </div>
+
             <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
             <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
             <div class="workspace-setup-card mb-2">


### PR DESCRIPTION
## Summary
- make template-seeded agents inherit the configured system model when a template omits a model, avoiding the legacy default-agent fallback
- add a template-agent preview endpoint plus a create_template_agents opt-out flag for workspace creation
- show an inline template-agent roster review in the create-workspace modal, including create/reuse status, model source, tools, and warnings

## Tests
- go test ./internal/sessionhttp ./internal/server
- npx eslint internal/web/static/js/modules/sessions.js internal/web/static/js/modules/project-templates-manage.js internal/web/static/js/modules/workspace-hub.js internal/web/static/js/modules/workspace-map.js
- node --test --test-reporter=dot internal/web/static/js/modules/*.test.js