### PR TITLE
feat(workspace): agent system prompts + detail links, fix mission panel loading

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -402,6 +402,26 @@
 .ws-cmd-rk { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-ink-faint); }
 .ws-cmd-rv { font-family: var(--ws-font-mono); font-size: 12px; color: #eef0f3; }
 
+.ws-cmd-unit-name-link { color: inherit; text-decoration: none; border-bottom: 1px dashed transparent; transition: color 0.15s, border-color 0.15s; }
+.ws-cmd-unit-name-link:hover, .ws-cmd-unit-name-link:focus-visible { color: var(--ws-faction); border-bottom-color: var(--ws-faction-deep); outline: none; }
+
+/* System-prompt preview block on a unit card (opens the full prompt modal). */
+.ws-cmd-prompt {
+  display: flex; flex-direction: column; gap: 5px; width: 100%; text-align: left;
+  margin: 0 13px 11px; padding: 9px 11px; box-sizing: border-box; width: calc(100% - 26px);
+  border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.18); color: inherit; cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.ws-cmd-prompt:hover { border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.06); }
+.ws-cmd-prompt:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-prompt-head { display: flex; justify-content: space-between; align-items: center; }
+.ws-cmd-prompt-cta { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-faction); }
+.ws-cmd-prompt-preview {
+  font-size: 11.5px; line-height: 1.45; color: var(--ws-ink-dim);
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.ws-cmd-prompt-preview.is-empty { font-style: italic; color: var(--ws-ink-faint); }
+
 .ws-cmd-questlog { margin: 2px 13px 13px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
 .ws-cmd-ql-head { display: flex; justify-content: space-between; align-items: center; padding: 8px 11px; border-bottom: 1px solid var(--ws-line); }
 .ws-cmd-ql-t { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-dim); }

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -591,8 +591,26 @@ export class WorkspaceCommandView {
 
   syncMissionPanel() {
     const mission = typeof window !== 'undefined' ? window.workspaceMission : null;
-    if (mission && typeof mission.renderCommandSurfaces === 'function') {
+    if (!mission) return;
+    if (typeof mission.renderCommandSurfaces === 'function') {
       mission.renderCommandSurfaces();
+    }
+    // The Command view is the primary mission surface, but the mission module's
+    // initial auto-load is gated on the legacy Detailed goal card
+    // (#workspace-detail-goal-card), which no longer exists — so without this the
+    // panel sits at "Loading" until the user opens the Goal Settings tab. Kick
+    // off the first load ourselves when no state has been fetched yet.
+    if (
+      !this._missionLoadKicked &&
+      typeof mission.getState === 'function' &&
+      !mission.getState() &&
+      typeof mission.reload === 'function'
+    ) {
+      this._missionLoadKicked = true;
+      Promise.resolve(mission.reload()).catch(() => {
+        // Let a later render retry if the first load failed.
+        this._missionLoadKicked = false;
+      });
     }
   }
 

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -404,6 +404,7 @@ export class WorkspaceCommandView {
     this.bindReadout();
     this.bindMissionPanel();
     this.bindGarrison();
+    this.hydrateGarrisonPrompts();
     this.bindRail();
     this.mountCommandTagInput();
     this.syncMissionPanel();
@@ -1368,13 +1369,25 @@ export class WorkspaceCommandView {
       escapeHtml(modelLabel || '—') + '</span></div>' +
       '<div class="ws-cmd-row"><span class="ws-cmd-rk">Skills</span><span class="ws-cmd-rv">' +
       skillCount + '</span></div>' +
-      '</div>';
+      '</div>' +
+      this.promptBlockHTML(group, name, encoded);
+
+    // Link the unit name to the agent's detail page when one is reachable.
+    let nameInner = escapeHtml(name);
+    if (!group.isUnassigned && page.getAgentDetailTarget) {
+      const target = page.getAgentDetailTarget(name);
+      if (target && target.interactive && target.href) {
+        nameInner = '<a class="ws-cmd-unit-name-link" href="' + escapeHtml(target.href) +
+          '" title="' + escapeHtml(target.title || ('Open ' + name + ' details')) + '">' +
+          escapeHtml(name) + '</a>';
+      }
+    }
 
     return (
       '<article class="ws-cmd-unit' + (keeper ? ' is-keeper' : '') + '">' +
       '<div class="ws-cmd-unit-top">' +
       '<span class="ws-cmd-av" style="' + escapeHtml(avatar.style || '') + '">' + escapeHtml(avatar.initials) + '</span>' +
-      '<div class="ws-cmd-unit-id"><div class="ws-cmd-unit-name">' + escapeHtml(name) + '</div>' +
+      '<div class="ws-cmd-unit-id"><div class="ws-cmd-unit-name">' + nameInner + '</div>' +
       '<div class="ws-cmd-unit-role">' + roleBadge +
       '<span class="ws-cmd-state"><span class="ws-cmd-led ' + tone + '"></span>' + escapeHtml(status.label || 'Idle') + '</span>' +
       '</div></div>' +
@@ -1415,6 +1428,50 @@ export class WorkspaceCommandView {
     return '<div class="ws-cmd-questlog">' + head + items + '</div>';
   }
 
+  // System-prompt block on a unit card: a lazily-hydrated preview that opens the
+  // full system-prompt modal (base + workspace refinement + effective) on click.
+  // The preview text is filled in by hydrateGarrisonPrompts() once the
+  // effective-prompt fetch resolves.
+  promptBlockHTML(group, name, encoded) {
+    if (group.isUnassigned) return '';
+    return (
+      '<button type="button" class="ws-cmd-prompt" data-cmd-view-prompt="' + escapeHtml(encoded) + '"' +
+      ' title="View ' + escapeHtml(name) + ' system prompt"' +
+      ' aria-label="View ' + escapeHtml(name) + ' system prompt">' +
+      '<span class="ws-cmd-prompt-head"><span class="ws-cmd-rk">System Prompt</span>' +
+      '<span class="ws-cmd-prompt-cta">View ▸</span></span>' +
+      '<span class="ws-cmd-prompt-preview" data-cmd-prompt-name="' + escapeHtml(encoded) + '">Loading…</span>' +
+      '</button>'
+    );
+  }
+
+  hydrateGarrisonPrompts() {
+    const page = this.page;
+    if (!page || typeof page.ensureAgentPromptData !== 'function') return;
+    const root = this.container && this.container.querySelector('.ws-cmd-garrison');
+    if (!root) return;
+    const previews = root.querySelectorAll('.ws-cmd-prompt-preview[data-cmd-prompt-name]');
+    previews.forEach((el) => {
+      let name = '';
+      try { name = decodeURIComponent(el.getAttribute('data-cmd-prompt-name') || ''); }
+      catch (_e) { name = el.getAttribute('data-cmd-prompt-name') || ''; }
+      if (!name) return;
+      Promise.resolve(page.ensureAgentPromptData(name)).then((data) => {
+        if (!el.isConnected) return;
+        if (!data || data.error) {
+          el.textContent = 'System prompt unavailable.';
+          el.classList.add('is-empty');
+          return;
+        }
+        const preview = typeof page.buildAgentPromptPreview === 'function'
+          ? page.buildAgentPromptPreview(data)
+          : String(data.effective_prompt || data.base_system_prompt || '');
+        el.textContent = preview || 'No system prompt set.';
+        el.classList.toggle('is-empty', !preview);
+      }).catch(() => {});
+    });
+  }
+
   renderGarrison() {
     const page = this.page;
     let groups = [];
@@ -1435,6 +1492,11 @@ export class WorkspaceCommandView {
       const settingsBtn = event.target.closest('[data-cmd-manager-settings]');
       if (settingsBtn) {
         this.openStatModal('settings', settingsBtn);
+        return;
+      }
+      const promptBtn = event.target.closest('[data-cmd-view-prompt]');
+      if (promptBtn && page && typeof page.openAgentPromptModal === 'function') {
+        page.openAgentPromptModal(promptBtn.getAttribute('data-cmd-view-prompt'));
         return;
       }
       const addBtn = event.target.closest('[data-cmd-add-task]');

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -227,6 +227,12 @@ export class WorkspaceDetailPage {
     this.providerCatalogPromise = null;
     this.agentSkillsCache = new Map();
     this.agentSkillsPromises = new Map();
+    // Cached effective-prompt payloads (base + refinement + effective) keyed by
+    // normalized agent name, plus in-flight fetch promises for de-duping. Feeds
+    // both the flip-card prompt preview and the "View system prompt" modal.
+    this.agentPromptCache = new Map();
+    this.agentPromptPromises = new Map();
+    this.activeAgentPromptView = null;
     this.mcpManager = new WorkspaceMCPManager(this);
     this.nativeMCPManager = new WorkspaceNativeMCPManager(this);
     this.skillsManager = new WorkspaceSkillsManager(this);
@@ -1233,6 +1239,14 @@ export class WorkspaceDetailPage {
       agentModelHelp: document.getElementById('workspace-detail-agent-model-help'),
       agentModelSubmitBtn: document.getElementById('workspace-detail-agent-model-submit'),
 
+      // Agent system prompt modal
+      agentPromptModal: document.getElementById('workspace-detail-agent-prompt-modal'),
+      agentPromptTitle: document.getElementById('workspace-detail-agent-prompt-title'),
+      agentPromptAgentName: document.getElementById('workspace-detail-agent-prompt-agent-name'),
+      agentPromptBody: document.getElementById('workspace-detail-agent-prompt-body'),
+      agentPromptDetailLink: document.getElementById('workspace-detail-agent-prompt-detail-link'),
+      agentPromptCopyBtn: document.getElementById('workspace-detail-agent-prompt-copy'),
+
       // Workspace MCP modal
       mcpModal: document.getElementById('workspace-detail-mcp-modal'),
       mcpForm: document.getElementById('workspace-detail-mcp-form'),
@@ -1674,6 +1688,9 @@ export class WorkspaceDetailPage {
     );
     this.elements.agentModelModal?.addEventListener('hidden.bs.modal', () =>
       this.resetAgentModelModal()
+    );
+    this.elements.agentPromptCopyBtn?.addEventListener('click', () =>
+      this.copyAgentPromptToClipboard()
     );
 
     // Make workspace name and description editable
@@ -3146,11 +3163,14 @@ export class WorkspaceDetailPage {
     }
 
     if (this.hasWorkspaceAgentSnapshot(normalizedName)) {
-      const title = `${normalizedName} is a workspace-local agent. Global agent details are not available.`;
+      // Workspace-local agents (entry/manager agents) are hydrated into the
+      // agent store on startup, so /agents/<name> renders their detail page.
+      // The page degrades gracefully to a repair view if a snapshot is missing.
+      const title = `Open ${normalizedName} details (workspace-local agent)`;
       return {
         kind: 'workspace-local',
-        href: '',
-        interactive: false,
+        href: `/agents/${encodedAgentName}`,
+        interactive: true,
         title,
         ariaLabel: title
       };
@@ -3914,8 +3934,52 @@ export class WorkspaceDetailPage {
             <div class="workspace-detail-agent-chip-list">${mcpMarkup}</div>
           </div>
         </div>
+        ${this.renderAgentPromptSection(group, encodedAgentName)}
       </div>
     `;
+  }
+
+  // Renders the "System Prompt" section on the agent info back face: a short,
+  // lazily-loaded preview plus a button that opens the full prompt modal. The
+  // preview span carries a data-agent-prompt-key so refreshAgentCardPrompt() can
+  // fill it in once the effective-prompt fetch resolves (see toggleAgentCardFlip).
+  renderAgentPromptSection(group, encodedAgentName) {
+    const key = String(group?.key || '');
+    const cached = this.agentPromptCache.get(this.normalizeAgentName(group?.name));
+    const hasPrompt = cached && !cached.error;
+    const previewText = hasPrompt
+      ? this.buildAgentPromptPreview(cached)
+      : cached && cached.error
+        ? 'System prompt unavailable.'
+        : 'Flip to load the system prompt this agent uses in this workspace.';
+    const previewClass = hasPrompt ? '' : ' is-placeholder';
+    return `
+      <div class="workspace-detail-agent-prompt-section">
+        <div class="workspace-detail-agent-prompt-head">
+          <div class="workspace-detail-agent-info-label">System Prompt</div>
+          <button type="button"
+                  class="workspace-detail-agent-prompt-view-btn"
+                  title="View full system prompt"
+                  aria-label="View full system prompt for ${this.escapeAttribute(group?.name || 'agent')}"
+                  onclick="event.stopPropagation(); window.workspaceDetail?.openAgentPromptModal('${encodedAgentName}')">
+            View full
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
+            </svg>
+          </button>
+        </div>
+        <p class="workspace-detail-agent-prompt-preview${previewClass}" data-agent-prompt-key="${this.escapeAttribute(key)}">${this.escapeHtml(previewText)}</p>
+      </div>
+    `;
+  }
+
+  // Collapses a multi-line prompt into a single-line preview snippet.
+  buildAgentPromptPreview(data) {
+    const source =
+      String(data?.effective_prompt || data?.base_system_prompt || '').replace(/\s+/g, ' ').trim();
+    if (!source) return 'No system prompt set for this agent.';
+    const limit = 160;
+    return source.length > limit ? `${source.slice(0, limit).trim()}…` : source;
   }
 
   // Renders the agent info card's SKILLS chips from the skills that are
@@ -4019,6 +4083,197 @@ export class WorkspaceDetailPage {
     // The agent info card's SKILLS now renders synchronously from
     // workspace-effective skill bindings (see renderAgentWorkspaceSkillChips),
     // so flipping no longer needs to fetch the agent's global skill catalog.
+    //
+    // The system prompt preview IS async: lazy-load it on first flip so we only
+    // hit the effective-prompt endpoint for cards the user actually inspects.
+    this.ensureAgentPromptData(agentName).then(() => this.refreshAgentCardPrompt(agentName));
+  }
+
+  // Updates the flip-card's system prompt preview span in place once the
+  // effective-prompt payload is available, matching refreshAgentCardSkills().
+  refreshAgentCardPrompt(agentName) {
+    const key = this.normalizeAgentName(agentName);
+    if (!key) return false;
+    const card = this.getAgentCardElementByKey(key);
+    if (!card) return false;
+
+    const data = this.agentPromptCache.get(key);
+    const previews = card.querySelectorAll(
+      '.workspace-detail-agent-prompt-preview[data-agent-prompt-key]'
+    );
+    let updated = false;
+    previews.forEach(preview => {
+      if (preview.getAttribute('data-agent-prompt-key') !== key) return;
+      if (!data) return;
+      if (data.error) {
+        preview.textContent = 'System prompt unavailable.';
+        preview.classList.add('is-placeholder');
+      } else {
+        preview.textContent = this.buildAgentPromptPreview(data);
+        preview.classList.remove('is-placeholder');
+      }
+      updated = true;
+    });
+    return updated;
+  }
+
+  // Fetches (and caches) the workspace-effective prompt for an agent from
+  // GET /api/workspaces/{id}/agents/{name}/effective-prompt. De-dupes in-flight
+  // requests and returns the cached payload on repeat calls.
+  async ensureAgentPromptData(agentName, options = {}) {
+    const normalizedName = String(agentName || '').trim();
+    const key = this.normalizeAgentName(normalizedName);
+    if (!normalizedName || !key) return null;
+
+    if (!options.force && this.agentPromptCache.has(key)) {
+      return this.agentPromptCache.get(key);
+    }
+    if (this.agentPromptPromises.has(key)) {
+      return this.agentPromptPromises.get(key);
+    }
+
+    const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+    if (!workspaceId) return null;
+
+    const loadPromise = (async () => {
+      try {
+        const response = await fetch(
+          `/api/workspaces/${encodeURIComponent(workspaceId)}/agents/${encodeURIComponent(
+            normalizedName
+          )}/effective-prompt`
+        );
+        if (!response.ok) {
+          const failure = { error: true, status: response.status };
+          this.agentPromptCache.set(key, failure);
+          return failure;
+        }
+        const data = await response.json();
+        this.agentPromptCache.set(key, data);
+        return data;
+      } catch (_error) {
+        const failure = { error: true };
+        this.agentPromptCache.set(key, failure);
+        return failure;
+      } finally {
+        this.agentPromptPromises.delete(key);
+      }
+    })();
+
+    this.agentPromptPromises.set(key, loadPromise);
+    return loadPromise;
+  }
+
+  // Opens the "System Prompt" modal for an agent, showing the base prompt, the
+  // workspace's per-instance refinement, and the composed effective prompt.
+  async openAgentPromptModal(encodedAgentName = '') {
+    let agentName = '';
+    try {
+      agentName = decodeURIComponent(String(encodedAgentName || ''));
+    } catch (_error) {
+      agentName = String(encodedAgentName || '');
+    }
+    agentName = String(agentName || '').trim();
+    if (!agentName) return;
+
+    this.activeAgentPromptView = { agentName, data: null };
+
+    if (this.elements.agentPromptAgentName) {
+      this.elements.agentPromptAgentName.textContent = agentName;
+    }
+    if (this.elements.agentPromptTitle) {
+      this.elements.agentPromptTitle.textContent = `System Prompt · ${agentName}`;
+    }
+    if (this.elements.agentPromptDetailLink) {
+      const target = this.getAgentDetailTarget(agentName);
+      if (target.interactive && target.href) {
+        this.elements.agentPromptDetailLink.href = target.href;
+        this.elements.agentPromptDetailLink.classList.remove('d-none');
+      } else {
+        this.elements.agentPromptDetailLink.classList.add('d-none');
+      }
+    }
+    if (this.elements.agentPromptBody) {
+      this.elements.agentPromptBody.innerHTML =
+        '<div class="workspace-detail-loading">Loading system prompt…</div>';
+    }
+
+    if (this.elements.agentPromptModal && window.bootstrap) {
+      const modal =
+        typeof bootstrap.Modal.getOrCreateInstance === 'function'
+          ? bootstrap.Modal.getOrCreateInstance(this.elements.agentPromptModal)
+          : bootstrap.Modal.getInstance(this.elements.agentPromptModal) ||
+            new bootstrap.Modal(this.elements.agentPromptModal);
+      modal.show();
+    }
+
+    const data = await this.ensureAgentPromptData(agentName);
+    // Ignore a resolved fetch if the user has since opened a different agent.
+    if (!this.activeAgentPromptView || this.activeAgentPromptView.agentName !== agentName) {
+      return;
+    }
+    this.activeAgentPromptView.data = data;
+    this.renderAgentPromptModalBody(agentName, data);
+    // Keep the flip-card preview consistent with what the modal just loaded.
+    this.refreshAgentCardPrompt(agentName);
+  }
+
+  renderAgentPromptModalBody(agentName, data) {
+    const body = this.elements.agentPromptBody;
+    if (!body) return;
+
+    if (!data || data.error) {
+      body.innerHTML = `<div class="workspace-detail-empty">Could not load the system prompt for ${this.escapeHtml(
+        agentName
+      )}.</div>`;
+      return;
+    }
+
+    const base = String(data.base_system_prompt || '').trim();
+    const refinement = String(data.refinement || '').trim();
+    const effective = String(data.effective_prompt || '').trim();
+    const note = String(data.note || '').trim();
+
+    const section = (label, value, emptyLabel) => `
+      <div class="workspace-detail-agent-prompt-block">
+        <div class="workspace-detail-agent-prompt-block-label">${this.escapeHtml(label)}</div>
+        ${
+          value
+            ? `<pre class="workspace-detail-agent-prompt-pre">${this.escapeHtml(value)}</pre>`
+            : `<div class="workspace-detail-agent-prompt-empty">${this.escapeHtml(emptyLabel)}</div>`
+        }
+      </div>
+    `;
+
+    body.innerHTML = `
+      ${section('Base system prompt', base, 'No base system prompt set for this agent.')}
+      ${section(
+        'Workspace refinement',
+        refinement,
+        'No workspace-specific refinement (role, description, or custom instructions).'
+      )}
+      ${section('Effective prompt (composed)', effective, 'Nothing to compose.')}
+      ${
+        note
+          ? `<div class="workspace-detail-agent-prompt-hint">${this.escapeHtml(note)}</div>`
+          : ''
+      }
+    `;
+  }
+
+  async copyAgentPromptToClipboard() {
+    const view = this.activeAgentPromptView;
+    const data = view?.data;
+    const text = String(data?.effective_prompt || data?.base_system_prompt || '').trim();
+    if (!text) {
+      if (window.Toast) window.Toast.warning('No system prompt to copy.');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      if (window.Toast) window.Toast.success('System prompt copied.');
+    } catch (_error) {
+      if (window.Toast) window.Toast.error('Failed to copy system prompt.');
+    }
   }
 
   async loadAgentSkills(agentName, options = {}) {

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -507,7 +507,7 @@ test('workspace detail links catalog-backed agents to the global detail page', (
   assert.match(markup, /data-agent-detail-kind="global"/);
 });
 
-test('workspace detail keeps snapshot-backed local agents off the global detail route', () => {
+test('workspace detail links snapshot-backed local agents to their detail page', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   page.workspace = {
     entry_agent_name: 'Local Manager',
@@ -524,13 +524,14 @@ test('workspace detail keeps snapshot-backed local agents off the global detail 
     'summary-local'
   );
 
+  // Snapshot-backed local agents are hydrated into the agent store on startup,
+  // so /agents/<name> resolves (degrading to a repair view if it does not).
   assert.equal(target.kind, 'workspace-local');
-  assert.equal(target.interactive, false);
-  assert.equal(target.href, '');
-  assert.match(markup, /workspace-detail-agent-identity-link is-static/);
+  assert.equal(target.interactive, true);
+  assert.equal(target.href, '/agents/Local%20Manager');
   assert.match(markup, /data-agent-detail-kind="workspace-local"/);
-  assert.doesNotMatch(markup, /href="/);
-  assert.doesNotMatch(markup, /\/agents\/Local%20Manager/);
+  assert.match(markup, /href="\/agents\/Local%20Manager"/);
+  assert.doesNotMatch(markup, /is-static/);
 });
 
 test('workspace detail routes missing entry agents to workspace recovery', () => {
@@ -561,6 +562,30 @@ test('workspace detail routes missing entry agents to workspace recovery', () =>
   assert.match(backMarkup, /href="\/workspaces\/workspace-1\?addAgent=1&amp;seedAgentName=Missing\+Manager"/);
   assert.doesNotMatch(frontMarkup, /\/agents\/Missing%20Manager/);
   assert.doesNotMatch(backMarkup, /\/agents\/Missing%20Manager/);
+});
+
+test('buildAgentPromptPreview collapses whitespace and truncates long prompts', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+
+  assert.equal(
+    page.buildAgentPromptPreview({ effective_prompt: 'You are\n  a  helpful\tagent.' }),
+    'You are a helpful agent.'
+  );
+  assert.equal(
+    page.buildAgentPromptPreview({ base_system_prompt: '', effective_prompt: '' }),
+    'No system prompt set for this agent.'
+  );
+
+  const long = 'x'.repeat(400);
+  const preview = page.buildAgentPromptPreview({ effective_prompt: long });
+  assert.ok(preview.length <= 161, `preview should be capped, got ${preview.length}`);
+  assert.ok(preview.endsWith('…'), 'truncated preview should end with an ellipsis');
+
+  // Falls back to the base prompt when no composed prompt is present.
+  assert.equal(
+    page.buildAgentPromptPreview({ base_system_prompt: 'Base only.', effective_prompt: '' }),
+    'Base only.'
+  );
 });
 
 test('workspace detail agent back face does not render agent level copy', () => {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -1686,6 +1686,35 @@
     </div>
   </div>
 
+  <!-- Agent System Prompt Modal -->
+  <div class="modal fade" id="workspace-detail-agent-prompt-modal" tabindex="-1" aria-labelledby="workspace-detail-agent-prompt-title" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <div>
+            <div class="workspace-detail-agent-model-modal-kicker">Workspace Agent</div>
+            <h5 class="modal-title" id="workspace-detail-agent-prompt-title">System Prompt</h5>
+            <div id="workspace-detail-agent-prompt-agent-name" class="workspace-detail-agent-model-modal-value">--</div>
+          </div>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="workspace-detail-agent-prompt-body">
+          <div class="workspace-detail-loading">Loading system prompt…</div>
+        </div>
+        <div class="modal-footer">
+          <a href="#" id="workspace-detail-agent-prompt-detail-link" class="btn btn-outline-secondary d-none" target="_self" rel="noopener">
+            Open agent page
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="margin-left:0.25rem;vertical-align:-1px;">
+              <path d="M14,3H21V10H19V6.41L12.41,13L11,11.59L17.59,5H14V3M5,5H10V7H7V17H17V14H19V19H5V5Z"/>
+            </svg>
+          </a>
+          <button type="button" class="btn btn-primary" id="workspace-detail-agent-prompt-copy">Copy effective prompt</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Directory Explorer Modal -->
   <div class="modal fade" id="workspace-directory-explorer-modal" tabindex="-1" aria-labelledby="workspace-directory-explorer-title" aria-hidden="true">
     <div class="modal-dialog modal-xl modal-dialog-centered workspace-directory-explorer-dialog">
@@ -4172,6 +4201,111 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.55rem;
       margin-top: 0.1rem;
+    }
+
+    /* Back-face system prompt preview + "View full" affordance. */
+    .workspace-detail-agent-prompt-section {
+      margin-top: 0.55rem;
+      background: rgba(100, 116, 139, 0.06);
+      border: 1px solid rgba(100, 116, 139, 0.14);
+      border-radius: 8px;
+      padding: 0.55rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .workspace-detail-agent-prompt-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .workspace-detail-agent-prompt-view-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.2rem;
+      border: 1px solid rgba(148, 163, 184, 0.32);
+      background: transparent;
+      color: var(--text-secondary);
+      border-radius: 999px;
+      font-size: 0.62rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      padding: 0.12rem 0.5rem;
+      cursor: pointer;
+      transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+    }
+
+    .workspace-detail-agent-prompt-view-btn:hover,
+    .workspace-detail-agent-prompt-view-btn:focus-visible {
+      color: var(--text-primary);
+      border-color: var(--primary-color);
+      background: rgba(var(--primary-color-rgb, 255, 138, 86), 0.10);
+      outline: none;
+    }
+
+    .workspace-detail-agent-prompt-preview {
+      margin: 0;
+      font-size: 0.72rem;
+      line-height: 1.4;
+      color: var(--text-primary);
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .workspace-detail-agent-prompt-preview.is-placeholder {
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    /* System prompt modal body. */
+    .workspace-detail-agent-prompt-block {
+      margin-bottom: 1rem;
+    }
+
+    .workspace-detail-agent-prompt-block:last-child {
+      margin-bottom: 0;
+    }
+
+    .workspace-detail-agent-prompt-block-label {
+      font-size: 0.66rem;
+      font-weight: 700;
+      color: var(--text-secondary);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-bottom: 0.35rem;
+    }
+
+    .workspace-detail-agent-prompt-pre {
+      margin: 0;
+      padding: 0.7rem 0.8rem;
+      background: var(--bg-primary);
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 8px;
+      font-size: 0.78rem;
+      line-height: 1.5;
+      color: var(--text-primary);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      max-height: 320px;
+      overflow-y: auto;
+    }
+
+    .workspace-detail-agent-prompt-empty {
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
+    .workspace-detail-agent-prompt-hint {
+      font-size: 0.72rem;
+      color: var(--text-secondary);
+      border-top: 1px dashed rgba(148, 163, 184, 0.24);
+      padding-top: 0.6rem;
     }
 
     .workspace-detail-agent-info-block {


### PR DESCRIPTION
## Summary

Two changes to the workspace **Command view** (`/workspaces/{id}`):

### 1. Surface agent system prompts + link to detail pages (`69fd195d`)
- Each agent unit card now shows a **System Prompt** section: a lazily-loaded, line-clamped preview of the agent's *workspace-effective* prompt.
- Clicking it opens a modal with the **base prompt**, **workspace refinement** (role/description/custom instructions), and the composed **effective prompt** — plus a copy button. Wired to the existing (previously unused) `GET /api/workspaces/{id}/agents/{name}/effective-prompt` endpoint.
- Unit-card names and the modal's **"Open agent page"** action link to `/agents/{name}`.
- Enabled the detail-page link for snapshot-backed **workspace-local** agents (hydrated into the agent store on startup; the page degrades to a repair view if a snapshot is missing).
- Mirrored the preview/modal on the legacy detailed agent back face.

### 2. Fix mission panel stuck at "Loading" (`fe835911`)
The mission module only auto-loaded its state when the legacy Detailed goal card (`#workspace-detail-goal-card`) was present — an element removed when the Command view became the workspace page. So the goal panel (status, text, cadence/next/last) sat at "Loading" until the user manually opened the Goal Settings tab. `syncMissionPanel` now kicks off the first load itself when no state has been fetched, guarded against repeat fetches and retryable on failure.

## Testing
- 521 JS module tests pass (`node --test`); updated the local-agent routing test to the new enabled-link behavior and added a `buildAgentPromptPreview` test.
- Server builds clean; `go fmt` pre-commit hook clean.
- **Verified live in a browser** (isolated smoke server):
  - Prompt preview renders + truncates; modal shows base/refinement/effective + copy.
  - "Open agent page" navigates to the full Agent Details page.
  - Mission panel now resolves to real state on load ("Not set" / "No goal set" / "Manual only") instead of hanging at LOADING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)