### PR TITLE
fix(workspace): align light mode surfaces

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -2,8 +2,8 @@
  * workspace-command.css — Workspace Command view (interior "tactical" reskin)
  *
  * Opt-in tactical layout on the workspace detail page, scoped under `.ws-cmd`.
- * A dark surface regardless of the app's `data-bs-theme`. Mirrors the Map's
- * `.ws-map` visual system; the self-hosted @font-face declarations are already
+ * Mirrors the Map's `.ws-map` visual system with theme-responsive tactical
+ * tokens; the self-hosted @font-face declarations are already
  * provided globally by workspace-map.css, so this file only references them.
  *
  * Rules must NOT leak outside `.ws-cmd`. No ui-refresh.css edits, no `!important`.
@@ -41,8 +41,8 @@
   --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
 
   /* type (families vendored globally by workspace-map.css) */
-  --ws-font-display: 'Chakra Petch', system-ui, sans-serif;
-  --ws-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --ws-font-display: "Chakra Petch", system-ui, sans-serif;
+  --ws-font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   display: block;
   color: var(--ws-ink);
@@ -50,47 +50,116 @@
   letter-spacing: 0.2px;
 }
 
-.ws-cmd[hidden] { display: none; }
+.ws-cmd[hidden] {
+  display: none;
+}
 
 .ws-cmd .ws-tick {
-  font-family: var(--ws-font-mono); font-size: 10.5px; letter-spacing: 2.5px; text-transform: uppercase; color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
 }
 
 /* ---------- command bar ---------- */
 .ws-cmd-topbar {
-  display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
   border: 1px solid var(--ws-line);
   background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
-  padding: 14px 18px; margin-bottom: 18px;
-  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  padding: 14px 18px;
+  margin-bottom: 18px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 16px) 0,
+    100% 16px,
+    100% 100%,
+    16px 100%,
+    0 calc(100% - 16px)
+  );
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-nav { flex: 1 0 100%; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ws-cmd-nav {
+  flex: 1 0 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 .ws-cmd-nav-btn {
-  min-height: 30px; display: inline-flex; align-items: center; padding: 7px 10px; border: 1px solid var(--ws-line-bright);
-  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer;
-  font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; transition: 0.15s;
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  transition: 0.15s;
   text-decoration: none;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 10px 100%, 0 calc(100% - 10px));
 }
-.ws-cmd-nav-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); text-decoration: none; }
-.ws-cmd-nav-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-nav-btn:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  text-decoration: none;
+}
+.ws-cmd-nav-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-crest {
-  width: 50px; height: 50px; flex: 0 0 auto; display: grid; place-items: center;
-  border: 1px solid var(--ws-line-bright); color: var(--ws-faction);
+  width: 50px;
+  height: 50px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-faction);
   background: radial-gradient(circle at 50% 30%, rgba(70, 211, 154, 0.18), transparent 70%);
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-cmd-title { flex: 1 1 auto; min-width: 0; }
-.ws-cmd-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
-.ws-cmd-title .ws-dot { width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg); }
-.ws-cmd-title-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.ws-cmd-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ws-cmd-title .ws-kicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.ws-cmd-title .ws-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--ws-faction);
+  box-shadow: 0 0 8px var(--ws-faction);
+  transform: rotate(45deg);
+}
+.ws-cmd-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
 .ws-cmd-group-badge {
-  flex: 0 0 auto; align-self: center; margin-top: 4px; padding: 3px 8px;
+  flex: 0 0 auto;
+  align-self: center;
+  margin-top: 4px;
+  padding: 3px 8px;
   border: 1px solid var(--ws-group-accent-line, var(--ws-line-bright));
   background: var(--ws-group-accent-soft, rgba(70, 211, 154, 0.08));
   color: var(--ws-group-accent, var(--ws-faction));
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
   clip-path: polygon(0 0, 100% 0, 100% 70%, calc(100% - 6px) 100%, 0 100%);
 }
 .ws-cmd-topbar.is-group .ws-dot {
@@ -102,235 +171,762 @@
   border-color: var(--ws-group-accent-line, var(--ws-line-bright));
 }
 .ws-cmd-title h2 {
-  flex: 1 1 auto; min-width: 0; margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1px; text-transform: uppercase; color: #eef0f3;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 4px 0 0;
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #eef0f3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.ws-cmd-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
-.ws-cmd-description-row, .ws-cmd-tags-row { display: flex; align-items: flex-start; gap: 8px; margin-top: 8px; min-width: 0; }
+.ws-cmd-title .ws-sub {
+  margin-top: 3px;
+  color: var(--ws-ink-dim);
+  font-size: 13px;
+}
+.ws-cmd-description-row,
+.ws-cmd-tags-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 8px;
+  min-width: 0;
+}
 .ws-cmd-description {
-  flex: 1 1 auto; min-width: 0; margin: 0; color: var(--ws-ink-dim); font-size: 13px; line-height: 1.35;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  color: var(--ws-ink-dim);
+  font-size: 13px;
+  line-height: 1.35;
 }
-.ws-cmd-description.is-empty { color: var(--ws-ink-faint); font-style: italic; }
+.ws-cmd-description.is-empty {
+  color: var(--ws-ink-faint);
+  font-style: italic;
+}
 .ws-cmd-description.is-collapsed {
-  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .ws-cmd-mini-btn {
-  flex: 0 0 auto; padding: 4px 7px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
-  color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase;
+  flex: 0 0 auto;
+  padding: 4px 7px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
 }
-.ws-cmd-mini-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-mini-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-tags { flex: 1 1 auto; min-width: 0; display: flex; flex-wrap: wrap; gap: 5px; }
-.ws-cmd-tag, .ws-cmd-tag-empty {
-  max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  border: 1px solid var(--ws-line-bright); padding: 2px 7px; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 0.8px; text-transform: uppercase;
+.ws-cmd-mini-btn:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
 }
-.ws-cmd-tag { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.06); }
-.ws-cmd-tag.is-more { color: var(--ws-ink-dim); border-color: var(--ws-line-bright); background: transparent; }
-.ws-cmd-tag-empty { color: var(--ws-ink-faint); }
+.ws-cmd-mini-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-tags {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.ws-cmd-tag,
+.ws-cmd-tag-empty {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid var(--ws-line-bright);
+  padding: 2px 7px;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+.ws-cmd-tag {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.06);
+}
+.ws-cmd-tag.is-more {
+  color: var(--ws-ink-dim);
+  border-color: var(--ws-line-bright);
+  background: transparent;
+}
+.ws-cmd-tag-empty {
+  color: var(--ws-ink-faint);
+}
 .ws-cmd-identity-editor {
-  margin-top: 10px; padding: 10px; display: grid; gap: 8px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.2);
+  margin-top: 10px;
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.2);
 }
 .ws-cmd-identity-field {
-  width: 100%; min-width: 0; border: 1px solid var(--ws-line-bright); background: var(--ws-bg); color: var(--ws-ink);
-  padding: 8px 10px; font: inherit; font-size: 13px; line-height: 1.35;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg);
+  color: var(--ws-ink);
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.35;
 }
-.ws-cmd-identity-field:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-tags-editor-mount .tag-input { border-color: var(--ws-line-bright); background: var(--ws-bg); color: var(--ws-ink); }
-.ws-cmd-identity-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.ws-cmd-identity-save, .ws-cmd-identity-cancel {
-  padding: 7px 10px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase;
+.ws-cmd-identity-field:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
 }
-.ws-cmd-identity-save { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
-.ws-cmd-identity-save:disabled { opacity: 0.55; cursor: wait; }
-.ws-cmd-identity-save:focus-visible, .ws-cmd-identity-cancel:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-identity-error { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-alert); }
+.ws-cmd-tags-editor-mount .tag-input {
+  border-color: var(--ws-line-bright);
+  background: var(--ws-bg);
+  color: var(--ws-ink);
+}
+.ws-cmd-identity-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.ws-cmd-identity-save,
+.ws-cmd-identity-cancel {
+  padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.ws-cmd-identity-save {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-identity-save:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.ws-cmd-identity-save:focus-visible,
+.ws-cmd-identity-cancel:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-identity-error {
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  color: var(--ws-alert);
+}
 
-.ws-cmd-readout { display: flex; gap: 10px; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; }
+.ws-cmd-readout {
+  display: flex;
+  gap: 10px;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 .ws-cmd-stat {
-  min-width: 84px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
-  color: inherit; font: inherit; cursor: pointer; transition: 0.15s;
+  min-width: 84px;
+  text-align: center;
+  border: 1px solid var(--ws-line);
+  background: var(--ws-bg-2);
+  padding: 8px 12px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: 0.15s;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
-.ws-cmd-stat:hover { border-color: var(--ws-line-bright); background: rgba(70, 211, 154, 0.06); }
-.ws-cmd-stat:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; font-variant-numeric: tabular-nums; }
-.ws-cmd-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
-.ws-cmd-stat.is-alert { border-color: rgba(226, 101, 77, 0.55); background: rgba(226, 101, 77, 0.08); }
-.ws-cmd-stat.is-alert .ws-v, .ws-cmd-stat.is-alert .ws-l { color: var(--ws-alert); }
+.ws-cmd-stat:hover {
+  border-color: var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+}
+.ws-cmd-stat:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-stat .ws-v {
+  font-family: var(--ws-font-mono);
+  font-size: 20px;
+  font-weight: 700;
+  color: #eef0f3;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.ws-cmd-stat .ws-l {
+  font-size: 9.5px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+  margin-top: 5px;
+}
+.ws-cmd-stat.is-alert {
+  border-color: rgba(226, 101, 77, 0.55);
+  background: rgba(226, 101, 77, 0.08);
+}
+.ws-cmd-stat.is-alert .ws-v,
+.ws-cmd-stat.is-alert .ws-l {
+  color: var(--ws-alert);
+}
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
-.ws-cmd-layout { display: grid; grid-template-columns: 1fr 332px; gap: 18px; align-items: start; }
-.ws-cmd-main { min-width: 0; display: flex; flex-direction: column; gap: 18px; }
+.ws-cmd-layout {
+  display: grid;
+  grid-template-columns: 1fr 332px;
+  gap: 18px;
+  align-items: start;
+}
+.ws-cmd-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
 .ws-cmd-mission {
-  display: flex; justify-content: space-between; align-items: stretch; gap: 16px; min-width: 0;
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014);
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 16px;
+  min-width: 0;
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(180deg, var(--ws-panel), #0f1014);
   padding: 14px 16px;
-  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-mission-main { min-width: 0; display: flex; flex-direction: column; gap: 8px; }
-.ws-cmd-mission-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.ws-cmd-mission-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ws-cmd-mission-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
 .ws-cmd-mission-kicker {
-  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ws-faction);
 }
 .ws-cmd-mission-status {
-  display: inline-flex; align-items: center; min-height: 21px; padding: 3px 8px; border: 1px solid var(--ws-line-bright);
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.1px; text-transform: uppercase; color: var(--ws-ink-dim);
+  display: inline-flex;
+  align-items: center;
+  min-height: 21px;
+  padding: 3px 8px;
+  border: 1px solid var(--ws-line-bright);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  color: var(--ws-ink-dim);
   background: rgba(0, 0, 0, 0.18);
 }
-.ws-cmd-mission-status.is-enabled { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.07); }
+.ws-cmd-mission-status.is-enabled {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.07);
+}
 .ws-cmd-mission-status.is-paused,
-.ws-cmd-mission-status.is-manual { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.07); }
+.ws-cmd-mission-status.is-manual {
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+  background: rgba(232, 181, 75, 0.07);
+}
 .ws-cmd-mission-status.is-empty,
-.ws-cmd-mission-status.is-loading { color: var(--ws-ink-faint); }
+.ws-cmd-mission-status.is-loading {
+  color: var(--ws-ink-faint);
+}
 .ws-cmd-mission-title {
-  margin: 0; color: #eef0f3; font-size: 17px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase;
+  margin: 0;
+  color: #eef0f3;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
 }
 .ws-cmd-mission-text {
-  max-width: 88ch; margin: 0; color: var(--ws-ink); font-size: 13.5px; line-height: 1.45;
+  max-width: 88ch;
+  margin: 0;
+  color: var(--ws-ink);
+  font-size: 13.5px;
+  line-height: 1.45;
 }
-.ws-cmd-mission-text.is-empty { color: var(--ws-ink-faint); font-style: italic; }
-.ws-cmd-mission-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
+.ws-cmd-mission-text.is-empty {
+  color: var(--ws-ink-faint);
+  font-style: italic;
+}
+.ws-cmd-mission-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+}
 .ws-cmd-mission-meta span {
-  display: inline-flex; align-items: center; min-height: 22px; padding: 3px 8px; border: 1px solid var(--ws-line);
-  background: rgba(0, 0, 0, 0.18); color: var(--ws-ink-dim);
-  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 0.7px; text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 3px 8px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
 }
 .ws-cmd-mission-action-status {
-  min-height: 15px; color: var(--ws-ink-dim); font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 0.4px;
+  min-height: 15px;
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.4px;
 }
-.ws-cmd-mission-action-status.is-error { color: var(--ws-alert); }
-.ws-cmd-mission-actions { display: flex; align-items: flex-start; justify-content: flex-end; gap: 8px; flex-wrap: wrap; flex: 0 0 auto; }
+.ws-cmd-mission-action-status.is-error {
+  color: var(--ws-alert);
+}
+.ws-cmd-mission-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+}
 .ws-cmd-mission-btn {
-  min-height: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 7px 10px;
-  border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase;
-  text-decoration: none; transition: 0.13s;
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: 0.13s;
 }
 .ws-cmd-mission-btn.is-primary {
-  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
-.ws-cmd-mission-btn.has-findings { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.08); }
-.ws-cmd-mission-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); text-decoration: none; }
-.ws-cmd-mission-btn:disabled { color: var(--ws-ink-faint); border-color: var(--ws-line); cursor: not-allowed; opacity: 0.72; }
-.ws-cmd-mission-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-mission-btn.has-findings {
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+  background: rgba(232, 181, 75, 0.08);
+}
+.ws-cmd-mission-btn:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  text-decoration: none;
+}
+.ws-cmd-mission-btn:disabled {
+  color: var(--ws-ink-faint);
+  border-color: var(--ws-line);
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+.ws-cmd-mission-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-garrison {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014); min-height: 200px;
-  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(180deg, var(--ws-panel), #0f1014);
+  min-height: 200px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-rail { display: flex; flex-direction: column; gap: 16px; }
+.ws-cmd-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
 
 /* rail panels */
 .ws-cmd-panel {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014);
-  clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(180deg, var(--ws-panel), #0f1014);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 12px) 0,
+    100% 12px,
+    100% 100%,
+    12px 100%,
+    0 calc(100% - 12px)
+  );
   box-shadow: var(--ws-glow);
 }
-.ws-cmd-panel.is-managing { border-color: var(--ws-line-bright); background: linear-gradient(180deg, #1c1f26, #0f1014); }
-.ws-cmd-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 11px 14px; border-bottom: 1px solid var(--ws-line); }
-.ws-cmd-panel-title { display: flex; align-items: center; gap: 9px; }
-.ws-cmd-panel-title h4 { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #e3e6ea; }
-.ws-cmd-panel-count { font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-faint); }
-.ws-cmd-panel-tools { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+.ws-cmd-panel.is-managing {
+  border-color: var(--ws-line-bright);
+  background: linear-gradient(180deg, #1c1f26, #0f1014);
+}
+.ws-cmd-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.ws-cmd-panel-title h4 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #e3e6ea;
+}
+.ws-cmd-panel-count {
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-panel-tools {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
 .ws-cmd-panel-more {
-  width: 26px; height: 24px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
-  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; transition: 0.15s;
+  width: 26px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  transition: 0.15s;
 }
-.ws-cmd-panel-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-panel-more:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-panel-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
+.ws-cmd-panel-more:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-panel-more:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-panel-body {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .ws-cmd-panel-action {
-  min-height: 24px; padding: 5px 7px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
-  color: var(--ws-faction); cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+  min-height: 24px;
+  padding: 5px 7px;
+  border: 1px solid var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
-.ws-cmd-panel-action:hover { background: rgba(70, 211, 154, 0.14); border-color: var(--ws-faction); }
-.ws-cmd-panel-action:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-rail-empty { padding: 16px 6px; text-align: center; font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-panel-action:hover {
+  background: rgba(70, 211, 154, 0.14);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-panel-action:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-rail-empty {
+  padding: 16px 6px;
+  text-align: center;
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  color: var(--ws-ink-faint);
+  letter-spacing: 0.5px;
+}
 .ws-cmd-rail-item {
-  display: flex; flex-direction: column; align-items: flex-start; gap: 2px; width: 100%; text-align: left;
-  padding: 8px 9px; border: 1px solid transparent; background: none; color: var(--ws-ink); cursor: pointer; text-decoration: none; transition: 0.13s;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  background: none;
+  color: var(--ws-ink);
+  cursor: pointer;
+  text-decoration: none;
+  transition: 0.13s;
 }
-.ws-cmd-rail-item.is-static { cursor: default; }
-.ws-cmd-rail-item:hover:not(.is-static) { border-color: var(--ws-line-bright); background: var(--ws-bg-2); }
-.ws-cmd-rail-item:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
-.ws-cmd-rail-line { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; min-width: 0; }
-.ws-cmd-rail-t { flex: 1 1 auto; min-width: 0; font-size: 13px; color: #eef0f3; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-cmd-rail-m { width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--ws-font-mono); font-size: 9.5px; color: var(--ws-ink-faint); letter-spacing: 0.5px; }
+.ws-cmd-rail-item.is-static {
+  cursor: default;
+}
+.ws-cmd-rail-item:hover:not(.is-static) {
+  border-color: var(--ws-line-bright);
+  background: var(--ws-bg-2);
+}
+.ws-cmd-rail-item:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 1px;
+}
+.ws-cmd-rail-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+}
+.ws-cmd-rail-t {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  color: #eef0f3;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-rail-m {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  color: var(--ws-ink-faint);
+  letter-spacing: 0.5px;
+}
 .ws-cmd-rail-role {
-  flex: 0 0 auto; padding: 2px 6px; border: 1px solid var(--ws-line-bright);
-  font-family: var(--ws-font-mono); font-size: 8px; letter-spacing: 0.8px; text-transform: uppercase; color: var(--ws-ink-dim);
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid var(--ws-line-bright);
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--ws-ink-dim);
 }
-.ws-cmd-rail-role.is-project { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); background: rgba(232, 181, 75, 0.08); }
-.ws-cmd-rail-role.is-reference { color: var(--ws-ink-dim); }
+.ws-cmd-rail-role.is-project {
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+  background: rgba(232, 181, 75, 0.08);
+}
+.ws-cmd-rail-role.is-reference {
+  color: var(--ws-ink-dim);
+}
 .ws-cmd-rail-more {
-  margin-top: 4px; padding: 7px; border: 1px dashed var(--ws-line-bright); background: none; color: var(--ws-ink-dim); cursor: pointer;
-  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
+  margin-top: 4px;
+  padding: 7px;
+  border: 1px dashed var(--ws-line-bright);
+  background: none;
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
-.ws-cmd-rail-more:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-rail-item.is-missing .ws-cmd-rail-t { color: var(--ws-alert); }
+.ws-cmd-rail-more:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-rail-item.is-missing .ws-cmd-rail-t {
+  color: var(--ws-alert);
+}
 /* Notes multi-select rows: checkbox + open button on one line. */
-.ws-cmd-note-row { flex-direction: row; align-items: center; gap: 8px; padding: 4px 9px; }
-.ws-cmd-note-check { flex: 0 0 auto; width: 14px; height: 14px; accent-color: var(--ws-faction); cursor: pointer; }
+.ws-cmd-note-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 9px;
+}
+.ws-cmd-note-check {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  accent-color: var(--ws-faction);
+  cursor: pointer;
+}
 .ws-cmd-note-open {
-  flex: 1 1 auto; min-width: 0; display: flex; align-items: center; text-align: left;
-  padding: 4px 0; border: 0; background: none; color: var(--ws-ink); cursor: pointer;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  text-align: left;
+  padding: 4px 0;
+  border: 0;
+  background: none;
+  color: var(--ws-ink);
+  cursor: pointer;
 }
-.ws-cmd-note-open:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 1px; }
-.ws-cmd-note-tools { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0 8px; }
+.ws-cmd-note-open:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 1px;
+}
+.ws-cmd-note-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 2px 0 8px;
+}
 .ws-cmd-note-tool {
-  padding: 5px 9px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
-  cursor: pointer; text-decoration: none; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; transition: 0.13s;
+  padding: 5px 9px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  text-decoration: none;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
-.ws-cmd-note-tool:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-note-tool.is-danger:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
-.ws-cmd-note-tool:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-note-filter, .ws-cmd-modal-note-filter { margin-bottom: 8px; }
+.ws-cmd-note-tool:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-note-tool.is-danger:hover {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.4);
+}
+.ws-cmd-note-tool:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-note-filter,
+.ws-cmd-modal-note-filter {
+  margin-bottom: 8px;
+}
 .ws-cmd-files-drop,
 .ws-cmd-files-browse {
-  width: 100%; min-height: 34px; margin-bottom: 6px; display: grid; place-items: center;
-  border: 1px dashed var(--ws-line-bright); background: rgba(0, 0, 0, 0.18); color: var(--ws-ink-dim);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase;
-  transition: 0.13s; text-align: center;
+  width: 100%;
+  min-height: 34px;
+  margin-bottom: 6px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--ws-line-bright);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: 0.13s;
+  text-align: center;
 }
 .ws-cmd-files-drop:hover,
 .ws-cmd-files-drop.is-active,
 .ws-cmd-files-browse:hover {
-  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
 .ws-cmd-files-drop:focus-visible,
 .ws-cmd-files-browse:focus-visible {
-  outline: 2px solid var(--ws-faction); outline-offset: 2px;
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
 }
-.ws-cmd-systems-body { gap: 10px; }
+.ws-cmd-systems-body {
+  gap: 10px;
+}
 .ws-cmd-system-tabs {
-  display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 8px; border-bottom: 1px solid var(--ws-line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--ws-line);
 }
 .ws-cmd-system-tab {
-  min-height: 28px; padding: 6px 8px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
-  color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono); font-size: 9.5px;
-  letter-spacing: 0.9px; text-transform: uppercase; transition: 0.13s;
+  min-height: 28px;
+  padding: 6px 8px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
 .ws-cmd-system-tab:hover,
 .ws-cmd-system-tab.is-active {
-  color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
-.ws-cmd-system-tab:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-system-tab:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-system-host {
-  max-height: 72vh; overflow: auto; min-width: 0; padding-right: 2px;
+  max-height: 72vh;
+  overflow: auto;
+  min-width: 0;
+  padding-right: 2px;
 }
 .ws-cmd-system-host .workspace-detail-tools-card,
 .ws-cmd-system-host .workspace-detail-config-card {
-  margin: 0; border: 0; box-shadow: none; background: transparent; border-radius: 0; color: var(--text-primary);
+  margin: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+  border-radius: 0;
+  color: var(--text-primary);
 }
 .ws-cmd-system-host .workspace-detail-config-header,
 .ws-cmd-system-host .workspace-detail-config-nav {
   display: none;
 }
 .ws-cmd-system-host .workspace-detail-config-content {
-  padding: 0; border: 0; background: transparent;
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 .ws-cmd-system-host .workspace-detail-config-body {
   padding: 0;
@@ -339,221 +935,859 @@
   padding: 0;
 }
 .ws-cmd-members-host {
-  max-height: 72vh; overflow: auto; min-width: 0; padding-right: 2px;
+  max-height: 72vh;
+  overflow: auto;
+  min-width: 0;
+  padding-right: 2px;
 }
 /* Neutralize the mounted detail-view members bento card so it reads as a rail panel body. */
 .ws-cmd-members-host .workspace-detail-panel-members {
-  margin: 0; border: 0; box-shadow: none; background: transparent; border-radius: 0;
-  cursor: default; color: var(--text-primary); padding: 0;
+  margin: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+  border-radius: 0;
+  cursor: default;
+  color: var(--text-primary);
+  padding: 0;
 }
 .ws-cmd-members-host .workspace-detail-panel-members:hover {
-  box-shadow: none; border-color: transparent;
+  box-shadow: none;
+  border-color: transparent;
 }
-.ws-cmd-members-host .workspace-detail-panel-close { display: none; }
-.ws-cmd-members-host .workspace-detail-panel-header { padding: 0 0 8px; }
-.ws-cmd-members-host .workspace-detail-panel-body { padding: 0; max-height: none; }
+.ws-cmd-members-host .workspace-detail-panel-close {
+  display: none;
+}
+.ws-cmd-members-host .workspace-detail-panel-header {
+  padding: 0 0 8px;
+}
+.ws-cmd-members-host .workspace-detail-panel-body {
+  padding: 0;
+  max-height: none;
+}
 .ws-cmd-soon {
-  display: grid; place-items: center; min-height: 200px; padding: 24px;
-  font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); text-align: center;
+  display: grid;
+  place-items: center;
+  min-height: 200px;
+  padding: 24px;
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+  text-align: center;
 }
 
 /* ---------- garrison ---------- */
-.ws-cmd-garrison { padding: 14px; }
-.ws-cmd-garrison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-.ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child { grid-column: 1 / -1; }
+.ws-cmd-garrison {
+  padding: 14px;
+}
+.ws-cmd-garrison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child {
+  grid-column: 1 / -1;
+}
 
 .ws-cmd-unit {
-  border: 1px solid var(--ws-line); background: linear-gradient(165deg, #171a20, #0e0f13); overflow: hidden;
-  clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(165deg, #171a20, #0e0f13);
+  overflow: hidden;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 12px) 0,
+    100% 12px,
+    100% 100%,
+    12px 100%,
+    0 calc(100% - 12px)
+  );
 }
-.ws-cmd-unit.is-keeper { border-color: rgba(232, 181, 75, 0.32); }
-.ws-cmd-unit-top { display: flex; gap: 12px; padding: 13px 13px 11px; border-bottom: 1px solid var(--ws-line); }
+.ws-cmd-unit.is-keeper {
+  border-color: rgba(232, 181, 75, 0.32);
+}
+.ws-cmd-unit-top {
+  display: flex;
+  gap: 12px;
+  padding: 13px 13px 11px;
+  border-bottom: 1px solid var(--ws-line);
+}
 .ws-cmd-av {
-  width: 46px; height: 46px; flex: 0 0 auto; display: grid; place-items: center;
-  font-family: var(--ws-font-mono); font-weight: 700; font-size: 14px; color: #04110c;
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  font-family: var(--ws-font-mono);
+  font-weight: 700;
+  font-size: 14px;
+  color: #04110c;
   background: hsl(var(--agent-avatar-hue, 160) 52% 48%);
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-cmd-unit-id { flex: 1 1 auto; min-width: 0; }
-.ws-cmd-unit-name { font-size: 15px; font-weight: 700; letter-spacing: 0.4px; text-transform: uppercase; color: #f3f5f8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-cmd-unit-role { display: flex; align-items: center; gap: 8px; margin-top: 5px; flex-wrap: wrap; }
+.ws-cmd-unit-id {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ws-cmd-unit-name {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #f3f5f8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-unit-role {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 5px;
+  flex-wrap: wrap;
+}
 .ws-cmd-badge {
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase;
-  padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-ink-dim);
 }
-.ws-cmd-badge.is-keeper { color: var(--ws-keeper); border-color: rgba(232, 181, 75, 0.4); background: rgba(232, 181, 75, 0.08); }
-.ws-cmd-state { display: flex; align-items: center; gap: 6px; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-dim); }
-.ws-cmd-led { width: 7px; height: 7px; border-radius: 50%; background: var(--ws-idle); box-shadow: 0 0 7px var(--ws-idle); }
-.ws-cmd-led.working { background: var(--ws-working); box-shadow: 0 0 8px var(--ws-working); }
-.ws-cmd-led.alert { background: var(--ws-alert); box-shadow: 0 0 8px var(--ws-alert); }
-.ws-cmd-led.idle { background: var(--ws-idle); }
-.ws-cmd-unit-ctl { display: flex; align-items: flex-start; gap: 6px; }
-.ws-cmd-lock { color: var(--ws-keeper); font-size: 13px; line-height: 26px; }
+.ws-cmd-badge.is-keeper {
+  color: var(--ws-keeper);
+  border-color: rgba(232, 181, 75, 0.4);
+  background: rgba(232, 181, 75, 0.08);
+}
+.ws-cmd-state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-led {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ws-idle);
+  box-shadow: 0 0 7px var(--ws-idle);
+}
+.ws-cmd-led.working {
+  background: var(--ws-working);
+  box-shadow: 0 0 8px var(--ws-working);
+}
+.ws-cmd-led.alert {
+  background: var(--ws-alert);
+  box-shadow: 0 0 8px var(--ws-alert);
+}
+.ws-cmd-led.idle {
+  background: var(--ws-idle);
+}
+.ws-cmd-unit-ctl {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+.ws-cmd-lock {
+  color: var(--ws-keeper);
+  font-size: 13px;
+  line-height: 26px;
+}
 .ws-cmd-icon-btn {
-  width: 26px; height: 26px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
-  background: var(--ws-bg-2); color: var(--ws-faction); cursor: pointer; font-size: 14px; transition: 0.15s;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-size: 14px;
+  transition: 0.15s;
 }
-.ws-cmd-icon-btn.sm { width: 22px; height: 22px; font-size: 12px; }
-.ws-cmd-icon-btn:hover { background: rgba(70, 211, 154, 0.1); border-color: var(--ws-faction-deep); }
-.ws-cmd-icon-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-icon-btn.sm {
+  width: 22px;
+  height: 22px;
+  font-size: 12px;
+}
+.ws-cmd-icon-btn:hover {
+  background: rgba(70, 211, 154, 0.1);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-icon-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 
-.ws-cmd-unit-rows { padding: 11px 13px; display: flex; flex-direction: column; gap: 8px; }
-.ws-cmd-row { display: flex; justify-content: space-between; align-items: center; }
-.ws-cmd-rk { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-ink-faint); }
-.ws-cmd-rv { font-family: var(--ws-font-mono); font-size: 12px; color: #eef0f3; }
+.ws-cmd-unit-rows {
+  padding: 11px 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ws-cmd-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.ws-cmd-rk {
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-rv {
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+  color: #eef0f3;
+}
 
-.ws-cmd-unit-name-link { color: inherit; text-decoration: none; border-bottom: 1px dashed transparent; transition: color 0.15s, border-color 0.15s; }
-.ws-cmd-unit-name-link:hover, .ws-cmd-unit-name-link:focus-visible { color: var(--ws-faction); border-bottom-color: var(--ws-faction-deep); outline: none; }
+.ws-cmd-unit-name-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed transparent;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+.ws-cmd-unit-name-link:hover,
+.ws-cmd-unit-name-link:focus-visible {
+  color: var(--ws-faction);
+  border-bottom-color: var(--ws-faction-deep);
+  outline: none;
+}
 
 /* System-prompt preview block on a unit card (opens the full prompt modal). */
 .ws-cmd-prompt {
-  display: flex; flex-direction: column; gap: 5px; width: 100%; text-align: left;
-  margin: 0 13px 11px; padding: 9px 11px; box-sizing: border-box; width: calc(100% - 26px);
-  border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.18); color: inherit; cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  text-align: left;
+  margin: 0 13px 11px;
+  padding: 9px 11px;
+  box-sizing: border-box;
+  width: calc(100% - 26px);
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
 }
-.ws-cmd-prompt:hover { border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.06); }
-.ws-cmd-prompt:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-prompt-head { display: flex; justify-content: space-between; align-items: center; }
-.ws-cmd-prompt-cta { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-faction); }
+.ws-cmd-prompt:hover {
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.06);
+}
+.ws-cmd-prompt:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-prompt-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.ws-cmd-prompt-cta {
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--ws-faction);
+}
 .ws-cmd-prompt-preview {
-  font-size: 11.5px; line-height: 1.45; color: var(--ws-ink-dim);
-  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--ws-ink-dim);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-.ws-cmd-prompt-preview.is-empty { font-style: italic; color: var(--ws-ink-faint); }
+.ws-cmd-prompt-preview.is-empty {
+  font-style: italic;
+  color: var(--ws-ink-faint);
+}
 
-.ws-cmd-questlog { margin: 2px 13px 13px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
-.ws-cmd-ql-head { display: flex; justify-content: space-between; align-items: center; padding: 8px 11px; border-bottom: 1px solid var(--ws-line); }
-.ws-cmd-ql-t { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-dim); }
-.ws-cmd-ql-empty { padding: 13px 11px; text-align: center; font-family: var(--ws-font-mono); font-size: 10.5px; color: var(--ws-ink-faint); letter-spacing: 1px; }
-.ws-cmd-quest { display: flex; align-items: center; gap: 9px; padding: 9px 11px; }
-.ws-cmd-quest + .ws-cmd-quest { border-top: 1px solid var(--ws-line); }
-.ws-cmd-q-glyph { width: 22px; height: 22px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-keeper-deep); color: var(--ws-keeper); font-size: 11px; }
-.ws-cmd-q-name {
-  flex: 1 1 auto; min-width: 0; padding: 0; border: 0; background: none; text-align: left;
-  font: inherit; font-size: 13px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer;
+.ws-cmd-questlog {
+  margin: 2px 13px 13px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.22);
 }
-.ws-cmd-q-name:hover { color: var(--ws-faction); text-decoration: underline; text-underline-offset: 3px; }
-.ws-cmd-q-name:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-q-status { font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
-.ws-cmd-q-status.pending { color: var(--ws-keeper); border-color: var(--ws-keeper-deep); }
-.ws-cmd-q-status.working { color: var(--ws-working); border-color: var(--ws-faction-deep); }
-.ws-cmd-q-status.alert { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
-.ws-cmd-q-status.done { color: var(--ws-ink-faint); }
-.ws-cmd-q-run { width: 28px; height: 28px; flex: 0 0 auto; display: grid; place-items: center; border: 1px solid var(--ws-faction-deep); color: var(--ws-faction); background: rgba(70, 211, 154, 0.07); cursor: pointer; transition: 0.15s; }
-.ws-cmd-q-run:hover { background: var(--ws-faction); color: #04110c; }
-.ws-cmd-q-run:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-ql-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 11px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-ql-t {
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-ql-empty {
+  padding: 13px 11px;
+  text-align: center;
+  font-family: var(--ws-font-mono);
+  font-size: 10.5px;
+  color: var(--ws-ink-faint);
+  letter-spacing: 1px;
+}
+.ws-cmd-quest {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+}
+.ws-cmd-quest + .ws-cmd-quest {
+  border-top: 1px solid var(--ws-line);
+}
+.ws-cmd-q-glyph {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-keeper-deep);
+  color: var(--ws-keeper);
+  font-size: 11px;
+}
+.ws-cmd-q-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: left;
+  font: inherit;
+  font-size: 13px;
+  color: #eef0f3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.ws-cmd-q-name:hover {
+  color: var(--ws-faction);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.ws-cmd-q-name:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-q-status {
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-q-status.pending {
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+}
+.ws-cmd-q-status.working {
+  color: var(--ws-working);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-q-status.alert {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.4);
+}
+.ws-cmd-q-status.done {
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-q-run {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-faction-deep);
+  color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.07);
+  cursor: pointer;
+  transition: 0.15s;
+}
+.ws-cmd-q-run:hover {
+  background: var(--ws-faction);
+  color: #04110c;
+}
+.ws-cmd-q-run:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 
 /* ---------- stat manager modal (agents / tasks / mcp / skills) ---------- */
 /* Lives inside the .ws-cmd container so it inherits the tactical tokens, but is
    position:fixed so it overlays the viewport regardless of scroll position. */
 .ws-cmd-modal {
-  position: fixed; inset: 0; z-index: 1050; display: flex; align-items: center; justify-content: center; padding: 24px;
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
 }
-.ws-cmd-modal[hidden] { display: none; }
-.ws-cmd-modal-backdrop { position: absolute; inset: 0; background: rgba(3, 7, 8, 0.72); }
+.ws-cmd-modal[hidden] {
+  display: none;
+}
+.ws-cmd-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 7, 8, 0.72);
+}
 .ws-cmd-modal-panel {
-  position: relative; z-index: 1; width: 100%; max-width: 560px; max-height: 82vh; display: flex; flex-direction: column;
-  border: 1px solid var(--ws-line-bright); background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
-  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
-  box-shadow: var(--ws-glow); outline: none;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 560px;
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ws-line-bright);
+  background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
+  clip-path: polygon(
+    0 0,
+    calc(100% - 16px) 0,
+    100% 16px,
+    100% 100%,
+    16px 100%,
+    0 calc(100% - 16px)
+  );
+  box-shadow: var(--ws-glow);
+  outline: none;
 }
-.ws-cmd-modal-panel:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-modal-head { display: flex; align-items: center; gap: 12px; padding: 14px 16px; border-bottom: 1px solid var(--ws-line); }
-.ws-cmd-modal-title { margin: 0; font-size: 15px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: #eef0f3; }
-.ws-cmd-modal-count { font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); }
-.ws-cmd-modal-head-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.ws-cmd-modal-panel:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-modal-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-modal-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #eef0f3;
+}
+.ws-cmd-modal-count {
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-modal-head-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .ws-cmd-modal-add {
-  padding: 7px 12px; border: 1px solid var(--ws-faction-deep); background: rgba(70, 211, 154, 0.09); color: var(--ws-faction);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+  padding: 7px 12px;
+  border: 1px solid var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.09);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  transition: 0.13s;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
-.ws-cmd-modal-add:hover { background: rgba(70, 211, 154, 0.16); border-color: var(--ws-faction); }
-.ws-cmd-modal-add:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-add:hover {
+  background: rgba(70, 211, 154, 0.16);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-modal-add:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-modal-filter {
-  padding: 7px 10px; border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.1px; text-transform: uppercase; transition: 0.13s;
+  padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
 .ws-cmd-modal-filter[aria-pressed="true"],
-.ws-cmd-modal-filter:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
-.ws-cmd-modal-filter:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-modal-viewtoggle { display: inline-flex; border: 1px solid var(--ws-line-bright); }
-.ws-cmd-modal-view {
-  padding: 7px 11px; border: 0; border-right: 1px solid var(--ws-line-bright); background: var(--ws-bg-2); color: var(--ws-ink-dim);
-  cursor: pointer; font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.1px; text-transform: uppercase; transition: 0.13s;
+.ws-cmd-modal-filter:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
-.ws-cmd-modal-view:last-child { border-right: 0; }
+.ws-cmd-modal-filter:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-modal-viewtoggle {
+  display: inline-flex;
+  border: 1px solid var(--ws-line-bright);
+}
+.ws-cmd-modal-view {
+  padding: 7px 11px;
+  border: 0;
+  border-right: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  transition: 0.13s;
+}
+.ws-cmd-modal-view:last-child {
+  border-right: 0;
+}
 .ws-cmd-modal-view.is-active,
-.ws-cmd-modal-view:hover { color: var(--ws-faction); background: rgba(70, 211, 154, 0.08); }
-.ws-cmd-modal-view:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: -2px; }
+.ws-cmd-modal-view:hover {
+  color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-modal-view:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: -2px;
+}
 /* Board mode goes wide so status columns have room. */
-.ws-cmd-modal-panel.is-board { max-width: min(1240px, 96vw); }
-.ws-cmd-modal-board-body { flex: 1 1 auto; min-height: 0; padding: 12px 14px; }
-.ws-cmd-board-host { min-width: 0; height: 100%; overflow: auto; }
+.ws-cmd-modal-panel.is-board {
+  max-width: min(1240px, 96vw);
+}
+.ws-cmd-modal-board-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 12px 14px;
+}
+.ws-cmd-board-host {
+  min-width: 0;
+  height: 100%;
+  overflow: auto;
+}
 /* Neutralize the mounted detail board wrapper chrome inside the modal host. */
-.ws-cmd-board-host .workspace-detail-board { display: block; margin: 0; }
+.ws-cmd-board-host .workspace-detail-board {
+  display: block;
+  margin: 0;
+}
 /* MCP/Skills stat modals mount the live Workspace config surface. Go wide like the board
    and strip the config card's own header + tab strip so only the active manager pane shows. */
-.ws-cmd-modal-panel.is-config { max-width: min(1000px, 94vw); }
-.ws-cmd-modal-config-body { flex: 1 1 auto; min-height: 0; padding: 0; display: flex; flex-direction: column; }
+.ws-cmd-modal-panel.is-config {
+  max-width: min(1000px, 94vw);
+}
+.ws-cmd-modal-config-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
 /* The Tools modal stacks a sub-tab strip above the mounted surface. */
-.ws-cmd-modal-config-body .ws-cmd-system-tabs { flex: 0 0 auto; padding: 12px 14px 0; }
-.ws-cmd-config-host { min-width: 0; flex: 1 1 auto; min-height: 0; overflow: auto; }
+.ws-cmd-modal-config-body .ws-cmd-system-tabs {
+  flex: 0 0 auto;
+  padding: 12px 14px 0;
+}
+.ws-cmd-config-host {
+  min-width: 0;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
 .ws-cmd-config-host .workspace-detail-config-card.is-command-modal {
-  margin: 0; border: 0; background: transparent; box-shadow: none; clip-path: none;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  clip-path: none;
 }
 .workspace-detail-config-card.is-command-modal .workspace-detail-config-header,
-.workspace-detail-config-card.is-command-modal .workspace-detail-config-nav { display: none; }
-.workspace-detail-config-card.is-command-modal .workspace-detail-config-content { padding: 14px 16px; }
+.workspace-detail-config-card.is-command-modal .workspace-detail-config-nav {
+  display: none;
+}
+.workspace-detail-config-card.is-command-modal .workspace-detail-config-content {
+  padding: 14px 16px;
+}
 .ws-cmd-modal-close {
-  width: 30px; height: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
-  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-size: 16px; line-height: 1; transition: 0.13s;
+  width: 30px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  transition: 0.13s;
 }
-.ws-cmd-modal-close:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); }
-.ws-cmd-modal-close:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
-.ws-cmd-modal-body { padding: 12px 14px; overflow-y: auto; display: flex; flex-direction: column; gap: 8px; }
-.ws-cmd-modal-empty { padding: 28px 12px; text-align: center; font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 0.8px; color: var(--ws-ink-faint); }
-.ws-cmd-modal-foot { padding: 11px 14px; border-top: 1px solid var(--ws-line); display: flex; justify-content: flex-end; }
+.ws-cmd-modal-close:hover {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.4);
+}
+.ws-cmd-modal-close:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-modal-body {
+  padding: 12px 14px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ws-cmd-modal-empty {
+  padding: 28px 12px;
+  text-align: center;
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-modal-foot {
+  padding: 11px 14px;
+  border-top: 1px solid var(--ws-line);
+  display: flex;
+  justify-content: flex-end;
+}
 .ws-cmd-modal-detailed {
-  border: none; background: none; color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono);
-  font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; transition: 0.13s;
+  border: none;
+  background: none;
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
-.ws-cmd-modal-detailed:hover { color: var(--ws-faction); }
-.ws-cmd-modal-detailed:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-modal-detailed:hover {
+  color: var(--ws-faction);
+}
+.ws-cmd-modal-detailed:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 
 /* rows */
-.ws-cmd-mrow { display: flex; align-items: center; gap: 12px; padding: 11px 12px; border: 1px solid var(--ws-line); background: rgba(0, 0, 0, 0.22); }
+.ws-cmd-mrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 12px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.22);
+}
 .ws-cmd-mrow-av {
-  width: 34px; height: 34px; flex: 0 0 auto; display: grid; place-items: center; font-family: var(--ws-font-mono);
-  font-weight: 700; font-size: 11px; color: #04110c; background: hsl(var(--agent-avatar-hue, 160) 52% 48%);
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  font-family: var(--ws-font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  color: #04110c;
+  background: hsl(var(--agent-avatar-hue, 160) 52% 48%);
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-cmd-mrow-main { flex: 1 1 auto; min-width: 0; }
-.ws-cmd-mrow-name { display: flex; align-items: center; gap: 7px; font-size: 14px; color: #eef0f3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ws-cmd-mrow-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.ws-cmd-mrow-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ws-cmd-mrow-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 14px;
+  color: #eef0f3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-mrow-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
 .ws-cmd-mchip {
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 0.8px; text-transform: uppercase; padding: 2px 7px;
-  border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-ink-dim);
 }
-.ws-cmd-mchip.is-on { color: var(--ws-faction); border-color: var(--ws-faction-deep); }
-.ws-cmd-mchip.is-disabled { color: var(--ws-ink-faint); }
-.ws-cmd-mchip.is-keeper { color: var(--ws-keeper); border-color: rgba(232, 181, 75, 0.4); background: rgba(232, 181, 75, 0.08); }
-.ws-cmd-mrow-actions { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+.ws-cmd-mchip.is-on {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-mchip.is-disabled {
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-mchip.is-keeper {
+  color: var(--ws-keeper);
+  border-color: rgba(232, 181, 75, 0.4);
+  background: rgba(232, 181, 75, 0.08);
+}
+.ws-cmd-mrow-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
 .ws-cmd-mrow-btn {
-  padding: 5px 9px; min-width: 28px; display: grid; place-items: center; border: 1px solid var(--ws-line-bright);
-  background: var(--ws-bg-2); color: var(--ws-ink-dim); cursor: pointer; font-family: var(--ws-font-mono);
-  font-size: 10px; letter-spacing: 0.8px; text-transform: uppercase; transition: 0.13s;
+  padding: 5px 9px;
+  min-width: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  transition: 0.13s;
 }
-.ws-cmd-mrow-btn:hover { color: var(--ws-faction); border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.07); }
-.ws-cmd-mrow-btn.is-danger:hover { color: var(--ws-alert); border-color: rgba(226, 101, 77, 0.4); background: rgba(226, 101, 77, 0.07); }
-.ws-cmd-mrow-btn:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-cmd-mrow-btn:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.07);
+}
+.ws-cmd-mrow-btn.is-danger:hover {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.4);
+  background: rgba(226, 101, 77, 0.07);
+}
+.ws-cmd-mrow-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+
+/* Light mode keeps the tactical layout but uses the same neutral shell palette
+   as the rest of Ori's light UI. Dark mode continues to use the base charcoal tokens. */
+[data-bs-theme="light"] .ws-cmd {
+  --ws-bg: #eef1f3;
+  --ws-bg-2: #f7f8f9;
+  --ws-panel: #eceff2;
+  --ws-panel-2: #fbfcfd;
+  --ws-panel-deep: #dfe4e8;
+  --ws-line: #c8cdd3;
+  --ws-line-bright: #a8b0ba;
+
+  --ws-ink: #1f2128;
+  --ws-ink-dim: #5c5c5e;
+  --ws-ink-faint: #737a84;
+  --ws-ink-heading: #0a0a0a;
+
+  --ws-faction: #1f6b4e;
+  --ws-faction-deep: rgba(31, 107, 78, 0.34);
+  --ws-keeper: #9b641b;
+  --ws-keeper-deep: rgba(155, 100, 27, 0.34);
+  --ws-idle: #167c99;
+  --ws-working: #1f6b4e;
+  --ws-alert: #b94b3f;
+
+  --ws-on-accent: #ffffff;
+  --ws-avatar-text: #04110c;
+  --ws-field-bg: rgba(255, 255, 255, 0.62);
+  --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.7), 0 20px 42px -26px rgba(10, 10, 10, 0.34);
+}
+
+[data-bs-theme="light"] .ws-cmd-title h2,
+[data-bs-theme="light"] .ws-cmd-stat .ws-v,
+[data-bs-theme="light"] .ws-cmd-mission-title,
+[data-bs-theme="light"] .ws-cmd-panel-title h4,
+[data-bs-theme="light"] .ws-cmd-rail-t,
+[data-bs-theme="light"] .ws-cmd-unit-name,
+[data-bs-theme="light"] .ws-cmd-rv,
+[data-bs-theme="light"] .ws-cmd-q-name,
+[data-bs-theme="light"] .ws-cmd-modal-title,
+[data-bs-theme="light"] .ws-cmd-mrow-name {
+  color: var(--ws-ink-heading);
+}
+
+[data-bs-theme="light"] .ws-cmd-stat.is-alert .ws-v,
+[data-bs-theme="light"] .ws-cmd-stat.is-alert .ws-l {
+  color: var(--ws-alert);
+}
+
+[data-bs-theme="light"] .ws-cmd-mission,
+[data-bs-theme="light"] .ws-cmd-garrison,
+[data-bs-theme="light"] .ws-cmd-panel {
+  background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
+}
+
+[data-bs-theme="light"] .ws-cmd-panel.is-managing {
+  background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel-deep));
+}
+
+[data-bs-theme="light"] .ws-cmd-unit {
+  background: linear-gradient(165deg, var(--ws-panel-2), var(--ws-panel-deep));
+}
+
+[data-bs-theme="light"] .ws-cmd-identity-editor,
+[data-bs-theme="light"] .ws-cmd-files-drop,
+[data-bs-theme="light"] .ws-cmd-files-browse,
+[data-bs-theme="light"] .ws-cmd-prompt,
+[data-bs-theme="light"] .ws-cmd-questlog,
+[data-bs-theme="light"] .ws-cmd-mrow {
+  background: var(--ws-field-bg);
+}
+
+[data-bs-theme="light"] .ws-cmd-av,
+[data-bs-theme="light"] .ws-cmd-mrow-av {
+  color: var(--ws-avatar-text);
+}
+
+[data-bs-theme="light"] .ws-cmd-q-run:hover {
+  color: var(--ws-on-accent);
+}
 
 @media (max-width: 1100px) {
-  .ws-cmd-topbar { align-items: flex-start; }
-  .ws-cmd-title { flex-basis: calc(100% - 70px); }
-  .ws-cmd-readout { flex: 1 1 100%; justify-content: flex-start; }
-  .ws-cmd-garrison-grid { grid-template-columns: 1fr; }
-  .ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child { grid-column: auto; }
+  .ws-cmd-topbar {
+    align-items: flex-start;
+  }
+  .ws-cmd-title {
+    flex-basis: calc(100% - 70px);
+  }
+  .ws-cmd-readout {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+  .ws-cmd-garrison-grid {
+    grid-template-columns: 1fr;
+  }
+  .ws-cmd-garrison-grid.is-odd .ws-cmd-unit:last-child {
+    grid-column: auto;
+  }
 }
 @media (min-width: 1101px) {
   .ws-cmd-layout:has(.ws-cmd-systems-panel.is-managing) {
@@ -561,31 +1795,80 @@
   }
 }
 @media (max-width: 900px) {
-  .ws-cmd-layout { grid-template-columns: 1fr; }
-  .ws-cmd-mission { flex-direction: column; }
-  .ws-cmd-mission-actions { justify-content: flex-start; }
-  .ws-cmd-system-host { max-height: none; }
-  .ws-cmd-members-host { max-height: none; }
+  .ws-cmd-layout {
+    grid-template-columns: 1fr;
+  }
+  .ws-cmd-mission {
+    flex-direction: column;
+  }
+  .ws-cmd-mission-actions {
+    justify-content: flex-start;
+  }
+  .ws-cmd-system-host {
+    max-height: none;
+  }
+  .ws-cmd-members-host {
+    max-height: none;
+  }
 }
 @media (max-width: 640px) {
-  .ws-cmd-nav-btn { flex: 1 1 calc(50% - 8px); justify-content: center; }
-  .ws-cmd-crest { width: 42px; height: 42px; }
-  .ws-cmd-title h2 { font-size: 20px; }
-  .ws-cmd-panel-head { align-items: flex-start; }
-  .ws-cmd-panel-tools { flex-wrap: wrap; justify-content: flex-end; }
-  .ws-cmd-readout .ws-cmd-stat { flex: 1 1 calc(50% - 10px); }
-  .ws-cmd-mission-actions .ws-cmd-mission-btn { flex: 1 1 calc(50% - 8px); }
+  .ws-cmd-nav-btn {
+    flex: 1 1 calc(50% - 8px);
+    justify-content: center;
+  }
+  .ws-cmd-crest {
+    width: 42px;
+    height: 42px;
+  }
+  .ws-cmd-title h2 {
+    font-size: 20px;
+  }
+  .ws-cmd-panel-head {
+    align-items: flex-start;
+  }
+  .ws-cmd-panel-tools {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .ws-cmd-readout .ws-cmd-stat {
+    flex: 1 1 calc(50% - 10px);
+  }
+  .ws-cmd-mission-actions .ws-cmd-mission-btn {
+    flex: 1 1 calc(50% - 8px);
+  }
   /* Reserve space for the floating Workspace Assistant FAB so the last rail/panel
      controls are never trapped underneath it (PRD FR5.20). */
-  .ws-cmd { padding-bottom: 84px; }
+  .ws-cmd {
+    padding-bottom: 84px;
+  }
 }
 
 /* Auto-playing motion is opt-in via the OS "reduce motion" preference. */
-@keyframes ws-cmd-rise { from { opacity: 0; transform: translateY(8px); } }
-@keyframes ws-cmd-pulse { 50% { opacity: 0.35; } }
+@keyframes ws-cmd-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+@keyframes ws-cmd-pulse {
+  50% {
+    opacity: 0.35;
+  }
+}
 @media (prefers-reduced-motion: no-preference) {
-  .ws-cmd-topbar { animation: ws-cmd-rise 0.35s ease both; }
-  .ws-cmd-mission, .ws-cmd-garrison, .ws-cmd-rail { animation: ws-cmd-rise 0.4s ease both; animation-delay: 0.05s; }
-  .ws-cmd-led.working { animation: ws-cmd-pulse 1.5s ease-in-out infinite; }
-  .ws-cmd-modal-panel { animation: ws-cmd-rise 0.22s ease both; }
+  .ws-cmd-topbar {
+    animation: ws-cmd-rise 0.35s ease both;
+  }
+  .ws-cmd-mission,
+  .ws-cmd-garrison,
+  .ws-cmd-rail {
+    animation: ws-cmd-rise 0.4s ease both;
+    animation-delay: 0.05s;
+  }
+  .ws-cmd-led.working {
+    animation: ws-cmd-pulse 1.5s ease-in-out infinite;
+  }
+  .ws-cmd-modal-panel {
+    animation: ws-cmd-rise 0.22s ease both;
+  }
 }

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -2,12 +2,14 @@
  * workspace-construct.css — tactical reskin of the create-workspace modal.
  *
  * Everything is scoped under `.workspace-create-modal` (the #addFolderModal root)
- * so it cannot leak to other modals or pages. A dark tactical surface that mirrors
- * the Map's `.ws-map` / Command view's `.ws-cmd` visual system; the self-hosted
- * @font-face declarations are already provided globally by workspace-map.css.
+ * so it cannot leak to other modals or pages. It mirrors the Map's `.ws-map` /
+ * Command view's `.ws-cmd` visual system with theme-responsive tactical tokens;
+ * the self-hosted @font-face declarations are already provided globally by
+ * workspace-map.css.
  *
  * Styling only — the form logic, template picker, submission, and intake are
- * untouched. No ui-refresh.css edits, no `!important`.
+ * untouched. Scoped `!important` is used only where the global modal/input
+ * refresh layer also uses `!important`.
  *
  * Approach: the template's inline styles use app theme vars (var(--bg-primary),
  * var(--text-secondary), ...), so we redefine those vars locally to re-theme the
@@ -32,8 +34,8 @@
   --wc-idle: #4ec5e6;
   --wc-alert: #e2654d;
   --wc-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
-  --wc-font-display: 'Chakra Petch', system-ui, sans-serif;
-  --wc-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --wc-font-display: "Chakra Petch", system-ui, sans-serif;
+  --wc-font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   /* redefine app theme vars locally → the modal's inline var() usages go tactical */
   --bg-primary: var(--wc-panel);
@@ -46,82 +48,165 @@
 
 /* ---------- chrome ---------- */
 .workspace-create-modal .modal-content {
+  background: var(--wc-panel) !important;
+  border: 1px solid var(--wc-line) !important;
+  backdrop-filter: none !important;
   color: var(--wc-ink);
-  box-shadow: var(--wc-glow);
-  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  box-shadow: var(--wc-glow) !important;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 16px) 0,
+    100% 16px,
+    100% 100%,
+    16px 100%,
+    0 calc(100% - 16px)
+  );
 }
-.workspace-create-modal .modal-header { background: linear-gradient(180deg, var(--wc-panel-2), var(--wc-panel)); }
+.workspace-create-modal .modal-header {
+  background: linear-gradient(180deg, var(--wc-panel-2), var(--wc-panel)) !important;
+  border-bottom-color: var(--wc-line) !important;
+}
 .workspace-create-modal .modal-title {
-  font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; color: #eef0f3;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: #eef0f3;
 }
-.workspace-create-modal .btn-close { filter: invert(1) grayscale(1) brightness(1.4); opacity: 0.7; }
-.workspace-create-modal .btn-close:hover { opacity: 1; }
-.workspace-create-modal .modal-footer { background: linear-gradient(0deg, var(--wc-panel-2), var(--wc-panel)); }
+.workspace-create-modal .btn-close {
+  filter: invert(1) grayscale(1) brightness(1.4);
+  opacity: 0.7;
+}
+.workspace-create-modal .btn-close:hover {
+  opacity: 1;
+}
+.workspace-create-modal .modal-footer {
+  background: linear-gradient(0deg, var(--wc-panel-2), var(--wc-panel)) !important;
+  border-top-color: var(--wc-line) !important;
+}
 
 /* kicker line under the title area */
 .workspace-create-modal .modal-title::after {
-  content: 'Construct'; display: inline-block; margin-left: 10px;
-  font-family: var(--wc-font-mono); font-size: 9px; letter-spacing: 2px; color: var(--wc-faction);
-  border: 1px solid var(--wc-faction-deep); padding: 2px 6px; vertical-align: middle;
+  content: "Construct";
+  display: inline-block;
+  margin-left: 10px;
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: var(--wc-faction);
+  border: 1px solid var(--wc-faction-deep);
+  padding: 2px 6px;
+  vertical-align: middle;
 }
 
 /* ---------- inputs ---------- */
 .workspace-create-modal .modern-input {
-  background: var(--wc-bg-2); border: 1px solid var(--wc-line-bright); color: var(--wc-ink);
+  background: var(--wc-bg-2) !important;
+  border: 1px solid var(--wc-line-bright) !important;
+  color: var(--wc-ink) !important;
   font-family: var(--wc-font-mono);
 }
-.workspace-create-modal .modern-input::placeholder { color: var(--wc-ink-faint); }
-.workspace-create-modal .modern-input:focus {
-  border-color: var(--wc-faction-deep); box-shadow: 0 0 0 1px var(--wc-faction-deep); outline: none;
+.workspace-create-modal .modern-input::placeholder {
+  color: var(--wc-ink-faint);
 }
-.workspace-create-modal select.modern-input option { background: var(--wc-panel); color: var(--wc-ink); }
+.workspace-create-modal .modern-input:focus {
+  border-color: var(--wc-faction-deep) !important;
+  box-shadow: 0 0 0 1px var(--wc-faction-deep) !important;
+  background: var(--wc-bg-2) !important;
+  outline: none;
+}
+.workspace-create-modal select.modern-input option {
+  background: var(--wc-panel);
+  color: var(--wc-ink);
+}
 
 /* ---------- buttons ---------- */
 .workspace-create-modal .modern-btn-primary {
   background: linear-gradient(180deg, rgba(70, 211, 154, 0.18), rgba(70, 211, 154, 0.05));
-  border: 1px solid var(--wc-faction-deep); color: var(--wc-faction);
-  font-family: var(--wc-font-display); letter-spacing: 1px; text-transform: uppercase; font-weight: 700;
+  border: 1px solid var(--wc-faction-deep);
+  color: var(--wc-faction);
+  font-family: var(--wc-font-display);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-weight: 700;
 }
-.workspace-create-modal .modern-btn-primary:hover { background: var(--wc-faction); color: #04110c; }
+.workspace-create-modal .modern-btn-primary:hover {
+  background: var(--wc-faction);
+  color: #04110c;
+}
 .workspace-create-modal .modern-btn-secondary {
-  background: var(--wc-bg-2); border: 1px solid var(--wc-line-bright); color: var(--wc-ink-dim);
+  background: var(--wc-bg-2);
+  border: 1px solid var(--wc-line-bright);
+  color: var(--wc-ink-dim);
 }
-.workspace-create-modal .modern-btn-secondary:hover { color: var(--wc-faction); border-color: var(--wc-faction-deep); }
-.workspace-create-modal .modern-btn:focus-visible { outline: 2px solid var(--wc-faction); outline-offset: 2px; }
+.workspace-create-modal .modern-btn-secondary:hover {
+  color: var(--wc-faction);
+  border-color: var(--wc-faction-deep);
+}
+.workspace-create-modal .modern-btn:focus-visible {
+  outline: 2px solid var(--wc-faction);
+  outline-offset: 2px;
+}
 
 /* ---------- setup / advanced cards ---------- */
 .workspace-create-modal .workspace-setup-card,
 .workspace-create-modal .workspace-advanced-details {
-  background: rgba(0, 0, 0, 0.22); border: 1px solid var(--wc-line);
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--wc-line);
 }
 .workspace-create-modal .workspace-setup-title,
-.workspace-create-modal .workspace-advanced-summary-title { color: #eef0f3; }
+.workspace-create-modal .workspace-advanced-summary-title {
+  color: #eef0f3;
+}
 .workspace-create-modal .workspace-setup-help,
-.workspace-create-modal .workspace-advanced-summary-hint { color: var(--wc-ink-faint); }
+.workspace-create-modal .workspace-advanced-summary-hint {
+  color: var(--wc-ink-faint);
+}
 .workspace-create-modal .workspace-template-list-heading {
-  font-family: var(--wc-font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--wc-ink-faint);
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--wc-ink-faint);
 }
 
 /* ---------- template blueprint cards ---------- */
 .workspace-create-modal .workspace-template-card,
 .workspace-create-modal .workspace-template-row {
-  border: 1px solid var(--wc-line); background: var(--wc-panel-2); color: var(--wc-ink);
+  border: 1px solid var(--wc-line);
+  background: var(--wc-panel-2);
+  color: var(--wc-ink);
   clip-path: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
-  transition: transform 0.15s ease, border-color 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease;
 }
 .workspace-create-modal .workspace-template-card:hover,
-.workspace-create-modal .workspace-template-row:hover { border-color: var(--wc-line-bright); transform: translateY(-2px); }
+.workspace-create-modal .workspace-template-row:hover {
+  border-color: var(--wc-line-bright);
+  transform: translateY(-2px);
+}
 .workspace-create-modal .workspace-template-card.is-selected,
 .workspace-create-modal .workspace-template-row.is-selected {
-  border-color: var(--wc-faction-deep); background: rgba(70, 211, 154, 0.08);
+  border-color: var(--wc-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
 .workspace-create-modal .workspace-template-card:focus-visible,
-.workspace-create-modal .workspace-template-row:focus-visible { outline: 2px solid var(--wc-faction); outline-offset: 2px; }
-.workspace-create-modal .workspace-template-card-icon { color: var(--wc-faction); }
-.workspace-create-modal .workspace-template-card-label {
-  color: #f3f5f8; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase;
+.workspace-create-modal .workspace-template-row:focus-visible {
+  outline: 2px solid var(--wc-faction);
+  outline-offset: 2px;
 }
-.workspace-create-modal .workspace-template-card-desc { color: var(--wc-ink-faint); }
+.workspace-create-modal .workspace-template-card-icon {
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-template-card-label {
+  color: #f3f5f8;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-template-card-desc {
+  color: var(--wc-ink-faint);
+}
 
 .workspace-create-modal .workspace-template-agent-review {
   background: rgba(70, 211, 154, 0.06);
@@ -192,12 +277,151 @@
 }
 
 /* color picker: keep the swatch colors, tactical active ring */
-.workspace-create-modal .folder-color-btn.active { box-shadow: 0 0 0 2px var(--wc-faction); }
+.workspace-create-modal .folder-color-btn.active {
+  box-shadow: 0 0 0 2px var(--wc-faction);
+}
+
+/* Light mode keeps Construct's angular tactical layout, but uses the same
+   light neutral shell as the Workspace Map and Command views. */
+[data-bs-theme="light"] .workspace-create-modal {
+  --wc-bg: #eef1f3;
+  --wc-bg-2: #f7f8f9;
+  --wc-panel: #eceff2;
+  --wc-panel-2: #fbfcfd;
+  --wc-panel-deep: #dfe4e8;
+  --wc-line: #c8cdd3;
+  --wc-line-bright: #a8b0ba;
+  --wc-ink: #1f2128;
+  --wc-ink-dim: #5c5c5e;
+  --wc-ink-faint: #737a84;
+  --wc-ink-heading: #0a0a0a;
+  --wc-faction: #1f6b4e;
+  --wc-faction-deep: rgba(31, 107, 78, 0.34);
+  --wc-keeper: #9b641b;
+  --wc-idle: #167c99;
+  --wc-alert: #b94b3f;
+  --wc-field-bg: rgba(255, 255, 255, 0.66);
+  --wc-card-bg: linear-gradient(180deg, var(--wc-panel-2), var(--wc-panel));
+  --wc-glow: 0 0 0 1px rgba(255, 255, 255, 0.7), 0 22px 48px -28px rgba(10, 10, 10, 0.38);
+
+  --bg-primary: var(--wc-panel);
+  --text-primary: var(--wc-ink-heading);
+  --text-secondary: var(--wc-ink-dim);
+  --border-color: var(--wc-line);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modal-content {
+  color: var(--wc-ink);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modal-header,
+[data-bs-theme="light"] .workspace-create-modal .modal-footer {
+  background: var(--wc-card-bg);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modal-title,
+[data-bs-theme="light"] .workspace-create-modal .workspace-setup-title,
+[data-bs-theme="light"] .workspace-create-modal .workspace-advanced-summary-title,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-card-label,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-review-title,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-model strong {
+  color: var(--wc-ink-heading);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .btn-close {
+  filter: none;
+  opacity: 0.62;
+}
+
+[data-bs-theme="light"] .workspace-create-modal .btn-close:hover {
+  opacity: 0.9;
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modern-input,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-control {
+  background: var(--wc-field-bg);
+  border-color: var(--wc-line-bright);
+  color: var(--wc-ink);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modern-input::placeholder,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-control::placeholder {
+  color: var(--wc-ink-faint);
+}
+
+[data-bs-theme="light"] .workspace-create-modal select.modern-input option {
+  background: var(--wc-panel-2);
+  color: var(--wc-ink);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .modern-btn-primary:hover {
+  color: #ffffff;
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-setup-card,
+[data-bs-theme="light"] .workspace-create-modal .workspace-advanced-details,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-toggle,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-row {
+  background: var(--wc-field-bg);
+  border-color: var(--wc-line);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-card,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-row {
+  background: var(--wc-card-bg);
+  color: var(--wc-ink);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-card.is-selected,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-row.is-selected,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-review {
+  background: rgba(31, 107, 78, 0.08);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-card-desc,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-review-summary,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-review-status,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-warnings,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-model,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-field,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-note,
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-prompt summary {
+  color: var(--wc-ink-dim);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-prompt {
+  border-top-color: var(--wc-line);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-chip.create {
+  color: var(--wc-faction);
+  background: rgba(31, 107, 78, 0.1);
+  border-color: rgba(31, 107, 78, 0.26);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-chip.reuse {
+  color: var(--wc-keeper);
+}
+
+[data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-chip.entry {
+  color: var(--wc-idle);
+}
+
+[data-bs-theme="dark"] .workspace-create-modal .modern-input,
+[data-bs-theme="dark"] .workspace-create-modal .workspace-template-agent-control {
+  background: var(--wc-bg-2) !important;
+  border-color: var(--wc-line-bright) !important;
+  color: var(--wc-ink) !important;
+}
 
 /* honor the OS reduce-motion preference (drop the hover lift/transition) */
 @media (prefers-reduced-motion: reduce) {
   .workspace-create-modal .workspace-template-card,
-  .workspace-create-modal .workspace-template-row { transition: none; }
+  .workspace-create-modal .workspace-template-row {
+    transition: none;
+  }
   .workspace-create-modal .workspace-template-card:hover,
-  .workspace-create-modal .workspace-template-row:hover { transform: none; }
+  .workspace-create-modal .workspace-template-row:hover {
+    transform: none;
+  }
 }

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -1,8 +1,8 @@
 /*
  * workspace-map.css — Workspace Map view ("tactical command-center")
  *
- * Everything is scoped under `.ws-map`. The map is an intentional DARK surface
- * regardless of the app's `data-bs-theme`, so its tokens are defined here.
+ * Everything is scoped under `.ws-map`. The map uses theme-responsive tactical
+ * tokens: charcoal in dark mode, app-shell neutrals in light mode.
  * Rules must NOT leak into the launcher shell or Tree. No ui-refresh.css edits, no `!important`.
  *
  * Phase 1 = command-bar + theatre chrome + empty Overview (the shell).
@@ -11,20 +11,32 @@
 
 /* self-hosted fonts (latin subset) — names only used under .ws-map */
 @font-face {
-  font-family: 'Chakra Petch'; font-style: normal; font-weight: 500; font-display: swap;
-  src: url('/fonts/chakra-petch-500.woff2') format('woff2');
+  font-family: "Chakra Petch";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("/fonts/chakra-petch-500.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'Chakra Petch'; font-style: normal; font-weight: 700; font-display: swap;
-  src: url('/fonts/chakra-petch-700.woff2') format('woff2');
+  font-family: "Chakra Petch";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("/fonts/chakra-petch-700.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'JetBrains Mono'; font-style: normal; font-weight: 400; font-display: swap;
-  src: url('/fonts/jetbrains-mono-400.woff2') format('woff2');
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("/fonts/jetbrains-mono-400.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'JetBrains Mono'; font-style: normal; font-weight: 500; font-display: swap;
-  src: url('/fonts/jetbrains-mono-500.woff2') format('woff2');
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("/fonts/jetbrains-mono-500.woff2") format("woff2");
 }
 
 .ws-map {
@@ -57,8 +69,8 @@
   --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 40px -18px rgba(0, 0, 0, 0.8);
 
   /* type */
-  --ws-font-display: 'Chakra Petch', system-ui, sans-serif;
-  --ws-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --ws-font-display: "Chakra Petch", system-ui, sans-serif;
+  --ws-font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   display: block;
   color: var(--ws-ink);
@@ -67,78 +79,178 @@
   padding: 4px 2px 8px;
 }
 
-.ws-map[hidden] { display: none; }
+.ws-map[hidden] {
+  display: none;
+}
 
-.ws-map .ws-mono { font-family: var(--ws-font-mono); }
+.ws-map .ws-mono {
+  font-family: var(--ws-font-mono);
+}
 .ws-map .ws-tick {
   font-family: var(--ws-font-mono);
-  font-size: 10.5px; letter-spacing: 2.5px; text-transform: uppercase; color: var(--ws-ink-faint);
+  font-size: 10.5px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
 }
 
 /* ---------- command bar ---------- */
 .ws-map-topbar {
-  display: flex; align-items: center; gap: 18px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
   /* Narrow windows: readout + create button wrap below the title instead of
      overlapping it — the bar has no other width release valve. */
   flex-wrap: wrap;
   border: 1px solid var(--ws-line);
   background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
-  padding: 14px 18px; margin-bottom: 18px;
-  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  padding: 14px 18px;
+  margin-bottom: 18px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 16px) 0,
+    100% 16px,
+    100% 100%,
+    16px 100%,
+    0 calc(100% - 16px)
+  );
   box-shadow: var(--ws-glow);
 }
 .ws-map-crest {
-  width: 52px; height: 52px; flex: 0 0 auto; display: grid; place-items: center;
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
   border: 1px solid var(--ws-line-bright);
   background: radial-gradient(circle at 50% 30%, rgba(70, 211, 154, 0.18), transparent 70%);
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
   color: var(--ws-faction);
 }
-.ws-map-title { flex: 1 1 auto; min-width: 0; }
-.ws-map-title .ws-kicker { display: flex; align-items: center; gap: 10px; }
+.ws-map-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ws-map-title .ws-kicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 .ws-map-title .ws-kicker .ws-dot {
-  width: 6px; height: 6px; background: var(--ws-faction); box-shadow: 0 0 8px var(--ws-faction); transform: rotate(45deg);
+  width: 6px;
+  height: 6px;
+  background: var(--ws-faction);
+  box-shadow: 0 0 8px var(--ws-faction);
+  transform: rotate(45deg);
 }
 .ws-map-title h2 {
-  margin: 4px 0 0; font-weight: 700; font-size: 24px; letter-spacing: 1.5px; text-transform: uppercase; color: #eef0f3;
+  margin: 4px 0 0;
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #eef0f3;
 }
-.ws-map-title .ws-sub { margin-top: 3px; color: var(--ws-ink-dim); font-size: 13px; }
+.ws-map-title .ws-sub {
+  margin-top: 3px;
+  color: var(--ws-ink-dim);
+  font-size: 13px;
+}
 
-.ws-map-readout { display: flex; gap: 10px; flex-wrap: wrap; }
+.ws-map-readout {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
 .ws-map-stat {
-  min-width: 82px; text-align: center; border: 1px solid var(--ws-line); background: var(--ws-bg-2); padding: 8px 12px;
+  min-width: 82px;
+  text-align: center;
+  border: 1px solid var(--ws-line);
+  background: var(--ws-bg-2);
+  padding: 8px 12px;
   clip-path: polygon(0 0, 100% 0, 100% 100%, 8px 100%, 0 calc(100% - 8px));
 }
-.ws-map-stat .ws-v { font-family: var(--ws-font-mono); font-size: 20px; font-weight: 700; color: #eef0f3; line-height: 1; font-variant-numeric: tabular-nums; }
-.ws-map-stat .ws-l { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 5px; }
+.ws-map-stat .ws-v {
+  font-family: var(--ws-font-mono);
+  font-size: 20px;
+  font-weight: 700;
+  color: #eef0f3;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.ws-map-stat .ws-l {
+  font-size: 9.5px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+  margin-top: 5px;
+}
 
 .ws-map-create {
-  align-self: stretch; display: flex; align-items: center; gap: 9px; padding: 0 18px;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 18px;
   min-height: 46px; /* keeps its height when flex-wrap puts it on its own row */
   border: 1px solid var(--ws-faction-deep);
   background: linear-gradient(180deg, rgba(70, 211, 154, 0.16), rgba(70, 211, 154, 0.04));
-  color: var(--ws-faction); cursor: pointer;
-  font-family: var(--ws-font-display); font-size: 12px; letter-spacing: 2px; text-transform: uppercase; font-weight: 700;
-  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-family: var(--ws-font-display);
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-weight: 700;
+  clip-path: polygon(
+    10px 0,
+    100% 0,
+    100% calc(100% - 10px),
+    calc(100% - 10px) 100%,
+    0 100%,
+    0 10px
+  );
   transition: 0.15s;
 }
-.ws-map-create:hover { background: var(--ws-faction); color: #04110c; }
+.ws-map-create:hover {
+  background: var(--ws-faction);
+  color: #04110c;
+}
 
 /* ---------- layout ---------- */
-.ws-map-layout { display: grid; grid-template-columns: 1fr 338px; gap: 18px; align-items: start; }
+.ws-map-layout {
+  display: grid;
+  grid-template-columns: 1fr 338px;
+  gap: 18px;
+  align-items: start;
+}
 
 /* theatre panel */
 .ws-map-theatre {
-  position: relative; border: 1px solid var(--ws-line); min-height: 520px; overflow: hidden; padding: 44px 0 10px;
+  position: relative;
+  border: 1px solid var(--ws-line);
+  min-height: 520px;
+  overflow: hidden;
+  padding: 44px 0 10px;
   background:
     radial-gradient(120% 100% at 30% 20%, rgba(255, 255, 255, 0.025), transparent 55%),
     radial-gradient(90% 90% at 85% 90%, rgba(123, 108, 240, 0.04), transparent 55%),
     linear-gradient(180deg, #121419, #0d0e11);
-  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  clip-path: polygon(
+    0 0,
+    calc(100% - 16px) 0,
+    100% 16px,
+    100% 100%,
+    16px 100%,
+    0 calc(100% - 16px)
+  );
   box-shadow: var(--ws-glow);
 }
 .ws-map-theatre::before {
-  content: ""; position: absolute; inset: 0; opacity: 0.55;
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.55;
   background-image:
     linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.038) 1px, transparent 1px);
@@ -146,164 +258,437 @@
   -webkit-mask-image: radial-gradient(120% 100% at 50% 40%, #000 30%, transparent 88%);
   mask-image: radial-gradient(120% 100% at 50% 40%, #000 30%, transparent 88%);
 }
-.ws-map-theatre-tag { position: absolute; top: 14px; left: 16px; z-index: 6; display: flex; align-items: center; gap: 9px; }
-.ws-map-ix {
-  font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-faction);
-  border: 1px solid var(--ws-faction-deep); padding: 2px 6px;
+.ws-map-theatre-tag {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 9px;
 }
-.ws-map-theatre-tag h3 { margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #e3e6ea; }
+.ws-map-ix {
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  color: var(--ws-faction);
+  border: 1px solid var(--ws-faction-deep);
+  padding: 2px 6px;
+}
+.ws-map-theatre-tag h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #e3e6ea;
+}
 .ws-map-compass {
-  position: absolute; top: 14px; right: 16px; z-index: 6; width: 40px; height: 40px; display: grid; place-items: center;
-  border: 1px solid var(--ws-line-bright); background: var(--ws-bg-2);
-  font-family: var(--ws-font-mono); font-size: 9px; color: var(--ws-ink-faint);
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  z-index: 6;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  color: var(--ws-ink-faint);
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-map-compass b { color: var(--ws-faction); }
+.ws-map-compass b {
+  color: var(--ws-faction);
+}
 /* canvas holds absolutely-positioned tiles + districts */
-.ws-map-canvas { position: relative; z-index: 5; width: 100%; }
-.ws-map-canvas--empty { display: grid; place-items: center; min-height: 360px; }
-.ws-map-empty-cluster { text-align: center; }
+.ws-map-canvas {
+  position: relative;
+  z-index: 5;
+  width: 100%;
+}
+.ws-map-canvas--empty {
+  display: grid;
+  place-items: center;
+  min-height: 360px;
+}
+.ws-map-empty-cluster {
+  text-align: center;
+}
 .ws-map-empty-note {
-  margin-top: 14px; font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1px; color: var(--ws-ink-faint);
+  margin-top: 14px;
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: var(--ws-ink-faint);
 }
 
 /* district (group) zone */
 .ws-map-district {
-  position: absolute; z-index: 3; border: 1.4px dashed rgba(232, 134, 77, 0.35);
-  background: rgba(232, 134, 77, 0.04); border-radius: 16px;
+  position: absolute;
+  z-index: 3;
+  border: 1.4px dashed rgba(232, 134, 77, 0.35);
+  background: rgba(232, 134, 77, 0.04);
+  border-radius: 16px;
 }
 .ws-map-district-tag {
-  position: absolute; top: -11px; left: 16px; border: 1px solid rgba(232, 134, 77, 0.35); background: var(--ws-bg-2);
-  color: var(--ws-keeper); cursor: pointer;
-  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; padding: 2px 9px;
+  position: absolute;
+  top: -11px;
+  left: 16px;
+  border: 1px solid rgba(232, 134, 77, 0.35);
+  background: var(--ws-bg-2);
+  color: var(--ws-keeper);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding: 2px 9px;
 }
-.ws-map-district-tag:hover { background: rgba(232, 134, 77, 0.12); }
-.ws-map-district-tag:focus-visible { outline: 2px solid var(--ws-keeper); outline-offset: 2px; }
+.ws-map-district-tag:hover {
+  background: rgba(232, 134, 77, 0.12);
+}
+.ws-map-district-tag:focus-visible {
+  outline: 2px solid var(--ws-keeper);
+  outline-offset: 2px;
+}
 
 /* building tile */
 .ws-map-tile {
-  position: absolute; z-index: 5; width: 150px; padding: 0; border: 0; background: none; cursor: pointer;
-  display: flex; flex-direction: column; align-items: center; text-align: center;
-  transform: translateY(0); transition: transform 0.16s ease;
+  position: absolute;
+  z-index: 5;
+  width: 150px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  transform: translateY(0);
+  transition: transform 0.16s ease;
 }
-.ws-map-tile:hover { transform: translateY(-4px); }
-.ws-map-tile:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 4px; }
+.ws-map-tile:hover {
+  transform: translateY(-4px);
+}
+.ws-map-tile:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 4px;
+}
 .ws-map-tile.is-selected::before {
-  content: ""; position: absolute; top: 46px; left: 50%; width: 116px; height: 58px; transform: translate(-50%, -50%);
-  border: 1.5px solid var(--ws-faction); border-radius: 50% / 40%; box-shadow: 0 0 22px rgba(70, 211, 154, 0.35);
+  content: "";
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 116px;
+  height: 58px;
+  transform: translate(-50%, -50%);
+  border: 1.5px solid var(--ws-faction);
+  border-radius: 50% / 40%;
+  box-shadow: 0 0 22px rgba(70, 211, 154, 0.35);
 }
-.ws-map-struct { display: block; filter: drop-shadow(0 12px 12px rgba(0, 0, 0, 0.55)); }
+.ws-map-struct {
+  display: block;
+  filter: drop-shadow(0 12px 12px rgba(0, 0, 0, 0.55));
+}
 .ws-map-tile-flag {
-  position: absolute; top: -4px; right: 24px; z-index: 3; display: flex; align-items: center; gap: 4px;
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; color: var(--ws-ink-dim);
+  position: absolute;
+  top: -4px;
+  right: 24px;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  color: var(--ws-ink-dim);
 }
-.ws-map-led { width: 7px; height: 7px; border-radius: 50%; background: var(--ws-idle); box-shadow: 0 0 7px var(--ws-idle); }
-.ws-map-led.is-working { background: var(--ws-working); box-shadow: 0 0 8px var(--ws-working); }
-@keyframes ws-map-pulse { 50% { opacity: 0.3; } }
-@keyframes ws-map-rise { from { opacity: 0; transform: translateY(10px); } }
+.ws-map-led {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ws-idle);
+  box-shadow: 0 0 7px var(--ws-idle);
+}
+.ws-map-led.is-working {
+  background: var(--ws-working);
+  box-shadow: 0 0 8px var(--ws-working);
+}
+@keyframes ws-map-pulse {
+  50% {
+    opacity: 0.3;
+  }
+}
+@keyframes ws-map-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
 
 /* Auto-playing motion is opt-in via the OS "reduce motion" preference. */
 @media (prefers-reduced-motion: no-preference) {
-  .ws-map-tile { animation: ws-map-rise 0.4s ease both; animation-delay: calc(var(--i, 0) * 28ms); }
-  .ws-map-led.is-working { animation: ws-map-pulse 1.5s ease-in-out infinite; }
+  .ws-map-tile {
+    animation: ws-map-rise 0.4s ease both;
+    animation-delay: calc(var(--i, 0) * 28ms);
+  }
+  .ws-map-led.is-working {
+    animation: ws-map-pulse 1.5s ease-in-out infinite;
+  }
 }
 .ws-map-tile-crest {
-  position: absolute; top: 30px; left: 50%; transform: translateX(-50%); z-index: 4; font-size: 13px; color: #04110c;
-  text-shadow: 0 0 3px var(--ws-keeper); pointer-events: none;
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  font-size: 13px;
+  color: #04110c;
+  text-shadow: 0 0 3px var(--ws-keeper);
+  pointer-events: none;
 }
 
 /* Multi-select checkbox — subtle until the tile is hovered/focused or checked,
    so it doesn't compete with the tile's status flag and crest at rest. */
 .ws-map-tile-check {
-  position: absolute; top: -2px; left: 20px; z-index: 6; width: 15px; height: 15px; box-sizing: border-box;
-  border: 1.5px solid var(--ws-line-bright); background: rgba(12, 13, 16, 0.9); cursor: pointer;
-  opacity: 0; transition: opacity 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+  position: absolute;
+  top: -2px;
+  left: 20px;
+  z-index: 6;
+  width: 15px;
+  height: 15px;
+  box-sizing: border-box;
+  border: 1.5px solid var(--ws-line-bright);
+  background: rgba(12, 13, 16, 0.9);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease;
   clip-path: polygon(3px 0, 100% 0, 100% calc(100% - 3px), calc(100% - 3px) 100%, 0 100%, 0 3px);
 }
 .ws-map-tile:hover .ws-map-tile-check,
 .ws-map-tile:focus-visible .ws-map-tile-check,
-.ws-map-tile-check[aria-checked="true"] { opacity: 1; }
 .ws-map-tile-check[aria-checked="true"] {
-  background: var(--ws-faction); border-color: var(--ws-faction);
+  opacity: 1;
+}
+.ws-map-tile-check[aria-checked="true"] {
+  background: var(--ws-faction);
+  border-color: var(--ws-faction);
 }
 .ws-map-tile-check[aria-checked="true"]::after {
-  content: "✓"; position: absolute; inset: 0; display: grid; place-items: center;
-  font-size: 11px; font-weight: 700; line-height: 1; color: #04110c;
+  content: "✓";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  color: #04110c;
 }
-.ws-map-tile.is-multi .ws-map-struct { filter: drop-shadow(0 0 10px rgba(70, 211, 154, 0.55)); }
+.ws-map-tile.is-multi .ws-map-struct {
+  filter: drop-shadow(0 0 10px rgba(70, 211, 154, 0.55));
+}
 .ws-map-tile.is-multi::after {
-  content: ""; position: absolute; top: 46px; left: 50%; width: 120px; height: 60px; transform: translate(-50%, -50%);
-  border: 1.5px dashed var(--ws-faction); border-radius: 50% / 40%; opacity: 0.8; pointer-events: none;
+  content: "";
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 120px;
+  height: 60px;
+  transform: translate(-50%, -50%);
+  border: 1.5px dashed var(--ws-faction);
+  border-radius: 50% / 40%;
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 /* Contextual multi-select action bar — pinned to the bottom-center of the
    viewport (like a mail client's selection bar) so it stays reachable no matter
    how far the map has scrolled. */
 .ws-map-selbar {
-  position: fixed; left: 50%; bottom: 24px; transform: translateX(-50%); z-index: 1200;
-  display: flex; align-items: center; gap: 16px; padding: 9px 10px 9px 16px;
-  background: rgba(18, 19, 23, 0.96); border: 1px solid var(--ws-line-bright);
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 9px 10px 9px 16px;
+  background: rgba(18, 19, 23, 0.96);
+  border: 1px solid var(--ws-line-bright);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+  clip-path: polygon(
+    10px 0,
+    100% 0,
+    100% calc(100% - 10px),
+    calc(100% - 10px) 100%,
+    0 100%,
+    0 10px
+  );
 }
-.ws-map-selbar[hidden] { display: none; }
+.ws-map-selbar[hidden] {
+  display: none;
+}
 .ws-map-selbar-count {
-  font-family: var(--ws-font-mono); font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #e3e6ea;
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #e3e6ea;
 }
-.ws-map-selbar-actions { display: flex; gap: 8px; }
-.ws-map-selbar-del, .ws-map-selbar-clear {
-  padding: 7px 13px; cursor: pointer; font-family: var(--ws-font-display); font-size: 11px;
-  letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
+.ws-map-selbar-actions {
+  display: flex;
+  gap: 8px;
+}
+.ws-map-selbar-del,
+.ws-map-selbar-clear {
+  padding: 7px 13px;
+  cursor: pointer;
+  font-family: var(--ws-font-display);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 700;
+  transition: 0.15s;
+  white-space: nowrap;
   clip-path: polygon(7px 0, 100% 0, 100% calc(100% - 7px), calc(100% - 7px) 100%, 0 100%, 0 7px);
 }
-.ws-map-selbar-del { background: rgba(226, 96, 96, 0.1); border: 1px solid rgba(226, 96, 96, 0.45); color: #e78a8a; }
-.ws-map-selbar-del:hover { background: #c0392b; border-color: #c0392b; color: #fff; }
-.ws-map-selbar-clear { background: transparent; border: 1px solid var(--ws-line-bright); color: var(--ws-ink-dim); }
-.ws-map-selbar-clear:hover { border-color: var(--ws-faction); color: var(--ws-faction); }
-.ws-map-selbar-del:focus-visible, .ws-map-selbar-clear:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-map-selbar-del {
+  background: rgba(226, 96, 96, 0.1);
+  border: 1px solid rgba(226, 96, 96, 0.45);
+  color: #e78a8a;
+}
+.ws-map-selbar-del:hover {
+  background: #c0392b;
+  border-color: #c0392b;
+  color: #fff;
+}
+.ws-map-selbar-clear {
+  background: transparent;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-ink-dim);
+}
+.ws-map-selbar-clear:hover {
+  border-color: var(--ws-faction);
+  color: var(--ws-faction);
+}
+.ws-map-selbar-del:focus-visible,
+.ws-map-selbar-clear:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-map-tile-name {
-  margin-top: 2px; font-size: 12.5px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #eef0f3;
-  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9); max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  margin-top: 2px;
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #eef0f3;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .ws-map-tile-type {
-  font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 1px;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+  margin-top: 1px;
 }
 .ws-map-tile-meta {
-  margin-top: 5px; font-family: var(--ws-font-mono); font-size: 10px; color: var(--ws-ink-dim);
-  border: 1px solid var(--ws-line); background: rgba(13, 14, 17, 0.85); padding: 3px 9px;
+  margin-top: 5px;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  color: var(--ws-ink-dim);
+  border: 1px solid var(--ws-line);
+  background: rgba(13, 14, 17, 0.85);
+  padding: 3px 9px;
   clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
 }
 
 /* create pad */
 .ws-map-pad {
-  position: absolute; z-index: 4; width: 150px; border: 0; background: none; cursor: pointer;
-  display: flex; flex-direction: column; align-items: center;
+  position: absolute;
+  z-index: 4;
+  width: 150px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .ws-map-pad-plate {
-  width: 96px; height: 60px; display: grid; place-items: center; color: var(--ws-faction); font-size: 24px;
+  width: 96px;
+  height: 60px;
+  display: grid;
+  place-items: center;
+  color: var(--ws-faction);
+  font-size: 24px;
   border: 1.4px dashed var(--ws-line-bright);
-  background: repeating-linear-gradient(45deg, rgba(70, 211, 154, 0.04) 0 8px, transparent 8px 16px);
-  clip-path: polygon(50% 4%, 96% 50%, 50% 96%, 4% 50%); transition: 0.15s;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(70, 211, 154, 0.04) 0 8px,
+    transparent 8px 16px
+  );
+  clip-path: polygon(50% 4%, 96% 50%, 50% 96%, 4% 50%);
+  transition: 0.15s;
   /* Tile structs have ~28px of visual headroom above their floor diamond
      (floor center ≈ 57px down the 92px SVG vs this plate's 30px center);
      match it so the pad and its label sit on the tiles' baseline grid. */
   margin-top: 28px;
 }
-.ws-map-pad:hover .ws-map-pad-plate { border-color: var(--ws-faction-deep); background: rgba(70, 211, 154, 0.08); }
-.ws-map-pad:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 4px; }
-.ws-map-pad-label {
-  margin-top: 6px; font-family: var(--ws-font-mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint);
+.ws-map-pad:hover .ws-map-pad-plate {
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
 }
-.ws-map-pad--hero .ws-map-pad-plate { width: 120px; height: 76px; font-size: 30px; margin-top: 0; }
-.ws-map-pad--hero .ws-map-pad-label { font-size: 11px; }
+.ws-map-pad:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 4px;
+}
+.ws-map-pad-label {
+  margin-top: 6px;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+}
+.ws-map-pad--hero .ws-map-pad-plate {
+  width: 120px;
+  height: 76px;
+  font-size: 30px;
+  margin-top: 0;
+}
+.ws-map-pad--hero .ws-map-pad-label {
+  font-size: 11px;
+}
 
 /* overview panel — sticky so it (and its primary "Open" action) stays on screen
    beside the map without depending on whole-page scrolling to reach it. The grid
    parent already sets align-items:start; sticky pins it below the app navbar and
    caps its height to the viewport, scrolling internally if the roster is long. */
 .ws-map-overview {
-  border: 1px solid var(--ws-line); background: linear-gradient(180deg, var(--ws-panel), #0f1014); min-height: 520px;
-  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 14px 100%, 0 calc(100% - 14px));
+  border: 1px solid var(--ws-line);
+  background: linear-gradient(180deg, var(--ws-panel), #0f1014);
+  min-height: 520px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
   box-shadow: var(--ws-glow);
   position: sticky;
   align-self: start;
@@ -312,150 +697,462 @@
   overflow-y: auto;
 }
 .ws-map-overview-head {
-  display: flex; align-items: center; justify-content: space-between; padding: 13px 16px; border-bottom: 1px solid var(--ws-line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--ws-line);
 }
 .ws-map-overview-head h3 {
-  margin: 0; font-size: 13px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: #e3e6ea; display: inline;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #e3e6ea;
+  display: inline;
 }
-.ws-map-overview-body { padding: 16px; }
+.ws-map-overview-body {
+  padding: 16px;
+}
 .ws-map-overview-empty {
-  padding: 40px 16px; text-align: center; font-family: var(--ws-font-mono); font-size: 12px; letter-spacing: 1px; color: var(--ws-ink-faint);
+  padding: 40px 16px;
+  text-align: center;
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: var(--ws-ink-faint);
 }
-.ws-map-overview-empty .ws-big { display: block; font-size: 22px; color: var(--ws-ink-dim); margin-bottom: 10px; }
-
+.ws-map-overview-empty .ws-big {
+  display: block;
+  font-size: 22px;
+  color: var(--ws-ink-dim);
+  margin-bottom: 10px;
+}
 
 /* populated overview */
-.ws-map-ov-hero { display: flex; gap: 12px; align-items: center; padding-bottom: 14px; border-bottom: 1px solid var(--ws-line); }
-.ws-map-ov-herometa { flex: 1 1 auto; min-width: 0; }
+.ws-map-ov-hero {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-map-ov-herometa {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 .ws-map-ov-ic {
-  width: 44px; height: 44px; flex: 0 0 auto; display: grid; place-items: center;
-  font-family: var(--ws-font-mono); font-weight: 700; font-size: 13px; color: #04110c;
-  background: linear-gradient(150deg, var(--av, var(--ws-faction)), color-mix(in srgb, var(--av, var(--ws-faction)) 55%, #000));
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  font-family: var(--ws-font-mono);
+  font-weight: 700;
+  font-size: 13px;
+  color: #04110c;
+  background: linear-gradient(
+    150deg,
+    var(--av, var(--ws-faction)),
+    color-mix(in srgb, var(--av, var(--ws-faction)) 55%, #000)
+  );
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-map-ov-name { font-size: 17px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #f3f5f8; }
-.ws-map-ov-tag { font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--ws-ink-faint); margin-top: 3px; }
+.ws-map-ov-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #f3f5f8;
+}
+.ws-map-ov-tag {
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+  margin-top: 3px;
+}
 
 /* Workspace description — sits just under the hero. Clamped so a long blurb
    doesn't push the roster/stats out of view; the full text is on hover. */
 .ws-map-ov-desc {
-  margin: 12px 0 0; font-size: 12.5px; line-height: 1.5; color: var(--ws-ink-dim);
-  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; line-clamp: 3; overflow: hidden;
+  margin: 12px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ws-ink-dim);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
 }
-.ws-map-ov-desc.is-empty { font-style: italic; color: var(--ws-ink-faint); }
+.ws-map-ov-desc.is-empty {
+  font-style: italic;
+  color: var(--ws-ink-faint);
+}
 
 .ws-map-folder {
-  display: grid; gap: 7px; min-width: 0;
+  display: grid;
+  gap: 7px;
+  min-width: 0;
 }
 .ws-map-folder-badge {
-  justify-self: start; max-width: 100%; padding: 3px 9px;
-  border: 1px solid rgba(70, 211, 154, 0.26); background: rgba(70, 211, 154, 0.08); color: var(--ws-faction);
-  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.2px; text-transform: uppercase;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  justify-self: start;
+  max-width: 100%;
+  padding: 3px 9px;
+  border: 1px solid rgba(70, 211, 154, 0.26);
+  background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
 }
 .ws-map-folder.is-unlinked .ws-map-folder-badge {
-  border-color: rgba(232, 181, 75, 0.35); background: rgba(232, 181, 75, 0.1); color: var(--ws-keeper);
+  border-color: rgba(232, 181, 75, 0.35);
+  background: rgba(232, 181, 75, 0.1);
+  color: var(--ws-keeper);
 }
 .ws-map-folder-path {
-  display: block; min-width: 0;
-  font-family: var(--ws-font-mono); font-size: 10.5px; color: var(--ws-ink-dim);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: block;
+  min-width: 0;
+  font-family: var(--ws-font-mono);
+  font-size: 10.5px;
+  color: var(--ws-ink-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.ws-map-folder.is-unlinked .ws-map-folder-path { color: var(--ws-ink-faint); }
+.ws-map-folder.is-unlinked .ws-map-folder-path {
+  color: var(--ws-ink-faint);
+}
 
 .ws-map-tags {
-  display: flex; flex-wrap: wrap; gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 .ws-map-tag {
-  display: inline-flex; align-items: stretch; max-width: 100%;
-  border: 1px solid rgba(70, 211, 154, 0.24); background: rgba(70, 211, 154, 0.08); color: var(--ws-ink-dim);
-  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 0.7px;
+  display: inline-flex;
+  align-items: stretch;
+  max-width: 100%;
+  border: 1px solid rgba(70, 211, 154, 0.24);
+  background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.7px;
   overflow: hidden;
   clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
 }
 .ws-map-tag-label,
 .ws-map-tag-remove {
-  border: 0; background: transparent; color: inherit; font: inherit; cursor: pointer;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 .ws-map-tag-label {
-  min-width: 0; padding: 4px 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  min-width: 0;
+  padding: 4px 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .ws-map-tag-remove {
-  flex: 0 0 auto; width: 24px; border-left: 1px solid rgba(70, 211, 154, 0.2);
+  flex: 0 0 auto;
+  width: 24px;
+  border-left: 1px solid rgba(70, 211, 154, 0.2);
 }
 .ws-map-tag-label:hover,
 .ws-map-tag-remove:hover {
-  background: rgba(70, 211, 154, 0.14); color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.14);
+  color: var(--ws-faction);
 }
 .ws-map-tag-more {
-  padding: 4px 8px; color: var(--ws-ink-faint);
+  padding: 4px 8px;
+  color: var(--ws-ink-faint);
 }
 
 .ws-map-group-preview {
-  display: grid; gap: 5px; padding: 9px 10px;
-  border: 1px dashed rgba(232, 134, 77, 0.28); background: rgba(232, 134, 77, 0.05);
+  display: grid;
+  gap: 5px;
+  padding: 9px 10px;
+  border: 1px dashed rgba(232, 134, 77, 0.28);
+  background: rgba(232, 134, 77, 0.05);
 }
 .ws-map-group-count {
-  font-family: var(--ws-font-mono); font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--ws-keeper);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--ws-keeper);
 }
 .ws-map-group-names {
-  min-width: 0; font-size: 12px; line-height: 1.4; color: var(--ws-ink-dim);
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  min-width: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ws-ink-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ws-map-ov-label {
-  font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
   margin: 14px 0 8px;
 }
-.ws-map-ov-none { font-family: var(--ws-font-mono); font-size: 11px; color: var(--ws-ink-faint); }
+.ws-map-ov-none {
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  color: var(--ws-ink-faint);
+}
 
-.ws-map-ov-keeper { display: flex; align-items: center; gap: 10px; }
-.ws-map-ov-keeper-name { font-size: 13px; color: #eef0f3; }
-.ws-map-ov-keeper-badge { font-family: var(--ws-font-mono); font-size: 8.5px; letter-spacing: 1px; color: var(--ws-keeper); margin-top: 2px; }
+.ws-map-ov-keeper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.ws-map-ov-keeper-name {
+  font-size: 13px;
+  color: #eef0f3;
+}
+.ws-map-ov-keeper-badge {
+  font-family: var(--ws-font-mono);
+  font-size: 8.5px;
+  letter-spacing: 1px;
+  color: var(--ws-keeper);
+  margin-top: 2px;
+}
 
-.ws-map-ov-roster { display: flex; flex-wrap: wrap; gap: 7px; }
+.ws-map-ov-roster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
 .ws-map-av {
-  width: 30px; height: 30px; display: grid; place-items: center;
-  font-family: var(--ws-font-mono); font-weight: 700; font-size: 10px; color: #04110c;
-  background: linear-gradient(150deg, var(--av, var(--ws-faction)), color-mix(in srgb, var(--av, var(--ws-faction)) 55%, #000));
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  font-family: var(--ws-font-mono);
+  font-weight: 700;
+  font-size: 10px;
+  color: #04110c;
+  background: linear-gradient(
+    150deg,
+    var(--av, var(--ws-faction)),
+    color-mix(in srgb, var(--av, var(--ws-faction)) 55%, #000)
+  );
   clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
 }
-.ws-map-av.is-keeper { box-shadow: 0 0 0 1.5px var(--ws-keeper); }
+.ws-map-av.is-keeper {
+  box-shadow: 0 0 0 1.5px var(--ws-keeper);
+}
 
 .ws-map-ov-row {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 11px 0; border-bottom: 1px solid var(--ws-line);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--ws-line);
 }
-.ws-map-ov-row:first-of-type { border-top: 1px solid var(--ws-line); }
-.ws-map-ov-k { font-family: var(--ws-font-mono); font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ws-ink-faint); }
-.ws-map-ov-v { font-family: var(--ws-font-mono); font-size: 12px; color: #e3e6ea; }
+.ws-map-ov-row:first-of-type {
+  border-top: 1px solid var(--ws-line);
+}
+.ws-map-ov-k {
+  font-family: var(--ws-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+}
+.ws-map-ov-v {
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+  color: #e3e6ea;
+}
 
 /* Primary action lives in the hero row (top of the panel) so it stays reachable
    without scrolling to the bottom. */
 .ws-map-ov-open {
-  flex: 0 0 auto; align-self: center; text-align: center; padding: 9px 15px; border: 1px solid var(--ws-faction-deep); cursor: pointer;
-  background: linear-gradient(180deg, rgba(70, 211, 154, 0.16), rgba(70, 211, 154, 0.04)); color: var(--ws-faction);
-  font-family: var(--ws-font-display); font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
+  flex: 0 0 auto;
+  align-self: center;
+  text-align: center;
+  padding: 9px 15px;
+  border: 1px solid var(--ws-faction-deep);
+  cursor: pointer;
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.16), rgba(70, 211, 154, 0.04));
+  color: var(--ws-faction);
+  font-family: var(--ws-font-display);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 700;
+  transition: 0.15s;
+  white-space: nowrap;
   clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
 }
-.ws-map-ov-open:hover { background: var(--ws-faction); color: #04110c; }
-.ws-map-ov-open:focus-visible { outline: 2px solid var(--ws-faction); outline-offset: 2px; }
+.ws-map-ov-open:hover {
+  background: var(--ws-faction);
+  color: #04110c;
+}
+.ws-map-ov-open:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 
 /* Destructive action sits at the bottom of the panel, visually separated from
    the read-only stats above it and de-emphasized versus the primary Open. */
-.ws-map-ov-actions { margin-top: 16px; display: flex; justify-content: flex-end; }
+.ws-map-ov-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
 .ws-map-ov-delete {
-  padding: 8px 14px; cursor: pointer;
-  background: rgba(226, 96, 96, 0.08); border: 1px solid rgba(226, 96, 96, 0.4); color: #e78a8a;
-  font-family: var(--ws-font-display); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700; transition: 0.15s; white-space: nowrap;
+  padding: 8px 14px;
+  cursor: pointer;
+  background: rgba(226, 96, 96, 0.08);
+  border: 1px solid rgba(226, 96, 96, 0.4);
+  color: #e78a8a;
+  font-family: var(--ws-font-display);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 700;
+  transition: 0.15s;
+  white-space: nowrap;
   clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
 }
-.ws-map-ov-delete:hover { background: #c0392b; border-color: #c0392b; color: #fff; }
-.ws-map-ov-delete:focus-visible { outline: 2px solid #e78a8a; outline-offset: 2px; }
+.ws-map-ov-delete:hover {
+  background: #c0392b;
+  border-color: #c0392b;
+  color: #fff;
+}
+.ws-map-ov-delete:focus-visible {
+  outline: 2px solid #e78a8a;
+  outline-offset: 2px;
+}
+
+/* Light mode keeps the tactical structure but aligns surfaces and ink with the
+   surrounding Ori shell instead of mixing a dark command center into a light page. */
+[data-bs-theme="light"] .ws-map {
+  --ws-bg: #eef1f3;
+  --ws-bg-2: #f7f8f9;
+  --ws-panel: #eceff2;
+  --ws-panel-2: #fbfcfd;
+  --ws-panel-deep: #dfe4e8;
+  --ws-line: #c8cdd3;
+  --ws-line-bright: #a8b0ba;
+
+  --ws-ink: #1f2128;
+  --ws-ink-dim: #5c5c5e;
+  --ws-ink-faint: #737a84;
+  --ws-ink-heading: #0a0a0a;
+
+  --ws-faction: #1f6b4e;
+  --ws-faction-deep: rgba(31, 107, 78, 0.34);
+  --ws-keeper: #9b641b;
+  --ws-keeper-deep: rgba(155, 100, 27, 0.34);
+  --ws-idle: #167c99;
+  --ws-working: #1f6b4e;
+  --ws-alert: #b94b3f;
+
+  --ws-on-accent: #ffffff;
+  --ws-avatar-text: #04110c;
+  --ws-field-bg: rgba(255, 255, 255, 0.62);
+  --ws-grid-line: rgba(31, 33, 40, 0.08);
+  --ws-grid-line-soft: rgba(31, 33, 40, 0.06);
+  --ws-struct-shadow: drop-shadow(0 12px 14px rgba(10, 10, 10, 0.24));
+  --ws-title-shadow: 0 1px 0 rgba(255, 255, 255, 0.75);
+  --ws-selbar-bg: rgba(247, 248, 249, 0.96);
+  --ws-selbar-shadow: 0 14px 34px rgba(10, 10, 10, 0.18);
+  --ws-theatre-bg:
+    radial-gradient(120% 100% at 30% 20%, rgba(255, 255, 255, 0.45), transparent 55%),
+    radial-gradient(90% 90% at 85% 90%, rgba(31, 107, 78, 0.05), transparent 55%),
+    linear-gradient(180deg, #f4f6f7, #e6eaee);
+  --ws-glow: 0 0 0 1px rgba(255, 255, 255, 0.7), 0 20px 42px -26px rgba(10, 10, 10, 0.34);
+}
+
+[data-bs-theme="light"] .ws-map-title h2,
+[data-bs-theme="light"] .ws-map-stat .ws-v,
+[data-bs-theme="light"] .ws-map-theatre-tag h3,
+[data-bs-theme="light"] .ws-map-overview-head h3,
+[data-bs-theme="light"] .ws-map-ov-name,
+[data-bs-theme="light"] .ws-map-ov-keeper-name,
+[data-bs-theme="light"] .ws-map-ov-v,
+[data-bs-theme="light"] .ws-map-selbar-count {
+  color: var(--ws-ink-heading);
+}
+
+[data-bs-theme="light"] .ws-map-theatre {
+  background: var(--ws-theatre-bg);
+}
+
+[data-bs-theme="light"] .ws-map-theatre::before {
+  background-image:
+    linear-gradient(var(--ws-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--ws-grid-line-soft) 1px, transparent 1px);
+}
+
+[data-bs-theme="light"] .ws-map-overview {
+  background: linear-gradient(180deg, var(--ws-panel-2), var(--ws-panel));
+}
+
+[data-bs-theme="light"] .ws-map-struct {
+  filter: var(--ws-struct-shadow);
+}
+
+[data-bs-theme="light"] .ws-map-tile-name {
+  color: var(--ws-ink-heading);
+  text-shadow: var(--ws-title-shadow);
+}
+
+[data-bs-theme="light"] .ws-map-tile-meta,
+[data-bs-theme="light"] .ws-map-tile-check {
+  background: var(--ws-field-bg);
+}
+
+[data-bs-theme="light"] .ws-map-selbar {
+  background: var(--ws-selbar-bg);
+  box-shadow: var(--ws-selbar-shadow);
+}
+
+[data-bs-theme="light"] .ws-map-crest,
+[data-bs-theme="light"] .ws-map-create,
+[data-bs-theme="light"] .ws-map-ov-open,
+[data-bs-theme="light"] .ws-map-folder-badge,
+[data-bs-theme="light"] .ws-map-tag {
+  background-color: rgba(31, 107, 78, 0.07);
+}
+
+[data-bs-theme="light"] .ws-map-create:hover,
+[data-bs-theme="light"] .ws-map-ov-open:hover {
+  color: var(--ws-on-accent);
+}
+
+[data-bs-theme="light"] .ws-map-tile-crest,
+[data-bs-theme="light"] .ws-map-tile-check[aria-checked="true"]::after,
+[data-bs-theme="light"] .ws-map-ov-ic,
+[data-bs-theme="light"] .ws-map-av {
+  color: var(--ws-avatar-text);
+}
 
 @media (max-width: 900px) {
-  .ws-map-layout { grid-template-columns: 1fr; }
+  .ws-map-layout {
+    grid-template-columns: 1fr;
+  }
 
   /* Narrow windows: the overview stays in normal flow, stacked below the map,
      so plain page scrolling reveals map tiles first and the panel after them.


### PR DESCRIPTION
## Summary

- Add light-mode palette overrides for workspace map and command views
- Align the Create/Import Workspace modal with the same light neutral surfaces
- Preserve dark-mode modal/input styling while overriding global modal/input refresh rules where needed

## Validation

- `npx prettier --check internal/web/static/css/workspace-map.css internal/web/static/css/workspace-command.css internal/web/static/css/workspace-construct.css`
- `go test ./internal/web`
- `git diff --check`
- Playwright browser check for Create Workspace and Import Folder modals in light mode, plus Create Workspace in dark mode
