### PR TITLE
feat(workspace): workspace-local agent detail page + editable system prompt

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,6 +143,7 @@ export default defineConfig([
       'internal/web/static/js/modules/studio-dashboard.js',
       'internal/web/static/js/modules/studio.js',
       'internal/web/static/js/modules/workspace-detail.js',
+      'internal/web/static/js/modules/workspace-agent-detail.js',
       'internal/web/static/js/modules/workspace-detail-members.js',
       'internal/web/static/js/modules/workspace-detail-directory-explorer.js',
       'internal/web/static/js/modules/workspace-detail-file-modal.js',

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -905,6 +905,12 @@ func registerWorkspaceRuntimeRoutes(mux *http.ServeMux, s *Server) {
 		// Resolved effective prompt inspector (base + per-workspace refinement).
 		mux.HandleFunc("GET /api/workspaces/{workspaceID}/agents/{name}/effective-prompt", s.Handlers.Session.GetWorkspaceAgentEffectivePrompt)
 	}
+
+	// Editable base system prompt for a workspace-local agent, stored in the
+	// workspace config.json (the source of truth for these agents). Handled by
+	// the workspace handler which owns config.json access.
+	mux.HandleFunc("GET /api/workspaces/{workspaceID}/agents/{name}/system-prompt", s.Handlers.Workspace.GetWorkspaceAgentSystemPrompt)
+	mux.HandleFunc("PATCH /api/workspaces/{workspaceID}/agents/{name}/system-prompt", s.Handlers.Workspace.UpdateWorkspaceAgentSystemPrompt)
 }
 
 // registerActionCenterRoutes registers cross-workspace Action Center triage endpoints.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -428,6 +428,18 @@ func (s *Server) handleWorkspacesRoutes(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Workspace-scoped agent detail: /workspaces/{id}/agents/{name}. Workspace-
+	// local agents live only in the workspace config.json (not the global agent
+	// store), so this is their detail home rather than /agents/<name>.
+	if len(parts) == 3 && parts[1] == "agents" && strings.TrimSpace(parts[2]) != "" {
+		agentName, err := url.PathUnescape(parts[2])
+		if err != nil {
+			agentName = parts[2]
+		}
+		s.serveWorkspaceAgentDetail(w, workspaceID, agentName)
+		return
+	}
+
 	// Workspace notes app: /workspaces/{id}/notes[/noteId].
 	if len(parts) >= 2 && parts[1] == "notes" {
 		if len(parts) == 2 {
@@ -502,6 +514,20 @@ func (s *Server) serveWorkspaceDetail(w http.ResponseWriter, workspaceID string)
 	data.ShowSidebarToggle = true
 	data.Extra["WorkspaceID"] = workspaceID
 	s.renderAndWritePage(w, "workspace-detail", data)
+}
+
+// serveWorkspaceAgentDetail renders the detail page for a workspace-scoped
+// agent (an entry/manager agent defined in the workspace's config.json). These
+// agents are not registered in the global agent store, so they have no
+// /agents/<name> page; this workspace-scoped route is their home.
+func (s *Server) serveWorkspaceAgentDetail(w http.ResponseWriter, workspaceID, agentName string) {
+	data := s.prepareBasePageData("workspaces")
+	data.Title = "Workspace Agent - Ori Agent"
+	data.BrandText = "Ori Agent"
+	data.ShowSidebarToggle = true
+	data.Extra["WorkspaceID"] = workspaceID
+	data.Extra["AgentName"] = agentName
+	s.renderAndWritePage(w, "workspace-agent-detail", data)
 }
 
 func (s *Server) serveWorkspaceDiagnostics(w http.ResponseWriter, workspaceID string) {

--- a/internal/web/static/js/modules/workspace-agent-detail.js
+++ b/internal/web/static/js/modules/workspace-agent-detail.js
@@ -1,0 +1,314 @@
+// Workspace-scoped agent detail page.
+//
+// Renders a genuine detail "home" for workspace-local agents (entry/manager
+// agents defined in a workspace's config.json). These agents are not part of
+// the global agent store, so /agents/<name> would 404 — this page is served at
+// /workspaces/{id}/agents/{name} and assembles its data from workspace-scoped
+// endpoints.
+
+const ROLE_LABELS = {
+  orchestrator: 'Orchestrator',
+  coordinator: 'Coordinator',
+  worker: 'Worker',
+  specialist: 'Specialist',
+  researcher: 'Researcher',
+  reviewer: 'Reviewer'
+};
+
+export class WorkspaceAgentDetailPage {
+  constructor(workspaceId, agentName) {
+    this.workspaceId = String(workspaceId || '').trim();
+    this.agentName = String(agentName || '').trim();
+    this.el = (id) => document.getElementById(id);
+  }
+
+  async init() {
+    if (!this.workspaceId || !this.agentName) {
+      this.showError('This page needs both a workspace and an agent name.');
+      return;
+    }
+
+    document.title = `${this.agentName} · Workspace Agent - Ori Agent`;
+    this.setText('wad-breadcrumb-agent', this.agentName);
+
+    // Workspace name + entry-agent status (best-effort; failure is non-fatal).
+    await this.loadWorkspace();
+
+    let profile;
+    try {
+      profile = await this.loadProfile();
+    } catch (error) {
+      console.error('Failed to load workspace agent profile:', error);
+      this.showError('Could not load this agent from the workspace.');
+      return;
+    }
+
+    if (!profile) {
+      this.showError(
+        `“${this.agentName}” is not attached to this workspace. Open the workspace to review its roster.`
+      );
+      return;
+    }
+
+    this.renderIdentity(profile);
+    this.renderModel(profile);
+    this.reveal();
+
+    // Secondary sections load independently and degrade gracefully.
+    this.loadPrompt();
+    this.loadSkills();
+    this.loadMCP();
+  }
+
+  // ---- Data loading -------------------------------------------------------
+
+  async loadWorkspace() {
+    this.isEntryAgent = false;
+    try {
+      const res = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const ws = data?.workspace || data;
+      const name = String(ws?.name || '').trim();
+      if (name) {
+        this.setText('wad-breadcrumb-workspace', name);
+        const link = this.el('wad-breadcrumb-workspace');
+        if (link) link.title = name;
+      }
+      const entry = String(ws?.entry_agent_name || '').trim();
+      this.isEntryAgent = entry !== '' && this.normalize(entry) === this.normalize(this.agentName);
+    } catch (_error) {
+      // Breadcrumb name + entry-agent badge are advisory.
+    }
+  }
+
+  async loadProfile() {
+    const res = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}/agents`);
+    if (!res.ok) {
+      throw new Error(`agents list failed: ${res.status}`);
+    }
+    const data = await res.json();
+    const agents = Array.isArray(data?.agents) ? data.agents : [];
+    const target = this.normalize(this.agentName);
+    return agents.find((a) => this.normalize(a?.name) === target) || null;
+  }
+
+  async loadPrompt() {
+    const container = this.el('wad-prompt-blocks');
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/agents/${encodeURIComponent(
+          this.agentName
+        )}/effective-prompt`
+      );
+      if (!res.ok) throw new Error(`effective-prompt failed: ${res.status}`);
+      const body = await res.json();
+      const data = body?.data || body;
+      this.renderPrompt(data);
+    } catch (error) {
+      console.error('Failed to load effective prompt:', error);
+      if (container) {
+        container.innerHTML = `<div class="wad-prompt-body is-empty">Could not load the system prompt.</div>`;
+      }
+    }
+  }
+
+  async loadSkills() {
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/skill-bindings`
+      );
+      if (!res.ok) throw new Error(`skill-bindings failed: ${res.status}`);
+      const data = await res.json();
+      const bindings = Array.isArray(data?.bindings) ? data.bindings : [];
+      this.renderChips('wad-skills', 'wad-skills-count', bindings, (b) => ({
+        label: b?.skill_name,
+        enabled: b?.enabled !== false
+      }), 'No skills are bound to this workspace.');
+    } catch (error) {
+      console.error('Failed to load skill bindings:', error);
+      this.renderChipsError('wad-skills', 'wad-skills-count');
+    }
+  }
+
+  async loadMCP() {
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/mcp-bindings`
+      );
+      if (!res.ok) throw new Error(`mcp-bindings failed: ${res.status}`);
+      const data = await res.json();
+      const bindings = Array.isArray(data?.bindings) ? data.bindings : [];
+      this.renderChips('wad-mcp', 'wad-mcp-count', bindings, (b) => ({
+        label: b?.alias || b?.server_name,
+        enabled: b?.enabled !== false
+      }), 'No MCP servers are bound to this workspace.');
+    } catch (error) {
+      console.error('Failed to load MCP bindings:', error);
+      this.renderChipsError('wad-mcp', 'wad-mcp-count');
+    }
+  }
+
+  // ---- Rendering ----------------------------------------------------------
+
+  renderIdentity(profile) {
+    const name = String(profile?.name || this.agentName).trim();
+    const avatar = this.el('wad-avatar');
+    if (avatar) {
+      avatar.textContent = this.initials(name);
+      avatar.style.setProperty('--wad-hue', String(this.hue(name)));
+    }
+    this.setText('wad-name', name);
+
+    const role = this.roleLabel(profile?.role);
+    const type = String(profile?.type || '').trim();
+    const subtitleParts = [];
+    if (role) subtitleParts.push(role);
+    if (type) subtitleParts.push(type);
+    this.setText('wad-subtitle', subtitleParts.join(' · ') || 'Workspace agent');
+
+    const badges = this.el('wad-badges');
+    if (badges) {
+      const chips = [];
+      if (this.isEntryAgent) {
+        chips.push('<span class="wad-badge is-leader">Entry agent</span>');
+      }
+      chips.push('<span class="wad-badge is-muted">Workspace-local</span>');
+      const provider = String(profile?.provider || '').trim();
+      if (provider) {
+        chips.push(`<span class="wad-badge">${this.escape(provider)}</span>`);
+      }
+      badges.innerHTML = chips.join('');
+    }
+  }
+
+  renderModel(profile) {
+    this.setText('wad-model', String(profile?.model || '').trim() || 'Not set');
+    this.setText('wad-provider', String(profile?.provider || '').trim() || 'Not set');
+  }
+
+  renderPrompt(data) {
+    const container = this.el('wad-prompt-blocks');
+    if (!container) return;
+
+    const base = String(data?.base_system_prompt || '').trim();
+    const refinement = String(data?.refinement || '').trim();
+    const effective = String(data?.effective_prompt || '').trim();
+    const note = String(data?.note || '').trim();
+
+    const block = (label, value) => {
+      const empty = value === '';
+      return `
+        <div class="wad-prompt-block">
+          <div class="wad-prompt-label">${this.escape(label)}</div>
+          <div class="wad-prompt-body${empty ? ' is-empty' : ''}">${
+            empty ? 'None set.' : this.escape(value)
+          }</div>
+        </div>`;
+    };
+
+    // Show the composed prompt prominently; keep base/refinement for provenance
+    // only when they add information beyond the effective prompt.
+    const blocks = [block('Effective prompt', effective)];
+    if (refinement && refinement !== effective) {
+      blocks.push(block('Workspace refinement', refinement));
+    }
+    if (base && base !== effective) {
+      blocks.push(block('Base prompt', base));
+    }
+    container.innerHTML = blocks.join('');
+    this.setText('wad-prompt-note', note);
+  }
+
+  renderChips(listId, countId, bindings, map, emptyLabel) {
+    const list = this.el(listId);
+    const count = this.el(countId);
+    if (!list) return;
+
+    const items = (bindings || [])
+      .map(map)
+      .filter((it) => String(it?.label || '').trim() !== '');
+
+    if (count) count.textContent = items.length ? `(${items.length})` : '';
+
+    if (!items.length) {
+      list.innerHTML = `<div class="wad-empty">${this.escape(emptyLabel)}</div>`;
+      return;
+    }
+
+    list.innerHTML = items
+      .map((it) => {
+        const enabled = it.enabled !== false;
+        return `<span class="wad-chip${enabled ? '' : ' is-disabled'}" title="${
+          enabled ? 'Enabled' : 'Disabled'
+        }"><span class="wad-chip-dot"></span>${this.escape(it.label)}</span>`;
+      })
+      .join('');
+  }
+
+  renderChipsError(listId, countId) {
+    const list = this.el(listId);
+    const count = this.el(countId);
+    if (count) count.textContent = '';
+    if (list) list.innerHTML = `<div class="wad-empty">Could not load this list.</div>`;
+  }
+
+  reveal() {
+    this.el('wad-loading')?.classList.add('d-none');
+    this.el('wad-error')?.classList.add('d-none');
+    this.el('wad-content')?.classList.remove('d-none');
+  }
+
+  showError(detail) {
+    this.el('wad-loading')?.classList.add('d-none');
+    this.el('wad-content')?.classList.add('d-none');
+    const err = this.el('wad-error');
+    if (err) err.classList.remove('d-none');
+    if (detail) this.setText('wad-error-detail', detail);
+  }
+
+  // ---- Helpers ------------------------------------------------------------
+
+  normalize(value) {
+    return String(value || '').trim().toLowerCase();
+  }
+
+  roleLabel(role) {
+    const key = this.normalize(role);
+    if (!key) return '';
+    return ROLE_LABELS[key] || (role.charAt(0).toUpperCase() + role.slice(1));
+  }
+
+  initials(name) {
+    const words = String(name || '').trim().split(/\s+/).filter(Boolean);
+    if (!words.length) return '?';
+    if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+    return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+  }
+
+  hue(name) {
+    let hash = 0;
+    const str = String(name || '');
+    for (let i = 0; i < str.length; i += 1) {
+      hash = (hash << 5) - hash + str.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash) % 360;
+  }
+
+  setText(id, value) {
+    const node = this.el(id);
+    if (node) node.textContent = String(value == null ? '' : value);
+  }
+
+  escape(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}
+
+export default WorkspaceAgentDetailPage;

--- a/internal/web/static/js/modules/workspace-agent-detail.js
+++ b/internal/web/static/js/modules/workspace-agent-detail.js
@@ -94,22 +94,49 @@ export class WorkspaceAgentDetailPage {
   }
 
   async loadPrompt() {
-    const container = this.el('wad-prompt-blocks');
+    const [base, effective] = await Promise.all([
+      this.fetchBasePrompt(),
+      this.fetchEffectivePrompt()
+    ]);
+
+    // base === null means the editable prompt could not be loaded (e.g. the
+    // agent has no workspace-local config); fall back to read-only display.
+    this.promptEditable = base !== null;
+    this.currentPrompt = base === null ? '' : base;
+    this.renderPromptView(this.currentPrompt, this.promptEditable);
+    this.renderRefinement(effective);
+    this.bindPromptEditor();
+  }
+
+  async fetchBasePrompt() {
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/agents/${encodeURIComponent(
+          this.agentName
+        )}/system-prompt`
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      return String(data?.system_prompt || '');
+    } catch (error) {
+      console.error('Failed to load system prompt:', error);
+      return null;
+    }
+  }
+
+  async fetchEffectivePrompt() {
     try {
       const res = await fetch(
         `/api/workspaces/${encodeURIComponent(this.workspaceId)}/agents/${encodeURIComponent(
           this.agentName
         )}/effective-prompt`
       );
-      if (!res.ok) throw new Error(`effective-prompt failed: ${res.status}`);
+      if (!res.ok) return null;
       const body = await res.json();
-      const data = body?.data || body;
-      this.renderPrompt(data);
+      return body?.data || body;
     } catch (error) {
       console.error('Failed to load effective prompt:', error);
-      if (container) {
-        container.innerHTML = `<div class="wad-prompt-body is-empty">Could not load the system prompt.</div>`;
-      }
+      return null;
     }
   }
 
@@ -187,37 +214,129 @@ export class WorkspaceAgentDetailPage {
     this.setText('wad-provider', String(profile?.provider || '').trim() || 'Not set');
   }
 
-  renderPrompt(data) {
-    const container = this.el('wad-prompt-blocks');
-    if (!container) return;
-
-    const base = String(data?.base_system_prompt || '').trim();
-    const refinement = String(data?.refinement || '').trim();
-    const effective = String(data?.effective_prompt || '').trim();
-    const note = String(data?.note || '').trim();
-
-    const block = (label, value) => {
-      const empty = value === '';
-      return `
-        <div class="wad-prompt-block">
-          <div class="wad-prompt-label">${this.escape(label)}</div>
-          <div class="wad-prompt-body${empty ? ' is-empty' : ''}">${
-            empty ? 'None set.' : this.escape(value)
-          }</div>
-        </div>`;
-    };
-
-    // Show the composed prompt prominently; keep base/refinement for provenance
-    // only when they add information beyond the effective prompt.
-    const blocks = [block('Effective prompt', effective)];
-    if (refinement && refinement !== effective) {
-      blocks.push(block('Workspace refinement', refinement));
+  renderPromptView(prompt, editable) {
+    const view = this.el('wad-prompt-view');
+    const value = String(prompt || '').trim();
+    if (view) {
+      if (value) {
+        view.textContent = value;
+        view.classList.remove('is-empty');
+      } else {
+        view.textContent = editable
+          ? 'No system prompt set. Click Edit to add one.'
+          : 'No system prompt set.';
+        view.classList.add('is-empty');
+      }
     }
-    if (base && base !== effective) {
-      blocks.push(block('Base prompt', base));
+    // Only expose the Edit affordance when the prompt is actually editable.
+    this.el('wad-prompt-edit')?.classList.toggle('d-none', !editable);
+  }
+
+  renderRefinement(effective) {
+    const wrap = this.el('wad-refinement-wrap');
+    const body = this.el('wad-refinement');
+    const refinement = String(effective?.refinement || '').trim();
+    const note = String(effective?.note || '').trim();
+
+    if (wrap && body && refinement) {
+      body.textContent = refinement;
+      wrap.classList.remove('d-none');
+    } else if (wrap) {
+      wrap.classList.add('d-none');
     }
-    container.innerHTML = blocks.join('');
     this.setText('wad-prompt-note', note);
+  }
+
+  bindPromptEditor() {
+    if (this._promptBound) return;
+    this._promptBound = true;
+    this.el('wad-prompt-edit')?.addEventListener('click', () => this.enterEditMode());
+    this.el('wad-prompt-cancel')?.addEventListener('click', () => this.exitEditMode());
+    this.el('wad-prompt-save')?.addEventListener('click', () => this.savePrompt());
+  }
+
+  enterEditMode() {
+    const editor = this.el('wad-prompt-editor');
+    if (editor) editor.value = this.currentPrompt || '';
+    this.togglePromptEditing(true);
+    this.setPromptStatus('');
+    editor?.focus();
+  }
+
+  exitEditMode() {
+    this.togglePromptEditing(false);
+    this.setPromptStatus('');
+  }
+
+  togglePromptEditing(editing) {
+    this.el('wad-prompt-view')?.classList.toggle('d-none', editing);
+    this.el('wad-prompt-editor')?.classList.toggle('d-none', !editing);
+    this.el('wad-prompt-edit')?.classList.toggle('d-none', editing);
+    this.el('wad-prompt-cancel')?.classList.toggle('d-none', !editing);
+    this.el('wad-prompt-save')?.classList.toggle('d-none', !editing);
+  }
+
+  async savePrompt() {
+    const editor = this.el('wad-prompt-editor');
+    if (!editor) return;
+    const value = editor.value;
+
+    this.setPromptSaving(true);
+    this.setPromptStatus('Saving…');
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/agents/${encodeURIComponent(
+          this.agentName
+        )}/system-prompt`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ system_prompt: value })
+        }
+      );
+      if (!res.ok) {
+        const detail = await this.readError(res);
+        throw new Error(detail || `save failed: ${res.status}`);
+      }
+      const data = await res.json();
+      this.currentPrompt = String(data?.system_prompt ?? value.trim());
+      this.renderPromptView(this.currentPrompt, true);
+      this.togglePromptEditing(false);
+      this.setPromptStatus('Saved.', 'success');
+    } catch (error) {
+      console.error('Failed to save system prompt:', error);
+      this.setPromptStatus(error?.message || 'Could not save the system prompt.', 'error');
+    } finally {
+      this.setPromptSaving(false);
+    }
+  }
+
+  setPromptSaving(saving) {
+    const save = this.el('wad-prompt-save');
+    const cancel = this.el('wad-prompt-cancel');
+    if (save) {
+      save.disabled = saving;
+      save.textContent = saving ? 'Saving…' : 'Save';
+    }
+    if (cancel) cancel.disabled = saving;
+  }
+
+  setPromptStatus(message, kind) {
+    const status = this.el('wad-prompt-status');
+    if (!status) return;
+    status.textContent = message || '';
+    status.classList.remove('is-error', 'is-success');
+    if (kind === 'error') status.classList.add('is-error');
+    if (kind === 'success') status.classList.add('is-success');
+  }
+
+  async readError(res) {
+    try {
+      const data = await res.json();
+      return String(data?.error || data?.message || '').trim();
+    } catch (_error) {
+      return '';
+    }
   }
 
   renderChips(listId, countId, bindings, map, emptyLabel) {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3106,26 +3106,6 @@ export class WorkspaceDetailPage {
     const safeTitle = this.escapeAttribute(target.title || `Open ${agentName} details`);
     const safeAriaLabel = this.escapeAttribute(target.ariaLabel || target.title || `Open ${agentName} details`);
     const safeKind = this.escapeAttribute(target.kind || 'global');
-
-    // Workspace-local agents have no global detail route; open their details
-    // in-page (system prompt view) instead of navigating away.
-    if (target.action === 'agent-details') {
-      const encodedForCall = this.escapeAttribute(encodedAgentName);
-      return `
-      <button type="button"
-              class="workspace-detail-agent-link"
-              data-agent-detail-kind="${safeKind}"
-              title="${safeTitle}"
-              aria-label="${safeAriaLabel}"
-              onclick="event.stopPropagation(); window.workspaceDetail?.openAgentPromptModal('${encodedForCall}');">
-        <span class="workspace-detail-agent-link-label">${safeAgentName}</span>
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
-        </svg>
-      </button>
-    `;
-    }
-
     const safeHref = this.escapeAttribute(target.href);
     return `
       <a href="${safeHref}"
@@ -3186,18 +3166,18 @@ export class WorkspaceDetailPage {
     if (this.hasWorkspaceAgentSnapshot(normalizedName)) {
       // Workspace-local agents (entry/manager agents defined in the workspace's
       // config.json) are NOT part of the global agent store, so /agents/<name>
-      // would 404. They live only inside this workspace, so open their details
-      // in-page instead of navigating to a global detail route.
-      const title = `View ${normalizedName} details in this workspace`;
-      return {
-        kind: 'workspace-local',
-        href: '',
-        action: 'agent-details',
-        agentName: normalizedName,
-        interactive: true,
-        title,
-        ariaLabel: title
-      };
+      // would 404. They have a workspace-scoped detail page instead.
+      const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+      if (workspaceId) {
+        const title = `Open ${normalizedName} details`;
+        return {
+          kind: 'workspace-local',
+          href: `/workspaces/${encodeURIComponent(workspaceId)}/agents/${encodedAgentName}`,
+          interactive: true,
+          title,
+          ariaLabel: title
+        };
+      }
     }
 
     if (this.isWorkspaceEntryAgent(normalizedName)) {
@@ -3259,29 +3239,6 @@ export class WorkspaceDetailPage {
     }
 
     const safeKind = this.escapeAttribute(target.kind || 'global');
-
-    // Workspace-local agents open their details in-page (no global detail route).
-    if (target.action === 'agent-details') {
-      const encodedForCall = this.escapeAttribute(encodeURIComponent(group.name));
-      return `
-            <button type="button"
-               class="workspace-detail-agent-identity-link"
-               data-agent-detail-kind="${safeKind}"
-               title="${this.escapeAttribute(title)}"
-               aria-label="${this.escapeAttribute(target.ariaLabel || title)}"
-               aria-describedby="${summaryId}"
-               onclick="event.stopPropagation(); window.workspaceDetail?.openAgentPromptModal('${encodedForCall}');">
-              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
-              <span class="workspace-detail-agent-identity-copy">
-                <span class="workspace-detail-agent-name">${safeName}</span>
-                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(subtitle)}</span>
-              </span>
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
-              </svg>
-            </button>
-          `;
-    }
 
     return `
             <a href="${this.escapeAttribute(target.href)}"

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -3103,13 +3103,34 @@ export class WorkspaceDetailPage {
     `;
     }
 
-    const safeHref = this.escapeAttribute(target.href);
     const safeTitle = this.escapeAttribute(target.title || `Open ${agentName} details`);
     const safeAriaLabel = this.escapeAttribute(target.ariaLabel || target.title || `Open ${agentName} details`);
+    const safeKind = this.escapeAttribute(target.kind || 'global');
+
+    // Workspace-local agents have no global detail route; open their details
+    // in-page (system prompt view) instead of navigating away.
+    if (target.action === 'agent-details') {
+      const encodedForCall = this.escapeAttribute(encodedAgentName);
+      return `
+      <button type="button"
+              class="workspace-detail-agent-link"
+              data-agent-detail-kind="${safeKind}"
+              title="${safeTitle}"
+              aria-label="${safeAriaLabel}"
+              onclick="event.stopPropagation(); window.workspaceDetail?.openAgentPromptModal('${encodedForCall}');">
+        <span class="workspace-detail-agent-link-label">${safeAgentName}</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
+        </svg>
+      </button>
+    `;
+    }
+
+    const safeHref = this.escapeAttribute(target.href);
     return `
       <a href="${safeHref}"
          class="workspace-detail-agent-link"
-         data-agent-detail-kind="${this.escapeAttribute(target.kind || 'global')}"
+         data-agent-detail-kind="${safeKind}"
          title="${safeTitle}"
          aria-label="${safeAriaLabel}"
          onclick="event.stopPropagation();">
@@ -3163,13 +3184,16 @@ export class WorkspaceDetailPage {
     }
 
     if (this.hasWorkspaceAgentSnapshot(normalizedName)) {
-      // Workspace-local agents (entry/manager agents) are hydrated into the
-      // agent store on startup, so /agents/<name> renders their detail page.
-      // The page degrades gracefully to a repair view if a snapshot is missing.
-      const title = `Open ${normalizedName} details (workspace-local agent)`;
+      // Workspace-local agents (entry/manager agents defined in the workspace's
+      // config.json) are NOT part of the global agent store, so /agents/<name>
+      // would 404. They live only inside this workspace, so open their details
+      // in-page instead of navigating to a global detail route.
+      const title = `View ${normalizedName} details in this workspace`;
       return {
         kind: 'workspace-local',
-        href: `/agents/${encodedAgentName}`,
+        href: '',
+        action: 'agent-details',
+        agentName: normalizedName,
         interactive: true,
         title,
         ariaLabel: title
@@ -3234,10 +3258,35 @@ export class WorkspaceDetailPage {
           `;
     }
 
+    const safeKind = this.escapeAttribute(target.kind || 'global');
+
+    // Workspace-local agents open their details in-page (no global detail route).
+    if (target.action === 'agent-details') {
+      const encodedForCall = this.escapeAttribute(encodeURIComponent(group.name));
+      return `
+            <button type="button"
+               class="workspace-detail-agent-identity-link"
+               data-agent-detail-kind="${safeKind}"
+               title="${this.escapeAttribute(title)}"
+               aria-label="${this.escapeAttribute(target.ariaLabel || title)}"
+               aria-describedby="${summaryId}"
+               onclick="event.stopPropagation(); window.workspaceDetail?.openAgentPromptModal('${encodedForCall}');">
+              <span class="workspace-detail-agent-avatar" style="${avatar.style}" aria-hidden="true">${this.escapeHtml(avatar.initials)}</span>
+              <span class="workspace-detail-agent-identity-copy">
+                <span class="workspace-detail-agent-name">${safeName}</span>
+                <span class="workspace-detail-agent-subtitle">${this.escapeHtml(subtitle)}</span>
+              </span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"/>
+              </svg>
+            </button>
+          `;
+    }
+
     return `
             <a href="${this.escapeAttribute(target.href)}"
                class="workspace-detail-agent-identity-link"
-               data-agent-detail-kind="${this.escapeAttribute(target.kind || 'global')}"
+               data-agent-detail-kind="${safeKind}"
                title="${this.escapeAttribute(title)}"
                aria-label="${this.escapeAttribute(target.ariaLabel || title)}"
                aria-describedby="${summaryId}"

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -4181,7 +4181,16 @@ export class WorkspaceDetailPage {
     agentName = String(agentName || '').trim();
     if (!agentName) return;
 
-    this.activeAgentPromptView = { agentName, data: null };
+    // Workspace-local agents (those with a config.json snapshot) can edit their
+    // base system prompt in place; global agents remain read-only here.
+    const editable = this.hasWorkspaceAgentSnapshot(agentName);
+    this.activeAgentPromptView = {
+      agentName,
+      data: null,
+      editable,
+      editing: false,
+      basePrompt: ''
+    };
 
     if (this.elements.agentPromptAgentName) {
       this.elements.agentPromptAgentName.textContent = agentName;
@@ -4218,9 +4227,123 @@ export class WorkspaceDetailPage {
       return;
     }
     this.activeAgentPromptView.data = data;
+
+    // For editable agents, load the real base prompt from config.json (the
+    // effective-prompt endpoint reads the global store, which is empty for
+    // workspace-local agents). If the endpoint is unavailable, fall back to
+    // read-only display.
+    if (this.activeAgentPromptView.editable) {
+      const base = await this.fetchWorkspaceAgentBasePrompt(agentName);
+      if (!this.activeAgentPromptView || this.activeAgentPromptView.agentName !== agentName) {
+        return;
+      }
+      if (base == null) {
+        this.activeAgentPromptView.editable = false;
+      } else {
+        this.activeAgentPromptView.basePrompt = base;
+      }
+    }
+
     this.renderAgentPromptModalBody(agentName, data);
     // Keep the flip-card preview consistent with what the modal just loaded.
     this.refreshAgentCardPrompt(agentName);
+  }
+
+  async fetchWorkspaceAgentBasePrompt(agentName) {
+    const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+    if (!workspaceId) return null;
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(workspaceId)}/agents/${encodeURIComponent(
+          agentName
+        )}/system-prompt`
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      return String(data?.system_prompt || '');
+    } catch (error) {
+      console.error('Failed to load workspace agent base prompt:', error);
+      return null;
+    }
+  }
+
+  enterModalPromptEdit() {
+    const view = this.activeAgentPromptView;
+    if (!view || !view.editable) return;
+    view.editing = true;
+    this.renderAgentPromptModalBody(view.agentName, view.data);
+    document.getElementById('workspace-detail-agent-prompt-editor')?.focus();
+  }
+
+  cancelModalPromptEdit() {
+    const view = this.activeAgentPromptView;
+    if (!view) return;
+    view.editing = false;
+    this.renderAgentPromptModalBody(view.agentName, view.data);
+  }
+
+  async saveModalPrompt() {
+    const view = this.activeAgentPromptView;
+    if (!view || !view.editable) return;
+    const editor = document.getElementById('workspace-detail-agent-prompt-editor');
+    if (!editor) return;
+    const value = editor.value;
+    const workspaceId = String(this.workspaceId || this.workspace?.id || '').trim();
+    if (!workspaceId) return;
+
+    const status = document.getElementById('workspace-detail-agent-prompt-status');
+    const saveBtn = document.getElementById('workspace-detail-agent-prompt-save');
+    if (saveBtn) {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
+    }
+    if (status) {
+      status.textContent = 'Saving…';
+      status.classList.remove('is-error', 'is-success');
+    }
+
+    try {
+      const res = await fetch(
+        `/api/workspaces/${encodeURIComponent(workspaceId)}/agents/${encodeURIComponent(
+          view.agentName
+        )}/system-prompt`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ system_prompt: value })
+        }
+      );
+      if (!res.ok) {
+        let detail = '';
+        try {
+          const body = await res.json();
+          detail = String(body?.error || body?.message || '').trim();
+        } catch (_error) {
+          detail = '';
+        }
+        throw new Error(detail || `save failed: ${res.status}`);
+      }
+      const body = await res.json();
+      view.basePrompt = String(body?.system_prompt ?? value.trim());
+      view.editing = false;
+      this.renderAgentPromptModalBody(view.agentName, view.data);
+      // Invalidate the cached effective prompt so the flip-card preview refreshes.
+      this.agentPromptCache?.delete(this.normalizeAgentName(view.agentName));
+      this.refreshAgentCardPrompt(view.agentName);
+      if (window.Toast) window.Toast.success('System prompt saved.');
+    } catch (error) {
+      console.error('Failed to save system prompt:', error);
+      if (status) {
+        status.textContent = error?.message || 'Could not save the system prompt.';
+        status.classList.add('is-error');
+      }
+      if (window.Toast) window.Toast.error('Failed to save system prompt.');
+    } finally {
+      if (saveBtn) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+      }
+    }
   }
 
   renderAgentPromptModalBody(agentName, data) {
@@ -4234,7 +4357,7 @@ export class WorkspaceDetailPage {
       return;
     }
 
-    const base = String(data.base_system_prompt || '').trim();
+    const view = this.activeAgentPromptView || {};
     const refinement = String(data.refinement || '').trim();
     const effective = String(data.effective_prompt || '').trim();
     const note = String(data.note || '').trim();
@@ -4250,6 +4373,57 @@ export class WorkspaceDetailPage {
       </div>
     `;
 
+    // Editable path: workspace-local agents edit their base prompt (config.json)
+    // in place. The base comes from view.basePrompt, not the effective-prompt
+    // endpoint (whose base is the global store, empty for these agents).
+    if (view.editable) {
+      const base = String(view.basePrompt || '').trim();
+      const baseBlock = view.editing
+        ? `
+          <div class="workspace-detail-agent-prompt-block">
+            <div class="workspace-detail-agent-prompt-block-head">
+              <div class="workspace-detail-agent-prompt-block-label">Base system prompt</div>
+              <div class="workspace-detail-agent-prompt-edit-actions">
+                <button type="button" class="btn btn-sm btn-link p-0" onclick="window.workspaceDetail?.cancelModalPromptEdit()">Cancel</button>
+                <button type="button" class="btn btn-sm btn-primary" id="workspace-detail-agent-prompt-save" onclick="window.workspaceDetail?.saveModalPrompt()">Save</button>
+              </div>
+            </div>
+            <textarea id="workspace-detail-agent-prompt-editor" class="workspace-detail-agent-prompt-editor" rows="10" placeholder="Describe how this agent should behave…">${this.escapeHtml(
+              base
+            )}</textarea>
+            <div id="workspace-detail-agent-prompt-status" class="workspace-detail-agent-prompt-status"></div>
+          </div>`
+        : `
+          <div class="workspace-detail-agent-prompt-block">
+            <div class="workspace-detail-agent-prompt-block-head">
+              <div class="workspace-detail-agent-prompt-block-label">Base system prompt</div>
+              <button type="button" class="btn btn-sm btn-link p-0" onclick="window.workspaceDetail?.enterModalPromptEdit()">Edit</button>
+            </div>
+            ${
+              base
+                ? `<pre class="workspace-detail-agent-prompt-pre">${this.escapeHtml(base)}</pre>`
+                : `<div class="workspace-detail-agent-prompt-empty">No base system prompt set. Click Edit to add one.</div>`
+            }
+          </div>`;
+
+      body.innerHTML = `
+        ${baseBlock}
+        ${section(
+          'Workspace refinement',
+          refinement,
+          'No workspace-specific refinement (role, description, or custom instructions).'
+        )}
+        ${
+          note
+            ? `<div class="workspace-detail-agent-prompt-hint">${this.escapeHtml(note)}</div>`
+            : ''
+        }
+      `;
+      return;
+    }
+
+    // Read-only path (global agents): unchanged three-section view.
+    const base = String(data.base_system_prompt || '').trim();
     body.innerHTML = `
       ${section('Base system prompt', base, 'No base system prompt set for this agent.')}
       ${section(

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -507,7 +507,7 @@ test('workspace detail links catalog-backed agents to the global detail page', (
   assert.match(markup, /data-agent-detail-kind="global"/);
 });
 
-test('workspace detail opens snapshot-backed local agents in-page (no global route)', () => {
+test('workspace detail links snapshot-backed local agents to their workspace-scoped page', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   page.workspace = {
     entry_agent_name: 'Local Manager',
@@ -525,14 +525,12 @@ test('workspace detail opens snapshot-backed local agents in-page (no global rou
   );
 
   // Workspace-local agents are NOT in the global agent store, so /agents/<name>
-  // would 404. They open their details in-page instead of navigating away.
+  // would 404. They get a workspace-scoped detail page instead.
   assert.equal(target.kind, 'workspace-local');
   assert.equal(target.interactive, true);
-  assert.equal(target.action, 'agent-details');
-  assert.equal(target.href, '');
+  assert.equal(target.href, '/workspaces/workspace-1/agents/Local%20Manager');
   assert.match(markup, /data-agent-detail-kind="workspace-local"/);
-  assert.match(markup, /<button[^>]*type="button"/);
-  assert.match(markup, /openAgentPromptModal\('Local%20Manager'\)/);
+  assert.match(markup, /href="\/workspaces\/workspace-1\/agents\/Local%20Manager"/);
   assert.doesNotMatch(markup, /href="\/agents\/Local%20Manager"/);
   assert.doesNotMatch(markup, /is-static/);
 });

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -507,7 +507,7 @@ test('workspace detail links catalog-backed agents to the global detail page', (
   assert.match(markup, /data-agent-detail-kind="global"/);
 });
 
-test('workspace detail links snapshot-backed local agents to their detail page', () => {
+test('workspace detail opens snapshot-backed local agents in-page (no global route)', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   page.workspace = {
     entry_agent_name: 'Local Manager',
@@ -524,13 +524,16 @@ test('workspace detail links snapshot-backed local agents to their detail page',
     'summary-local'
   );
 
-  // Snapshot-backed local agents are hydrated into the agent store on startup,
-  // so /agents/<name> resolves (degrading to a repair view if it does not).
+  // Workspace-local agents are NOT in the global agent store, so /agents/<name>
+  // would 404. They open their details in-page instead of navigating away.
   assert.equal(target.kind, 'workspace-local');
   assert.equal(target.interactive, true);
-  assert.equal(target.href, '/agents/Local%20Manager');
+  assert.equal(target.action, 'agent-details');
+  assert.equal(target.href, '');
   assert.match(markup, /data-agent-detail-kind="workspace-local"/);
-  assert.match(markup, /href="\/agents\/Local%20Manager"/);
+  assert.match(markup, /<button[^>]*type="button"/);
+  assert.match(markup, /openAgentPromptModal\('Local%20Manager'\)/);
+  assert.doesNotMatch(markup, /href="\/agents\/Local%20Manager"/);
   assert.doesNotMatch(markup, /is-static/);
 });
 

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -103,6 +103,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/pages/workflows.tmpl",
 		"templates/pages/workspace-canvas.tmpl",
 		"templates/pages/workspace-detail.tmpl",
+		"templates/pages/workspace-agent-detail.tmpl",
 		"templates/pages/workspace-diagnostics.tmpl",
 		"templates/pages/workspace-task.tmpl",
 		"templates/pages/workspace-run.tmpl",
@@ -148,6 +149,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 	tr.templates["workflows"] = tmpl
 	tr.templates["workspace-canvas"] = tmpl
 	tr.templates["workspace-detail"] = tmpl
+	tr.templates["workspace-agent-detail"] = tmpl
 	tr.templates["workspace-diagnostics"] = tmpl
 	tr.templates["workspace-task"] = tmpl
 	tr.templates["workspace-run"] = tmpl
@@ -183,7 +185,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-codex-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-agent-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-codex-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/pages/workspace-agent-detail.tmpl
+++ b/internal/web/templates/pages/workspace-agent-detail.tmpl
@@ -1,0 +1,183 @@
+{{define "workspace-agent-detail"}}
+<!DOCTYPE html>
+<html data-bs-theme="light">
+{{template "head.tmpl" .}}
+
+<body class="bg-light">
+  {{template "navbar.tmpl" .}}
+
+  <div class="main-content-wrapper">
+    {{template "sidebar.tmpl" .}}
+
+    <div class="main-content">
+      <div class="container-fluid py-4">
+        <div id="workspace-agent-detail-view" class="workspace-agent-detail">
+          <!-- Header / breadcrumb -->
+          <div class="modern-card p-3 mb-3">
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+              <a href="/workspaces/{{.Extra.WorkspaceID}}" class="modern-btn modern-btn-secondary">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="me-1">
+                  <path d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"/>
+                </svg>
+                Back to Workspace
+              </a>
+              <nav aria-label="breadcrumb">
+                <ol class="breadcrumb mb-0" style="font-size: 0.875rem;">
+                  <li class="breadcrumb-item"><a href="/workspaces" style="color: var(--text-secondary); text-decoration: none;">Workspaces</a></li>
+                  <li class="breadcrumb-item"><a href="/workspaces/{{.Extra.WorkspaceID}}" style="color: var(--text-secondary); text-decoration: none;" id="wad-breadcrumb-workspace">Workspace</a></li>
+                  <li class="breadcrumb-item active" aria-current="page" id="wad-breadcrumb-agent">Agent</li>
+                </ol>
+              </nav>
+            </div>
+          </div>
+
+          <!-- Loading / error states -->
+          <div id="wad-loading" class="modern-card p-4 text-center">
+            <div class="wad-muted">Loading agent details…</div>
+          </div>
+          <div id="wad-error" class="modern-card p-4 d-none">
+            <h2 class="wad-error-title">Agent not found in this workspace</h2>
+            <p class="wad-muted" id="wad-error-detail">
+              This agent is not attached to this workspace. Open the workspace to review its roster.
+            </p>
+            <a href="/workspaces/{{.Extra.WorkspaceID}}" class="modern-btn modern-btn-primary">Open Workspace</a>
+          </div>
+
+          <!-- Content -->
+          <div id="wad-content" class="d-none">
+            <!-- Identity -->
+            <div class="modern-card p-4 mb-3">
+              <div class="wad-identity">
+                <span class="wad-avatar" id="wad-avatar" aria-hidden="true"></span>
+                <div class="wad-identity-copy">
+                  <h1 class="wad-name" id="wad-name">Agent</h1>
+                  <div class="wad-subtitle" id="wad-subtitle">Workspace agent</div>
+                  <div class="wad-badges" id="wad-badges"></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Model -->
+            <div class="modern-card p-4 mb-3">
+              <div class="wad-section-head">
+                <h2 class="wad-section-title">Model</h2>
+                <a class="wad-section-action" href="/workspaces/{{.Extra.WorkspaceID}}" title="Edit this agent's model on the workspace page">Edit in workspace</a>
+              </div>
+              <div class="wad-kv">
+                <div class="wad-kv-row"><span class="wad-kv-key">Model</span><span class="wad-kv-val" id="wad-model">—</span></div>
+                <div class="wad-kv-row"><span class="wad-kv-key">Provider</span><span class="wad-kv-val" id="wad-provider">—</span></div>
+              </div>
+            </div>
+
+            <!-- System prompt -->
+            <div class="modern-card p-4 mb-3">
+              <div class="wad-section-head">
+                <h2 class="wad-section-title">System prompt</h2>
+              </div>
+              <div id="wad-prompt-blocks"></div>
+              <p class="wad-note" id="wad-prompt-note"></p>
+            </div>
+
+            <!-- Skills -->
+            <div class="modern-card p-4 mb-3">
+              <div class="wad-section-head">
+                <h2 class="wad-section-title">Workspace skills <span class="wad-count" id="wad-skills-count"></span></h2>
+              </div>
+              <p class="wad-muted wad-scope-hint">Skills available to agents in this workspace.</p>
+              <div class="wad-chips" id="wad-skills"></div>
+            </div>
+
+            <!-- MCP -->
+            <div class="modern-card p-4 mb-3">
+              <div class="wad-section-head">
+                <h2 class="wad-section-title">MCP servers <span class="wad-count" id="wad-mcp-count"></span></h2>
+              </div>
+              <p class="wad-muted wad-scope-hint">MCP tool servers available to agents in this workspace.</p>
+              <div class="wad-chips" id="wad-mcp"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <style>
+    .workspace-agent-detail { max-width: 960px; }
+    .workspace-agent-detail .wad-muted { color: var(--text-secondary); }
+    .wad-error-title { font-size: 1.15rem; font-weight: 700; color: var(--text-primary); margin-bottom: 0.4rem; }
+
+    .wad-identity { display: flex; align-items: center; gap: 1rem; }
+    .wad-avatar {
+      width: 64px; height: 64px; border-radius: 12px; flex-shrink: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: #fff; font-size: 1.2rem; font-weight: 800; letter-spacing: 0.04em;
+      border: 1px solid hsla(var(--wad-hue, 205), 70%, 34%, 0.35);
+      background: linear-gradient(135deg, hsla(var(--wad-hue, 205), 72%, 42%, 0.9), hsla(var(--wad-hue, 205), 74%, 28%, 0.95));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.18);
+    }
+    .wad-identity-copy { min-width: 0; }
+    .wad-name { font-size: 1.4rem; font-weight: 800; color: var(--text-primary); margin: 0 0 0.15rem; }
+    .wad-subtitle { color: var(--text-secondary); font-size: 0.85rem; font-weight: 600; }
+    .wad-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.55rem; }
+    .wad-badge {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      padding: 0.16rem 0.55rem; border-radius: 999px; font-size: 0.72rem; font-weight: 700;
+      background: rgba(14,165,233,0.12); color: #0369a1; border: 1px solid rgba(14,165,233,0.25);
+    }
+    .wad-badge.is-leader { background: rgba(245,158,11,0.14); color: #92400e; border-color: rgba(245,158,11,0.35); }
+    .wad-badge.is-muted { background: var(--surface-2, rgba(148,163,184,0.14)); color: var(--text-secondary); border-color: rgba(148,163,184,0.3); }
+
+    .wad-section-head { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.8rem; }
+    .wad-section-title { font-size: 0.95rem; font-weight: 700; color: var(--text-primary); margin: 0; }
+    .wad-count { color: var(--text-secondary); font-weight: 600; font-size: 0.82rem; }
+    .wad-section-action { font-size: 0.78rem; font-weight: 600; color: #0369a1; text-decoration: none; white-space: nowrap; }
+    .wad-section-action:hover { text-decoration: underline; }
+    .wad-scope-hint { font-size: 0.78rem; margin: -0.35rem 0 0.7rem; }
+
+    .wad-kv { display: flex; flex-direction: column; gap: 0.4rem; }
+    .wad-kv-row { display: flex; gap: 0.75rem; align-items: baseline; }
+    .wad-kv-key { width: 84px; flex-shrink: 0; color: var(--text-secondary); font-size: 0.78rem; font-weight: 600; }
+    .wad-kv-val { color: var(--text-primary); font-size: 0.86rem; font-weight: 600; font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace); }
+
+    .wad-prompt-block { margin-bottom: 1rem; }
+    .wad-prompt-block:last-child { margin-bottom: 0; }
+    .wad-prompt-label { font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-secondary); margin-bottom: 0.35rem; }
+    .wad-prompt-body {
+      white-space: pre-wrap; word-break: break-word;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+      font-size: 0.8rem; line-height: 1.5; color: var(--text-primary);
+      background: var(--surface-2, rgba(148,163,184,0.08)); border: 1px solid rgba(148,163,184,0.2);
+      border-radius: 8px; padding: 0.7rem 0.85rem; max-height: 340px; overflow: auto;
+    }
+    .wad-prompt-body.is-empty { color: var(--text-secondary); font-style: italic; font-family: inherit; }
+    .wad-note { color: var(--text-secondary); font-size: 0.75rem; margin: 0.75rem 0 0; }
+
+    .wad-chips { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+    .wad-chip {
+      display: inline-flex; align-items: center; gap: 0.35rem;
+      padding: 0.24rem 0.6rem; border-radius: 8px; font-size: 0.78rem; font-weight: 600;
+      background: var(--surface-2, rgba(148,163,184,0.1)); color: var(--text-primary);
+      border: 1px solid rgba(148,163,184,0.25);
+    }
+    .wad-chip.is-disabled { opacity: 0.55; }
+    .wad-chip-dot { width: 7px; height: 7px; border-radius: 50%; background: #22c55e; flex-shrink: 0; }
+    .wad-chip.is-disabled .wad-chip-dot { background: #94a3b8; }
+    .wad-empty { color: var(--text-secondary); font-size: 0.82rem; font-style: italic; }
+  </style>
+
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module">
+    import { WorkspaceAgentDetailPage } from '/js/modules/workspace-agent-detail.js';
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const workspaceId = "{{.Extra.WorkspaceID}}";
+      const agentName = "{{.Extra.AgentName}}";
+      const page = new WorkspaceAgentDetailPage(workspaceId, agentName);
+      page.init().catch((error) => {
+        console.error('Failed to initialize workspace agent detail page:', error);
+      });
+    });
+  </script>
+</body>
+</html>
+{{end}}

--- a/internal/web/templates/pages/workspace-agent-detail.tmpl
+++ b/internal/web/templates/pages/workspace-agent-detail.tmpl
@@ -69,12 +69,25 @@
               </div>
             </div>
 
-            <!-- System prompt -->
+            <!-- System prompt (editable base prompt from config.json) -->
             <div class="modern-card p-4 mb-3">
               <div class="wad-section-head">
                 <h2 class="wad-section-title">System prompt</h2>
+                <div class="wad-prompt-actions">
+                  <button id="wad-prompt-edit" class="wad-section-action" type="button">Edit</button>
+                  <button id="wad-prompt-cancel" class="wad-section-action d-none" type="button">Cancel</button>
+                  <button id="wad-prompt-save" class="wad-section-action is-primary d-none" type="button">Save</button>
+                </div>
               </div>
-              <div id="wad-prompt-blocks"></div>
+              <div id="wad-prompt-view" class="wad-prompt-body is-empty">Loading…</div>
+              <textarea id="wad-prompt-editor" class="wad-prompt-editor d-none" rows="14"
+                        placeholder="Describe how this agent should behave…"></textarea>
+              <div id="wad-prompt-status" class="wad-note" role="status" aria-live="polite"></div>
+
+              <div id="wad-refinement-wrap" class="wad-refinement d-none">
+                <div class="wad-prompt-label">Workspace refinement</div>
+                <div id="wad-refinement" class="wad-prompt-body"></div>
+              </div>
               <p class="wad-note" id="wad-prompt-note"></p>
             </div>
 
@@ -151,6 +164,25 @@
     }
     .wad-prompt-body.is-empty { color: var(--text-secondary); font-style: italic; font-family: inherit; }
     .wad-note { color: var(--text-secondary); font-size: 0.75rem; margin: 0.75rem 0 0; }
+    .wad-note.is-error { color: #dc2626; }
+    .wad-note.is-success { color: #16a34a; }
+
+    .wad-prompt-actions { display: flex; align-items: center; gap: 0.75rem; }
+    .wad-section-action { background: none; border: none; padding: 0; cursor: pointer; }
+    .wad-section-action.is-primary { color: #16a34a; font-weight: 700; }
+    .wad-section-action:disabled { opacity: 0.5; cursor: default; }
+
+    .wad-prompt-editor {
+      width: 100%; resize: vertical; min-height: 220px;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+      font-size: 0.8rem; line-height: 1.5; color: var(--text-primary);
+      background: var(--surface-2, rgba(148,163,184,0.08)); border: 1px solid rgba(56,189,248,0.5);
+      border-radius: 8px; padding: 0.7rem 0.85rem;
+    }
+    .wad-prompt-editor:focus { outline: 2px solid rgba(56,189,248,0.85); outline-offset: 1px; }
+
+    .wad-refinement { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid rgba(148,163,184,0.2); }
+    .wad-refinement .wad-prompt-label { margin-bottom: 0.35rem; }
 
     .wad-chips { display: flex; flex-wrap: wrap; gap: 0.4rem; }
     .wad-chip {

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -3739,6 +3739,21 @@
       outline: none;
     }
 
+    /* When rendered as a <button> (workspace-local agents open details in-page),
+       strip the native button chrome so it matches the anchor variant. */
+    button.workspace-detail-agent-identity-link,
+    button.workspace-detail-agent-link {
+      appearance: none;
+      -webkit-appearance: none;
+      background: none;
+      border: none;
+      margin: 0;
+      padding: 0;
+      font: inherit;
+      cursor: pointer;
+      text-align: left;
+    }
+
     .workspace-detail-agent-identity-link.is-static {
       cursor: default;
     }

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -3739,21 +3739,6 @@
       outline: none;
     }
 
-    /* When rendered as a <button> (workspace-local agents open details in-page),
-       strip the native button chrome so it matches the anchor variant. */
-    button.workspace-detail-agent-identity-link,
-    button.workspace-detail-agent-link {
-      appearance: none;
-      -webkit-appearance: none;
-      background: none;
-      border: none;
-      margin: 0;
-      padding: 0;
-      font: inherit;
-      cursor: pointer;
-      text-align: left;
-    }
-
     .workspace-detail-agent-identity-link.is-static {
       cursor: default;
     }

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -4308,6 +4308,46 @@
       padding-top: 0.6rem;
     }
 
+    .workspace-detail-agent-prompt-block-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .workspace-detail-agent-prompt-block-head .workspace-detail-agent-prompt-block-label {
+      margin-bottom: 0;
+    }
+
+    .workspace-detail-agent-prompt-edit-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .workspace-detail-agent-prompt-editor {
+      width: 100%;
+      resize: vertical;
+      min-height: 180px;
+      padding: 0.7rem 0.8rem;
+      background: var(--bg-primary);
+      border: 1px solid rgba(56, 189, 248, 0.5);
+      border-radius: 8px;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+      font-size: 0.78rem;
+      line-height: 1.5;
+      color: var(--text-primary);
+    }
+
+    .workspace-detail-agent-prompt-editor:focus {
+      outline: 2px solid rgba(56, 189, 248, 0.85);
+      outline-offset: 1px;
+    }
+
+    .workspace-detail-agent-prompt-status.is-error { color: #dc2626; }
+    .workspace-detail-agent-prompt-status.is-success { color: #16a34a; }
+
     .workspace-detail-agent-info-block {
       background: rgba(100, 116, 139, 0.06);
       border: 1px solid rgba(100, 116, 139, 0.14);

--- a/internal/workspace/http_handlers_agent.go
+++ b/internal/workspace/http_handlers_agent.go
@@ -393,3 +393,124 @@ func (h *HTTPHandler) UpdateWorkspaceAgentModel(w http.ResponseWriter, r *http.R
 		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
 	}
 }
+
+// maxWorkspaceAgentSystemPromptLen bounds a workspace-local agent's editable
+// base system prompt. Generous, but guards against accidental huge payloads.
+const maxWorkspaceAgentSystemPromptLen = 20000
+
+// workspaceAgentNameFromPath returns the {name} path value with any ":instance"
+// suffix stripped, since agent config (model, prompt) is per agent name.
+func workspaceAgentNameFromPath(r *http.Request) string {
+	name := strings.TrimSpace(r.PathValue("name"))
+	if idx := strings.Index(name, ":"); idx >= 0 {
+		name = name[:idx]
+	}
+	return strings.TrimSpace(name)
+}
+
+// GetWorkspaceAgentSystemPrompt handles GET
+// /api/workspaces/{workspaceID}/agents/{name}/system-prompt and returns the
+// base system prompt stored in a workspace-local agent's config.json. The
+// workspace config.json is the single source of truth for these agents.
+func (h *HTTPHandler) GetWorkspaceAgentSystemPrompt(w http.ResponseWriter, r *http.Request) {
+	workspaceID := strings.TrimSpace(r.PathValue("workspaceID"))
+	agentName := workspaceAgentNameFromPath(r)
+	if workspaceID == "" || agentName == "" {
+		orihttp.BadRequest(w, "workspace id and agent name are required")
+		return
+	}
+
+	if _, err := h.store.Get(workspaceID); err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace %s not found", workspaceID))
+		return
+	}
+
+	ag, ok, err := h.store.GetWorkspaceAgent(workspaceID, agentName)
+	if err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to read workspace agent: %v", err))
+		return
+	}
+	if !ok || ag == nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace agent %q not found", agentName))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(map[string]any{
+		"agent":         agentName,
+		"system_prompt": ag.Settings.SystemPrompt,
+		"source":        "workspace",
+	}); encErr != nil {
+		logger.Error("Failed to encode workspace agent system prompt", logger.Fields{"error": encErr})
+	}
+}
+
+// UpdateWorkspaceAgentSystemPromptRequest is the body for PATCH
+// /api/workspaces/{id}/agents/{name}/system-prompt.
+type UpdateWorkspaceAgentSystemPromptRequest struct {
+	SystemPrompt *string `json:"system_prompt"`
+}
+
+// UpdateWorkspaceAgentSystemPrompt handles PATCH
+// /api/workspaces/{workspaceID}/agents/{name}/system-prompt and writes the base
+// system prompt into the workspace-local agent's config.json. It never touches
+// the global agent store; the workspace config.json is the source of truth.
+func (h *HTTPHandler) UpdateWorkspaceAgentSystemPrompt(w http.ResponseWriter, r *http.Request) {
+	workspaceID := strings.TrimSpace(r.PathValue("workspaceID"))
+	agentName := workspaceAgentNameFromPath(r)
+	if workspaceID == "" || agentName == "" {
+		orihttp.BadRequest(w, "workspace id and agent name are required")
+		return
+	}
+
+	var req UpdateWorkspaceAgentSystemPromptRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.SystemPrompt == nil {
+		orihttp.BadRequest(w, "system_prompt is required")
+		return
+	}
+	// Trim outer whitespace (also drops stray leading/trailing newlines) while
+	// preserving intentional internal formatting. Empty is allowed (clears it).
+	prompt := strings.TrimSpace(*req.SystemPrompt)
+	if len(prompt) > maxWorkspaceAgentSystemPromptLen {
+		orihttp.BadRequest(w, fmt.Sprintf("system_prompt exceeds %d characters", maxWorkspaceAgentSystemPromptLen))
+		return
+	}
+
+	if _, err := h.store.Get(workspaceID); err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace %s not found", workspaceID))
+		return
+	}
+
+	ag, ok, err := h.store.GetWorkspaceAgent(workspaceID, agentName)
+	if err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to read workspace agent: %v", err))
+		return
+	}
+	if !ok || ag == nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace agent %q not found", agentName))
+		return
+	}
+
+	ag.Settings.SystemPrompt = prompt
+	if err := h.store.SaveWorkspaceAgent(workspaceID, agentName, ag); err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to save workspace agent: %v", err))
+		return
+	}
+
+	logger.Info("Updated workspace agent system prompt", logger.Fields{
+		"workspace_id": workspaceID, "agent": agentName, "length": len(prompt),
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if encErr := json.NewEncoder(w).Encode(map[string]any{
+		"message":       "Agent system prompt updated",
+		"agent":         agentName,
+		"system_prompt": prompt,
+		"source":        "workspace",
+	}); encErr != nil {
+		logger.Error("Failed to encode response", logger.Fields{"error": encErr})
+	}
+}

--- a/internal/workspace/http_handlers_agent_model_test.go
+++ b/internal/workspace/http_handlers_agent_model_test.go
@@ -130,6 +130,119 @@ func TestHTTPHandler_UpdateWorkspaceAgentModel(t *testing.T) {
 	}
 }
 
+func TestHTTPHandler_WorkspaceAgentSystemPrompt_RoundTrip(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:             "ws-sp",
+		Name:           "Prompt",
+		Status:         StatusActive,
+		AgentInstances: AgentInstancesFromNames("Chief of Staff"),
+		SharedData:     map[string]any{"entry_agent_name": "Chief of Staff"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SaveWorkspaceAgent(ws.ID, "Chief of Staff", &agent.Agent{
+		Type: "orchestration",
+		Role: "orchestrator",
+		Settings: types.Settings{
+			Model:        "gpt-5.5",
+			Provider:     "codex",
+			SystemPrompt: "old prompt",
+			Temperature:  0.3,
+		},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	// GET returns the current prompt.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/ws-sp/agents/Chief%20of%20Staff/system-prompt", nil)
+	getReq.SetPathValue("workspaceID", "ws-sp")
+	getReq.SetPathValue("name", "Chief of Staff")
+	getRec := httptest.NewRecorder()
+	handler.GetWorkspaceAgentSystemPrompt(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", getRec.Code, getRec.Body.String())
+	}
+	var getResp struct {
+		SystemPrompt string `json:"system_prompt"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &getResp); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if getResp.SystemPrompt != "old prompt" {
+		t.Fatalf("get system_prompt=%q, want %q", getResp.SystemPrompt, "old prompt")
+	}
+
+	// PATCH updates the prompt (and trims outer whitespace).
+	body, _ := json.Marshal(map[string]string{"system_prompt": "  You are the chief of staff.  "})
+	patchReq := httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-sp/agents/Chief%20of%20Staff/system-prompt", bytes.NewReader(body))
+	patchReq.SetPathValue("workspaceID", "ws-sp")
+	patchReq.SetPathValue("name", "Chief of Staff")
+	patchRec := httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentSystemPrompt(patchRec, patchReq)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("patch status=%d body=%s", patchRec.Code, patchRec.Body.String())
+	}
+
+	ag, ok, err := store.GetWorkspaceAgent(ws.ID, "Chief of Staff")
+	if err != nil || !ok || ag == nil {
+		t.Fatalf("reload agent: ok=%v err=%v", ok, err)
+	}
+	if ag.Settings.SystemPrompt != "You are the chief of staff." {
+		t.Fatalf("system_prompt=%q, want trimmed value", ag.Settings.SystemPrompt)
+	}
+	// Model/provider/other settings must be preserved (prompt only).
+	if ag.Settings.Model != "gpt-5.5" || ag.Settings.Provider != "codex" || ag.Settings.Temperature != 0.3 {
+		t.Fatalf("other settings clobbered: %+v", ag.Settings)
+	}
+}
+
+func TestHTTPHandler_UpdateWorkspaceAgentSystemPrompt_Validation(t *testing.T) {
+	store := NewInMemoryStore()
+	handler := NewHTTPHandler(store, nil, nil)
+
+	ws := &Workspace{
+		ID:             "ws-spval",
+		Name:           "PromptVal",
+		Status:         StatusActive,
+		AgentInstances: AgentInstancesFromNames("Manager"),
+		SharedData:     map[string]any{"entry_agent_name": "Manager"},
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SaveWorkspaceAgent(ws.ID, "Manager", &agent.Agent{
+		Type:     "general",
+		Settings: types.Settings{Model: "m", Provider: "p"},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	// Missing system_prompt field -> 400.
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-spval/agents/Manager/system-prompt", bytes.NewReader([]byte(`{}`)))
+	req.SetPathValue("workspaceID", "ws-spval")
+	req.SetPathValue("name", "Manager")
+	rec := httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentSystemPrompt(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing system_prompt: status=%d, want 400", rec.Code)
+	}
+
+	// Unknown agent -> 404.
+	body, _ := json.Marshal(map[string]string{"system_prompt": "hi"})
+	req = httptest.NewRequest(http.MethodPatch, "/api/workspaces/ws-spval/agents/Ghost/system-prompt", bytes.NewReader(body))
+	req.SetPathValue("workspaceID", "ws-spval")
+	req.SetPathValue("name", "Ghost")
+	rec = httptest.NewRecorder()
+	handler.UpdateWorkspaceAgentSystemPrompt(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown agent: status=%d, want 404", rec.Code)
+	}
+}
+
 func TestHTTPHandler_UpdateWorkspaceAgentModel_Validation(t *testing.T) {
 	store := NewInMemoryStore()
 	handler := NewHTTPHandler(store, nil, nil)


### PR DESCRIPTION
## Summary

Workspace-local agents (entry/manager agents defined in a workspace's `config.json`) are not in the global agent store, so linking their name to `/agents/<name>` produced a 404 "Agent not found" page, and their system prompt was read-only everywhere (no edit API existed). This branch gives them a real home and makes their base system prompt editable.

## Changes

- **Fix broken link:** the workspace page no longer links workspace-local agents to the global `/agents/<name>` route (which 404s). They now route to a workspace-scoped page.
- **New detail page** `/workspaces/{id}/agents/{name}`: breadcrumb, identity, model, system prompt, workspace skills, and MCP servers, with a graceful "not found in this workspace" state.
- **Editable base system prompt** (the config.json value, source of truth):
  - New `GET`/`PATCH /api/workspaces/{id}/agents/{name}/system-prompt` reading/writing `Settings.SystemPrompt` in the workspace-local agent's `config.json` (global store untouched, model/other settings preserved; length-validated, outer-whitespace trimmed).
  - Inline edit/save/cancel on the **detail page**.
  - Inline edit/save/cancel in the **workspace "System Prompt" modal** (global agents stay read-only). The modal now shows the real prompt from config.json instead of the empty global-store base.

## Testing

- Go: `GET`/`PATCH` system-prompt round-trip + validation tests; `go test ./internal/workspace/`, `go vet`, build all pass.
- JS: `node --test` (26/26), eslint clean.
- **End-to-end (isolated smoke server, seeded workspace-local agent):** verified the detail page and the modal both display the real `config.json` prompt and that an in-browser edit persists to disk and is returned by the GET endpoint.

## Notes

- Static assets are embedded in the binary, so this needs a server rebuild + restart to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)