### PR TITLE
feat(map): group selected workspaces + fix clipped multi-select bar

### DIFF
--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -546,6 +546,7 @@
   display: flex;
   gap: 8px;
 }
+.ws-map-selbar-group,
 .ws-map-selbar-del,
 .ws-map-selbar-clear {
   padding: 7px 13px;
@@ -558,6 +559,15 @@
   transition: 0.15s;
   white-space: nowrap;
   clip-path: polygon(7px 0, 100% 0, 100% calc(100% - 7px), calc(100% - 7px) 100%, 0 100%, 0 7px);
+}
+.ws-map-selbar-group {
+  background: var(--ws-faction-soft, rgba(45, 212, 145, 0.12));
+  border: 1px solid var(--ws-faction);
+  color: var(--ws-faction);
+}
+.ws-map-selbar-group:hover {
+  background: var(--ws-faction);
+  color: #04120b;
 }
 .ws-map-selbar-del {
   background: rgba(226, 96, 96, 0.1);
@@ -578,6 +588,7 @@
   border-color: var(--ws-faction);
   color: var(--ws-faction);
 }
+.ws-map-selbar-group:focus-visible,
 .ws-map-selbar-del:focus-visible,
 .ws-map-selbar-clear:focus-visible {
   outline: 2px solid var(--ws-faction);

--- a/internal/web/static/js/modules/workspace-hub.js
+++ b/internal/web/static/js/modules/workspace-hub.js
@@ -3501,9 +3501,18 @@ console.log('[workspace-hub.js] FILE LOADED');
     }
   }
 
-  // Reset and open the Create Group modal (used by the toolbar button and the
-  // Cmd/Ctrl+G shortcut).
-  function openCreateGroupModal() {
+  // When set, the Create Group modal groups this explicit id set instead of the
+  // List view's checkbox selection. The Map view's "Group selected" action uses
+  // it to funnel its own multi-select set through the same modal + create flow.
+  // Reset to null on every modal open so a cancelled map-group never leaks into
+  // a later List-view group.
+  let pendingGroupMemberIds = null;
+
+  // Reset and open the Create Group modal. Called by the List toolbar button,
+  // the Cmd/Ctrl+G shortcut (no arg → group the List selection), and the Map
+  // view's "Group selected" action (memberIds → group that explicit set).
+  function openCreateGroupModal(memberIds) {
+    pendingGroupMemberIds = Array.isArray(memberIds) && memberIds.length ? memberIds.slice() : null;
     if (!elements.launcherGroupModal || typeof bootstrap === 'undefined' || !bootstrap.Modal) return;
     const modal = bootstrap.Modal.getInstance(elements.launcherGroupModal) || new bootstrap.Modal(elements.launcherGroupModal);
     if (elements.launcherGroupNameInput) elements.launcherGroupNameInput.value = '';
@@ -3514,10 +3523,11 @@ console.log('[workspace-hub.js] FILE LOADED');
   }
 
   async function createGroupFromSelection() {
-    // Top-level ids only: moving a checked group into the new group carries its
-    // members with it, so we must not also move the members (that would flatten
-    // them out of their group).
-    const selected = getTopLevelSelectedIds();
+    // Map view supplies an explicit id set; List view derives one from its
+    // checkbox selection. Top-level ids only: moving a checked group into the
+    // new group carries its members with it, so we must not also move the
+    // members (that would flatten them out of their group).
+    const selected = pendingGroupMemberIds || getTopLevelSelectedIds();
     if (selected.length === 0) return;
 
     const name = (elements.launcherGroupNameInput?.value || '').trim();
@@ -3568,7 +3578,9 @@ console.log('[workspace-hub.js] FILE LOADED');
       if (elements.launcherGroupDescriptionInput) elements.launcherGroupDescriptionInput.value = '';
       if (elements.launcherGroupEntryAgentSelect) elements.launcherGroupEntryAgentSelect.value = '';
 
-      // Reset selection + refresh
+      // Reset selection + refresh. Clearing the List selection is harmless when
+      // the members came from the Map view (that selection set is empty).
+      pendingGroupMemberIds = null;
       clearLauncherSelection({ render: false });
       await loadWorkspaces();
     } catch (err) {
@@ -4671,6 +4683,9 @@ console.log('[workspace-hub.js] FILE LOADED');
   // Batch delete (confirm + Trash + Undo) reused by the Map view's multi-select
   // action bar; also reloads on success, which re-mounts the map.
   window.WorkspaceHub.deleteWorkspaces = confirmAndDeleteWorkspaces;
+  // Group an explicit id set (the Map view's multi-select) via the shared Create
+  // Group modal + create/reparent flow; reloads on success, re-mounting the map.
+  window.WorkspaceHub.groupWorkspaces = (ids) => openCreateGroupModal(ids);
   window.WorkspaceHub.__test = {
     getLauncherCardDropIntent,
     getLauncherTreeDropIntent,

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -342,6 +342,7 @@
       '<div class="ws-map-selbar" data-ws-selbar' + (n ? '' : ' hidden') + '>' +
       '<span class="ws-map-selbar-count" data-ws-selbar-count>' + n + ' selected</span>' +
       '<div class="ws-map-selbar-actions">' +
+      '<button type="button" class="ws-map-selbar-group" data-ws-selbar-group>⊕ Group</button>' +
       '<button type="button" class="ws-map-selbar-del" data-ws-selbar-delete>✕ Delete</button>' +
       '<button type="button" class="ws-map-selbar-clear" data-ws-selbar-clear>Clear</button>' +
       '</div>' +
@@ -552,7 +553,6 @@
       '<div class="ws-map-theatre-tag"><span class="ws-map-ix">MAP</span><h3>All Workspaces</h3></div>' +
       '<div class="ws-map-compass">N<b>▲</b></div>' +
       canvas +
-      selBarHTML() +
       '</section>' +
       '<aside class="ws-map-overview" role="region" aria-label="Workspace overview">' +
       '<div class="ws-map-overview-head"><div><span class="ws-map-ix">WS</span> <h3>Overview</h3></div></div>' +
@@ -560,7 +560,13 @@
       overviewBodyHTML(findWs(workspaces, selectedId), options) +
       '</div>' +
       '</aside>' +
-      '</div>'
+      '</div>' +
+      // The selbar is position:fixed, so it must live OUTSIDE .ws-map-theatre —
+      // that panel's clip-path + overflow:hidden would otherwise clip the bar
+      // (fixed descendants are still clipped by an ancestor's clip-path), making
+      // it invisible at the viewport bottom. Kept inside the container so
+      // bindSelBar/updateSelBar still resolve it.
+      selBarHTML()
     );
   }
 
@@ -725,7 +731,19 @@
     }
   }
 
+  function groupMulti() {
+    var ids = multiIds();
+    if (!ids.length) return;
+    // Reuse the hub's Create Group modal + create/reparent flow. On success it
+    // reloads and re-mounts the map, where mount() prunes the grouped ids.
+    if (window.WorkspaceHub && typeof window.WorkspaceHub.groupWorkspaces === 'function') {
+      window.WorkspaceHub.groupWorkspaces(ids);
+    }
+  }
+
   function bindSelBar(container) {
+    var group = container.querySelector('[data-ws-selbar-group]');
+    if (group) group.addEventListener('click', function () { groupMulti(); });
     var del = container.querySelector('[data-ws-selbar-delete]');
     if (del) del.addEventListener('click', function () { deleteMulti(); });
     var clr = container.querySelector('[data-ws-selbar-clear]');
@@ -811,6 +829,7 @@
     computeStats: computeStats,
     computeMaxCols: computeMaxCols,
     tileHTML: tileHTML,
-    overviewBodyHTML: overviewBodyHTML
+    overviewBodyHTML: overviewBodyHTML,
+    selBarHTML: selBarHTML
   };
 })();

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -334,3 +334,11 @@ test('overviewBodyHTML labels the delete action "Delete group" for group workspa
   const html = overviewBodyHTML({ id: 'grp-1', name: 'Research Fleet', kind: 'group' });
   assert.match(html, /data-ws-delete="grp-1"[^>]*>✕ Delete group</);
 });
+
+test('selBarHTML offers group, delete, and clear actions for the multi-select set', () => {
+  const { selBarHTML } = loadOriWorkspaceMap();
+  const html = selBarHTML();
+  assert.match(html, /data-ws-selbar-group/);
+  assert.match(html, /data-ws-selbar-delete/);
+  assert.match(html, /data-ws-selbar-clear/);
+});


### PR DESCRIPTION
## What

Adds a **Group** action to the Workspace **Map** view's multi-select bar, and fixes a bug that made the whole bar invisible.

### Group selected workspaces
- New **⊕ Group** button in the map's multi-select action bar. It reuses the List view's Create Group modal + create/reparent flow via a new `WorkspaceHub.groupWorkspaces(ids)` entry point, so both views share one code path (create group workspace → PATCH `parent_id` on each selected workspace → reload).
- The hub's group-create flow now accepts an explicit member-id set (`pendingGroupMemberIds`, reset on every modal open so a cancelled map-group can't leak into a later List-view group).

### Fix: multi-select bar was clipped away
- The action bar is `position: fixed` but was rendered inside `.ws-map-theatre`, whose `clip-path` + `overflow: hidden` clip **all** descendants — including fixed ones — so the bar (pinned to the viewport bottom, outside the theatre box) was scissored off and never visible.
- Moved `selBarHTML()` to the unclipped `.ws-map` root. This also restores the pre-existing **Delete** and **Clear** actions, which had the same problem since they shipped in #171.

## Why
Users could multi-select tiles on the map (checkbox / Cmd·Ctrl·Shift-click) but had no way to group them there, and the intended Delete/Clear bar was invisible due to the clipping bug.

## Testing
- `node --test workspace-map.test.js` — 26/26 pass (added a `selBarHTML` assertion)
- `node --test workspace-hub.test.js` — 27/27 pass
- `go build ./cmd/server` clean; eslint clean
- Verified live: multi-select on the map now shows **⊕ Group · ✕ Delete · Clear** bottom-center; Group creates a group and reparents the selected workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)