### PR TITLE
feat(workspace): add agent command deck

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -24,7 +24,7 @@
   /* ink */
   --ws-ink: #d6d9de;
   --ws-ink-dim: #8b909a;
-  --ws-ink-faint: #5a5f6a;
+  --ws-ink-faint: #7d838e;
 
   /* semantic accents */
   --ws-faction: #46d39a;
@@ -451,6 +451,22 @@
   color: var(--ws-faction);
   border-color: var(--ws-faction-deep);
   background: rgba(70, 211, 154, 0.07);
+}
+.ws-cmd-mission-status.is-running {
+  color: var(--ws-idle);
+  border-color: color-mix(in srgb, var(--ws-idle) 46%, var(--ws-line));
+  background: color-mix(in srgb, var(--ws-idle) 8%, transparent);
+}
+.ws-cmd-mission-status.is-completed {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.07);
+}
+.ws-cmd-mission-status.is-failed,
+.ws-cmd-mission-status.is-blocked {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.42);
+  background: rgba(226, 101, 77, 0.07);
 }
 .ws-cmd-mission-status.is-paused,
 .ws-cmd-mission-status.is-manual {
@@ -1332,6 +1348,714 @@
   outline-offset: 2px;
 }
 
+/* ---------- agent command deck ---------- */
+.ws-cmd-garrison {
+  position: relative;
+  padding: 0;
+  overflow: hidden;
+  background:
+    linear-gradient(rgba(70, 211, 154, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(70, 211, 154, 0.025) 1px, transparent 1px),
+    linear-gradient(180deg, var(--ws-panel), #0f1014);
+  background-size:
+    28px 28px,
+    28px 28px,
+    auto;
+}
+.ws-cmd-deck {
+  display: grid;
+  grid-template-columns: minmax(170px, 0.62fr) minmax(220px, 0.85fr) minmax(320px, 1.45fr);
+  min-height: 540px;
+}
+.ws-cmd-roster,
+.ws-cmd-agent-stage,
+.ws-cmd-agent-overview {
+  min-width: 0;
+}
+.ws-cmd-roster {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--ws-line);
+  background: rgba(7, 8, 11, 0.58);
+}
+.ws-cmd-roster-head {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-roster-head > div {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+.ws-cmd-roster-head span,
+.ws-cmd-stage-kicker,
+.ws-cmd-overview-label,
+.ws-cmd-loadout-kicker,
+.ws-cmd-unassigned-kicker {
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.7px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-roster-head strong {
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  color: var(--ws-faction);
+}
+.ws-cmd-roster-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ws-line-bright) transparent;
+}
+.ws-cmd-roster-item {
+  position: relative;
+  width: 100%;
+  min-height: 78px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0 0 6px;
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ws-ink);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+}
+.ws-cmd-roster-item::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px -1px;
+  width: 2px;
+  background: transparent;
+}
+.ws-cmd-roster-item:hover {
+  border-color: var(--ws-line-bright);
+  background: rgba(255, 255, 255, 0.025);
+}
+.ws-cmd-roster-item.is-selected {
+  border-color: rgba(70, 211, 154, 0.45);
+  background: linear-gradient(90deg, rgba(70, 211, 154, 0.13), rgba(70, 211, 154, 0.025));
+  transform: translateX(2px);
+}
+.ws-cmd-roster-item.is-selected::before {
+  background: var(--ws-faction);
+  box-shadow: 0 0 12px var(--ws-faction);
+}
+.ws-cmd-roster-item.is-entry.is-selected {
+  border-color: rgba(232, 181, 75, 0.45);
+  background: linear-gradient(90deg, rgba(232, 181, 75, 0.13), rgba(232, 181, 75, 0.025));
+}
+.ws-cmd-roster-item.is-entry.is-selected::before {
+  background: var(--ws-keeper);
+  box-shadow: 0 0 12px var(--ws-keeper);
+}
+.ws-cmd-roster-item:focus-visible,
+.ws-cmd-agent-tab:focus-visible,
+.ws-cmd-agent-action:focus-visible,
+.ws-cmd-loadout-edit:focus-visible,
+.ws-cmd-activity-item:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-roster-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.ws-cmd-roster-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.45px;
+  text-transform: uppercase;
+  color: #f3f5f8;
+}
+.ws-cmd-roster-role {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-roster-copy .ws-cmd-state {
+  margin-top: 1px;
+  font-size: 8px;
+}
+.ws-cmd-roster-entry,
+.ws-cmd-roster-count {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 2px 4px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  font-family: var(--ws-font-mono);
+  font-size: 7px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-roster-entry {
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+}
+.ws-cmd-roster-count {
+  top: auto;
+  bottom: 6px;
+}
+.ws-cmd-character {
+  --character-accent: hsl(var(--agent-character-hue) 64% 54%);
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.28));
+}
+.ws-cmd-character.is-roster {
+  width: 46px;
+  height: 58px;
+}
+.ws-cmd-character.is-stage {
+  width: min(220px, 82%);
+  aspect-ratio: 100 / 118;
+}
+.ws-cmd-character svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+.ws-cmd-character-body {
+  fill: color-mix(in srgb, var(--character-accent) 20%, #12171c);
+  stroke: color-mix(in srgb, var(--character-accent) 56%, var(--ws-line-bright));
+  stroke-width: 2;
+}
+.ws-cmd-character-head {
+  fill: color-mix(in srgb, var(--character-accent) 28%, #151a20);
+  stroke: var(--character-accent);
+  stroke-width: 2;
+}
+.ws-cmd-character-visor {
+  fill: color-mix(in srgb, var(--character-accent) 70%, white);
+  opacity: 0.9;
+  filter: drop-shadow(0 0 5px var(--character-accent));
+}
+.ws-cmd-character-shoulders,
+.ws-cmd-character-line {
+  fill: none;
+  stroke: color-mix(in srgb, var(--character-accent) 70%, var(--ws-line-bright));
+  stroke-width: 2;
+}
+.ws-cmd-character-line.is-soft {
+  opacity: 0.36;
+}
+.ws-cmd-character-emblem {
+  fill: var(--character-accent);
+  filter: drop-shadow(0 0 4px var(--character-accent));
+}
+.ws-cmd-character.alert {
+  --character-accent: var(--ws-alert);
+}
+.ws-cmd-character.working {
+  --character-accent: var(--ws-working);
+}
+.ws-cmd-agent-stage {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: hidden;
+  border-right: 1px solid var(--ws-line);
+  padding: 18px 16px 16px;
+  background:
+    radial-gradient(circle at 50% 34%, rgba(70, 211, 154, 0.13), transparent 48%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+}
+.ws-cmd-agent-stage.alert {
+  background:
+    radial-gradient(circle at 50% 34%, rgba(226, 101, 77, 0.14), transparent 48%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+}
+.ws-cmd-stage-grid {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  opacity: 0.28;
+  background:
+    linear-gradient(90deg, transparent 49.5%, rgba(70, 211, 154, 0.15) 50%, transparent 50.5%),
+    repeating-linear-gradient(0deg, transparent 0 23px, rgba(255, 255, 255, 0.035) 24px);
+  mask-image: linear-gradient(to bottom, black, transparent 80%);
+}
+.ws-cmd-stage-character {
+  min-height: 220px;
+  width: 100%;
+  display: grid;
+  place-items: center;
+}
+.ws-cmd-stage-copy {
+  width: 100%;
+  text-align: center;
+}
+.ws-cmd-stage-copy h3 {
+  margin: 5px 0 7px;
+  font-size: clamp(17px, 2vw, 22px);
+  letter-spacing: 0.75px;
+  text-transform: uppercase;
+  color: #f3f5f8;
+}
+.ws-cmd-stage-badges {
+  min-height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.ws-cmd-stage-role {
+  margin: 8px 0;
+  color: var(--ws-ink-dim);
+  font-size: 12px;
+}
+.ws-cmd-stage-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin: 0;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-stage-status strong {
+  color: var(--ws-ink);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+.ws-cmd-stage-actions {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding-top: 16px;
+}
+.ws-cmd-agent-action,
+.ws-cmd-loadout-edit {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: var(--ws-bg-2);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  text-decoration: none;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.ws-cmd-agent-action:hover,
+.ws-cmd-loadout-edit:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  text-decoration: none;
+}
+.ws-cmd-agent-action.is-primary {
+  color: #06120d;
+  border-color: var(--ws-faction);
+  background: var(--ws-faction);
+}
+.ws-cmd-agent-action.is-danger:hover {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.48);
+}
+.ws-cmd-agent-lock {
+  align-self: center;
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  color: var(--ws-keeper);
+  text-transform: uppercase;
+}
+.ws-cmd-agent-overview {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: rgba(12, 13, 16, 0.72);
+}
+.ws-cmd-agent-tabs {
+  display: flex;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--ws-line);
+  scrollbar-width: thin;
+}
+.ws-cmd-agent-tab {
+  position: relative;
+  min-height: 54px;
+  flex: 1 0 auto;
+  padding: 10px 11px;
+  border: 0;
+  border-right: 1px solid var(--ws-line);
+  background: transparent;
+  color: var(--ws-ink-faint);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 8.5px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.ws-cmd-agent-tab::after {
+  content: "";
+  position: absolute;
+  inset: auto 10px 0;
+  height: 2px;
+  background: transparent;
+}
+.ws-cmd-agent-tab:hover {
+  color: var(--ws-ink);
+  background: rgba(255, 255, 255, 0.025);
+}
+.ws-cmd-agent-tab.is-active {
+  color: var(--ws-faction);
+}
+.ws-cmd-agent-tab.is-active::after {
+  background: var(--ws-faction);
+  box-shadow: 0 0 9px var(--ws-faction);
+}
+.ws-cmd-agent-panel-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 486px;
+  overflow: auto;
+  padding: 16px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ws-line-bright) transparent;
+}
+.ws-cmd-agent-tabpanel[hidden] {
+  display: none;
+}
+.ws-cmd-overview-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-overview-hero > div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.ws-cmd-overview-hero strong {
+  color: #f1f3f6;
+  font-size: 14px;
+}
+.ws-cmd-overview-hero p,
+.ws-cmd-overview-brief p {
+  margin: 0;
+  color: var(--ws-ink-dim);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.ws-cmd-overview-signal {
+  flex: 0 0 auto;
+  padding: 3px 6px;
+  border: 1px solid var(--ws-line-bright);
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.ws-cmd-overview-signal.working {
+  color: var(--ws-working);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-overview-signal.alert {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.42);
+}
+.ws-cmd-overview-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 10px;
+}
+.ws-cmd-overview-stats > div {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.13);
+}
+.ws-cmd-overview-stats span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--ws-font-mono);
+  font-size: 7.5px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-overview-stats strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 17px;
+}
+.ws-cmd-overview-brief {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  align-items: baseline;
+  margin-top: 12px;
+  padding: 12px 2px;
+}
+.ws-cmd-agent-tabpanel .ws-cmd-questlog {
+  margin: 0;
+}
+.ws-cmd-agent-task-list {
+  display: grid;
+  gap: 7px;
+}
+.ws-cmd-agent-task-list .workspace-detail-item {
+  margin: 0;
+}
+.ws-cmd-loadout-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 9px;
+}
+.ws-cmd-loadout-card {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.16);
+}
+.ws-cmd-loadout-card:first-child {
+  grid-column: 1 / -1;
+}
+.ws-cmd-loadout-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 9px;
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-loadout-card strong {
+  color: #f1f3f6;
+  font-family: var(--ws-font-mono);
+  font-size: 12px;
+}
+.ws-cmd-loadout-edit {
+  min-height: 24px;
+  padding: 4px 7px;
+  font-size: 8px;
+}
+.ws-cmd-loadout-readonly {
+  font-size: 8px;
+  text-transform: uppercase;
+}
+.ws-cmd-loadout-chips {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+.ws-cmd-loadout-chip {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 3px 6px;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+}
+.ws-cmd-loadout-chip.skill {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-loadout-chip.mcp {
+  color: var(--ws-idle);
+}
+.ws-cmd-loadout-empty {
+  color: var(--ws-ink-faint);
+  font-size: 10px;
+  font-style: italic;
+}
+.ws-cmd-loadout-prompt {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 9px;
+  padding: 12px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.2);
+}
+.ws-cmd-loadout-prompt > div {
+  min-width: 0;
+}
+.ws-cmd-loadout-title {
+  color: var(--ws-ink);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.ws-cmd-loadout-prompt p {
+  margin: 5px 0 0;
+  color: var(--ws-ink-dim);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+.ws-cmd-loadout-prompt.is-error {
+  border-color: rgba(226, 101, 77, 0.42);
+}
+.ws-cmd-activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ws-cmd-activity-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  padding: 10px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.15);
+  color: var(--ws-ink);
+  text-align: left;
+  cursor: pointer;
+}
+.ws-cmd-activity-item:hover {
+  border-color: var(--ws-line-bright);
+  background: rgba(255, 255, 255, 0.025);
+}
+.ws-cmd-activity-kind {
+  padding: 3px 5px;
+  border: 1px solid var(--ws-faction-deep);
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 7.5px;
+  text-transform: uppercase;
+}
+.ws-cmd-activity-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ws-cmd-activity-copy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+.ws-cmd-activity-copy span,
+.ws-cmd-activity-item time {
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  text-transform: capitalize;
+}
+.ws-cmd-tab-empty,
+.ws-cmd-deck-empty {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 7px;
+  min-height: 220px;
+  padding: 24px;
+  text-align: center;
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-tab-empty strong,
+.ws-cmd-deck-empty strong {
+  color: var(--ws-ink);
+  text-transform: uppercase;
+}
+.ws-cmd-tab-empty span,
+.ws-cmd-deck-empty span {
+  font-size: 11px;
+}
+.ws-cmd-deck-empty-glyph {
+  color: var(--ws-faction);
+  font-size: 44px;
+  text-shadow: 0 0 18px rgba(70, 211, 154, 0.5);
+}
+.ws-cmd-unassigned {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 8px;
+  align-items: center;
+  margin: 8px;
+  padding: 9px;
+  border: 1px dashed rgba(232, 181, 75, 0.45);
+  background: rgba(232, 181, 75, 0.045);
+}
+.ws-cmd-unassigned > div {
+  min-width: 0;
+}
+.ws-cmd-unassigned strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ws-keeper);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.ws-cmd-unassigned-count {
+  grid-row: 1 / 3;
+  grid-column: 2;
+  color: var(--ws-keeper);
+  font-family: var(--ws-font-mono);
+  font-size: 16px;
+}
+.ws-cmd-unassigned .ws-cmd-agent-action {
+  grid-column: 1 / -1;
+  min-height: 25px;
+  margin-top: 3px;
+  padding: 4px 7px;
+  color: var(--ws-keeper);
+  border-color: var(--ws-keeper-deep);
+}
+.ws-cmd-mission.is-empty {
+  min-height: 0;
+  max-height: 160px;
+}
+
 /* ---------- stat manager modal (agents / tasks / mcp / skills) ---------- */
 /* Lives inside the .ws-cmd container so it inherits the tactical tokens, but is
    position:fixed so it overlays the viewport regardless of scroll position. */
@@ -1704,7 +2428,7 @@
 
   --ws-ink: #1f2128;
   --ws-ink-dim: #5c5c5e;
-  --ws-ink-faint: #737a84;
+  --ws-ink-faint: #626a74;
   --ws-ink-heading: #0a0a0a;
 
   --ws-faction: #1f6b4e;
@@ -1727,6 +2451,10 @@
 [data-bs-theme="light"] .ws-cmd-panel-title h4,
 [data-bs-theme="light"] .ws-cmd-rail-t,
 [data-bs-theme="light"] .ws-cmd-unit-name,
+[data-bs-theme="light"] .ws-cmd-roster-name,
+[data-bs-theme="light"] .ws-cmd-stage-copy h3,
+[data-bs-theme="light"] .ws-cmd-overview-hero strong,
+[data-bs-theme="light"] .ws-cmd-loadout-card strong,
 [data-bs-theme="light"] .ws-cmd-rv,
 [data-bs-theme="light"] .ws-cmd-q-name,
 [data-bs-theme="light"] .ws-cmd-modal-title,
@@ -1753,6 +2481,25 @@
   background: linear-gradient(165deg, var(--ws-panel-2), var(--ws-panel-deep));
 }
 
+[data-bs-theme="light"] .ws-cmd-roster,
+[data-bs-theme="light"] .ws-cmd-agent-overview {
+  background: rgba(247, 248, 249, 0.78);
+}
+
+[data-bs-theme="light"] .ws-cmd-agent-stage {
+  background:
+    radial-gradient(circle at 50% 34%, rgba(31, 107, 78, 0.12), transparent 48%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.52), transparent);
+}
+
+[data-bs-theme="light"] .ws-cmd-overview-hero,
+[data-bs-theme="light"] .ws-cmd-overview-stats > div,
+[data-bs-theme="light"] .ws-cmd-loadout-card,
+[data-bs-theme="light"] .ws-cmd-loadout-prompt,
+[data-bs-theme="light"] .ws-cmd-activity-item {
+  background: rgba(255, 255, 255, 0.62);
+}
+
 [data-bs-theme="light"] .ws-cmd-identity-editor,
 [data-bs-theme="light"] .ws-cmd-files-drop,
 [data-bs-theme="light"] .ws-cmd-files-browse,
@@ -1769,6 +2516,34 @@
 
 [data-bs-theme="light"] .ws-cmd-q-run:hover {
   color: var(--ws-on-accent);
+}
+
+[data-bs-theme="light"] .ws-cmd-agent-action.is-primary {
+  color: var(--ws-on-accent);
+}
+
+@media (max-width: 1199px) {
+  .ws-cmd-mission.is-empty {
+    max-height: none;
+  }
+  .ws-cmd-deck {
+    grid-template-columns: minmax(220px, 0.8fr) minmax(340px, 1.2fr);
+  }
+  .ws-cmd-roster {
+    grid-column: 1 / -1;
+    border-right: 0;
+    border-bottom: 1px solid var(--ws-line);
+  }
+  .ws-cmd-roster-list {
+    display: flex;
+    gap: 6px;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+  .ws-cmd-roster-item {
+    flex: 0 0 210px;
+    margin-bottom: 0;
+  }
 }
 
 @media (max-width: 1100px) {
@@ -1811,6 +2586,34 @@
     max-height: none;
   }
 }
+@media (max-width: 767px) {
+  .ws-cmd-deck {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ws-cmd-agent-stage {
+    min-height: 450px;
+    border-right: 0;
+    border-bottom: 1px solid var(--ws-line);
+  }
+  .ws-cmd-agent-panel-body {
+    max-height: none;
+  }
+  .ws-cmd-overview-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .ws-cmd-loadout-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ws-cmd-loadout-card:first-child {
+    grid-column: auto;
+  }
+  .ws-cmd-activity-item {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+  .ws-cmd-activity-item time {
+    grid-column: 2;
+  }
+}
 @media (max-width: 640px) {
   .ws-cmd-nav-btn {
     flex: 1 1 calc(50% - 8px);
@@ -1836,6 +2639,22 @@
   .ws-cmd-mission-actions .ws-cmd-mission-btn {
     flex: 1 1 calc(50% - 8px);
   }
+  .ws-cmd-agent-stage {
+    min-height: 420px;
+  }
+  .ws-cmd-stage-character {
+    min-height: 190px;
+  }
+  .ws-cmd-agent-tab {
+    min-width: max-content;
+  }
+  .ws-cmd-overview-hero,
+  .ws-cmd-loadout-prompt {
+    flex-direction: column;
+  }
+  .ws-cmd-overview-brief {
+    grid-template-columns: 1fr;
+  }
   /* Reserve space for the floating Workspace Assistant FAB so the last rail/panel
      controls are never trapped underneath it (PRD FR5.20). */
   .ws-cmd {
@@ -1855,6 +2674,16 @@
     opacity: 0.35;
   }
 }
+@keyframes ws-cmd-character-breathe {
+  50% {
+    transform: translateY(-4px) scale(1.012);
+  }
+}
+@keyframes ws-cmd-character-scan {
+  50% {
+    opacity: 0.58;
+  }
+}
 @media (prefers-reduced-motion: no-preference) {
   .ws-cmd-topbar {
     animation: ws-cmd-rise 0.35s ease both;
@@ -1867,6 +2696,12 @@
   }
   .ws-cmd-led.working {
     animation: ws-cmd-pulse 1.5s ease-in-out infinite;
+  }
+  .ws-cmd-agent-stage .ws-cmd-character.is-stage {
+    animation: ws-cmd-character-breathe 3.8s ease-in-out infinite;
+  }
+  .ws-cmd-character.working .ws-cmd-character-visor {
+    animation: ws-cmd-character-scan 1.25s ease-in-out infinite;
   }
   .ws-cmd-modal-panel {
     animation: ws-cmd-rise 0.22s ease both;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -8,6 +8,7 @@
  */
 // Legacy view preference from the deleted Detailed/Command toggle; cleared on boot.
 const LEGACY_STORAGE_KEY = 'oriWorkspaceDetailView';
+const AGENT_TAB_KEYS = ['overview', 'tasks', 'loadout', 'recent'];
 
 function escapeHtml(value) {
   return String(value == null ? '' : value).replace(/[&<>"']/g, function (c) {
@@ -37,8 +38,17 @@ export class WorkspaceCommandView {
     this.commandTagError = '';
     this.activeSystemTab = 'memory';
     this.activeToolsTab = 'mcp';
+    this.selectedAgentKey = '';
+    this.agentSelectionInitialized = false;
+    this.activeAgentTab = 'overview';
+    this.agentRosterScroll = { top: 0, left: 0 };
+    this.agentOverviewScroll = 0;
+    this.pendingAgentFocusKey = '';
+    this.pendingAgentTabFocus = '';
+    this.agentPromptLoadingKey = '';
+    this.lastAnnouncedAgentStatus = '';
     this.sharedSurfaceAnchors = {};
-    this.boundGlobalKeydown = (event) => this.handleGlobalKeydown(event);
+    this.boundGlobalKeydown = event => this.handleGlobalKeydown(event);
     this.setup();
   }
 
@@ -51,7 +61,11 @@ export class WorkspaceCommandView {
   // The Detailed view (and its toggle) is gone: drop the stale localStorage
   // preference and strip any lingering ?view= param from deep links.
   retireLegacyViewPreference() {
-    try { localStorage.removeItem(LEGACY_STORAGE_KEY); } catch (err) { /* storage may be unavailable */ }
+    try {
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
+    } catch (err) {
+      /* storage may be unavailable */
+    }
     try {
       const params = new URLSearchParams(window.location.search);
       if (params.has('view')) {
@@ -94,7 +108,7 @@ export class WorkspaceCommandView {
     let agents = 0;
     try {
       agents = (page.buildAgentGroups() || []).filter(
-        (g) => g.isWorkspaceAgent && !g.isUnassigned
+        g => g.isWorkspaceAgent && !g.isUnassigned
       ).length;
     } catch (err) {
       agents = Array.isArray(ws.agent_instances) ? ws.agent_instances.length : 0;
@@ -102,7 +116,7 @@ export class WorkspaceCommandView {
     // Canonical "open" = pending + in-progress, matching the server-side
     // open_task_count Map/Cards/Tree all read (see workspace.ComputeMapSummaryFields).
     const tasks = Array.isArray(page.tasks) ? page.tasks : [];
-    const openTasks = tasks.filter((t) => {
+    const openTasks = tasks.filter(t => {
       const s = String((t && t.status) || '').toLowerCase();
       return s === 'pending' || s === 'in_progress';
     }).length;
@@ -118,18 +132,27 @@ export class WorkspaceCommandView {
     const settings = ws.workspace_settings || {};
     const mode = String((settings.workflow && settings.workflow.mode) || '').toLowerCase();
     switch (mode) {
-      case 'guided': return 'Guided';
-      case 'direct': return 'Direct';
-      case 'plan_then_execute': return 'Autonomous';
-      case '': return '';
-      default: return mode.charAt(0).toUpperCase() + mode.slice(1);
+      case 'guided':
+        return 'Guided';
+      case 'direct':
+        return 'Direct';
+      case 'plan_then_execute':
+        return 'Autonomous';
+      case '':
+        return '';
+      default:
+        return mode.charAt(0).toUpperCase() + mode.slice(1);
     }
   }
 
   missionSummary() {
     const mission = typeof window !== 'undefined' ? window.workspaceMission : null;
     if (mission && typeof mission.getSummary === 'function') {
-      try { return mission.getSummary() || {}; } catch (err) { return {}; }
+      try {
+        return mission.getSummary() || {};
+      } catch (err) {
+        return {};
+      }
     }
     return {};
   }
@@ -149,15 +172,24 @@ export class WorkspaceCommandView {
   workspaceTags() {
     const page = this.page || {};
     if (typeof page.getWorkspaceTags === 'function') {
-      try { return page.getWorkspaceTags(); } catch (err) { return []; }
+      try {
+        return page.getWorkspaceTags();
+      } catch (err) {
+        return [];
+      }
     }
     const ws = page.workspace || {};
-    return Array.isArray(ws.tags) ? ws.tags.map(tag => String(tag || '').trim()).filter(Boolean) : [];
+    return Array.isArray(ws.tags)
+      ? ws.tags.map(tag => String(tag || '').trim()).filter(Boolean)
+      : [];
   }
 
   workflowHref() {
     const page = this.page || {};
-    if (typeof page.collectWorkspaceWorkflowReferences === 'function' && typeof page.buildBehaviorStudioHref === 'function') {
+    if (
+      typeof page.collectWorkspaceWorkflowReferences === 'function' &&
+      typeof page.buildBehaviorStudioHref === 'function'
+    ) {
       try {
         const refs = page.collectWorkspaceWorkflowReferences();
         if (Array.isArray(refs) && refs.length === 1) {
@@ -186,14 +218,28 @@ export class WorkspaceCommandView {
 
   statBoxHTML(value, label, sectionKey, ariaLabel, extraClass = '') {
     const className = ('ws-cmd-stat ' + String(extraClass || '')).trim();
-    return '<button type="button" class="' + escapeHtml(className) + '" data-cmd-section="' + escapeHtml(sectionKey) +
-      '" aria-label="' + escapeHtml(ariaLabel) + '"><div class="ws-v">' + escapeHtml(value) +
-      '</div><div class="ws-l">' + escapeHtml(label) + '</div></button>';
+    return (
+      '<button type="button" class="' +
+      escapeHtml(className) +
+      '" data-cmd-section="' +
+      escapeHtml(sectionKey) +
+      '" aria-label="' +
+      escapeHtml(ariaLabel) +
+      '"><div class="ws-v">' +
+      escapeHtml(value) +
+      '</div><div class="ws-l">' +
+      escapeHtml(label) +
+      '</div></button>'
+    );
   }
 
   isGroupWorkspace() {
     const ws = (this.page && this.page.workspace) || {};
-    return String(ws.kind || '').trim().toLowerCase() === 'group';
+    return (
+      String(ws.kind || '')
+        .trim()
+        .toLowerCase() === 'group'
+    );
   }
 
   hexToRgba(hex, alpha) {
@@ -236,7 +282,8 @@ export class WorkspaceCommandView {
       : '';
     const tags = this.workspaceTags();
     const isLongDescription = Array.from(description).length > 150;
-    const descriptionClass = 'ws-cmd-description' +
+    const descriptionClass =
+      'ws-cmd-description' +
       (!description ? ' is-empty' : '') +
       (isLongDescription && !this.identityExpanded ? ' is-collapsed' : '');
     const descriptionText = description || 'No description';
@@ -245,44 +292,83 @@ export class WorkspaceCommandView {
     const subtitle = this.commandSubtitle(mode);
 
     return (
-      '<header class="ws-cmd-topbar' + (isGroup ? ' is-group' : '') + '"' + this.groupAccentStyle(ws) + '>' +
+      '<header class="ws-cmd-topbar' +
+      (isGroup ? ' is-group' : '') +
+      '"' +
+      this.groupAccentStyle(ws) +
+      '>' +
       '<div class="ws-cmd-nav">' +
       '<a class="ws-cmd-nav-btn" href="/workspaces" aria-label="Back to workspaces">Workspaces</a>' +
-      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(this.workspaceRoute('/canvas')) + '">Canvas</a>' +
-      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(this.workspaceRoute('/diagnostics')) + '">Diagnostics</a>' +
-      '<a class="ws-cmd-nav-btn" href="' + escapeHtml(workflowHref) + '">Orchestration Skills</a>' +
+      '<a class="ws-cmd-nav-btn" href="' +
+      escapeHtml(this.workspaceRoute('/canvas')) +
+      '">Canvas</a>' +
+      '<a class="ws-cmd-nav-btn" href="' +
+      escapeHtml(this.workspaceRoute('/diagnostics')) +
+      '">Diagnostics</a>' +
+      '<a class="ws-cmd-nav-btn" href="' +
+      escapeHtml(workflowHref) +
+      '">Orchestration Skills</a>' +
       '</div>' +
       '<div class="ws-cmd-crest">' +
       '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">' +
       '<path d="M3 21V9l9-6 9 6v12"/><path d="M9 21v-6h6v6"/><path d="M3 21h18"/></svg>' +
       '</div>' +
       '<div class="ws-cmd-title">' +
-      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">' + escapeHtml(kicker) + '</span></div>' +
+      '<div class="ws-kicker"><span class="ws-dot"></span><span class="ws-tick">' +
+      escapeHtml(kicker) +
+      '</span></div>' +
       '<div class="ws-cmd-title-row">' +
-      '<h2>' + escapeHtml(name) + '</h2>' +
+      '<h2>' +
+      escapeHtml(name) +
+      '</h2>' +
       groupBadge +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="name" aria-label="Edit workspace name">Edit</button>' +
       '</div>' +
       '<div class="ws-sub" id="workspace-command-subtitle" data-workflow-label="' +
-      escapeHtml(workflowLabel) + '"' + (subtitle ? '' : ' hidden') + '>' + escapeHtml(subtitle) + '</div>' +
+      escapeHtml(workflowLabel) +
+      '"' +
+      (subtitle ? '' : ' hidden') +
+      '>' +
+      escapeHtml(subtitle) +
+      '</div>' +
       '<div class="ws-cmd-description-row">' +
-      '<p class="' + descriptionClass + '">' + escapeHtml(descriptionText) + '</p>' +
+      '<p class="' +
+      descriptionClass +
+      '">' +
+      escapeHtml(descriptionText) +
+      '</p>' +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="description" aria-label="Edit workspace description and intent">Edit</button>' +
       (isLongDescription
         ? '<button type="button" class="ws-cmd-mini-btn" data-cmd-toggle-description aria-expanded="' +
-          (this.identityExpanded ? 'true' : 'false') + '">' + (this.identityExpanded ? 'Less' : 'More') + '</button>'
+          (this.identityExpanded ? 'true' : 'false') +
+          '">' +
+          (this.identityExpanded ? 'Less' : 'More') +
+          '</button>'
         : '') +
       '</div>' +
       '<div class="ws-cmd-tags-row">' +
-      '<div class="ws-cmd-tags">' + this.commandTagsHTML(tags) + '</div>' +
+      '<div class="ws-cmd-tags">' +
+      this.commandTagsHTML(tags) +
+      '</div>' +
       '<button type="button" class="ws-cmd-mini-btn" data-cmd-edit-identity="tags" aria-label="Edit workspace tags">Edit</button>' +
       '</div>' +
       this.identityEditorHTML(name, description) +
       '</div>' +
       '<div class="ws-cmd-readout">' +
       this.statBoxHTML(stats.agents, 'Agents', 'agents', 'View agents') +
-      this.statBoxHTML(stats.openTasks, 'Open Tasks', 'tasks', 'View open tasks', this.hasAttentionTasks() ? 'is-alert' : '') +
-      this.statBoxHTML(stats.tools, 'Tools', 'tools', 'Open tools: MCP, skills, plugins, and find tools') +
+      this.statBoxHTML(
+        stats.openTasks,
+        'Open Tasks',
+        'tasks',
+        'View open tasks',
+        this.hasAttentionTasks() ? 'is-alert' : ''
+      ) +
+      this.statBoxHTML(
+        stats.tools,
+        'Tools',
+        'tools',
+        'Open tools: MCP, skills, plugins, and find tools'
+      ) +
       '</div>' +
       '</header>'
     );
@@ -292,45 +378,75 @@ export class WorkspaceCommandView {
     const summary = this.missionSummary();
     const missionText = String(summary.mission || '').trim();
     const title = summary.title || (missionText ? 'Current goal' : 'Workspace goal');
-    const text = summary.text || (missionText || 'Loading workspace goal...');
+    const text = summary.text || missionText || 'Loading workspace goal...';
     const statusLabel = summary.label || 'Loading';
     const statusClass = summary.className || 'is-loading';
     const cadence = summary.cadenceLabel || 'Cadence: loading';
     const nextRun = summary.nextLabel || 'Next: loading';
     const lastRun = summary.lastLabel || 'Last: loading';
-    const findingsHref = summary.findingsHref || (this.workspaceId()
-      ? '/action-center?workspace=' + encodeURIComponent(this.workspaceId())
-      : '/action-center');
+    const findingsHref =
+      summary.findingsHref ||
+      (this.workspaceId()
+        ? '/action-center?workspace=' + encodeURIComponent(this.workspaceId())
+        : '/action-center');
     const findingsLabel = summary.findingsLabel || 'Findings';
     const runDisabled = summary.canRun === true ? '' : ' disabled';
     const runTitle = summary.runTitle || 'Set a goal before running';
     const actionStatus = summary.actionStatus || '';
 
+    const editLabel = missionText ? 'Edit Goal' : 'Set Goal';
+    const missionClass = 'ws-cmd-mission' + (missionText ? '' : ' is-empty');
+
     return (
-      '<section class="ws-cmd-mission" id="workspace-command-mission-card" aria-labelledby="workspace-command-mission-title">' +
+      '<section class="' +
+      missionClass +
+      '" id="workspace-command-mission-card" aria-labelledby="workspace-command-mission-title">' +
       '<div class="ws-cmd-mission-main">' +
       '<div class="ws-cmd-mission-head">' +
       '<span class="ws-cmd-mission-kicker">Mission</span>' +
-      '<span class="ws-cmd-mission-status ' + escapeHtml(statusClass) + '" id="workspace-command-mission-status">' +
-      escapeHtml(statusLabel) + '</span>' +
+      '<span class="ws-cmd-mission-status ' +
+      escapeHtml(statusClass) +
+      '" id="workspace-command-mission-status">' +
+      escapeHtml(statusLabel) +
+      '</span>' +
       '</div>' +
-      '<h3 id="workspace-command-mission-title" class="ws-cmd-mission-title">' + escapeHtml(title) + '</h3>' +
-      '<p id="workspace-command-mission-text" class="ws-cmd-mission-text' + (missionText ? '' : ' is-empty') + '">' +
-      escapeHtml(text) + '</p>' +
+      '<h3 id="workspace-command-mission-title" class="ws-cmd-mission-title">' +
+      escapeHtml(title) +
+      '</h3>' +
+      '<p id="workspace-command-mission-text" class="ws-cmd-mission-text' +
+      (missionText ? '' : ' is-empty') +
+      '">' +
+      escapeHtml(text) +
+      '</p>' +
       '<div class="ws-cmd-mission-meta" aria-label="Mission automation timing">' +
-      '<span id="workspace-command-mission-cadence">' + escapeHtml(cadence) + '</span>' +
-      '<span id="workspace-command-mission-next-run">' + escapeHtml(nextRun) + '</span>' +
-      '<span id="workspace-command-mission-last-run">' + escapeHtml(lastRun) + '</span>' +
+      '<span id="workspace-command-mission-cadence">' +
+      escapeHtml(cadence) +
+      '</span>' +
+      '<span id="workspace-command-mission-next-run">' +
+      escapeHtml(nextRun) +
+      '</span>' +
+      '<span id="workspace-command-mission-last-run">' +
+      escapeHtml(lastRun) +
+      '</span>' +
       '</div>' +
       '<div class="ws-cmd-mission-action-status" id="workspace-command-mission-action-status" aria-live="polite">' +
-      escapeHtml(actionStatus) + '</div>' +
+      escapeHtml(actionStatus) +
+      '</div>' +
       '</div>' +
       '<div class="ws-cmd-mission-actions">' +
-      '<button type="button" class="ws-cmd-mission-btn" id="workspace-command-mission-edit" data-cmd-mission-action="edit">Set Goal</button>' +
+      '<button type="button" class="ws-cmd-mission-btn" id="workspace-command-mission-edit" data-cmd-mission-action="edit">' +
+      editLabel +
+      '</button>' +
       '<button type="button" class="ws-cmd-mission-btn is-primary" id="workspace-command-mission-run" data-cmd-mission-action="run"' +
-      runDisabled + ' title="' + escapeHtml(runTitle) + '">Run now</button>' +
-      '<a class="ws-cmd-mission-btn" id="workspace-command-mission-findings" href="' + escapeHtml(findingsHref) + '">' +
-      escapeHtml(findingsLabel) + '</a>' +
+      runDisabled +
+      ' title="' +
+      escapeHtml(runTitle) +
+      '">Run now</button>' +
+      '<a class="ws-cmd-mission-btn" id="workspace-command-mission-findings" href="' +
+      escapeHtml(findingsHref) +
+      '">' +
+      escapeHtml(findingsLabel) +
+      '</a>' +
       '</div>' +
       '</section>'
     );
@@ -340,8 +456,14 @@ export class WorkspaceCommandView {
     const arr = Array.isArray(tags) ? tags : [];
     if (!arr.length) return '<span class="ws-cmd-tag-empty">No tags</span>';
     const limit = 8;
-    const shown = arr.slice(0, limit).map(tag => '<span class="ws-cmd-tag">' + escapeHtml(tag) + '</span>').join('');
-    const more = arr.length > limit ? '<span class="ws-cmd-tag is-more">+' + (arr.length - limit) + '</span>' : '';
+    const shown = arr
+      .slice(0, limit)
+      .map(tag => '<span class="ws-cmd-tag">' + escapeHtml(tag) + '</span>')
+      .join('');
+    const more =
+      arr.length > limit
+        ? '<span class="ws-cmd-tag is-more">+' + (arr.length - limit) + '</span>'
+        : '';
     return shown + more;
   }
 
@@ -352,13 +474,21 @@ export class WorkspaceCommandView {
       const isDescription = mode === 'description';
       const value = isDescription ? description : name;
       const field = isDescription
-        ? '<textarea class="ws-cmd-identity-field" data-cmd-identity-input rows="2">' + escapeHtml(value) + '</textarea>'
-        : '<input class="ws-cmd-identity-field" data-cmd-identity-input type="text" value="' + escapeHtml(value) + '">';
+        ? '<textarea class="ws-cmd-identity-field" data-cmd-identity-input rows="2">' +
+          escapeHtml(value) +
+          '</textarea>'
+        : '<input class="ws-cmd-identity-field" data-cmd-identity-input type="text" value="' +
+          escapeHtml(value) +
+          '">';
       return (
-        '<form class="ws-cmd-identity-editor" data-cmd-identity-form="' + escapeHtml(mode) + '">' +
+        '<form class="ws-cmd-identity-editor" data-cmd-identity-form="' +
+        escapeHtml(mode) +
+        '">' +
         field +
         '<div class="ws-cmd-identity-actions">' +
-        '<button type="submit" class="ws-cmd-identity-save"' + (this.identitySaving ? ' disabled' : '') + '>Save</button>' +
+        '<button type="submit" class="ws-cmd-identity-save"' +
+        (this.identitySaving ? ' disabled' : '') +
+        '>Save</button>' +
         '<button type="button" class="ws-cmd-identity-cancel" data-cmd-cancel-identity>Cancel</button>' +
         '</div>' +
         '</form>'
@@ -368,9 +498,15 @@ export class WorkspaceCommandView {
       return (
         '<div class="ws-cmd-identity-editor" data-cmd-identity-form="tags">' +
         '<div class="ws-cmd-tags-editor-mount" data-cmd-tags-mount></div>' +
-        (this.commandTagError ? '<div class="ws-cmd-identity-error" role="alert">' + escapeHtml(this.commandTagError) + '</div>' : '') +
+        (this.commandTagError
+          ? '<div class="ws-cmd-identity-error" role="alert">' +
+            escapeHtml(this.commandTagError) +
+            '</div>'
+          : '') +
         '<div class="ws-cmd-identity-actions">' +
-        '<button type="button" class="ws-cmd-identity-save" data-cmd-save-tags' + (this.identitySaving ? ' disabled' : '') + '>Save</button>' +
+        '<button type="button" class="ws-cmd-identity-save" data-cmd-save-tags' +
+        (this.identitySaving ? ' disabled' : '') +
+        '>Save</button>' +
         '<button type="button" class="ws-cmd-identity-cancel" data-cmd-cancel-identity>Cancel</button>' +
         '</div>' +
         '</div>'
@@ -381,8 +517,13 @@ export class WorkspaceCommandView {
 
   render() {
     if (!this.container) return;
+    this.captureAgentDeckViewState();
     if (this.commandTagInput) {
-      try { this.commandTagDraft = this.commandTagInput.getTags(); } catch (err) { /* keep existing draft */ }
+      try {
+        this.commandTagDraft = this.commandTagInput.getTags();
+      } catch (err) {
+        /* keep existing draft */
+      }
       this.destroyCommandTagInput();
     }
     const ws = (this.page && this.page.workspace) || {};
@@ -395,21 +536,26 @@ export class WorkspaceCommandView {
       '<div class="ws-cmd-layout">' +
       '<main class="ws-cmd-main">' +
       this.renderMissionPanel() +
-      '<section class="ws-cmd-garrison">' + this.renderGarrison() + '</section>' +
+      '<section class="ws-cmd-garrison">' +
+      this.renderGarrison() +
+      '</section>' +
       '</main>' +
-      '<aside class="ws-cmd-rail">' + this.renderRail() + '</aside>' +
+      '<aside class="ws-cmd-rail">' +
+      this.renderRail() +
+      '</aside>' +
       '</div>';
 
     this.bindIdentityControls();
     this.bindReadout();
     this.bindMissionPanel();
     this.bindGarrison();
-    this.hydrateGarrisonPrompts();
     this.bindRail();
     this.mountCommandTagInput();
     this.syncMissionPanel();
     this.syncSharedSurfaces();
     this.mountNoteFilterBar();
+    this.restoreAgentDeckViewState();
+    this.hydrateActiveAgentPrompt();
 
     // The stat manager modal lives inside the .ws-cmd container (so it inherits
     // the tactical tokens) but survives full re-renders: re-attach + repaint it.
@@ -426,7 +572,7 @@ export class WorkspaceCommandView {
     const root = this.container && this.container.querySelector('.ws-cmd-topbar');
     if (!root) return;
 
-    root.addEventListener('click', (event) => {
+    root.addEventListener('click', event => {
       const editBtn = event.target.closest('[data-cmd-edit-identity]');
       if (editBtn) {
         const field = editBtn.getAttribute('data-cmd-edit-identity');
@@ -457,7 +603,7 @@ export class WorkspaceCommandView {
       }
     });
 
-    root.addEventListener('submit', (event) => {
+    root.addEventListener('submit', event => {
       const form = event.target.closest('[data-cmd-identity-form]');
       if (!form) return;
       event.preventDefault();
@@ -468,7 +614,7 @@ export class WorkspaceCommandView {
       }
     });
 
-    root.addEventListener('keydown', (event) => {
+    root.addEventListener('keydown', event => {
       if (event.key === 'Escape' && event.target.closest('[data-cmd-identity-form]')) {
         event.preventDefault();
         this.cancelIdentityEdit();
@@ -493,7 +639,11 @@ export class WorkspaceCommandView {
     this.render();
     const input = this.container && this.container.querySelector('[data-cmd-identity-input]');
     if (input && typeof input.focus === 'function') {
-      try { input.focus({ preventScroll: true }); } catch (err) { input.focus(); }
+      try {
+        input.focus({ preventScroll: true });
+      } catch (err) {
+        input.focus();
+      }
       if (typeof input.select === 'function') input.select();
     }
   }
@@ -511,7 +661,8 @@ export class WorkspaceCommandView {
     const page = this.page || {};
     if (typeof page.saveWorkspaceIdentityField !== 'function') return;
     const ws = page.workspace || {};
-    const currentValue = mode === 'description' ? String(ws.description || '') : String(ws.name || '');
+    const currentValue =
+      mode === 'description' ? String(ws.description || '') : String(ws.name || '');
     this.identitySaving = true;
     const result = await page.saveWorkspaceIdentityField(mode, value, { currentValue });
     this.identitySaving = false;
@@ -540,7 +691,11 @@ export class WorkspaceCommandView {
 
   destroyCommandTagInput() {
     if (!this.commandTagInput) return;
-    try { this.commandTagInput.destroy?.(); } catch (err) { /* no-op */ }
+    try {
+      this.commandTagInput.destroy?.();
+    } catch (err) {
+      /* no-op */
+    }
     this.commandTagInput = null;
   }
 
@@ -566,7 +721,7 @@ export class WorkspaceCommandView {
   bindReadout() {
     const root = this.container && this.container.querySelector('.ws-cmd-readout');
     if (!root) return;
-    root.addEventListener('click', (event) => {
+    root.addEventListener('click', event => {
       const sectionBtn = event.target.closest('[data-cmd-section]');
       if (!sectionBtn) return;
       this.openStatModal(sectionBtn.getAttribute('data-cmd-section'), sectionBtn);
@@ -576,7 +731,7 @@ export class WorkspaceCommandView {
   bindMissionPanel() {
     const root = this.container && this.container.querySelector('.ws-cmd-mission');
     if (!root) return;
-    root.addEventListener('click', (event) => {
+    root.addEventListener('click', event => {
       const btn = event.target.closest('[data-cmd-mission-action]');
       if (!btn) return;
       const action = btn.getAttribute('data-cmd-mission-action');
@@ -618,15 +773,24 @@ export class WorkspaceCommandView {
 
   statSectionMeta(section) {
     switch (String(section || '')) {
-      case 'agents': return { title: 'Agents', addLabel: '＋ Add Agent' };
-      case 'tasks': return { title: this.taskModalShowAll ? 'Tasks' : 'Open Tasks', addLabel: '＋ Add Task' };
-      case 'mcp': return { title: 'MCP Servers', addLabel: '＋ Add MCP' };
-      case 'skills': return { title: 'Skills', addLabel: '＋ Add Skill' };
-      case 'tools': return { title: 'Tools', addLabel: '' };
-      case 'settings': return { title: 'Manager Settings', addLabel: '' };
-      case 'mission': return { title: 'Goal Settings', addLabel: '' };
-      case 'intent': return { title: 'Workspace Intent', addLabel: '' };
-      default: return null;
+      case 'agents':
+        return { title: 'Agents', addLabel: '＋ Add Agent' };
+      case 'tasks':
+        return { title: this.taskModalShowAll ? 'Tasks' : 'Open Tasks', addLabel: '＋ Add Task' };
+      case 'mcp':
+        return { title: 'MCP Servers', addLabel: '＋ Add MCP' };
+      case 'skills':
+        return { title: 'Skills', addLabel: '＋ Add Skill' };
+      case 'tools':
+        return { title: 'Tools', addLabel: '' };
+      case 'settings':
+        return { title: 'Manager Settings', addLabel: '' };
+      case 'mission':
+        return { title: 'Goal Settings', addLabel: '' };
+      case 'intent':
+        return { title: 'Workspace Intent', addLabel: '' };
+      default:
+        return null;
     }
   }
 
@@ -651,7 +815,11 @@ export class WorkspaceCommandView {
     this.setCommandBackgroundInert(true);
     const panel = el.querySelector('.ws-cmd-modal-panel');
     if (panel && typeof panel.focus === 'function') {
-      try { panel.focus({ preventScroll: true }); } catch (err) { panel.focus(); }
+      try {
+        panel.focus({ preventScroll: true });
+      } catch (err) {
+        panel.focus();
+      }
     }
   }
 
@@ -688,10 +856,18 @@ export class WorkspaceCommandView {
       if (child === this.statModalEl) return;
       if (isInert) {
         child.setAttribute('aria-hidden', 'true');
-        try { child.inert = true; } catch (err) { /* inert may be readonly in tests */ }
+        try {
+          child.inert = true;
+        } catch (err) {
+          /* inert may be readonly in tests */
+        }
       } else {
         child.removeAttribute('aria-hidden');
-        try { child.inert = false; } catch (err) { /* inert may be readonly in tests */ }
+        try {
+          child.inert = false;
+        } catch (err) {
+          /* inert may be readonly in tests */
+        }
       }
     });
   }
@@ -699,9 +875,11 @@ export class WorkspaceCommandView {
   modalFocusableElements() {
     const panel = this.statModalEl && this.statModalEl.querySelector('.ws-cmd-modal-panel');
     if (!panel || typeof panel.querySelectorAll !== 'function') return [];
-    return Array.from(panel.querySelectorAll(
-      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
-    )).filter(el => el && !el.hidden && typeof el.focus === 'function');
+    return Array.from(
+      panel.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter(el => el && !el.hidden && typeof el.focus === 'function');
   }
 
   trapStatModalFocus(event) {
@@ -727,14 +905,15 @@ export class WorkspaceCommandView {
 
   ensureStatModal() {
     if (this.statModalEl) return this.statModalEl;
-    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function')
+      return null;
     const el = document.createElement('div');
     el.className = 'ws-cmd-modal';
     el.hidden = true;
     el.innerHTML =
       '<div class="ws-cmd-modal-backdrop" data-cmd-modal-action="close"></div>' +
       '<div class="ws-cmd-modal-panel" role="dialog" aria-modal="true" tabindex="-1"></div>';
-    el.addEventListener('click', (event) => {
+    el.addEventListener('click', event => {
       const toolsTab = event.target.closest('[data-cmd-tools-tab]');
       if (toolsTab) {
         this.setToolsTab(toolsTab.getAttribute('data-cmd-tools-tab'));
@@ -742,9 +921,12 @@ export class WorkspaceCommandView {
       }
       const btn = event.target.closest('[data-cmd-modal-action]');
       if (!btn) return;
-      this.handleStatModalAction(btn.getAttribute('data-cmd-modal-action'), btn.getAttribute('data-cmd-id'));
+      this.handleStatModalAction(
+        btn.getAttribute('data-cmd-modal-action'),
+        btn.getAttribute('data-cmd-id')
+      );
     });
-    el.addEventListener('keydown', (event) => {
+    el.addEventListener('keydown', event => {
       if (event.key === 'Escape') {
         event.stopPropagation();
         this.closeStatModal();
@@ -787,7 +969,8 @@ export class WorkspaceCommandView {
     if (!host) return;
     const config = this.mountSharedSurface('config', '#workspace-detail-settings-panel', host);
     if (!config) {
-      host.innerHTML = '<div class="ws-cmd-modal-empty">Workspace configuration is unavailable.</div>';
+      host.innerHTML =
+        '<div class="ws-cmd-modal-empty">Workspace configuration is unavailable.</div>';
       return;
     }
     // is-command-modal hides the config header/tab strip so only the active pane shows.
@@ -825,14 +1008,18 @@ export class WorkspaceCommandView {
     if (tab.host === 'tools') {
       this.restoreSharedSurface('config');
       const tools = this.mountSharedSurface('tools', '#workspace-detail-tools-card', host);
-      if (!tools) { host.innerHTML = '<div class="ws-cmd-modal-empty">Find Tools is unavailable.</div>'; return; }
+      if (!tools) {
+        host.innerHTML = '<div class="ws-cmd-modal-empty">Find Tools is unavailable.</div>';
+        return;
+      }
       if (tools.style) tools.style.display = '';
       return;
     }
     this.restoreSharedSurface('tools');
     const config = this.mountSharedSurface('config', '#workspace-detail-settings-panel', host);
     if (!config) {
-      host.innerHTML = '<div class="ws-cmd-modal-empty">Workspace configuration is unavailable.</div>';
+      host.innerHTML =
+        '<div class="ws-cmd-modal-empty">Workspace configuration is unavailable.</div>';
       return;
     }
     if (config.classList) config.classList.add('is-command-modal');
@@ -861,14 +1048,17 @@ export class WorkspaceCommandView {
 
   // A config-surface or the Tools modal currently holds a shared surface on loan.
   statModalHoldsSharedSurface() {
-    return this.sectionUsesConfigSurface(this.statModalSection) || this.statModalSection === 'tools';
+    return (
+      this.sectionUsesConfigSurface(this.statModalSection) || this.statModalSection === 'tools'
+    );
   }
 
   ensureTaskFilterBar() {
     if (this.taskFilterBar) return this.taskFilterBar;
     const helper = this.tagFilterHelper();
     if (!helper || typeof helper.createTagFilterBar !== 'function') return null;
-    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function')
+      return null;
     const holder = document.createElement('div');
     this.taskFilterBar = helper.createTagFilterBar({
       container: holder,
@@ -888,7 +1078,11 @@ export class WorkspaceCommandView {
     const page = this.page || {};
     const tasks = Array.isArray(page.tasks) ? page.tasks : [];
     const helper = this.tagFilterHelper();
-    if (helper && typeof helper.collectTags === 'function' && typeof bar.setAvailableTags === 'function') {
+    if (
+      helper &&
+      typeof helper.collectTags === 'function' &&
+      typeof bar.setAvailableTags === 'function'
+    ) {
       bar.setAvailableTags(helper.collectTags(tasks));
     }
     host.innerHTML = '';
@@ -896,9 +1090,11 @@ export class WorkspaceCommandView {
   }
 
   syncBoardSurface({ load = false } = {}) {
-    const inBoard = this.statModalSection === 'tasks' &&
+    const inBoard =
+      this.statModalSection === 'tasks' &&
       this.taskModalBoardMode &&
-      this.statModalEl && !this.statModalEl.hidden;
+      this.statModalEl &&
+      !this.statModalEl.hidden;
     if (!inBoard) {
       this.restoreSharedSurface('board');
       return;
@@ -923,23 +1119,40 @@ export class WorkspaceCommandView {
     if (section === 'tools') {
       const tabs = this.toolsTabs();
       const active = this.toolsTab(this.activeToolsTab);
-      const tabButtons = tabs.map(tab => (
-        '<button type="button" class="ws-cmd-system-tab' + (tab.key === active.key ? ' is-active' : '') +
-        '" data-cmd-tools-tab="' + escapeHtml(tab.key) + '" role="tab" aria-selected="' +
-        (tab.key === active.key ? 'true' : 'false') + '">' + escapeHtml(tab.label) + '</button>'
-      )).join('');
+      const tabButtons = tabs
+        .map(
+          tab =>
+            '<button type="button" class="ws-cmd-system-tab' +
+            (tab.key === active.key ? ' is-active' : '') +
+            '" data-cmd-tools-tab="' +
+            escapeHtml(tab.key) +
+            '" role="tab" aria-selected="' +
+            (tab.key === active.key ? 'true' : 'false') +
+            '">' +
+            escapeHtml(tab.label) +
+            '</button>'
+        )
+        .join('');
       return (
         '<header class="ws-cmd-modal-head">' +
-        '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
-        '<span class="ws-cmd-modal-count">' + this.statModalCount('tools') + '</span>' +
+        '<h3 class="ws-cmd-modal-title">' +
+        escapeHtml(meta.title) +
+        '</h3>' +
+        '<span class="ws-cmd-modal-count">' +
+        this.statModalCount('tools') +
+        '</span>' +
         '<div class="ws-cmd-modal-head-actions">' +
         '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
         '</div>' +
         '</header>' +
         '<div class="ws-cmd-modal-body ws-cmd-modal-config-body">' +
-        '<div class="ws-cmd-system-tabs" role="tablist" aria-label="Workspace tools">' + tabButtons + '</div>' +
+        '<div class="ws-cmd-system-tabs" role="tablist" aria-label="Workspace tools">' +
+        tabButtons +
+        '</div>' +
         '<div class="ws-cmd-config-host" data-cmd-tools-host>' +
-        '<div class="ws-cmd-modal-empty">Loading ' + escapeHtml(active.label) + '...</div>' +
+        '<div class="ws-cmd-modal-empty">Loading ' +
+        escapeHtml(active.label) +
+        '...</div>' +
         '</div></div>'
       );
     }
@@ -953,7 +1166,9 @@ export class WorkspaceCommandView {
         : '<span class="ws-cmd-modal-count">' + this.statModalCount(section) + '</span>';
       return (
         '<header class="ws-cmd-modal-head">' +
-        '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
+        '<h3 class="ws-cmd-modal-title">' +
+        escapeHtml(meta.title) +
+        '</h3>' +
         countChip +
         '<div class="ws-cmd-modal-head-actions">' +
         '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
@@ -961,14 +1176,17 @@ export class WorkspaceCommandView {
         '</header>' +
         '<div class="ws-cmd-modal-body ws-cmd-modal-config-body">' +
         '<div class="ws-cmd-config-host" data-cmd-config-host>' +
-        '<div class="ws-cmd-modal-empty">Loading ' + escapeHtml(meta.title) + '...</div>' +
+        '<div class="ws-cmd-modal-empty">Loading ' +
+        escapeHtml(meta.title) +
+        '...</div>' +
         '</div></div>'
       );
     }
     const boardMode = section === 'tasks' && this.taskModalBoardMode;
-    const taskFilterHost = section === 'tasks'
-      ? '<div class="ws-cmd-modal-note-filter" data-cmd-task-filter></div>'
-      : '';
+    const taskFilterHost =
+      section === 'tasks'
+        ? '<div class="ws-cmd-modal-note-filter" data-cmd-task-filter></div>'
+        : '';
     const body = boardMode
       ? '<div class="ws-cmd-modal-body ws-cmd-modal-board-body">' +
         '<div class="ws-cmd-board-host" data-cmd-board-host>' +
@@ -977,12 +1195,18 @@ export class WorkspaceCommandView {
       : '<div class="ws-cmd-modal-body">' + taskFilterHost + this.statModalRows(section) + '</div>';
     return (
       '<header class="ws-cmd-modal-head">' +
-      '<h3 class="ws-cmd-modal-title">' + escapeHtml(meta.title) + '</h3>' +
-      '<span class="ws-cmd-modal-count">' + this.statModalCount(section) + '</span>' +
+      '<h3 class="ws-cmd-modal-title">' +
+      escapeHtml(meta.title) +
+      '</h3>' +
+      '<span class="ws-cmd-modal-count">' +
+      this.statModalCount(section) +
+      '</span>' +
       '<div class="ws-cmd-modal-head-actions">' +
       this.taskViewToggleHTML(section) +
       (boardMode ? '' : this.statModalFilterToggleHTML(section)) +
-      '<button type="button" class="ws-cmd-modal-add" data-cmd-modal-action="add">' + escapeHtml(meta.addLabel) + '</button>' +
+      '<button type="button" class="ws-cmd-modal-add" data-cmd-modal-action="add">' +
+      escapeHtml(meta.addLabel) +
+      '</button>' +
       '<button type="button" class="ws-cmd-modal-close" data-cmd-modal-action="close" aria-label="Close manager">×</button>' +
       '</div>' +
       '</header>' +
@@ -995,8 +1219,13 @@ export class WorkspaceCommandView {
   // and Goal Settings (the goal modal's "Advanced settings" button).
   sectionUsesConfigSurface(section) {
     const key = String(section || '');
-    return key === 'mcp' || key === 'skills' || key === 'settings' ||
-      key === 'mission' || key === 'intent';
+    return (
+      key === 'mcp' ||
+      key === 'skills' ||
+      key === 'settings' ||
+      key === 'mission' ||
+      key === 'intent'
+    );
   }
 
   // Config sections that carry no list count in the modal header.
@@ -1010,10 +1239,16 @@ export class WorkspaceCommandView {
     const board = this.taskModalBoardMode;
     return (
       '<div class="ws-cmd-modal-viewtoggle" role="tablist" aria-label="Task view">' +
-      '<button type="button" class="ws-cmd-modal-view' + (board ? '' : ' is-active') +
-      '" data-cmd-modal-action="view-list" aria-pressed="' + (board ? 'false' : 'true') + '">List</button>' +
-      '<button type="button" class="ws-cmd-modal-view' + (board ? ' is-active' : '') +
-      '" data-cmd-modal-action="view-board" aria-pressed="' + (board ? 'true' : 'false') + '">Board</button>' +
+      '<button type="button" class="ws-cmd-modal-view' +
+      (board ? '' : ' is-active') +
+      '" data-cmd-modal-action="view-list" aria-pressed="' +
+      (board ? 'false' : 'true') +
+      '">List</button>' +
+      '<button type="button" class="ws-cmd-modal-view' +
+      (board ? ' is-active' : '') +
+      '" data-cmd-modal-action="view-board" aria-pressed="' +
+      (board ? 'true' : 'false') +
+      '">Board</button>' +
       '</div>'
     );
   }
@@ -1022,26 +1257,40 @@ export class WorkspaceCommandView {
     if (String(section || '') !== 'tasks') return '';
     const label = this.taskModalShowAll ? 'Show open' : 'Show all';
     const pressed = this.taskModalShowAll ? 'true' : 'false';
-    return '<button type="button" class="ws-cmd-modal-filter" data-cmd-modal-action="toggle-task-filter" aria-pressed="' +
-      pressed + '">' + escapeHtml(label) + '</button>';
+    return (
+      '<button type="button" class="ws-cmd-modal-filter" data-cmd-modal-action="toggle-task-filter" aria-pressed="' +
+      pressed +
+      '">' +
+      escapeHtml(label) +
+      '</button>'
+    );
   }
 
   statModalCount(section) {
     switch (String(section || '')) {
-      case 'agents': return this.agentRowData().length;
-      case 'tasks': return this.taskRowData({ includeAll: this.taskModalShowAll }).length;
-      case 'mcp': return this.mcpRowData().length;
-      case 'skills': return this.skillRowData().length;
-      case 'tools': return this.mcpRowData().length + this.skillRowData().length;
-      default: return 0;
+      case 'agents':
+        return this.agentRowData().length;
+      case 'tasks':
+        return this.taskRowData({ includeAll: this.taskModalShowAll }).length;
+      case 'mcp':
+        return this.mcpRowData().length;
+      case 'skills':
+        return this.skillRowData().length;
+      case 'tools':
+        return this.mcpRowData().length + this.skillRowData().length;
+      default:
+        return 0;
     }
   }
 
   statModalRows(section) {
     switch (String(section || '')) {
-      case 'agents': return this.agentRowsHTML();
-      case 'tasks': return this.taskRowsHTML();
-      default: return '';
+      case 'agents':
+        return this.agentRowsHTML();
+      case 'tasks':
+        return this.taskRowsHTML();
+      default:
+        return '';
     }
   }
 
@@ -1052,58 +1301,84 @@ export class WorkspaceCommandView {
   agentRowData() {
     const page = this.page || {};
     let groups = [];
-    try { groups = page.buildAgentGroups() || []; } catch (err) { groups = []; }
-    return groups.filter((g) => g && g.isWorkspaceAgent && !g.isUnassigned);
+    try {
+      groups = page.buildAgentGroups() || [];
+    } catch (err) {
+      groups = [];
+    }
+    return groups.filter(g => g && g.isWorkspaceAgent && !g.isUnassigned);
   }
 
   agentRowsHTML() {
     const page = this.page || {};
     const groups = this.agentRowData();
     if (!groups.length) return this.modalEmptyHTML('No agents yet. Add one to build the roster.');
-    return groups.map((group) => {
-      const name = String(group.name || 'Agent');
-      const encoded = encodeURIComponent(name);
-      const keeper = page.isWorkspaceEntryAgent ? page.isWorkspaceEntryAgent(name) : false;
-      const avatar = page.getAgentAvatarPresentation
-        ? page.getAgentAvatarPresentation(name)
-        : { initials: name.slice(0, 2).toUpperCase(), style: '' };
-      const status = page.getAgentRosterStatus
-        ? page.getAgentRosterStatus(name)
-        : { key: 'idle', label: 'Idle' };
-      const tone = this.statusTone(status.key, status.label);
-      let modelLabel = '';
-      if (page.getAgentProfile && page.getAgentModelPresentation) {
-        const m = page.getAgentModelPresentation(page.getAgentProfile(name));
-        modelLabel = m && !m.empty ? m.model : '';
-      }
-      let skillCount = 0;
-      if (page.getAgentSkillSummary) {
-        const sk = page.getAgentSkillSummary(name);
-        skillCount = (sk && sk.count) || 0;
-      }
-      const chips =
-        (keeper ? '<span class="ws-cmd-mchip is-keeper">★ Entry Agent</span>' : '') +
-        '<span class="ws-cmd-mchip">' + escapeHtml(modelLabel || '—') + '</span>' +
-        '<span class="ws-cmd-mchip">Skills · ' + skillCount + '</span>';
-      const removeCtl = keeper
-        ? '<span class="ws-cmd-lock" title="Entry agent — can\'t be removed">🔒</span>'
-        : '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
-          escapeHtml(encoded) + '" title="Remove agent" aria-label="Remove ' + escapeHtml(name) + '">✕</button>';
-      return (
-        '<div class="ws-cmd-mrow">' +
-        '<span class="ws-cmd-mrow-av" style="' + escapeHtml(avatar.style || '') + '">' + escapeHtml(avatar.initials) + '</span>' +
-        '<div class="ws-cmd-mrow-main">' +
-        '<div class="ws-cmd-mrow-name"><span class="ws-cmd-led ' + tone + '"></span>' + escapeHtml(name) + '</div>' +
-        '<div class="ws-cmd-mrow-chips">' + chips + '</div>' +
-        '</div>' +
-        '<div class="ws-cmd-mrow-actions">' +
-        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="edit" data-cmd-id="' +
-        escapeHtml(encoded) + '" title="Edit model" aria-label="Edit model for ' + escapeHtml(name) + '">Model</button>' +
-        removeCtl +
-        '</div>' +
-        '</div>'
-      );
-    }).join('');
+    return groups
+      .map(group => {
+        const name = String(group.name || 'Agent');
+        const encoded = encodeURIComponent(name);
+        const keeper = page.isWorkspaceEntryAgent ? page.isWorkspaceEntryAgent(name) : false;
+        const avatar = page.getAgentAvatarPresentation
+          ? page.getAgentAvatarPresentation(name)
+          : { initials: name.slice(0, 2).toUpperCase(), style: '' };
+        const status = page.getAgentRosterStatus
+          ? page.getAgentRosterStatus(name)
+          : { key: 'idle', label: 'Idle' };
+        const tone = this.statusTone(status.key, status.label);
+        let modelLabel = '';
+        if (page.getAgentProfile && page.getAgentModelPresentation) {
+          const m = page.getAgentModelPresentation(page.getAgentProfile(name));
+          modelLabel = m && !m.empty ? m.model : '';
+        }
+        let skillCount = 0;
+        if (page.getAgentSkillSummary) {
+          const sk = page.getAgentSkillSummary(name);
+          skillCount = (sk && sk.count) || 0;
+        }
+        const chips =
+          (keeper ? '<span class="ws-cmd-mchip is-keeper">★ Entry Agent</span>' : '') +
+          '<span class="ws-cmd-mchip">' +
+          escapeHtml(modelLabel || '—') +
+          '</span>' +
+          '<span class="ws-cmd-mchip">Skills · ' +
+          skillCount +
+          '</span>';
+        const removeCtl = keeper
+          ? '<span class="ws-cmd-lock" title="Entry agent — can\'t be removed">🔒</span>'
+          : '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+            escapeHtml(encoded) +
+            '" title="Remove agent" aria-label="Remove ' +
+            escapeHtml(name) +
+            '">✕</button>';
+        return (
+          '<div class="ws-cmd-mrow">' +
+          '<span class="ws-cmd-mrow-av" style="' +
+          escapeHtml(avatar.style || '') +
+          '">' +
+          escapeHtml(avatar.initials) +
+          '</span>' +
+          '<div class="ws-cmd-mrow-main">' +
+          '<div class="ws-cmd-mrow-name"><span class="ws-cmd-led ' +
+          tone +
+          '"></span>' +
+          escapeHtml(name) +
+          '</div>' +
+          '<div class="ws-cmd-mrow-chips">' +
+          chips +
+          '</div>' +
+          '</div>' +
+          '<div class="ws-cmd-mrow-actions">' +
+          '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="edit" data-cmd-id="' +
+          escapeHtml(encoded) +
+          '" title="Edit model" aria-label="Edit model for ' +
+          escapeHtml(name) +
+          '">Model</button>' +
+          removeCtl +
+          '</div>' +
+          '</div>'
+        );
+      })
+      .join('');
   }
 
   isOpenTask(task) {
@@ -1127,7 +1402,7 @@ export class WorkspaceCommandView {
   taskRowData({ includeAll = false } = {}) {
     const page = this.page || {};
     const tasks = Array.isArray(page.tasks) ? page.tasks : [];
-    const base = includeAll ? tasks : tasks.filter((task) => this.isOpenTask(task));
+    const base = includeAll ? tasks : tasks.filter(task => this.isOpenTask(task));
     return this.applyTaskTagFilter(base);
   }
 
@@ -1135,41 +1410,64 @@ export class WorkspaceCommandView {
     const tasks = this.taskRowData({ includeAll: this.taskModalShowAll });
     if (!tasks.length) {
       return this.modalEmptyHTML(
-        this.taskModalShowAll ? 'No tasks yet. Add one to get started.' : 'No open tasks. Use Show all to view completed tasks.'
+        this.taskModalShowAll
+          ? 'No tasks yet. Add one to get started.'
+          : 'No open tasks. Use Show all to view completed tasks.'
       );
     }
-    return tasks.map((t) => {
-      const id = String(t.id || '');
-      const label = String(t.description || t.name || t.title || 'Task');
-      const assignee = String(t.to || t.agent_name || t.assigned_to || '');
-      const tone = this.taskTone(t.status);
-      const statusText = String(t.status || 'pending').replace('_', ' ');
-      return (
-        '<div class="ws-cmd-mrow">' +
-        '<div class="ws-cmd-mrow-main">' +
-        '<div class="ws-cmd-mrow-name">' + escapeHtml(label) + '</div>' +
-        '<div class="ws-cmd-mrow-chips">' +
-        '<span class="ws-cmd-mchip ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
-        (assignee ? '<span class="ws-cmd-mchip">' + escapeHtml(assignee) + '</span>' : '') +
-        '</div>' +
-        '</div>' +
-        '<div class="ws-cmd-mrow-actions">' +
-        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="run" data-cmd-id="' +
-        escapeHtml(id) + '" title="Run" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
-        '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="open" data-cmd-id="' +
-        escapeHtml(id) + '" title="Open" aria-label="Open task ' + escapeHtml(label) + '">↗</button>' +
-        '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
-        escapeHtml(id) + '" title="Delete" aria-label="Delete task ' + escapeHtml(label) + '">✕</button>' +
-        '</div>' +
-        '</div>'
-      );
-    }).join('');
+    return tasks
+      .map(t => {
+        const id = String(t.id || '');
+        const label = String(t.description || t.name || t.title || 'Task');
+        const assignee = String(t.to || t.agent_name || t.assigned_to || '');
+        const tone = this.taskTone(t.status);
+        const statusText = String(t.status || 'pending').replace('_', ' ');
+        return (
+          '<div class="ws-cmd-mrow">' +
+          '<div class="ws-cmd-mrow-main">' +
+          '<div class="ws-cmd-mrow-name">' +
+          escapeHtml(label) +
+          '</div>' +
+          '<div class="ws-cmd-mrow-chips">' +
+          '<span class="ws-cmd-mchip ws-cmd-q-status ' +
+          tone +
+          '">' +
+          escapeHtml(statusText) +
+          '</span>' +
+          (assignee ? '<span class="ws-cmd-mchip">' + escapeHtml(assignee) + '</span>' : '') +
+          '</div>' +
+          '</div>' +
+          '<div class="ws-cmd-mrow-actions">' +
+          '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="run" data-cmd-id="' +
+          escapeHtml(id) +
+          '" title="Run" aria-label="Run task ' +
+          escapeHtml(label) +
+          '">▶</button>' +
+          '<button type="button" class="ws-cmd-mrow-btn" data-cmd-modal-action="open" data-cmd-id="' +
+          escapeHtml(id) +
+          '" title="Open" aria-label="Open task ' +
+          escapeHtml(label) +
+          '">↗</button>' +
+          '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
+          escapeHtml(id) +
+          '" title="Delete" aria-label="Delete task ' +
+          escapeHtml(label) +
+          '">✕</button>' +
+          '</div>' +
+          '</div>'
+        );
+      })
+      .join('');
   }
 
   mcpRowData() {
     const page = this.page || {};
     if (typeof page.getWorkspaceMCPBindings === 'function') {
-      try { return page.getWorkspaceMCPBindings({ includeDisabled: true }) || []; } catch (err) { /* fall through */ }
+      try {
+        return page.getWorkspaceMCPBindings({ includeDisabled: true }) || [];
+      } catch (err) {
+        /* fall through */
+      }
     }
     const ws = page.workspace || {};
     return Array.isArray(ws.mcp_bindings) ? ws.mcp_bindings : [];
@@ -1178,7 +1476,11 @@ export class WorkspaceCommandView {
   skillRowData() {
     const page = this.page || {};
     if (typeof page.getWorkspaceSkillBindings === 'function') {
-      try { return page.getWorkspaceSkillBindings({ includeDisabled: true }) || []; } catch (err) { /* fall through */ }
+      try {
+        return page.getWorkspaceSkillBindings({ includeDisabled: true }) || [];
+      } catch (err) {
+        /* fall through */
+      }
     }
     const ws = page.workspace || {};
     return Array.isArray(ws.skill_bindings) ? ws.skill_bindings : [];
@@ -1188,7 +1490,10 @@ export class WorkspaceCommandView {
     const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null) || {};
     const section = this.statModalSection;
     const a = String(action || '');
-    if (a === 'close') { this.closeStatModal(); return; }
+    if (a === 'close') {
+      this.closeStatModal();
+      return;
+    }
     if (a === 'toggle-task-filter' && section === 'tasks') {
       this.taskModalShowAll = !this.taskModalShowAll;
       this.renderStatModalBody();
@@ -1214,15 +1519,28 @@ export class WorkspaceCommandView {
     // add/edit/delete arrive through that panel's handlers, not this switch.
     switch (section) {
       case 'agents':
-        if (a === 'add') { this.closeStatModal(); if (typeof page.openAddAgentModal === 'function') page.openAddAgentModal(); }
-        else if (a === 'edit') { this.closeStatModal(); if (typeof page.openAgentModelModal === 'function') page.openAgentModelModal(id); }
-        else if (a === 'delete') { if (typeof page.removeAgentFromWorkspace === 'function') page.removeAgentFromWorkspace(id); }
+        if (a === 'add') {
+          this.closeStatModal();
+          if (typeof page.openAddAgentModal === 'function') page.openAddAgentModal();
+        } else if (a === 'edit') {
+          this.closeStatModal();
+          if (typeof page.openAgentModelModal === 'function') page.openAgentModelModal(id);
+        } else if (a === 'delete') {
+          if (typeof page.removeAgentFromWorkspace === 'function')
+            page.removeAgentFromWorkspace(id);
+        }
         break;
       case 'tasks':
-        if (a === 'add') { this.closeStatModal(); if (typeof page.showAddTaskModal === 'function') page.showAddTaskModal(); }
-        else if (a === 'run') { if (typeof page.executeTask === 'function') page.executeTask(id); }
-        else if (a === 'open') { if (typeof page.openTask === 'function') page.openTask(id); }
-        else if (a === 'delete') { if (typeof page.deleteTask === 'function') page.deleteTask(id); }
+        if (a === 'add') {
+          this.closeStatModal();
+          if (typeof page.showAddTaskModal === 'function') page.showAddTaskModal();
+        } else if (a === 'run') {
+          if (typeof page.executeTask === 'function') page.executeTask(id);
+        } else if (a === 'open') {
+          if (typeof page.openTask === 'function') page.openTask(id);
+        } else if (a === 'delete') {
+          if (typeof page.deleteTask === 'function') page.deleteTask(id);
+        }
         break;
       default:
         break;
@@ -1245,7 +1563,8 @@ export class WorkspaceCommandView {
         this.render();
         break;
       case 'copy':
-        if (typeof page.copySelectedNotesToClipboard === 'function') page.copySelectedNotesToClipboard();
+        if (typeof page.copySelectedNotesToClipboard === 'function')
+          page.copySelectedNotesToClipboard();
         break;
       case 'delete':
         if (typeof page.deleteSelectedNotes === 'function') page.deleteSelectedNotes();
@@ -1268,7 +1587,8 @@ export class WorkspaceCommandView {
         if (page && typeof page.createNewSession === 'function') page.createNewSession();
         break;
       case 'folders':
-        if (page && typeof page.showAddDirectoryModal === 'function') page.showAddDirectoryModal(triggerButton);
+        if (page && typeof page.showAddDirectoryModal === 'function')
+          page.showAddDirectoryModal(triggerButton);
         break;
       case 'files':
         if (page && typeof page.showFileModal === 'function') page.showFileModal();
@@ -1296,7 +1616,9 @@ export class WorkspaceCommandView {
 
     switch (String(sectionKey || '')) {
       case 'notes': {
-        const note = (Array.isArray(page.notes) ? page.notes : []).find(item => String(item.id || '') === id);
+        const note = (Array.isArray(page.notes) ? page.notes : []).find(
+          item => String(item.id || '') === id
+        );
         if (note && typeof page.showNoteModal === 'function') page.showNoteModal(note);
         break;
       }
@@ -1321,7 +1643,7 @@ export class WorkspaceCommandView {
     }
   }
 
-  // ---------- garrison (agents as unit cards) ----------
+  // ---------- agent command deck ----------
 
   statusTone(statusKey, statusLabel) {
     const s = (String(statusKey || '') + ' ' + String(statusLabel || '')).toLowerCase();
@@ -1332,189 +1654,969 @@ export class WorkspaceCommandView {
 
   taskTone(status) {
     switch (String(status || '').toLowerCase()) {
-      case 'in_progress': return 'working';
-      case 'failed': case 'cancelled': return 'alert';
-      case 'completed': case 'done': return 'done';
-      default: return 'pending';
+      case 'in_progress':
+        return 'working';
+      case 'failed':
+      case 'cancelled':
+        return 'alert';
+      case 'completed':
+      case 'done':
+        return 'done';
+      default:
+        return 'pending';
     }
   }
 
-  unitCardHTML(group) {
-    const page = this.page;
-    const name = String(group.name || 'Agent');
-    const encoded = encodeURIComponent(name);
-    const keeper = !group.isUnassigned && page.isWorkspaceEntryAgent
-      ? page.isWorkspaceEntryAgent(name) : false;
-
-    const avatar = page.getAgentAvatarPresentation
-      ? page.getAgentAvatarPresentation(name)
-      : { initials: name.slice(0, 2).toUpperCase(), style: '' };
-    const status = !group.isUnassigned && page.getAgentRosterStatus
-      ? page.getAgentRosterStatus(name)
-      : { key: 'idle', label: 'Unassigned' };
-    const tone = this.statusTone(status.key, status.label);
-
-    let modelLabel = '';
-    if (!group.isUnassigned && page.getAgentProfile && page.getAgentModelPresentation) {
-      const m = page.getAgentModelPresentation(page.getAgentProfile(name));
-      modelLabel = m && !m.empty ? m.model : '';
+  normalizeAgentKey(name) {
+    const page = this.page || {};
+    if (typeof page.normalizeAgentName === 'function') {
+      return String(page.normalizeAgentName(name) || '');
     }
-    let skillCount = 0;
-    if (!group.isUnassigned && page.getAgentSkillSummary) {
-      const sk = page.getAgentSkillSummary(name);
-      skillCount = (sk && sk.count) || 0;
+    return String(name || '')
+      .trim()
+      .toLowerCase();
+  }
+
+  agentSelectionStorageKey() {
+    const workspaceId = this.workspaceId();
+    return workspaceId ? `ori-workspace-command-agent:${workspaceId}` : '';
+  }
+
+  readPersistedAgentKey() {
+    const storageKey = this.agentSelectionStorageKey();
+    if (!storageKey || typeof localStorage === 'undefined') return '';
+    try {
+      return this.normalizeAgentKey(localStorage.getItem(storageKey));
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  persistAgentKey(key) {
+    const storageKey = this.agentSelectionStorageKey();
+    const normalized = this.normalizeAgentKey(key);
+    if (!storageKey || !normalized || typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(storageKey, normalized);
+    } catch (_error) {
+      // Storage is best effort; rendering and selection must continue without it.
+    }
+  }
+
+  agentGroups() {
+    const page = this.page || {};
+    let rawGroups = [];
+    try {
+      rawGroups = typeof page.buildAgentGroups === 'function' ? page.buildAgentGroups() || [] : [];
+    } catch (_error) {
+      rawGroups = [];
     }
 
-    const roleBadge = group.isUnassigned
-      ? '<span class="ws-cmd-badge">Unassigned</span>'
-      : (keeper
-          ? '<span class="ws-cmd-badge is-keeper">★ Entry Agent</span>'
-          : '');
+    const agents = [];
+    const seen = new Set();
+    let unassigned = null;
+    rawGroups.forEach(group => {
+      if (!group) return;
+      if (group.isUnassigned) {
+        if (!unassigned && Array.isArray(group.tasks) && group.tasks.length > 0) {
+          unassigned = group;
+        }
+        return;
+      }
+      if (!group.isWorkspaceAgent) return;
+      const key = this.normalizeAgentKey(group.key || group.name);
+      if (!key || seen.has(key)) return;
+      seen.add(key);
+      agents.push(group);
+    });
 
-    const ctl = group.isUnassigned
-      ? ''
-      : (keeper
-          ? '<span class="ws-cmd-lock" title="Entry agent — locked, can\'t be removed">🔒</span>' +
-            '<button type="button" class="ws-cmd-icon-btn" data-cmd-manager-settings="1"' +
-            ' title="Manager settings" aria-label="Manager settings for ' + escapeHtml(name) + '">⚙</button>'
-          : '') +
-        '<button type="button" class="ws-cmd-icon-btn" data-cmd-add-task="' + escapeHtml(encoded) +
-        '" title="Add a task for ' + escapeHtml(name) + '" aria-label="Add a task for ' + escapeHtml(name) + '">＋</button>';
+    agents.sort((left, right) => {
+      const leftEntry = this.isEntryAgentGroup(left);
+      const rightEntry = this.isEntryAgentGroup(right);
+      if (leftEntry === rightEntry) return 0;
+      return leftEntry ? -1 : 1;
+    });
+    return { agents, unassigned };
+  }
 
-    const rows = group.isUnassigned ? '' :
-      '<div class="ws-cmd-unit-rows">' +
-      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Model</span><span class="ws-cmd-rv">' +
-      escapeHtml(modelLabel || '—') + '</span></div>' +
-      '<div class="ws-cmd-row"><span class="ws-cmd-rk">Skills</span><span class="ws-cmd-rv">' +
-      skillCount + '</span></div>' +
-      '</div>' +
-      this.promptBlockHTML(group, name, encoded);
+  isEntryAgentGroup(group) {
+    const page = this.page || {};
+    return Boolean(
+      group &&
+      typeof page.isWorkspaceEntryAgent === 'function' &&
+      page.isWorkspaceEntryAgent(group.name)
+    );
+  }
 
-    // Link the unit name to the agent's detail page when one is reachable.
-    let nameInner = escapeHtml(name);
-    if (!group.isUnassigned && page.getAgentDetailTarget) {
-      const target = page.getAgentDetailTarget(name);
-      if (target && target.interactive && target.href) {
-        nameInner = '<a class="ws-cmd-unit-name-link" href="' + escapeHtml(target.href) +
-          '" title="' + escapeHtml(target.title || ('Open ' + name + ' details')) + '">' +
-          escapeHtml(name) + '</a>';
+  reconcileAgentSelection(groups) {
+    const agents = Array.isArray(groups) ? groups : [];
+    const keys = new Set(agents.map(group => this.normalizeAgentKey(group.key || group.name)));
+    let selected = this.normalizeAgentKey(this.selectedAgentKey);
+
+    if (!this.agentSelectionInitialized) {
+      const persisted = this.readPersistedAgentKey();
+      if (persisted && keys.has(persisted)) selected = persisted;
+      this.agentSelectionInitialized = true;
+    }
+
+    if (!selected || !keys.has(selected)) {
+      const entry = agents.find(group => this.isEntryAgentGroup(group));
+      selected = this.normalizeAgentKey(
+        entry?.key || entry?.name || agents[0]?.key || agents[0]?.name
+      );
+    }
+
+    this.selectedAgentKey = selected;
+    if (selected) this.persistAgentKey(selected);
+    return selected;
+  }
+
+  selectedAgentGroup(groups) {
+    const agents = Array.isArray(groups) ? groups : [];
+    const selected = this.reconcileAgentSelection(agents);
+    return (
+      agents.find(group => this.normalizeAgentKey(group.key || group.name) === selected) || null
+    );
+  }
+
+  agentRolePresentation(group) {
+    const page = this.page || {};
+    if (typeof page.getAgentGroupRolePresentation === 'function') {
+      try {
+        return (
+          page.getAgentGroupRolePresentation(group) || {
+            label: 'Agent',
+            detail: 'Agent',
+            roles: []
+          }
+        );
+      } catch (_error) {
+        // Fall through to the group roles.
       }
     }
+    const roles = Array.from(
+      new Set(
+        (Array.isArray(group?.roles) ? group.roles : [])
+          .map(role => String(role || '').trim())
+          .filter(Boolean)
+      )
+    );
+    return {
+      label: roles.length > 1 ? 'Multiple roles' : roles[0] || 'Agent',
+      detail: roles.join(', ') || 'Agent',
+      roles
+    };
+  }
+
+  agentViewModel(group) {
+    if (!group) return null;
+    const page = this.page || {};
+    const name = String(group.name || 'Agent');
+    const key = this.normalizeAgentKey(group.key || name);
+    const status =
+      typeof page.getAgentRosterStatus === 'function'
+        ? page.getAgentRosterStatus(name)
+        : { key: 'idle', label: 'Idle', detail: 'No active tasks' };
+    const role = this.agentRolePresentation(group);
+    const skills =
+      typeof page.getAgentSkillSummary === 'function'
+        ? page.getAgentSkillSummary(name)
+        : { count: 0, names: [] };
+    const mcpNames =
+      typeof page.getEffectiveWorkspaceMCPServerNames === 'function'
+        ? page.getEffectiveWorkspaceMCPServerNames(name)
+        : [];
+    const profile = typeof page.getAgentProfile === 'function' ? page.getAgentProfile(name) : null;
+    const model =
+      typeof page.getAgentModelPresentation === 'function'
+        ? page.getAgentModelPresentation(profile)
+        : { model: '', label: 'Model not set', empty: true };
+    const tasks = Array.isArray(group.tasks) ? group.tasks : [];
+    const currentTask =
+      tasks.find(task => String(task?.status || '').toLowerCase() === 'in_progress') || null;
+
+    return {
+      group,
+      key,
+      name,
+      encodedName: encodeURIComponent(name),
+      entry: this.isEntryAgentGroup(group),
+      instanceCount: Math.max(1, Number(group.instanceCount || 1)),
+      role,
+      status,
+      tone: this.statusTone(status?.key, status?.label),
+      skills,
+      mcpNames: Array.isArray(mcpNames) ? mcpNames : [],
+      profile,
+      model,
+      tasks,
+      currentTask
+    };
+  }
+
+  agentCharacterHTML(agent, variant = 'roster') {
+    if (!agent) return '';
+    const key = String(agent.key || agent.name || 'agent');
+    let hash = 0;
+    for (let index = 0; index < key.length; index += 1) {
+      hash = (hash * 33 + key.charCodeAt(index)) >>> 0;
+    }
+    const hue = hash % 360;
+    const visor = 28 + (hash % 3) * 5;
+    const antenna =
+      hash % 2 === 0
+        ? '<path d="M50 24V12M50 12L57 7" class="ws-cmd-character-line"/>'
+        : '<path d="M50 24V10M44 8H56" class="ws-cmd-character-line"/>';
+    const emblem =
+      hash % 3 === 0
+        ? '<path d="M50 63L57 70L50 77L43 70Z" class="ws-cmd-character-emblem"/>'
+        : hash % 3 === 1
+          ? '<circle cx="50" cy="69" r="7" class="ws-cmd-character-emblem"/>'
+          : '<path d="M42 75L50 61L58 75Z" class="ws-cmd-character-emblem"/>';
+    const variantClass = variant === 'stage' ? ' is-stage' : ' is-roster';
 
     return (
-      '<article class="ws-cmd-unit' + (keeper ? ' is-keeper' : '') + '">' +
-      '<div class="ws-cmd-unit-top">' +
-      '<span class="ws-cmd-av" style="' + escapeHtml(avatar.style || '') + '">' + escapeHtml(avatar.initials) + '</span>' +
-      '<div class="ws-cmd-unit-id"><div class="ws-cmd-unit-name">' + nameInner + '</div>' +
-      '<div class="ws-cmd-unit-role">' + roleBadge +
-      '<span class="ws-cmd-state"><span class="ws-cmd-led ' + tone + '"></span>' + escapeHtml(status.label || 'Idle') + '</span>' +
-      '</div></div>' +
-      '<div class="ws-cmd-unit-ctl">' + ctl + '</div>' +
+      '<span class="ws-cmd-character' +
+      variantClass +
+      ' ' +
+      escapeHtml(agent.tone || 'idle') +
+      '" style="--agent-character-hue:' +
+      hue +
+      '" aria-hidden="true">' +
+      '<svg viewBox="0 0 100 118" focusable="false">' +
+      '<path d="M18 92L28 56L38 47H62L72 56L82 92L69 108H31Z" class="ws-cmd-character-body"/>' +
+      '<path d="M32 30L42 21H58L68 30V49L59 58H41L32 49Z" class="ws-cmd-character-head"/>' +
+      '<path d="M' +
+      visor +
+      ' 34H' +
+      (100 - visor) +
+      'V45H' +
+      visor +
+      'Z" class="ws-cmd-character-visor"/>' +
+      '<path d="M18 92L5 83L12 66L28 59M82 92L95 83L88 66L72 59" class="ws-cmd-character-shoulders"/>' +
+      antenna +
+      emblem +
+      '<path d="M28 91H72" class="ws-cmd-character-line is-soft"/>' +
+      '</svg>' +
+      '</span>'
+    );
+  }
+
+  rosterItemHTML(agent) {
+    const selected = agent.key === this.selectedAgentKey;
+    const count =
+      agent.instanceCount > 1
+        ? '<span class="ws-cmd-roster-count" aria-label="' +
+          agent.instanceCount +
+          ' instances">' +
+          agent.instanceCount +
+          '×</span>'
+        : '';
+    const entry = agent.entry ? '<span class="ws-cmd-roster-entry">Entry</span>' : '';
+    return (
+      '<button type="button" class="ws-cmd-roster-item' +
+      (selected ? ' is-selected' : '') +
+      (agent.entry ? ' is-entry' : '') +
+      '" data-cmd-select-agent="' +
+      escapeHtml(agent.encodedName) +
+      '" data-agent-key="' +
+      escapeHtml(agent.key) +
+      '" aria-pressed="' +
+      (selected ? 'true' : 'false') +
+      '" aria-label="Select ' +
+      escapeHtml(agent.name) +
+      ', ' +
+      escapeHtml(agent.status?.label || 'Idle') +
+      (agent.instanceCount > 1 ? ', ' + agent.instanceCount + ' instances' : '') +
+      '">' +
+      this.agentCharacterHTML(agent, 'roster') +
+      '<span class="ws-cmd-roster-copy">' +
+      '<span class="ws-cmd-roster-name">' +
+      escapeHtml(agent.name) +
+      '</span>' +
+      '<span class="ws-cmd-roster-role">' +
+      escapeHtml(agent.role?.label || 'Agent') +
+      '</span>' +
+      '<span class="ws-cmd-state"><span class="ws-cmd-led ' +
+      escapeHtml(agent.tone) +
+      '"></span>' +
+      escapeHtml(agent.status?.label || 'Idle') +
+      '</span>' +
+      '</span>' +
+      entry +
+      count +
+      '</button>'
+    );
+  }
+
+  agentDetailTarget(agent) {
+    const page = this.page || {};
+    if (!agent || typeof page.getAgentDetailTarget !== 'function') return null;
+    try {
+      const target = page.getAgentDetailTarget(agent.name);
+      return target && target.interactive && target.href ? target : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  agentStageHTML(agent) {
+    const target = this.agentDetailTarget(agent);
+    const detailAction = target
+      ? '<a class="ws-cmd-agent-action" href="' + escapeHtml(target.href) + '">Open Agent</a>'
+      : '';
+    const entry = agent.entry ? '<span class="ws-cmd-badge is-keeper">★ Entry Agent</span>' : '';
+    const remove = agent.entry
+      ? '<span class="ws-cmd-agent-lock" title="The entry agent cannot be removed">Entry agent locked</span>'
+      : '<button type="button" class="ws-cmd-agent-action is-danger" data-cmd-remove-agent="' +
+        escapeHtml(agent.encodedName) +
+        '">Remove</button>';
+    const instance =
+      agent.instanceCount > 1
+        ? '<span class="ws-cmd-badge">' + agent.instanceCount + ' instances</span>'
+        : '';
+
+    return (
+      '<section class="ws-cmd-agent-stage ' +
+      escapeHtml(agent.tone) +
+      '" aria-labelledby="ws-cmd-selected-agent-name">' +
+      '<div class="ws-cmd-stage-grid" aria-hidden="true"></div>' +
+      '<div class="ws-cmd-stage-character">' +
+      this.agentCharacterHTML(agent, 'stage') +
       '</div>' +
-      rows +
-      this.questLogHTML(group, encoded) +
-      '</article>'
+      '<div class="ws-cmd-stage-copy">' +
+      '<span class="ws-cmd-stage-kicker">Selected Agent</span>' +
+      '<h3 id="ws-cmd-selected-agent-name">' +
+      escapeHtml(agent.name) +
+      '</h3>' +
+      '<div class="ws-cmd-stage-badges">' +
+      entry +
+      instance +
+      '</div>' +
+      '<p class="ws-cmd-stage-role">' +
+      escapeHtml(agent.role?.detail || 'Agent') +
+      '</p>' +
+      '<p class="ws-cmd-stage-status"><span class="ws-cmd-led ' +
+      escapeHtml(agent.tone) +
+      '"></span><strong>' +
+      escapeHtml(agent.status?.label || 'Idle') +
+      '</strong><span>' +
+      escapeHtml(agent.status?.detail || 'No active tasks') +
+      '</span></p>' +
+      '</div>' +
+      '<div class="ws-cmd-stage-actions">' +
+      '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-task="' +
+      escapeHtml(agent.encodedName) +
+      '">Give Task</button>' +
+      detailAction +
+      (agent.entry
+        ? '<button type="button" class="ws-cmd-agent-action" data-cmd-manager-settings="1">Manager Settings</button>'
+        : '') +
+      remove +
+      '</div>' +
+      '</section>'
     );
   }
 
   questLogHTML(group, encoded) {
     const tasks = this.applyTaskTagFilter(Array.isArray(group.tasks) ? group.tasks : []);
-    const add = group.isUnassigned ? '' :
-      '<button type="button" class="ws-cmd-icon-btn sm" data-cmd-add-task="' + escapeHtml(encoded) +
-      '" aria-label="Add task">＋</button>';
-    const head = '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Tasks · ' + tasks.length + '</span>' + add + '</div>';
+    const add = group.isUnassigned
+      ? ''
+      : '<button type="button" class="ws-cmd-icon-btn sm" data-cmd-add-task="' +
+        escapeHtml(encoded) +
+        '" aria-label="Add task">＋</button>';
+    const head =
+      '<div class="ws-cmd-ql-head"><span class="ws-cmd-ql-t">Tasks · ' +
+      tasks.length +
+      '</span>' +
+      add +
+      '</div>';
     if (!tasks.length) {
-      const emptyText = this.taskFilterActiveTags().length ? '— no tasks match the tag filter —' : '— no tasks yet —';
-      return '<div class="ws-cmd-questlog">' + head + '<div class="ws-cmd-ql-empty">' + emptyText + '</div></div>';
-    }
-    const items = tasks.map((t) => {
-      const label = String(t.description || t.name || t.title || 'Task');
-      const tone = this.taskTone(t.status);
-      const statusText = String(t.status || 'pending').replace('_', ' ');
-      const taskId = String(t.id || '');
+      const emptyText = this.taskFilterActiveTags().length
+        ? '— no tasks match the tag filter —'
+        : '— no tasks yet —';
       return (
-        '<div class="ws-cmd-quest">' +
-        '<span class="ws-cmd-q-glyph">&bull;</span>' +
-        '<button type="button" class="ws-cmd-q-name" data-cmd-open-task="' + escapeHtml(taskId) +
-        '" aria-label="Open task ' + escapeHtml(label) + '">' + escapeHtml(label) + '</button>' +
-        '<span class="ws-cmd-q-status ' + tone + '">' + escapeHtml(statusText) + '</span>' +
-        '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' + escapeHtml(taskId) +
-        '" title="Run" aria-label="Run task ' + escapeHtml(label) + '">▶</button>' +
-        '</div>'
+        '<div class="ws-cmd-questlog">' +
+        head +
+        '<div class="ws-cmd-ql-empty">' +
+        emptyText +
+        '</div></div>'
       );
-    }).join('');
+    }
+    const items = tasks
+      .map(t => {
+        const label = String(t.description || t.name || t.title || 'Task');
+        const tone = this.taskTone(t.status);
+        const statusText = String(t.status || 'pending').replace('_', ' ');
+        const taskId = String(t.id || '');
+        return (
+          '<div class="ws-cmd-quest">' +
+          '<span class="ws-cmd-q-glyph">&bull;</span>' +
+          '<button type="button" class="ws-cmd-q-name" data-cmd-open-task="' +
+          escapeHtml(taskId) +
+          '" aria-label="Open task ' +
+          escapeHtml(label) +
+          '">' +
+          escapeHtml(label) +
+          '</button>' +
+          '<span class="ws-cmd-q-status ' +
+          tone +
+          '">' +
+          escapeHtml(statusText) +
+          '</span>' +
+          '<button type="button" class="ws-cmd-q-run" data-cmd-run-task="' +
+          escapeHtml(taskId) +
+          '" title="Run" aria-label="Run task ' +
+          escapeHtml(label) +
+          '">▶</button>' +
+          '</div>'
+        );
+      })
+      .join('');
     return '<div class="ws-cmd-questlog">' + head + items + '</div>';
   }
 
-  // System-prompt block on a unit card: a lazily-hydrated preview that opens the
-  // full system-prompt modal (base + workspace refinement + effective) on click.
-  // The preview text is filled in by hydrateGarrisonPrompts() once the
-  // effective-prompt fetch resolves.
-  promptBlockHTML(group, name, encoded) {
-    if (group.isUnassigned) return '';
+  overviewTabHTML(agent) {
+    const currentTask = agent.currentTask
+      ? escapeHtml(agent.currentTask.description || agent.currentTask.name || 'Current task')
+      : 'No task in progress';
+    const currentDetail = agent.currentTask
+      ? 'This agent is actively executing assigned work.'
+      : 'Ready for a new assignment.';
     return (
-      '<button type="button" class="ws-cmd-prompt" data-cmd-view-prompt="' + escapeHtml(encoded) + '"' +
-      ' title="View ' + escapeHtml(name) + ' system prompt"' +
-      ' aria-label="View ' + escapeHtml(name) + ' system prompt">' +
-      '<span class="ws-cmd-prompt-head"><span class="ws-cmd-rk">System Prompt</span>' +
-      '<span class="ws-cmd-prompt-cta">View ▸</span></span>' +
-      '<span class="ws-cmd-prompt-preview" data-cmd-prompt-name="' + escapeHtml(encoded) + '">Loading…</span>' +
-      '</button>'
+      '<div class="ws-cmd-overview-hero">' +
+      '<div><span class="ws-cmd-overview-label">Current assignment</span>' +
+      '<strong>' +
+      currentTask +
+      '</strong><p>' +
+      currentDetail +
+      '</p></div>' +
+      '<span class="ws-cmd-overview-signal ' +
+      escapeHtml(agent.tone) +
+      '">' +
+      escapeHtml(agent.status?.label || 'Idle') +
+      '</span></div>' +
+      '<div class="ws-cmd-overview-stats">' +
+      '<div><span>Tasks</span><strong>' +
+      agent.tasks.length +
+      '</strong></div>' +
+      '<div><span>Skills</span><strong>' +
+      Number(agent.skills?.count || 0) +
+      '</strong></div>' +
+      '<div><span>MCP tools</span><strong>' +
+      agent.mcpNames.length +
+      '</strong></div>' +
+      '<div><span>Instances</span><strong>' +
+      agent.instanceCount +
+      '</strong></div>' +
+      '</div>' +
+      '<div class="ws-cmd-overview-brief">' +
+      '<span class="ws-cmd-overview-label">Role profile</span>' +
+      '<p>' +
+      escapeHtml(agent.role?.detail || 'Agent') +
+      '</p>' +
+      '<span class="ws-cmd-overview-label">Status detail</span>' +
+      '<p>' +
+      escapeHtml(agent.status?.detail || 'No active tasks') +
+      '</p>' +
+      '</div>'
     );
   }
 
-  hydrateGarrisonPrompts() {
-    const page = this.page;
-    if (!page || typeof page.ensureAgentPromptData !== 'function') return;
-    const root = this.container && this.container.querySelector('.ws-cmd-garrison');
-    if (!root) return;
-    const previews = root.querySelectorAll('.ws-cmd-prompt-preview[data-cmd-prompt-name]');
-    previews.forEach((el) => {
-      let name = '';
-      try { name = decodeURIComponent(el.getAttribute('data-cmd-prompt-name') || ''); }
-      catch (_e) { name = el.getAttribute('data-cmd-prompt-name') || ''; }
-      if (!name) return;
-      Promise.resolve(page.ensureAgentPromptData(name)).then((data) => {
-        if (!el.isConnected) return;
-        if (!data || data.error) {
-          el.textContent = 'System prompt unavailable.';
-          el.classList.add('is-empty');
-          return;
-        }
-        const preview = typeof page.buildAgentPromptPreview === 'function'
-          ? page.buildAgentPromptPreview(data)
-          : String(data.effective_prompt || data.base_system_prompt || '');
-        el.textContent = preview || 'No system prompt set.';
-        el.classList.toggle('is-empty', !preview);
-      }).catch(() => {});
+  tasksTabHTML(agent) {
+    const page = this.page || {};
+    if (typeof page.renderAgentTasksContent === 'function') {
+      try {
+        return (
+          '<div class="ws-cmd-agent-task-list">' +
+          page.renderAgentTasksContent(agent.tasks) +
+          '</div>'
+        );
+      } catch (_error) {
+        // Fall back to the compact command task list.
+      }
+    }
+    return this.questLogHTML(agent.group, agent.encodedName);
+  }
+
+  chipListHTML(items, emptyText, tone = '') {
+    const values = Array.isArray(items) ? items.filter(Boolean) : [];
+    if (!values.length) {
+      return '<span class="ws-cmd-loadout-empty">' + escapeHtml(emptyText) + '</span>';
+    }
+    return values
+      .map(
+        item =>
+          '<span class="ws-cmd-loadout-chip ' +
+          escapeHtml(tone) +
+          '">' +
+          escapeHtml(item) +
+          '</span>'
+      )
+      .join('');
+  }
+
+  promptCacheEntry(agent) {
+    const cache = this.page && this.page.agentPromptCache;
+    if (!cache || typeof cache.get !== 'function' || !agent) return null;
+    return cache.get(agent.key) || null;
+  }
+
+  promptLoadoutHTML(agent) {
+    const page = this.page || {};
+    const cached = this.promptCacheEntry(agent);
+    const loading = this.agentPromptLoadingKey === agent.key;
+    if (loading) {
+      return (
+        '<div class="ws-cmd-loadout-prompt is-loading" aria-live="polite">' +
+        '<div><span class="ws-cmd-loadout-title">System prompt</span>' +
+        '<p>Loading effective prompt…</p></div></div>'
+      );
+    }
+    if (cached && cached.error) {
+      return (
+        '<div class="ws-cmd-loadout-prompt is-error">' +
+        '<div><span class="ws-cmd-loadout-title">System prompt unavailable</span>' +
+        '<p>The effective prompt could not be loaded.</p></div>' +
+        '<button type="button" class="ws-cmd-agent-action" data-cmd-retry-prompt="' +
+        escapeHtml(agent.encodedName) +
+        '">Retry</button></div>'
+      );
+    }
+    if (cached && !cached.error) {
+      const preview =
+        typeof page.buildAgentPromptPreview === 'function'
+          ? page.buildAgentPromptPreview(cached)
+          : String(cached.effective_prompt || cached.base_system_prompt || '');
+      return (
+        '<div class="ws-cmd-loadout-prompt">' +
+        '<div><span class="ws-cmd-loadout-title">System prompt</span><p>' +
+        escapeHtml(preview || 'No system prompt set for this agent.') +
+        '</p></div>' +
+        '<button type="button" class="ws-cmd-agent-action" data-cmd-view-prompt="' +
+        escapeHtml(agent.encodedName) +
+        '">View full</button></div>'
+      );
+    }
+    return (
+      '<div class="ws-cmd-loadout-prompt is-loading" aria-live="polite">' +
+      '<div><span class="ws-cmd-loadout-title">System prompt</span>' +
+      '<p>Preparing effective prompt…</p></div></div>'
+    );
+  }
+
+  loadoutTabHTML(agent) {
+    const page = this.page || {};
+    const editable =
+      typeof page.agentAllowsModelEditing === 'function'
+        ? page.agentAllowsModelEditing(agent.profile)
+        : false;
+    const model =
+      agent.model && !agent.model.empty ? agent.model.label || agent.model.model : 'Model not set';
+    const modelAction = editable
+      ? '<button type="button" class="ws-cmd-loadout-edit" data-cmd-edit-model="' +
+        escapeHtml(agent.encodedName) +
+        '">Change</button>'
+      : '<span class="ws-cmd-loadout-readonly">Read only</span>';
+    const skillNames = Array.isArray(agent.skills?.names) ? agent.skills.names : [];
+    return (
+      '<div class="ws-cmd-loadout-grid">' +
+      '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">Model</span>' +
+      modelAction +
+      '</header><strong>' +
+      escapeHtml(model) +
+      '</strong></section>' +
+      '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">Skills</span>' +
+      '<span>' +
+      skillNames.length +
+      '</span></header><div class="ws-cmd-loadout-chips">' +
+      this.chipListHTML(skillNames, 'No workspace skills attached.', 'skill') +
+      '</div></section>' +
+      '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">MCP tools</span>' +
+      '<span>' +
+      agent.mcpNames.length +
+      '</span></header><div class="ws-cmd-loadout-chips">' +
+      this.chipListHTML(agent.mcpNames, 'No MCP tools attached.', 'mcp') +
+      '</div></section>' +
+      '</div>' +
+      this.promptLoadoutHTML(agent)
+    );
+  }
+
+  recentActivityItems(agent) {
+    if (!agent) return [];
+    const page = this.page || {};
+    const key = agent.key;
+    const tasks = Array.isArray(page.tasks) ? page.tasks : agent.tasks;
+    const sessions = Array.isArray(page.sessions) ? page.sessions : [];
+    const items = [];
+
+    tasks.forEach(task => {
+      if (this.normalizeAgentKey(task?.to) !== key) return;
+      const timestamp = task?.updated_at || task?.created_at;
+      const time = Date.parse(timestamp || '');
+      if (!Number.isFinite(time)) return;
+      items.push({
+        id: String(task.id || ''),
+        kind: 'Task',
+        title: String(task.description || task.name || task.title || 'Untitled task'),
+        status: String(task.status || 'pending').replaceAll('_', ' '),
+        timestamp: String(timestamp),
+        time
+      });
     });
+    sessions.forEach(session => {
+      if (this.normalizeAgentKey(session?.agent_name) !== key) return;
+      const timestamp = session?.updated_at || session?.created_at;
+      const time = Date.parse(timestamp || '');
+      if (!Number.isFinite(time)) return;
+      items.push({
+        id: String(session.id || ''),
+        kind: 'Session',
+        title: String(session.title || session.name || 'Untitled session'),
+        status: 'Workspace session',
+        timestamp: String(timestamp),
+        time
+      });
+    });
+
+    return items.sort((left, right) => right.time - left.time);
+  }
+
+  formatActivityTimestamp(timestamp) {
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime())
+      ? ''
+      : date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  recentActivityTabHTML(agent) {
+    const items = this.recentActivityItems(agent);
+    if (!items.length) {
+      return (
+        '<div class="ws-cmd-tab-empty"><strong>No recent activity</strong>' +
+        '<span>Tasks and sessions attributed to this agent will appear here.</span></div>'
+      );
+    }
+    return (
+      '<div class="ws-cmd-activity-list">' +
+      items
+        .map(
+          item =>
+            '<button type="button" class="ws-cmd-activity-item" data-cmd-' +
+            (item.kind === 'Task' ? 'open-task' : 'open-session') +
+            '="' +
+            escapeHtml(item.id) +
+            '">' +
+            '<span class="ws-cmd-activity-kind">' +
+            escapeHtml(item.kind) +
+            '</span>' +
+            '<span class="ws-cmd-activity-copy"><strong>' +
+            escapeHtml(item.title) +
+            '</strong>' +
+            '<span>' +
+            escapeHtml(item.status) +
+            '</span></span>' +
+            '<time datetime="' +
+            escapeHtml(item.timestamp) +
+            '">' +
+            escapeHtml(this.formatActivityTimestamp(item.timestamp)) +
+            '</time></button>'
+        )
+        .join('') +
+      '</div>'
+    );
+  }
+
+  unassignedQueueHTML(group) {
+    const tasks = Array.isArray(group?.tasks) ? group.tasks : [];
+    if (!tasks.length) return '';
+    return (
+      '<section class="ws-cmd-unassigned" aria-labelledby="ws-cmd-unassigned-title">' +
+      '<div><span class="ws-cmd-unassigned-kicker">Dispatch queue</span>' +
+      '<strong id="ws-cmd-unassigned-title">Unassigned tasks</strong></div>' +
+      '<span class="ws-cmd-unassigned-count">' +
+      tasks.length +
+      '</span>' +
+      '<button type="button" class="ws-cmd-agent-action" data-cmd-open-agent-manager="tasks">Review</button>' +
+      '</section>'
+    );
+  }
+
+  agentTabsHTML(agent) {
+    const tabs = [
+      { key: 'overview', label: 'Overview' },
+      { key: 'tasks', label: 'Tasks' },
+      { key: 'loadout', label: 'Loadout' },
+      { key: 'recent', label: 'Recent Activity' }
+    ];
+    const safeKey = agent.key.replace(/[^a-z0-9_-]+/gi, '-');
+    const tabList = tabs
+      .map(tab => {
+        const active = tab.key === this.activeAgentTab;
+        return (
+          '<button type="button" role="tab" class="ws-cmd-agent-tab' +
+          (active ? ' is-active' : '') +
+          '" id="ws-cmd-agent-tab-' +
+          safeKey +
+          '-' +
+          tab.key +
+          '" aria-selected="' +
+          (active ? 'true' : 'false') +
+          '" aria-controls="ws-cmd-agent-panel-' +
+          safeKey +
+          '-' +
+          tab.key +
+          '" tabindex="' +
+          (active ? '0' : '-1') +
+          '" data-cmd-agent-tab="' +
+          tab.key +
+          '">' +
+          tab.label +
+          '</button>'
+        );
+      })
+      .join('');
+    const content = {
+      overview: this.overviewTabHTML(agent),
+      tasks: this.tasksTabHTML(agent),
+      loadout: this.loadoutTabHTML(agent),
+      recent: this.recentActivityTabHTML(agent)
+    };
+    const panels = tabs
+      .map(tab => {
+        const active = tab.key === this.activeAgentTab;
+        return (
+          '<section role="tabpanel" class="ws-cmd-agent-tabpanel' +
+          (active ? ' is-active' : '') +
+          '" id="ws-cmd-agent-panel-' +
+          safeKey +
+          '-' +
+          tab.key +
+          '" aria-labelledby="ws-cmd-agent-tab-' +
+          safeKey +
+          '-' +
+          tab.key +
+          '"' +
+          (active ? '' : ' hidden') +
+          '>' +
+          content[tab.key] +
+          '</section>'
+        );
+      })
+      .join('');
+    return (
+      '<section class="ws-cmd-agent-overview" aria-label="' +
+      escapeHtml(agent.name) +
+      ' overview">' +
+      '<div class="ws-cmd-agent-tabs" role="tablist" aria-label="Agent overview sections">' +
+      tabList +
+      '</div>' +
+      '<div class="ws-cmd-agent-panel-body">' +
+      panels +
+      '</div>' +
+      '</section>'
+    );
   }
 
   renderGarrison() {
-    const page = this.page;
-    let groups = [];
-    try { groups = page.buildAgentGroups() || []; } catch (err) { groups = []; }
-    const units = groups.filter((g) => g && (g.isWorkspaceAgent || (g.isUnassigned && (g.tasks || []).length)));
-    if (!units.length) {
-      return '<div class="ws-cmd-soon">No agents yet.</div>';
+    if (!AGENT_TAB_KEYS.includes(this.activeAgentTab)) this.activeAgentTab = 'overview';
+    const groups = this.agentGroups();
+    const selectedGroup = this.selectedAgentGroup(groups.agents);
+    if (!selectedGroup) {
+      this.selectedAgentKey = '';
+      return (
+        '<div class="ws-cmd-deck-empty"><div class="ws-cmd-deck-empty-glyph">◇</div>' +
+        '<strong>No agents in this workspace</strong>' +
+        '<span>Add an agent to begin assigning work.</span>' +
+        '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-agent>Add Agent</button></div>'
+      );
     }
-    const gridClass = 'ws-cmd-garrison-grid' + (units.length > 1 && units.length % 2 === 1 ? ' is-odd' : '');
-    return '<div class="' + gridClass + '">' + units.map((g) => this.unitCardHTML(g)).join('') + '</div>';
+    const agents = groups.agents.map(group => this.agentViewModel(group)).filter(Boolean);
+    const selected = agents.find(agent => agent.key === this.selectedAgentKey) || agents[0];
+    const roster = agents.map(agent => this.rosterItemHTML(agent)).join('');
+    const statusAnnouncement = selected.name + ' selected. ' + (selected.status?.label || 'Idle');
+    const announce = statusAnnouncement === this.lastAnnouncedAgentStatus ? '' : statusAnnouncement;
+    this.lastAnnouncedAgentStatus = statusAnnouncement;
+    return (
+      '<div class="ws-cmd-deck">' +
+      '<aside class="ws-cmd-roster" aria-label="Workspace agents">' +
+      '<header class="ws-cmd-roster-head"><div><span>Agent roster</span><strong>' +
+      agents.length +
+      '</strong></div><button type="button" class="ws-cmd-icon-btn" data-cmd-add-agent' +
+      ' aria-label="Add agent">＋</button></header>' +
+      '<div class="ws-cmd-roster-list">' +
+      roster +
+      '</div>' +
+      this.unassignedQueueHTML(groups.unassigned) +
+      '</aside>' +
+      this.agentStageHTML(selected) +
+      this.agentTabsHTML(selected) +
+      '<div class="ws-cmd-agent-live sr-only" aria-live="polite" aria-atomic="true">' +
+      escapeHtml(announce) +
+      '</div>' +
+      '</div>'
+    );
+  }
+
+  captureAgentDeckViewState() {
+    if (!this.container || typeof this.container.querySelector !== 'function') return;
+    const roster = this.container.querySelector('.ws-cmd-roster-list');
+    const overview = this.container.querySelector('.ws-cmd-agent-panel-body');
+    if (roster) {
+      this.agentRosterScroll = {
+        top: Number(roster.scrollTop || 0),
+        left: Number(roster.scrollLeft || 0)
+      };
+    }
+    if (overview) this.agentOverviewScroll = Number(overview.scrollTop || 0);
+  }
+
+  restoreAgentDeckViewState() {
+    if (!this.container || typeof this.container.querySelector !== 'function') return;
+    const roster = this.container.querySelector('.ws-cmd-roster-list');
+    const overview = this.container.querySelector('.ws-cmd-agent-panel-body');
+    if (roster) {
+      roster.scrollTop = Number(this.agentRosterScroll?.top || 0);
+      roster.scrollLeft = Number(this.agentRosterScroll?.left || 0);
+    }
+    if (overview) overview.scrollTop = this.agentOverviewScroll || 0;
+
+    if (this.pendingAgentFocusKey) {
+      const target = this.container.querySelector(
+        '[data-agent-key="' + this.pendingAgentFocusKey + '"]'
+      );
+      if (target && typeof target.focus === 'function') target.focus();
+      this.pendingAgentFocusKey = '';
+    }
+    if (this.pendingAgentTabFocus) {
+      const target = this.container.querySelector(
+        '[data-cmd-agent-tab="' + this.pendingAgentTabFocus + '"]'
+      );
+      if (target && typeof target.focus === 'function') target.focus();
+      this.pendingAgentTabFocus = '';
+    }
+  }
+
+  selectAgent(encodedName, { focus = true } = {}) {
+    let name = '';
+    try {
+      name = decodeURIComponent(String(encodedName || ''));
+    } catch (_error) {
+      name = String(encodedName || '');
+    }
+    const key = this.normalizeAgentKey(name);
+    if (!key) return;
+    this.selectedAgentKey = key;
+    this.agentSelectionInitialized = true;
+    this.persistAgentKey(key);
+    this.agentOverviewScroll = 0;
+    if (focus) this.pendingAgentFocusKey = key;
+    this.render();
+  }
+
+  setActiveAgentTab(key, { focus = true } = {}) {
+    const normalized = String(key || '').toLowerCase();
+    if (!AGENT_TAB_KEYS.includes(normalized)) return;
+    this.activeAgentTab = normalized;
+    this.agentOverviewScroll = 0;
+    if (focus) this.pendingAgentTabFocus = normalized;
+    this.render();
+  }
+
+  hydrateActiveAgentPrompt({ force = false } = {}) {
+    if (this.activeAgentTab !== 'loadout') return;
+    const page = this.page || {};
+    if (typeof page.ensureAgentPromptData !== 'function') return;
+    const groups = this.agentGroups();
+    const group = groups.agents.find(
+      item => this.normalizeAgentKey(item.key || item.name) === this.selectedAgentKey
+    );
+    const agent = this.agentViewModel(group);
+    if (!agent) return;
+    const cached = this.promptCacheEntry(agent);
+    if (!force && cached) return;
+    if (this.agentPromptLoadingKey === agent.key) return;
+
+    this.agentPromptLoadingKey = agent.key;
+    Promise.resolve(page.ensureAgentPromptData(agent.name, force ? { force: true } : {}))
+      .catch(() => ({ error: true }))
+      .finally(() => {
+        if (this.agentPromptLoadingKey === agent.key) this.agentPromptLoadingKey = '';
+        if (
+          this.active &&
+          this.selectedAgentKey === agent.key &&
+          this.activeAgentTab === 'loadout'
+        ) {
+          this.render();
+        }
+      });
+  }
+
+  handleAgentTabKeydown(event) {
+    const current = event?.target?.closest?.('[data-cmd-agent-tab]');
+    if (!current) return;
+    const root = this.container?.querySelector?.('.ws-cmd-agent-tabs');
+    const tabs =
+      root && typeof root.querySelectorAll === 'function'
+        ? Array.from(root.querySelectorAll('[data-cmd-agent-tab]'))
+        : [];
+    if (!tabs.length) return;
+    const index = tabs.indexOf(current);
+    let next = index;
+    if (event.key === 'ArrowRight') next = (index + 1) % tabs.length;
+    else if (event.key === 'ArrowLeft') next = (index - 1 + tabs.length) % tabs.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = tabs.length - 1;
+    else return;
+    event.preventDefault();
+    this.setActiveAgentTab(tabs[next].getAttribute('data-cmd-agent-tab'));
   }
 
   bindGarrison() {
     const root = this.container && this.container.querySelector('.ws-cmd-garrison');
     if (!root) return;
-    root.addEventListener('click', (event) => {
+    root.addEventListener('keydown', event => this.handleAgentTabKeydown(event));
+    root.addEventListener('click', event => {
       const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      const selectBtn = event.target.closest('[data-cmd-select-agent]');
+      if (selectBtn) {
+        this.selectAgent(selectBtn.getAttribute('data-cmd-select-agent'));
+        return;
+      }
+      const tabBtn = event.target.closest('[data-cmd-agent-tab]');
+      if (tabBtn) {
+        this.setActiveAgentTab(tabBtn.getAttribute('data-cmd-agent-tab'), { focus: false });
+        return;
+      }
       const settingsBtn = event.target.closest('[data-cmd-manager-settings]');
       if (settingsBtn) {
         this.openStatModal('settings', settingsBtn);
         return;
       }
+      const addAgentBtn = event.target.closest('[data-cmd-add-agent]');
+      if (addAgentBtn && page && typeof page.openAddAgentModal === 'function') {
+        page.openAddAgentModal();
+        return;
+      }
       const promptBtn = event.target.closest('[data-cmd-view-prompt]');
       if (promptBtn && page && typeof page.openAgentPromptModal === 'function') {
         page.openAgentPromptModal(promptBtn.getAttribute('data-cmd-view-prompt'));
+        return;
+      }
+      const retryBtn = event.target.closest('[data-cmd-retry-prompt]');
+      if (retryBtn) {
+        this.hydrateActiveAgentPrompt({ force: true });
+        return;
+      }
+      const modelBtn = event.target.closest('[data-cmd-edit-model]');
+      if (modelBtn && page && typeof page.openAgentModelModal === 'function') {
+        page.openAgentModelModal(modelBtn.getAttribute('data-cmd-edit-model'));
+        return;
+      }
+      const removeBtn = event.target.closest('[data-cmd-remove-agent]');
+      if (removeBtn && page && typeof page.removeAgentFromWorkspace === 'function') {
+        page.removeAgentFromWorkspace(removeBtn.getAttribute('data-cmd-remove-agent'));
         return;
       }
       const addBtn = event.target.closest('[data-cmd-add-task]');
@@ -1530,7 +2632,16 @@ export class WorkspaceCommandView {
       const openBtn = event.target.closest('[data-cmd-open-task]');
       if (openBtn && page && page.openTask) {
         page.openTask(openBtn.getAttribute('data-cmd-open-task'));
+        return;
       }
+      const sessionBtn = event.target.closest('[data-cmd-open-session]');
+      if (sessionBtn && page && page.openSession) {
+        page.openSession(sessionBtn.getAttribute('data-cmd-open-session'));
+        return;
+      }
+      const managerBtn = event.target.closest('[data-cmd-open-agent-manager]');
+      if (managerBtn)
+        this.openStatModal(managerBtn.getAttribute('data-cmd-open-agent-manager'), managerBtn);
     });
   }
 
@@ -1544,17 +2655,34 @@ export class WorkspaceCommandView {
       ? items.join('')
       : '<div class="ws-cmd-rail-empty">' + escapeHtml(emptyText) + '</div>';
     return (
-      '<section class="ws-cmd-panel' + (isManaging ? ' is-managing' : '') + (!hasItems ? ' is-empty' : '') + '">' +
+      '<section class="ws-cmd-panel' +
+      (isManaging ? ' is-managing' : '') +
+      (!hasItems ? ' is-empty' : '') +
+      '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><h4>' + escapeHtml(title) + '</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-title"><h4>' +
+      escapeHtml(title) +
+      '</h4><span class="ws-cmd-panel-count">' +
+      count +
+      '</span></div>' +
       '<div class="ws-cmd-panel-tools">' +
       '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="' +
-        escapeHtml(sectionKey) + '">' + escapeHtml(primaryLabel) + '</button>' +
-      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="' + escapeHtml(sectionKey) +
-      '" aria-expanded="' + (isManaging ? 'true' : 'false') +
-      '" title="' + (isManaging ? 'Close Command manager' : 'Manage in Command view') +
-      '" aria-label="' + (isManaging ? 'Close ' : 'Manage ') +
-      escapeHtml(title) + ' in Command view">' + (isManaging ? '×' : '▸') + '</button>' +
+      escapeHtml(sectionKey) +
+      '">' +
+      escapeHtml(primaryLabel) +
+      '</button>' +
+      '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="' +
+      escapeHtml(sectionKey) +
+      '" aria-expanded="' +
+      (isManaging ? 'true' : 'false') +
+      '" title="' +
+      (isManaging ? 'Close Command manager' : 'Manage in Command view') +
+      '" aria-label="' +
+      (isManaging ? 'Close ' : 'Manage ') +
+      escapeHtml(title) +
+      ' in Command view">' +
+      (isManaging ? '×' : '▸') +
+      '</button>' +
       '</div>' +
       '</div>' +
       (shouldShowBody ? '<div class="ws-cmd-panel-body">' + body + '</div>' : '') +
@@ -1567,23 +2695,38 @@ export class WorkspaceCommandView {
     const attr = opts || {};
     const limit = attr.expanded ? arr.length : 5;
     const shown = arr.slice(0, limit);
-    const items = shown.map((it) => {
+    const items = shown.map(it => {
       const label = escapeHtml(labelOf(it));
       const meta = attr.metaOf ? escapeHtml(attr.metaOf(it)) : '';
-      const inner = '<span class="ws-cmd-rail-t">' + label + '</span>' +
+      const inner =
+        '<span class="ws-cmd-rail-t">' +
+        label +
+        '</span>' +
         (meta ? '<span class="ws-cmd-rail-m">' + meta + '</span>' : '');
       if (attr.href) {
-        return '<a class="ws-cmd-rail-item" href="' + escapeHtml(attr.href(it)) + '">' + inner + '</a>';
+        return (
+          '<a class="ws-cmd-rail-item" href="' + escapeHtml(attr.href(it)) + '">' + inner + '</a>'
+        );
       }
       if (attr.action) {
-        return '<button type="button" class="ws-cmd-rail-item" ' + attr.action(it) + '>' + inner + '</button>';
+        return (
+          '<button type="button" class="ws-cmd-rail-item" ' +
+          attr.action(it) +
+          '>' +
+          inner +
+          '</button>'
+        );
       }
       return '<div class="ws-cmd-rail-item is-static">' + inner + '</div>';
     });
     if (arr.length > shown.length) {
-      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="' +
-        escapeHtml(attr.sectionKey || '') + '">+ ' +
-        (arr.length - shown.length) + ' more</button>');
+      items.push(
+        '<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="' +
+          escapeHtml(attr.sectionKey || '') +
+          '">+ ' +
+          (arr.length - shown.length) +
+          ' more</button>'
+      );
     }
     return items;
   }
@@ -1591,7 +2734,11 @@ export class WorkspaceCommandView {
   getWorkspaceProjectPath() {
     const page = this.page || {};
     if (typeof page.getWorkspaceProjectPath === 'function') {
-      try { return String(page.getWorkspaceProjectPath() || '').trim(); } catch (err) { return ''; }
+      try {
+        return String(page.getWorkspaceProjectPath() || '').trim();
+      } catch (err) {
+        return '';
+      }
     }
     return String((page.workspace && page.workspace.project_path) || '').trim();
   }
@@ -1608,13 +2755,15 @@ export class WorkspaceCommandView {
     if (dirs.length) return dirs;
     const projectPath = this.getWorkspaceProjectPath();
     if (!projectPath) return [];
-    return [{
-      id: '__project_path__',
-      name: this.folderDisplayName(projectPath),
-      path: projectPath,
-      source: 'project_path',
-      isProjectPathOnly: true
-    }];
+    return [
+      {
+        id: '__project_path__',
+        name: this.folderDisplayName(projectPath),
+        path: projectPath,
+        source: 'project_path',
+        isProjectPathOnly: true
+      }
+    ];
   }
 
   folderRole(dir) {
@@ -1622,13 +2771,19 @@ export class WorkspaceCommandView {
     if (dir && dir.isProjectPathOnly) return { label: 'Project Folder', className: 'is-project' };
     let primaryDirectoryId = '';
     try {
-      primaryDirectoryId = typeof page.getPrimaryDirectoryId === 'function' ? String(page.getPrimaryDirectoryId() || '') : '';
+      primaryDirectoryId =
+        typeof page.getPrimaryDirectoryId === 'function'
+          ? String(page.getPrimaryDirectoryId() || '')
+          : '';
     } catch (err) {
       primaryDirectoryId = '';
     }
     let isProject = false;
     try {
-      isProject = typeof page.isProjectDirectory === 'function' ? Boolean(page.isProjectDirectory(dir)) : false;
+      isProject =
+        typeof page.isProjectDirectory === 'function'
+          ? Boolean(page.isProjectDirectory(dir))
+          : false;
     } catch (err) {
       isProject = false;
     }
@@ -1642,25 +2797,41 @@ export class WorkspaceCommandView {
     const arr = Array.isArray(rows) ? rows : [];
     const limit = expanded ? arr.length : 5;
     const shown = arr.slice(0, limit);
-    const items = shown.map((dir) => {
+    const items = shown.map(dir => {
       const id = String(dir.id || '');
       const role = this.folderRole(dir);
       const name = dir.title || dir.name || dir.path || 'Unnamed Directory';
       const path = String(dir.path || '');
       const source = String(dir.source || 'reference');
       const inner =
-        '<span class="ws-cmd-rail-line"><span class="ws-cmd-rail-t">' + escapeHtml(name) + '</span>' +
-        '<span class="ws-cmd-rail-role ' + escapeHtml(role.className) + '">' + escapeHtml(role.label) + '</span></span>' +
+        '<span class="ws-cmd-rail-line"><span class="ws-cmd-rail-t">' +
+        escapeHtml(name) +
+        '</span>' +
+        '<span class="ws-cmd-rail-role ' +
+        escapeHtml(role.className) +
+        '">' +
+        escapeHtml(role.label) +
+        '</span></span>' +
         (path ? '<span class="ws-cmd-rail-m">' + escapeHtml(path) + '</span>' : '');
       if (dir.isProjectPathOnly) {
         return '<div class="ws-cmd-rail-item is-static">' + inner + '</div>';
       }
-      return '<button type="button" class="ws-cmd-rail-item" data-cmd-open-section="folders" data-cmd-item-id="' +
-        escapeHtml(id) + '" data-cmd-item-source="' + escapeHtml(source) + '">' + inner + '</button>';
+      return (
+        '<button type="button" class="ws-cmd-rail-item" data-cmd-open-section="folders" data-cmd-item-id="' +
+        escapeHtml(id) +
+        '" data-cmd-item-source="' +
+        escapeHtml(source) +
+        '">' +
+        inner +
+        '</button>'
+      );
     });
     if (arr.length > shown.length) {
-      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="folders">+ ' +
-        (arr.length - shown.length) + ' more</button>');
+      items.push(
+        '<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="folders">+ ' +
+          (arr.length - shown.length) +
+          ' more</button>'
+      );
     }
     return items;
   }
@@ -1687,7 +2858,11 @@ export class WorkspaceCommandView {
     const parts = [];
     const size = Number(file?.file_meta?.size || file?.size || 0);
     if (size > 0 && typeof page.formatFileSize === 'function') {
-      try { parts.push(page.formatFileSize(size)); } catch (err) { /* keep going */ }
+      try {
+        parts.push(page.formatFileSize(size));
+      } catch (err) {
+        /* keep going */
+      }
     }
     const folder = String(file?.file_meta?.relative_path || file?.relative_path || '').trim();
     if (folder) parts.push(folder);
@@ -1701,22 +2876,30 @@ export class WorkspaceCommandView {
     const arr = Array.isArray(files) ? files : [];
     const limit = expanded ? arr.length : 5;
     const shown = arr.slice(0, limit);
-    const items = shown.map((file) => {
+    const items = shown.map(file => {
       const id = String(file?.id || file?.file_meta?.name || this.fileTitle(file));
       const title = this.fileTitle(file);
       const meta = this.fileMeta(file);
       const missingClass = file?.file_meta?.status === 'missing' ? ' is-missing' : '';
       return (
-        '<button type="button" class="ws-cmd-rail-item' + missingClass +
-        '" data-cmd-open-section="files" data-cmd-item-id="' + escapeHtml(id) + '">' +
-        '<span class="ws-cmd-rail-t">' + escapeHtml(title) + '</span>' +
+        '<button type="button" class="ws-cmd-rail-item' +
+        missingClass +
+        '" data-cmd-open-section="files" data-cmd-item-id="' +
+        escapeHtml(id) +
+        '">' +
+        '<span class="ws-cmd-rail-t">' +
+        escapeHtml(title) +
+        '</span>' +
         (meta ? '<span class="ws-cmd-rail-m">' + escapeHtml(meta) + '</span>' : '') +
         '</button>'
       );
     });
     if (arr.length > shown.length) {
-      items.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="files">+ ' +
-        (arr.length - shown.length) + ' more</button>');
+      items.push(
+        '<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="files">+ ' +
+          (arr.length - shown.length) +
+          ' more</button>'
+      );
     }
     return items;
   }
@@ -1728,16 +2911,25 @@ export class WorkspaceCommandView {
       ? items.join('')
       : '<div class="ws-cmd-rail-empty">No files yet.</div>';
     return (
-      '<section class="ws-cmd-panel ws-cmd-files-panel' + (expanded ? ' is-managing' : '') +
-      (count ? '' : ' is-empty') + '">' +
+      '<section class="ws-cmd-panel ws-cmd-files-panel' +
+      (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') +
+      '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><h4>Files</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-title"><h4>Files</h4><span class="ws-cmd-panel-count">' +
+      count +
+      '</span></div>' +
       '<div class="ws-cmd-panel-tools">' +
       '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="files">Upload</button>' +
       '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="files" aria-expanded="' +
-      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Files manager' : 'Manage Files in Command view') +
-      '" aria-label="' + (expanded ? 'Close Files manager' : 'Manage Files in Command view') + '">' +
-      (expanded ? '×' : '▸') + '</button>' +
+      (expanded ? 'true' : 'false') +
+      '" title="' +
+      (expanded ? 'Close Files manager' : 'Manage Files in Command view') +
+      '" aria-label="' +
+      (expanded ? 'Close Files manager' : 'Manage Files in Command view') +
+      '">' +
+      (expanded ? '×' : '▸') +
+      '</button>' +
       '</div>' +
       '</div>' +
       '<div class="ws-cmd-panel-body">' +
@@ -1756,8 +2948,18 @@ export class WorkspaceCommandView {
     // stat-box manager; Manager Settings → entry-agent modal; Goal Settings → "Set Goal";
     // Intent & Setup → header description edit. Systems keeps only workspace state/automation.
     return [
-      { key: 'memory', label: 'Memory', tabId: 'workspace-detail-config-memory-tab', host: 'config' },
-      { key: 'triggers', label: 'Triggers', tabId: 'workspace-detail-config-triggers-tab', host: 'config' }
+      {
+        key: 'memory',
+        label: 'Memory',
+        tabId: 'workspace-detail-config-memory-tab',
+        host: 'config'
+      },
+      {
+        key: 'triggers',
+        label: 'Triggers',
+        tabId: 'workspace-detail-config-triggers-tab',
+        host: 'config'
+      }
     ];
   }
 
@@ -1767,8 +2969,18 @@ export class WorkspaceCommandView {
   toolsTabs() {
     return [
       { key: 'mcp', label: 'MCP', tabId: 'workspace-detail-config-mcp-tab', host: 'config' },
-      { key: 'skills', label: 'Skills', tabId: 'workspace-detail-config-skills-tab', host: 'config' },
-      { key: 'plugins', label: 'Plugins', tabId: 'workspace-detail-config-plugins-tab', host: 'config' },
+      {
+        key: 'skills',
+        label: 'Skills',
+        tabId: 'workspace-detail-config-skills-tab',
+        host: 'config'
+      },
+      {
+        key: 'plugins',
+        label: 'Plugins',
+        tabId: 'workspace-detail-config-plugins-tab',
+        host: 'config'
+      },
       { key: 'find', label: 'Find Tools', tabId: '', host: 'tools' }
     ];
   }
@@ -1783,13 +2995,20 @@ export class WorkspaceCommandView {
   // the header intent editor). Kept separate from systemTabs() on purpose.
   configTabIdFor(key) {
     switch (String(key || '')) {
-      case 'mcp': return 'workspace-detail-config-mcp-tab';
-      case 'skills': return 'workspace-detail-config-skills-tab';
-      case 'plugins': return 'workspace-detail-config-plugins-tab';
-      case 'settings': return 'workspace-detail-config-settings-tab';
-      case 'mission': return 'workspace-detail-config-mission-tab';
-      case 'intent': return 'workspace-detail-config-intent-tab';
-      default: return '';
+      case 'mcp':
+        return 'workspace-detail-config-mcp-tab';
+      case 'skills':
+        return 'workspace-detail-config-skills-tab';
+      case 'plugins':
+        return 'workspace-detail-config-plugins-tab';
+      case 'settings':
+        return 'workspace-detail-config-settings-tab';
+      case 'mission':
+        return 'workspace-detail-config-mission-tab';
+      case 'intent':
+        return 'workspace-detail-config-intent-tab';
+      default:
+        return '';
     }
   }
 
@@ -1801,28 +3020,50 @@ export class WorkspaceCommandView {
   renderSystemsPanel(expanded) {
     const tabs = this.systemTabs();
     const active = this.systemTab(this.activeSystemTab);
-    const tabButtons = tabs.map(tab => (
-      '<button type="button" class="ws-cmd-system-tab' + (tab.key === active.key ? ' is-active' : '') +
-      '" data-cmd-system-tab="' + escapeHtml(tab.key) + '" aria-selected="' +
-      (tab.key === active.key ? 'true' : 'false') + '">' + escapeHtml(tab.label) + '</button>'
-    )).join('');
+    const tabButtons = tabs
+      .map(
+        tab =>
+          '<button type="button" class="ws-cmd-system-tab' +
+          (tab.key === active.key ? ' is-active' : '') +
+          '" data-cmd-system-tab="' +
+          escapeHtml(tab.key) +
+          '" aria-selected="' +
+          (tab.key === active.key ? 'true' : 'false') +
+          '">' +
+          escapeHtml(tab.label) +
+          '</button>'
+      )
+      .join('');
     return (
-      '<section class="ws-cmd-panel ws-cmd-systems-panel' + (expanded ? ' is-managing' : '') + '">' +
+      '<section class="ws-cmd-panel ws-cmd-systems-panel' +
+      (expanded ? ' is-managing' : '') +
+      '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><h4>Systems</h4><span class="ws-cmd-panel-count">' + tabs.length + '</span></div>' +
+      '<div class="ws-cmd-panel-title"><h4>Systems</h4><span class="ws-cmd-panel-count">' +
+      tabs.length +
+      '</span></div>' +
       '<div class="ws-cmd-panel-tools">' +
       '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="systems">Open</button>' +
       '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="systems" aria-expanded="' +
-      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') +
-      '" aria-label="' + (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') + '">' +
-      (expanded ? '×' : '▸') + '</button>' +
+      (expanded ? 'true' : 'false') +
+      '" title="' +
+      (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') +
+      '" aria-label="' +
+      (expanded ? 'Close Systems manager' : 'Manage Systems in Command view') +
+      '">' +
+      (expanded ? '×' : '▸') +
+      '</button>' +
       '</div>' +
       '</div>' +
       (expanded
         ? '<div class="ws-cmd-panel-body ws-cmd-systems-body">' +
-          '<div class="ws-cmd-system-tabs" role="tablist" aria-label="Workspace systems">' + tabButtons + '</div>' +
+          '<div class="ws-cmd-system-tabs" role="tablist" aria-label="Workspace systems">' +
+          tabButtons +
+          '</div>' +
           '<div class="ws-cmd-system-host" data-cmd-system-host>' +
-          '<div class="ws-cmd-rail-empty">Loading ' + escapeHtml(active.label) + '...</div>' +
+          '<div class="ws-cmd-rail-empty">Loading ' +
+          escapeHtml(active.label) +
+          '...</div>' +
           '</div>' +
           '</div>'
         : '') +
@@ -1841,16 +3082,25 @@ export class WorkspaceCommandView {
     if (!this.isGroupWorkspace()) return '';
     const count = this.detachmentMemberCount();
     return (
-      '<section class="ws-cmd-panel ws-cmd-detachment-panel' + (expanded ? ' is-managing' : '') +
-      (count ? '' : ' is-empty') + '">' +
+      '<section class="ws-cmd-panel ws-cmd-detachment-panel' +
+      (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') +
+      '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><h4>Detachment</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-title"><h4>Detachment</h4><span class="ws-cmd-panel-count">' +
+      count +
+      '</span></div>' +
       '<div class="ws-cmd-panel-tools">' +
       '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="members">Add Member</button>' +
       '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="members" aria-expanded="' +
-      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Detachment manager' : 'Manage members in Command view') +
-      '" aria-label="' + (expanded ? 'Close Detachment manager' : 'Manage members in Command view') + '">' +
-      (expanded ? '×' : '▸') + '</button>' +
+      (expanded ? 'true' : 'false') +
+      '" title="' +
+      (expanded ? 'Close Detachment manager' : 'Manage members in Command view') +
+      '" aria-label="' +
+      (expanded ? 'Close Detachment manager' : 'Manage members in Command view') +
+      '">' +
+      (expanded ? '×' : '▸') +
+      '</button>' +
       '</div>' +
       '</div>' +
       (expanded
@@ -1892,28 +3142,42 @@ export class WorkspaceCommandView {
     const arr = Array.isArray(list) ? list : [];
     const limit = expanded ? arr.length : 5;
     const shown = arr.slice(0, limit);
-    const rows = shown.map((note) => {
+    const rows = shown.map(note => {
       const id = String(note.id || '');
       const label = escapeHtml(note.name || note.title || 'Untitled Note');
       const checkbox = expanded
-        ? '<input type="checkbox" class="ws-cmd-note-check" data-cmd-note-select="' + escapeHtml(id) + '"' +
-          (this.isNoteSelected(id) ? ' checked' : '') + ' aria-label="Select ' + label + '">'
+        ? '<input type="checkbox" class="ws-cmd-note-check" data-cmd-note-select="' +
+          escapeHtml(id) +
+          '"' +
+          (this.isNoteSelected(id) ? ' checked' : '') +
+          ' aria-label="Select ' +
+          label +
+          '">'
         : '';
       return (
         '<div class="ws-cmd-rail-item ws-cmd-note-row">' +
         checkbox +
         '<button type="button" class="ws-cmd-note-open" data-cmd-open-section="notes" data-cmd-item-id="' +
-        escapeHtml(id) + '"><span class="ws-cmd-rail-t">' + label + '</span></button>' +
+        escapeHtml(id) +
+        '"><span class="ws-cmd-rail-t">' +
+        label +
+        '</span></button>' +
         '</div>'
       );
     });
     if (arr.length > shown.length) {
-      rows.push('<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="notes">+ ' +
-        (arr.length - shown.length) + ' more</button>');
+      rows.push(
+        '<button type="button" class="ws-cmd-rail-more" data-cmd-manage-section="notes">+ ' +
+          (arr.length - shown.length) +
+          ' more</button>'
+      );
     }
     if (expanded && !arr.length) {
-      rows.push('<div class="ws-cmd-rail-empty">' +
-        (total ? 'No notes match the active tag filter.' : 'No notes yet.') + '</div>');
+      rows.push(
+        '<div class="ws-cmd-rail-empty">' +
+          (total ? 'No notes match the active tag filter.' : 'No notes yet.') +
+          '</div>'
+      );
     }
     return rows;
   }
@@ -1924,7 +3188,9 @@ export class WorkspaceCommandView {
       '<button type="button" class="ws-cmd-note-tool" data-cmd-note-action="select-all">Select all</button>' +
       '<button type="button" class="ws-cmd-note-tool" data-cmd-note-action="copy">Copy</button>' +
       '<button type="button" class="ws-cmd-note-tool is-danger" data-cmd-note-action="delete">Delete</button>' +
-      '<a class="ws-cmd-note-tool" href="' + escapeHtml(this.workspaceRoute('/notes')) + '">View all</a>' +
+      '<a class="ws-cmd-note-tool" href="' +
+      escapeHtml(this.workspaceRoute('/notes')) +
+      '">View all</a>' +
       '</div>'
     );
   }
@@ -1939,18 +3205,29 @@ export class WorkspaceCommandView {
       ? '<div class="ws-cmd-note-filter" data-cmd-note-filter></div>' +
         this.noteMultiSelectToolbarHTML() +
         rows
-      : (visible.length ? rows : '<div class="ws-cmd-rail-empty">No notes yet.</div>');
+      : visible.length
+        ? rows
+        : '<div class="ws-cmd-rail-empty">No notes yet.</div>';
     return (
-      '<section class="ws-cmd-panel ws-cmd-notes-panel' + (expanded ? ' is-managing' : '') +
-      (count ? '' : ' is-empty') + '">' +
+      '<section class="ws-cmd-panel ws-cmd-notes-panel' +
+      (expanded ? ' is-managing' : '') +
+      (count ? '' : ' is-empty') +
+      '">' +
       '<div class="ws-cmd-panel-head">' +
-      '<div class="ws-cmd-panel-title"><h4>Notes</h4><span class="ws-cmd-panel-count">' + count + '</span></div>' +
+      '<div class="ws-cmd-panel-title"><h4>Notes</h4><span class="ws-cmd-panel-count">' +
+      count +
+      '</span></div>' +
       '<div class="ws-cmd-panel-tools">' +
       '<button type="button" class="ws-cmd-panel-action" data-cmd-primary-section="notes">New Note</button>' +
       '<button type="button" class="ws-cmd-panel-more" data-cmd-manage-section="notes" aria-expanded="' +
-      (expanded ? 'true' : 'false') + '" title="' + (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') +
-      '" aria-label="' + (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') + '">' +
-      (expanded ? '×' : '▸') + '</button>' +
+      (expanded ? 'true' : 'false') +
+      '" title="' +
+      (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') +
+      '" aria-label="' +
+      (expanded ? 'Close Notes manager' : 'Manage Notes in Command view') +
+      '">' +
+      (expanded ? '×' : '▸') +
+      '</button>' +
       '</div>' +
       '</div>' +
       (hasBody ? '<div class="ws-cmd-panel-body">' + body + '</div>' : '') +
@@ -1962,7 +3239,8 @@ export class WorkspaceCommandView {
     if (this.noteFilterBar) return this.noteFilterBar;
     const helper = this.tagFilterHelper();
     if (!helper || typeof helper.createTagFilterBar !== 'function') return null;
-    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function')
+      return null;
     const holder = document.createElement('div');
     this.noteFilterBar = helper.createTagFilterBar({
       container: holder,
@@ -1980,7 +3258,11 @@ export class WorkspaceCommandView {
     if (!bar || !bar.element) return;
     const notes = Array.isArray(this.page && this.page.notes) ? this.page.notes : [];
     const helper = this.tagFilterHelper();
-    if (helper && typeof helper.collectTags === 'function' && typeof bar.setAvailableTags === 'function') {
+    if (
+      helper &&
+      typeof helper.collectTags === 'function' &&
+      typeof bar.setAvailableTags === 'function'
+    ) {
       bar.setAvailableTags(helper.collectTags(notes));
     }
     host.innerHTML = '';
@@ -2003,24 +3285,55 @@ export class WorkspaceCommandView {
     const systemsExpanded = this.activeRailSection === 'systems';
     const detachmentExpanded = this.activeRailSection === 'members';
 
-    const scheduleItems = this.railItems(schedules, (s) => s.name || s.task_description || 'Unnamed Schedule', {
-      sectionKey: 'schedules',
-      expanded: schedulesExpanded,
-      action: (s) => 'data-cmd-open-section="schedules" data-cmd-item-id="' + escapeHtml(String(s.id || '')) + '"'
-    });
-    const sessionItems = this.railItems(sessions, (s) => s.title || s.name || 'Untitled Session', {
+    const scheduleItems = this.railItems(
+      schedules,
+      s => s.name || s.task_description || 'Unnamed Schedule',
+      {
+        sectionKey: 'schedules',
+        expanded: schedulesExpanded,
+        action: s =>
+          'data-cmd-open-section="schedules" data-cmd-item-id="' +
+          escapeHtml(String(s.id || '')) +
+          '"'
+      }
+    );
+    const sessionItems = this.railItems(sessions, s => s.title || s.name || 'Untitled Session', {
       sectionKey: 'sessions',
       expanded: sessionsExpanded,
-      action: (s) => 'data-cmd-open-section="sessions" data-cmd-item-id="' + escapeHtml(String(s.id || '')) + '"',
-      metaOf: (s) => s.agent_name || ''
+      action: s =>
+        'data-cmd-open-section="sessions" data-cmd-item-id="' +
+        escapeHtml(String(s.id || '')) +
+        '"',
+      metaOf: s => s.agent_name || ''
     });
     const folderItems = this.folderRailItems(dirs, foldersExpanded);
 
     return (
       this.renderNotesPanel(notes, notesExpanded) +
-      this.railPanelHTML('schedules', 'Schedules', scheduleItems, schedules.length, 'No schedules yet.', 'Open Schedules') +
-      this.railPanelHTML('sessions', 'Sessions', sessionItems, sessions.length, 'No sessions yet.', 'New Session') +
-      this.railPanelHTML('folders', 'Linked Folders', folderItems, dirs.length, 'No linked folders yet.', 'Link Folder') +
+      this.railPanelHTML(
+        'schedules',
+        'Schedules',
+        scheduleItems,
+        schedules.length,
+        'No schedules yet.',
+        'Open Schedules'
+      ) +
+      this.railPanelHTML(
+        'sessions',
+        'Sessions',
+        sessionItems,
+        sessions.length,
+        'No sessions yet.',
+        'New Session'
+      ) +
+      this.railPanelHTML(
+        'folders',
+        'Linked Folders',
+        folderItems,
+        dirs.length,
+        'No linked folders yet.',
+        'Link Folder'
+      ) +
       this.renderDetachmentPanel(detachmentExpanded) +
       this.renderFilesPanel(files, filesExpanded) +
       this.renderSystemsPanel(systemsExpanded)
@@ -2041,12 +3354,14 @@ export class WorkspaceCommandView {
     if (!this.sharedSurfaceAnchors) this.sharedSurfaceAnchors = {};
     const existing = this.sharedSurfaceAnchors[key];
     if (existing && existing.node) return existing;
-    if (typeof document === 'undefined' || typeof document.getElementById !== 'function') return null;
+    if (typeof document === 'undefined' || typeof document.getElementById !== 'function')
+      return null;
     const node = document.querySelector ? document.querySelector(selector) : null;
     if (!node || !node.parentNode) return null;
-    const anchor = typeof document.createComment === 'function'
-      ? document.createComment('workspace-command-' + key + '-anchor')
-      : null;
+    const anchor =
+      typeof document.createComment === 'function'
+        ? document.createComment('workspace-command-' + key + '-anchor')
+        : null;
     if (anchor && node.parentNode) {
       node.parentNode.insertBefore(anchor, node);
     }
@@ -2067,7 +3382,8 @@ export class WorkspaceCommandView {
   restoreSharedSurface(key) {
     const record = this.sharedSurfaceAnchors && this.sharedSurfaceAnchors[key];
     if (!record || !record.node) return;
-    const parent = record.anchor && record.anchor.parentNode ? record.anchor.parentNode : record.parent;
+    const parent =
+      record.anchor && record.anchor.parentNode ? record.anchor.parentNode : record.parent;
     if (!parent || typeof parent.insertBefore !== 'function') return;
     if (record.node.parentNode === parent) return;
     parent.insertBefore(record.node, record.anchor ? record.anchor.nextSibling : null);
@@ -2105,7 +3421,11 @@ export class WorkspaceCommandView {
       tabBtn.click();
     }
 
-    if (!usedBootstrap && typeof Event === 'function' && typeof tabBtn.dispatchEvent === 'function') {
+    if (
+      !usedBootstrap &&
+      typeof Event === 'function' &&
+      typeof tabBtn.dispatchEvent === 'function'
+    ) {
       tabBtn.dispatchEvent(new Event('shown.bs.tab', { bubbles: true }));
     }
   }
@@ -2139,19 +3459,23 @@ export class WorkspaceCommandView {
     if (!page) return;
     switch (String(key || '')) {
       case 'mcp':
-        if (typeof page.renderWorkspaceMCPBindings === 'function') page.renderWorkspaceMCPBindings();
+        if (typeof page.renderWorkspaceMCPBindings === 'function')
+          page.renderWorkspaceMCPBindings();
         if (page.nativeMCPManager && typeof page.nativeMCPManager.load === 'function') {
           page.nativeMCPManager.load();
         }
         break;
       case 'skills':
-        if (typeof page.renderWorkspaceSkillBindings === 'function') page.renderWorkspaceSkillBindings();
+        if (typeof page.renderWorkspaceSkillBindings === 'function')
+          page.renderWorkspaceSkillBindings();
         break;
       case 'plugins':
-        if (typeof page.renderWorkspacePluginBindings === 'function') page.renderWorkspacePluginBindings();
+        if (typeof page.renderWorkspacePluginBindings === 'function')
+          page.renderWorkspacePluginBindings();
         break;
       case 'memory':
-        if (page.memoryManager && typeof page.memoryManager.load === 'function') page.memoryManager.load();
+        if (page.memoryManager && typeof page.memoryManager.load === 'function')
+          page.memoryManager.load();
         break;
       case 'settings':
         if (typeof page.renderWorkspaceSettings === 'function') page.renderWorkspaceSettings();
@@ -2173,8 +3497,8 @@ export class WorkspaceCommandView {
     // The config/tools nodes may be on loan to an open stat modal (MCP/Skills/Manager
     // Settings or the Tools modal) — don't steal them back mid-view on a background
     // re-render (single-node arbitration, PRD FR6.26).
-    const modalHoldsSurface = this.statModalHoldsSharedSurface() &&
-      this.statModalEl && !this.statModalEl.hidden;
+    const modalHoldsSurface =
+      this.statModalHoldsSharedSurface() && this.statModalEl && !this.statModalEl.hidden;
     if (modalHoldsSurface) return;
 
     const host = this.container && this.container.querySelector('[data-cmd-system-host]');
@@ -2188,14 +3512,16 @@ export class WorkspaceCommandView {
     if (tab.host === 'tools') {
       this.restoreSharedSurface('config');
       const tools = this.mountSharedSurface('tools', '#workspace-detail-tools-card', host);
-      if (!tools) host.innerHTML = '<div class="ws-cmd-rail-empty">Find Tools is unavailable.</div>';
+      if (!tools)
+        host.innerHTML = '<div class="ws-cmd-rail-empty">Find Tools is unavailable.</div>';
       return;
     }
 
     this.restoreSharedSurface('tools');
     const config = this.mountSharedSurface('config', '#workspace-detail-settings-panel', host);
     if (!config) {
-      host.innerHTML = '<div class="ws-cmd-rail-empty">Workspace configuration is unavailable.</div>';
+      host.innerHTML =
+        '<div class="ws-cmd-rail-empty">Workspace configuration is unavailable.</div>';
       return;
     }
     // Shed any modal-only chrome hiding if this node was last used inside a stat modal.
@@ -2212,7 +3538,11 @@ export class WorkspaceCommandView {
     }
     const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
     if (page && page.membersPanel && typeof page.membersPanel.syncWorkspace === 'function') {
-      try { await page.membersPanel.syncWorkspace(page.workspace); } catch (err) { /* keep going */ }
+      try {
+        await page.membersPanel.syncWorkspace(page.workspace);
+      } catch (err) {
+        /* keep going */
+      }
     }
     // Re-query after the await: a later render may have replaced the host.
     const host = this.container && this.container.querySelector('[data-cmd-members-host]');
@@ -2228,7 +3558,9 @@ export class WorkspaceCommandView {
       try {
         page.membersPanel.rollupsLoaded = true;
         void page.membersPanel.loadRollups();
-      } catch (err) { /* keep going */ }
+      } catch (err) {
+        /* keep going */
+      }
     }
   }
 
@@ -2249,7 +3581,7 @@ export class WorkspaceCommandView {
   bindRail() {
     const root = this.container && this.container.querySelector('.ws-cmd-rail');
     if (!root) return;
-    root.addEventListener('click', (event) => {
+    root.addEventListener('click', event => {
       const systemTab = event.target.closest('[data-cmd-system-tab]');
       if (systemTab) {
         this.openSystemTab(systemTab.getAttribute('data-cmd-system-tab'));
@@ -2284,7 +3616,7 @@ export class WorkspaceCommandView {
         );
       }
     });
-    root.addEventListener('change', (event) => {
+    root.addEventListener('change', event => {
       const cb = event.target.closest('[data-cmd-note-select]');
       if (!cb) return;
       const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
@@ -2292,18 +3624,18 @@ export class WorkspaceCommandView {
         page.toggleNoteSelection(cb.getAttribute('data-cmd-note-select'), cb.checked);
       }
     });
-    root.addEventListener('dragover', (event) => {
+    root.addEventListener('dragover', event => {
       const dropZone = event.target.closest('[data-cmd-file-drop]');
       if (!dropZone) return;
       event.preventDefault();
       this.setFileDropActive(dropZone, true);
     });
-    root.addEventListener('dragleave', (event) => {
+    root.addEventListener('dragleave', event => {
       const dropZone = event.target.closest('[data-cmd-file-drop]');
       if (!dropZone) return;
       this.setFileDropActive(dropZone, false);
     });
-    root.addEventListener('drop', (event) => {
+    root.addEventListener('drop', event => {
       const dropZone = event.target.closest('[data-cmd-file-drop]');
       if (!dropZone) return;
       event.preventDefault();

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -110,7 +110,7 @@ test('taskTone maps a task status to a visual tone', () => {
 });
 
 test('opsModeLabel maps workflow modes to friendly labels', () => {
-  const withMode = (mode) => {
+  const withMode = mode => {
     view.page = { workspace: { workspace_settings: { workflow: { mode } } } };
     return view.opsModeLabel();
   };
@@ -235,7 +235,10 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   // reflects the filtered open-task count specifically — the modal title and
   // per-agent quest-log header stay "Tasks" since those list every task
   // regardless of status, so "Open Tasks" there would misdescribe them.
-  assert.doesNotMatch(container.innerHTML, /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Tools · MCP|Ops mode|Deploy|✦/);
+  assert.doesNotMatch(
+    container.innerHTML,
+    /Quest Log|Keeper|Field Unit|Intel|Comms|Supply Lines|Standing Orders|Tools · MCP|Ops mode|Deploy|✦/
+  );
 });
 
 test('command subtitle includes mission automation state when mission state is loaded', () => {
@@ -251,7 +254,12 @@ test('command subtitle includes mission automation state when mission state is l
     identityEditMode: '',
     page: {
       workspaceId: 'workspace-1',
-      workspace: { name: 'Mission Workspace', description: '', mcp_bindings: [], skill_bindings: [] },
+      workspace: {
+        name: 'Mission Workspace',
+        description: '',
+        mcp_bindings: [],
+        skill_bindings: []
+      },
       tasks: [],
       buildAgentGroups: () => []
     }
@@ -306,6 +314,7 @@ test('mission panel renders loaded goal state and findings link', () => {
     assert.match(html, /Cadence: Daily at 09:00/);
     assert.match(html, /href="\/action-center\?workspace=workspace-1"/);
     assert.match(html, />Findings \(2\)<\/a>/);
+    assert.match(html, />Edit Goal<\/button>/);
     assert.doesNotMatch(html, /id="workspace-command-mission-run"[^>]* disabled/);
   } finally {
     globalThis.window = originalWindow;
@@ -339,6 +348,7 @@ test('mission panel disables Run Now when no saved goal is runnable', () => {
     const html = commandView.renderMissionPanel();
 
     assert.match(html, /No workspace goal yet\./);
+    assert.match(html, />Set Goal<\/button>/);
     assert.match(html, /id="workspace-command-mission-run"[^>]* disabled/);
     assert.match(html, /title="Set a goal before running"/);
   } finally {
@@ -352,8 +362,12 @@ test('mission panel actions delegate to workspace mission APIs', () => {
   const originalWindow = globalThis.window;
   globalThis.window = {
     workspaceMission: {
-      openGoalModal() { calls.push('edit'); },
-      runNow(button) { calls.push(['run', button.getAttribute('data-cmd-mission-action')]); }
+      openGoalModal() {
+        calls.push('edit');
+      },
+      runNow(button) {
+        calls.push(['run', button.getAttribute('data-cmd-mission-action')]);
+      }
     }
   };
   const commandView = Object.create(WorkspaceCommandView.prototype);
@@ -381,7 +395,10 @@ test('mission panel actions delegate to workspace mission APIs', () => {
 });
 
 test('detailed view is deleted; shared hosts and goal modal survive in the template', () => {
-  const template = readFileSync(new URL('../../../templates/pages/workspace-detail.tmpl', import.meta.url), 'utf8');
+  const template = readFileSync(
+    new URL('../../../templates/pages/workspace-detail.tmpl', import.meta.url),
+    'utf8'
+  );
 
   // The Detailed subtree and its toggle are gone.
   assert.equal(template.includes('id="workspace-detail-view"'), false);
@@ -399,7 +416,10 @@ test('detailed view is deleted; shared hosts and goal modal survive in the templ
     'id="workspace-detail-members-panel"'
   ]) {
     const idx = template.indexOf(id);
-    assert.ok(idx > hostsStart && idx < hostsEnd, id + ' must live inside the shared-hosts container');
+    assert.ok(
+      idx > hostsStart && idx < hostsEnd,
+      id + ' must live inside the shared-hosts container'
+    );
   }
 
   // Goal modal is still present with its accessibility hooks.
@@ -445,7 +465,7 @@ test('command rail badges project and reference directory roles', () => {
         { id: 'dir-ref', name: 'Reference', path: '/tmp/reference', source: 'reference' }
       ],
       getPrimaryDirectoryId: () => 'dir-project',
-      isProjectDirectory: (dir) => dir.id === 'dir-project'
+      isProjectDirectory: dir => dir.id === 'dir-project'
     }
   });
 
@@ -464,7 +484,14 @@ test('command bar shows group badge and color accent for group workspaces', () =
     identityEditMode: '',
     page: {
       workspaceId: 'grp-1',
-      workspace: { name: 'Alpha Group', kind: 'group', color: '#3b82f6', description: '', mcp_bindings: [], skill_bindings: [] },
+      workspace: {
+        name: 'Alpha Group',
+        kind: 'group',
+        color: '#3b82f6',
+        description: '',
+        mcp_bindings: [],
+        skill_bindings: []
+      },
       tasks: [],
       buildAgentGroups: () => []
     }
@@ -491,7 +518,13 @@ test('group accent color is sourced from the members-panel group node (detail wo
     page: {
       workspaceId: 'grp-1',
       // The detail workspace object carries no color; the tree node does.
-      workspace: { name: 'Alpha Group', kind: 'group', description: '', mcp_bindings: [], skill_bindings: [] },
+      workspace: {
+        name: 'Alpha Group',
+        kind: 'group',
+        description: '',
+        mcp_bindings: [],
+        skill_bindings: []
+      },
       membersPanel: { group: { color: '#8b5cf6' } },
       tasks: [],
       buildAgentGroups: () => []
@@ -515,7 +548,13 @@ test('command bar omits group treatment for non-group workspaces', () => {
     identityEditMode: '',
     page: {
       workspaceId: 'ws-1',
-      workspace: { name: 'Solo Outpost', kind: 'workspace', description: '', mcp_bindings: [], skill_bindings: [] },
+      workspace: {
+        name: 'Solo Outpost',
+        kind: 'workspace',
+        description: '',
+        mcp_bindings: [],
+        skill_bindings: []
+      },
       tasks: [],
       buildAgentGroups: () => []
     }
@@ -562,7 +601,10 @@ test('notes panel exposes tag filter host, multi-select toolbar, and per-note ch
     noteFilterBar: null,
     page: {
       workspaceId: 'ws-1',
-      notes: [{ id: 'n1', name: 'Alpha' }, { id: 'n2', name: 'Beta' }],
+      notes: [
+        { id: 'n1', name: 'Alpha' },
+        { id: 'n2', name: 'Beta' }
+      ],
       selectedNoteIds: new Set(['n1'])
     }
   });
@@ -596,7 +638,9 @@ test('handleNoteAction delegates bulk actions to the page', () => {
   const calls = [];
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
-    render() { calls.push('render'); },
+    render() {
+      calls.push('render');
+    },
     page: {
       toggleSelectAllNotes: () => calls.push('select-all'),
       copySelectedNotesToClipboard: () => calls.push('copy'),
@@ -615,7 +659,8 @@ test('note and task tag filters reuse OriTagFilterBar.filterItems on active tags
   const originalWindow = globalThis.window;
   globalThis.window = {
     OriTagFilterBar: {
-      filterItems: (items, active) => items.filter(i => (i.tags || []).some(t => active.includes(t)))
+      filterItems: (items, active) =>
+        items.filter(i => (i.tags || []).some(t => active.includes(t)))
     }
   };
   try {
@@ -625,13 +670,25 @@ test('note and task tag filters reuse OriTagFilterBar.filterItems on active tags
       taskFilterBar: { getActiveTags: () => ['urgent'] },
       taskModalShowAll: true,
       page: {
-        notes: [{ id: 'n1', tags: ['urgent'] }, { id: 'n2', tags: ['later'] }],
-        tasks: [{ id: 't1', tags: ['urgent'] }, { id: 't2', tags: [] }]
+        notes: [
+          { id: 'n1', tags: ['urgent'] },
+          { id: 'n2', tags: ['later'] }
+        ],
+        tasks: [
+          { id: 't1', tags: ['urgent'] },
+          { id: 't2', tags: [] }
+        ]
       }
     });
 
-    assert.deepEqual(commandView.visibleNotes(commandView.page.notes).map(n => n.id), ['n1']);
-    assert.deepEqual(commandView.taskRowData({ includeAll: true }).map(t => t.id), ['t1']);
+    assert.deepEqual(
+      commandView.visibleNotes(commandView.page.notes).map(n => n.id),
+      ['n1']
+    );
+    assert.deepEqual(
+      commandView.taskRowData({ includeAll: true }).map(t => t.id),
+      ['t1']
+    );
   } finally {
     globalThis.window = originalWindow;
   }
@@ -663,10 +720,16 @@ test('view-board / view-list toggle flips board mode and hands the board node ba
   Object.assign(commandView, {
     statModalSection: 'tasks',
     taskModalBoardMode: false,
-    page: { setView: (v) => calls.push(['setView', v]) },
-    renderStatModalBody() { calls.push(['render']); },
-    syncBoardSurface(opts) { calls.push(['sync', opts && opts.load === true]); },
-    restoreSharedSurface(key) { calls.push(['restore', key]); }
+    page: { setView: v => calls.push(['setView', v]) },
+    renderStatModalBody() {
+      calls.push(['render']);
+    },
+    syncBoardSurface(opts) {
+      calls.push(['sync', opts && opts.load === true]);
+    },
+    restoreSharedSurface(key) {
+      calls.push(['restore', key]);
+    }
   });
 
   commandView.handleStatModalAction('view-board');
@@ -763,8 +826,12 @@ test('files rail actions delegate to existing file modal and upload paths', asyn
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     page: {
-      showFileModal() { calls.push(['modal']); },
-      async uploadFiles(fileList) { calls.push(['upload', fileList]); }
+      showFileModal() {
+        calls.push(['modal']);
+      },
+      async uploadFiles(fileList) {
+        calls.push(['upload', fileList]);
+      }
     }
   });
 
@@ -786,21 +853,31 @@ test('files drop handler owns Command drop zones without duplicate page fallback
     container: {
       querySelector(selector) {
         return selector === '.ws-cmd-rail'
-          ? { addEventListener(type, listener) { listeners[type] = listener; } }
+          ? {
+              addEventListener(type, listener) {
+                listeners[type] = listener;
+              }
+            }
           : null;
       }
     },
     page: {
-      async uploadFiles(fileList) { calls.push(['upload', fileList]); }
+      async uploadFiles(fileList) {
+        calls.push(['upload', fileList]);
+      }
     }
   });
 
   commandView.bindRail();
   listeners.drop({
-    target: { closest: selector => selector === '[data-cmd-file-drop]' ? dropZone : null },
+    target: { closest: selector => (selector === '[data-cmd-file-drop]' ? dropZone : null) },
     dataTransfer: { files },
-    preventDefault() { prevented = true; },
-    stopPropagation() { stopped = true; }
+    preventDefault() {
+      prevented = true;
+    },
+    stopPropagation() {
+      stopped = true;
+    }
   });
 
   assert.equal(prevented, true);
@@ -837,7 +914,9 @@ test('openSystemTab keeps Command active and selects the requested Systems tab',
   Object.assign(commandView, {
     activeRailSection: '',
     activeSystemTab: 'memory',
-    render() { renders.push([this.activeRailSection, this.activeSystemTab]); }
+    render() {
+      renders.push([this.activeRailSection, this.activeSystemTab]);
+    }
   });
 
   commandView.openSystemTab('triggers');
@@ -857,15 +936,23 @@ test('systems shared surface mounts config without cloning persistence logic', (
     activeSystemTab: 'memory',
     statModalSection: '',
     statModalEl: null,
-    container: { querySelector: selector => selector === '[data-cmd-system-host]' ? host : null },
+    container: { querySelector: selector => (selector === '[data-cmd-system-host]' ? host : null) },
     mountSharedSurface(key, selector) {
       calls.push(['mount', key, selector]);
       return { key };
     },
-    restoreSharedSurface(key) { calls.push(['restore', key]); },
-    showConfigTab(tab) { calls.push(['tab', tab.key]); },
-    refreshSystemTabData(tab) { calls.push(['refresh', tab.key]); },
-    expandMountedConfig(node) { calls.push(['expand', node.key]); }
+    restoreSharedSurface(key) {
+      calls.push(['restore', key]);
+    },
+    showConfigTab(tab) {
+      calls.push(['tab', tab.key]);
+    },
+    refreshSystemTabData(tab) {
+      calls.push(['refresh', tab.key]);
+    },
+    expandMountedConfig(node) {
+      calls.push(['expand', node.key]);
+    }
   });
 
   commandView.syncSharedSurfaces();
@@ -885,21 +972,42 @@ test('tools modal mounts the config surface for MCP/Skills/Plugins and the tools
   const host = { innerHTML: '', appendChild() {} };
   const base = {
     statModalSection: 'tools',
-    statModalEl: { hidden: false, querySelector: sel => sel === '[data-cmd-tools-host]' ? host : null },
-    mountSharedSurface(key, selector) { calls.push(['mount', key, selector]); return { key }; },
-    restoreSharedSurface(key) { calls.push(['restore', key]); },
-    showConfigTab(tab) { calls.push(['tab', tab.tabId]); },
-    refreshConfigData(key) { calls.push(['refresh', key]); },
-    expandMountedConfig(node) { calls.push(['expand', node.key]); }
+    statModalEl: {
+      hidden: false,
+      querySelector: sel => (sel === '[data-cmd-tools-host]' ? host : null)
+    },
+    mountSharedSurface(key, selector) {
+      calls.push(['mount', key, selector]);
+      return { key };
+    },
+    restoreSharedSurface(key) {
+      calls.push(['restore', key]);
+    },
+    showConfigTab(tab) {
+      calls.push(['tab', tab.tabId]);
+    },
+    refreshConfigData(key) {
+      calls.push(['refresh', key]);
+    },
+    expandMountedConfig(node) {
+      calls.push(['expand', node.key]);
+    }
   };
 
-  const plugins = Object.assign(Object.create(WorkspaceCommandView.prototype), base, { activeToolsTab: 'plugins' });
+  const plugins = Object.assign(Object.create(WorkspaceCommandView.prototype), base, {
+    activeToolsTab: 'plugins'
+  });
   plugins.syncToolsModalSurface();
 
-  const find = Object.assign(Object.create(WorkspaceCommandView.prototype), base, { activeToolsTab: 'find' });
+  const find = Object.assign(Object.create(WorkspaceCommandView.prototype), base, {
+    activeToolsTab: 'find'
+  });
   calls.length = 0;
   find.syncToolsModalSurface();
-  assert.deepEqual(calls, [['restore', 'config'], ['mount', 'tools', '#workspace-detail-tools-card']]);
+  assert.deepEqual(calls, [
+    ['restore', 'config'],
+    ['mount', 'tools', '#workspace-detail-tools-card']
+  ]);
 });
 
 test('escape closes the active rail manager without leaving Command', () => {
@@ -1013,10 +1121,18 @@ test('rail primary actions use command-view management hooks', () => {
       }
     },
     page: {
-      showNoteModal() { calls.push('new-note'); },
-      showSchedulesModal() { calls.push('open-schedules'); },
-      createNewSession() { calls.push('new-session'); },
-      showAddDirectoryModal() { calls.push('link-folder'); }
+      showNoteModal() {
+        calls.push('new-note');
+      },
+      showSchedulesModal() {
+        calls.push('open-schedules');
+      },
+      createNewSession() {
+        calls.push('new-session');
+      },
+      showAddDirectoryModal() {
+        calls.push('link-folder');
+      }
     }
   });
 
@@ -1043,10 +1159,18 @@ test('rail item actions open existing management flows from Command view', () =>
     },
     page: {
       notes: [{ id: 'note-1', name: 'Launch note' }],
-      showNoteModal(note) { calls.push(['note', note.id]); },
-      openSchedule(id) { calls.push(['schedule', id]); },
-      openSession(id) { calls.push(['session', id]); },
-      openDirectoryExplorer(id, source) { calls.push(['folder', id, source]); }
+      showNoteModal(note) {
+        calls.push(['note', note.id]);
+      },
+      openSchedule(id) {
+        calls.push(['schedule', id]);
+      },
+      openSession(id) {
+        calls.push(['session', id]);
+      },
+      openDirectoryExplorer(id, source) {
+        calls.push(['folder', id, source]);
+      }
     }
   });
 
@@ -1084,8 +1208,12 @@ test('quest-log task name opens the existing task flow', () => {
       }
     },
     page: {
-      openTask(id) { calls.push(['open', id]); },
-      executeTask(id) { calls.push(['run', id]); }
+      openTask(id) {
+        calls.push(['open', id]);
+      },
+      executeTask(id) {
+        calls.push(['run', id]);
+      }
     }
   });
 
@@ -1158,14 +1286,22 @@ test('stat modal inerts command background and traps tab focus', () => {
   const topbar = {
     attrs: {},
     inert: false,
-    setAttribute(name, value) { this.attrs[name] = value; },
-    removeAttribute(name) { delete this.attrs[name]; }
+    setAttribute(name, value) {
+      this.attrs[name] = value;
+    },
+    removeAttribute(name) {
+      delete this.attrs[name];
+    }
   };
   const layout = {
     attrs: {},
     inert: false,
-    setAttribute(name, value) { this.attrs[name] = value; },
-    removeAttribute(name) { delete this.attrs[name]; }
+    setAttribute(name, value) {
+      this.attrs[name] = value;
+    },
+    removeAttribute(name) {
+      delete this.attrs[name];
+    }
   };
   const modal = {};
   const commandView = Object.create(WorkspaceCommandView.prototype);
@@ -1182,8 +1318,20 @@ test('stat modal inerts command background and traps tab focus', () => {
   assert.equal(topbar.attrs['aria-hidden'], undefined);
   assert.equal(layout.inert, false);
 
-  const first = { hidden: false, focused: 0, focus() { this.focused += 1; } };
-  const last = { hidden: false, focused: 0, focus() { this.focused += 1; } };
+  const first = {
+    hidden: false,
+    focused: 0,
+    focus() {
+      this.focused += 1;
+    }
+  };
+  const last = {
+    hidden: false,
+    focused: 0,
+    focus() {
+      this.focused += 1;
+    }
+  };
   const originalDocument = globalThis.document;
   globalThis.document = { activeElement: last };
   commandView.statModalEl = {
@@ -1197,7 +1345,12 @@ test('stat modal inerts command background and traps tab focus', () => {
   };
   let prevented = 0;
   try {
-    commandView.trapStatModalFocus({ key: 'Tab', preventDefault() { prevented += 1; } });
+    commandView.trapStatModalFocus({
+      key: 'Tab',
+      preventDefault() {
+        prevented += 1;
+      }
+    });
   } finally {
     globalThis.document = originalDocument;
   }
@@ -1233,7 +1386,9 @@ test('skills manager modal hosts the live config surface', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     page: {
-      getWorkspaceSkillBindings: () => [{ id: 's1', skillName: 'summarize', enabled: true, trusted: true }]
+      getWorkspaceSkillBindings: () => [
+        { id: 's1', skillName: 'summarize', enabled: true, trusted: true }
+      ]
     }
   });
 
@@ -1356,9 +1511,15 @@ test('agents modal add/edit hand off to page flows and close the modal; delete s
       this.statModalSection = '';
     },
     page: {
-      openAddAgentModal() { calls.push(['add']); },
-      openAgentModelModal(id) { calls.push(['edit', id]); },
-      removeAgentFromWorkspace(id) { calls.push(['delete', id]); }
+      openAddAgentModal() {
+        calls.push(['add']);
+      },
+      openAgentModelModal(id) {
+        calls.push(['edit', id]);
+      },
+      removeAgentFromWorkspace(id) {
+        calls.push(['delete', id]);
+      }
     }
   });
 
@@ -1377,10 +1538,16 @@ test('mcp/skills CRUD is not routed through handleStatModalAction (lives in the 
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     statModalSection: 'mcp',
-    closeStatModal() { calls.push(['close']); },
+    closeStatModal() {
+      calls.push(['close']);
+    },
     page: {
-      openWorkspaceMCPModal() { calls.push(['mcp-modal']); },
-      deleteWorkspaceMCPBinding() { calls.push(['mcp-delete']); }
+      openWorkspaceMCPModal() {
+        calls.push(['mcp-modal']);
+      },
+      deleteWorkspaceMCPBinding() {
+        calls.push(['mcp-delete']);
+      }
     }
   });
 
@@ -1394,9 +1561,14 @@ test('mcp/skills CRUD is not routed through handleStatModalAction (lives in the 
 
 test('config-surface stat sections no longer emit an Open Systems footer', () => {
   const commandView = Object.create(WorkspaceCommandView.prototype);
-  Object.assign(commandView, { page: { getWorkspaceMCPBindings: () => [], getWorkspaceSkillBindings: () => [] } });
+  Object.assign(commandView, {
+    page: { getWorkspaceMCPBindings: () => [], getWorkspaceSkillBindings: () => [] }
+  });
   for (const section of ['mcp', 'skills', 'settings', 'mission', 'intent']) {
-    assert.doesNotMatch(commandView.statModalHTML(section), /Open Systems|data-cmd-modal-action="detailed"/);
+    assert.doesNotMatch(
+      commandView.statModalHTML(section),
+      /Open Systems|data-cmd-modal-action="detailed"/
+    );
   }
   // The removed footer builder is gone entirely.
   assert.equal(typeof commandView.statModalFooterHTML, 'undefined');
@@ -1404,7 +1576,13 @@ test('config-surface stat sections no longer emit an Open Systems footer', () =>
 
 test('closing a config-surface stat modal restores the shared node and re-syncs the rail', () => {
   const calls = [];
-  const node = { classList: { remove(c) { calls.push(['unclass', c]); } } };
+  const node = {
+    classList: {
+      remove(c) {
+        calls.push(['unclass', c]);
+      }
+    }
+  };
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
     statModalSection: 'settings',
@@ -1412,15 +1590,23 @@ test('closing a config-surface stat modal restores the shared node and re-syncs 
     taskModalBoardMode: false,
     statModalEl: { hidden: false },
     sharedSurfaceAnchors: { config: { node } },
-    restoreSharedSurface(key) { calls.push(['restore', key]); },
-    syncSystemsSurface() { calls.push(['syncSystems']); },
+    restoreSharedSurface(key) {
+      calls.push(['restore', key]);
+    },
+    syncSystemsSurface() {
+      calls.push(['syncSystems']);
+    },
     setCommandBackgroundInert() {}
   });
 
   commandView.closeStatModal();
 
   // Sheds the modal-only chrome class, hands the node home, then re-offers it to the rail.
-  assert.deepEqual(calls, [['unclass', 'is-command-modal'], ['restore', 'config'], ['syncSystems']]);
+  assert.deepEqual(calls, [
+    ['unclass', 'is-command-modal'],
+    ['restore', 'config'],
+    ['syncSystems']
+  ]);
   assert.equal(commandView.statModalEl.hidden, true);
 });
 
@@ -1430,8 +1616,15 @@ test('syncSystemsSurface yields while a config-surface stat modal holds the conf
   Object.assign(commandView, {
     statModalSection: 'mcp',
     statModalEl: { hidden: false },
-    container: { querySelector() { calls.push('query'); return null; } },
-    restoreSharedSurface(key) { calls.push(['restore', key]); }
+    container: {
+      querySelector() {
+        calls.push('query');
+        return null;
+      }
+    },
+    restoreSharedSurface(key) {
+      calls.push(['restore', key]);
+    }
   });
 
   commandView.syncSystemsSurface();
@@ -1440,28 +1633,258 @@ test('syncSystemsSurface yields while a config-surface stat modal holds the conf
   assert.deepEqual(calls, []);
 });
 
-test('entry-agent unit card exposes a manager-settings gear; other agents do not', () => {
+test('entry-agent stage exposes manager settings while other agents expose removal', () => {
   const page = {
     isWorkspaceEntryAgent: name => name === 'Atlas',
-    getAgentAvatarPresentation: name => ({ initials: name.slice(0, 2), style: '' }),
     getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' }),
     getAgentProfile: () => ({}),
     getAgentModelPresentation: () => ({ empty: false, model: 'gpt-test' }),
-    getAgentSkillSummary: () => ({ count: 1 })
+    getAgentSkillSummary: () => ({ count: 1 }),
+    getEffectiveWorkspaceMCPServerNames: () => []
   };
   const commandView = Object.create(WorkspaceCommandView.prototype);
   Object.assign(commandView, {
-    page,
+    page
+  });
+
+  const keeperAgent = commandView.agentViewModel({
+    key: 'atlas',
+    name: 'Atlas',
+    isWorkspaceAgent: true,
+    isUnassigned: false,
+    tasks: []
+  });
+  const otherAgent = commandView.agentViewModel({
+    key: 'builder',
+    name: 'Builder',
+    isWorkspaceAgent: true,
+    isUnassigned: false,
+    tasks: []
+  });
+  const keeper = commandView.agentStageHTML(keeperAgent);
+  const other = commandView.agentStageHTML(otherAgent);
+
+  assert.match(keeper, /data-cmd-manager-settings/);
+  assert.match(keeper, /Entry Agent/);
+  assert.doesNotMatch(keeper, /data-cmd-remove-agent/);
+  assert.doesNotMatch(other, /data-cmd-manager-settings/);
+  assert.match(other, /data-cmd-remove-agent/);
+});
+
+test('command deck defaults to the entry agent and groups same-name instances', () => {
+  const groups = [
+    {
+      key: 'builder',
+      name: 'Builder',
+      isWorkspaceAgent: true,
+      isUnassigned: false,
+      instanceCount: 2,
+      roles: ['Writer', 'Reviewer'],
+      tasks: []
+    },
+    {
+      key: 'atlas',
+      name: 'Atlas',
+      isWorkspaceAgent: true,
+      isUnassigned: false,
+      instanceCount: 1,
+      roles: ['Coordinator'],
+      tasks: []
+    }
+  ];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    selectedAgentKey: '',
+    agentSelectionInitialized: false,
+    activeAgentTab: 'overview',
+    page: {
+      workspaceId: 'workspace-1',
+      workspace: { id: 'workspace-1' },
+      buildAgentGroups: () => groups,
+      isWorkspaceEntryAgent: name => name === 'Atlas',
+      getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle', detail: 'No active tasks' }),
+      getAgentGroupRolePresentation: group => ({
+        label: group.roles.length > 1 ? 'Multiple roles' : group.roles[0],
+        detail: group.roles.join(', '),
+        roles: group.roles
+      }),
+      getAgentSkillSummary: () => ({ count: 0, names: [] }),
+      getEffectiveWorkspaceMCPServerNames: () => [],
+      getAgentProfile: () => ({}),
+      getAgentModelPresentation: () => ({ empty: true, label: 'Model not set' })
+    },
     applyTaskTagFilter: tasks => tasks || [],
     taskFilterActiveTags: () => []
   });
 
-  const keeper = commandView.unitCardHTML({ name: 'Atlas', isWorkspaceAgent: true, isUnassigned: false, tasks: [] });
-  const other = commandView.unitCardHTML({ name: 'Builder', isWorkspaceAgent: true, isUnassigned: false, tasks: [] });
+  const html = commandView.renderGarrison();
 
-  assert.match(keeper, /data-cmd-manager-settings/);
-  assert.match(keeper, /ws-cmd-unit is-keeper/);
-  assert.doesNotMatch(other, /data-cmd-manager-settings/);
+  assert.equal(commandView.selectedAgentKey, 'atlas');
+  assert.match(html, /data-cmd-select-agent="Atlas"/);
+  assert.match(html, /data-cmd-select-agent="Builder"/);
+  assert.match(html, /aria-label="2 instances">2×/);
+  assert.match(html, /ws-cmd-agent-stage idle/);
+  assert.match(html, /role="tab"/);
+  assert.doesNotMatch(html, /ws-cmd-unit/);
+});
+
+test('persisted command-deck selection wins when the agent still exists and falls back after removal', () => {
+  const originalLocalStorage = globalThis.localStorage;
+  const saved = new Map([['ori-workspace-command-agent:workspace-1', 'builder']]);
+  globalThis.localStorage = {
+    getItem: key => saved.get(key) || null,
+    setItem: (key, value) => saved.set(key, value)
+  };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    selectedAgentKey: '',
+    agentSelectionInitialized: false,
+    page: {
+      workspaceId: 'workspace-1',
+      isWorkspaceEntryAgent: name => name === 'Atlas'
+    }
+  });
+  const atlas = { key: 'atlas', name: 'Atlas' };
+  const builder = { key: 'builder', name: 'Builder' };
+
+  try {
+    assert.equal(commandView.reconcileAgentSelection([atlas, builder]), 'builder');
+    assert.equal(commandView.reconcileAgentSelection([atlas]), 'atlas');
+    assert.equal(saved.get('ori-workspace-command-agent:workspace-1'), 'atlas');
+  } finally {
+    globalThis.localStorage = originalLocalStorage;
+  }
+});
+
+test('geometric agent character is deterministic and does not inject agent markup', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  const agent = { key: '<img src=x>', name: '<img src=x>', tone: 'working' };
+  const first = commandView.agentCharacterHTML(agent, 'stage');
+  const second = commandView.agentCharacterHTML(agent, 'stage');
+
+  assert.equal(first, second);
+  assert.match(first, /<svg viewBox="0 0 100 118"/);
+  assert.match(first, /ws-cmd-character is-stage working/);
+  assert.doesNotMatch(first, /<img/);
+});
+
+test('recent activity uses attributable persisted timestamps and orders newest first', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      tasks: [
+        {
+          id: 'old',
+          to: 'Atlas',
+          description: 'Old task',
+          status: 'pending',
+          updated_at: '2026-07-01T10:00:00Z'
+        },
+        {
+          id: 'new',
+          to: 'Atlas',
+          description: 'New task',
+          status: 'completed',
+          updated_at: '2026-07-03T10:00:00Z'
+        },
+        { id: 'invalid', to: 'Atlas', description: 'Invalid task', updated_at: 'not-a-date' },
+        {
+          id: 'other',
+          to: 'Builder',
+          description: 'Other task',
+          updated_at: '2026-07-04T10:00:00Z'
+        }
+      ],
+      sessions: [
+        {
+          id: 'session-1',
+          agent_name: 'Atlas',
+          title: 'Planning session',
+          created_at: '2026-07-02T10:00:00Z'
+        }
+      ]
+    }
+  });
+
+  const items = commandView.recentActivityItems({ key: 'atlas', tasks: [] });
+
+  assert.deepEqual(
+    items.map(item => item.id),
+    ['new', 'session-1', 'old']
+  );
+  assert.deepEqual(
+    items.map(item => item.kind),
+    ['Task', 'Session', 'Task']
+  );
+});
+
+test('effective prompt hydration is Loadout-only and retries with force', async () => {
+  const calls = [];
+  const group = { key: 'atlas', name: 'Atlas', isWorkspaceAgent: true, tasks: [] };
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    active: true,
+    activeAgentTab: 'overview',
+    selectedAgentKey: 'atlas',
+    agentPromptLoadingKey: '',
+    page: {
+      buildAgentGroups: () => [group],
+      ensureAgentPromptData: async (name, options) => {
+        calls.push([name, options]);
+        return { effective_prompt: 'Prompt' };
+      },
+      getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' }),
+      getAgentSkillSummary: () => ({ count: 0, names: [] }),
+      getEffectiveWorkspaceMCPServerNames: () => [],
+      getAgentProfile: () => ({}),
+      getAgentModelPresentation: () => ({ empty: true })
+    },
+    render() {}
+  });
+
+  commandView.hydrateActiveAgentPrompt();
+  assert.deepEqual(calls, []);
+
+  commandView.activeAgentTab = 'loadout';
+  commandView.hydrateActiveAgentPrompt({ force: true });
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.deepEqual(calls, [['Atlas', { force: true }]]);
+});
+
+test('agent tabs support arrow, Home, and End keyboard navigation', () => {
+  const calls = [];
+  const tabs = ['overview', 'tasks', 'loadout', 'recent'].map(key => ({
+    key,
+    closest: selector => (selector === '[data-cmd-agent-tab]' ? null : null),
+    getAttribute: name => (name === 'data-cmd-agent-tab' ? key : '')
+  }));
+  tabs.forEach(tab => {
+    tab.closest = selector => (selector === '[data-cmd-agent-tab]' ? tab : null);
+  });
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector: selector =>
+        selector === '.ws-cmd-agent-tabs' ? { querySelectorAll: () => tabs } : null
+    },
+    setActiveAgentTab(key) {
+      calls.push(key);
+    }
+  });
+  const event = (key, target) => ({
+    key,
+    target,
+    preventDefault() {
+      calls.push('prevented');
+    }
+  });
+
+  commandView.handleAgentTabKeydown(event('ArrowRight', tabs[0]));
+  commandView.handleAgentTabKeydown(event('Home', tabs[2]));
+  commandView.handleAgentTabKeydown(event('End', tabs[1]));
+
+  assert.deepEqual(calls, ['prevented', 'tasks', 'prevented', 'overview', 'prevented', 'recent']);
 });
 
 test('retireLegacyViewPreference clears the stored pref and strips ?view= deep links', () => {
@@ -1470,10 +1893,18 @@ test('retireLegacyViewPreference clears the stored pref and strips ?view= deep l
   const removed = [];
   const replaceStateCalls = [];
   try {
-    globalThis.localStorage = { removeItem(key) { removed.push(key); } };
+    globalThis.localStorage = {
+      removeItem(key) {
+        removed.push(key);
+      }
+    };
     globalThis.window = {
       location: { search: '?view=detailed&tab=notes', pathname: '/workspaces/abc' },
-      history: { replaceState(state, title, url) { replaceStateCalls.push(url); } }
+      history: {
+        replaceState(state, title, url) {
+          replaceStateCalls.push(url);
+        }
+      }
     };
 
     const commandView = Object.create(WorkspaceCommandView.prototype);
@@ -1499,7 +1930,9 @@ test('setup always activates Command view', () => {
   const container = {
     hidden: true,
     innerHTML: '',
-    querySelector() { return null; },
+    querySelector() {
+      return null;
+    },
     appendChild() {}
   };
 
@@ -1513,7 +1946,11 @@ test('setup always activates Command view', () => {
     };
     globalThis.window = {
       location: { search: '', pathname: '/workspaces/abc' },
-      history: { replaceState() { throw new Error('must not rewrite a clean URL'); } }
+      history: {
+        replaceState() {
+          throw new Error('must not rewrite a clean URL');
+        }
+      }
     };
     globalThis.localStorage = { removeItem() {} };
 

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -613,8 +613,7 @@ export class WorkspaceDetailPage {
     for (const file of files) {
       const hasExtension = file.name.includes('.');
       const isLikelyFolder =
-        (!file.type && file.size === 0) ||
-        (!file.type && !hasExtension && file.size < 4096);
+        (!file.type && file.size === 0) || (!file.type && !hasExtension && file.size < 4096);
       if (isLikelyFolder) {
         if (window.Toast) {
           window.Toast.info('To add a folder, use the Linked Folders panel instead.', {
@@ -972,7 +971,6 @@ export class WorkspaceDetailPage {
     });
   }
 
-
   /**
    * Cache DOM elements
    */
@@ -1107,9 +1105,7 @@ export class WorkspaceDetailPage {
         'workspace-detail-task-result-next-steps-actions'
       ),
       taskResultCopyBtn: document.getElementById('workspace-detail-task-result-copy'),
-      taskResultPromoteModal: document.getElementById(
-        'workspace-detail-task-result-promote-modal'
-      ),
+      taskResultPromoteModal: document.getElementById('workspace-detail-task-result-promote-modal'),
       taskResultPromoteTitleInput: document.getElementById(
         'workspace-detail-task-result-promote-title'
       ),
@@ -1160,13 +1156,9 @@ export class WorkspaceDetailPage {
         'workspace-detail-project-template-refresh'
       ),
       projectTemplatePathInput: document.getElementById('workspace-detail-project-template-path'),
-      projectTemplateBrowseBtn: document.getElementById(
-        'workspace-detail-project-template-browse'
-      ),
+      projectTemplateBrowseBtn: document.getElementById('workspace-detail-project-template-browse'),
       projectNameInput: document.getElementById('workspace-detail-project-name'),
-      projectTemplateSubmitBtn: document.getElementById(
-        'workspace-detail-project-template-submit'
-      ),
+      projectTemplateSubmitBtn: document.getElementById('workspace-detail-project-template-submit'),
       projectTemplateError: document.getElementById('workspace-detail-project-template-error'),
 
       // Assist modal — the assist page swaps in for the Command view surface.
@@ -1441,8 +1433,12 @@ export class WorkspaceDetailPage {
     // Note buttons
     this.elements.addNoteBtn?.addEventListener('click', () => this.showNoteModal());
     this.elements.selectAllNotesBtn?.addEventListener('click', () => this.toggleSelectAllNotes());
-    this.elements.copyAllNotesBtn?.addEventListener('click', () => this.copySelectedNotesToClipboard());
-    this.elements.deleteSelectedNotesBtn?.addEventListener('click', () => this.deleteSelectedNotes());
+    this.elements.copyAllNotesBtn?.addEventListener('click', () =>
+      this.copySelectedNotesToClipboard()
+    );
+    this.elements.deleteSelectedNotesBtn?.addEventListener('click', () =>
+      this.deleteSelectedNotes()
+    );
 
     // "View all" -> workspace notes app. The href is set here (not in the
     // template) because the workspace ID isn't known at server-render time.
@@ -1453,47 +1449,59 @@ export class WorkspaceDetailPage {
     // "Open task editor" icon button: opens the task modal in auto mode with whatever
     // text is currently in the entry-prompt input, so users can review/configure before saving.
     this.elements.homeAssistantConfigureTaskBtn?.addEventListener('click', () => {
-      if (!window.taskModalController || typeof window.taskModalController.openForCreate !== 'function') {
+      if (
+        !window.taskModalController ||
+        typeof window.taskModalController.openForCreate !== 'function'
+      ) {
         console.warn('Task modal controller not available');
         return;
       }
       const input = this.elements.homeAssistantInput;
       const description = String(input?.value || '').trim();
-      window.taskModalController.openForCreate(this.workspaceId, description, () => {
-        if (input) input.value = '';
-        this.loadTasks?.();
-        this.loadSchedules?.();
-      }, {
-        forceAutoMode: true,
-        prefillAutoDescription: description,
-      });
+      window.taskModalController.openForCreate(
+        this.workspaceId,
+        description,
+        () => {
+          if (input) input.value = '';
+          this.loadTasks?.();
+          this.loadSchedules?.();
+        },
+        {
+          forceAutoMode: true,
+          prefillAutoDescription: description
+        }
+      );
     });
 
     // Quick "Create Description" button: route multiline /note templates to the note modal
     // instead of stuffing markdown (with newlines) into the single-line entry input where it
     // collapses to garbage.
-    this.elements.homeAssistantQuickNotesBtn?.addEventListener('click', (event) => {
-      const button = event.currentTarget;
-      const prompt = button?.getAttribute('data-home-prompt') || '';
-      if (!prompt.startsWith('/note ') || !prompt.includes('\n')) return;
-      event.stopImmediatePropagation();
-      event.preventDefault();
-      const body = prompt.slice('/note '.length);
-      const lines = body.split('\n');
-      let title = '';
-      let content = body;
-      if (lines[0]?.startsWith('# ')) {
-        title = lines[0].slice(2).trim();
-        content = lines.slice(1).join('\n').replace(/^\n+/, '');
-      }
-      this.showNoteModal();
-      window.requestAnimationFrame(() => {
-        const titleInput = document.getElementById('noteNameInput');
-        const contentInput = document.getElementById('noteContentInput');
-        if (titleInput && title) titleInput.value = title;
-        if (contentInput) contentInput.value = content;
-      });
-    }, true);
+    this.elements.homeAssistantQuickNotesBtn?.addEventListener(
+      'click',
+      event => {
+        const button = event.currentTarget;
+        const prompt = button?.getAttribute('data-home-prompt') || '';
+        if (!prompt.startsWith('/note ') || !prompt.includes('\n')) return;
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        const body = prompt.slice('/note '.length);
+        const lines = body.split('\n');
+        let title = '';
+        let content = body;
+        if (lines[0]?.startsWith('# ')) {
+          title = lines[0].slice(2).trim();
+          content = lines.slice(1).join('\n').replace(/^\n+/, '');
+        }
+        this.showNoteModal();
+        window.requestAnimationFrame(() => {
+          const titleInput = document.getElementById('noteNameInput');
+          const contentInput = document.getElementById('noteContentInput');
+          if (titleInput && title) titleInput.value = title;
+          if (contentInput) contentInput.value = content;
+        });
+      },
+      true
+    );
 
     // Directory buttons
     this.elements.createProjectBtn?.addEventListener('click', event => {
@@ -1515,7 +1523,10 @@ export class WorkspaceDetailPage {
       this.updateProjectTemplateModalState();
     });
     this.elements.projectTemplatePathInput?.addEventListener('input', () => {
-      if (this.elements.projectTemplatePathInput?.value.trim() && this.elements.projectTemplateSelect) {
+      if (
+        this.elements.projectTemplatePathInput?.value.trim() &&
+        this.elements.projectTemplateSelect
+      ) {
         this.elements.projectTemplateSelect.value = '';
       }
       this.updateProjectTemplateModalState();
@@ -1996,13 +2007,13 @@ export class WorkspaceDetailPage {
 
   getWorkspaceTags(workspace = this.workspace) {
     if (!workspace || !Array.isArray(workspace.tags)) return [];
-    return workspace.tags
-      .map(tag => String(tag || '').trim())
-      .filter(Boolean);
+    return workspace.tags.map(tag => String(tag || '').trim()).filter(Boolean);
   }
 
   normalizeWorkspaceTagValue(value) {
-    return String(value || '').trim().toLowerCase();
+    return String(value || '')
+      .trim()
+      .toLowerCase();
   }
 
   normalizeWorkspaceTagList(tags) {
@@ -2114,7 +2125,9 @@ export class WorkspaceDetailPage {
   async saveWorkspaceTags() {
     if (this.workspaceTagsSaving) return;
 
-    const draft = this.workspaceTagInput ? this.workspaceTagInput.getTags() : this.workspaceTagDraft;
+    const draft = this.workspaceTagInput
+      ? this.workspaceTagInput.getTags()
+      : this.workspaceTagDraft;
 
     this.workspaceTagsSaving = true;
     if (this.elements.workspaceTagsSaveBtn) {
@@ -2935,7 +2948,10 @@ export class WorkspaceDetailPage {
   renderChildren() {
     // Groups manage members through the dedicated Members panel; the
     // read-only child cards would duplicate it.
-    const isGroup = String(this.workspace?.kind || '').trim().toLowerCase() === 'group';
+    const isGroup =
+      String(this.workspace?.kind || '')
+        .trim()
+        .toLowerCase() === 'group';
 
     // Show/hide the children panel based on whether there are children
     if (this.elements.childrenPanel) {
@@ -3065,9 +3081,13 @@ export class WorkspaceDetailPage {
   refreshTaskActivityBadges() {
     if (this._taskActivity.size === 0) return;
     const runningIds = new Set();
-    for (const t of (this.tasks || [])) {
+    for (const t of this.tasks || []) {
       if (!t) continue;
-      if (String(t.status || '').trim().toLowerCase() === 'in_progress') {
+      if (
+        String(t.status || '')
+          .trim()
+          .toLowerCase() === 'in_progress'
+      ) {
         runningIds.add(t.id);
       }
     }
@@ -3104,7 +3124,9 @@ export class WorkspaceDetailPage {
     }
 
     const safeTitle = this.escapeAttribute(target.title || `Open ${agentName} details`);
-    const safeAriaLabel = this.escapeAttribute(target.ariaLabel || target.title || `Open ${agentName} details`);
+    const safeAriaLabel = this.escapeAttribute(
+      target.ariaLabel || target.title || `Open ${agentName} details`
+    );
     const safeKind = this.escapeAttribute(target.kind || 'global');
     const safeHref = this.escapeAttribute(target.href);
     return `
@@ -3454,9 +3476,7 @@ export class WorkspaceDetailPage {
 
   getAgentGroupRolePresentation(group) {
     const roles = Array.isArray(group?.roles)
-      ? group.roles
-          .map(role => String(role || '').trim())
-          .filter(Boolean)
+      ? group.roles.map(role => String(role || '').trim()).filter(Boolean)
       : [];
     const uniqueRoles = [];
     const seen = new Set();
@@ -3487,10 +3507,14 @@ export class WorkspaceDetailPage {
       .split(/[\s._-]+/)
       .map(part => part.trim())
       .filter(Boolean);
-    const initials = (words.length > 1 ? `${words[0][0]}${words[words.length - 1][0]}` : words[0]?.slice(0, 2) || 'A')
-      .toUpperCase()
-      .replace(/[^A-Z0-9]/g, '')
-      .slice(0, 2) || 'A';
+    const initials =
+      (words.length > 1
+        ? `${words[0][0]}${words[words.length - 1][0]}`
+        : words[0]?.slice(0, 2) || 'A'
+      )
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '')
+        .slice(0, 2) || 'A';
 
     let hash = 0;
     for (let index = 0; index < key.length; index += 1) {
@@ -3541,7 +3565,9 @@ export class WorkspaceDetailPage {
       if (!task) continue;
       if (this.normalizeAgentName(task.to) !== key) continue;
 
-      const status = String(task.status || '').trim().toLowerCase();
+      const status = String(task.status || '')
+        .trim()
+        .toLowerCase();
       if (status === 'in_progress') {
         return { key: 'working', label: 'Working', detail: 'Task in progress' };
       }
@@ -3576,7 +3602,9 @@ export class WorkspaceDetailPage {
     }
 
     const chips = summary.visible
-      .map(skill => `<span class="workspace-detail-agent-skill-chip">${this.escapeHtml(skill)}</span>`)
+      .map(
+        skill => `<span class="workspace-detail-agent-skill-chip">${this.escapeHtml(skill)}</span>`
+      )
       .join('');
     const overflow =
       summary.overflow > 0
@@ -3605,7 +3633,9 @@ export class WorkspaceDetailPage {
   renderAgentModelPowerBadge(agentName, profile, encodedAgentName = '') {
     const presentation = this.getAgentModelPresentation(profile);
     const editable = this.agentAllowsModelEditing(profile);
-    const title = presentation.empty ? `Set model for ${agentName}` : `Change model for ${agentName}`;
+    const title = presentation.empty
+      ? `Set model for ${agentName}`
+      : `Change model for ${agentName}`;
     const badgeClass = `workspace-detail-agent-model-badge${editable ? ' is-editable' : ''}${presentation.empty ? ' is-empty' : ''}`;
     const modelMarkup = presentation.empty
       ? '<span>Model not set</span>'
@@ -3715,9 +3745,7 @@ export class WorkspaceDetailPage {
             ? `Remove all ${group.instanceCount} ${group.name} instances from workspace`
             : `Remove ${group.name} from workspace`;
         const removeButton =
-          group.isWorkspaceAgent &&
-          !group.isUnassigned &&
-          !this.isWorkspaceEntryAgent(group.name)
+          group.isWorkspaceAgent && !group.isUnassigned && !this.isWorkspaceEntryAgent(group.name)
             ? `
         <button type="button"
                 class="workspace-detail-agent-remove-btn"
@@ -3760,11 +3788,10 @@ export class WorkspaceDetailPage {
           </svg>
         </button>
       `;
-        const backFace = canFlip
-          ? this.renderAgentBackFace(group, cardMeta, encodedAgentName)
-          : '';
+        const backFace = canFlip ? this.renderAgentBackFace(group, cardMeta, encodedAgentName) : '';
         const flippedClass = isFlipped ? ' is-flipped' : '';
-        const leaderClass = !group.isUnassigned && this.isWorkspaceEntryAgent(group.name) ? ' is-leader' : '';
+        const leaderClass =
+          !group.isUnassigned && this.isWorkspaceEntryAgent(group.name) ? ' is-leader' : '';
         const unassignedClass = group.isUnassigned ? ' is-unassigned' : '';
         const detailLink = group.isUnassigned
           ? `
@@ -3884,9 +3911,7 @@ export class WorkspaceDetailPage {
         ? `Remove all ${group.instanceCount} ${group.name} instances from workspace`
         : `Remove ${group.name} from workspace`;
     const removeButton =
-      group.isWorkspaceAgent &&
-      !group.isUnassigned &&
-      !this.isWorkspaceEntryAgent(group.name)
+      group.isWorkspaceAgent && !group.isUnassigned && !this.isWorkspaceEntryAgent(group.name)
         ? `
       <button type="button"
               class="workspace-detail-agent-remove-btn"
@@ -3981,8 +4006,9 @@ export class WorkspaceDetailPage {
 
   // Collapses a multi-line prompt into a single-line preview snippet.
   buildAgentPromptPreview(data) {
-    const source =
-      String(data?.effective_prompt || data?.base_system_prompt || '').replace(/\s+/g, ' ').trim();
+    const source = String(data?.effective_prompt || data?.base_system_prompt || '')
+      .replace(/\s+/g, ' ')
+      .trim();
     if (!source) return 'No system prompt set for this agent.';
     const limit = 160;
     return source.length > limit ? `${source.slice(0, limit).trim()}…` : source;
@@ -4330,6 +4356,7 @@ export class WorkspaceDetailPage {
       // Invalidate the cached effective prompt so the flip-card preview refreshes.
       this.agentPromptCache?.delete(this.normalizeAgentName(view.agentName));
       this.refreshAgentCardPrompt(view.agentName);
+      window.workspaceCommand?.refresh();
       if (window.Toast) window.Toast.success('System prompt saved.');
     } catch (error) {
       console.error('Failed to save system prompt:', error);
@@ -4433,9 +4460,7 @@ export class WorkspaceDetailPage {
       )}
       ${section('Effective prompt (composed)', effective, 'Nothing to compose.')}
       ${
-        note
-          ? `<div class="workspace-detail-agent-prompt-hint">${this.escapeHtml(note)}</div>`
-          : ''
+        note ? `<div class="workspace-detail-agent-prompt-hint">${this.escapeHtml(note)}</div>` : ''
       }
     `;
   }
@@ -4538,15 +4563,15 @@ export class WorkspaceDetailPage {
 
       let group = groupByKey.get(normalized);
       if (!group) {
-          group = {
-            key: normalized,
-            name: isUnassigned ? 'Unassigned' : String(name || '').trim(),
-            isWorkspaceAgent,
-            isUnassigned,
-            instanceCount: 0,
-            roles: [],
-            tasks: []
-          };
+        group = {
+          key: normalized,
+          name: isUnassigned ? 'Unassigned' : String(name || '').trim(),
+          isWorkspaceAgent,
+          isUnassigned,
+          instanceCount: 0,
+          roles: [],
+          tasks: []
+        };
         groupByKey.set(normalized, group);
         groups.push(group);
       } else if (isWorkspaceAgent) {
@@ -4824,7 +4849,11 @@ export class WorkspaceDetailPage {
     const resultData = this.getDisplayResult(task, subtasks);
     const hasResultData = !!resultData;
     const hasAssistData = !!statusInfo.isBlocked;
-    const taskTerminalState = task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled' || task.status === 'timeout';
+    const taskTerminalState =
+      task.status === 'completed' ||
+      task.status === 'failed' ||
+      task.status === 'cancelled' ||
+      task.status === 'timeout';
     const isRerun = !isParent && taskTerminalState;
     const executeTitle = isParent
       ? hasUnassignedSubtasks
@@ -4833,7 +4862,9 @@ export class WorkspaceDetailPage {
           ? 'A subtask is already running'
           : 'Execute workflow now'
       : !assignedAgent
-        ? (isRerun ? 'Will auto-assign a workspace agent before re-running' : 'Will auto-assign a workspace agent before execution')
+        ? isRerun
+          ? 'Will auto-assign a workspace agent before re-running'
+          : 'Will auto-assign a workspace agent before execution'
         : awaitingNextStep
           ? 'Execute the next internal step'
           : task.status === 'in_progress'
@@ -4955,13 +4986,15 @@ export class WorkspaceDetailPage {
                 title="${this.escapeHtml(executeTitle)}"
                 aria-label="${isRerun ? 'Re-run' : 'Execute'} task ${taskLabel}"
                 ${canExecute ? '' : 'disabled'}>
-          ${isRerun
-            ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          ${
+            isRerun
+              ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                  <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/>
                </svg>`
-            : `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              : `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                  <path d="M8,5.14V19.14L19,12.14L8,5.14Z"/>
-               </svg>`}
+               </svg>`
+          }
         </button>
         <button type="button" class="workspace-detail-item-delete" onclick="event.stopPropagation(); window.workspaceDetail?.deleteTask('${task.id}')" title="Delete task" aria-label="Delete task ${this.escapeHtml(task.description || task.name || 'Untitled Task')}">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -6388,9 +6421,7 @@ export class WorkspaceDetailPage {
     if (!normalizedAgentName || !normalizedKey) return;
 
     if (this.isWorkspaceEntryAgent(normalizedAgentName)) {
-      window.alert(
-        `"${normalizedAgentName}" is the workspace entry agent and can't be removed.`
-      );
+      window.alert(`"${normalizedAgentName}" is the workspace entry agent and can't be removed.`);
       return;
     }
 
@@ -6616,11 +6647,19 @@ export class WorkspaceDetailPage {
 
     const humanLoop = this.getTaskHumanLoop(task);
     const humanLoopState = String(humanLoop?.state || '').toLowerCase();
-    if (humanLoop && (humanLoopState === 'blocked' || humanLoopState === 'waiting_for_choice' || task?.status === 'waiting_for_choice')) {
+    if (
+      humanLoop &&
+      (humanLoopState === 'blocked' ||
+        humanLoopState === 'waiting_for_choice' ||
+        task?.status === 'waiting_for_choice')
+    ) {
       const reason = String(humanLoop.reason || '').trim();
       return {
         className: 'blocked',
-        label: task?.status === 'waiting_for_choice' || humanLoopState === 'waiting_for_choice' ? 'Waiting for Choice' : 'Needs Input',
+        label:
+          task?.status === 'waiting_for_choice' || humanLoopState === 'waiting_for_choice'
+            ? 'Waiting for Choice'
+            : 'Needs Input',
         isBlocked: true,
         reason
       };
@@ -6911,11 +6950,18 @@ export class WorkspaceDetailPage {
 
   canPromoteTaskResultToWorkflow(sourceTask, text) {
     if (!sourceTask || typeof sourceTask !== 'object') return false;
-    if (String(sourceTask.status || '').trim().toLowerCase() !== 'completed') return false;
+    if (
+      String(sourceTask.status || '')
+        .trim()
+        .toLowerCase() !== 'completed'
+    )
+      return false;
     if (!String(sourceTask.result || '').trim()) return false;
     if (String(sourceTask.error || '').trim()) return false;
 
-    const resultType = String(sourceTask.result_type || '').trim().toLowerCase();
+    const resultType = String(sourceTask.result_type || '')
+      .trim()
+      .toLowerCase();
     if (resultType === 'task_list') return true;
 
     const structuredResult = sourceTask.structured_result;
@@ -7020,7 +7066,8 @@ export class WorkspaceDetailPage {
     this.currentTaskResultPromotionSubmitting = Boolean(isSubmitting);
     if (this.elements.taskResultPromoteSubmitBtn) {
       this.elements.taskResultPromoteSubmitBtn.disabled = this.currentTaskResultPromotionSubmitting;
-      this.elements.taskResultPromoteSubmitBtn.textContent = this.currentTaskResultPromotionSubmitting
+      this.elements.taskResultPromoteSubmitBtn.textContent = this
+        .currentTaskResultPromotionSubmitting
         ? 'Creating...'
         : 'Create';
     }
@@ -10126,7 +10173,9 @@ export class WorkspaceDetailPage {
       // Workspace-local agents persist to the workspace config.json via a
       // workspace-scoped endpoint, and their model picker is not type-filtered.
       isWorkspaceAgent:
-        String(profile.source || '').trim().toLowerCase() === 'workspace',
+        String(profile.source || '')
+          .trim()
+          .toLowerCase() === 'workspace',
       workspaceId: this.workspace?.id || ''
     };
 
@@ -10691,7 +10740,9 @@ export class WorkspaceDetailPage {
         ? raw.planning
         : {};
     const taskMarkdown =
-      raw.task_markdown && typeof raw.task_markdown === 'object' && !Array.isArray(raw.task_markdown)
+      raw.task_markdown &&
+      typeof raw.task_markdown === 'object' &&
+      !Array.isArray(raw.task_markdown)
         ? raw.task_markdown
         : {};
     const boolOrDefault = (value, fallback) => (typeof value === 'boolean' ? value : fallback);
@@ -10965,9 +11016,8 @@ export class WorkspaceDetailPage {
         normalized.task_markdown.generate_agent_views !== false;
     }
     if (this.elements.settingsTaskMarkdownStatus) {
-      this.elements.settingsTaskMarkdownStatus.textContent = this.getTaskMarkdownStatusText(
-        normalized
-      );
+      this.elements.settingsTaskMarkdownStatus.textContent =
+        this.getTaskMarkdownStatusText(normalized);
     }
   }
 
@@ -11044,8 +11094,7 @@ export class WorkspaceDetailPage {
       task_markdown: {
         enabled: this.elements.settingsTaskMarkdownEnabledInput?.checked === true,
         path: String(this.elements.settingsTaskMarkdownPathInput?.value || '').trim(),
-        generate_agent_views:
-          this.elements.settingsTaskMarkdownAgentViewsInput?.checked !== false
+        generate_agent_views: this.elements.settingsTaskMarkdownAgentViewsInput?.checked !== false
       }
     });
 
@@ -11227,7 +11276,8 @@ export class WorkspaceDetailPage {
     try {
       await this.loadTasks();
       if (this.elements.settingsTaskMarkdownStatus) {
-        this.elements.settingsTaskMarkdownStatus.textContent = 'Imported task map and refreshed tasks.';
+        this.elements.settingsTaskMarkdownStatus.textContent =
+          'Imported task map and refreshed tasks.';
       }
       if (window.Toast) {
         window.Toast.success('Markdown tasks imported');
@@ -11303,7 +11353,6 @@ export class WorkspaceDetailPage {
     return ids;
   }
 
-
   async loadWorkspaceAgentSnapshots() {
     this.workspaceAgentSnapshots = new Set();
     this.workspaceAgentProfiles = new Map();
@@ -11328,7 +11377,10 @@ export class WorkspaceDetailPage {
           type: String(agent?.type || '').trim(),
           model: String(agent?.model || '').trim(),
           provider: String(agent?.provider || '').trim(),
-          source: String(agent?.source || 'workspace').trim().toLowerCase() || 'workspace'
+          source:
+            String(agent?.source || 'workspace')
+              .trim()
+              .toLowerCase() || 'workspace'
         });
       });
     } catch (_err) {
@@ -11767,7 +11819,12 @@ export class WorkspaceDetailPage {
     const humanLoopState = String(task?.context?.human_loop?.state || '')
       .trim()
       .toLowerCase();
-    if (humanLoopState === 'blocked' || humanLoopState === 'waiting_for_choice' || status === 'waiting_for_choice') return 'waiting_for_choice';
+    if (
+      humanLoopState === 'blocked' ||
+      humanLoopState === 'waiting_for_choice' ||
+      status === 'waiting_for_choice'
+    )
+      return 'waiting_for_choice';
     return status || 'pending';
   }
 
@@ -14110,7 +14167,11 @@ export class WorkspaceDetailPage {
   }
 
   isGroupWorkspace() {
-    return String(this.workspace?.kind || '').trim().toLowerCase() === 'group';
+    return (
+      String(this.workspace?.kind || '')
+        .trim()
+        .toLowerCase() === 'group'
+    );
   }
 
   syncProjectActionState() {
@@ -14356,11 +14417,14 @@ export class WorkspaceDetailPage {
     this.setProjectTemplateSubmitting(true);
     this.clearProjectTemplateError();
     try {
-      const response = await fetch(`/api/workspaces/${encodeURIComponent(this.workspaceId)}/project`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/project`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        }
+      );
       const result = await response.json().catch(() => ({}));
       if (!response.ok || result.error) {
         throw new Error(result.error || 'Failed to create project');
@@ -14426,7 +14490,9 @@ export class WorkspaceDetailPage {
         this.workspace.primary_directory_id =
           typeof workspace.primary_directory_id === 'string' ? workspace.primary_directory_id : '';
         this.workspace.project_path =
-          typeof workspace.project_path === 'string' ? workspace.project_path : this.workspace.project_path || '';
+          typeof workspace.project_path === 'string'
+            ? workspace.project_path
+            : this.workspace.project_path || '';
         this.workspace.shared_data =
           workspace.shared_data && typeof workspace.shared_data === 'object'
             ? workspace.shared_data
@@ -15171,7 +15237,12 @@ export class WorkspaceDetailPage {
     // starts clean. We check live state to avoid stale labels persisting
     // after a completion event sneaks past the heartbeat goroutine.
     const task = this.tasks?.find?.(t => t?.id === taskId);
-    if (task && String(task.status || '').trim().toLowerCase() !== 'in_progress') {
+    if (
+      task &&
+      String(task.status || '')
+        .trim()
+        .toLowerCase() !== 'in_progress'
+    ) {
       this._taskActivity.delete(taskId);
     }
 
@@ -15180,7 +15251,7 @@ export class WorkspaceDetailPage {
   }
 
   taskActivityLabelFor(eventType, payload) {
-    const data = (payload && typeof payload === 'object') ? payload : {};
+    const data = payload && typeof payload === 'object' ? payload : {};
     switch (eventType) {
       case 'task.thinking': {
         const phase = String(data.phase || '').trim();
@@ -15237,8 +15308,12 @@ export class WorkspaceDetailPage {
     }
     const ago = this.formatTaskActivityAgo(activity.at);
     const text = activity.label
-      ? (ago ? `${activity.label} · ${ago}` : activity.label)
-      : (ago ? `Active ${ago}` : 'Active');
+      ? ago
+        ? `${activity.label} · ${ago}`
+        : activity.label
+      : ago
+        ? `Active ${ago}`
+        : 'Active';
     slot.textContent = text;
     slot.hidden = false;
   }
@@ -15758,11 +15833,8 @@ export class WorkspaceDetailPage {
       btn.disabled = isBusy || total === 0;
       btn.setAttribute('aria-pressed', allSelected ? 'true' : 'false');
       btn.setAttribute('aria-label', allSelected ? 'Deselect all notes' : 'Select all notes');
-      btn.title = total === 0
-        ? 'No notes to select'
-        : allSelected
-          ? 'Clear selection'
-          : 'Select every note';
+      btn.title =
+        total === 0 ? 'No notes to select' : allSelected ? 'Clear selection' : 'Select every note';
     }
 
     if (this.elements.copyAllNotesBtn) {
@@ -15770,9 +15842,10 @@ export class WorkspaceDetailPage {
       // and surface the selected count through the tooltip + aria-label.
       const btn = this.elements.copyAllNotesBtn;
       btn.disabled = isBusy || selectedCount === 0;
-      const label = selectedCount > 0
-        ? `Copy ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`
-        : 'Copy selected notes';
+      const label =
+        selectedCount > 0
+          ? `Copy ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`
+          : 'Copy selected notes';
       btn.title = selectedCount === 0 ? 'Select notes to copy' : label;
       btn.setAttribute('aria-label', label);
     }
@@ -15782,9 +15855,10 @@ export class WorkspaceDetailPage {
       // and surface the selected count through the tooltip + aria-label.
       const btn = this.elements.deleteSelectedNotesBtn;
       btn.disabled = isBusy || selectedCount === 0;
-      const label = selectedCount > 0
-        ? `Delete ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`
-        : 'Delete selected notes';
+      const label =
+        selectedCount > 0
+          ? `Delete ${selectedCount} selected note${selectedCount === 1 ? '' : 's'}`
+          : 'Delete selected notes';
       btn.title = selectedCount === 0 ? 'Select notes to delete' : label;
       btn.setAttribute('aria-label', label);
     }

--- a/internal/web/static/js/modules/workspace-mission.js
+++ b/internal/web/static/js/modules/workspace-mission.js
@@ -88,14 +88,14 @@
     commandActionStatus: '#workspace-command-mission-action-status',
     commandEditBtn: '#workspace-command-mission-edit',
     commandRunBtn: '#workspace-command-mission-run',
-    commandFindingsBtn: '#workspace-command-mission-findings',
+    commandFindingsBtn: '#workspace-command-mission-findings'
   };
 
   // Plain-language summary of each autonomy policy. The quick-edit modal only
   // displays the current value (read-only) — it's changed in Advanced settings.
   const AUTONOMY_LABELS = {
     watch: { label: 'Watch', desc: 'reports findings only, makes no changes' },
-    propose: { label: 'Propose', desc: 'may draft inside the workspace, no external changes' },
+    propose: { label: 'Propose', desc: 'may draft inside the workspace, no external changes' }
   };
 
   let latestState = null;
@@ -103,6 +103,7 @@
   // Guards against overlapping runs and keeps the goal card's Run button
   // disabled while a run is in flight (see renderGoalCard).
   let runInProgress = false;
+  let lastRunOutcome = null;
   const RUN_POLL_INTERVAL_MS = 2000;
   const RUN_POLL_TIMEOUT_MS = 120000;
 
@@ -124,7 +125,7 @@
       domWrap: SELECTORS.cadenceDomWrap,
       intervalWrap: SELECTORS.cadenceIntervalWrap,
       enabled: SELECTORS.enabled,
-      enabledHint: SELECTORS.enabledHint,
+      enabledHint: SELECTORS.enabledHint
     },
     modal: {
       type: SELECTORS.goalModalCadenceType,
@@ -137,8 +138,8 @@
       domWrap: SELECTORS.goalModalCadenceDomWrap,
       intervalWrap: SELECTORS.goalModalCadenceIntervalWrap,
       enabled: SELECTORS.goalModalEnabled,
-      enabledHint: SELECTORS.goalModalEnabledHint,
-    },
+      enabledHint: SELECTORS.goalModalEnabledHint
+    }
   };
 
   function $(sel) {
@@ -255,7 +256,7 @@
       daily: ['timeWrap'],
       weekly: ['timeWrap', 'dowWrap'],
       monthly: ['timeWrap', 'domWrap'],
-      interval: ['intervalWrap'],
+      interval: ['intervalWrap']
     };
     const visible = new Set(wraps[type] || []);
     for (const key of ['timeWrap', 'dowWrap', 'domWrap', 'intervalWrap']) {
@@ -299,14 +300,14 @@
       return {
         type: 'weekly',
         time_of_day: $(fields.time).value || '09:00',
-        day_of_week: parseInt($(fields.dow).value, 10),
+        day_of_week: parseInt($(fields.dow).value, 10)
       };
     }
     if (type === 'monthly') {
       return {
         type: 'monthly',
         time_of_day: $(fields.time).value || '09:00',
-        day_of_month: parseInt($(fields.dom).value, 10) || 1,
+        day_of_month: parseInt($(fields.dom).value, 10) || 1
       };
     }
     if (type === 'interval') {
@@ -346,7 +347,7 @@
     return {
       mission: $(SELECTORS.goalModalText).value,
       cadence: readCadenceFields(CADENCE_SURFACES.modal),
-      mission_enabled: $(SELECTORS.goalModalEnabled).checked,
+      mission_enabled: $(SELECTORS.goalModalEnabled).checked
     };
   }
 
@@ -387,20 +388,27 @@
     return {
       href: wsId ? `/action-center?workspace=${encodeURIComponent(wsId)}` : '/action-center',
       label: openFindings > 0 ? `Findings (${openFindings})` : 'Findings',
-      hasFindings: openFindings > 0,
+      hasFindings: openFindings > 0
     };
   }
 
   function commandSummary(state) {
     const current = state || latestState || {};
     const mission = String(current.mission || '').trim();
-    const status = missionStatus(current);
+    const status = runInProgress
+      ? { label: 'Running', className: 'is-running' }
+      : mission && lastRunOutcome
+        ? lastRunOutcome
+        : missionStatus(current);
     const findings = buildFindingsMeta(current);
     const mcp = Array.isArray(current.unclassified_mcp_ids) ? current.unclassified_mcp_ids : [];
-    const skills = Array.isArray(current.unclassified_skill_ids) ? current.unclassified_skill_ids : [];
-    const actionStatus = mission && mcp.length + skills.length > 0
-      ? 'Classify MCP or skill bindings before scheduled runs.'
-      : '';
+    const skills = Array.isArray(current.unclassified_skill_ids)
+      ? current.unclassified_skill_ids
+      : [];
+    const actionStatus =
+      mission && mcp.length + skills.length > 0
+        ? 'Classify MCP or skill bindings before scheduled runs.'
+        : '';
     return {
       mission,
       label: status.label,
@@ -413,11 +421,15 @@
       nextTitle: current.next_mission_run_at ? fmtTime(current.next_mission_run_at) : '',
       lastTitle: current.last_mission_run_at ? fmtTime(current.last_mission_run_at) : '',
       canRun: !!mission && !runInProgress,
-      runTitle: mission ? 'Run this goal check now' : 'Set a goal before running',
+      runTitle: runInProgress
+        ? 'A goal run is already in progress'
+        : mission
+          ? 'Run this goal check now'
+          : 'Set a goal before running',
       findingsHref: findings.href,
       findingsLabel: findings.label,
       hasFindings: findings.hasFindings,
-      actionStatus,
+      actionStatus
     };
   }
 
@@ -476,7 +488,8 @@
       findingsBtn.textContent = summary.findingsLabel;
       findingsBtn.classList.toggle('has-findings', summary.hasFindings);
     }
-    if (!runInProgress) setCommandActionStatus(summary.actionStatus, summary.actionStatus ? 'error' : null);
+    if (!runInProgress)
+      setCommandActionStatus(summary.actionStatus, summary.actionStatus ? 'error' : null);
     renderCommandSubtitle(state);
   }
 
@@ -532,7 +545,9 @@
     // (the live "Running…" / result message must not be cleared by a poll).
     if (!runInProgress) {
       const mcp = Array.isArray(state.unclassified_mcp_ids) ? state.unclassified_mcp_ids : [];
-      const skills = Array.isArray(state.unclassified_skill_ids) ? state.unclassified_skill_ids : [];
+      const skills = Array.isArray(state.unclassified_skill_ids)
+        ? state.unclassified_skill_ids
+        : [];
       if (mission && mcp.length + skills.length > 0) {
         setGoalActionStatus('Classify MCP or skill bindings before scheduled runs.', 'error');
       } else {
@@ -615,7 +630,9 @@
   // goal can run (manually or on a schedule).
   function unclassifiedCounts(state) {
     const mcp = Array.isArray(state.unclassified_mcp_ids) ? state.unclassified_mcp_ids.length : 0;
-    const skills = Array.isArray(state.unclassified_skill_ids) ? state.unclassified_skill_ids.length : 0;
+    const skills = Array.isArray(state.unclassified_skill_ids)
+      ? state.unclassified_skill_ids.length
+      : 0;
     return { mcp, skills, total: mcp + skills };
   }
 
@@ -662,7 +679,7 @@
     // Autonomy
     const radios = document.querySelectorAll(SELECTORS.autonomyRadios);
     const policy = state.autonomy_policy || 'propose';
-    radios.forEach((r) => {
+    radios.forEach(r => {
       r.checked = r.value === policy;
     });
 
@@ -688,7 +705,7 @@
       home: 'Watch over home devices, maintenance, and recurring household needs.',
       finance: 'Monitor finance for risks, opportunities, and reconciliation issues.',
       health: 'Track health routines, appointments, and check-ins.',
-      travel: 'Maintain trip plans, bookings, and travel-readiness checklists.',
+      travel: 'Maintain trip plans, bookings, and travel-readiness checklists.'
     };
     for (const [key, hint] of Object.entries(hints)) {
       if (name.includes(key)) {
@@ -699,7 +716,9 @@
   }
 
   function readFormState() {
-    const policy = Array.from(document.querySelectorAll(SELECTORS.autonomyRadios)).find((r) => r.checked);
+    const policy = Array.from(document.querySelectorAll(SELECTORS.autonomyRadios)).find(
+      r => r.checked
+    );
     const cadence = readCadenceFields(CADENCE_SURFACES.form);
 
     const minPriority = $(SELECTORS.notifPriority).value;
@@ -718,7 +737,7 @@
       cadence,
       notification_policy,
       mission_enabled: $(SELECTORS.enabled).checked,
-      mission_cadence_heartbeat: heartbeatEl ? heartbeatEl.checked : false,
+      mission_cadence_heartbeat: heartbeatEl ? heartbeatEl.checked : false
     };
   }
 
@@ -735,7 +754,7 @@
     const resp = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/mission`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(payload)
     });
     if (!resp.ok) {
       const body = await resp.json().catch(() => ({}));
@@ -750,7 +769,7 @@
   async function triggerMission(endpoint) {
     const wsId = getWorkspaceId();
     const resp = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/mission/${endpoint}`, {
-      method: 'POST',
+      method: 'POST'
     });
     if (!resp.ok) {
       const body = await resp.json().catch(() => ({}));
@@ -766,6 +785,7 @@
     try {
       const state = await fetchMissionState();
       latestState = state;
+      lastRunOutcome = null;
       renderReadOnly(state);
       populateFormFromState(state);
       populateGoalModalFromState(state);
@@ -819,7 +839,7 @@
   }
 
   function sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   // Repaint the read-only surfaces (goal card + advanced status strip + run
@@ -844,7 +864,7 @@
     const noGoal = !String(state.mission || '').trim();
     const buttons = [
       [$(SELECTORS.baselineBtn), isFirstRun],
-      [$(SELECTORS.triggerBtn), !isFirstRun],
+      [$(SELECTORS.triggerBtn), !isFirstRun]
     ];
     for (const [btn, visible] of buttons) {
       if (!btn) continue;
@@ -881,7 +901,7 @@
         return {
           done: true,
           failed: (state.mission_failure_count || 0) > beforeFailures,
-          runId: r.run_id,
+          runId: r.run_id
         };
       }
     }
@@ -894,6 +914,7 @@
   async function handleRunClick(endpoint, button, report) {
     if (runInProgress) return;
     runInProgress = true;
+    lastRunOutcome = null;
     let originalLabel;
     if (button) {
       button.disabled = true;
@@ -905,22 +926,29 @@
     let message = 'Run complete.';
     let kind = null;
     try {
-      const result = await executeRun(endpoint, (msg) => report(msg));
+      const result = await executeRun(endpoint, msg => report(msg));
       if (!result.done) {
         message = 'Still running — this is taking a while. Use Refresh to check status.';
         kind = 'error';
+        lastRunOutcome = { label: 'Running', className: 'is-running' };
       } else if (result.failed) {
         message = 'Run finished with an error. Check the Action Center or server logs.';
         kind = 'error';
+        lastRunOutcome = { label: 'Failed', className: 'is-failed' };
+      } else {
+        lastRunOutcome = { label: 'Completed', className: 'is-completed' };
       }
     } catch (e) {
       kind = 'error';
       if (e.status === 412) {
         message = 'Classify workspace bindings before running.';
+        lastRunOutcome = { label: 'Blocked', className: 'is-blocked' };
       } else if (e.status === 503) {
         message = 'Goal runner is not configured on this server.';
+        lastRunOutcome = { label: 'Failed', className: 'is-failed' };
       } else {
         message = `Run failed: ${e.message}`;
+        lastRunOutcome = { label: 'Failed', className: 'is-failed' };
       }
     }
 
@@ -952,7 +980,7 @@
 
     const goalModalForm = $(SELECTORS.goalModalForm);
     if (goalModalForm) {
-      goalModalForm.addEventListener('submit', async (evt) => {
+      goalModalForm.addEventListener('submit', async evt => {
         evt.preventDefault();
         const payload = readGoalModalState();
         if (payload.mission_enabled && !String(payload.mission || '').trim()) {
@@ -969,6 +997,7 @@
         setGoalModalStatus('Saving...');
         try {
           await saveMission(payload);
+          lastRunOutcome = null;
           await reload();
           hideGoalModal();
           setGoalActionStatus('Goal saved.');
@@ -994,7 +1023,7 @@
 
     const form = $(SELECTORS.form);
     if (form) {
-      form.addEventListener('submit', async (evt) => {
+      form.addEventListener('submit', async evt => {
         evt.preventDefault();
         const payload = readFormState();
         if (payload.mission_enabled && !payload.cadence) {
@@ -1006,12 +1035,16 @@
         setStatusText('Saving...');
         try {
           await saveMission(payload);
+          lastRunOutcome = null;
           setStatusText('Goal settings saved.');
           await reload();
           setGoalActionStatus('Goal saved.');
         } catch (e) {
           if (e.status === 412) {
-            setStatusText('Classify your workspace bindings before enabling goal automation.', 'error');
+            setStatusText(
+              'Classify your workspace bindings before enabling goal automation.',
+              'error'
+            );
             setGoalActionStatus('Classify workspace bindings before enabling this goal.', 'error');
           } else {
             setStatusText(`Save failed: ${e.message}`, 'error');
@@ -1068,13 +1101,13 @@
     if (typeof window === 'undefined') return;
     window.workspaceMission = Object.assign(window.workspaceMission || {}, {
       getState: () => latestState,
-      getSummary: () => latestState ? commandSummary(latestState) : {},
+      getSummary: () => (latestState ? commandSummary(latestState) : {}),
       renderCommandSurfaces: () => {
         if (latestState) renderCommandPanel(latestState);
       },
       openGoalModal,
       runNow: runNowFromCommand,
-      reload,
+      reload
     });
   }
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -25,10 +25,7 @@ test.describe('Smoke Tests', () => {
     });
 
     // Filter out expected errors (add patterns as needed)
-    const unexpectedErrors = errors.filter(e =>
-      !e.includes('favicon') &&
-      !e.includes('404')
-    );
+    const unexpectedErrors = errors.filter(e => !e.includes('favicon') && !e.includes('404'));
 
     expect(unexpectedErrors).toHaveLength(0);
   });
@@ -64,7 +61,7 @@ test.describe('Smoke Tests', () => {
 
 test.describe('Onboarding', () => {
   async function installBaseOnboardingRoutes(page) {
-    await page.route('**/api/onboarding/status', async (route) => {
+    await page.route('**/api/onboarding/status', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -79,7 +76,7 @@ test.describe('Onboarding', () => {
         })
       });
     });
-    await page.route('**/api/onboarding/names', async (route) => {
+    await page.route('**/api/onboarding/names', async route => {
       const body = route.request().postDataJSON();
       await route.fulfill({
         status: 200,
@@ -90,7 +87,7 @@ test.describe('Onboarding', () => {
         })
       });
     });
-    await page.route('**/api/onboarding/step', async (route) => {
+    await page.route('**/api/onboarding/step', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -107,24 +104,24 @@ test.describe('Onboarding', () => {
     await expect(page.locator('#onboardingStepLabel')).toHaveText('Step 1 of 3');
     await expect(page.locator('#onboardingWorkspaceRoot')).toHaveCount(0);
     await expect(page.locator('#onboardingVaultRoot')).toHaveCount(0);
-    await expect(page.getByText('Storage locations can be changed later in Settings when you need them.')).toBeVisible();
+    await expect(
+      page.getByText('Storage locations can be changed later in Settings when you need them.')
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Set Up Later' })).toBeVisible();
   });
 
   test('auto-selects a recommended model before continuing', async ({ page }) => {
     await installBaseOnboardingRoutes(page);
-    await page.route('**/api/providers', async (route) => {
+    await page.route('**/api/providers', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          providers: [
-            { name: 'ollama', display_name: 'Ollama', available: true }
-          ]
+          providers: [{ name: 'ollama', display_name: 'Ollama', available: true }]
         })
       });
     });
-    await page.route('**/api/settings/available-models?provider=ollama', async (route) => {
+    await page.route('**/api/settings/available-models?provider=ollama', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -132,7 +129,12 @@ test.describe('Onboarding', () => {
           available: true,
           model_options: [
             { id: 'llama-small', label: 'Llama Small', description: 'Fast', recommended: false },
-            { id: 'llama-balanced', label: 'Llama Balanced', description: 'Recommended', recommended: true }
+            {
+              id: 'llama-balanced',
+              label: 'Llama Balanced',
+              description: 'Recommended',
+              recommended: true
+            }
           ]
         })
       });
@@ -151,7 +153,7 @@ test.describe('Onboarding', () => {
 
   test('blocks progress when no usable provider is available', async ({ page }) => {
     await installBaseOnboardingRoutes(page);
-    await page.route('**/api/providers', async (route) => {
+    await page.route('**/api/providers', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -169,7 +171,10 @@ test.describe('Onboarding', () => {
 });
 
 test.describe('Home First Run', () => {
-  test('makes workspace creation the primary next step when no workspaces exist', async ({ page, request }) => {
+  test('makes workspace creation the primary next step when no workspaces exist', async ({
+    page,
+    request
+  }) => {
     const response = await request.get('/api/workspaces');
     const data = await response.json();
     test.skip((data.workspaces || []).length !== 0, 'requires an empty workspace store');
@@ -177,8 +182,13 @@ test.describe('Home First Run', () => {
     await page.goto('/');
     await expect(page.locator('#homeFirstRunHero')).toBeVisible();
     await expect(page.locator('#homeFirstRunStart')).toHaveText('Create Workspace');
-    await expect(page.locator('#homeAssistantInput')).toHaveAttribute('placeholder', 'Plan a product launch…');
-    await expect(page.getByText('Create a workspace for a software project', { exact: true })).toBeVisible();
+    await expect(page.locator('#homeAssistantInput')).toHaveAttribute(
+      'placeholder',
+      'Plan a product launch…'
+    );
+    await expect(
+      page.getByText('Create a workspace for a software project', { exact: true })
+    ).toBeVisible();
   });
 });
 
@@ -188,7 +198,9 @@ test.describe('Agent Management', () => {
     await expect(page.locator('body')).toBeVisible();
 
     // Look for create agent button (adjust selector based on your UI)
-    const createBtn = page.locator('button:has-text("Create"), [data-bs-target="#addAgentModal"]').first();
+    const createBtn = page
+      .locator('button:has-text("Create"), [data-bs-target="#addAgentModal"]')
+      .first();
 
     if (await createBtn.isVisible()) {
       await createBtn.click();
@@ -226,7 +238,7 @@ test.describe('Agent Management', () => {
 
 test.describe('Workspace Import Flow', () => {
   test('import modal supports picker selection and duplicate override', async ({ page }) => {
-    await page.route('**/api/folder-picker/select-path', async (route) => {
+    await page.route('**/api/folder-picker/select-path', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -238,7 +250,7 @@ test.describe('Workspace Import Flow', () => {
       });
     });
 
-    await page.route('**/api/workspaces/import/check*', async (route) => {
+    await page.route('**/api/workspaces/import/check*', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -253,7 +265,7 @@ test.describe('Workspace Import Flow', () => {
       });
     });
 
-    await page.route('**/api/workspaces/import/duplicate-action', async (route) => {
+    await page.route('**/api/workspaces/import/duplicate-action', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -262,7 +274,7 @@ test.describe('Workspace Import Flow', () => {
     });
 
     let importAttemptCount = 0;
-    await page.route('**/api/workspaces/import', async (route) => {
+    await page.route('**/api/workspaces/import', async route => {
       importAttemptCount += 1;
       const body = route.request().postDataJSON();
 
@@ -404,7 +416,12 @@ test.describe('Workspace Agent Character Roster', () => {
       shared_data: {},
       skill_bindings: [
         { id: 'skill-planning', skill_name: 'workspace-planning', enabled: true, trusted: true },
-        { id: 'skill-research', skill_name: 'browser:control-in-app-browser', enabled: true, trusted: true }
+        {
+          id: 'skill-research',
+          skill_name: 'browser:control-in-app-browser',
+          enabled: true,
+          trusted: true
+        }
       ],
       agent_skill_access: [
         { agent_instance_id: 'manager-1', enabled_binding_ids: ['skill-planning'] },
@@ -419,23 +436,81 @@ test.describe('Workspace Agent Character Roster', () => {
       status: 'active'
     };
     const tasks = [
-      { id: 'task-1', workspace_id: 'roster-ws', to: 'Roster Manager', status: 'pending', description: 'Plan the work' },
-      { id: 'task-2', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'waiting_for_choice', description: 'Choose source' },
-      { id: 'task-3', workspace_id: 'roster-ws', to: 'Research Analyst', status: 'in_progress', description: 'Read source', parent_task_id: 'task-1' }
+      {
+        id: 'task-1',
+        workspace_id: 'roster-ws',
+        to: 'Roster Manager',
+        status: 'pending',
+        description: 'Plan the work'
+      },
+      {
+        id: 'task-2',
+        workspace_id: 'roster-ws',
+        to: 'Research Analyst',
+        status: 'waiting_for_choice',
+        description: 'Choose source'
+      },
+      {
+        id: 'task-3',
+        workspace_id: 'roster-ws',
+        to: 'Research Analyst',
+        status: 'in_progress',
+        description: 'Read source',
+        parent_task_id: 'task-1'
+      }
     ];
     const catalogAgents = [
       ...(options.omitRosterManagerFromCatalog
         ? []
-        : [{ name: 'Roster Manager', type: 'general', source: 'user', model: 'claude-opus-4', provider: 'anthropic', capabilities: ['files'] }]),
-      { name: 'Research Analyst', type: 'research', source: 'user', model: 'claude-sonnet-4', provider: 'anthropic', allow_web_search: true }
+        : [
+            {
+              name: 'Roster Manager',
+              type: 'general',
+              source: 'user',
+              model: 'claude-opus-4',
+              provider: 'anthropic',
+              capabilities: ['files']
+            }
+          ]),
+      {
+        name: 'Research Analyst',
+        type: 'research',
+        source: 'user',
+        model: 'claude-sonnet-4',
+        provider: 'anthropic',
+        allow_web_search: true
+      }
     ];
     const snapshotAgents = Array.isArray(options.snapshotAgents) ? options.snapshotAgents : [];
 
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          needs_onboarding: false,
+          current_step: 3,
+          completed: true,
+          skipped: false,
+          steps_completed: [0, 1, 2],
+          user_name: 'Tester',
+          assistant_name: 'Ori'
+        })
+      });
+    });
     await page.route('**/api/orchestration/workspace?id=roster-ws', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(workspace) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(workspace)
+      });
     });
     await page.route('**/api/workspaces/roster-ws/agent-snapshots', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ agents: snapshotAgents }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ agents: snapshotAgents })
+      });
     });
     await page.route('**/api/agents/dashboard/list', async route => {
       await route.fulfill({
@@ -457,55 +532,177 @@ test.describe('Workspace Agent Character Roster', () => {
       });
     });
     await page.route('**/api/orchestration/tasks?workspace_id=roster-ws', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ tasks }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tasks })
+      });
     });
     await page.route('**/api/sessions?folder_id=roster-ws', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sessions: [] }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sessions: [] })
+      });
     });
     await page.route('**/api/workspaces/roster-ws/notes', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ notes: [] }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [] })
+      });
+    });
+    await page.route('**/api/workspaces/roster-ws/mission', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          mission: '',
+          mission_enabled: false,
+          cadence: null,
+          mission_execution_count: 0,
+          mission_failure_count: 0,
+          open_findings_count: 0
+        })
+      });
+    });
+    await page.route('**/api/workspaces/roster-ws/agents/*/effective-prompt', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          base_system_prompt: 'You are a focused workspace agent.',
+          effective_prompt: 'You are a focused workspace agent.'
+        })
+      });
     });
     await page.route('**/api/workspaces/roster-ws', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(workspace) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(workspace)
+      });
     });
     await page.route('**/api/workspaces?tree=true', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspaces: [workspace], folders: [workspace] }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ workspaces: [workspace], folders: [workspace] })
+      });
     });
     await page.route('**/api/orchestration/workspace/activate?id=roster-ws', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true })
+      });
     });
     await page.route('**/api/project-templates', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ templates: [] }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ templates: [] })
+      });
     });
   }
 
-  // The Detailed agent character cards were deleted with the Detailed view;
-  // the Command Garrison unit cards are the roster surface now. (The old
-  // local-agent identity-routing test died with the links — Garrison renders
-  // no per-agent identity links, so local agents can't be mis-routed to
-  // missing global pages.)
-  test('garrison renders truthful unit cards from the roster data', async ({ page }) => {
+  test('command deck selects roster characters and updates the shared agent overview', async ({
+    page
+  }) => {
     await installRosterRoutes(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto('/workspaces/roster-ws');
 
-    const units = page.locator('#workspaceCommandView .ws-cmd-unit');
-    await expect(units).toHaveCount(2);
+    const roster = page.locator('#workspaceCommandView .ws-cmd-roster-item');
+    await expect(roster).toHaveCount(2);
+    await expect(roster.first()).toHaveAttribute('aria-pressed', 'true');
+    await expect(roster.first()).toContainText('Roster Manager');
+    await expect(roster.first()).toContainText('Entry');
+    await expect(roster.first().locator('.ws-cmd-character svg')).toBeVisible();
+    await expect(roster.nth(1)).toContainText('Working');
+    await expect(roster.nth(1)).toContainText('2×');
 
-    // Entry agent leads with the keeper badge and truthful status/identity.
-    await expect(units.first()).toHaveClass(/is-keeper/);
-    await expect(units.first().locator('.ws-cmd-av')).toHaveText('RM');
-    await expect(units.first().locator('.ws-cmd-unit-name')).toHaveText('Roster Manager');
-    await expect(units.first().locator('.ws-cmd-badge.is-keeper')).toContainText('Entry Agent');
-    await expect(units.first().locator('.ws-cmd-state')).toContainText('Idle');
-    await expect(units.nth(1).locator('.ws-cmd-state')).toContainText('Working');
+    const stage = page.locator('#workspaceCommandView .ws-cmd-agent-stage');
+    await expect(stage.locator('h3')).toHaveText('Roster Manager');
+    await expect(stage).toContainText('Entry Agent');
+    await expect(stage).toContainText('Idle');
 
-    // Model and skills rows render for real agents.
-    await expect(units.first().locator('.ws-cmd-unit-rows')).toContainText('Model');
-    await expect(units.first().locator('.ws-cmd-unit-rows')).toContainText('Skills');
+    await roster.nth(1).click();
+    await expect(stage.locator('h3')).toHaveText('Research Analyst');
+    await expect(stage).toContainText('Working');
 
-    // Quest logs list the roster tasks.
-    await expect(units.first().locator('.ws-cmd-questlog')).toBeVisible();
+    await page.getByRole('tab', { name: 'Tasks' }).click();
+    await expect(page.locator('.ws-cmd-agent-tabpanel.is-active')).toContainText('Choose source');
+
+    await page.getByRole('tab', { name: 'Loadout' }).click();
+    await expect(page.locator('.ws-cmd-agent-tabpanel.is-active')).toContainText('Model');
+    await expect(page.locator('.ws-cmd-agent-tabpanel.is-active')).toContainText('Skills');
+    await expect(page.locator('.ws-cmd-loadout-prompt')).toContainText(
+      'You are a focused workspace agent.'
+    );
+  });
+
+  test('command deck uses the required desktop, tablet, and mobile layouts without page overflow', async ({
+    page
+  }) => {
+    await installRosterRoutes(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/workspaces/roster-ws');
+    await expect(page.locator('.ws-cmd-roster-item')).toHaveCount(2);
+    await expect(page.locator('.ws-cmd-deck')).toBeVisible();
+
+    const mission = page.locator('#workspace-command-mission-card');
+    await expect(mission).toBeVisible();
+    expect((await mission.boundingBox())?.height || 0).toBeLessThanOrEqual(160);
+
+    const desktopGeometry = await page.locator('.ws-cmd-deck').evaluate(element => {
+      const roster = element.querySelector('.ws-cmd-roster')?.getBoundingClientRect();
+      const stage = element.querySelector('.ws-cmd-agent-stage')?.getBoundingClientRect();
+      const overview = element.querySelector('.ws-cmd-agent-overview')?.getBoundingClientRect();
+      return {
+        rosterTop: roster?.top,
+        stageTop: stage?.top,
+        overviewTop: overview?.top,
+        rosterRight: roster?.right,
+        stageLeft: stage?.left,
+        stageRight: stage?.right,
+        overviewLeft: overview?.left
+      };
+    });
+    expect(
+      Math.abs((desktopGeometry.rosterTop || 0) - (desktopGeometry.stageTop || 0))
+    ).toBeLessThan(2);
+    expect(
+      Math.abs((desktopGeometry.stageTop || 0) - (desktopGeometry.overviewTop || 0))
+    ).toBeLessThan(2);
+    expect(desktopGeometry.rosterRight).toBeLessThanOrEqual(desktopGeometry.stageLeft || 0);
+    expect(desktopGeometry.stageRight).toBeLessThanOrEqual(desktopGeometry.overviewLeft || 0);
+
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const tabletGeometry = await page.locator('.ws-cmd-deck').evaluate(element => {
+      const roster = element.querySelector('.ws-cmd-roster')?.getBoundingClientRect();
+      const stage = element.querySelector('.ws-cmd-agent-stage')?.getBoundingClientRect();
+      const overview = element.querySelector('.ws-cmd-agent-overview')?.getBoundingClientRect();
+      return { rosterBottom: roster?.bottom, stageTop: stage?.top, overviewTop: overview?.top };
+    });
+    expect(tabletGeometry.rosterBottom).toBeLessThanOrEqual(tabletGeometry.stageTop || 0);
+    expect(
+      Math.abs((tabletGeometry.stageTop || 0) - (tabletGeometry.overviewTop || 0))
+    ).toBeLessThan(2);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    const mobileGeometry = await page.locator('.ws-cmd-deck').evaluate(element => {
+      const stage = element.querySelector('.ws-cmd-agent-stage')?.getBoundingClientRect();
+      const overview = element.querySelector('.ws-cmd-agent-overview')?.getBoundingClientRect();
+      return {
+        stageBottom: stage?.bottom,
+        overviewTop: overview?.top,
+        pageWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth
+      };
+    });
+    expect(mobileGeometry.stageBottom).toBeLessThanOrEqual(mobileGeometry.overviewTop || 0);
+    expect(mobileGeometry.pageWidth).toBeLessThanOrEqual(mobileGeometry.viewportWidth);
   });
 });
 
@@ -550,15 +747,27 @@ test.describe('Task Output Contracts', () => {
       expect(taskId).toBeTruthy();
 
       await page.goto(`/workspaces/${workspaceId}/task/${taskId}`);
-      await expect(page.locator('#workspace-task-automation-storage')).toContainText('Storage destination');
-      await expect(page.locator('#workspace-task-automation-columns')).toContainText('date, location, pollen_count');
+      await expect(page.locator('#workspace-task-automation-storage')).toContainText(
+        'Storage destination'
+      );
+      await expect(page.locator('#workspace-task-automation-columns')).toContainText(
+        'date, location, pollen_count'
+      );
 
       await page.locator('.workspace-task-advanced-summary').click();
-      await expect(page.locator('#workspace-task-automation-storage [data-action="open-automation-storage-modal"]')).toBeVisible();
-      await page.locator('#workspace-task-automation-storage [data-action="open-automation-storage-modal"]').click();
+      await expect(
+        page.locator(
+          '#workspace-task-automation-storage [data-action="open-automation-storage-modal"]'
+        )
+      ).toBeVisible();
+      await page
+        .locator('#workspace-task-automation-storage [data-action="open-automation-storage-modal"]')
+        .click();
       await expect(page.locator('#taskModalOutputContractSection')).toBeVisible();
       await expect(page.locator('#taskModalAutoSaveWriteMode')).toHaveValue('append');
-      await expect(page.locator('#taskModalOutputContractRows [data-output-contract-name]').first()).toHaveValue('date');
+      await expect(
+        page.locator('#taskModalOutputContractRows [data-output-contract-name]').first()
+      ).toHaveValue('date');
     } finally {
       if (workspaceId) {
         await request.delete(`/api/orchestration/workspace?id=${workspaceId}`);
@@ -566,7 +775,10 @@ test.describe('Task Output Contracts', () => {
     }
   });
 
-  test('shows storage destination immediately after enabling CSV storage', async ({ page, request }) => {
+  test('shows storage destination immediately after enabling CSV storage', async ({
+    page,
+    request
+  }) => {
     let workspaceId = '';
     const workspaceResp = await request.post('/api/orchestration/workspace', {
       data: {
@@ -578,7 +790,7 @@ test.describe('Task Output Contracts', () => {
     const workspaceData = await workspaceResp.json();
     workspaceId = workspaceData.workspace_id;
 
-    await page.route('**/api/orchestration/tasks/output-spec/suggest', async (route) => {
+    await page.route('**/api/orchestration/tasks/output-spec/suggest', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -616,13 +828,21 @@ test.describe('Task Output Contracts', () => {
 
       await page.goto(`/workspaces/${workspaceId}/task/${taskId}`);
       await page.locator('.workspace-task-advanced-summary').click();
-      await expect(page.locator('#workspace-task-automation-columns')).toContainText('Save each run of this task to a dataset');
+      await expect(page.locator('#workspace-task-automation-columns')).toContainText(
+        'Save each run of this task to a dataset'
+      );
 
-      await page.locator('#workspace-task-automation-columns [data-action="toggle-csv-storage"]').check();
+      await page
+        .locator('#workspace-task-automation-columns [data-action="toggle-csv-storage"]')
+        .check();
 
-      await expect(page.locator('#workspace-task-automation-storage')).toContainText('Storage destination');
+      await expect(page.locator('#workspace-task-automation-storage')).toContainText(
+        'Storage destination'
+      );
       await expect(page.locator('#workspace-task-automation-storage')).toContainText('Custom path');
-      await expect(page.locator('#workspace-task-automation-columns')).toContainText('What each run returns');
+      await expect(page.locator('#workspace-task-automation-columns')).toContainText(
+        'What each run returns'
+      );
       await expect(page.locator('#workspace-task-automation-columns')).toContainText('date');
     } finally {
       if (workspaceId) {
@@ -633,7 +853,10 @@ test.describe('Task Output Contracts', () => {
 });
 
 test.describe('Workspace File Folders', () => {
-  test('creates a folder, uploads into it, browses it, and moves the file', async ({ page, request }) => {
+  test('creates a folder, uploads into it, browses it, and moves the file', async ({
+    page,
+    request
+  }) => {
     test.setTimeout(60000);
 
     let workspaceId = '';
@@ -648,7 +871,7 @@ test.describe('Workspace File Folders', () => {
     workspaceId = workspaceData.workspace_id;
 
     try {
-      await page.addInitScript((id) => {
+      await page.addInitScript(id => {
         window.sessionStorage.setItem(`workspace-detail-entry-agent-prompt-dismissed:${id}`, '1');
       }, workspaceId);
       await page.goto(`/workspaces/${workspaceId}`);
@@ -657,7 +880,9 @@ test.describe('Workspace File Folders', () => {
         Boolean((window as any).workspaceDetail?.fileModalManager?.fileModalElements?.modal)
       );
 
-      await page.locator('#workspaceCommandView .ws-cmd-files-panel [data-cmd-primary-section="files"]').click();
+      await page
+        .locator('#workspaceCommandView .ws-cmd-files-panel [data-cmd-primary-section="files"]')
+        .click();
       await expect(page.locator('#hubAddFileModal')).toBeVisible();
 
       page.once('dialog', async dialog => {
@@ -674,36 +899,51 @@ test.describe('Workspace File Folders', () => {
       });
       await expect(page.locator('#hubSelectedFilesPreview')).toBeVisible();
 
-      const uploadResponse = page.waitForResponse(response =>
-        response.url().includes(`/api/workspaces/${workspaceId}/files`) &&
-        response.request().method() === 'POST'
+      const uploadResponse = page.waitForResponse(
+        response =>
+          response.url().includes(`/api/workspaces/${workspaceId}/files`) &&
+          response.request().method() === 'POST'
       );
       await page.locator('#hubAddFileSubmitBtn').click();
       expect((await uploadResponse).ok()).toBeTruthy();
       await expect(page.locator('#hubAddFileModal.show')).toHaveCount(0);
-      await expect(page.locator('#workspaceCommandView .ws-cmd-files-panel')).toContainText('folder-smoke-report.txt');
+      await expect(page.locator('#workspaceCommandView .ws-cmd-files-panel')).toContainText(
+        'folder-smoke-report.txt'
+      );
 
-      await page.locator('#workspaceCommandView .ws-cmd-files-panel [data-cmd-open-section="files"]').first().click();
+      await page
+        .locator('#workspaceCommandView .ws-cmd-files-panel [data-cmd-open-section="files"]')
+        .first()
+        .click();
       const explorer = page.locator('#workspace-directory-explorer-modal');
       await expect(explorer).toBeVisible();
-      await expect(explorer.locator('.workspace-directory-tree-main', { hasText: 'research' })).toBeVisible();
+      await expect(
+        explorer.locator('.workspace-directory-tree-main', { hasText: 'research' })
+      ).toBeVisible();
 
-      await expect(explorer.locator('.workspace-directory-preview-code')).toContainText('workspace folder smoke test');
+      await expect(explorer.locator('.workspace-directory-preview-code')).toContainText(
+        'workspace folder smoke test'
+      );
 
       page.once('dialog', async dialog => {
         expect(dialog.type()).toBe('prompt');
         await dialog.accept('archive');
       });
       await explorer.locator('[data-action="move-workspace-file"]').click();
-      await expect(explorer.locator('.workspace-directory-tree-main', { hasText: 'archive' })).toBeVisible();
-      await expect(explorer.locator('.workspace-directory-preview-subtitle')).toContainText('archive/');
+      await expect(
+        explorer.locator('.workspace-directory-tree-main', { hasText: 'archive' })
+      ).toBeVisible();
+      await expect(explorer.locator('.workspace-directory-preview-subtitle')).toContainText(
+        'archive/'
+      );
 
       const treeResp = await request.get(`/api/workspaces/${workspaceId}/files/tree`);
       expect(treeResp.ok()).toBeTruthy();
       const treeData = await treeResp.json();
-      const movedFile = (treeData.files || []).find((item: any) =>
-        item.relative_path?.includes('archive/') &&
-        item.relative_path?.endsWith('folder-smoke-report.txt')
+      const movedFile = (treeData.files || []).find(
+        (item: any) =>
+          item.relative_path?.includes('archive/') &&
+          item.relative_path?.endsWith('folder-smoke-report.txt')
       );
       expect(movedFile).toBeTruthy();
 
@@ -742,7 +982,7 @@ test.describe('Floating Workspace Assistant', () => {
   }
 
   async function suppressOnboarding(page) {
-    await page.route('**/api/onboarding/status', async (route) => {
+    await page.route('**/api/onboarding/status', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -760,7 +1000,7 @@ test.describe('Floating Workspace Assistant', () => {
   }
 
   async function suppressEntryAgentPrompt(page, workspaceId: string) {
-    await page.addInitScript((id) => {
+    await page.addInitScript(id => {
       window.sessionStorage.setItem(`workspace-detail-entry-agent-prompt-dismissed:${id}`, '1');
     }, workspaceId);
   }
@@ -772,7 +1012,10 @@ test.describe('Floating Workspace Assistant', () => {
     await expect(page.locator('#workspaceCommandView')).toBeVisible();
   }
 
-  test('replaces the workspace-detail inline bar with a full floating assistant panel', async ({ page, request }) => {
+  test('replaces the workspace-detail inline bar with a full floating assistant panel', async ({
+    page,
+    request
+  }) => {
     let workspaceId = '';
     workspaceId = await createTemporaryWorkspace(request, 'Playwright Floating Assistant');
 
@@ -800,7 +1043,10 @@ test.describe('Floating Workspace Assistant', () => {
     }
   });
 
-  test('creates a workspace task from the floating assistant task mode', async ({ page, request }) => {
+  test('creates a workspace task from the floating assistant task mode', async ({
+    page,
+    request
+  }) => {
     test.setTimeout(45000);
 
     let workspaceId = '';
@@ -826,7 +1072,10 @@ test.describe('Floating Workspace Assistant', () => {
     }
   });
 
-  test('saves a workspace note from the floating assistant note mode', async ({ page, request }) => {
+  test('saves a workspace note from the floating assistant note mode', async ({
+    page,
+    request
+  }) => {
     test.setTimeout(45000);
 
     let workspaceId = '';
@@ -871,9 +1120,16 @@ test.describe('Floating Workspace Assistant', () => {
 
       await gotoWorkspaceCommand(page, workspaceId);
       await page.locator('#hubSupportChatLauncher').click();
-      await page.locator('#hubSupportChatPanel').getByRole('button', { name: 'Note', exact: true }).click();
+      await page
+        .locator('#hubSupportChatPanel')
+        .getByRole('button', { name: 'Note', exact: true })
+        .click();
 
-      for (const selector of ['#homeAssistantQuickPlan', '#homeAssistantQuickTasks', '#homeAssistantQuickReview']) {
+      for (const selector of [
+        '#homeAssistantQuickPlan',
+        '#homeAssistantQuickTasks',
+        '#homeAssistantQuickReview'
+      ]) {
         const button = page.locator('#hubSupportChatPanel').locator(selector);
         const prompt = await button.getAttribute('data-home-prompt');
         expect(prompt).toBeTruthy();
@@ -898,7 +1154,7 @@ test.describe('Floating Workspace Assistant', () => {
 
     try {
       await suppressOnboarding(page);
-      await page.route('**/api/chat', async (route) => {
+      await page.route('**/api/chat', async route => {
         chatPayload = route.request().postDataJSON();
         chatSessionId = route.request().headers()['x-session-id'] || '';
         await route.fulfill({
@@ -919,20 +1175,25 @@ test.describe('Floating Workspace Assistant', () => {
       await page.locator('#homeAssistantInput').fill('What should happen next in this workspace?');
       await page.locator('#homeAssistantSendBtn').click();
 
-      await expect(page.locator('#homeAssistantConversation')).toContainText('Workspace manager inline response');
+      await expect(page.locator('#homeAssistantConversation')).toContainText(
+        'Workspace manager inline response'
+      );
       expect(chatPayload?.route_context?.workspace_id).toBe(workspaceId);
       expect(chatPayload?.route_context?.surface).toBe('workspace_detail');
       expect(chatSessionId).toBeTruthy();
 
-      await page.locator('#homeAssistantActions').getByRole('button', { name: 'Open Chat' }).click();
+      await page
+        .locator('#homeAssistantActions')
+        .getByRole('button', { name: 'Open Chat' })
+        .click();
       await expect(page.locator('#chatPanel')).toHaveAttribute('aria-hidden', 'false');
       const activeSessionId = await page.evaluate(() => {
         const manager = (window as any).sessionManager;
         return String(
           manager?.getActiveSessionId?.() ||
-          manager?.activeSessionId ||
-          manager?.currentSessionId ||
-          ''
+            manager?.activeSessionId ||
+            manager?.currentSessionId ||
+            ''
         );
       });
       expect(activeSessionId).toBe(chatSessionId);
@@ -943,7 +1204,10 @@ test.describe('Floating Workspace Assistant', () => {
     }
   });
 
-  test('keeps home dashboard and workspace canvas inline assistant bars', async ({ page, request }) => {
+  test('keeps home dashboard and workspace canvas inline assistant bars', async ({
+    page,
+    request
+  }) => {
     let workspaceId = '';
     workspaceId = await createTemporaryWorkspace(request, 'Playwright Inline Assistant Regression');
 
@@ -956,7 +1220,10 @@ test.describe('Floating Workspace Assistant', () => {
 
       await page.goto(`/workspaces/${workspaceId}/canvas`);
       await expect(page.locator('#homeAssistantCard.modern-card')).toBeVisible();
-      await expect(page.locator('#homeAssistantInput')).toHaveAttribute('placeholder', /from this canvas/);
+      await expect(page.locator('#homeAssistantInput')).toHaveAttribute(
+        'placeholder',
+        /from this canvas/
+      );
       await expect(page.locator('#homeAssistantWorkspaceModeSwitch')).toBeVisible();
       await expect(page.locator('#hubSupportChat')).toHaveCount(0);
     } finally {
@@ -976,7 +1243,7 @@ test.describe('Home Workspace Routing', () => {
       onChat?: () => void;
     }
   ) {
-    await page.route(`**/api/workspaces/${options.workspaceId}`, async (route) => {
+    await page.route(`**/api/workspaces/${options.workspaceId}`, async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -986,7 +1253,7 @@ test.describe('Home Workspace Routing', () => {
         })
       });
     });
-    await page.route('**/api/chat', async (route) => {
+    await page.route('**/api/chat', async route => {
       options.onChat?.();
       await route.fulfill({
         status: 200,
@@ -999,7 +1266,7 @@ test.describe('Home Workspace Routing', () => {
   }
 
   test('asks the user to choose when workspace routing is ambiguous', async ({ page }) => {
-    await page.route('**/api/home-assistant/route', async (route) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1019,7 +1286,12 @@ test.describe('Home Workspace Routing', () => {
           workspace_resolution: {
             state: 'ambiguous',
             candidates: [
-              { id: 'ws-alpha', name: 'Launch Alpha', score: 8, reasons: ['matched workspace goal'] },
+              {
+                id: 'ws-alpha',
+                name: 'Launch Alpha',
+                score: 8,
+                reasons: ['matched workspace goal']
+              },
               { id: 'ws-beta', name: 'Launch Beta', score: 7, reasons: ['matched workspace goal'] }
             ]
           }
@@ -1038,7 +1310,7 @@ test.describe('Home Workspace Routing', () => {
   });
 
   test('offers workspace creation when no existing workspace fits', async ({ page }) => {
-    await page.route('**/api/home-assistant/route', async (route) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1079,9 +1351,11 @@ test.describe('Home Workspace Routing', () => {
     await installWorkspaceAssistantMocks(page, {
       workspaceId: 'ws-cabinet',
       entryAgentName: 'Cabinet Manager',
-      onChat: () => { chatCalls += 1; }
+      onChat: () => {
+        chatCalls += 1;
+      }
     });
-    await page.route('**/api/home-assistant/route', async (route) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1126,12 +1400,14 @@ test.describe('Home Workspace Routing', () => {
     await page.locator('#homeAssistantSendBtn').click();
 
     await expect.poll(() => chatCalls).toBe(1);
-    await expect(page.locator('#homeAssistantConversation')).toContainText('Workspace manager is ready.');
+    await expect(page.locator('#homeAssistantConversation')).toContainText(
+      'Workspace manager is ready.'
+    );
     await expect(page.locator('#homeAssistantActions')).toContainText('Choose Another Workspace');
   });
 
   test('lets the user override a confident workspace match', async ({ page }) => {
-    await page.route('**/api/workspaces/ws-cabinet', async (route) => {
+    await page.route('**/api/workspaces/ws-cabinet', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1141,7 +1417,7 @@ test.describe('Home Workspace Routing', () => {
         })
       });
     });
-    await page.route('**/api/workspaces/ws-ops', async (route) => {
+    await page.route('**/api/workspaces/ws-ops', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1151,7 +1427,7 @@ test.describe('Home Workspace Routing', () => {
         })
       });
     });
-    await page.route('**/api/chat', async (route) => {
+    await page.route('**/api/chat', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1160,7 +1436,7 @@ test.describe('Home Workspace Routing', () => {
         })
       });
     });
-    await page.route('**/api/home-assistant/route', async (route) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1207,15 +1483,24 @@ test.describe('Home Workspace Routing', () => {
     await page.locator('#homeAssistantInput').fill('build the cabinet roadmap');
     await page.locator('#homeAssistantSendBtn').click();
 
-    await expect.poll(() => page.evaluate(() => (window as any).__handoffWorkspaceIds)).toEqual(['ws-cabinet']);
-    await page.locator('#homeAssistantActions').getByText('Choose Another Workspace', { exact: true }).click();
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__handoffWorkspaceIds))
+      .toEqual(['ws-cabinet']);
+    await page
+      .locator('#homeAssistantActions')
+      .getByText('Choose Another Workspace', { exact: true })
+      .click();
     await expect(page.locator('#homeAssistantRoutingSummary')).toContainText('Choose Workspace');
     await page.locator('#homeAssistantActions').getByText('Ops Hub', { exact: true }).click();
-    await expect.poll(() => page.evaluate(() => (window as any).__handoffWorkspaceIds)).toEqual(['ws-cabinet', 'ws-ops']);
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__handoffWorkspaceIds))
+      .toEqual(['ws-cabinet', 'ws-ops']);
   });
 
-  test('shows a repair-required state when the matched workspace has no runnable entry agent', async ({ page }) => {
-    await page.route('**/api/home-assistant/route', async (route) => {
+  test('shows a repair-required state when the matched workspace has no runnable entry agent', async ({
+    page
+  }) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1238,7 +1523,12 @@ test.describe('Home Workspace Routing', () => {
             selected_workspace_name: 'Broken Ops',
             repair_reason: 'workspace has no entry agent',
             candidates: [
-              { id: 'ws-broken', name: 'Broken Ops', score: 12, reasons: ['matched workspace name'] }
+              {
+                id: 'ws-broken',
+                name: 'Broken Ops',
+                score: 12,
+                reasons: ['matched workspace name']
+              }
             ]
           }
         })
@@ -1249,8 +1539,12 @@ test.describe('Home Workspace Routing', () => {
     await page.locator('#homeAssistantInput').fill('build the broken ops roadmap');
     await page.locator('#homeAssistantSendBtn').click();
 
-    await expect(page.locator('#homeAssistantRoutingSummary')).toContainText('Entry Agent Required');
-    await expect(page.locator('#homeAssistantActions').getByText('Open Workspace Setup', { exact: true })).toBeVisible();
+    await expect(page.locator('#homeAssistantRoutingSummary')).toContainText(
+      'Entry Agent Required'
+    );
+    await expect(
+      page.locator('#homeAssistantActions').getByText('Open Workspace Setup', { exact: true })
+    ).toBeVisible();
   });
 
   test('resumes a created workspace prompt once the new workspace is ready', async ({ page }) => {
@@ -1258,9 +1552,11 @@ test.describe('Home Workspace Routing', () => {
     await installWorkspaceAssistantMocks(page, {
       workspaceId: 'ws-new',
       entryAgentName: 'New Workspace Manager',
-      onChat: () => { chatCalls += 1; }
+      onChat: () => {
+        chatCalls += 1;
+      }
     });
-    await page.route('**/api/home-assistant/route', async (route) => {
+    await page.route('**/api/home-assistant/route', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1297,12 +1593,17 @@ test.describe('Home Workspace Routing', () => {
     });
     await page.locator('#homeAssistantInput').fill('build a robotics dashboard from scratch');
     await page.locator('#homeAssistantSendBtn').click();
-    await page.locator('#homeAssistantActions').getByText('Create Workspace', { exact: true }).click();
+    await page
+      .locator('#homeAssistantActions')
+      .getByText('Create Workspace', { exact: true })
+      .click();
 
     await page.evaluate(() => {
-      window.dispatchEvent(new CustomEvent('ori:workspace-created', {
-        detail: { workspaceId: 'ws-new', workspaceName: 'New Workspace' }
-      }));
+      window.dispatchEvent(
+        new CustomEvent('ori:workspace-created', {
+          detail: { workspaceId: 'ws-new', workspaceName: 'New Workspace' }
+        })
+      );
       return (window as any).OriAskRouting.refreshWorkspaceIdentity({
         workspace_id: 'ws-new',
         page_path: '/workspaces/ws-new',
@@ -1317,19 +1618,23 @@ test.describe('Home Workspace Routing', () => {
   test('waits for repair before resuming a preserved workspace prompt', async ({ page }) => {
     let workspaceReady = false;
     let chatCalls = 0;
-    await page.route('**/api/workspaces/ws-broken', async (route) => {
+    await page.route('**/api/workspaces/ws-broken', async route => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(workspaceReady ? {
-          id: 'ws-broken',
-          entry_agent_name: 'Broken Ops Manager'
-        } : {
-          id: 'ws-broken'
-        })
+        body: JSON.stringify(
+          workspaceReady
+            ? {
+                id: 'ws-broken',
+                entry_agent_name: 'Broken Ops Manager'
+              }
+            : {
+                id: 'ws-broken'
+              }
+        )
       });
     });
-    await page.route('**/api/chat', async (route) => {
+    await page.route('**/api/chat', async route => {
       chatCalls += 1;
       await route.fulfill({
         status: 200,
@@ -1340,20 +1645,23 @@ test.describe('Home Workspace Routing', () => {
 
     await page.goto('/');
     await page.evaluate(() => {
-      window.sessionStorage.setItem('ori.homeAssistant.pendingWorkspacePrompt', JSON.stringify({
-        prompt: 'finish the broken ops roadmap',
-        routeContext: {
-          surface: 'dashboard',
-          page_path: '/',
-          workspace_id: '',
-          session_id: '',
-          origin: 'ask_ori'
-        },
-        expectedWorkspaceId: 'ws-broken',
-        intentKey: 'general_task',
-        source: 'repair',
-        createdAt: Date.now()
-      }));
+      window.sessionStorage.setItem(
+        'ori.homeAssistant.pendingWorkspacePrompt',
+        JSON.stringify({
+          prompt: 'finish the broken ops roadmap',
+          routeContext: {
+            surface: 'dashboard',
+            page_path: '/',
+            workspace_id: '',
+            session_id: '',
+            origin: 'ask_ori'
+          },
+          expectedWorkspaceId: 'ws-broken',
+          intentKey: 'general_task',
+          source: 'repair',
+          createdAt: Date.now()
+        })
+      );
       (window as any).sessionManager = {
         sessions: [],
         async createSessionWithAgentInFolder(agentName: string, folderId: string) {
@@ -1362,21 +1670,25 @@ test.describe('Home Workspace Routing', () => {
       };
     });
 
-    await page.evaluate(() => (window as any).OriAskRouting.refreshWorkspaceIdentity({
-      workspace_id: 'ws-broken',
-      page_path: '/workspaces/ws-broken',
-      surface: 'workspace_detail',
-      origin: 'ask_ori'
-    }));
+    await page.evaluate(() =>
+      (window as any).OriAskRouting.refreshWorkspaceIdentity({
+        workspace_id: 'ws-broken',
+        page_path: '/workspaces/ws-broken',
+        surface: 'workspace_detail',
+        origin: 'ask_ori'
+      })
+    );
     expect(chatCalls).toBe(0);
 
     workspaceReady = true;
-    await page.evaluate(() => (window as any).OriAskRouting.refreshWorkspaceIdentity({
-      workspace_id: 'ws-broken',
-      page_path: '/workspaces/ws-broken',
-      surface: 'workspace_detail',
-      origin: 'ask_ori'
-    }));
+    await page.evaluate(() =>
+      (window as any).OriAskRouting.refreshWorkspaceIdentity({
+        workspace_id: 'ws-broken',
+        page_path: '/workspaces/ws-broken',
+        surface: 'workspace_detail',
+        origin: 'ask_ori'
+      })
+    );
     await expect.poll(() => chatCalls).toBe(1);
   });
 });

--- a/tests/workspace-detail.a11y.spec.js
+++ b/tests/workspace-detail.a11y.spec.js
@@ -1,37 +1,63 @@
 import { test, expect } from '@playwright/test';
 
-test('workspace detail accessibility', async ({ page }) => {
-  const baseUrl = process.env.BASE_URL || 'http://localhost:8765';
-  await page.goto(`${baseUrl}/workspaces`, { waitUntil: 'domcontentloaded' });
-
-  const firstWorkspace = page
-    .locator(
-      'button[aria-label^="Open workspace"], [data-workspace-id], a[href^="/workspaces/"], [onclick*="viewWorkspace"]'
-    )
-    .first();
-
-  await expect(firstWorkspace).toBeVisible();
-  await firstWorkspace.click();
-  await page.waitForURL(/\/workspaces\/[^/]+$/);
-  await expect(page.locator('#workspaceCommandView .ws-cmd-title h2')).toBeVisible();
-
-  await page.addScriptTag({
-    url: 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js'
-  });
-
-  const results = await page.evaluate(async () => {
-    const root = document.querySelector('#workspaceCommandView');
-    if (!root) {
-      throw new Error('workspaceCommandView root not found');
-    }
-
-    return await window.axe.run(root, {
-      runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] }
+for (const theme of ['light', 'dark']) {
+  test(`workspace detail accessibility (${theme})`, async ({ page }) => {
+    const baseUrl = process.env.BASE_URL || 'http://localhost:8765';
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.addInitScript(selectedTheme => {
+      window.localStorage.setItem('ori-theme', selectedTheme);
+    }, theme);
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          needs_onboarding: false,
+          current_step: 3,
+          completed: true,
+          skipped: false,
+          steps_completed: [0, 1, 2],
+          user_name: 'Tester',
+          assistant_name: 'Ori'
+        })
+      });
     });
-  });
+    const workspacesResponse = await page.request.get(`${baseUrl}/api/workspaces?tree=true`);
+    expect(workspacesResponse.ok()).toBeTruthy();
+    const workspaceData = await workspacesResponse.json();
+    const workspaceId = workspaceData.workspaces?.find(
+      workspace => workspace.kind === 'workspace' && workspace.agent_count > 0
+    )?.id;
+    expect(workspaceId).toBeTruthy();
 
-  expect(
-    results.violations,
-    JSON.stringify(results.violations, null, 2)
-  ).toEqual([]);
-});
+    await page.goto(`${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}`, {
+      waitUntil: 'domcontentloaded'
+    });
+    await expect(page.locator('#workspaceCommandView .ws-cmd-title h2')).toBeVisible();
+    await page.locator('#workspaceCommandView').evaluate(async root => {
+      const finiteAnimations = root
+        .getAnimations({ subtree: true })
+        .filter(animation => animation.effect?.getTiming().iterations !== Infinity);
+      await Promise.all(
+        finiteAnimations.map(animation => animation.finished.catch(() => undefined))
+      );
+    });
+
+    await page.addScriptTag({
+      url: 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js'
+    });
+
+    const results = await page.evaluate(async () => {
+      const root = document.querySelector('#workspaceCommandView');
+      if (!root) {
+        throw new Error('workspaceCommandView root not found');
+      }
+
+      return await window.axe.run(root, {
+        runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] }
+      });
+    });
+
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Motivation

The workspace details page presented agents as repeated configuration cards, making selection, status, and current work difficult to scan. This redesign makes the agent team a compact, game-like command deck while preserving existing workflows.

## Summary

- replace repeated agent cards with a grouped roster and deterministic SVG characters
- add a selected-agent stage with Give Task, Open Agent, settings, and removal actions
- add accessible Overview, Tasks, Loadout, and Recent Activity tabs
- preserve duplicate-agent grouping, entry-agent rules, unassigned tasks, and existing task actions
- add persistent agent selection, rerender/scroll stability, and Loadout-only prompt hydration with retry
- compact the Mission HUD and expose running, completed, blocked, and failed outcomes
- add desktop, tablet, and mobile layouts with reduced-motion support
- improve light and dark theme contrast and extend axe coverage to both themes

## Validation

- npm run lint
- make test-js (527 tests passed)
- go test ./internal/web/...
- command-deck Playwright interaction and responsive tests (2 passed)
- workspace-detail axe audits in light and dark themes (2 passed)
- Prettier checks passed for every changed file

## Known environment limitations

- make test-unit reaches the provider integration test but the configured OpenAI account returns HTTP 429 insufficient_quota; affected frontend and workspace tests pass.
- repository-wide npm run format:check reports 185 pre-existing unformatted files; all files changed by this PR pass Prettier.