### PR TITLE
fix: anchor agent store + workspace allowlist to stable data dir (agents survive restarts)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,53 @@ func defaultUtilitySettings() UtilitySettings {
 	}
 }
 
+// DefaultDataDir returns the application's base data directory used to anchor
+// runtime state (agent store, and any future CWD-independent data).
+//
+// Resolution order:
+//  1. ORI_DATA_DIR, if set (made absolute).
+//  2. A stable per-user application-support directory
+//     (~/Library/Application Support/OriAgent on macOS, ~/.ori-agent elsewhere).
+//  3. The current working directory as a last resort when the home directory
+//     cannot be determined.
+//
+// Unlike the older CWD-based fallbacks in this package, this deliberately does
+// NOT default to the working directory when a home directory is available, so
+// that the resolved location is identical regardless of where the process was
+// launched from (e.g. the menu-bar app vs. a terminal). This is what makes the
+// agent store survive restarts under a different working directory.
+func DefaultDataDir() string {
+	if dir := strings.TrimSpace(os.Getenv("ORI_DATA_DIR")); dir != "" {
+		if abs, err := filepath.Abs(dir); err == nil {
+			return abs
+		}
+		return dir
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		if platform.IsMacOS() {
+			return filepath.Join(home, "Library", "Application Support", "OriAgent")
+		}
+		return filepath.Join(home, ".ori-agent")
+	}
+
+	// Home directory unavailable: fall back to the working directory.
+	if cwd, err := os.Getwd(); err == nil {
+		if abs, absErr := filepath.Abs(cwd); absErr == nil {
+			return abs
+		}
+		return cwd
+	}
+	return "."
+}
+
+// DefaultAgentStorePath returns the path to the agent store index file
+// (agents.json) inside the stable data directory. Individual agents are stored
+// in an "agents/" folder alongside it.
+func DefaultAgentStorePath() string {
+	return filepath.Join(DefaultDataDir(), "agents.json")
+}
+
 // DefaultWorkspaceRoot returns the fallback directory used for new workspace folders.
 func DefaultWorkspaceRoot() string {
 	home, err := os.UserHomeDir()

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -182,14 +182,25 @@ func (b *ServerBuilder) initializeWorkspaceStore() error {
 		// allowlist, which means nothing in the shared workspaces tree will
 		// auto-hydrate into this data directory. Workspaces are added to the
 		// allowlist when explicitly imported via the workspace import API.
-		allowlist, err := workspace.LoadAllowlist(workspace.DefaultAllowlistFilename)
+		allowlistPath := resolveAllowlistPath()
+		allowlist, err := workspace.LoadAllowlist(allowlistPath)
 		if err != nil {
 			logger.Warn("Failed to load workspace allowlist", logger.Fields{"error": err.Error()})
-			allowlist = workspace.NewAllowlist(workspace.DefaultAllowlistFilename)
+			allowlist = workspace.NewAllowlist(allowlistPath)
 		}
 		b.workspaceAllowlist = allowlist
 		if b.sessionHandler != nil {
 			b.sessionHandler.SetWorkspaceAllowlist(allowlist)
+		}
+
+		// Treat the local workspace tree (~/Ori Workspaces) as owned by this data
+		// directory: backfill every workspace physically present there into the
+		// allowlist so agents from workspaces created locally are restored (and
+		// not wiped) on startup. Foreign workspaces that are not in the local
+		// folder tree stay gated, preserving cross-worktree isolation. Runs before
+		// the wipe/restore below.
+		if fileStore != nil {
+			workspace.BackfillLocalWorkspacesIntoAllowlist(fileStore, allowlist)
 		}
 
 		// First wipe agents whose only source is a non-allowlisted workspace

--- a/internal/server/initialization.go
+++ b/internal/server/initialization.go
@@ -9,6 +9,7 @@ import (
 
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/johnjallday/ori-agent/internal/authdiscovery"
 	"github.com/johnjallday/ori-agent/internal/config"
@@ -225,12 +226,20 @@ func localProviderContextOptions(prefix string) map[string]any {
 }
 
 // resolveAgentStorePath determines the agent store path from environment or default.
+//
+// The default anchors the store to a stable data directory (see
+// config.DefaultAgentStorePath) rather than the current working directory, so
+// agents created under one launch method (e.g. the menu-bar app) remain visible
+// after a restart under a different working directory (e.g. a terminal launch).
+// AGENT_STORE_PATH still takes precedence for explicit overrides.
 func resolveAgentStorePath() string {
-	agentStorePath := "agents.json"
-	if p := os.Getenv("AGENT_STORE_PATH"); p != "" {
-		agentStorePath = p
-	} else if abs, err := filepath.Abs(agentStorePath); err == nil {
-		agentStorePath = abs
+	agentStorePath := config.DefaultAgentStorePath()
+	if p := strings.TrimSpace(os.Getenv("AGENT_STORE_PATH")); p != "" {
+		if abs, err := filepath.Abs(p); err == nil {
+			agentStorePath = abs
+		} else {
+			agentStorePath = p
+		}
 	}
 
 	verbose := os.Getenv("ORI_VERBOSE") == "true"
@@ -243,11 +252,144 @@ func resolveAgentStorePath() string {
 
 // createFileStore creates a new file-based storage system for agents.
 func createFileStore(agentStorePath string, defaultConf types.Settings) (store.Store, error) {
+	if err := migrateLegacyAgentStore(agentStorePath); err != nil {
+		logger.Verbosef("Warning: legacy agent store migration failed: %v", err)
+	}
+
 	st, err := store.NewFileStore(agentStorePath, defaultConf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file store: %w", err)
 	}
 	return st, nil
+}
+
+// migrateLegacyAgentStore performs a one-time adoption of agents that were
+// previously written next to the current working directory (the old
+// CWD-relative "<cwd>/agents/" location) into the resolved stable store.
+//
+// It is a no-op when the destination already contains agents, when the legacy
+// location resolves to the same directory as the destination, or when there is
+// nothing to adopt. Existing agents in the destination are never overwritten.
+func migrateLegacyAgentStore(agentStorePath string) error {
+	destAgentsDir := filepath.Join(filepath.Dir(agentStorePath), "agents")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil // can't locate a legacy dir; nothing to do
+	}
+	legacyAgentsDir := filepath.Join(cwd, "agents")
+
+	// Same directory (e.g. CWD already is the data dir): nothing to migrate.
+	if absEqual(legacyAgentsDir, destAgentsDir) {
+		return nil
+	}
+
+	legacyAgents := agentDirNames(legacyAgentsDir)
+	if len(legacyAgents) == 0 {
+		return nil // nothing to adopt
+	}
+
+	// Only adopt when the destination has no agents yet, so we never clobber a
+	// populated stable store.
+	if len(agentDirNames(destAgentsDir)) > 0 {
+		return nil
+	}
+
+	if err := os.MkdirAll(destAgentsDir, 0o755); err != nil {
+		return err
+	}
+
+	adopted := 0
+	for _, name := range legacyAgents {
+		src := filepath.Join(legacyAgentsDir, name)
+		dst := filepath.Join(destAgentsDir, name)
+		if _, statErr := os.Stat(dst); statErr == nil {
+			continue // never overwrite an existing agent
+		}
+		if err := copyDir(src, dst); err != nil {
+			logger.Verbosef("Warning: failed to migrate agent %q: %v", name, err)
+			continue
+		}
+		adopted++
+	}
+
+	if adopted > 0 {
+		logger.Info("Adopted legacy agents into stable data dir", logger.Fields{
+			"count": adopted,
+			"from":  legacyAgentsDir,
+			"to":    destAgentsDir,
+		})
+	}
+	return nil
+}
+
+// agentDirNames returns the names of immediate subdirectories of dir, which for
+// the agent store correspond to individual agents. Returns nil when dir is
+// missing or unreadable.
+func agentDirNames(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names
+}
+
+// absEqual reports whether two paths resolve to the same absolute location.
+func absEqual(a, b string) bool {
+	aa, aerr := filepath.Abs(a)
+	bb, berr := filepath.Abs(b)
+	if aerr != nil || berr != nil {
+		return a == b
+	}
+	return aa == bb
+}
+
+// copyDir recursively copies the directory tree at src to dst.
+func copyDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyFile copies a single file from src to dst, preserving its permissions.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src) //nolint:gosec // paths derived from local agent store dirs
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(src); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	return os.WriteFile(dst, data, mode)
 }
 
 // loadLocationZones loads location zones from the specified file path.

--- a/internal/server/initialization.go
+++ b/internal/server/initialization.go
@@ -250,6 +250,17 @@ func resolveAgentStorePath() string {
 	return agentStorePath
 }
 
+// resolveAllowlistPath determines the per-data-dir workspace allowlist path.
+//
+// Like the agent store, this is anchored to the stable data directory rather
+// than the current working directory. The allowlist gates which workspaces'
+// agent snapshots hydrate into the global store on startup; resolving it
+// against CWD meant the gate silently emptied whenever the server was launched
+// from a different directory, dropping every workspace's agents from /agents.
+func resolveAllowlistPath() string {
+	return filepath.Join(config.DefaultDataDir(), workspace.DefaultAllowlistFilename)
+}
+
 // createFileStore creates a new file-based storage system for agents.
 func createFileStore(agentStorePath string, defaultConf types.Settings) (store.Store, error) {
 	if err := migrateLegacyAgentStore(agentStorePath); err != nil {

--- a/internal/server/initialization_test.go
+++ b/internal/server/initialization_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 func TestLoadDefaultSettings(t *testing.T) {
@@ -312,6 +313,17 @@ func writeAgent(t *testing.T, agentsDir, name string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "agent_settings.json"), []byte(`{"type":"tool-calling","Settings":{}}`), 0o644); err != nil {
 		t.Fatalf("write agent settings: %v", err)
+	}
+}
+
+func TestResolveAllowlistPath_AnchoredToDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ORI_DATA_DIR", dataDir)
+
+	got := resolveAllowlistPath()
+	want := filepath.Join(dataDir, workspace.DefaultAllowlistFilename)
+	if got != want {
+		t.Fatalf("expected allowlist path %q, got %q", want, got)
 	}
 }
 

--- a/internal/server/initialization_test.go
+++ b/internal/server/initialization_test.go
@@ -276,6 +276,105 @@ func TestLoadLocationZones_NonExistentFile(t *testing.T) {
 	}
 }
 
+func TestResolveAgentStorePath_DefaultsToStableDataDir(t *testing.T) {
+	// With ORI_DATA_DIR set, the default agent store must live inside it and be
+	// independent of the current working directory.
+	dataDir := t.TempDir()
+	t.Setenv("ORI_DATA_DIR", dataDir)
+	t.Setenv("AGENT_STORE_PATH", "")
+
+	got := resolveAgentStorePath()
+	want := filepath.Join(dataDir, "agents.json")
+	if got != want {
+		t.Fatalf("expected agent store %q, got %q", want, got)
+	}
+}
+
+// chdir switches the working directory for the duration of the test.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+// writeAgent creates a minimal agent folder under agentsDir.
+func writeAgent(t *testing.T, agentsDir, name string) {
+	t.Helper()
+	dir := filepath.Join(agentsDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent_settings.json"), []byte(`{"type":"tool-calling","Settings":{}}`), 0o644); err != nil {
+		t.Fatalf("write agent settings: %v", err)
+	}
+}
+
+func TestMigrateLegacyAgentStore_AdoptsCWDAgents(t *testing.T) {
+	// Legacy agents live under <cwd>/agents; the stable store is empty.
+	cwd := t.TempDir()
+	chdir(t, cwd)
+	writeAgent(t, filepath.Join(cwd, "agents"), "alice")
+	writeAgent(t, filepath.Join(cwd, "agents"), "bob")
+
+	dataDir := t.TempDir()
+	storePath := filepath.Join(dataDir, "agents.json")
+
+	if err := migrateLegacyAgentStore(storePath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	for _, name := range []string{"alice", "bob"} {
+		p := filepath.Join(dataDir, "agents", name, "agent_settings.json")
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected adopted agent %q at %s: %v", name, p, err)
+		}
+	}
+}
+
+func TestMigrateLegacyAgentStore_SkipsWhenDestPopulated(t *testing.T) {
+	cwd := t.TempDir()
+	chdir(t, cwd)
+	writeAgent(t, filepath.Join(cwd, "agents"), "legacy")
+
+	dataDir := t.TempDir()
+	storePath := filepath.Join(dataDir, "agents.json")
+	// Destination already has an agent; migration must not touch it or import legacy.
+	writeAgent(t, filepath.Join(dataDir, "agents"), "existing")
+
+	if err := migrateLegacyAgentStore(storePath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, "agents", "legacy")); !os.IsNotExist(err) {
+		t.Errorf("legacy agent should not be adopted into a populated store (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "agents", "existing")); err != nil {
+		t.Errorf("existing agent should be untouched: %v", err)
+	}
+}
+
+func TestMigrateLegacyAgentStore_NoopWhenSameDir(t *testing.T) {
+	// When the stable store resolves to the CWD itself, there is nothing to move.
+	cwd := t.TempDir()
+	chdir(t, cwd)
+	writeAgent(t, filepath.Join(cwd, "agents"), "solo")
+
+	storePath := filepath.Join(cwd, "agents.json")
+	if err := migrateLegacyAgentStore(storePath); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// Agent stays exactly where it was; no duplication.
+	if _, err := os.Stat(filepath.Join(cwd, "agents", "solo")); err != nil {
+		t.Errorf("agent should remain in place: %v", err)
+	}
+}
+
 func TestCreateLocationManager(t *testing.T) {
 	mgr := createLocationManager(nil, "test_zones.json")
 	if mgr == nil {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -292,6 +292,17 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	if responded {
 		return
 	}
+
+	// Local creation implies this data directory owns the workspace: allowlist it
+	// so its agent snapshots are restored (and not wiped) on subsequent startups,
+	// mirroring the import flow. Best-effort; a failure only affects later agent
+	// hydration, not this creation.
+	if h.workspaceAllowlist != nil && ws != nil {
+		if err := h.workspaceAllowlist.Add(ws.ID); err != nil {
+			logger.Warn("Failed to allowlist created workspace", logger.Fields{"id": ws.ID, "error": err.Error()})
+		}
+	}
+
 	agentSeedWarnings := append(seed.Warnings, prov.agentToolWarnings...)
 
 	// Completeness/ordering backstop: when the workspace was created with an

--- a/internal/store/file_store.go
+++ b/internal/store/file_store.go
@@ -403,9 +403,13 @@ func (s *fileStore) saveUnlocked() error {
 }
 
 func (s *fileStore) load() error {
-	b, err := os.ReadFile(s.path)
-	if err != nil {
-		return err
+	// The index file (s.path) is only a compatibility stub; the agents/ directory
+	// is the source of truth. A missing index must therefore NOT abort loading —
+	// otherwise agents present on disk (e.g. freshly adopted from a legacy
+	// location) would be ignored until a later save recreated the index.
+	b, readErr := os.ReadFile(s.path)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return readErr
 	}
 
 	s.mu.Lock()
@@ -416,29 +420,31 @@ func (s *fileStore) load() error {
 		s.agents = make(map[string]*agent.Agent)
 	}
 
-	// Try to parse the JSON first
-	var rawConfig map[string]any
-	if err := json.Unmarshal(b, &rawConfig); err != nil {
-		return err
-	}
-
-	// Check if this is the old format with "agents" key
-	if _, hasAgents := rawConfig["agents"]; hasAgents {
-		// Old format: {"agents": {...}, "current": "..."}
-		var in struct {
-			Agents map[string]*agent.Agent `json:"agents"`
-		}
-		if err := json.Unmarshal(b, &in); err != nil {
+	if readErr == nil {
+		// Try to parse the JSON index.
+		var rawConfig map[string]any
+		if err := json.Unmarshal(b, &rawConfig); err != nil {
 			return err
 		}
-		if in.Agents != nil {
-			s.agents = in.Agents
+
+		// Check if this is the old format with "agents" key
+		if _, hasAgents := rawConfig["agents"]; hasAgents {
+			// Old format: {"agents": {...}, "current": "..."}
+			var in struct {
+				Agents map[string]*agent.Agent `json:"agents"`
+			}
+			if err := json.Unmarshal(b, &in); err != nil {
+				return err
+			}
+			if in.Agents != nil {
+				s.agents = in.Agents
+			}
+			// Normalize migrated agents from legacy schema.
+			for _, ag := range s.agents {
+				s.normalizeLoadedAgent(ag)
+			}
+			return nil
 		}
-		// Normalize migrated agents from legacy schema.
-		for _, ag := range s.agents {
-			s.normalizeLoadedAgent(ag)
-		}
-		return nil
 	}
 
 	// Load individual agent files from agents/ directory (nested structure)

--- a/internal/store/file_store_test.go
+++ b/internal/store/file_store_test.go
@@ -173,6 +173,35 @@ func TestFileStore_Load_NestedMinimalSettings_MigratesDefaults(t *testing.T) {
 	}
 }
 
+func TestFileStore_Load_NestedAgents_NoIndexFile(t *testing.T) {
+	// The agents/ directory is the source of truth. A missing index file
+	// (agents.json) must NOT prevent agents on disk from loading — this is the
+	// regression that made freshly-adopted legacy agents invisible on first start.
+	tempDir := t.TempDir()
+	indexPath := filepath.Join(tempDir, "agents.json") // intentionally not created
+
+	agentDir := filepath.Join(tempDir, "agents", "orphan")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("failed creating agent directory: %v", err)
+	}
+	settings := `{"type":"general","Settings":{"model":"gpt-4o-mini","temperature":1}}`
+	if err := os.WriteFile(filepath.Join(agentDir, "agent_settings.json"), []byte(settings), 0o644); err != nil {
+		t.Fatalf("failed writing agent settings: %v", err)
+	}
+
+	if _, err := os.Stat(indexPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: index file should not exist (err=%v)", err)
+	}
+
+	fs := &fileStore{path: indexPath, agents: make(map[string]*agent.Agent)}
+	if err := fs.load(); err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+	if got, ok := fs.agents["orphan"]; !ok || got == nil {
+		t.Fatalf("expected orphan agent to load without an index file; agents=%v", fs.ListAgents())
+	}
+}
+
 func TestFileStore_Load_OldTopLevelFormat_MigratesDefaults(t *testing.T) {
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "agents_index.json")

--- a/internal/workspace/agent_snapshot_store.go
+++ b/internal/workspace/agent_snapshot_store.go
@@ -179,6 +179,39 @@ func SnapshotAllWorkspaces(workspaces Store, agents store.Store) {
 	}
 }
 
+// BackfillLocalWorkspacesIntoAllowlist adds every non-trashed workspace present
+// in the given (local folder) store to the allowlist. It is used at startup to
+// treat the local ~/Ori Workspaces tree as owned by this data directory, so
+// agents referenced by locally-created workspaces are restored — and protected
+// from the non-allowlisted wipe — even though creation predates or bypasses the
+// explicit import flow. Foreign workspaces not present in the local tree are
+// left out, preserving cross-data-directory isolation.
+func BackfillLocalWorkspacesIntoAllowlist(local Store, allowlist *Allowlist) {
+	if local == nil || allowlist == nil {
+		return
+	}
+	added := 0
+	eachWorkspaceMeta(local, func(ws *Workspace) {
+		if ws.Status == StatusTrashed {
+			return
+		}
+		if allowlist.Contains(ws.ID) {
+			return
+		}
+		if err := allowlist.Add(ws.ID); err != nil {
+			logger.Warn("backfill allowlist: add failed", logger.Fields{
+				"workspace_id": ws.ID,
+				"error":        err.Error(),
+			})
+			return
+		}
+		added++
+	})
+	if added > 0 {
+		logger.Info("Local workspaces backfilled into allowlist", logger.Fields{"workspaces": added})
+	}
+}
+
 // RestoreAllWorkspaceAgents walks the workspace store once and restores any
 // workspace-local agent snapshots into the global agent registry when the
 // importing/running environment does not already have those agents.

--- a/internal/workspace/agent_snapshot_store_test.go
+++ b/internal/workspace/agent_snapshot_store_test.go
@@ -417,3 +417,32 @@ func TestReferencedAgentNames_Dedupes(t *testing.T) {
 		t.Fatalf("expected 3 unique names, got %v", got)
 	}
 }
+
+func TestBackfillLocalWorkspacesIntoAllowlist(t *testing.T) {
+	local := NewInMemoryStore()
+	live := &Workspace{ID: "ws-live", Name: "Live", AgentInstances: AgentInstancesFromNames("Research Lead")}
+	trashed := &Workspace{ID: "ws-trashed", Name: "Trashed", Status: StatusTrashed}
+	if err := local.Save(live); err != nil {
+		t.Fatalf("save live: %v", err)
+	}
+	if err := local.Save(trashed); err != nil {
+		t.Fatalf("save trashed: %v", err)
+	}
+
+	allowlist := NewAllowlist(filepath.Join(t.TempDir(), "workspace_allowlist.json"))
+
+	BackfillLocalWorkspacesIntoAllowlist(local, allowlist)
+
+	if !allowlist.Contains("ws-live") {
+		t.Errorf("expected live workspace to be allowlisted")
+	}
+	if allowlist.Contains("ws-trashed") {
+		t.Errorf("trashed workspace must not be allowlisted")
+	}
+
+	// Idempotent: a second run adds nothing and does not error.
+	BackfillLocalWorkspacesIntoAllowlist(local, allowlist)
+	if ids := allowlist.IDs(); len(ids) != 1 {
+		t.Errorf("expected exactly 1 allowlisted id after re-run, got %v", ids)
+	}
+}


### PR DESCRIPTION
## Problem

Agents disappeared from the **/agents** page after restarting the server:

1. Agents created via the global Agents page were gone after a restart.
2. Agents seeded into a workspace from a template roster (e.g. Research Lead / Source Scout / Synthesis Writer) were missing from the global roster.

## Root cause — CWD-relative runtime state

Two independent defects, same class: state was resolved against the process **working directory** instead of a stable data directory. Because launch methods use different CWDs (menu-bar app → `~/Library/Application Support/OriAgent`; terminal/`go run` → `<repo>/ori-data`), each launch read a *different*, often empty, store/allowlist.

- **Agent store path**: `resolveAgentStorePath()` used `filepath.Abs("agents.json")` → `<cwd>/agents.json`, so `<cwd>/agents/` varied per launch.
- **Workspace agent allowlist**: `workspace_allowlist.json` (which gates whether a workspace's agent snapshots hydrate into the global store, and drives `WipeNonAllowlistedAgentSnapshots`) was a bare CWD-relative filename → empty when launched elsewhere → workspace-seeded agents wiped / not restored. Creating a workspace also never allowlisted it (only explicit import did).

## Fixes

**Store (commit 1)**
- `config.DefaultDataDir()` / `DefaultAgentStorePath()`: honor `ORI_DATA_DIR`, else a stable per-user dir (`~/Library/Application Support/OriAgent` on macOS, `~/.ori-agent` elsewhere) — never CWD when a home dir exists. `AGENT_STORE_PATH` still overrides.
- One-time migration adopts agents from the legacy `<cwd>/agents` location into the stable store when it's empty (never overwrites).
- `store.load()` now scans the `agents/` directory even when the `agents.json` index file is absent (the directory is the source of truth), so adopted agents appear on the first start.

**Workspace allowlist (commit 2)**
- `resolveAllowlistPath()`: anchor the allowlist to `config.DefaultDataDir()`.
- `BackfillLocalWorkspacesIntoAllowlist()`: at startup (before wipe/restore), allowlist every workspace physically present in the local `~/Ori Workspaces` tree — heals already-created workspaces. Foreign workspaces not in the local tree stay gated, preserving cross-data-directory isolation.
- `createWorkspace` allowlists the workspace on local creation, mirroring the import flow.

## Verification

All end-to-end against the built binary:

- Agent created from CWD-A survives a restart from CWD-B (same data dir); written to `$DATA/agents/`, not the launch CWD.
- Legacy `<cwd>/agents` adopted on first start; skipped when the stable store is already populated; no-op when same dir.
- Workspace created from the `research-project` template registers its 3 agents in `/agents`, and they persist across restart.
- Reproduced the exact orphan (global agent records removed + allowlist cleared, only folder snapshots left): on next startup the log showed `backfilled into allowlist | workspaces=1` → `snapshots restored | agents=3`, and `/api/agents` listed all 3 again.

Unit tests added for the stable store path, legacy migration (adopt / skip-when-populated / noop-same-dir), index-less load, the anchored allowlist path, and the local backfill (trashed-skip + idempotency). `go build ./...`, `go vet`, and the `server`/`config`/`store`/`workspace`/`sessionhttp` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)