### PR TITLE
feat(agents): stale-edit versioning + agent-centric workspace assignment (G1)

### DIFF
--- a/internal/agenthttp/agent_version.go
+++ b/internal/agenthttp/agent_version.go
@@ -1,0 +1,83 @@
+package agenthttp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// agentConfigVersion returns a short, deterministic token that changes only when
+// an agent's *editable definition* changes. It is the optimistic-concurrency
+// token used to detect stale edits (Agents page redesign, PRD FR13): the detail
+// endpoint echoes it, and handleUpdate rejects a PUT whose expected version no
+// longer matches the stored agent.
+//
+// The token is derived from the config-defining fields only — deliberately NOT
+// from statistics or evolution. Statistics.UpdatedAt is bumped on every message
+// (RecordMessage/RecordTokens), so hashing activity would fire false conflicts
+// on any busy agent. The field set mirrors the shared-definition fields the
+// update handler already treats as consequential.
+func agentConfigVersion(a *agent.Agent) string {
+	if a == nil {
+		return ""
+	}
+
+	// Canonical projection of the editable definition. json.Marshal emits struct
+	// fields in declaration order and map keys sorted, so this is stable across
+	// calls and serialization round-trips.
+	type versionedSettings struct {
+		Model           string  `json:"model"`
+		Temperature     float64 `json:"temperature"`
+		SystemPrompt    string  `json:"system_prompt"`
+		Provider        string  `json:"provider"`
+		ReasoningEffort string  `json:"reasoning_effort"`
+		MaxOutputTokens int     `json:"max_output_tokens"`
+		AllowWebSearch  bool    `json:"allow_web_search"`
+	}
+	type versionedMetadata struct {
+		Description    string                     `json:"description"`
+		Tags           []string                   `json:"tags"`
+		AvatarColor    string                     `json:"avatar_color"`
+		Favorite       bool                       `json:"favorite"`
+		RoutingProfile *types.AgentRoutingProfile `json:"routing_profile"`
+	}
+	payload := struct {
+		Type     string            `json:"type"`
+		Role     types.AgentRole   `json:"role"`
+		Settings versionedSettings `json:"settings"`
+		Metadata versionedMetadata `json:"metadata"`
+	}{
+		Type: a.Type,
+		Role: a.Role,
+		Settings: versionedSettings{
+			Model:           a.Settings.Model,
+			Temperature:     a.Settings.Temperature,
+			SystemPrompt:    a.Settings.SystemPrompt,
+			Provider:        a.Settings.Provider,
+			ReasoningEffort: a.Settings.ReasoningEffort,
+			MaxOutputTokens: a.Settings.MaxOutputTokens,
+			AllowWebSearch:  a.Settings.IsWebSearchAllowed(),
+		},
+	}
+	if a.Metadata != nil {
+		payload.Metadata = versionedMetadata{
+			Description:    a.Metadata.Description,
+			Tags:           a.Metadata.Tags,
+			AvatarColor:    a.Metadata.AvatarColor,
+			Favorite:       a.Metadata.Favorite,
+			RoutingProfile: a.Metadata.RoutingProfile,
+		}
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		// Marshal of this closed struct cannot realistically fail; return empty so
+		// callers treat the version as absent rather than panicking.
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:8]) // 16 hex chars — ample collision resistance here
+}

--- a/internal/agenthttp/agent_version_test.go
+++ b/internal/agenthttp/agent_version_test.go
@@ -1,0 +1,144 @@
+package agenthttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// TestAgentConfigVersion_StableAndSensitive verifies the concurrency token is
+// deterministic, changes when the editable definition changes, and — critically
+// — does NOT change when only activity statistics change (RecordMessage bumps
+// Statistics.UpdatedAt on every message, which must not trigger false 409s).
+func TestAgentConfigVersion_StableAndSensitive(t *testing.T) {
+	base := &agent.Agent{
+		Type: agent.TypeGeneral,
+		Role: types.RoleGeneral,
+		Settings: types.Settings{
+			Model:        "gpt-4o-mini",
+			Temperature:  0.7,
+			SystemPrompt: "hello",
+		},
+		Metadata: &types.AgentMetadata{Description: "d", Tags: []string{"a", "b"}},
+	}
+	base.InitializeStatistics()
+
+	v1 := agentConfigVersion(base)
+	if v1 == "" {
+		t.Fatal("expected non-empty version")
+	}
+	if got := agentConfigVersion(base); got != v1 {
+		t.Errorf("version not stable: %q vs %q", v1, got)
+	}
+
+	// Activity-only change must not move the token.
+	base.Statistics.RecordMessage(100, 0.01)
+	if got := agentConfigVersion(base); got != v1 {
+		t.Errorf("activity changed version: %q -> %q", v1, got)
+	}
+
+	// Config change must move the token.
+	base.Settings.SystemPrompt = "goodbye"
+	if got := agentConfigVersion(base); got == v1 {
+		t.Errorf("system prompt change did not move version (%q)", got)
+	}
+
+	if agentConfigVersion(nil) != "" {
+		t.Error("nil agent should yield empty version")
+	}
+}
+
+// versionTestHandlers builds an agent Handler and a DashboardHandler over the
+// same store, plus one editable agent with no workspace membership (so the
+// shared-edit guard never interferes with the stale-edit assertions).
+func versionTestHandlers(t *testing.T, agentName string) (*Handler, *DashboardHandler) {
+	t.Helper()
+	st, err := store.NewFileStore(filepath.Join(t.TempDir(), "agents_index.json"), types.Settings{Model: "gpt-4o-mini", Temperature: 1.0})
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := st.CreateAgent(agentName, &store.CreateAgentConfig{Type: agent.TypeGeneral}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return New(st), NewDashboardHandler(st)
+}
+
+func fetchAgentVersion(t *testing.T, dash *DashboardHandler, name string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/"+name+"/detail", nil)
+	rr := httptest.NewRecorder()
+	dash.GetAgentDetail(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("detail GET: expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	return resp.Version
+}
+
+// TestStaleEditRejected verifies the detail endpoint echoes a version and that
+// handleUpdate (PATCH) rejects an update carrying a stale version (409) while
+// accepting the current one (PRD FR13).
+func TestStaleEditRejected(t *testing.T) {
+	h, dash := versionTestHandlers(t, "Solo")
+
+	version := fetchAgentVersion(t, dash, "Solo")
+	if version == "" {
+		t.Fatal("expected detail to include a version token")
+	}
+
+	// Stale version → 409.
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Solo", strings.NewReader(`{"system_prompt":"v2","expected_version":"deadbeefdeadbeef"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("stale edit: expected 409, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "stale_agent_edit") {
+		t.Errorf("expected stale_agent_edit error, got %s", rr.Body.String())
+	}
+
+	// Correct version → 200.
+	req = httptest.NewRequest(http.MethodPatch, "/api/agents/Solo", strings.NewReader(`{"system_prompt":"v2","expected_version":"`+version+`"}`))
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("current version: expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// The version must have moved after the successful edit; the old token is now
+	// stale.
+	newVersion := fetchAgentVersion(t, dash, "Solo")
+	if newVersion == version {
+		t.Error("version did not change after a config edit")
+	}
+	req = httptest.NewRequest(http.MethodPatch, "/api/agents/Solo", strings.NewReader(`{"system_prompt":"v3","expected_version":"`+version+`"}`))
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("reused old version: expected 409, got %d", rr.Code)
+	}
+}
+
+// TestUpdateWithoutVersionSkipsCheck verifies back-compat: an update that omits
+// expected_version is not subjected to the concurrency check.
+func TestUpdateWithoutVersionSkipsCheck(t *testing.T) {
+	h, _ := versionTestHandlers(t, "Solo")
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Solo", strings.NewReader(`{"system_prompt":"no-version"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("no-version update: expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -411,6 +411,11 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		AvatarColor    *string                    `json:"avatar_color,omitempty"`
 		Favorite       *bool                      `json:"favorite,omitempty"`
 		RoutingProfile *types.AgentRoutingProfile `json:"routing_profile,omitempty"`
+		// ExpectedVersion is the optimistic-concurrency token the client received
+		// from GET /api/agents/{name}. When present and no longer matching the
+		// stored agent, the update is rejected as stale (PRD FR13). Omitted =
+		// no concurrency check (back-compat for existing callers).
+		ExpectedVersion *string `json:"expected_version,omitempty"`
 		// ConfirmSharedEdit acknowledges that this edit changes a definition
 		// shared by multiple workspaces (PRD FR9). Required when the agent is
 		// attached to >1 workspace and a shared-definition field is being
@@ -420,6 +425,21 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
+	}
+
+	// Stale-edit guard (PRD FR13): if the caller sent the version it loaded and the
+	// stored definition has since changed, reject before mutating so a concurrent
+	// edit is not silently clobbered. Checked against the current stored agent.
+	if req.ExpectedVersion != nil {
+		current := agentConfigVersion(agent)
+		if *req.ExpectedVersion != current {
+			_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+				"error":           "stale_agent_edit",
+				"message":         fmt.Sprintf("%q was changed since you loaded it. Reload the latest version and reapply your edit.", agentName),
+				"current_version": current,
+			})
+			return
+		}
 	}
 
 	// Workspace membership drives the shared-edit / rename guards (PRD FR9/FR10).

--- a/internal/agenthttp/dashboard_handlers.go
+++ b/internal/agenthttp/dashboard_handlers.go
@@ -99,6 +99,10 @@ type AgentDetailResponse struct {
 	MaxOutputTokens int                    `json:"max_output_tokens,omitempty"`
 	SystemPrompt    string                 `json:"system_prompt"`
 	AllowWebSearch  bool                   `json:"allow_web_search"`
+	// Version is an optimistic-concurrency token over the editable definition.
+	// The Agents page echoes it back on update so the server can reject stale
+	// edits (PRD FR13). Empty for CLI agents, which are read-only.
+	Version string `json:"version,omitempty"`
 	// ClaudeSync carries read-only ~/.claude state for the Claude Code agent.
 	ClaudeSync any `json:"claude_sync,omitempty"`
 	// CodexSync carries read-only ~/.codex state for the Codex CLI agent.
@@ -324,6 +328,7 @@ func (h *DashboardHandler) GetAgentDetail(w http.ResponseWriter, r *http.Request
 		MaxOutputTokens: ag.Settings.MaxOutputTokens,
 		SystemPrompt:    ag.Settings.SystemPrompt,
 		AllowWebSearch:  ag.Settings.IsWebSearchAllowed(),
+		Version:         agentConfigVersion(ag),
 	}
 
 	// Return JSON response

--- a/internal/agenthttp/workspace_assignment.go
+++ b/internal/agenthttp/workspace_assignment.go
@@ -1,0 +1,205 @@
+package agenthttp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// assignWorkspacesRequest is the desired-state body for PUT
+// /api/agents/{name}/workspaces: the complete set of workspace IDs the agent
+// should belong to. The server reconciles current membership to this set.
+type assignWorkspacesRequest struct {
+	WorkspaceIDs []string `json:"workspace_ids"`
+}
+
+// AssignWorkspaces reconciles an agent's workspace membership to the desired set
+// in one call (Agents page redesign, PRD FR9 / §7.2). It is the agent-centric
+// counterpart to the workspace-centric POST/DELETE
+// /api/workspaces/{id}/agents endpoints: the Workspaces tab edits membership
+// from the agent's perspective, so a single atomic-validated call is cleaner
+// than a client-side fan-out.
+//
+// Semantics:
+//   - Body carries the full desired workspace-ID set; the diff against current
+//     membership yields adds and removes.
+//   - Pre-flight validates the whole request (agent exists and is editable,
+//     every desired workspace resolves, no removal strips a workspace's entry
+//     agent) BEFORE any mutation, so a bad request fails without partial writes.
+//   - Removing an agent from a workspace drops every instance of it there.
+func (h *Handler) AssignWorkspaces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+
+	agentName := agentNameFromWorkspacesPath(r.URL.Path)
+	if agentName == "" {
+		orihttp.BadRequest(w, "Agent name is required")
+		return
+	}
+	if h.workspaceStore == nil {
+		orihttp.InternalError(w, "workspace store unavailable")
+		return
+	}
+
+	// CLI agents are built-in and cannot be attached/detached this way.
+	if h.isCLIAgent(agentName) {
+		orihttp.BadRequest(w, "CLI agents are built-in and cannot be assigned to workspaces")
+		return
+	}
+	if _, ok := h.State.GetAgent(agentName); !ok {
+		orihttp.NotFound(w, "Agent not found")
+		return
+	}
+
+	var req assignWorkspacesRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	desired := normalizeIDSet(req.WorkspaceIDs)
+
+	// Current membership (metadata-only cache; no full hydrate).
+	membership := workspace.WorkspaceMembershipFor(h.workspaceStore, agentName)
+	current := make(map[string]workspace.WorkspaceRef, len(membership.Workspaces))
+	for _, ref := range membership.Workspaces {
+		current[ref.ID] = ref
+	}
+
+	// Diff into add / remove sets.
+	var toAdd, toRemove []string
+	for id := range desired {
+		if _, in := current[id]; !in {
+			toAdd = append(toAdd, id)
+		}
+	}
+	for id, ref := range current {
+		if _, keep := desired[id]; keep {
+			continue
+		}
+		// Blocking the entry agent's removal mirrors the workspace store's
+		// ErrWorkspaceEntryAgentRequired guard; the UI must reassign the entry
+		// agent first.
+		if ref.EntryPoint {
+			_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+				"error":        "entry_agent_removal_blocked",
+				"message":      fmt.Sprintf("%q is the entry agent of %q and cannot be unassigned. Set a different entry agent first.", agentName, ref.Name),
+				"workspace_id": id,
+			})
+			return
+		}
+		toRemove = append(toRemove, id)
+	}
+
+	// Pre-flight: every desired workspace must resolve. Fail before mutating.
+	for _, id := range toAdd {
+		if _, err := h.workspaceStore.Get(id); err != nil {
+			orihttp.BadRequest(w, fmt.Sprintf("Workspace not found: %s", id))
+			return
+		}
+	}
+
+	// Apply removals, then additions. Stable order keeps behavior deterministic
+	// and test-friendly.
+	sort.Strings(toRemove)
+	sort.Strings(toAdd)
+
+	for _, id := range toRemove {
+		if err := h.removeAgentFromWorkspace(id, agentName); err != nil {
+			logger.Error("assign workspaces: remove failed", logger.Fields{"agent": agentName, "workspace": id, "error": err})
+			orihttp.InternalError(w, fmt.Sprintf("Failed to unassign from workspace %s: %v", id, err))
+			return
+		}
+	}
+	for _, id := range toAdd {
+		ws, err := h.workspaceStore.Get(id)
+		if err != nil {
+			orihttp.BadRequest(w, fmt.Sprintf("Workspace not found: %s", id))
+			return
+		}
+		if err := ws.AddAgent(agentName); err != nil {
+			// Already a member is a no-op success (idempotent reconcile).
+			if errors.Is(err, workspace.ErrAgentAlreadyInWorkspace) {
+				continue
+			}
+			logger.Error("assign workspaces: add failed", logger.Fields{"agent": agentName, "workspace": id, "error": err})
+			orihttp.InternalError(w, fmt.Sprintf("Failed to assign to workspace %s: %v", id, err))
+			return
+		}
+		if err := h.workspaceStore.Save(ws); err != nil {
+			orihttp.InternalError(w, fmt.Sprintf("Failed to save workspace %s: %v", id, err))
+			return
+		}
+	}
+
+	// Return the reconciled membership so the client can refresh without a
+	// second round trip.
+	updated := workspace.WorkspaceMembershipFor(h.workspaceStore, agentName)
+	orihttp.Success(w, map[string]any{
+		"success":         true,
+		"agent":           agentName,
+		"workspace_count": updated.Count,
+		"workspaces":      updated.Workspaces,
+	})
+}
+
+// removeAgentFromWorkspace drops every instance of agentName from the workspace,
+// then persists it. A workspace where the agent is not present is a no-op.
+func (h *Handler) removeAgentFromWorkspace(workspaceID, agentName string) error {
+	ws, err := h.workspaceStore.Get(workspaceID)
+	if err != nil {
+		return err
+	}
+	// Collect instance IDs first; RemoveAgentInstance mutates the slice.
+	var instanceIDs []string
+	for _, inst := range ws.AgentInstances {
+		if strings.EqualFold(inst.Name, agentName) {
+			instanceIDs = append(instanceIDs, inst.ID)
+		}
+	}
+	if len(instanceIDs) == 0 {
+		return nil
+	}
+	for _, id := range instanceIDs {
+		if err := ws.RemoveAgentInstance(id); err != nil {
+			return err
+		}
+	}
+	return h.workspaceStore.Save(ws)
+}
+
+// normalizeIDSet trims, drops blanks, and dedups a workspace-ID slice into a set.
+func normalizeIDSet(ids []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		set[id] = struct{}{}
+	}
+	return set
+}
+
+// agentNameFromWorkspacesPath extracts {name} from
+// /api/agents/{name}/workspaces, URL-decoding the segment.
+func agentNameFromWorkspacesPath(path string) string {
+	rest := strings.TrimPrefix(path, "/api/agents/")
+	rest = strings.TrimSuffix(rest, "/workspaces")
+	rest = strings.Trim(rest, "/")
+	if rest == "" {
+		return ""
+	}
+	if decoded, err := url.PathUnescape(rest); err == nil {
+		return decoded
+	}
+	return rest
+}

--- a/internal/agenthttp/workspace_assignment_test.go
+++ b/internal/agenthttp/workspace_assignment_test.go
@@ -1,0 +1,142 @@
+package agenthttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func assignReq(t *testing.T, h *Handler, agentName, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/agents/"+agentName+"/workspaces", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.AssignWorkspaces(rr, req)
+	return rr
+}
+
+func assignedCount(t *testing.T, rr *httptest.ResponseRecorder) int {
+	t.Helper()
+	var resp struct {
+		WorkspaceCount int `json:"workspace_count"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode assign response: %v (body=%s)", err, rr.Body.String())
+	}
+	return resp.WorkspaceCount
+}
+
+// TestAssignWorkspaces_AddAndRemove reconciles an agent that starts in ws-a into
+// {ws-b, ws-c}: ws-a is dropped, ws-b/ws-c are added. The agent is a non-entry
+// instance everywhere here (entry is "Lead").
+func TestAssignWorkspaces_AddAndRemove(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Lead", "Helper"},
+		map[string][]string{
+			"ws-a": {"Lead", "Helper"},
+			"ws-b": {"Lead"},
+			"ws-c": {"Lead"},
+		},
+	)
+
+	rr := assignReq(t, h, "Helper", `{"workspace_ids":["ws-b","ws-c"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := assignedCount(t, rr); got != 2 {
+		t.Fatalf("expected membership count 2, got %d", got)
+	}
+
+	// Verify by re-reading: Helper should now be in ws-b and ws-c, not ws-a.
+	for wsID, want := range map[string]bool{"ws-a": false, "ws-b": true, "ws-c": true} {
+		ws, err := h.workspaceStore.Get(wsID)
+		if err != nil {
+			t.Fatalf("get %s: %v", wsID, err)
+		}
+		found := false
+		for _, inst := range ws.AgentInstances {
+			if inst.Name == "Helper" {
+				found = true
+			}
+		}
+		if found != want {
+			t.Errorf("ws %s: Helper present=%v, want %v", wsID, found, want)
+		}
+	}
+}
+
+// TestAssignWorkspaces_Idempotent verifies reassigning the same set is a no-op
+// that still returns success.
+func TestAssignWorkspaces_Idempotent(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Lead", "Helper"},
+		map[string][]string{"ws-a": {"Lead", "Helper"}},
+	)
+	rr := assignReq(t, h, "Helper", `{"workspace_ids":["ws-a"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := assignedCount(t, rr); got != 1 {
+		t.Fatalf("expected count 1, got %d", got)
+	}
+}
+
+// TestAssignWorkspaces_EmptySetRemovesAll clears membership when the agent is not
+// an entry agent anywhere.
+func TestAssignWorkspaces_EmptySetRemovesAll(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Lead", "Helper"},
+		map[string][]string{"ws-a": {"Lead", "Helper"}, "ws-b": {"Lead", "Helper"}},
+	)
+	rr := assignReq(t, h, "Helper", `{"workspace_ids":[]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := assignedCount(t, rr); got != 0 {
+		t.Fatalf("expected count 0, got %d", got)
+	}
+}
+
+// TestAssignWorkspaces_EntryAgentRemovalBlocked verifies you cannot unassign an
+// agent from a workspace where it is the entry agent.
+func TestAssignWorkspaces_EntryAgentRemovalBlocked(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Lead"},
+		map[string][]string{"ws-a": {"Lead"}},
+	)
+	rr := assignReq(t, h, "Lead", `{"workspace_ids":[]}`)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "entry_agent_removal_blocked") {
+		t.Errorf("expected entry_agent_removal_blocked, got %s", rr.Body.String())
+	}
+}
+
+// TestAssignWorkspaces_UnknownWorkspaceRejected verifies a desired ID that does
+// not resolve fails before any mutation.
+func TestAssignWorkspaces_UnknownWorkspaceRejected(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Lead", "Helper"},
+		map[string][]string{"ws-a": {"Lead", "Helper"}},
+	)
+	rr := assignReq(t, h, "Helper", `{"workspace_ids":["ws-a","ghost"]}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	// ws-a membership must be untouched by the failed request.
+	ws, err := h.workspaceStore.Get("ws-a")
+	if err != nil {
+		t.Fatalf("get ws-a: %v", err)
+	}
+	found := false
+	for _, inst := range ws.AgentInstances {
+		if inst.Name == "Helper" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Helper should remain in ws-a after a rejected assignment")
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -195,6 +195,11 @@ func registerAgentRoutes(mux *http.ServeMux, s *Server) {
 			avatarHandler.ServeHTTP(w, r)
 			return
 		}
+		// Agent-centric workspace assignment: PUT /api/agents/{name}/workspaces
+		if strings.HasSuffix(r.URL.Path, "/workspaces") && r.Method == http.MethodPut {
+			agentHandler.AssignWorkspaces(w, r)
+			return
+		}
 		// Regular agent requests - delegate to agentHandler
 		agentHandler.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
## Summary

First seam-PR (**G1**) of the game-inspired Agents page redesign. Backend-only and **inert** — no UI consumes these endpoints yet, so `dev` stays shippable. See `tasks/prd-agents-page-ui.md` (local) for the full plan.

## What's here

- **Stale-edit concurrency token.** `GET /api/agents/{name}` now returns a `version` field (`agentConfigVersion`): a content hash over the *editable definition only* (type/role/settings/metadata). `handleUpdate` (PATCH) accepts `expected_version` and returns `409 { error: "stale_agent_edit", current_version }` on mismatch; omitting it preserves existing behavior.
  - **Design note:** the version is deliberately **not** derived from `Statistics.UpdatedAt` — that field is bumped on *every message* (`RecordMessage`/`RecordTokens`), which would fire false conflicts on any busy agent. A hash over config fields changes only on real edits and needs no new persisted field or migration.
- **Agent-centric workspace assignment.** New `PUT /api/agents/{name}/workspaces` takes the full desired workspace-ID set and reconciles membership from the agent's perspective (the workspace-centric `POST/DELETE /api/workspaces/{id}/agents` endpoints already exist; this is their counterpart for the Workspaces tab). Diffs into add/remove, pre-flight-validates (agent editable, every workspace resolves, entry-agent removal blocked) **before** any write, and is idempotent.

## Tests

`internal/agenthttp/agent_version_test.go` + `workspace_assignment_test.go`:
- version stability, config-sensitivity, and activity-immunity; GET echo; 409 stale / 200 current / back-compat no-version
- assignment add+remove, idempotent, empty-set clears, entry-agent removal blocked (409), unknown workspace rejected (400, no partial write)

`go test ./internal/agenthttp/` green · `go vet` clean · `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)