### PR TITLE
feat(agents): roster + stage read-only shell, persistent selection (G2)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -232,6 +232,13 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveAgents(w http.ResponseWriter, r *http.Request) {
 	data := s.prepareBasePageData("agents")
 	data.ShowSidebarToggle = true // Enable sidebar toggle
+	// Opt-in roster/stage redesign (Agents page redesign, G2). Off by default so
+	// the group lands inert; ?view=roster serves the new page. G5 flips the
+	// default once the flow reaches parity.
+	if r.URL.Query().Get("view") == "roster" {
+		s.renderAndWritePage(w, "agents-roster", data)
+		return
+	}
 	s.renderAndWritePage(w, "agents", data)
 }
 

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -1,0 +1,434 @@
+/*
+ * Agents roster + stage layout (game-inspired, "themed not skinned").
+ * Reuses the app's existing design tokens; no new palette. Roster rail on the
+ * left, selected-agent stage on the right.
+ */
+
+.agents-roster-page {
+  --roster-rail-width: 340px;
+  --roster-gap: 18px;
+  --roster-radius: 14px;
+}
+
+.roster-layout {
+  display: grid;
+  grid-template-columns: var(--roster-rail-width) minmax(0, 1fr);
+  gap: var(--roster-gap);
+  padding: 20px;
+  max-width: 1500px;
+  margin: 0 auto;
+  align-items: start;
+}
+
+/* ---- Roster rail ---------------------------------------------------------- */
+
+.roster-rail {
+  position: sticky;
+  top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: calc(100vh - 96px);
+}
+
+.roster-rail__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.roster-rail__title {
+  font-size: 24px;
+  margin: 0;
+  line-height: 1.1;
+}
+
+.roster-rail__subtitle {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--text-secondary, #6b7280);
+}
+
+.roster-rail__classic {
+  font-size: 12px;
+  text-decoration: none;
+  color: var(--text-secondary, #6b7280);
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 999px;
+  padding: 5px 11px;
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.roster-rail__classic:hover,
+.roster-rail__classic:focus-visible {
+  color: var(--primary-color, #4f46e5);
+  border-color: var(--primary-color, #4f46e5);
+}
+
+.roster-rail__controls {
+  display: flex;
+  gap: 8px;
+}
+
+.roster-search {
+  flex: 1 1 auto;
+  display: block;
+}
+
+.roster-search input,
+.roster-sort select {
+  width: 100%;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 10px;
+  padding: 9px 12px;
+  font-size: 14px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+}
+
+.roster-sort select {
+  width: auto;
+  cursor: pointer;
+}
+
+.roster-search input:focus-visible,
+.roster-sort select:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 1px;
+  border-color: var(--primary-color, #4f46e5);
+}
+
+.roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: var(--roster-radius);
+}
+
+.roster-list:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 2px;
+}
+
+/* Roster card */
+.roster-card {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 12px;
+  background: var(--bg-primary, #fff);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
+}
+
+.roster-card:hover {
+  border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 45%, var(--border-color, #e5e7eb));
+}
+
+.roster-card[aria-selected="true"] {
+  border-color: var(--primary-color, #4f46e5);
+  background: color-mix(in srgb, var(--primary-color, #4f46e5) 8%, var(--bg-primary, #fff));
+  box-shadow: inset 3px 0 0 var(--primary-color, #4f46e5);
+}
+
+.roster-card__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  color: #fff;
+  overflow: hidden;
+}
+
+.roster-card__body {
+  min-width: 0;
+}
+
+.roster-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-primary, #111827);
+}
+
+.roster-card__meta {
+  font-size: 12px;
+  color: var(--text-secondary, #6b7280);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.roster-card__status {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--border-color, #9ca3af);
+  flex: none;
+}
+
+.roster-card__status.is-idle { background: #9ca3af; }
+.roster-card__status.is-active { background: #22c55e; }
+.roster-card__status.is-error { background: #ef4444; }
+.roster-card__status.is-disabled { background: #d1d5db; }
+
+.roster-empty {
+  text-align: center;
+  color: var(--text-secondary, #6b7280);
+  font-size: 13px;
+  padding: 20px;
+}
+
+.roster-linkbtn {
+  background: none;
+  border: none;
+  color: var(--primary-color, #4f46e5);
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: underline;
+}
+
+/* ---- Stage ---------------------------------------------------------------- */
+
+.roster-stage {
+  min-height: 420px;
+}
+
+.stage-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 420px;
+  border: 1px dashed var(--border-color, #d1d5db);
+  border-radius: var(--roster-radius);
+  color: var(--text-secondary, #6b7280);
+  text-align: center;
+  padding: 24px;
+}
+
+.stage-placeholder__art {
+  font-size: 46px;
+  opacity: 0.4;
+}
+
+.stage {
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: var(--roster-radius);
+  background: var(--bg-primary, #fff);
+  overflow: hidden;
+}
+
+.stage__hero {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  grid-template-areas:
+    "avatar ident"
+    "vitals vitals";
+  gap: 14px 16px;
+  padding: 22px 24px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--primary-color, #4f46e5) 6%, transparent), transparent);
+}
+
+.stage__avatar {
+  grid-area: avatar;
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 24px;
+  color: #fff;
+  overflow: hidden;
+}
+
+.stage__ident { grid-area: ident; align-self: center; min-width: 0; }
+
+.stage__name {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.stage__class {
+  margin-top: 4px;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #6b7280);
+}
+
+.stage__vitals {
+  grid-area: vitals;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.vital {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: var(--bg-secondary, #f3f4f6);
+  border: 1px solid var(--border-color, #e5e7eb);
+  color: var(--text-primary, #111827);
+}
+
+.vital b { font-weight: 600; }
+.vital span { color: var(--text-secondary, #6b7280); }
+
+/* Tabs */
+.stage__tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.stage__tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--text-secondary, #6b7280);
+  cursor: pointer;
+}
+
+.stage__tab:hover { color: var(--text-primary, #111827); }
+
+.stage__tab.is-active {
+  color: var(--primary-color, #4f46e5);
+  border-bottom-color: var(--primary-color, #4f46e5);
+  font-weight: 600;
+}
+
+.stage__tab:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: -2px;
+  border-radius: 4px 4px 0 0;
+}
+
+.stage__panels { padding: 20px 24px; }
+.stage__panel[hidden] { display: none; }
+
+.stage-facts {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 8px 16px;
+  margin: 0 0 16px;
+}
+
+.stage-facts dt { color: var(--text-secondary, #6b7280); font-size: 13px; }
+.stage-facts dd { margin: 0; font-size: 14px; color: var(--text-primary, #111827); }
+
+.stage-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-primary, #111827);
+  padding-top: 14px;
+  border-top: 1px solid var(--border-color, #eee);
+}
+
+.stage-prompt pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--bg-secondary, #f8f9fb);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 10px;
+  max-height: 460px;
+  overflow: auto;
+  color: var(--text-primary, #111827);
+}
+
+.stage-hint { color: var(--text-secondary, #6b7280); font-size: 13px; margin: 0; }
+
+.stage-workspaces { display: flex; flex-direction: column; gap: 8px; }
+
+.ws-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.ws-row a { text-decoration: none; color: var(--text-primary, #111827); }
+.ws-row a:hover { color: var(--primary-color, #4f46e5); }
+
+.ws-entry-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary-color, #4f46e5) 14%, transparent);
+  color: var(--primary-color, #4f46e5);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0);
+  white-space: nowrap; border: 0;
+}
+
+/* ---- Dark theme nudges ---------------------------------------------------- */
+
+[data-bs-theme="dark"] .vital,
+[data-bs-theme="dark"] .stage-prompt pre {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+[data-bs-theme="dark"] .roster-card,
+[data-bs-theme="dark"] .stage,
+[data-bs-theme="dark"] .roster-search input,
+[data-bs-theme="dark"] .roster-sort select {
+  background: var(--bg-primary, #1f2430);
+}
+
+/* ---- Responsive ----------------------------------------------------------- */
+
+@media (max-width: 860px) {
+  .roster-layout {
+    grid-template-columns: 1fr;
+  }
+  .roster-rail {
+    position: static;
+    max-height: none;
+  }
+  .roster-list {
+    max-height: 320px;
+  }
+}

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -1,0 +1,470 @@
+/*
+ * Agents roster + stage controller (game-inspired Agents page, G2).
+ *
+ * Read-only shell: browse the roster, select an agent, inspect its vitals and
+ * three tabs (Overview / Prompt / Workspaces). Selection persists across
+ * reloads (URL ?agent= + localStorage). The system prompt is loaded lazily —
+ * its DOM is only built the first time the Prompt tab is opened for an agent.
+ *
+ * Editing (Overview/Prompt saves, workspace assignment, create/delete) arrives
+ * in later groups; this file deliberately renders everything read-only.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'ori.roster.selectedAgent';
+  var TAB_ORDER = ['overview', 'prompt', 'workspaces'];
+
+  var state = {
+    agents: [],
+    filtered: [],
+    byName: {},
+    selected: null,
+    detailCache: {},
+    query: '',
+    sort: 'name-asc',
+    focusIndex: -1,
+  };
+
+  var els = {};
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    els = {
+      list: document.getElementById('rosterList'),
+      count: document.getElementById('rosterCount'),
+      search: document.getElementById('rosterSearch'),
+      sort: document.getElementById('rosterSort'),
+      empty: document.getElementById('rosterEmpty'),
+      clearSearch: document.getElementById('rosterClearSearch'),
+      placeholder: document.getElementById('stagePlaceholder'),
+      stage: document.getElementById('stage'),
+      avatar: document.getElementById('stageAvatar'),
+      name: document.getElementById('stageName'),
+      klass: document.getElementById('stageClass'),
+      vitals: document.getElementById('stageVitals'),
+      overviewFacts: document.getElementById('overviewFacts'),
+      overviewDesc: document.getElementById('overviewDesc'),
+      promptBody: document.getElementById('promptBody'),
+      workspacesBody: document.getElementById('workspacesBody'),
+    };
+
+    els.search.addEventListener('input', onSearch);
+    els.sort.addEventListener('change', onSort);
+    els.clearSearch.addEventListener('click', function () {
+      els.search.value = '';
+      onSearch();
+      els.search.focus();
+    });
+    els.list.addEventListener('click', onListClick);
+    els.list.addEventListener('keydown', onListKeydown);
+
+    var tabs = document.querySelectorAll('.stage__tab');
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () { activateTab(tab.dataset.tab, true); });
+      tab.addEventListener('keydown', onTabKeydown);
+    });
+
+    window.addEventListener('popstate', function () {
+      var name = new URLSearchParams(window.location.search).get('agent');
+      if (name && state.byName[name]) selectAgent(name, { push: false });
+    });
+
+    loadAgents();
+  }
+
+  /* ---- data ---------------------------------------------------------------- */
+
+  function loadAgents() {
+    fetch('/api/agents/dashboard/list?sort_by=name&order=asc')
+      .then(function (r) {
+        if (!r.ok) throw new Error('list ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var agents = Array.isArray(data) ? data : (data && data.agents) || [];
+        state.agents = agents;
+        state.byName = {};
+        agents.forEach(function (a) { state.byName[a.name] = a; });
+        applyFilterSort();
+        restoreSelection();
+      })
+      .catch(function (err) {
+        els.count.textContent = 'Could not load agents.';
+        console.error('[roster] load failed', err);
+      });
+  }
+
+  function fetchDetail(name) {
+    if (state.detailCache[name]) return Promise.resolve(state.detailCache[name]);
+    return fetch('/api/agents/' + encodeURIComponent(name) + '/detail')
+      .then(function (r) {
+        if (!r.ok) throw new Error('detail ' + r.status);
+        return r.json();
+      })
+      .then(function (detail) {
+        state.detailCache[name] = detail;
+        return detail;
+      });
+  }
+
+  /* ---- roster -------------------------------------------------------------- */
+
+  function applyFilterSort() {
+    var q = state.query.trim().toLowerCase();
+    var list = state.agents.filter(function (a) {
+      if (!q) return true;
+      var hay = (a.name + ' ' + (a.role || '') + ' ' + ((a.metadata && a.metadata.description) || '')).toLowerCase();
+      return hay.indexOf(q) !== -1;
+    });
+
+    list.sort(function (a, b) {
+      switch (state.sort) {
+        case 'name-desc': return b.name.localeCompare(a.name);
+        case 'workspaces-desc': return (b.workspace_count || 0) - (a.workspace_count || 0) || a.name.localeCompare(b.name);
+        case 'active-desc': return lastActive(b) - lastActive(a) || a.name.localeCompare(b.name);
+        default: return a.name.localeCompare(b.name);
+      }
+    });
+
+    state.filtered = list;
+    renderRoster();
+  }
+
+  function renderRoster() {
+    els.list.innerHTML = '';
+    var total = state.agents.length;
+    var shown = state.filtered.length;
+
+    if (shown === 0) {
+      els.empty.hidden = false;
+      els.count.textContent = total === 0 ? 'No agents yet.' : '0 of ' + total + ' agents';
+      return;
+    }
+    els.empty.hidden = true;
+    els.count.textContent = shown === total ? total + ' agent' + (total === 1 ? '' : 's') : shown + ' of ' + total + ' agents';
+
+    var frag = document.createDocumentFragment();
+    state.filtered.forEach(function (agent, idx) {
+      frag.appendChild(buildCard(agent, idx));
+    });
+    els.list.appendChild(frag);
+    highlightSelected();
+  }
+
+  function buildCard(agent, idx) {
+    var li = document.createElement('li');
+    li.className = 'roster-card';
+    li.setAttribute('role', 'option');
+    li.id = 'roster-opt-' + idx;
+    li.dataset.name = agent.name;
+    li.setAttribute('aria-selected', 'false');
+
+    var status = healthKind(agent);
+    var metaBits = [];
+    if (agent.model) metaBits.push(agent.model);
+    var wc = agent.workspace_count || 0;
+    metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
+
+    li.innerHTML =
+      avatarMarkup(agent, 'roster-card__avatar') +
+      '<div class="roster-card__body">' +
+      '<p class="roster-card__name">' + esc(agent.name) + '</p>' +
+      '<p class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</p>' +
+      '</div>' +
+      '<span class="roster-card__status is-' + status + '" title="' + esc(status) + '"></span>';
+    return li;
+  }
+
+  function highlightSelected() {
+    var options = els.list.querySelectorAll('.roster-card');
+    options.forEach(function (opt) {
+      var isSel = opt.dataset.name === state.selected;
+      opt.setAttribute('aria-selected', isSel ? 'true' : 'false');
+      if (isSel) els.list.setAttribute('aria-activedescendant', opt.id);
+    });
+  }
+
+  /* ---- selection ----------------------------------------------------------- */
+
+  function restoreSelection() {
+    var fromUrl = new URLSearchParams(window.location.search).get('agent');
+    var fromStore = safeStorageGet();
+    var pick = (fromUrl && state.byName[fromUrl] && fromUrl) ||
+      (fromStore && state.byName[fromStore] && fromStore) ||
+      (state.filtered[0] && state.filtered[0].name) || null;
+    if (pick) selectAgent(pick, { push: false });
+  }
+
+  function selectAgent(name, opts) {
+    opts = opts || {};
+    if (!state.byName[name]) return;
+    state.selected = name;
+    state.focusIndex = state.filtered.findIndex(function (a) { return a.name === name; });
+    safeStorageSet(name);
+    syncUrl(name, opts.push !== false);
+    highlightSelected();
+    renderStage(name);
+  }
+
+  /* ---- stage --------------------------------------------------------------- */
+
+  function renderStage(name) {
+    var listItem = state.byName[name];
+    els.placeholder.hidden = true;
+    els.stage.hidden = false;
+
+    // Reset to Overview and clear the lazy Prompt tab for the new agent.
+    activateTab('overview', false);
+    els.promptBody.dataset.loadedFor = '';
+    els.promptBody.innerHTML = '<p class="stage-hint">Loading system prompt…</p>';
+
+    // Hero + roster-derived vitals render immediately from the list item.
+    els.avatar.outerHTML = avatarMarkup(listItem, 'stage__avatar', 'stageAvatar');
+    els.avatar = document.getElementById('stageAvatar');
+    els.name.textContent = listItem.name;
+    els.klass.textContent = titleCase(listItem.role || listItem.type || 'agent');
+
+    renderWorkspaces(listItem);
+
+    // Detail (model config) fills Overview; may fail gracefully.
+    els.overviewFacts.innerHTML = '<p class="stage-hint">Loading…</p>';
+    els.overviewDesc.textContent = '';
+    fetchDetail(name)
+      .then(function (detail) {
+        if (state.selected !== name) return; // selection moved on
+        renderVitals(listItem, detail);
+        renderOverview(listItem, detail);
+      })
+      .catch(function (err) {
+        if (state.selected !== name) return;
+        renderVitals(listItem, null);
+        els.overviewFacts.innerHTML = '<p class="stage-hint">Could not load agent details.</p>';
+        console.error('[roster] detail failed', err);
+      });
+  }
+
+  function renderVitals(listItem, detail) {
+    var vitals = [];
+    vitals.push(vital('Status', titleCase(String(listItem.status || 'idle'))));
+    if (detail && detail.model) vitals.push(vital('Model', detail.model));
+    if (detail && detail.provider) vitals.push(vital('Provider', titleCase(detail.provider)));
+    var msgs = listItem.statistics && listItem.statistics.message_count;
+    if (msgs) vitals.push(vital('Messages', String(msgs)));
+    var cost = listItem.statistics && listItem.statistics.total_cost;
+    if (cost) vitals.push(vital('Cost', '$' + Number(cost).toFixed(2)));
+    els.vitals.innerHTML = vitals.join('');
+  }
+
+  function renderOverview(listItem, detail) {
+    var facts = [
+      ['Role', titleCase(listItem.role || '—')],
+      ['Type', titleCase(listItem.type || '—')],
+      ['Model', detail.model || '—'],
+      ['Provider', detail.provider ? titleCase(detail.provider) : '—'],
+      ['Temperature', detail.temperature != null ? String(detail.temperature) : '—'],
+    ];
+    if (detail.reasoning_effort) facts.push(['Reasoning effort', titleCase(detail.reasoning_effort)]);
+    if (detail.max_output_tokens) facts.push(['Max output tokens', String(detail.max_output_tokens)]);
+    facts.push(['Web search', detail.allow_web_search ? 'Allowed' : 'Off']);
+
+    els.overviewFacts.innerHTML = facts.map(function (f) {
+      return '<dt>' + esc(f[0]) + '</dt><dd>' + esc(f[1]) + '</dd>';
+    }).join('');
+
+    var desc = (listItem.metadata && listItem.metadata.description) || '';
+    els.overviewDesc.textContent = desc || 'No description written yet.';
+  }
+
+  function renderPrompt(name) {
+    if (els.promptBody.dataset.loadedFor === name) return;
+    els.promptBody.dataset.loadedFor = name;
+    els.promptBody.innerHTML = '<p class="stage-hint">Loading system prompt…</p>';
+    fetchDetail(name)
+      .then(function (detail) {
+        if (state.selected !== name) return;
+        var prompt = (detail && detail.system_prompt) || '';
+        if (!prompt.trim()) {
+          els.promptBody.innerHTML = '<p class="stage-hint">This agent has no custom system prompt.</p>';
+          return;
+        }
+        var pre = document.createElement('pre');
+        pre.textContent = prompt;
+        els.promptBody.innerHTML = '';
+        els.promptBody.appendChild(pre);
+      })
+      .catch(function () {
+        els.promptBody.innerHTML = '<p class="stage-hint">Could not load the system prompt.</p>';
+      });
+  }
+
+  function renderWorkspaces(listItem) {
+    var workspaces = Array.isArray(listItem.workspaces) ? listItem.workspaces : [];
+    if (workspaces.length === 0) {
+      els.workspacesBody.innerHTML = '<p class="stage-hint">Not attached to any workspace — this is a reusable library agent.</p>';
+      return;
+    }
+    els.workspacesBody.innerHTML = workspaces.map(function (ws) {
+      var name = esc(ws.name || 'Workspace');
+      var link = ws.id ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + name + '</a>' : name;
+      var pill = ws.entry_point ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+      return '<div class="ws-row"><span>' + link + '</span>' + pill + '</div>';
+    }).join('');
+  }
+
+  /* ---- tabs ---------------------------------------------------------------- */
+
+  function activateTab(tabName, focus) {
+    TAB_ORDER.forEach(function (t) {
+      var tab = document.getElementById('tab-' + t);
+      var panel = document.getElementById('panel-' + t);
+      var active = t === tabName;
+      tab.classList.toggle('is-active', active);
+      tab.setAttribute('aria-selected', active ? 'true' : 'false');
+      tab.tabIndex = active ? 0 : -1;
+      panel.hidden = !active;
+      panel.classList.toggle('is-active', active);
+    });
+    if (tabName === 'prompt' && state.selected) renderPrompt(state.selected);
+    if (focus) document.getElementById('tab-' + tabName).focus();
+  }
+
+  function onTabKeydown(e) {
+    var current = e.currentTarget.dataset.tab;
+    var idx = TAB_ORDER.indexOf(current);
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      var next = e.key === 'ArrowRight' ? (idx + 1) % TAB_ORDER.length : (idx - 1 + TAB_ORDER.length) % TAB_ORDER.length;
+      activateTab(TAB_ORDER[next], true);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      activateTab(TAB_ORDER[0], true);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      activateTab(TAB_ORDER[TAB_ORDER.length - 1], true);
+    }
+  }
+
+  /* ---- roster interaction -------------------------------------------------- */
+
+  function onListClick(e) {
+    var card = e.target.closest('.roster-card');
+    if (card && card.dataset.name) selectAgent(card.dataset.name);
+  }
+
+  function onListKeydown(e) {
+    var n = state.filtered.length;
+    if (n === 0) return;
+    var idx = state.focusIndex < 0 ? 0 : state.focusIndex;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectByIndex(Math.min(idx + 1, n - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectByIndex(Math.max(idx - 1, 0));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      selectByIndex(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      selectByIndex(n - 1);
+    }
+  }
+
+  function selectByIndex(i) {
+    var agent = state.filtered[i];
+    if (!agent) return;
+    selectAgent(agent.name);
+    var opt = els.list.querySelector('.roster-card[data-name="' + cssEscape(agent.name) + '"]');
+    if (opt && opt.scrollIntoView) opt.scrollIntoView({ block: 'nearest' });
+  }
+
+  function onSearch() {
+    state.query = els.search.value || '';
+    applyFilterSort();
+  }
+
+  function onSort() {
+    state.sort = els.sort.value || 'name-asc';
+    applyFilterSort();
+    if (state.selected) highlightSelected();
+  }
+
+  /* ---- helpers ------------------------------------------------------------- */
+
+  function vital(label, value) {
+    return '<span class="vital"><span>' + esc(label) + '</span><b>' + esc(value) + '</b></span>';
+  }
+
+  function avatarMarkup(agent, className, id) {
+    var idAttr = id ? ' id="' + id + '"' : '';
+    var image = agent && agent.metadata && agent.metadata.avatar_image;
+    if (image) {
+      return '<div class="' + className + '"' + idAttr + ' style="padding:0;overflow:hidden;">' +
+        '<img src="/avatars/' + esc(String(image)) + '" alt="" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover;"></div>';
+    }
+    var color = (agent && agent.metadata && agent.metadata.avatar_color) || colorFor(agent ? agent.name : '');
+    return '<div class="' + className + '"' + idAttr + ' style="background:' + esc(color) + ';">' + esc(initials(agent ? agent.name : '')) + '</div>';
+  }
+
+  function initials(name) {
+    var parts = String(name || '?').trim().split(/\s+/);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+
+  function colorFor(name) {
+    var palette = ['#4f46e5', '#0891b2', '#7c3aed', '#059669', '#d97706', '#db2777', '#2563eb', '#dc2626'];
+    var sum = 0;
+    String(name || '').split('').forEach(function (c) { sum += c.charCodeAt(0); });
+    return palette[sum % palette.length];
+  }
+
+  function healthKind(agent) {
+    var s = String((agent && agent.status) || 'idle').toLowerCase();
+    if (s === 'active') return 'active';
+    if (s === 'error') return 'error';
+    if (s === 'disabled') return 'disabled';
+    return 'idle';
+  }
+
+  function lastActive(agent) {
+    var v = agent && agent.statistics && agent.statistics.last_active;
+    var t = v ? Date.parse(v) : 0;
+    return isNaN(t) ? 0 : t;
+  }
+
+  function titleCase(s) {
+    s = String(s || '').replace(/[_-]+/g, ' ').trim();
+    if (!s) return '';
+    return s.replace(/\w\S*/g, function (w) { return w.charAt(0).toUpperCase() + w.slice(1); });
+  }
+
+  function syncUrl(name, push) {
+    var params = new URLSearchParams(window.location.search);
+    params.set('view', 'roster');
+    params.set('agent', name);
+    var url = window.location.pathname + '?' + params.toString();
+    if (push) window.history.pushState({ agent: name }, '', url);
+    else window.history.replaceState({ agent: name }, '', url);
+  }
+
+  function safeStorageGet() {
+    try { return window.localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
+  }
+  function safeStorageSet(v) {
+    try { window.localStorage.setItem(STORAGE_KEY, v); } catch (e) { /* ignore */ }
+  }
+
+  function cssEscape(s) {
+    if (window.CSS && window.CSS.escape) return window.CSS.escape(s);
+    return String(s).replace(/"/g, '\\"');
+  }
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+})();

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -93,6 +93,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 		"templates/components/workspaces/workspace-details-modal.tmpl",
 		"templates/pages/index.tmpl",
 		"templates/pages/agents.tmpl",
+		"templates/pages/agents-roster.tmpl",
 		"templates/pages/agents-detail.tmpl",
 		"templates/pages/agents-claude-detail.tmpl",
 		"templates/pages/agents-codex-detail.tmpl",
@@ -139,6 +140,7 @@ func (tr *TemplateRenderer) LoadTemplates() error {
 
 	tr.templates["index"] = tmpl
 	tr.templates["agents"] = tmpl
+	tr.templates["agents-roster"] = tmpl
 	tr.templates["agents-detail"] = tmpl
 	tr.templates["agents-claude-detail"] = tmpl
 	tr.templates["agents-codex-detail"] = tmpl
@@ -185,7 +187,7 @@ func (tr *TemplateRenderer) RenderTemplate(name string, data TemplateData) (stri
 	switch name {
 	case "index":
 		templateName = "base.tmpl"
-	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-agent-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-detail", "agents-claude-detail", "agents-codex-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
+	case "settings", "profile", "vault", "workflows", "workspace-canvas", "workspace-detail", "workspace-agent-detail", "workspace-diagnostics", "workspace-task", "workspace-run", "usage", "mcp", "plugins", "models", "review", "agents-roster", "agents-detail", "agents-claude-detail", "agents-codex-detail", "agents-create", "skills", "templates", "workspaces", "personalize", "note-page", "action-center":
 		// These templates use {{define "name"}}, so execute by defined name
 		templateName = name
 	case "agents":

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -1,0 +1,107 @@
+{{define "agents-roster"}}
+<!DOCTYPE html>
+<html lang="en">
+{{template "head.tmpl" .}}
+<link rel="stylesheet" href="/css/agents-roster.css">
+
+<body class="bg-light agents-roster-page" data-sidebar-default="hidden">
+  <a class="skip-link" href="#roster-main">Skip to Main Content</a>
+
+  {{template "navbar.tmpl" .}}
+
+  <div class="app-shell">
+    {{template "sidebar.tmpl" .}}
+
+    <main class="main-content" id="roster-main" role="main" aria-labelledby="roster-title">
+      <div class="roster-layout">
+        <!-- Roster rail: browse + select -->
+        <section class="roster-rail" aria-label="Agent roster">
+          <header class="roster-rail__header">
+            <div class="roster-rail__titles">
+              <h1 id="roster-title" class="roster-rail__title">Agents</h1>
+              <p class="roster-rail__subtitle" id="rosterCount" aria-live="polite">Loading roster…</p>
+            </div>
+            <a class="roster-rail__classic" href="/agents" title="Switch back to the classic dashboard">Classic view</a>
+          </header>
+
+          <div class="roster-rail__controls">
+            <label class="roster-search" for="rosterSearch">
+              <span class="visually-hidden">Search agents</span>
+              <input id="rosterSearch" type="search" placeholder="Search agents…" autocomplete="off" spellcheck="false">
+            </label>
+            <label class="roster-sort" for="rosterSort">
+              <span class="visually-hidden">Sort agents</span>
+              <select id="rosterSort" aria-label="Sort agents">
+                <option value="name-asc">Name A–Z</option>
+                <option value="name-desc">Name Z–A</option>
+                <option value="workspaces-desc">Most workspaces</option>
+                <option value="active-desc">Recently active</option>
+              </select>
+            </label>
+          </div>
+
+          <ul class="roster-list" id="rosterList" role="listbox" aria-label="Agents" tabindex="0" aria-activedescendant="">
+            <!-- roster cards injected here -->
+          </ul>
+
+          <div class="roster-empty" id="rosterEmpty" hidden>
+            <p>No agents match your search.</p>
+            <button type="button" id="rosterClearSearch" class="roster-linkbtn">Clear search</button>
+          </div>
+        </section>
+
+        <!-- Stage: selected agent -->
+        <section class="roster-stage" aria-label="Selected agent" aria-live="polite">
+          <div class="stage-placeholder" id="stagePlaceholder">
+            <div class="stage-placeholder__art" aria-hidden="true">◈</div>
+            <p>Select an agent from the roster to view its details.</p>
+          </div>
+
+          <article class="stage" id="stage" hidden>
+            <header class="stage__hero">
+              <div class="stage__avatar" id="stageAvatar" aria-hidden="true"></div>
+              <div class="stage__ident">
+                <h2 class="stage__name" id="stageName"></h2>
+                <div class="stage__class" id="stageClass"></div>
+              </div>
+              <div class="stage__vitals" id="stageVitals" role="group" aria-label="Agent vitals">
+                <!-- vitals chips injected -->
+              </div>
+            </header>
+
+            <nav class="stage__tabs" role="tablist" aria-label="Agent detail sections">
+              <button class="stage__tab is-active" role="tab" id="tab-overview" aria-controls="panel-overview" aria-selected="true" data-tab="overview" type="button">Overview</button>
+              <button class="stage__tab" role="tab" id="tab-prompt" aria-controls="panel-prompt" aria-selected="false" data-tab="prompt" type="button" tabindex="-1">Prompt</button>
+              <button class="stage__tab" role="tab" id="tab-workspaces" aria-controls="panel-workspaces" aria-selected="false" data-tab="workspaces" type="button" tabindex="-1">Workspaces</button>
+            </nav>
+
+            <div class="stage__panels">
+              <section class="stage__panel is-active" role="tabpanel" id="panel-overview" aria-labelledby="tab-overview" tabindex="0">
+                <dl class="stage-facts" id="overviewFacts"></dl>
+                <div class="stage-desc" id="overviewDesc"></div>
+              </section>
+              <section class="stage__panel" role="tabpanel" id="panel-prompt" aria-labelledby="tab-prompt" tabindex="0" hidden>
+                <div class="stage-prompt" id="promptBody">
+                  <p class="stage-hint">Loading system prompt…</p>
+                </div>
+              </section>
+              <section class="stage__panel" role="tabpanel" id="panel-workspaces" aria-labelledby="tab-workspaces" tabindex="0" hidden>
+                <div class="stage-workspaces" id="workspacesBody"></div>
+              </section>
+            </div>
+          </article>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  {{template "theme-init.tmpl" .}}
+  {{template "scripts-dx-utils.tmpl" .}}
+  <script defer src="/js/app.js"></script>
+  <script defer src="/js/modules/sidebar.js"></script>
+  <script defer src="/js/modules/themeManager.js"></script>
+  <script defer src="/js/agents-roster.js"></script>
+</body>
+
+</html>
+{{end}}


### PR DESCRIPTION
## Summary

Second seam-PR (**G2**) of the game-inspired Agents page redesign. **Opt-in and inert** — the new page is served only on `/agents?view=roster`; the live dashboard (`/agents`) is untouched until G5 flips the default. Builds on G1 (#180). Full plan in `tasks/prd-agents-page-ui.md` (local).

## What's here

- **`agents-roster.tmpl`** — a two-pane character-select layout: a **roster rail** (search + sort + agent cards) beside a **selected-agent stage** with hero, vitals, and Overview / Prompt / Workspaces tabs. Themed, not skinned — built on the existing Ori design tokens, light/dark aware, responsive (panes stack under 860px).
- **`agents-roster.js`** — read-only controller. Loads `GET /api/agents/dashboard/list`, renders cards, and on select fetches `GET /api/agents/{name}/detail` for the stage. Selection **persists across reloads** via URL `?agent=` + localStorage (restore order URL → storage → first). The system prompt is **lazy** — its DOM is only built the first time the Prompt tab is opened. Roster is a keyboard listbox; tabs are a keyboard tablist.
- **`agents-roster.css`** — roster/stage styling on app tokens, dark-theme nudges, focus-visible states.
- Registered `agents-roster` via the three `templates.go` edits; wired the `?view=roster` branch in `serveAgents`.

## Verification

Driven end-to-end in a real browser against an isolated smoke server (6 seeded agents, incl. CLI agents):
- roster renders; search + sort work
- card select swaps the stage and updates `?agent=`; deep-link + reload restore the selection
- all three tabs render; Prompt loads lazily (rendered only on tab open)
- console clean (fixed a missing `scripts-dx-utils` include so `app.js`/`sidebar.js` get the `Logger` global)
- dark mode verified

`go build ./...`, `go vet`, and `eslint` all clean. No backend behavior changes.

## Not in scope (later groups)

Editing (Overview/Prompt saves, workspace assignment, create/delete) is G3–G4; a11y/mobile hardening + Playwright/axe are G5, which also flips the default view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)