### PR TITLE
feat(agents): workspaces assignment tab + create/delete lifecycle (G4)

### DIFF
--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -67,6 +67,25 @@
   border-color: var(--primary-color, #4f46e5);
 }
 
+.roster-rail__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.roster-rail__new {
+  font-size: 12px;
+  border: 1px solid var(--primary-color, #4f46e5);
+  color: #fff;
+  background: var(--primary-color, #4f46e5);
+  border-radius: 999px;
+  padding: 5px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.roster-rail__new:hover { filter: brightness(1.05); }
+.roster-rail__new:focus-visible { outline: 2px solid var(--primary-color, #4f46e5); outline-offset: 2px; }
+
 .roster-rail__controls {
   display: flex;
   gap: 8px;
@@ -238,6 +257,7 @@
 }
 
 .stage__hero {
+  position: relative;
   display: grid;
   grid-template-columns: 64px minmax(0, 1fr);
   grid-template-areas:
@@ -248,6 +268,21 @@
   border-bottom: 1px solid var(--border-color, #e5e7eb);
   background: linear-gradient(180deg, color-mix(in srgb, var(--primary-color, #4f46e5) 6%, transparent), transparent);
 }
+
+.stage__delete {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  font-size: 12px;
+  border: 1px solid color-mix(in srgb, #dc2626 55%, var(--border-color, #e5e7eb));
+  color: #dc2626;
+  background: transparent;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.stage__delete:hover { background: color-mix(in srgb, #dc2626 12%, transparent); }
+.stage__delete:focus-visible { outline: 2px solid #dc2626; outline-offset: 2px; }
 
 .stage__avatar {
   grid-area: avatar;
@@ -544,6 +579,49 @@
 @media (max-width: 560px) {
   .field { grid-template-columns: 1fr; gap: 4px; }
 }
+
+/* ---- Workspaces assignment + create panel (G4) ---------------------------- */
+
+.ws-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ws-check {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 10px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.ws-check:hover { border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 40%, var(--border-color, #e5e7eb)); }
+.ws-check input { width: auto; }
+.ws-check__name { flex: 1; }
+.ws-check.is-locked { cursor: default; opacity: 0.85; }
+.ws-check.is-locked:hover { border-color: var(--border-color, #e5e7eb); }
+
+.create-panel {
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: var(--roster-radius);
+  background: var(--bg-primary, #fff);
+  overflow: hidden;
+}
+.create-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+.create-panel__head h2 { margin: 0; font-size: 20px; }
+.create-panel__body { padding: 20px 24px; }
+
+[data-bs-theme="dark"] .create-panel,
+[data-bs-theme="dark"] .ws-check { background: var(--bg-primary, #1f2430); }
 
 .visually-hidden {
   position: absolute;

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -1,5 +1,5 @@
 /*
- * Agents roster + stage controller (game-inspired Agents page, G2 + G3).
+ * Agents roster + stage controller (game-inspired Agents page, G2–G4).
  *
  * Browse the roster, select an agent, and inspect/edit it on the stage across
  * three tabs (Overview / Prompt / Workspaces). Selection persists across
@@ -10,7 +10,11 @@
  * PATCH /api/agents/{name} (expected_version), inline validation, a stale-edit
  * conflict banner with reload, shared-definition confirmation, and an
  * unsaved-changes guard on tab/card switches. CLI/built-in agents (no version
- * token) stay read-only. Workspaces editing + create/delete land in G4.
+ * token) stay read-only.
+ *
+ * G4 adds the Workspaces tab editor (reconcile membership via
+ * PUT /api/agents/{name}/workspaces) plus create-agent and delete-agent
+ * lifecycle from the roster/stage.
  */
 (function () {
   'use strict';
@@ -29,7 +33,9 @@
     query: '',
     sort: 'name-asc',
     focusIndex: -1,
-    dirty: { overview: false, prompt: false },
+    dirty: { overview: false, prompt: false, workspaces: false },
+    allWorkspaces: null,
+    creating: false,
   };
 
   var els = {};
@@ -54,6 +60,11 @@
       overviewDesc: document.getElementById('overviewDesc'),
       promptBody: document.getElementById('promptBody'),
       workspacesBody: document.getElementById('workspacesBody'),
+      stageDelete: document.getElementById('stageDelete'),
+      newAgentBtn: document.getElementById('newAgentBtn'),
+      createPanel: document.getElementById('createPanel'),
+      createBody: document.getElementById('createBody'),
+      createCancel: document.getElementById('createCancel'),
     };
 
     els.search.addEventListener('input', onSearch);
@@ -65,6 +76,9 @@
     });
     els.list.addEventListener('click', onListClick);
     els.list.addEventListener('keydown', onListKeydown);
+    els.newAgentBtn.addEventListener('click', openCreate);
+    els.createCancel.addEventListener('click', closeCreate);
+    els.stageDelete.addEventListener('click', onDeleteClick);
 
     var tabs = document.querySelectorAll('.stage__tab');
     tabs.forEach(function (tab) {
@@ -224,20 +238,22 @@
 
   function renderStage(name) {
     var listItem = state.byName[name];
+    state.creating = false;
+    els.createPanel.hidden = true;
     els.placeholder.hidden = true;
     els.stage.hidden = false;
 
     setActiveTab('overview');
     els.promptBody.dataset.loadedFor = '';
     els.promptBody.innerHTML = '<p class="stage-hint">Loading system prompt…</p>';
+    els.stageDelete.hidden = true;
 
     els.avatar.outerHTML = avatarMarkup(listItem, 'stage__avatar', 'stageAvatar');
     els.avatar = document.getElementById('stageAvatar');
     els.name.textContent = listItem.name;
     els.klass.textContent = titleCase(listItem.role || listItem.type || 'agent');
 
-    renderWorkspaces(listItem);
-
+    els.workspacesBody.innerHTML = '<p class="stage-hint">Loading…</p>';
     els.overviewFacts.innerHTML = '<p class="stage-hint">Loading…</p>';
     els.overviewDesc.textContent = '';
     fetchDetail(name)
@@ -245,11 +261,16 @@
         if (state.selected !== name) return;
         renderVitals(listItem, detail);
         renderOverview(name, detail);
+        renderWorkspaces(name, listItem, detail);
+        // Deletable only for editable (non-CLI) agents; the server still guards
+        // system-assistant and workspace-attached deletes.
+        els.stageDelete.hidden = !isEditable(detail);
       })
       .catch(function (err) {
         if (state.selected !== name) return;
         renderVitals(listItem, null);
         els.overviewFacts.innerHTML = '<p class="stage-hint">Could not load agent details.</p>';
+        renderWorkspaces(name, listItem, null);
         console.error('[roster] detail failed', err);
       });
   }
@@ -468,18 +489,217 @@
 
   /* ---- workspaces (read-only in G3) ---------------------------------------- */
 
-  function renderWorkspaces(listItem) {
-    var workspaces = Array.isArray(listItem.workspaces) ? listItem.workspaces : [];
-    if (workspaces.length === 0) {
-      els.workspacesBody.innerHTML = '<p class="stage-hint">Not attached to any workspace — this is a reusable library agent.</p>';
+  function renderWorkspaces(name, listItem, detail) {
+    var members = Array.isArray(listItem.workspaces) ? listItem.workspaces : [];
+
+    // CLI / built-in agents cannot be attached — show the membership read-only.
+    if (!isEditable(detail)) {
+      els.workspacesBody.innerHTML = members.length === 0
+        ? '<p class="stage-hint">Not attached to any workspace.</p>'
+        : members.map(readonlyWsRow).join('');
       return;
     }
-    els.workspacesBody.innerHTML = workspaces.map(function (ws) {
-      var nm = esc(ws.name || 'Workspace');
-      var link = ws.id ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + nm + '</a>' : nm;
-      var pill = ws.entry_point ? '<span class="ws-entry-pill">Entry agent</span>' : '';
-      return '<div class="ws-row"><span>' + link + '</span>' + pill + '</div>';
+
+    els.workspacesBody.innerHTML = '<p class="stage-hint">Loading workspaces…</p>';
+    fetchWorkspaces()
+      .then(function (all) {
+        if (state.selected !== name) return;
+        renderWorkspacesEditor(name, members, all);
+      })
+      .catch(function () {
+        if (state.selected !== name) return;
+        // Fall back to a read-only view of current memberships.
+        els.workspacesBody.innerHTML = (members.length === 0
+          ? '<p class="stage-hint">Not attached to any workspace.</p>'
+          : members.map(readonlyWsRow).join('')) +
+          '<p class="stage-hint">Could not load the full workspace list to edit assignments.</p>';
+      });
+  }
+
+  function readonlyWsRow(ws) {
+    var nm = esc(ws.name || 'Workspace');
+    var link = ws.id ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + nm + '</a>' : nm;
+    var pill = ws.entry_point ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+    return '<div class="ws-row"><span>' + link + '</span>' + pill + '</div>';
+  }
+
+  function renderWorkspacesEditor(name, members, all) {
+    var memberIds = {};
+    var entryIds = {};
+    members.forEach(function (m) { memberIds[m.id] = true; if (m.entry_point) entryIds[m.id] = true; });
+
+    var rows = all.map(function (ws) {
+      var isMember = !!memberIds[ws.id];
+      var isEntry = !!entryIds[ws.id];
+      // The agent can't be unassigned from a workspace it's the entry agent of;
+      // lock that checkbox and explain, matching the server guard.
+      var disabled = isEntry ? ' disabled' : '';
+      var pill = isEntry ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+      return '<label class="ws-check' + (disabled ? ' is-locked' : '') + '">' +
+        '<input type="checkbox" data-ws-id="' + esc(ws.id) + '"' + (isMember ? ' checked' : '') + disabled + '>' +
+        '<span class="ws-check__name">' + esc(ws.name || ws.id) + '</span>' + pill + '</label>';
     }).join('');
+
+    els.workspacesBody.innerHTML =
+      (all.length === 0 ? '<p class="stage-hint">No workspaces exist yet. Create one from the Workspaces page.</p>' : '') +
+      '<form class="ws-list" id="workspacesForm">' + rows + '</form>' +
+      saveBar('workspaces');
+
+    wireDirty('workspaces', document.getElementById('workspacesForm'));
+    wireSaveBar('workspaces', function () { saveWorkspaces(name, members); });
+  }
+
+  function saveWorkspaces(name, members) {
+    var checks = els.workspacesBody.querySelectorAll('input[data-ws-id]');
+    var desired = [];
+    checks.forEach(function (c) { if (c.checked) desired.push(c.getAttribute('data-ws-id')); });
+    // Entry-agent memberships have disabled (unchecked-proof) boxes but must stay
+    // in the desired set so the server doesn't try to remove them.
+    members.forEach(function (m) { if (m.entry_point && desired.indexOf(m.id) === -1) desired.push(m.id); });
+
+    setSaving('workspaces', true);
+    fetch('/api/agents/' + encodeURIComponent(name) + '/workspaces', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspace_ids: desired }),
+    })
+      .then(function (r) {
+        return r.json().catch(function () { return {}; }).then(function (data) { return { status: r.status, data: data }; });
+      })
+      .then(function (res) {
+        setSaving('workspaces', false);
+        if (res.status >= 200 && res.status < 300) {
+          state.dirty.workspaces = false;
+          // Reflect the reconciled membership everywhere.
+          var item = state.byName[name];
+          if (item) { item.workspaces = res.data.workspaces || []; item.workspace_count = res.data.workspace_count || 0; }
+          refreshRosterMeta(name, state.detailCache[name] || {});
+          renderWorkspaces(name, item, state.detailCache[name]);
+          showStatus('workspaces', 'Saved.', 'ok');
+        } else if (res.status === 409 && res.data && res.data.error === 'entry_agent_removal_blocked') {
+          showStatus('workspaces', res.data.message || 'Cannot remove the entry agent.', 'error');
+        } else {
+          showStatus('workspaces', (res.data && res.data.message) || ('Save failed (' + res.status + ').'), 'error');
+        }
+      })
+      .catch(function () { setSaving('workspaces', false); showStatus('workspaces', 'Network error — not saved.', 'error'); });
+  }
+
+  function fetchWorkspaces() {
+    if (state.allWorkspaces) return Promise.resolve(state.allWorkspaces);
+    return fetch('/api/workspaces')
+      .then(function (r) { if (!r.ok) throw new Error('workspaces ' + r.status); return r.json(); })
+      .then(function (data) {
+        var list = (data && data.workspaces) || [];
+        // Only assignable (non-trashed / non-missing) workspaces.
+        list = list.filter(function (w) { var s = String(w.status || '').toLowerCase(); return s !== 'trashed' && s !== 'missing'; });
+        list.sort(function (a, b) { return String(a.name || '').localeCompare(String(b.name || '')); });
+        state.allWorkspaces = list;
+        return list;
+      });
+  }
+
+  /* ---- create agent -------------------------------------------------------- */
+
+  function openCreate() {
+    if (!guardUnsaved()) return;
+    state.creating = true;
+    els.stage.hidden = true;
+    els.placeholder.hidden = true;
+    els.createPanel.hidden = false;
+    els.createBody.innerHTML =
+      '<form class="stage-form" id="createForm" novalidate>' +
+      field('Name', textInput('cr-name', '', 'Unique agent name')) +
+      field('Role', selectInput('cr-role', ROLES, 'general', titleCase)) +
+      field('Model', textInput('cr-model', 'gpt-4o-mini')) +
+      field('Description', textareaInput('cr-description', '', 3)) +
+      '</form>' +
+      '<div class="save-bar" id="savebar-create">' +
+      '<span class="save-status is-muted"></span>' +
+      '<button type="button" class="btn-ghost" id="createCancel2">Cancel</button>' +
+      '<button type="button" class="btn-primary" id="createSubmit">Create agent</button>' +
+      '</div>';
+    document.getElementById('createSubmit').addEventListener('click', submitCreate);
+    document.getElementById('createCancel2').addEventListener('click', closeCreate);
+    var nameInput = document.getElementById('cr-name');
+    if (nameInput) nameInput.focus();
+  }
+
+  function closeCreate() {
+    state.creating = false;
+    els.createPanel.hidden = true;
+    if (state.selected) { els.stage.hidden = false; }
+    else { els.placeholder.hidden = false; }
+  }
+
+  function submitCreate() {
+    var name = val('cr-name').trim();
+    var status = document.querySelector('#savebar-create .save-status');
+    if (!name) { status.textContent = 'Name is required.'; status.className = 'save-status is-error'; return; }
+    var body = {
+      name: name,
+      type: 'tool-calling',
+      role: val('cr-role'),
+      model: val('cr-model').trim(),
+      description: val('cr-description'),
+    };
+    var submit = document.getElementById('createSubmit');
+    submit.disabled = true; submit.textContent = 'Creating…';
+    fetch('/api/agents', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (res) {
+        submit.disabled = false; submit.textContent = 'Create agent';
+        if (res.status >= 200 && res.status < 300) {
+          reloadThenSelect(name);
+          closeCreate();
+        } else {
+          status.textContent = (res.data && res.data.message) || ('Create failed (' + res.status + ').');
+          status.className = 'save-status is-error';
+        }
+      })
+      .catch(function () { submit.disabled = false; submit.textContent = 'Create agent'; status.textContent = 'Network error.'; status.className = 'save-status is-error'; });
+  }
+
+  // Reload the roster from the server, then select the named agent if present.
+  function reloadThenSelect(name) {
+    fetch('/api/agents/dashboard/list?sort_by=name&order=asc')
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var agents = Array.isArray(data) ? data : (data && data.agents) || [];
+        state.agents = agents;
+        state.byName = {};
+        agents.forEach(function (a) { state.byName[a.name] = a; });
+        state.detailCache = {};
+        applyFilterSort();
+        if (name && state.byName[name]) selectAgent(name, { push: true });
+        else if (state.filtered[0]) selectAgent(state.filtered[0].name, { push: false });
+        else { els.stage.hidden = true; els.placeholder.hidden = false; state.selected = null; }
+      });
+  }
+
+  /* ---- delete agent -------------------------------------------------------- */
+
+  function onDeleteClick() {
+    var name = state.selected;
+    if (!name) return;
+    if (!window.confirm('Delete “' + name + '”? This permanently removes the agent and cannot be undone.')) return;
+    deleteAgent(name);
+  }
+
+  function deleteAgent(name) {
+    fetch('/api/agents?name=' + encodeURIComponent(name), { method: 'DELETE' })
+      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (res) {
+        if (res.status >= 200 && res.status < 300) {
+          resetDirty();
+          safeStorageSet('');
+          reloadThenSelect(null);
+        } else {
+          // Attached-to-workspace (409) or built-in (400): surface on the stage.
+          window.alert((res.data && res.data.message) || ('Delete failed (' + res.status + ').'));
+        }
+      })
+      .catch(function () { window.alert('Network error — agent not deleted.'); });
   }
 
   function refreshRosterMeta(name, detail) {
@@ -569,6 +789,7 @@
       state.dirty[tab] = false;
       if (tab === 'overview') renderOverview(state.selected, state.detailCache[state.selected]);
       else if (tab === 'prompt') { els.promptBody.dataset.loadedFor = ''; renderPrompt(state.selected); }
+      else if (tab === 'workspaces') renderWorkspaces(state.selected, state.byName[state.selected], state.detailCache[state.selected]);
     });
     markDirty(tab, false);
   }
@@ -617,7 +838,7 @@
 
   /* ---- unsaved guard ------------------------------------------------------- */
 
-  function anyDirty() { return !!(state.dirty.overview || state.dirty.prompt); }
+  function anyDirty() { return !!(state.dirty.overview || state.dirty.prompt || state.dirty.workspaces); }
 
   function guardUnsaved() {
     if (!anyDirty()) return true;
@@ -626,7 +847,7 @@
     return ok;
   }
 
-  function resetDirty() { state.dirty.overview = false; state.dirty.prompt = false; }
+  function resetDirty() { state.dirty.overview = false; state.dirty.prompt = false; state.dirty.workspaces = false; }
 
   /* ---- roster interaction -------------------------------------------------- */
 

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -21,7 +21,10 @@
               <h1 id="roster-title" class="roster-rail__title">Agents</h1>
               <p class="roster-rail__subtitle" id="rosterCount" aria-live="polite">Loading roster…</p>
             </div>
-            <a class="roster-rail__classic" href="/agents" title="Switch back to the classic dashboard">Classic view</a>
+            <div class="roster-rail__actions">
+              <button type="button" id="newAgentBtn" class="roster-rail__new" title="Create a new agent">+ New</button>
+              <a class="roster-rail__classic" href="/agents" title="Switch back to the classic dashboard">Classic view</a>
+            </div>
           </header>
 
           <div class="roster-rail__controls">
@@ -67,6 +70,7 @@
               <div class="stage__vitals" id="stageVitals" role="group" aria-label="Agent vitals">
                 <!-- vitals chips injected -->
               </div>
+              <button type="button" id="stageDelete" class="stage__delete" hidden title="Delete this agent">Delete</button>
             </header>
 
             <nav class="stage__tabs" role="tablist" aria-label="Agent detail sections">
@@ -89,6 +93,15 @@
                 <div class="stage-workspaces" id="workspacesBody"></div>
               </section>
             </div>
+          </article>
+
+          <!-- Create-agent panel (toggled from the roster "+ New" button) -->
+          <article class="create-panel" id="createPanel" hidden aria-label="Create a new agent">
+            <header class="create-panel__head">
+              <h2>New agent</h2>
+              <button type="button" id="createCancel" class="btn-ghost">Cancel</button>
+            </header>
+            <div class="create-panel__body" id="createBody"></div>
           </article>
         </section>
       </div>


### PR DESCRIPTION
## Summary

Fourth seam-PR (**G4**) of the game-inspired Agents page redesign. Adds workspace assignment and agent create/delete to the stage, still behind `/agents?view=roster` (inert until G5 flips the default). Rebased onto `dev` after G3 (#182) merged — clean G4-only diff. Builds on G1 (#180) + G2 (#181) + G3 (#182).

## What's here

- **Workspaces tab is now an editor** — a checklist of all assignable (non-trashed) workspaces from `GET /api/workspaces`; checked = member. Saving reconciles membership via **`PUT /api/agents/{name}/workspaces`** (the G1 endpoint) and updates the roster card's workspace count. Entry-agent memberships are locked (disabled checkbox + "Entry agent" pill) to match the server guard, and a `409 entry_agent_removal_blocked` is surfaced inline. CLI / built-in agents stay read-only.
- **Create** — a "+ New" button opens a create panel (name / role / model / description) that `POST`s `/api/agents`, shows inline validation errors, and auto-selects the new agent in the roster.
- **Delete** — a stage hero button with a confirm step `DELETE`s the agent, reloads the roster, and falls back to the first remaining agent. Attached (`409 attached_agent_delete_blocked`) and built-in (`400`) deletes are reported instead of applied; the delete button is hidden for read-only (CLI) agents.

## Verification

Driven end-to-end in a real browser against an isolated smoke server (agent + two workspaces):
- assign both workspaces → save → persisted (count 2, roster card shows "2 workspaces"); the agent became their entry agent so the checkboxes correctly locked with pills
- create an agent → auto-selected on the stage, URL updated
- delete an unattached agent → selection fell back to the first agent
- attached-delete guard returned `409`

Console clean; `eslint` and `go build ./...` clean. No backend changes (uses G1 + existing create/delete/workspaces endpoints).

## Not in scope

G5 (final group): a11y/keyboard/mobile hardening, Playwright + axe regression tests, and flipping `?view=roster` to the default (plus any legacy-path cleanup that the flip enables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)