### PR TITLE
feat(agents): a11y + mobile polish, default the roster, built-in highlight (G5)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -232,14 +232,13 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveAgents(w http.ResponseWriter, r *http.Request) {
 	data := s.prepareBasePageData("agents")
 	data.ShowSidebarToggle = true // Enable sidebar toggle
-	// Opt-in roster/stage redesign (Agents page redesign, G2). Off by default so
-	// the group lands inert; ?view=roster serves the new page. G5 flips the
-	// default once the flow reaches parity.
-	if r.URL.Query().Get("view") == "roster" {
-		s.renderAndWritePage(w, "agents-roster", data)
+	// The roster/stage redesign is now the default Agents page (G5). The classic
+	// dashboard remains reachable at ?view=classic as a fallback.
+	if r.URL.Query().Get("view") == "classic" {
+		s.renderAndWritePage(w, "agents", data)
 		return
 	}
-	s.renderAndWritePage(w, "agents", data)
+	s.renderAndWritePage(w, "agents-roster", data)
 }
 
 // serveActionCenter renders the cross-workspace Action Center page. The page

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -161,6 +161,23 @@
   border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 45%, var(--border-color, #e5e7eb));
 }
 
+/* Built-in "permanent residency" agents (CLI + Ori): a warm amber tint sets
+   them apart from user agents, kept distinct from the green selection cue. */
+.roster-card.is-permanent {
+  background: color-mix(in srgb, #f59e0b 22%, var(--bg-primary, #fff));
+  border-color: color-mix(in srgb, #f59e0b 45%, var(--border-color, #e5e7eb));
+}
+.roster-card.is-permanent .roster-card__meta {
+  /* Keep the secondary line readable on the filled amber background. */
+  color: color-mix(in srgb, var(--text-primary, #111827) 72%, transparent);
+}
+.roster-card.is-permanent:hover {
+  border-color: color-mix(in srgb, #f59e0b 65%, var(--border-color, #e5e7eb));
+}
+[data-bs-theme="dark"] .roster-card.is-permanent {
+  background: color-mix(in srgb, #f59e0b 20%, var(--bg-primary, #1f2430));
+}
+
 .roster-card[aria-selected="true"] {
   border-color: var(--primary-color, #4f46e5);
   background: color-mix(in srgb, var(--primary-color, #4f46e5) 8%, var(--bg-primary, #fff));
@@ -184,14 +201,40 @@
   min-width: 0;
 }
 
+.roster-card__namerow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .roster-card__name {
   font-size: 14px;
   font-weight: 600;
   margin: 0;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--text-primary, #111827);
+}
+
+.roster-card__badge {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: #92400e;
+  background: #fbe6c8;
+  border: 1px solid color-mix(in srgb, #f59e0b 45%, transparent);
+}
+
+[data-bs-theme="dark"] .roster-card__badge {
+  color: #fbbf24;
+  background: color-mix(in srgb, #f59e0b 18%, transparent);
 }
 
 .roster-card__meta {

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -8,6 +8,14 @@
   --roster-rail-width: 340px;
   --roster-gap: 18px;
   --roster-radius: 14px;
+  /* Accent used for small text/links. Lightened on dark so the brand primary
+     (which may be dark) still clears AA contrast on near-black surfaces. */
+  --roster-accent: var(--primary-color, #4f46e5);
+}
+
+[data-bs-theme="dark"] .agents-roster-page,
+.agents-roster-page[data-bs-theme="dark"] {
+  --roster-accent: color-mix(in srgb, var(--primary-color, #4f46e5) 38%, white);
 }
 
 .roster-layout {
@@ -218,7 +226,7 @@
 .roster-linkbtn {
   background: none;
   border: none;
-  color: var(--primary-color, #4f46e5);
+  color: var(--roster-accent, #4f46e5);
   cursor: pointer;
   font-size: 13px;
   text-decoration: underline;
@@ -358,7 +366,9 @@
 .stage__tab:hover { color: var(--text-primary, #111827); }
 
 .stage__tab.is-active {
-  color: var(--primary-color, #4f46e5);
+  /* High-contrast text; the colored underline + weight signal the active tab
+     (the brand primary can be too dark for AA as text on dark surfaces). */
+  color: var(--text-primary, #111827);
   border-bottom-color: var(--primary-color, #4f46e5);
   font-weight: 600;
 }
@@ -428,7 +438,7 @@
   padding: 2px 8px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--primary-color, #4f46e5) 14%, transparent);
-  color: var(--primary-color, #4f46e5);
+  color: var(--roster-accent, #4f46e5);
 }
 
 /* ---- Editable forms (G3) -------------------------------------------------- */
@@ -509,12 +519,16 @@
   color: var(--text-secondary, #9ca3af);
   margin-right: auto;
 }
-.save-bar.is-dirty .dirty-note { color: var(--primary-color, #4f46e5); }
+.save-bar.is-dirty .dirty-note { color: var(--roster-accent, #4f46e5); }
 
 .save-status { font-size: 12px; }
-.save-status.is-ok { color: #16a34a; }
+.save-status.is-ok { color: #15803d; }
 .save-status.is-error { color: #dc2626; }
 .save-status.is-muted { color: var(--text-secondary, #9ca3af); }
+
+/* Brighter status text for sufficient contrast on dark surfaces. */
+[data-bs-theme="dark"] .save-status.is-ok { color: #4ade80; }
+[data-bs-theme="dark"] .save-status.is-error { color: #f87171; }
 
 .btn-primary,
 .btn-ghost {
@@ -650,12 +664,33 @@
 @media (max-width: 860px) {
   .roster-layout {
     grid-template-columns: 1fr;
+    padding: 14px;
+    gap: 14px;
   }
   .roster-rail {
     position: static;
     max-height: none;
   }
+  /* Roster becomes a scrollable strip above the full-width stage. */
   .roster-list {
-    max-height: 320px;
+    max-height: 44vh;
+  }
+  .stage__hero {
+    grid-template-columns: 52px minmax(0, 1fr);
+    padding: 18px 18px 16px;
+  }
+  .stage__avatar { width: 52px; height: 52px; font-size: 20px; }
+  .stage__delete { top: 12px; right: 14px; }
+  .stage__panels { padding: 16px; }
+  .stage-facts { grid-template-columns: 1fr; gap: 2px 0; }
+  .stage-facts dt { margin-top: 8px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .roster-card,
+  .roster-rail__classic,
+  .btn-primary,
+  .btn-ghost {
+    transition: none;
   }
 }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -191,6 +191,10 @@
     var wc = agent.workspace_count || 0;
     metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
 
+    // Concise spoken label so screen readers don't read the raw dot markup.
+    var wcLabel = wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
+    li.setAttribute('aria-label', agent.name + ', ' + status + ', ' + wcLabel);
+
     li.innerHTML =
       avatarMarkup(agent, 'roster-card__avatar') +
       '<div class="roster-card__body">' +
@@ -299,24 +303,21 @@
     var editable = isEditable(detail);
 
     if (!editable) {
-      els.overviewFacts.className = 'stage-facts';
-      els.overviewFacts.innerHTML = readonlyFacts(detail);
+      els.overviewFacts.innerHTML = '<dl class="stage-facts">' + readonlyFacts(detail) + '</dl>';
       els.overviewDesc.innerHTML = '<p class="stage-hint">This is a built-in agent and cannot be edited here.</p>';
       return;
     }
 
-    // The editable form manages its own layout, so drop the read-only facts grid.
-    els.overviewFacts.className = 'stage-editwrap';
     els.overviewFacts.innerHTML =
       '<form class="stage-form" id="overviewForm" novalidate>' +
-      field('Role', selectInput('ov-role', ROLES, detail.role, titleCase)) +
-      field('Model', textInput('ov-model', detail.model || '')) +
-      field('Provider', textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…')) +
-      field('Temperature', numInput('ov-temperature', detail.temperature, '0', '2', '0.1')) +
-      field('Reasoning effort', selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) { return v ? titleCase(v) : 'Default'; })) +
-      field('Max output tokens', numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1')) +
+      field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
+      field('Model', textInput('ov-model', detail.model || ''), 'ov-model') +
+      field('Provider', textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…'), 'ov-provider') +
+      field('Temperature', numInput('ov-temperature', detail.temperature, '0', '2', '0.1'), 'ov-temperature') +
+      field('Reasoning effort', selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) { return v ? titleCase(v) : 'Default'; }), 'ov-reasoning') +
+      field('Max output tokens', numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1'), 'ov-maxtokens') +
       field('Web search', checkInput('ov-websearch', detail.allow_web_search)) +
-      field('Description', textareaInput('ov-description', (detail.metadata && detail.metadata.description) || '', 3)) +
+      field('Description', textareaInput('ov-description', (detail.metadata && detail.metadata.description) || '', 3), 'ov-description') +
       '</form>' +
       saveBar('overview');
 
@@ -609,10 +610,10 @@
     els.createPanel.hidden = false;
     els.createBody.innerHTML =
       '<form class="stage-form" id="createForm" novalidate>' +
-      field('Name', textInput('cr-name', '', 'Unique agent name')) +
-      field('Role', selectInput('cr-role', ROLES, 'general', titleCase)) +
-      field('Model', textInput('cr-model', 'gpt-4o-mini')) +
-      field('Description', textareaInput('cr-description', '', 3)) +
+      field('Name', textInput('cr-name', '', 'Unique agent name'), 'cr-name') +
+      field('Role', selectInput('cr-role', ROLES, 'general', titleCase), 'cr-role') +
+      field('Model', textInput('cr-model', 'gpt-4o-mini'), 'cr-model') +
+      field('Description', textareaInput('cr-description', '', 3), 'cr-description') +
       '</form>' +
       '<div class="save-bar" id="savebar-create">' +
       '<span class="save-status is-muted"></span>' +
@@ -879,9 +880,13 @@
 
   /* ---- form field builders ------------------------------------------------- */
 
-  function field(label, control) {
-    return '<div class="field"><label class="field__label">' + esc(label) + '</label>' +
-      '<div class="field__control">' + control + '</div></div>';
+  function field(label, control, forId) {
+    // Associate the label with its control (forId) for a11y; controls that carry
+    // their own wrapping label (e.g. the checkbox) pass no forId and get a span.
+    var lab = forId
+      ? '<label class="field__label" for="' + forId + '">' + esc(label) + '</label>'
+      : '<span class="field__label">' + esc(label) + '</span>';
+    return '<div class="field">' + lab + '<div class="field__control">' + control + '</div></div>';
   }
   function textInput(id, value, placeholder) {
     return '<input id="' + id + '" type="text" value="' + esc(value) + '"' +
@@ -940,7 +945,8 @@
   }
 
   function colorFor(name) {
-    var palette = ['#4f46e5', '#0891b2', '#7c3aed', '#059669', '#d97706', '#db2777', '#2563eb', '#dc2626'];
+    // 700-level shades so white initials clear WCAG AA contrast (>= 4.5:1).
+    var palette = ['#4338ca', '#0e7490', '#6d28d9', '#047857', '#b45309', '#be185d', '#1d4ed8', '#b91c1c'];
     var sum = 0;
     String(name || '').split('').forEach(function (c) { sum += c.charCodeAt(0); });
     return palette[sum % palette.length];
@@ -968,7 +974,7 @@
 
   function syncUrl(name, push) {
     var params = new URLSearchParams(window.location.search);
-    params.set('view', 'roster');
+    params.delete('view'); // roster is the default Agents page now
     params.set('agent', name);
     var url = window.location.pathname + '?' + params.toString();
     if (push) window.history.pushState({ agent: name }, '', url);

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -179,7 +179,7 @@
 
   function buildCard(agent, idx) {
     var li = document.createElement('li');
-    li.className = 'roster-card';
+    li.className = 'roster-card' + (isPermanent(agent) ? ' is-permanent' : '');
     li.setAttribute('role', 'option');
     li.id = 'roster-opt-' + idx;
     li.dataset.name = agent.name;
@@ -191,14 +191,21 @@
     var wc = agent.workspace_count || 0;
     metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
 
+    var permanent = isPermanent(agent);
+
     // Concise spoken label so screen readers don't read the raw dot markup.
     var wcLabel = wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
-    li.setAttribute('aria-label', agent.name + ', ' + status + ', ' + wcLabel);
+    li.setAttribute('aria-label', agent.name + (permanent ? ', built-in' : '') + ', ' + status + ', ' + wcLabel);
 
+    var badge = permanent
+      ? '<span class="roster-card__badge" title="Built-in agent — always available and cannot be deleted">Built-in</span>'
+      : '';
     li.innerHTML =
       avatarMarkup(agent, 'roster-card__avatar') +
       '<div class="roster-card__body">' +
-      '<p class="roster-card__name">' + esc(agent.name) + '</p>' +
+      '<div class="roster-card__namerow">' +
+      '<span class="roster-card__name">' + esc(agent.name) + '</span>' + badge +
+      '</div>' +
       '<p class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</p>' +
       '</div>' +
       '<span class="roster-card__status is-' + status + '" title="' + esc(status) + '"></span>';
@@ -950,6 +957,18 @@
     var sum = 0;
     String(name || '').split('').forEach(function (c) { sum += c.charCodeAt(0); });
     return palette[sum % palette.length];
+  }
+
+  // "Permanent residency" agents: the built-in CLI agents (Claude Code, Codex,
+  // Gemini CLI) and the Ori system assistant. They're always available and the
+  // server won't delete them.
+  function isPermanent(agent) {
+    if (!agent) return false;
+    var source = String(agent.source || '').toLowerCase();
+    var role = String(agent.role || '').toLowerCase();
+    if (source === 'cli' || role === 'cli_agent') return true;
+    var name = String(agent.name || '').trim().toLowerCase();
+    return name === 'ori' || name === '__assistant__';
   }
 
   function healthKind(agent) {

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -23,7 +23,7 @@
             </div>
             <div class="roster-rail__actions">
               <button type="button" id="newAgentBtn" class="roster-rail__new" title="Create a new agent">+ New</button>
-              <a class="roster-rail__classic" href="/agents" title="Switch back to the classic dashboard">Classic view</a>
+              <a class="roster-rail__classic" href="/agents?view=classic" title="Switch to the classic dashboard">Classic view</a>
             </div>
           </header>
 
@@ -81,7 +81,7 @@
 
             <div class="stage__panels">
               <section class="stage__panel is-active" role="tabpanel" id="panel-overview" aria-labelledby="tab-overview" tabindex="0">
-                <dl class="stage-facts" id="overviewFacts"></dl>
+                <div class="stage-editwrap" id="overviewFacts"></div>
                 <div class="stage-desc" id="overviewDesc"></div>
               </section>
               <section class="stage__panel" role="tabpanel" id="panel-prompt" aria-labelledby="tab-prompt" tabindex="0" hidden>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1659,6 +1659,7 @@
                 <p>Monitor health, start chats, and fix configuration issues.</p>
             </div>
             <div class="header-actions">
+                <a class="btn" href="/agents" title="Switch to the new roster view">New Agents view</a>
                 <a class="btn btn-primary" href="/agents/create">
                     <span>+</span> New Agent
                 </a>

--- a/tests/agents-roster.a11y.spec.js
+++ b/tests/agents-roster.a11y.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+// Accessibility regression for the Agents roster/stage, in both themes.
+// Mirrors tests/workspace-detail.a11y.spec.js: axe-core is loaded from a CDN and
+// scoped to the roster layout so pre-existing chrome (navbar/sidebar) doesn't
+// mask regressions in this component.
+const baseUrl = process.env.BASE_URL || 'http://localhost:8765';
+
+for (const theme of ['light', 'dark']) {
+  test(`agents roster accessibility (${theme})`, async ({ page, request }) => {
+    const name = `PW A11y ${theme} ${Date.now()}`;
+    const create = await request.post(`${baseUrl}/api/agents`, {
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+    });
+    expect(create.ok()).toBeTruthy();
+
+    try {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.addInitScript(selectedTheme => {
+        window.localStorage.setItem('ori-theme', selectedTheme);
+      }, theme);
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expect(page.locator('#stageName')).toHaveText(name);
+      await expect(page.locator('#overviewFacts .stage-form')).toBeVisible();
+
+      await page.addScriptTag({ url: 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js' });
+      const results = await page.evaluate(async () => {
+        const root = document.querySelector('.roster-layout');
+        return await window.axe.run(root, {
+          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+        });
+      });
+      expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+    } finally {
+      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+    }
+  });
+}

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+// Happy-path regression for the game-inspired Agents page (roster + stage).
+// Assumes a running server; create/cleanup a throwaway agent via the API so the
+// test is self-contained and order-independent.
+const baseUrl = process.env.BASE_URL || 'http://localhost:8765';
+
+test.describe('Agents roster', () => {
+  test('browse, select, edit, assign workspace, and delete', async ({ page, request }) => {
+    const name = `PW Roster ${Date.now()}`;
+
+    const create = await request.post(`${baseUrl}/api/agents`, {
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+    });
+    expect(create.ok()).toBeTruthy();
+
+    try {
+      // Keep onboarding out of the way and pin a theme for determinism.
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      // Roster is the default Agents view; deep-link straight to our agent.
+      await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      await expect(page.locator('#rosterList')).toBeVisible();
+      await expect(page.locator('#stageName')).toHaveText(name);
+
+      // Overview edit → save → persisted.
+      const desc = page.locator('#ov-description');
+      await expect(desc).toBeVisible();
+      await desc.fill('Edited by Playwright.');
+      const save = page.locator('#savebar-overview [data-role="save"]');
+      await expect(save).toBeEnabled();
+      await save.click();
+      await expect
+        .poll(async () => {
+          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(name)}/detail`);
+          return (await r.json()).metadata?.description;
+        })
+        .toBe('Edited by Playwright.');
+
+      // Prompt tab lazy-loads an editable textarea.
+      await page.locator('#tab-prompt').click();
+      await expect(page.locator('#pr-prompt')).toBeVisible();
+
+      // Workspaces tab renders the editable assignment list.
+      await page.locator('#tab-workspaces').click();
+      await expect(page.locator('#panel-workspaces')).toBeVisible();
+
+      // Delete via the stage button (auto-accept the confirm dialog).
+      page.once('dialog', dialog => dialog.accept());
+      await page.locator('#stageDelete').click();
+      await expect
+        .poll(async () => {
+          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(name)}/detail`);
+          return r.status();
+        })
+        .toBe(404);
+    } finally {
+      // Best-effort cleanup if the test bailed before the delete step.
+      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Final seam-PR (**G5**) of the game-inspired Agents page redesign. Makes the roster the **default** Agents view, hardens accessibility, adds regression tests, and highlights the built-in agents. Completes the epic (G1 #180 · G2 #181 · G3 #182 · G4 #183).

## What's here

- **Default flip:** `serveAgents` now serves the roster/stage page; the classic dashboard remains at `/agents?view=classic` (links both ways). The redundant `view=roster` URL param is dropped.
- **Built-in highlight:** the "permanent residency" agents — CLI agents (Claude Code, Codex, Gemini CLI) and the Ori system assistant — get a **filled amber card + "Built-in" badge**, kept visually distinct from the green selection highlight. The badge + an `aria-label` note are the non-color cues.
- **Accessibility** (driven by an axe spec, both themes):
  - darkened the avatar palette to 700-level shades so white initials meet AA;
  - active-tab text uses `--text-primary` with the colored underline as the active cue;
  - a lightened `--roster-accent` on dark for links/pills/dirty-note; badge/fill contrast tuned for AA in both themes;
  - associated every form input with a `<label for>`, gave roster cards a concise `aria-label`, and stopped rendering a form inside a `<dl>`.
- **Mobile:** single-column stack under 860px (roster strip above a full-width stage), condensed hero/facts, reduced-motion query.
- **Tests:** `tests/agents-roster.spec.ts` (browse → select → edit → delete) and `tests/agents-roster.a11y.spec.js` (axe, light + dark). Both pass.

## Verification

Driven end-to-end in a real browser against an isolated server: the default flip renders the roster, built-in cards are highlighted, and both Playwright specs pass. `go build`, `go vet`, and `eslint` are clean; full `go test ./...` is green except the pre-existing live-OpenAI integration test (`internal/llm/TestProviderIntegration`, 429 quota, env-dependent, API-key-gated in CI).

## Epic complete

With this merged, the roster/stage redesign is the live Agents page: browse a roster, select an agent onto a stage, and edit its Overview, Prompt, and Workspaces — plus create/delete — all against the G1 endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)