### PR TITLE
Revamp workspace details operations map

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -487,10 +487,10 @@
 .ws-cmd-map-belt {
   position: absolute;
   right: 18px;
-  bottom: 18px;
+  top: 18px;
   z-index: 3;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 8px;
 }
 .ws-cmd-map-belt-btn {
@@ -807,6 +807,29 @@
 }
 .ws-cmd-map-agent.alert .ws-cmd-map-agent-path {
   background: linear-gradient(90deg, transparent, rgba(226, 101, 77, 0.9), transparent);
+}
+.ws-cmd-map-entry-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  min-height: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--ws-keeper-deep);
+  background: rgba(232, 181, 75, 0.12);
+  color: var(--ws-keeper);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: uppercase;
+  padding: 4px 6px;
+}
+.ws-cmd-map-entry-badge i {
+  font-size: 10px;
+  line-height: 1;
 }
 .ws-cmd-map-agent-copy {
   width: 100%;
@@ -3433,17 +3456,18 @@
     min-height: 560px;
   }
   .ws-cmd-map-world {
-    padding: 24px 16px 88px;
+    padding: 78px 16px 24px;
   }
   .ws-cmd-map-floor {
     inset: 14px;
   }
   .ws-cmd-map-belt {
-    left: 50%;
-    right: auto;
-    bottom: 16px;
+    top: 16px;
+    right: 16px;
+    bottom: auto;
+    left: auto;
     flex-direction: row;
-    transform: translateX(-50%);
+    transform: none;
   }
   .ws-cmd-map-belt-btn {
     width: 44px;

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -115,6 +115,39 @@
   outline: 2px solid var(--ws-faction);
   outline-offset: 2px;
 }
+.ws-cmd-view-switch {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.2);
+}
+.ws-cmd-view-btn {
+  min-height: 28px;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ws-ink-faint);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+.ws-cmd-view-btn:hover {
+  color: var(--ws-faction);
+}
+.ws-cmd-view-btn.is-active {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
+}
+.ws-cmd-view-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-crest {
   width: 50px;
   height: 50px;
@@ -381,6 +414,755 @@
 .ws-cmd-stat.is-alert .ws-v,
 .ws-cmd-stat.is-alert .ws-l {
   color: var(--ws-alert);
+}
+
+/* ---------- Operations Map mode ---------- */
+.ws-cmd-map-shell {
+  position: relative;
+}
+.ws-cmd-opmap {
+  position: relative;
+  min-height: clamp(560px, 62vh, 780px);
+  overflow: hidden;
+  border: 1px solid var(--ws-line);
+  background:
+    radial-gradient(circle at 28% 28%, rgba(78, 149, 224, 0.14), transparent 28%),
+    radial-gradient(circle at 72% 74%, rgba(232, 181, 75, 0.1), transparent 26%),
+    linear-gradient(rgba(70, 211, 154, 0.026) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(70, 211, 154, 0.024) 1px, transparent 1px),
+    linear-gradient(180deg, var(--ws-panel), #0c0d11 78%);
+  background-size:
+    auto,
+    auto,
+    42px 42px,
+    42px 42px,
+    auto;
+  box-shadow: var(--ws-glow);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
+}
+.ws-cmd-map-world {
+  min-height: inherit;
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 40px 82px 76px 40px;
+  isolation: isolate;
+}
+.ws-cmd-map-floor {
+  position: absolute;
+  inset: 24px;
+  z-index: -1;
+  border: 1px solid rgba(70, 211, 154, 0.13);
+  background:
+    linear-gradient(120deg, transparent 0 44%, rgba(70, 211, 154, 0.1) 45% 46%, transparent 47%),
+    radial-gradient(circle at 50% 46%, rgba(70, 211, 154, 0.1), transparent 42%),
+    repeating-linear-gradient(0deg, transparent 0 37px, rgba(70, 211, 154, 0.045) 38px 39px),
+    repeating-linear-gradient(90deg, transparent 0 37px, rgba(70, 211, 154, 0.04) 38px 39px);
+  clip-path: polygon(3% 0, 100% 0, 100% 92%, 94% 100%, 0 100%, 0 7%);
+}
+.ws-cmd-map-floor::before,
+.ws-cmd-map-floor::after {
+  content: "";
+  position: absolute;
+  border: 1px solid rgba(70, 211, 154, 0.12);
+  pointer-events: none;
+}
+.ws-cmd-map-floor::before {
+  inset: 13%;
+}
+.ws-cmd-map-floor::after {
+  width: 160px;
+  height: 160px;
+  left: calc(50% - 80px);
+  top: calc(50% - 80px);
+  border-radius: 50%;
+}
+.ws-cmd-map-belt {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ws-cmd-map-belt-btn {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.84);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+}
+.ws-cmd-map-belt-btn i {
+  font-size: 18px;
+  line-height: 1;
+}
+.ws-cmd-map-belt-btn:hover,
+.ws-cmd-map-belt-btn.is-active {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.1);
+}
+.ws-cmd-map-window-backdrop {
+  position: fixed;
+  inset: clamp(76px, 10vh, 112px) 16px 16px;
+  z-index: 10010;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(2, 3, 6, 0.48);
+  backdrop-filter: blur(2px);
+}
+.ws-cmd-map-window {
+  width: min(780px, 100%);
+  max-height: min(760px, 100%);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--ws-line-bright);
+  background:
+    linear-gradient(rgba(70, 211, 154, 0.028) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(70, 211, 154, 0.025) 1px, transparent 1px),
+    linear-gradient(180deg, #15171c, #0b0c10);
+  background-size:
+    34px 34px,
+    34px 34px,
+    auto;
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.5),
+    var(--ws-glow);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
+}
+.ws-cmd-map-window-inventory {
+  width: min(980px, 100%);
+}
+.ws-cmd-map-window-inspector {
+  width: min(620px, 100%);
+}
+.ws-cmd-map-window-head {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.2);
+}
+.ws-cmd-map-window-head div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ws-faction);
+  font-family: var(--ws-font-display);
+  font-size: 17px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+.ws-cmd-map-window-head span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-map-window-close {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+}
+.ws-cmd-map-window-close:hover {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction-deep);
+}
+.ws-cmd-map-window-body {
+  min-height: 0;
+  overflow: auto;
+  padding: 14px;
+}
+.ws-cmd-map-window-section {
+  min-width: 0;
+}
+.ws-cmd-map-window-section.is-objective .ws-cmd-mission {
+  box-shadow: none;
+}
+.ws-cmd-map-zone-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 0 12px;
+}
+.ws-cmd-map-zone-head div {
+  min-width: 0;
+}
+.ws-cmd-map-zone-head span {
+  display: block;
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+}
+.ws-cmd-map-zone-head strong {
+  display: block;
+  margin-top: 3px;
+  color: #eef0f3;
+  font-size: 15px;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+  overflow-wrap: anywhere;
+}
+.ws-cmd-map-zone-count {
+  min-width: 32px;
+  min-height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.06);
+  font-family: var(--ws-font-mono);
+  font-size: 14px;
+}
+.ws-cmd-map-task-list,
+.ws-cmd-map-station-grid,
+.ws-cmd-map-agent-field,
+.ws-cmd-map-inspector-card {
+  padding: 0;
+}
+.ws-cmd-map-task-list {
+  display: grid;
+  gap: 8px;
+}
+.ws-cmd-map-task-row,
+.ws-cmd-map-station,
+.ws-cmd-map-inventory-slot {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--ws-ink);
+  cursor: pointer;
+  text-align: left;
+}
+.ws-cmd-map-task-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 10px;
+}
+.ws-cmd-map-task-row:hover,
+.ws-cmd-map-station:hover,
+.ws-cmd-map-inventory-slot:hover {
+  border-color: var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+}
+.ws-cmd-map-task-row:focus-visible,
+.ws-cmd-map-station:focus-visible,
+.ws-cmd-map-inventory-slot:focus-visible,
+.ws-cmd-map-zone-action:focus-visible,
+.ws-cmd-map-inventory-total:focus-visible,
+.ws-cmd-map-inventory-badge:focus-visible,
+.ws-cmd-map-inventory-group button:focus-visible,
+.ws-cmd-map-agent:focus-visible,
+.ws-cmd-map-belt-btn:focus-visible,
+.ws-cmd-map-window-close:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-map-task-name,
+.ws-cmd-map-slot-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-map-task-status,
+.ws-cmd-map-inventory-slot em {
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  font-style: normal;
+}
+.ws-cmd-map-task-row.alert .ws-cmd-map-task-status {
+  color: var(--ws-alert);
+}
+.ws-cmd-map-task-row.working .ws-cmd-map-task-status {
+  color: var(--ws-faction);
+}
+.ws-cmd-map-zone-action {
+  margin-top: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+.ws-cmd-map-station-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.ws-cmd-map-station {
+  min-height: 82px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 11px;
+}
+.ws-cmd-map-station span {
+  color: var(--ws-ink-dim);
+  font-size: 12px;
+}
+.ws-cmd-map-station strong {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 24px;
+}
+.ws-cmd-map-agent-field {
+  width: min(100%, 980px);
+  min-height: 410px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+  align-content: center;
+  justify-content: center;
+  gap: 18px;
+  position: relative;
+}
+.ws-cmd-map-agent {
+  min-width: 0;
+  min-height: 152px;
+  position: relative;
+  display: grid;
+  place-items: center;
+  gap: 5px;
+  padding: 12px 10px 10px;
+  border: 1px solid var(--ws-line);
+  background: radial-gradient(circle at 50% 24%, rgba(70, 211, 154, 0.13), rgba(0, 0, 0, 0.16) 62%);
+  color: var(--ws-ink);
+  cursor: pointer;
+  transition:
+    transform 0.22s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 12px), calc(100% - 12px) 100%, 0 100%);
+}
+.ws-cmd-map-agent:hover,
+.ws-cmd-map-agent.is-selected {
+  border-color: var(--ws-faction);
+  background: radial-gradient(circle at 50% 24%, rgba(70, 211, 154, 0.23), rgba(0, 0, 0, 0.12) 64%);
+}
+.ws-cmd-map-agent.alert {
+  border-color: rgba(226, 101, 77, 0.52);
+  background: radial-gradient(circle at 50% 24%, rgba(226, 101, 77, 0.2), rgba(0, 0, 0, 0.12) 64%);
+}
+.ws-cmd-map-agent.working {
+  border-color: rgba(70, 211, 154, 0.52);
+}
+.ws-cmd-map-agent.toward-tasks {
+  transform: translateY(-4px);
+}
+.ws-cmd-map-agent.toward-tools {
+  transform: translate(5px, -5px);
+}
+.ws-cmd-map-agent.is-selected {
+  transform: translateY(-7px);
+}
+.ws-cmd-map-agent-path {
+  position: absolute;
+  inset: auto 16px 12px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(70, 211, 154, 0.8), transparent);
+  opacity: 0.32;
+}
+.ws-cmd-map-agent.alert .ws-cmd-map-agent-path {
+  background: linear-gradient(90deg, transparent, rgba(226, 101, 77, 0.9), transparent);
+}
+.ws-cmd-map-agent-copy {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  text-align: center;
+}
+.ws-cmd-map-agent-copy strong,
+.ws-cmd-map-agent-copy span,
+.ws-cmd-map-agent-copy em {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-map-agent-copy strong {
+  color: #eef0f3;
+  font-size: 13px;
+}
+.ws-cmd-map-agent-copy span {
+  color: var(--ws-ink-dim);
+  font-size: 11px;
+}
+.ws-cmd-map-agent-copy em {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+  font-style: normal;
+}
+.ws-cmd-map-agent.alert .ws-cmd-map-agent-copy em {
+  color: var(--ws-alert);
+}
+.ws-cmd-map-inspector-card {
+  display: grid;
+  gap: 12px;
+}
+.ws-cmd-map-agent-sheet-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-map-agent-sheet-head .ws-cmd-character {
+  width: 74px;
+  height: 74px;
+  flex: 0 0 auto;
+}
+.ws-cmd-map-agent-sheet-head div {
+  min-width: 0;
+}
+.ws-cmd-map-agent-sheet-head span {
+  display: block;
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+.ws-cmd-map-agent-sheet-head strong {
+  display: block;
+  margin-top: 3px;
+  color: #eef0f3;
+  font-family: var(--ws-font-display);
+  font-size: 22px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  overflow-wrap: anywhere;
+}
+.ws-cmd-map-agent-sheet-head p {
+  margin: 6px 0 0;
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-sheet {
+  display: grid;
+  gap: 12px;
+}
+.ws-cmd-rpg-status-strip,
+.ws-cmd-rpg-sheet-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-rpg-status-strip strong,
+.ws-cmd-rpg-status-strip span:last-child,
+.ws-cmd-rpg-sheet-row strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.ws-cmd-rpg-status-strip span:last-child {
+  color: var(--ws-ink-dim);
+  font-size: 12px;
+}
+.ws-cmd-rpg-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+.ws-cmd-rpg-stat {
+  min-height: 82px;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 5px;
+  border: 1px solid var(--ws-line);
+  background:
+    radial-gradient(circle at 50% 20%, rgba(70, 211, 154, 0.11), transparent 58%),
+    rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-rpg-stat span,
+.ws-cmd-rpg-quest-card span,
+.ws-cmd-rpg-sheet-row span {
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-stat strong {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-display);
+  font-size: 27px;
+  line-height: 1;
+}
+.ws-cmd-rpg-quest-card {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+}
+.ws-cmd-rpg-quest-card strong {
+  min-width: 0;
+  color: #eef0f3;
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+.ws-cmd-rpg-quest-card p {
+  margin: 0;
+  min-width: 0;
+  color: var(--ws-ink-dim);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+.ws-cmd-rpg-sheet-row {
+  justify-content: space-between;
+  align-items: flex-start;
+}
+.ws-cmd-rpg-sheet-row strong {
+  color: var(--ws-ink);
+  font-size: 12px;
+  text-align: right;
+}
+.ws-cmd-rpg-effects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.ws-cmd-rpg-effects span {
+  min-height: 25px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  padding: 4px 8px;
+}
+.ws-cmd-map-inspector-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ws-cmd-map-inventory-box {
+  display: grid;
+  gap: 12px;
+}
+.ws-cmd-map-inventory-summary {
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+.ws-cmd-map-inventory-total {
+  width: 100%;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.07);
+  color: var(--ws-ink);
+  font-family: var(--ws-font-display);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  padding: 10px 12px;
+}
+.ws-cmd-map-inventory-total strong {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 20px;
+}
+.ws-cmd-map-inventory-badges {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+.ws-cmd-map-inventory-badge {
+  min-width: 0;
+  min-height: 46px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  padding: 7px 8px;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+}
+.ws-cmd-map-inventory-badge i {
+  color: var(--ws-faction);
+  font-size: 16px;
+}
+.ws-cmd-map-inventory-badge span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-map-inventory-badge strong {
+  color: var(--ws-faction);
+}
+.ws-cmd-map-inventory-badge.is-active {
+  border-color: var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.08);
+  color: var(--ws-faction);
+}
+.ws-cmd-map-inventory-drawer {
+  display: grid;
+  gap: 10px;
+}
+.ws-cmd-map-inventory-group {
+  display: none;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.16);
+}
+.ws-cmd-map-inventory-group.is-active {
+  display: block;
+}
+.ws-cmd-map-inventory-group header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border-bottom: 1px solid var(--ws-line);
+}
+.ws-cmd-map-inventory-group header span {
+  display: block;
+  color: var(--ws-ink-faint);
+  font-size: 11px;
+}
+.ws-cmd-map-inventory-group header strong {
+  color: #eef0f3;
+}
+.ws-cmd-map-inventory-group button {
+  border: 1px solid var(--ws-faction-deep);
+  background: rgba(70, 211, 154, 0.07);
+  color: var(--ws-faction);
+  cursor: pointer;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 7px 9px;
+}
+.ws-cmd-map-inventory-list {
+  padding: 8px 9px;
+}
+.ws-cmd-map-inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+  gap: 9px;
+}
+.ws-cmd-map-inventory-slot {
+  min-height: 116px;
+  display: grid;
+  grid-template-rows: auto minmax(0, auto) auto;
+  justify-items: center;
+  align-content: center;
+  gap: 7px;
+  padding: 10px 8px;
+  text-align: center;
+  background:
+    radial-gradient(circle at 50% 20%, rgba(70, 211, 154, 0.09), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-empty {
+  cursor: default;
+  color: var(--ws-ink-faint);
+  border-style: dashed;
+  opacity: 0.68;
+}
+.ws-cmd-map-inventory-slot.is-empty:hover {
+  border-color: var(--ws-line);
+  background: rgba(0, 0, 0, 0.16);
+}
+.ws-cmd-map-slot-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.07);
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 18px;
+  line-height: 1;
+}
+.ws-cmd-map-slot-name {
+  width: 100%;
+  color: #eef0f3;
+  font-size: 12px;
+  font-weight: 700;
+}
+.ws-cmd-map-empty {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  color: var(--ws-ink-faint);
+  font-size: 13px;
+}
+.ws-cmd-map-empty strong {
+  color: var(--ws-ink);
 }
 
 /* ---------- layout (garrison + rail scaffold; filled in Phase 2-3) ---------- */
@@ -2526,6 +3308,9 @@
   .ws-cmd-mission.is-empty {
     max-height: none;
   }
+  .ws-cmd-map-world {
+    padding: 34px 76px 72px 34px;
+  }
   .ws-cmd-deck {
     grid-template-columns: minmax(220px, 0.8fr) minmax(340px, 1.2fr);
   }
@@ -2550,6 +3335,9 @@
   .ws-cmd-topbar {
     align-items: flex-start;
   }
+  .ws-cmd-view-switch {
+    margin-left: 0;
+  }
   .ws-cmd-title {
     flex-basis: calc(100% - 70px);
   }
@@ -2573,6 +3361,12 @@
   .ws-cmd-layout {
     grid-template-columns: 1fr;
   }
+  .ws-cmd-map-world {
+    padding: 28px 72px 72px 28px;
+  }
+  .ws-cmd-map-window-backdrop {
+    padding: 18px;
+  }
   .ws-cmd-mission {
     flex-direction: column;
   }
@@ -2589,6 +3383,16 @@
 @media (max-width: 767px) {
   .ws-cmd-deck {
     grid-template-columns: minmax(0, 1fr);
+  }
+  .ws-cmd-map-agent-field {
+    min-height: 0;
+    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  }
+  .ws-cmd-rpg-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .ws-cmd-map-inventory-grid {
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
   }
   .ws-cmd-agent-stage {
     min-height: 450px;
@@ -2618,6 +3422,61 @@
   .ws-cmd-nav-btn {
     flex: 1 1 calc(50% - 8px);
     justify-content: center;
+  }
+  .ws-cmd-view-switch {
+    flex: 1 1 100%;
+  }
+  .ws-cmd-view-btn {
+    flex: 1 1 0;
+  }
+  .ws-cmd-opmap {
+    min-height: 560px;
+  }
+  .ws-cmd-map-world {
+    padding: 24px 16px 88px;
+  }
+  .ws-cmd-map-floor {
+    inset: 14px;
+  }
+  .ws-cmd-map-belt {
+    left: 50%;
+    right: auto;
+    bottom: 16px;
+    flex-direction: row;
+    transform: translateX(-50%);
+  }
+  .ws-cmd-map-belt-btn {
+    width: 44px;
+    height: 44px;
+  }
+  .ws-cmd-map-window-backdrop {
+    padding: 12px;
+  }
+  .ws-cmd-map-window {
+    max-height: calc(100% - 12px);
+  }
+  .ws-cmd-map-station-grid,
+  .ws-cmd-map-inventory-badges {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ws-cmd-map-task-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ws-cmd-map-inventory-group header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .ws-cmd-map-inventory-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .ws-cmd-map-inventory-slot {
+    min-height: 104px;
+  }
+  .ws-cmd-rpg-sheet-row {
+    display: grid;
+  }
+  .ws-cmd-rpg-sheet-row strong {
+    text-align: left;
   }
   .ws-cmd-crest {
     width: 42px;
@@ -2690,7 +3549,9 @@
   }
   .ws-cmd-mission,
   .ws-cmd-garrison,
-  .ws-cmd-rail {
+  .ws-cmd-rail,
+  .ws-cmd-map-world,
+  .ws-cmd-map-window {
     animation: ws-cmd-rise 0.4s ease both;
     animation-delay: 0.05s;
   }
@@ -2705,5 +3566,11 @@
   }
   .ws-cmd-modal-panel {
     animation: ws-cmd-rise 0.22s ease both;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ws-cmd-map-agent,
+  .ws-cmd-map-window {
+    transition: none;
   }
 }

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -589,8 +589,9 @@
   inset: clamp(76px, 10vh, 112px) 16px 16px;
   z-index: 10010;
   display: grid;
-  place-items: center;
+  place-items: start center;
   padding: 28px;
+  overflow: hidden;
   background: rgba(2, 3, 6, 0.48);
   backdrop-filter: blur(2px);
 }
@@ -625,7 +626,7 @@
   width: min(980px, 100%);
 }
 .ws-cmd-map-window-inspector {
-  width: min(620px, 100%);
+  width: min(940px, 100%);
 }
 .ws-cmd-map-window-head {
   min-height: 54px;
@@ -1037,6 +1038,23 @@
   display: grid;
   gap: 12px;
 }
+@media (min-width: 760px) {
+  .ws-cmd-map-window-inspector .ws-cmd-map-inspector-card {
+    grid-template-columns: minmax(0, 1fr) minmax(290px, 0.74fr);
+    align-items: start;
+  }
+  .ws-cmd-map-window-inspector .ws-cmd-map-agent-sheet-head {
+    grid-column: 1 / -1;
+  }
+  .ws-cmd-map-window-inspector .ws-cmd-rpg-sheet {
+    grid-column: 1;
+  }
+  .ws-cmd-map-window-inspector .ws-cmd-rpg-command-panel {
+    grid-column: 2;
+    grid-row: 2;
+    align-self: start;
+  }
+}
 .ws-cmd-map-agent-sheet-head {
   display: flex;
   align-items: center;
@@ -1255,6 +1273,123 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+.ws-cmd-rpg-command-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(70, 211, 154, 0.18);
+  background:
+    linear-gradient(120deg, rgba(70, 211, 154, 0.08), transparent 58%), rgba(0, 0, 0, 0.18);
+  padding: 12px;
+}
+.ws-cmd-rpg-command-panel header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.ws-cmd-rpg-command-panel header span {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-command-panel header strong {
+  min-width: 0;
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-rpg-command-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.ws-cmd-rpg-command {
+  width: 100%;
+  min-width: 0;
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--ws-line);
+  background: rgba(5, 7, 10, 0.44);
+  color: var(--ws-ink);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  padding: 9px;
+}
+.ws-cmd-rpg-command i {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+  color: var(--ws-faction);
+  font-size: 15px;
+}
+.ws-cmd-rpg-command span {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.ws-cmd-rpg-command strong,
+.ws-cmd-rpg-command small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-rpg-command strong {
+  color: #eef0f3;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-command small {
+  color: var(--ws-ink-faint);
+  font-size: 11px;
+}
+.ws-cmd-rpg-command:hover {
+  border-color: var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.07);
+  text-decoration: none;
+}
+.ws-cmd-rpg-command:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-rpg-command.is-primary {
+  border-color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.12);
+}
+.ws-cmd-rpg-command.is-alert {
+  border-color: rgba(226, 101, 77, 0.55);
+  background: rgba(226, 101, 77, 0.1);
+}
+.ws-cmd-rpg-command.is-alert i {
+  color: var(--ws-alert);
+  border-color: rgba(226, 101, 77, 0.48);
+  background: rgba(226, 101, 77, 0.08);
+}
+.ws-cmd-rpg-command.is-needs-input {
+  border-color: rgba(240, 138, 75, 0.58);
+  background: rgba(240, 138, 75, 0.1);
+}
+.ws-cmd-rpg-command.is-needs-input i {
+  color: var(--ws-input);
+  border-color: rgba(240, 138, 75, 0.5);
+  background: rgba(240, 138, 75, 0.08);
 }
 .ws-cmd-map-inventory-box {
   display: grid;
@@ -3794,7 +3929,8 @@
   }
   .ws-cmd-map-station-grid,
   .ws-cmd-map-inventory-badges,
-  .ws-cmd-rpg-class-grid {
+  .ws-cmd-rpg-class-grid,
+  .ws-cmd-rpg-command-grid {
     grid-template-columns: minmax(0, 1fr);
   }
   .ws-cmd-map-task-row {

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -487,6 +487,111 @@
   top: calc(50% - 80px);
   border-radius: 50%;
 }
+.ws-cmd-map-stations {
+  position: absolute;
+  inset: 72px 42px 42px;
+  z-index: 3;
+  pointer-events: none;
+}
+.ws-cmd-map-station-node {
+  position: absolute;
+  width: 142px;
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(70, 211, 154, 0.16);
+  background:
+    linear-gradient(120deg, rgba(70, 211, 154, 0.08), transparent 62%), rgba(5, 7, 10, 0.62);
+  color: var(--ws-ink);
+  cursor: pointer;
+  pointer-events: auto;
+  text-align: left;
+  padding: 8px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(4px);
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%);
+}
+.ws-cmd-map-station-node.is-objective {
+  top: 0;
+  left: 0;
+}
+.ws-cmd-map-station-node.is-quests {
+  bottom: 7%;
+  left: 4%;
+}
+.ws-cmd-map-station-node.is-inventory {
+  top: 70px;
+  right: 0;
+}
+.ws-cmd-map-station-node.is-sessions {
+  right: 5%;
+  bottom: 6%;
+}
+.ws-cmd-map-station-node.is-systems {
+  top: 0;
+  left: calc(50% - 71px);
+}
+.ws-cmd-map-station-node:hover,
+.ws-cmd-map-station-node.is-active {
+  border-color: var(--ws-faction);
+  background:
+    linear-gradient(120deg, rgba(70, 211, 154, 0.14), transparent 62%), rgba(5, 7, 10, 0.76);
+}
+.ws-cmd-map-station-node:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-map-station-node.has-signal::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+  border: 1px solid rgba(70, 211, 154, 0.18);
+  pointer-events: none;
+  animation: ws-cmd-station-signal 1.8s ease-in-out infinite;
+}
+.ws-cmd-map-station-icon {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(70, 211, 154, 0.06);
+  color: var(--ws-faction);
+  font-size: 15px;
+}
+.ws-cmd-map-station-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.ws-cmd-map-station-copy strong,
+.ws-cmd-map-station-copy small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-cmd-map-station-copy strong {
+  color: #eef0f3;
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-map-station-copy small {
+  color: var(--ws-ink-faint);
+  font-size: 10px;
+}
+.ws-cmd-map-station-node em {
+  min-width: 24px;
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  font-style: normal;
+  text-align: right;
+}
 .ws-cmd-map-belt {
   position: absolute;
   right: 18px;
@@ -3835,6 +3940,12 @@
   .ws-cmd-map-world {
     padding: 28px 72px 72px 28px;
   }
+  .ws-cmd-map-stations {
+    inset: 82px 22px 28px;
+  }
+  .ws-cmd-map-station-node {
+    width: 126px;
+  }
   .ws-cmd-map-window-backdrop {
     padding: 18px;
   }
@@ -3920,6 +4031,39 @@
   .ws-cmd-map-belt-btn {
     width: 44px;
     height: 44px;
+  }
+  .ws-cmd-map-stations {
+    inset: auto 14px 18px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 6px;
+  }
+  .ws-cmd-map-station-node,
+  .ws-cmd-map-station-node.is-objective,
+  .ws-cmd-map-station-node.is-quests,
+  .ws-cmd-map-station-node.is-inventory,
+  .ws-cmd-map-station-node.is-sessions,
+  .ws-cmd-map-station-node.is-systems {
+    position: static;
+    width: min(106px, calc(33.33vw - 14px));
+    min-height: 46px;
+    grid-template-columns: 26px minmax(0, 1fr);
+    gap: 6px;
+    padding: 7px;
+  }
+  .ws-cmd-map-station-node em,
+  .ws-cmd-map-station-copy small {
+    display: none;
+  }
+  .ws-cmd-map-station-icon {
+    width: 26px;
+    height: 26px;
+    font-size: 13px;
+  }
+  .ws-cmd-map-station-copy strong {
+    font-size: 9px;
   }
   .ws-cmd-map-window-backdrop {
     padding: 12px;
@@ -4017,6 +4161,12 @@
     opacity: 0.58;
   }
 }
+@keyframes ws-cmd-station-signal {
+  50% {
+    opacity: 0.3;
+    transform: scale(1.05);
+  }
+}
 @media (prefers-reduced-motion: no-preference) {
   .ws-cmd-topbar {
     animation: ws-cmd-rise 0.35s ease both;
@@ -4053,5 +4203,8 @@
   .ws-cmd-map-agent,
   .ws-cmd-map-window {
     transition: none;
+  }
+  .ws-cmd-map-station-node.has-signal::after {
+    animation: none;
   }
 }

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -487,111 +487,6 @@
   top: calc(50% - 80px);
   border-radius: 50%;
 }
-.ws-cmd-map-stations {
-  position: absolute;
-  inset: 72px 42px 42px;
-  z-index: 3;
-  pointer-events: none;
-}
-.ws-cmd-map-station-node {
-  position: absolute;
-  width: 142px;
-  min-height: 58px;
-  display: grid;
-  grid-template-columns: 32px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid rgba(70, 211, 154, 0.16);
-  background:
-    linear-gradient(120deg, rgba(70, 211, 154, 0.08), transparent 62%), rgba(5, 7, 10, 0.62);
-  color: var(--ws-ink);
-  cursor: pointer;
-  pointer-events: auto;
-  text-align: left;
-  padding: 8px;
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
-  backdrop-filter: blur(4px);
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%);
-}
-.ws-cmd-map-station-node.is-objective {
-  top: 0;
-  left: 0;
-}
-.ws-cmd-map-station-node.is-quests {
-  bottom: 7%;
-  left: 4%;
-}
-.ws-cmd-map-station-node.is-inventory {
-  top: 70px;
-  right: 0;
-}
-.ws-cmd-map-station-node.is-sessions {
-  right: 5%;
-  bottom: 6%;
-}
-.ws-cmd-map-station-node.is-systems {
-  top: 0;
-  left: calc(50% - 71px);
-}
-.ws-cmd-map-station-node:hover,
-.ws-cmd-map-station-node.is-active {
-  border-color: var(--ws-faction);
-  background:
-    linear-gradient(120deg, rgba(70, 211, 154, 0.14), transparent 62%), rgba(5, 7, 10, 0.76);
-}
-.ws-cmd-map-station-node:focus-visible {
-  outline: 2px solid var(--ws-faction);
-  outline-offset: 2px;
-}
-.ws-cmd-map-station-node.has-signal::after {
-  content: "";
-  position: absolute;
-  inset: -7px;
-  border: 1px solid rgba(70, 211, 154, 0.18);
-  pointer-events: none;
-  animation: ws-cmd-station-signal 1.8s ease-in-out infinite;
-}
-.ws-cmd-map-station-icon {
-  width: 32px;
-  height: 32px;
-  display: grid;
-  place-items: center;
-  border: 1px solid var(--ws-line-bright);
-  background: rgba(70, 211, 154, 0.06);
-  color: var(--ws-faction);
-  font-size: 15px;
-}
-.ws-cmd-map-station-copy {
-  min-width: 0;
-  display: grid;
-  gap: 2px;
-}
-.ws-cmd-map-station-copy strong,
-.ws-cmd-map-station-copy small {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.ws-cmd-map-station-copy strong {
-  color: #eef0f3;
-  font-family: var(--ws-font-mono);
-  font-size: 10px;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-.ws-cmd-map-station-copy small {
-  color: var(--ws-ink-faint);
-  font-size: 10px;
-}
-.ws-cmd-map-station-node em {
-  min-width: 24px;
-  color: var(--ws-faction);
-  font-family: var(--ws-font-mono);
-  font-size: 11px;
-  font-style: normal;
-  text-align: right;
-}
 .ws-cmd-map-belt {
   position: absolute;
   right: 18px;
@@ -3940,12 +3835,6 @@
   .ws-cmd-map-world {
     padding: 28px 72px 72px 28px;
   }
-  .ws-cmd-map-stations {
-    inset: 82px 22px 28px;
-  }
-  .ws-cmd-map-station-node {
-    width: 126px;
-  }
   .ws-cmd-map-window-backdrop {
     padding: 18px;
   }
@@ -4031,39 +3920,6 @@
   .ws-cmd-map-belt-btn {
     width: 44px;
     height: 44px;
-  }
-  .ws-cmd-map-stations {
-    inset: auto 14px 18px;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    justify-content: center;
-    gap: 6px;
-  }
-  .ws-cmd-map-station-node,
-  .ws-cmd-map-station-node.is-objective,
-  .ws-cmd-map-station-node.is-quests,
-  .ws-cmd-map-station-node.is-inventory,
-  .ws-cmd-map-station-node.is-sessions,
-  .ws-cmd-map-station-node.is-systems {
-    position: static;
-    width: min(106px, calc(33.33vw - 14px));
-    min-height: 46px;
-    grid-template-columns: 26px minmax(0, 1fr);
-    gap: 6px;
-    padding: 7px;
-  }
-  .ws-cmd-map-station-node em,
-  .ws-cmd-map-station-copy small {
-    display: none;
-  }
-  .ws-cmd-map-station-icon {
-    width: 26px;
-    height: 26px;
-    font-size: 13px;
-  }
-  .ws-cmd-map-station-copy strong {
-    font-size: 9px;
   }
   .ws-cmd-map-window-backdrop {
     padding: 12px;
@@ -4161,12 +4017,6 @@
     opacity: 0.58;
   }
 }
-@keyframes ws-cmd-station-signal {
-  50% {
-    opacity: 0.3;
-    transform: scale(1.05);
-  }
-}
 @media (prefers-reduced-motion: no-preference) {
   .ws-cmd-topbar {
     animation: ws-cmd-rise 0.35s ease both;
@@ -4203,8 +4053,5 @@
   .ws-cmd-map-agent,
   .ws-cmd-map-window {
     transition: none;
-  }
-  .ws-cmd-map-station-node.has-signal::after {
-    animation: none;
   }
 }

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -34,6 +34,9 @@
   --ws-idle: #4ec5e6;
   --ws-working: #46d39a;
   --ws-alert: #e2654d;
+  --ws-waiting: #e8b54b;
+  --ws-input: #f08a4b;
+  --ws-done: #93d66b;
 
   /* geometry */
   --ws-clip: 14px;
@@ -673,8 +676,37 @@
 .ws-cmd-map-window-section {
   min-width: 0;
 }
+.ws-cmd-map-quest-frame {
+  display: grid;
+  gap: 12px;
+}
+.ws-cmd-map-quest-frame-head {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(70, 211, 154, 0.2);
+  background: linear-gradient(90deg, rgba(70, 211, 154, 0.1), transparent 58%), rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-map-quest-frame-head span {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-map-quest-frame-head strong {
+  color: #eef0f3;
+  font-family: var(--ws-font-display);
+  font-size: 16px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
 .ws-cmd-map-window-section.is-objective .ws-cmd-mission {
   box-shadow: none;
+  clip-path: none;
 }
 .ws-cmd-map-zone-head {
   display: flex;
@@ -737,10 +769,24 @@
 }
 .ws-cmd-map-task-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
+  min-height: 52px;
   padding: 9px 10px;
+}
+.ws-cmd-map-task-marker {
+  min-height: 24px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--ws-line);
+  background: rgba(70, 211, 154, 0.06);
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  padding: 3px 7px;
 }
 .ws-cmd-map-task-row:hover,
 .ws-cmd-map-station:hover,
@@ -782,6 +828,12 @@
 }
 .ws-cmd-map-task-row.working .ws-cmd-map-task-status {
   color: var(--ws-faction);
+}
+.ws-cmd-map-task-row.needs-input .ws-cmd-map-task-status {
+  color: var(--ws-input);
+}
+.ws-cmd-map-task-row.done .ws-cmd-map-task-status {
+  color: var(--ws-done);
 }
 .ws-cmd-map-zone-action {
   margin-top: 12px;
@@ -856,6 +908,22 @@
 .ws-cmd-map-agent.working {
   border-color: rgba(70, 211, 154, 0.52);
 }
+.ws-cmd-map-agent.waiting {
+  border-color: rgba(232, 181, 75, 0.46);
+  background: radial-gradient(circle at 50% 24%, rgba(232, 181, 75, 0.16), rgba(0, 0, 0, 0.12) 64%);
+}
+.ws-cmd-map-agent.needs-input {
+  border-color: rgba(240, 138, 75, 0.58);
+  background: radial-gradient(circle at 50% 24%, rgba(240, 138, 75, 0.2), rgba(0, 0, 0, 0.12) 64%);
+}
+.ws-cmd-map-agent.done {
+  border-color: rgba(147, 214, 107, 0.46);
+  background: radial-gradient(
+    circle at 50% 24%,
+    rgba(147, 214, 107, 0.14),
+    rgba(0, 0, 0, 0.12) 64%
+  );
+}
 .ws-cmd-map-agent.toward-tasks {
   transform: translateY(-4px);
 }
@@ -874,6 +942,31 @@
 }
 .ws-cmd-map-agent.alert .ws-cmd-map-agent-path {
   background: linear-gradient(90deg, transparent, rgba(226, 101, 77, 0.9), transparent);
+}
+.ws-cmd-map-agent.waiting .ws-cmd-map-agent-path {
+  background: linear-gradient(90deg, transparent, rgba(232, 181, 75, 0.86), transparent);
+}
+.ws-cmd-map-agent.needs-input .ws-cmd-map-agent-path {
+  background: linear-gradient(90deg, transparent, rgba(240, 138, 75, 0.9), transparent);
+}
+.ws-cmd-map-agent.done .ws-cmd-map-agent-path {
+  background: linear-gradient(90deg, transparent, rgba(147, 214, 107, 0.84), transparent);
+}
+.ws-cmd-map-agent-status {
+  position: absolute;
+  top: 9px;
+  left: 9px;
+  z-index: 1;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.24);
+}
+.ws-cmd-map-agent-status .ws-cmd-led {
+  width: 8px;
+  height: 8px;
 }
 .ws-cmd-map-entry-badge {
   position: absolute;
@@ -931,6 +1024,15 @@
 .ws-cmd-map-agent.alert .ws-cmd-map-agent-copy em {
   color: var(--ws-alert);
 }
+.ws-cmd-map-agent.waiting .ws-cmd-map-agent-copy em {
+  color: var(--ws-waiting);
+}
+.ws-cmd-map-agent.needs-input .ws-cmd-map-agent-copy em {
+  color: var(--ws-input);
+}
+.ws-cmd-map-agent.done .ws-cmd-map-agent-copy em {
+  color: var(--ws-done);
+}
 .ws-cmd-map-inspector-card {
   display: grid;
   gap: 12px;
@@ -981,6 +1083,36 @@
 .ws-cmd-rpg-sheet {
   display: grid;
   gap: 12px;
+}
+.ws-cmd-rpg-class-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.ws-cmd-rpg-class-card {
+  min-width: 0;
+  min-height: 68px;
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  padding: 11px;
+  border: 1px solid var(--ws-line);
+  background:
+    linear-gradient(120deg, rgba(70, 211, 154, 0.08), transparent 58%), rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-rpg-class-card span,
+.ws-cmd-rpg-loadout > span {
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-class-card strong {
+  min-width: 0;
+  color: #eef0f3;
+  font-size: 13px;
+  overflow-wrap: anywhere;
 }
 .ws-cmd-rpg-status-strip,
 .ws-cmd-rpg-sheet-row {
@@ -1053,6 +1185,44 @@
   color: var(--ws-ink-dim);
   font-size: 12px;
   overflow-wrap: anywhere;
+}
+.ws-cmd-rpg-loadout {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--ws-line);
+  background: rgba(0, 0, 0, 0.18);
+}
+.ws-cmd-rpg-loadout div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.ws-cmd-rpg-loadout em {
+  min-width: 0;
+  max-width: 100%;
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--ws-line);
+  background: rgba(70, 211, 154, 0.05);
+  color: var(--ws-ink);
+  font-size: 11px;
+  font-style: normal;
+  padding: 5px 7px;
+}
+.ws-cmd-rpg-loadout small {
+  color: var(--ws-faction);
+  font-family: var(--ws-font-mono);
+  font-size: 9px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ws-cmd-rpg-loadout.is-empty strong {
+  color: var(--ws-ink-dim);
+  font-size: 12px;
 }
 .ws-cmd-rpg-sheet-row {
   justify-content: space-between;
@@ -1204,6 +1374,7 @@
   gap: 9px;
 }
 .ws-cmd-map-inventory-slot {
+  position: relative;
   min-height: 116px;
   display: grid;
   grid-template-rows: auto minmax(0, auto) auto;
@@ -1216,11 +1387,65 @@
     radial-gradient(circle at 50% 20%, rgba(70, 211, 154, 0.09), transparent 52%),
     rgba(0, 0, 0, 0.22);
 }
+.ws-cmd-map-inventory-slot::before {
+  content: "";
+  position: absolute;
+  inset: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.035);
+  pointer-events: none;
+}
+.ws-cmd-map-slot-type {
+  position: absolute;
+  top: 7px;
+  left: 7px;
+  z-index: 1;
+  min-height: 18px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(70, 211, 154, 0.16);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 8px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  padding: 2px 5px;
+}
+.ws-cmd-map-inventory-slot.is-notes {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(78, 197, 230, 0.12), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-schedules {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(232, 181, 75, 0.12), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-sessions {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(70, 211, 154, 0.11), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-folders {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(160, 132, 232, 0.12), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-files {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(214, 217, 222, 0.09), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
+.ws-cmd-map-inventory-slot.is-systems {
+  background:
+    radial-gradient(circle at 50% 20%, rgba(240, 138, 75, 0.13), transparent 52%),
+    rgba(0, 0, 0, 0.22);
+}
 .ws-cmd-map-inventory-slot.is-empty {
   cursor: default;
   color: var(--ws-ink-faint);
   border-style: dashed;
-  opacity: 0.68;
+  opacity: 0.72;
 }
 .ws-cmd-map-inventory-slot.is-empty:hover {
   border-color: var(--ws-line);
@@ -1974,6 +2199,18 @@
   background: var(--ws-alert);
   box-shadow: 0 0 8px var(--ws-alert);
 }
+.ws-cmd-led.waiting {
+  background: var(--ws-waiting);
+  box-shadow: 0 0 8px var(--ws-waiting);
+}
+.ws-cmd-led.needs-input {
+  background: var(--ws-input);
+  box-shadow: 0 0 8px var(--ws-input);
+}
+.ws-cmd-led.done {
+  background: var(--ws-done);
+  box-shadow: 0 0 8px var(--ws-done);
+}
 .ws-cmd-led.idle {
   background: var(--ws-idle);
 }
@@ -2449,6 +2686,15 @@
 }
 .ws-cmd-character.working {
   --character-accent: var(--ws-working);
+}
+.ws-cmd-character.waiting {
+  --character-accent: var(--ws-waiting);
+}
+.ws-cmd-character.needs-input {
+  --character-accent: var(--ws-input);
+}
+.ws-cmd-character.done {
+  --character-accent: var(--ws-done);
 }
 .ws-cmd-agent-stage {
   position: relative;
@@ -3547,7 +3793,8 @@
     max-height: calc(100% - 12px);
   }
   .ws-cmd-map-station-grid,
-  .ws-cmd-map-inventory-badges {
+  .ws-cmd-map-inventory-badges,
+  .ws-cmd-rpg-class-grid {
     grid-template-columns: minmax(0, 1fr);
   }
   .ws-cmd-map-task-row {
@@ -3646,8 +3893,15 @@
     animation: ws-cmd-rise 0.4s ease both;
     animation-delay: 0.05s;
   }
-  .ws-cmd-led.working {
+  .ws-cmd-led.working,
+  .ws-cmd-led.needs-input {
     animation: ws-cmd-pulse 1.5s ease-in-out infinite;
+  }
+  .ws-cmd-map-agent.working .ws-cmd-character {
+    animation: ws-cmd-character-breathe 3.8s ease-in-out infinite;
+  }
+  .ws-cmd-map-agent.needs-input .ws-cmd-map-agent-status {
+    animation: ws-cmd-pulse 1.1s ease-in-out infinite;
   }
   .ws-cmd-agent-stage .ws-cmd-character.is-stage {
     animation: ws-cmd-character-breathe 3.8s ease-in-out infinite;

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -491,9 +491,18 @@
   z-index: 3;
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: 6px;
+  padding: 5px;
+  border: 1px solid rgba(70, 211, 154, 0.18);
+  background:
+    linear-gradient(180deg, rgba(17, 22, 29, 0.9), rgba(6, 8, 12, 0.9)), rgba(6, 8, 12, 0.88);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 16px 32px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
 }
 .ws-cmd-map-belt-btn {
+  position: relative;
   width: 46px;
   height: 46px;
   display: grid;
@@ -504,15 +513,73 @@
   cursor: pointer;
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
 }
+.ws-cmd-map-belt-btn .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .ws-cmd-map-belt-btn i {
   font-size: 18px;
   line-height: 1;
+}
+.ws-cmd-map-belt-btn::after {
+  content: attr(aria-label);
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  z-index: 2;
+  min-width: max-content;
+  max-width: 180px;
+  padding: 7px 9px;
+  border: 1px solid rgba(70, 211, 154, 0.24);
+  background: rgba(7, 10, 14, 0.94);
+  color: var(--ws-ink);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: 0;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+.ws-cmd-map-belt-btn:first-child::after {
+  left: 0;
+  transform: translate(0, -2px);
+}
+.ws-cmd-map-belt-btn:last-child::after {
+  right: 0;
+  left: auto;
+  transform: translate(0, -2px);
 }
 .ws-cmd-map-belt-btn:hover,
 .ws-cmd-map-belt-btn.is-active {
   color: var(--ws-faction);
   border-color: var(--ws-faction);
   background: rgba(70, 211, 154, 0.1);
+}
+.ws-cmd-map-belt-btn:hover::after,
+.ws-cmd-map-belt-btn:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+.ws-cmd-map-belt-btn:first-child:hover::after,
+.ws-cmd-map-belt-btn:first-child:focus-visible::after,
+.ws-cmd-map-belt-btn:last-child:hover::after,
+.ws-cmd-map-belt-btn:last-child:focus-visible::after {
+  transform: translate(0, 0);
 }
 .ws-cmd-map-window-backdrop {
   position: fixed;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2876,6 +2876,9 @@ export class WorkspaceCommandView {
       .map((agent, index) => {
         const selected = agent.key === this.selectedAgentKey;
         const destination = agent.destination || 'hub';
+        const entryBadge = agent.entry
+          ? '<span class="ws-cmd-map-entry-badge" title="Entry Agent"><i class="bi bi-star-fill" aria-hidden="true"></i><span>Entry</span></span>'
+          : '';
         return (
           '<button type="button" class="ws-cmd-map-agent ' +
           escapeHtml(agent.tone) +
@@ -2893,9 +2896,11 @@ export class WorkspaceCommandView {
           '" aria-label="Select ' +
           escapeHtml(agent.name) +
           ', ' +
+          (agent.entry ? 'Entry Agent, ' : '') +
           escapeHtml(agent.status?.label || 'Idle') +
           '">' +
           '<span class="ws-cmd-map-agent-path" aria-hidden="true"></span>' +
+          entryBadge +
           this.agentCharacterHTML(agent, 'roster') +
           '<span class="ws-cmd-map-agent-copy"><strong>' +
           escapeHtml(agent.name) +

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -8,7 +8,9 @@
  */
 // Legacy view preference from the deleted Detailed/Command toggle; cleared on boot.
 const LEGACY_STORAGE_KEY = 'oriWorkspaceDetailView';
+const VIEW_MODE_STORAGE_KEY = 'oriWorkspaceCommandViewMode';
 const AGENT_TAB_KEYS = ['overview', 'tasks', 'loadout', 'recent'];
+const COMMAND_VIEW_MODES = ['details', 'map'];
 
 function escapeHtml(value) {
   return String(value == null ? '' : value).replace(/[&<>"']/g, function (c) {
@@ -24,7 +26,11 @@ export class WorkspaceCommandView {
     this.page = page || null;
     this.container = document.getElementById('workspaceCommandView');
     this.active = false;
+    this.viewMode = this.readCommandViewModePreference();
     this.activeRailSection = '';
+    this.activeMapWindow = '';
+    this.mapInventoryOpen = false;
+    this.mapInventorySection = '';
     this.statModalSection = '';
     this.statModalEl = null;
     this.statModalTrigger = null;
@@ -58,8 +64,50 @@ export class WorkspaceCommandView {
     this.activate();
   }
 
-  // The Detailed view (and its toggle) is gone: drop the stale localStorage
-  // preference and strip any lingering ?view= param from deep links.
+  normalizeCommandViewMode(mode) {
+    const normalized = String(mode || '')
+      .trim()
+      .toLowerCase();
+    return COMMAND_VIEW_MODES.includes(normalized) ? normalized : 'details';
+  }
+
+  readCommandViewModePreference() {
+    if (typeof localStorage === 'undefined') return 'details';
+    try {
+      return this.normalizeCommandViewMode(localStorage.getItem(VIEW_MODE_STORAGE_KEY));
+    } catch (_error) {
+      return 'details';
+    }
+  }
+
+  persistCommandViewMode(mode) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(VIEW_MODE_STORAGE_KEY, this.normalizeCommandViewMode(mode));
+    } catch (_error) {
+      // Storage is best effort; the current render can continue without persistence.
+    }
+  }
+
+  setCommandViewMode(mode, { focus = true } = {}) {
+    const nextMode = this.normalizeCommandViewMode(mode);
+    if (nextMode === this.viewMode) return;
+    this.viewMode = nextMode;
+    this.persistCommandViewMode(nextMode);
+    this.activeRailSection = '';
+    if (nextMode === 'details') {
+      this.activeMapWindow = '';
+      this.mapInventoryOpen = false;
+      this.mapInventorySection = '';
+    }
+    this.restoreSharedSurfaces();
+    this.render();
+    if (!focus || !this.container || typeof this.container.querySelector !== 'function') return;
+    const btn = this.container.querySelector('[data-cmd-view-mode="' + nextMode + '"]');
+    if (btn && typeof btn.focus === 'function') btn.focus();
+  }
+
+  // Drop the stale preference and URL param from the old deleted Detailed/Command toggle.
   retireLegacyViewPreference() {
     try {
       localStorage.removeItem(LEGACY_STORAGE_KEY);
@@ -97,6 +145,16 @@ export class WorkspaceCommandView {
   handleGlobalKeydown(event) {
     if (!this.active || !event || event.key !== 'Escape') return;
     if (this.statModalSection || this.identityEditMode) return;
+    if (this.viewMode === 'map' && this.activeMapWindow) {
+      this.activeMapWindow = '';
+      this.render();
+      return;
+    }
+    if (this.viewMode === 'map' && this.mapInventoryOpen) {
+      this.mapInventoryOpen = false;
+      this.render();
+      return;
+    }
     if (!this.activeRailSection) return;
     this.activeRailSection = '';
     this.render();
@@ -233,6 +291,33 @@ export class WorkspaceCommandView {
     );
   }
 
+  commandViewSwitchHTML() {
+    const modes = [
+      { key: 'details', label: 'Details' },
+      { key: 'map', label: 'Map' }
+    ];
+    return (
+      '<div class="ws-cmd-view-switch" role="group" aria-label="Workspace view">' +
+      modes
+        .map(mode => {
+          const active = this.viewMode === mode.key;
+          return (
+            '<button type="button" class="ws-cmd-view-btn' +
+            (active ? ' is-active' : '') +
+            '" data-cmd-view-mode="' +
+            escapeHtml(mode.key) +
+            '" aria-pressed="' +
+            (active ? 'true' : 'false') +
+            '">' +
+            escapeHtml(mode.label) +
+            '</button>'
+          );
+        })
+        .join('') +
+      '</div>'
+    );
+  }
+
   isGroupWorkspace() {
     const ws = (this.page && this.page.workspace) || {};
     return (
@@ -308,6 +393,7 @@ export class WorkspaceCommandView {
       '<a class="ws-cmd-nav-btn" href="' +
       escapeHtml(workflowHref) +
       '">Orchestration Skills</a>' +
+      this.commandViewSwitchHTML() +
       '</div>' +
       '<div class="ws-cmd-crest">' +
       '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">' +
@@ -531,25 +617,32 @@ export class WorkspaceCommandView {
     const mode = this.opsModeLabel();
     const stats = this.computeStats();
 
-    this.container.innerHTML =
-      this.commandBarHTML(ws, name, mode, stats) +
-      '<div class="ws-cmd-layout">' +
-      '<main class="ws-cmd-main">' +
-      this.renderMissionPanel() +
-      '<section class="ws-cmd-garrison">' +
-      this.renderGarrison() +
-      '</section>' +
-      '</main>' +
-      '<aside class="ws-cmd-rail">' +
-      this.renderRail() +
-      '</aside>' +
-      '</div>';
+    const body =
+      this.viewMode === 'map'
+        ? this.renderOperationsMap()
+        : '<div class="ws-cmd-layout">' +
+          '<main class="ws-cmd-main">' +
+          this.renderMissionPanel() +
+          '<section class="ws-cmd-garrison">' +
+          this.renderGarrison() +
+          '</section>' +
+          '</main>' +
+          '<aside class="ws-cmd-rail">' +
+          this.renderRail() +
+          '</aside>' +
+          '</div>';
+
+    this.container.innerHTML = this.commandBarHTML(ws, name, mode, stats) + body;
 
     this.bindIdentityControls();
     this.bindReadout();
     this.bindMissionPanel();
-    this.bindGarrison();
-    this.bindRail();
+    if (this.viewMode === 'map') {
+      this.bindOperationsMap();
+    } else {
+      this.bindGarrison();
+      this.bindRail();
+    }
     this.mountCommandTagInput();
     this.syncMissionPanel();
     this.syncSharedSurfaces();
@@ -573,6 +666,11 @@ export class WorkspaceCommandView {
     if (!root) return;
 
     root.addEventListener('click', event => {
+      const viewBtn = event.target.closest('[data-cmd-view-mode]');
+      if (viewBtn) {
+        this.setCommandViewMode(viewBtn.getAttribute('data-cmd-view-mode'), { focus: false });
+        return;
+      }
       const editBtn = event.target.closest('[data-cmd-edit-identity]');
       if (editBtn) {
         const field = editBtn.getAttribute('data-cmd-edit-identity');
@@ -2457,6 +2555,792 @@ export class WorkspaceCommandView {
       '</div>' +
       '</div>'
     );
+  }
+
+  // ---------- Operations Map mode ----------
+
+  taskStatusLabel(status) {
+    const normalized = String(status || 'pending')
+      .trim()
+      .replaceAll('_', ' ');
+    return normalized ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : 'Pending';
+  }
+
+  taskUpdatedTime(task) {
+    const raw = task?.updated_at || task?.created_at || '';
+    const time = Date.parse(raw);
+    return Number.isFinite(time) ? time : 0;
+  }
+
+  taskHumanLoopState(task) {
+    return String(task?.context?.human_loop?.state || '')
+      .trim()
+      .toLowerCase();
+  }
+
+  isBlockedTask(task) {
+    const status = String(task?.status || '')
+      .trim()
+      .toLowerCase();
+    const humanLoop = this.taskHumanLoopState(task);
+    return status === 'blocked' || humanLoop === 'blocked';
+  }
+
+  isNeedsInputTask(task) {
+    const status = String(task?.status || '')
+      .trim()
+      .toLowerCase();
+    const humanLoop = this.taskHumanLoopState(task);
+    return (
+      status === 'waiting_for_choice' ||
+      humanLoop === 'waiting_for_choice' ||
+      task?.context?.execution_step_waiting === true
+    );
+  }
+
+  isWorkingTask(task) {
+    return (
+      String(task?.status || '')
+        .trim()
+        .toLowerCase() === 'in_progress'
+    );
+  }
+
+  isQueuedTask(task) {
+    return (
+      String(task?.status || '')
+        .trim()
+        .toLowerCase() === 'pending'
+    );
+  }
+
+  taskPriority(task) {
+    if (this.isBlockedTask(task)) return 0;
+    if (this.isNeedsInputTask(task)) return 1;
+    if (this.isWorkingTask(task)) return 2;
+    if (this.isQueuedTask(task)) return 3;
+    return 4;
+  }
+
+  mapAgentStatus(agent) {
+    const tasks = Array.isArray(agent?.tasks) ? agent.tasks : [];
+    if (tasks.some(task => this.isBlockedTask(task))) {
+      return {
+        key: 'blocked',
+        label: 'Blocked',
+        detail: 'Needs attention before work can continue'
+      };
+    }
+    if (tasks.some(task => this.isNeedsInputTask(task))) {
+      return { key: 'needs-input', label: 'Needs input', detail: 'Waiting for user input' };
+    }
+    if (tasks.some(task => this.isWorkingTask(task))) {
+      return { key: 'working', label: 'Working', detail: 'Task in progress' };
+    }
+    if (tasks.some(task => this.isQueuedTask(task))) {
+      return { key: 'waiting', label: 'Waiting', detail: 'Task queued' };
+    }
+    return agent?.status || { key: 'idle', label: 'Idle', detail: 'No active tasks' };
+  }
+
+  mapAgentViewModels() {
+    const groups = this.agentGroups();
+    const selectedGroup = this.selectedAgentGroup(groups.agents);
+    if (!selectedGroup) {
+      this.selectedAgentKey = '';
+      return { agents: [], unassigned: groups.unassigned, selected: null };
+    }
+    const agents = groups.agents
+      .map(group => this.agentViewModel(group))
+      .filter(Boolean)
+      .map(agent => {
+        const status = this.mapAgentStatus(agent);
+        return {
+          ...agent,
+          status,
+          tone: this.statusTone(status.key, status.label),
+          destination: this.agentMapDestination(agent, status)
+        };
+      });
+    const selected = agents.find(agent => agent.key === this.selectedAgentKey) || agents[0] || null;
+    if (selected) this.selectedAgentKey = selected.key;
+    return { agents, unassigned: groups.unassigned, selected };
+  }
+
+  priorityTaskForAgent(agent) {
+    const tasks = Array.isArray(agent?.tasks) ? agent.tasks.slice() : [];
+    if (!tasks.length) return null;
+    return tasks.sort((left, right) => {
+      const priorityDelta = this.taskPriority(left) - this.taskPriority(right);
+      if (priorityDelta !== 0) return priorityDelta;
+      return this.taskUpdatedTime(right) - this.taskUpdatedTime(left);
+    })[0];
+  }
+
+  latestTaskActivity(task) {
+    const taskId = String(task?.id || '');
+    const map = this.page && this.page._taskActivity;
+    if (!taskId || !map || typeof map.get !== 'function') return null;
+    return map.get(taskId) || null;
+  }
+
+  formatRelativeTime(value) {
+    const time = typeof value === 'number' ? value : Date.parse(value || '');
+    if (!Number.isFinite(time) || time <= 0) return '';
+    const diff = Date.now() - time;
+    const abs = Math.abs(diff);
+    const ahead = diff < 0;
+    if (abs < 60000) return 'just now';
+    const mins = Math.round(abs / 60000);
+    if (mins < 60) return ahead ? 'in ' + mins + 'm' : mins + 'm ago';
+    const hours = Math.round(abs / 3600000);
+    if (hours < 24) return ahead ? 'in ' + hours + 'h' : hours + 'h ago';
+    const days = Math.round(abs / 86400000);
+    if (days < 7) return ahead ? 'in ' + days + 'd' : days + 'd ago';
+    return new Date(time).toLocaleDateString();
+  }
+
+  agentActivitySummary(agent) {
+    const task = agent?.currentTask || this.priorityTaskForAgent(agent);
+    if (!task) {
+      const recent = this.recentActivityItems(agent)[0];
+      if (!recent) return null;
+      return {
+        taskLabel: recent.title,
+        statusLabel: recent.status,
+        activityLabel: recent.kind + ' updated',
+        whenLabel: this.formatRelativeTime(recent.time),
+        timestamp: recent.timestamp
+      };
+    }
+    const activity = this.latestTaskActivity(task);
+    const timestamp = activity?.at || this.taskUpdatedTime(task);
+    return {
+      taskLabel: String(task.description || task.name || task.title || 'Untitled task'),
+      statusLabel: this.taskStatusLabel(task.status),
+      activityLabel: activity?.label || this.taskStatusLabel(task.status),
+      whenLabel: this.formatRelativeTime(timestamp),
+      timestamp: task.updated_at || task.created_at || ''
+    };
+  }
+
+  agentMapDestination(agent, status = agent?.status) {
+    const key = String(status?.key || '')
+      .trim()
+      .toLowerCase();
+    if (key === 'blocked' || key === 'needs-input') return 'tasks';
+    if (key === 'working') {
+      const summary = this.agentActivitySummary(agent);
+      return /tool|→/.test(String(summary?.activityLabel || '').toLowerCase()) ? 'tools' : 'tasks';
+    }
+    if (key === 'waiting') return 'hub';
+    return 'hub';
+  }
+
+  openMapTasks() {
+    const page = this.page || {};
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    const terminal = new Set(['completed', 'cancelled', 'timeout']);
+    return tasks
+      .filter(task => !task?.parent_task_id)
+      .filter(task => !terminal.has(String(task?.status || '').toLowerCase()))
+      .sort((left, right) => {
+        const priorityDelta = this.taskPriority(left) - this.taskPriority(right);
+        if (priorityDelta !== 0) return priorityDelta;
+        return this.taskUpdatedTime(right) - this.taskUpdatedTime(left);
+      });
+  }
+
+  mapZoneHeaderHTML(kicker, title, count = '') {
+    return (
+      '<header class="ws-cmd-map-zone-head"><div><span>' +
+      escapeHtml(kicker) +
+      '</span><strong>' +
+      escapeHtml(title) +
+      '</strong></div>' +
+      (count !== '' ? '<span class="ws-cmd-map-zone-count">' + escapeHtml(count) + '</span>' : '') +
+      '</header>'
+    );
+  }
+
+  mapWindowOptions() {
+    return [
+      { key: 'objective', label: 'Workspace Objective', icon: 'bi-bullseye' },
+      { key: 'objectives', label: 'Objectives', icon: 'bi-list-check' },
+      { key: 'inventory', label: 'Inventory', icon: 'bi-box-seam' },
+      { key: 'stations', label: 'Stations', icon: 'bi-cpu' }
+    ];
+  }
+
+  renderMapToolTray() {
+    return (
+      '<nav class="ws-cmd-map-belt" aria-label="Map windows">' +
+      this.mapWindowOptions()
+        .map(item => {
+          const active = this.activeMapWindow === item.key;
+          return (
+            '<button type="button" class="ws-cmd-map-belt-btn' +
+            (active ? ' is-active' : '') +
+            '" data-cmd-map-window="' +
+            escapeHtml(item.key) +
+            '" aria-label="' +
+            escapeHtml(item.label) +
+            '" aria-pressed="' +
+            (active ? 'true' : 'false') +
+            '" title="' +
+            escapeHtml(item.label) +
+            '"><i class="bi ' +
+            escapeHtml(item.icon) +
+            '" aria-hidden="true"></i><span class="sr-only">' +
+            escapeHtml(item.label) +
+            '</span></button>'
+          );
+        })
+        .join('') +
+      '</nav>'
+    );
+  }
+
+  renderMapMissionPanel() {
+    return (
+      '<div class="ws-cmd-map-window-section is-objective">' + this.renderMissionPanel() + '</div>'
+    );
+  }
+
+  renderMapTasksPanel() {
+    const tasks = this.openMapTasks();
+    const shown = tasks.slice(0, 4);
+    const rows = shown.length
+      ? shown
+          .map(task => {
+            const id = String(task.id || '');
+            const label = String(task.description || task.name || task.title || 'Untitled task');
+            const status = String(task.status || 'pending')
+              .trim()
+              .toLowerCase();
+            return (
+              '<button type="button" class="ws-cmd-map-task-row ' +
+              escapeHtml(this.taskTone(status)) +
+              '" data-cmd-open-task="' +
+              escapeHtml(id) +
+              '">' +
+              '<span class="ws-cmd-map-task-name">' +
+              escapeHtml(label) +
+              '</span><span class="ws-cmd-map-task-status">' +
+              escapeHtml(this.taskStatusLabel(status)) +
+              '</span></button>'
+            );
+          })
+          .join('')
+      : '<div class="ws-cmd-map-empty">No open tasks.</div>';
+    return (
+      '<div class="ws-cmd-map-window-section is-objectives">' +
+      this.mapZoneHeaderHTML('Objectives', 'Active Tasks', tasks.length) +
+      '<div class="ws-cmd-map-task-list">' +
+      rows +
+      '</div>' +
+      '<button type="button" class="ws-cmd-map-zone-action" data-cmd-map-open-modal="tasks">Open Tasks</button>' +
+      '</div>'
+    );
+  }
+
+  renderMapStationsPanel() {
+    const stats = this.computeStats();
+    const systemsCount = this.systemTabs().length;
+    return (
+      '<div class="ws-cmd-map-window-section is-stations">' +
+      this.mapZoneHeaderHTML('Stations', 'Tools & Systems', stats.tools + systemsCount) +
+      '<div class="ws-cmd-map-station-grid">' +
+      '<button type="button" class="ws-cmd-map-station" data-cmd-map-open-modal="tools"><span>MCP + Skills</span><strong>' +
+      escapeHtml(stats.tools) +
+      '</strong></button>' +
+      '<button type="button" class="ws-cmd-map-station" data-cmd-map-inventory-action="systems"><span>Systems</span><strong>' +
+      escapeHtml(systemsCount) +
+      '</strong></button>' +
+      '</div>' +
+      '</div>'
+    );
+  }
+
+  renderMapAgentUnits(agents) {
+    if (!agents.length) {
+      return (
+        '<div class="ws-cmd-map-empty is-agent-empty">' +
+        '<strong>No agents in this workspace</strong>' +
+        '<span>Add an agent to begin assigning work.</span>' +
+        '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-agent>Add Agent</button>' +
+        '</div>'
+      );
+    }
+    return agents
+      .map((agent, index) => {
+        const selected = agent.key === this.selectedAgentKey;
+        const destination = agent.destination || 'hub';
+        return (
+          '<button type="button" class="ws-cmd-map-agent ' +
+          escapeHtml(agent.tone) +
+          (selected ? ' is-selected' : '') +
+          ' toward-' +
+          escapeHtml(destination) +
+          '" data-cmd-map-select-agent="' +
+          escapeHtml(agent.encodedName) +
+          '" data-agent-key="' +
+          escapeHtml(agent.key) +
+          '" style="--agent-map-index:' +
+          index +
+          '" aria-pressed="' +
+          (selected ? 'true' : 'false') +
+          '" aria-label="Select ' +
+          escapeHtml(agent.name) +
+          ', ' +
+          escapeHtml(agent.status?.label || 'Idle') +
+          '">' +
+          '<span class="ws-cmd-map-agent-path" aria-hidden="true"></span>' +
+          this.agentCharacterHTML(agent, 'roster') +
+          '<span class="ws-cmd-map-agent-copy"><strong>' +
+          escapeHtml(agent.name) +
+          '</strong><span>' +
+          escapeHtml(agent.role?.label || 'Agent') +
+          '</span><em>' +
+          escapeHtml(agent.status?.label || 'Idle') +
+          '</em></span></button>'
+        );
+      })
+      .join('');
+  }
+
+  renderMapAgentsZone(agents) {
+    return (
+      '<section class="ws-cmd-map-world" data-map-zone="agents" aria-label="Agent units">' +
+      '<div class="ws-cmd-map-floor" aria-hidden="true"></div>' +
+      '<div class="ws-cmd-map-agent-field">' +
+      this.renderMapAgentUnits(agents) +
+      '</div></section>'
+    );
+  }
+
+  renderMapInspector(agent) {
+    if (!agent) {
+      return '<div class="ws-cmd-map-empty">Select an agent to inspect assignment, activity, and loadout.</div>';
+    }
+    const summary = this.agentActivitySummary(agent);
+    const tasks = Array.isArray(agent.tasks) ? agent.tasks : [];
+    const openTaskCount = tasks.filter(task => {
+      const status = String(task?.status || '').toLowerCase();
+      return !['completed', 'cancelled', 'timeout'].includes(status);
+    }).length;
+    const detailTarget = this.agentDetailTarget(agent);
+    const detailAction = detailTarget
+      ? '<a class="ws-cmd-agent-action" href="' + escapeHtml(detailTarget.href) + '">Open Agent</a>'
+      : '';
+    const statCards = [
+      { label: 'Quests', value: openTaskCount },
+      { label: 'Skills', value: Number(agent.skills?.count || 0) },
+      { label: 'Tools', value: agent.mcpNames.length },
+      { label: 'Units', value: agent.instanceCount }
+    ];
+    const statusEffects = [
+      agent.entry ? 'Entry Agent' : '',
+      agent.status?.label || 'Idle',
+      agent.model?.empty ? '' : agent.model?.label || ''
+    ].filter(Boolean);
+    return (
+      '<div class="ws-cmd-map-inspector-card" aria-label="' +
+      escapeHtml(agent.name) +
+      ' sheet">' +
+      '<div class="ws-cmd-map-agent-sheet-head">' +
+      this.agentCharacterHTML(agent, 'roster') +
+      '<div><span>Unit Sheet</span><strong>' +
+      escapeHtml(agent.name) +
+      '</strong><p>' +
+      escapeHtml(agent.role?.label || 'Agent') +
+      '</p></div></div>' +
+      '<div class="ws-cmd-rpg-sheet">' +
+      '<div class="ws-cmd-rpg-status-strip"><span class="ws-cmd-led ' +
+      escapeHtml(agent.tone) +
+      '"></span><strong>' +
+      escapeHtml(agent.status?.label || 'Idle') +
+      '</strong><span>' +
+      escapeHtml(agent.status?.detail || 'No active tasks') +
+      '</span></div>' +
+      '<div class="ws-cmd-rpg-stat-grid">' +
+      statCards
+        .map(
+          stat =>
+            '<div class="ws-cmd-rpg-stat"><span>' +
+            escapeHtml(stat.label) +
+            '</span><strong>' +
+            escapeHtml(stat.value) +
+            '</strong></div>'
+        )
+        .join('') +
+      '</div>' +
+      '<section class="ws-cmd-rpg-quest-card"><span>Current Quest</span><strong>' +
+      escapeHtml(summary?.taskLabel || 'No task in progress') +
+      '</strong><p>' +
+      escapeHtml(summary?.statusLabel || agent.status?.label || 'Idle') +
+      (summary?.activityLabel ? ' · ' + escapeHtml(summary.activityLabel) : '') +
+      (summary?.whenLabel ? ' · ' + escapeHtml(summary.whenLabel) : '') +
+      '</p></section>' +
+      '<div class="ws-cmd-rpg-sheet-row"><span>Recent Activity</span><strong>' +
+      escapeHtml(summary?.activityLabel || 'No recent activity') +
+      (summary?.whenLabel ? ' · ' + escapeHtml(summary.whenLabel) : '') +
+      '</strong></div>' +
+      '<div class="ws-cmd-rpg-effects">' +
+      statusEffects.map(effect => '<span>' + escapeHtml(effect) + '</span>').join('') +
+      '</div></div>' +
+      '<div class="ws-cmd-map-inspector-actions">' +
+      '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-task="' +
+      escapeHtml(agent.encodedName) +
+      '">Give Task</button>' +
+      detailAction +
+      '</div></div>'
+    );
+  }
+
+  mapInventoryGroups() {
+    const page = this.page || {};
+    const folders = this.folderRowData();
+    const files = this.fileRowData();
+    return [
+      {
+        key: 'notes',
+        label: 'Notes',
+        icon: 'bi-journal-text',
+        count: Array.isArray(page.notes) ? page.notes.length : 0,
+        action: 'New Note',
+        empty: 'No notes yet.',
+        items: (Array.isArray(page.notes) ? page.notes : []).map(note => ({
+          label: note.name || note.title || 'Untitled Note',
+          meta: '',
+          section: 'notes',
+          id: String(note.id || '')
+        }))
+      },
+      {
+        key: 'schedules',
+        label: 'Schedules',
+        icon: 'bi-calendar2-week',
+        count: Array.isArray(page.schedules) ? page.schedules.length : 0,
+        action: 'Open Schedules',
+        empty: 'No schedules yet.',
+        items: (Array.isArray(page.schedules) ? page.schedules : []).map(schedule => ({
+          label: schedule.name || schedule.task_description || 'Unnamed Schedule',
+          meta: '',
+          section: 'schedules',
+          id: String(schedule.id || '')
+        }))
+      },
+      {
+        key: 'sessions',
+        label: 'Sessions',
+        icon: 'bi-chat-dots',
+        count: Array.isArray(page.sessions) ? page.sessions.length : 0,
+        action: 'New Session',
+        empty: 'No sessions yet.',
+        items: (Array.isArray(page.sessions) ? page.sessions : []).map(session => ({
+          label: session.title || session.name || 'Untitled Session',
+          meta: session.agent_name || '',
+          section: 'sessions',
+          id: String(session.id || '')
+        }))
+      },
+      {
+        key: 'folders',
+        label: 'Linked Folders',
+        icon: 'bi-folder2-open',
+        count: folders.length,
+        action: 'Link Folder',
+        empty: 'No linked folders yet.',
+        items: folders.map(folder => ({
+          label: folder.title || folder.name || folder.path || 'Unnamed Directory',
+          meta: folder.path || '',
+          section: 'folders',
+          id: String(folder.id || ''),
+          source: String(folder.source || 'reference')
+        }))
+      },
+      {
+        key: 'files',
+        label: 'Files',
+        icon: 'bi-file-earmark-text',
+        count: files.length,
+        action: 'Upload',
+        empty: 'No files yet.',
+        items: files.map(file => ({
+          label: this.fileTitle(file),
+          meta: this.fileMeta(file),
+          section: 'files',
+          id: String(file?.id || file?.file_meta?.name || this.fileTitle(file))
+        }))
+      },
+      {
+        key: 'systems',
+        label: 'Systems',
+        icon: 'bi-cpu',
+        count: this.systemTabs().length,
+        action: 'Open Systems',
+        empty: 'No systems configured.',
+        items: this.systemTabs().map(tab => ({
+          label: tab.label,
+          meta: 'Workspace system',
+          section: 'systems',
+          id: tab.key
+        }))
+      }
+    ];
+  }
+
+  renderMapInventoryItems(group) {
+    const items = Array.isArray(group?.items) ? group.items : [];
+    const visibleItems = items.slice(0, 11);
+    const slotCount = Math.max(
+      8,
+      Math.min(12, visibleItems.length + (visibleItems.length ? 1 : 0))
+    );
+    const slots = visibleItems.map(item => {
+      const attrs =
+        item.section === 'systems'
+          ? 'data-cmd-map-system-tab="' + escapeHtml(item.id) + '"'
+          : 'data-cmd-open-section="' +
+            escapeHtml(item.section) +
+            '" data-cmd-item-id="' +
+            escapeHtml(item.id) +
+            '" data-cmd-item-source="' +
+            escapeHtml(item.source || '') +
+            '"';
+      return (
+        '<button type="button" class="ws-cmd-map-inventory-slot" ' +
+        attrs +
+        ' aria-label="Open ' +
+        escapeHtml(item.label) +
+        '"><span class="ws-cmd-map-slot-icon"><i class="bi ' +
+        escapeHtml(group?.icon || 'bi-box') +
+        '" aria-hidden="true"></i></span><span class="ws-cmd-map-slot-name">' +
+        escapeHtml(item.label) +
+        '</span>' +
+        (item.meta
+          ? '<em>' + escapeHtml(item.meta) + '</em>'
+          : '<em>' + escapeHtml(group?.label || 'Item') + '</em>') +
+        '</button>'
+      );
+    });
+    while (slots.length < slotCount) {
+      slots.push(
+        '<div class="ws-cmd-map-inventory-slot is-empty"><span class="ws-cmd-map-slot-icon">+</span><span class="ws-cmd-map-slot-name">' +
+          escapeHtml(slots.length === 0 ? group?.empty || 'Empty slot' : 'Empty') +
+          '</span></div>'
+      );
+    }
+    return '<div class="ws-cmd-map-inventory-grid">' + slots.join('') + '</div>';
+  }
+
+  renderMapInventory() {
+    const groups = this.mapInventoryGroups();
+    const total = groups.reduce((sum, group) => sum + Number(group.count || 0), 0);
+    const activeKey = this.mapInventorySection || groups[0]?.key || '';
+    if (!this.mapInventorySection) this.mapInventorySection = activeKey;
+    return (
+      '<div class="ws-cmd-map-inventory-box">' +
+      '<div class="ws-cmd-map-inventory-summary">' +
+      '<div class="ws-cmd-map-inventory-total"><span>Items</span><strong>' +
+      escapeHtml(total) +
+      '</strong></div>' +
+      '<div class="ws-cmd-map-inventory-badges">' +
+      groups
+        .map(
+          group =>
+            '<button type="button" class="ws-cmd-map-inventory-badge' +
+            (activeKey === group.key ? ' is-active' : '') +
+            '" data-cmd-map-inventory-section="' +
+            escapeHtml(group.key) +
+            '"><i class="bi ' +
+            escapeHtml(group.icon || 'bi-box') +
+            '" aria-hidden="true"></i><span>' +
+            escapeHtml(group.label) +
+            '</span><strong>' +
+            escapeHtml(group.count) +
+            '</strong></button>'
+        )
+        .join('') +
+      '</div></div>' +
+      '<div class="ws-cmd-map-inventory-drawer">' +
+      groups
+        .map(
+          group =>
+            '<section class="ws-cmd-map-inventory-group' +
+            (activeKey === group.key ? ' is-active' : '') +
+            '">' +
+            '<header><div><span>' +
+            escapeHtml(group.label) +
+            '</span><strong>' +
+            escapeHtml(group.count) +
+            '</strong></div>' +
+            '<button type="button" data-cmd-map-inventory-action="' +
+            escapeHtml(group.key) +
+            '">' +
+            escapeHtml(group.action) +
+            '</button></header>' +
+            '<div class="ws-cmd-map-inventory-list">' +
+            this.renderMapInventoryItems(group) +
+            '</div></section>'
+        )
+        .join('') +
+      '</div></div>'
+    );
+  }
+
+  renderMapWindow(selectedAgent) {
+    const key = String(this.activeMapWindow || '').trim();
+    if (!key) return '';
+    const option =
+      this.mapWindowOptions().find(item => item.key === key) ||
+      (key === 'inspector'
+        ? { key: 'inspector', label: 'Unit Sheet', icon: 'bi-person-vcard' }
+        : null);
+    if (!option) return '';
+    const body = {
+      objective: () => this.renderMapMissionPanel(),
+      objectives: () => this.renderMapTasksPanel(),
+      inventory: () => this.renderMapInventory(),
+      stations: () => this.renderMapStationsPanel(),
+      inspector: () => this.renderMapInspector(selectedAgent)
+    }[key];
+    if (!body) return '';
+    return (
+      '<div class="ws-cmd-map-window-backdrop" data-cmd-map-window-backdrop>' +
+      '<section class="ws-cmd-map-window ws-cmd-map-window-' +
+      escapeHtml(key) +
+      '" role="dialog" aria-modal="true" aria-label="' +
+      escapeHtml(option.label) +
+      '">' +
+      '<header class="ws-cmd-map-window-head"><div><i class="bi ' +
+      escapeHtml(option.icon) +
+      '" aria-hidden="true"></i><span>' +
+      escapeHtml(option.label) +
+      '</span></div>' +
+      '<button type="button" class="ws-cmd-map-window-close" data-cmd-map-window-close aria-label="Close map window">×</button></header>' +
+      '<div class="ws-cmd-map-window-body">' +
+      body() +
+      '</div></section></div>'
+    );
+  }
+
+  renderOperationsMap() {
+    const { agents, selected } = this.mapAgentViewModels();
+    return (
+      '<div class="ws-cmd-map-shell">' +
+      '<div class="ws-cmd-opmap" role="region" aria-label="Workspace operations map">' +
+      this.renderMapAgentsZone(agents) +
+      this.renderMapToolTray() +
+      '</div>' +
+      this.renderMapWindow(selected) +
+      '</div>'
+    );
+  }
+
+  runMapInventoryAction(sectionKey, triggerButton) {
+    const section = String(sectionKey || '').trim();
+    if (section === 'systems') {
+      this.setCommandViewMode('details', { focus: false });
+      this.openSystemTab(this.activeSystemTab || 'memory');
+      return;
+    }
+    this.runRailPrimaryAction(section, triggerButton);
+  }
+
+  bindOperationsMap() {
+    const root = this.container && this.container.querySelector('.ws-cmd-map-shell');
+    if (!root) return;
+    root.addEventListener('click', event => {
+      const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      const closeWindow = event.target.closest('[data-cmd-map-window-close]');
+      if (closeWindow) {
+        this.activeMapWindow = '';
+        this.render();
+        return;
+      }
+      const backdrop = event.target.closest('[data-cmd-map-window-backdrop]');
+      if (backdrop && event.target === backdrop) {
+        this.activeMapWindow = '';
+        this.render();
+        return;
+      }
+      const windowBtn = event.target.closest('[data-cmd-map-window]');
+      if (windowBtn) {
+        const nextWindow = windowBtn.getAttribute('data-cmd-map-window');
+        this.activeMapWindow = this.activeMapWindow === nextWindow ? '' : nextWindow;
+        if (this.activeMapWindow === 'inventory' && !this.mapInventorySection) {
+          this.mapInventorySection = 'notes';
+        }
+        this.render();
+        return;
+      }
+      const selectBtn = event.target.closest('[data-cmd-map-select-agent]');
+      if (selectBtn) {
+        this.activeMapWindow = 'inspector';
+        this.selectAgent(selectBtn.getAttribute('data-cmd-map-select-agent'), { focus: false });
+        return;
+      }
+      const addAgentBtn = event.target.closest('[data-cmd-add-agent]');
+      if (addAgentBtn && page && typeof page.openAddAgentModal === 'function') {
+        page.openAddAgentModal();
+        return;
+      }
+      const addTaskBtn = event.target.closest('[data-cmd-add-task]');
+      if (addTaskBtn && page && typeof page.showAddTaskModalForAgent === 'function') {
+        page.showAddTaskModalForAgent(addTaskBtn.getAttribute('data-cmd-add-task'));
+        return;
+      }
+      const openTaskBtn = event.target.closest('[data-cmd-open-task]');
+      if (openTaskBtn && page && typeof page.openTask === 'function') {
+        page.openTask(openTaskBtn.getAttribute('data-cmd-open-task'));
+        return;
+      }
+      const modalBtn = event.target.closest('[data-cmd-map-open-modal]');
+      if (modalBtn) {
+        this.openStatModal(modalBtn.getAttribute('data-cmd-map-open-modal'), modalBtn);
+        return;
+      }
+      const inventoryToggle = event.target.closest('[data-cmd-map-inventory-toggle]');
+      if (inventoryToggle) {
+        this.activeMapWindow = this.activeMapWindow === 'inventory' ? '' : 'inventory';
+        this.mapInventoryOpen = this.activeMapWindow === 'inventory';
+        if (!this.mapInventorySection) this.mapInventorySection = 'notes';
+        this.render();
+        return;
+      }
+      const inventorySection = event.target.closest('[data-cmd-map-inventory-section]');
+      if (inventorySection) {
+        this.activeMapWindow = 'inventory';
+        this.mapInventoryOpen = true;
+        this.mapInventorySection = inventorySection.getAttribute('data-cmd-map-inventory-section');
+        this.render();
+        return;
+      }
+      const inventoryAction = event.target.closest('[data-cmd-map-inventory-action]');
+      if (inventoryAction) {
+        this.runMapInventoryAction(
+          inventoryAction.getAttribute('data-cmd-map-inventory-action'),
+          inventoryAction
+        );
+        return;
+      }
+      const systemTab = event.target.closest('[data-cmd-map-system-tab]');
+      if (systemTab) {
+        this.setCommandViewMode('details', { focus: false });
+        this.openSystemTab(systemTab.getAttribute('data-cmd-map-system-tab'));
+        return;
+      }
+      const itemBtn = event.target.closest('[data-cmd-open-section][data-cmd-item-id]');
+      if (itemBtn) {
+        this.openRailItem(
+          itemBtn.getAttribute('data-cmd-open-section'),
+          itemBtn.getAttribute('data-cmd-item-id'),
+          itemBtn.getAttribute('data-cmd-item-source')
+        );
+      }
+    });
   }
 
   captureAgentDeckViewState() {

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2704,7 +2704,7 @@ export class WorkspaceCommandView {
   }
 
   agentActivitySummary(agent) {
-    const task = agent?.currentTask || this.priorityTaskForAgent(agent);
+    const task = this.priorityTaskForAgent(agent) || agent?.currentTask;
     if (!task) {
       const recent = this.recentActivityItems(agent)[0];
       if (!recent) return null;
@@ -2974,6 +2974,134 @@ export class WorkspaceCommandView {
     );
   }
 
+  latestAgentSession(agent) {
+    return this.recentActivityItems(agent).find(item => item.kind === 'Session') || null;
+  }
+
+  mapTaskCommandLabel(task) {
+    if (!task) return '';
+    const status = String(task?.status || '')
+      .trim()
+      .toLowerCase();
+    if (this.isBlockedTask(task) || this.isNeedsInputTask(task)) return 'Resolve Quest';
+    if (this.isWorkingTask(task)) return 'Track Quest';
+    if (this.isQueuedTask(task)) return 'Open Queue';
+    if (status === 'completed' || status === 'done') return 'Review Output';
+    return 'Open Quest';
+  }
+
+  renderMapAgentCommandMenu(agent, detailTarget) {
+    const task = this.priorityTaskForAgent(agent) || agent?.currentTask;
+    const taskId = String(task?.id || '').trim();
+    const taskLabel = taskId ? this.mapTaskCommandLabel(task) : '';
+    const taskTone = task ? this.taskTone(task.status) : '';
+    const taskDetail = task
+      ? this.taskStatusLabel(task.status || agent?.status?.label || 'pending')
+      : 'No quest selected';
+    const session = this.latestAgentSession(agent);
+    const sessionId = String(session?.id || '').trim();
+    const loadoutDetail =
+      Number(agent?.skills?.count || 0) +
+      ' skills / ' +
+      Number(agent?.mcpNames?.length || 0) +
+      ' tools';
+    const action = ({ label, detail, icon, className = '', attrs = '', href = '' }) => {
+      const content =
+        '<i class="bi ' +
+        escapeHtml(icon) +
+        '" aria-hidden="true"></i><span><strong>' +
+        escapeHtml(label) +
+        '</strong><small>' +
+        escapeHtml(detail) +
+        '</small></span>';
+      if (href) {
+        return (
+          '<a class="ws-cmd-rpg-command ' +
+          escapeHtml(className) +
+          '" href="' +
+          escapeHtml(href) +
+          '">' +
+          content +
+          '</a>'
+        );
+      }
+      return (
+        '<button type="button" class="ws-cmd-rpg-command ' +
+        escapeHtml(className) +
+        '" ' +
+        attrs +
+        '>' +
+        content +
+        '</button>'
+      );
+    };
+    const actions = [];
+    if (taskId) {
+      const urgent = this.isBlockedTask(task) || this.isNeedsInputTask(task);
+      actions.push(
+        action({
+          label: taskLabel,
+          detail: taskDetail,
+          icon: urgent ? 'bi-exclamation-triangle' : 'bi-journal-check',
+          className: urgent ? 'is-primary is-' + taskTone : 'is-' + taskTone,
+          attrs: 'data-cmd-open-task="' + escapeHtml(taskId) + '"'
+        })
+      );
+    }
+    actions.push(
+      action({
+        label: 'Give Task',
+        detail: taskId ? 'New assignment' : 'Assign first quest',
+        icon: 'bi-plus-lg',
+        className: taskId ? '' : 'is-primary',
+        attrs: 'data-cmd-add-task="' + escapeHtml(agent.encodedName) + '"'
+      })
+    );
+    actions.push(
+      sessionId
+        ? action({
+            label: 'Continue Session',
+            detail: session.title || 'Open agent chat',
+            icon: 'bi-chat-dots',
+            attrs: 'data-cmd-open-session="' + escapeHtml(sessionId) + '"'
+          })
+        : action({
+            label: 'Start Session',
+            detail: 'Open agent chat',
+            icon: 'bi-chat-dots',
+            attrs: 'data-cmd-map-new-session="' + escapeHtml(agent.encodedName) + '"'
+          })
+    );
+    actions.push(
+      action({
+        label: 'Configure Loadout',
+        detail: loadoutDetail,
+        icon: 'bi-sliders',
+        attrs:
+          'data-cmd-map-agent-tab="loadout" data-cmd-agent-name="' +
+          escapeHtml(agent.encodedName) +
+          '"'
+      })
+    );
+    if (detailTarget?.href) {
+      actions.push(
+        action({
+          label: 'Open Agent',
+          detail: 'Full profile',
+          icon: 'bi-person-vcard',
+          href: detailTarget.href
+        })
+      );
+    }
+    return (
+      '<section class="ws-cmd-rpg-command-panel"><header><span>Command Menu</span><strong>' +
+      escapeHtml(agent.status?.label || 'Ready') +
+      '</strong></header><div class="ws-cmd-rpg-command-grid">' +
+      actions.join('') +
+      '</div></section>'
+    );
+  }
+
   renderMapInspector(agent) {
     if (!agent) {
       return '<div class="ws-cmd-map-empty">Select an agent to inspect assignment, activity, and loadout.</div>';
@@ -2985,9 +3113,6 @@ export class WorkspaceCommandView {
       return !['completed', 'cancelled', 'timeout'].includes(status);
     }).length;
     const detailTarget = this.agentDetailTarget(agent);
-    const detailAction = detailTarget
-      ? '<a class="ws-cmd-agent-action" href="' + escapeHtml(detailTarget.href) + '">Open Agent</a>'
-      : '';
     const classLabel = agent.role?.detail || agent.role?.label || 'Agent';
     const modelLabel = agent.model?.empty ? 'Model not set' : agent.model?.label || 'Model not set';
     const statCards = [
@@ -3057,12 +3182,8 @@ export class WorkspaceCommandView {
       '<div class="ws-cmd-rpg-effects">' +
       statusEffects.map(effect => '<span>' + escapeHtml(effect) + '</span>').join('') +
       '</div></div>' +
-      '<div class="ws-cmd-map-inspector-actions">' +
-      '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-task="' +
-      escapeHtml(agent.encodedName) +
-      '">Give Task</button>' +
-      detailAction +
-      '</div></div>'
+      this.renderMapAgentCommandMenu(agent, detailTarget) +
+      '</div>'
     );
   }
 
@@ -3375,9 +3496,31 @@ export class WorkspaceCommandView {
         page.showAddTaskModalForAgent(addTaskBtn.getAttribute('data-cmd-add-task'));
         return;
       }
+      const newSessionBtn = event.target.closest('[data-cmd-map-new-session]');
+      if (newSessionBtn && page) {
+        if (typeof page.createNewSessionForAgent === 'function') {
+          page.createNewSessionForAgent(newSessionBtn.getAttribute('data-cmd-map-new-session'));
+        } else if (typeof page.createNewSession === 'function') {
+          page.createNewSession();
+        }
+        return;
+      }
       const openTaskBtn = event.target.closest('[data-cmd-open-task]');
       if (openTaskBtn && page && typeof page.openTask === 'function') {
         page.openTask(openTaskBtn.getAttribute('data-cmd-open-task'));
+        return;
+      }
+      const openSessionBtn = event.target.closest('[data-cmd-open-session]');
+      if (openSessionBtn && page && typeof page.openSession === 'function') {
+        page.openSession(openSessionBtn.getAttribute('data-cmd-open-session'));
+        return;
+      }
+      const agentTabBtn = event.target.closest('[data-cmd-map-agent-tab]');
+      if (agentTabBtn) {
+        const encodedName = agentTabBtn.getAttribute('data-cmd-agent-name');
+        if (encodedName) this.selectAgent(encodedName, { focus: false });
+        this.setCommandViewMode('details', { focus: false });
+        this.setActiveAgentTab(agentTabBtn.getAttribute('data-cmd-map-agent-tab'));
         return;
       }
       const modalBtn = event.target.closest('[data-cmd-map-open-modal]');

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2804,112 +2804,6 @@ export class WorkspaceCommandView {
     );
   }
 
-  mapStationNodes(agents = []) {
-    const stats = this.computeStats();
-    const groups = this.mapInventoryGroups();
-    const groupCounts = Object.fromEntries(
-      groups.map(group => [group.key, Number(group.count || 0)])
-    );
-    const totalItems = groups.reduce((sum, group) => sum + Number(group.count || 0), 0);
-    const destinations = Array.isArray(agents)
-      ? agents.reduce((map, agent) => {
-          const key = String(agent?.destination || 'hub');
-          map[key] = (map[key] || 0) + 1;
-          return map;
-        }, {})
-      : {};
-    return [
-      {
-        key: 'objective',
-        label: 'Objective',
-        detail: 'Main quest',
-        icon: 'bi-bullseye',
-        count: this.missionSummary().mission ? 'Set' : 'Open',
-        window: 'objective',
-        signal: destinations.hub || 0
-      },
-      {
-        key: 'quests',
-        label: 'Quests',
-        detail: 'Active tasks',
-        icon: 'bi-list-check',
-        count: this.openMapTasks().length,
-        window: 'objectives',
-        signal: destinations.tasks || 0
-      },
-      {
-        key: 'inventory',
-        label: 'Inventory',
-        detail: 'Workspace items',
-        icon: 'bi-box-seam',
-        count: totalItems,
-        window: 'inventory',
-        section: 'notes'
-      },
-      {
-        key: 'sessions',
-        label: 'Sessions',
-        detail: 'Agent chats',
-        icon: 'bi-chat-dots',
-        count: groupCounts.sessions || 0,
-        window: 'inventory',
-        section: 'sessions'
-      },
-      {
-        key: 'systems',
-        label: 'Systems',
-        detail: 'Tools online',
-        icon: 'bi-cpu',
-        count: stats.tools + Number(groupCounts.systems || 0),
-        window: 'stations',
-        signal: destinations.tools || 0
-      }
-    ];
-  }
-
-  renderMapStationNodes(agents = []) {
-    const nodes = this.mapStationNodes(agents);
-    return (
-      '<nav class="ws-cmd-map-stations" aria-label="Map stations">' +
-      nodes
-        .map(node => {
-          const active =
-            this.activeMapWindow === node.window &&
-            (!node.section ||
-              node.window !== 'inventory' ||
-              String(this.mapInventorySection || 'notes') === node.section);
-          const attrs = node.section
-            ? 'data-cmd-map-inventory-section="' + escapeHtml(node.section) + '"'
-            : 'data-cmd-map-window="' + escapeHtml(node.window) + '"';
-          return (
-            '<button type="button" class="ws-cmd-map-station-node is-' +
-            escapeHtml(node.key) +
-            (active ? ' is-active' : '') +
-            (node.signal ? ' has-signal' : '') +
-            '" data-cmd-map-station-key="' +
-            escapeHtml(node.key) +
-            '" ' +
-            attrs +
-            ' aria-label="Open ' +
-            escapeHtml(node.label) +
-            ' station" aria-pressed="' +
-            (active ? 'true' : 'false') +
-            '"><span class="ws-cmd-map-station-icon"><i class="bi ' +
-            escapeHtml(node.icon) +
-            '" aria-hidden="true"></i></span><span class="ws-cmd-map-station-copy"><strong>' +
-            escapeHtml(node.label) +
-            '</strong><small>' +
-            escapeHtml(node.detail) +
-            '</small></span><em>' +
-            escapeHtml(node.count) +
-            '</em></button>'
-          );
-        })
-        .join('') +
-      '</nav>'
-    );
-  }
-
   renderMapMissionPanel() {
     return (
       '<div class="ws-cmd-map-window-section is-objective">' +
@@ -3040,7 +2934,6 @@ export class WorkspaceCommandView {
     return (
       '<section class="ws-cmd-map-world" data-map-zone="agents" aria-label="Agent units">' +
       '<div class="ws-cmd-map-floor" aria-hidden="true"></div>' +
-      this.renderMapStationNodes(agents) +
       '<div class="ws-cmd-map-agent-field">' +
       this.renderMapAgentUnits(agents) +
       '</div></section>'

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2804,6 +2804,112 @@ export class WorkspaceCommandView {
     );
   }
 
+  mapStationNodes(agents = []) {
+    const stats = this.computeStats();
+    const groups = this.mapInventoryGroups();
+    const groupCounts = Object.fromEntries(
+      groups.map(group => [group.key, Number(group.count || 0)])
+    );
+    const totalItems = groups.reduce((sum, group) => sum + Number(group.count || 0), 0);
+    const destinations = Array.isArray(agents)
+      ? agents.reduce((map, agent) => {
+          const key = String(agent?.destination || 'hub');
+          map[key] = (map[key] || 0) + 1;
+          return map;
+        }, {})
+      : {};
+    return [
+      {
+        key: 'objective',
+        label: 'Objective',
+        detail: 'Main quest',
+        icon: 'bi-bullseye',
+        count: this.missionSummary().mission ? 'Set' : 'Open',
+        window: 'objective',
+        signal: destinations.hub || 0
+      },
+      {
+        key: 'quests',
+        label: 'Quests',
+        detail: 'Active tasks',
+        icon: 'bi-list-check',
+        count: this.openMapTasks().length,
+        window: 'objectives',
+        signal: destinations.tasks || 0
+      },
+      {
+        key: 'inventory',
+        label: 'Inventory',
+        detail: 'Workspace items',
+        icon: 'bi-box-seam',
+        count: totalItems,
+        window: 'inventory',
+        section: 'notes'
+      },
+      {
+        key: 'sessions',
+        label: 'Sessions',
+        detail: 'Agent chats',
+        icon: 'bi-chat-dots',
+        count: groupCounts.sessions || 0,
+        window: 'inventory',
+        section: 'sessions'
+      },
+      {
+        key: 'systems',
+        label: 'Systems',
+        detail: 'Tools online',
+        icon: 'bi-cpu',
+        count: stats.tools + Number(groupCounts.systems || 0),
+        window: 'stations',
+        signal: destinations.tools || 0
+      }
+    ];
+  }
+
+  renderMapStationNodes(agents = []) {
+    const nodes = this.mapStationNodes(agents);
+    return (
+      '<nav class="ws-cmd-map-stations" aria-label="Map stations">' +
+      nodes
+        .map(node => {
+          const active =
+            this.activeMapWindow === node.window &&
+            (!node.section ||
+              node.window !== 'inventory' ||
+              String(this.mapInventorySection || 'notes') === node.section);
+          const attrs = node.section
+            ? 'data-cmd-map-inventory-section="' + escapeHtml(node.section) + '"'
+            : 'data-cmd-map-window="' + escapeHtml(node.window) + '"';
+          return (
+            '<button type="button" class="ws-cmd-map-station-node is-' +
+            escapeHtml(node.key) +
+            (active ? ' is-active' : '') +
+            (node.signal ? ' has-signal' : '') +
+            '" data-cmd-map-station-key="' +
+            escapeHtml(node.key) +
+            '" ' +
+            attrs +
+            ' aria-label="Open ' +
+            escapeHtml(node.label) +
+            ' station" aria-pressed="' +
+            (active ? 'true' : 'false') +
+            '"><span class="ws-cmd-map-station-icon"><i class="bi ' +
+            escapeHtml(node.icon) +
+            '" aria-hidden="true"></i></span><span class="ws-cmd-map-station-copy"><strong>' +
+            escapeHtml(node.label) +
+            '</strong><small>' +
+            escapeHtml(node.detail) +
+            '</small></span><em>' +
+            escapeHtml(node.count) +
+            '</em></button>'
+          );
+        })
+        .join('') +
+      '</nav>'
+    );
+  }
+
   renderMapMissionPanel() {
     return (
       '<div class="ws-cmd-map-window-section is-objective">' +
@@ -2934,6 +3040,7 @@ export class WorkspaceCommandView {
     return (
       '<section class="ws-cmd-map-world" data-map-zone="agents" aria-label="Agent units">' +
       '<div class="ws-cmd-map-floor" aria-hidden="true"></div>' +
+      this.renderMapStationNodes(agents) +
       '<div class="ws-cmd-map-agent-field">' +
       this.renderMapAgentUnits(agents) +
       '</div></section>'

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -1745,8 +1745,11 @@ export class WorkspaceCommandView {
 
   statusTone(statusKey, statusLabel) {
     const s = (String(statusKey || '') + ' ' + String(statusLabel || '')).toLowerCase();
-    if (/work|run|busy|active|progress/.test(s)) return 'working';
     if (/error|fail|blocked/.test(s)) return 'alert';
+    if (/needs?[-_\s]?input|choice|human/.test(s)) return 'needs-input';
+    if (/work|run|busy|active|progress/.test(s)) return 'working';
+    if (/wait|queue|pending|scheduled/.test(s)) return 'waiting';
+    if (/complete|done|success/.test(s)) return 'done';
     return 'idle';
   }
 
@@ -2803,7 +2806,11 @@ export class WorkspaceCommandView {
 
   renderMapMissionPanel() {
     return (
-      '<div class="ws-cmd-map-window-section is-objective">' + this.renderMissionPanel() + '</div>'
+      '<div class="ws-cmd-map-window-section is-objective">' +
+      '<div class="ws-cmd-map-quest-frame">' +
+      '<div class="ws-cmd-map-quest-frame-head"><span>Main Quest</span><strong>Workspace Objective</strong></div>' +
+      this.renderMissionPanel() +
+      '</div></div>'
     );
   }
 
@@ -2812,19 +2819,22 @@ export class WorkspaceCommandView {
     const shown = tasks.slice(0, 4);
     const rows = shown.length
       ? shown
-          .map(task => {
+          .map((task, index) => {
             const id = String(task.id || '');
             const label = String(task.description || task.name || task.title || 'Untitled task');
             const status = String(task.status || 'pending')
               .trim()
               .toLowerCase();
+            const questNumber = String(index + 1).padStart(2, '0');
             return (
               '<button type="button" class="ws-cmd-map-task-row ' +
               escapeHtml(this.taskTone(status)) +
               '" data-cmd-open-task="' +
               escapeHtml(id) +
               '">' +
-              '<span class="ws-cmd-map-task-name">' +
+              '<span class="ws-cmd-map-task-marker">Quest ' +
+              escapeHtml(questNumber) +
+              '</span><span class="ws-cmd-map-task-name">' +
               escapeHtml(label) +
               '</span><span class="ws-cmd-map-task-status">' +
               escapeHtml(this.taskStatusLabel(status)) +
@@ -2832,7 +2842,7 @@ export class WorkspaceCommandView {
             );
           })
           .join('')
-      : '<div class="ws-cmd-map-empty">No open tasks.</div>';
+      : '<div class="ws-cmd-map-empty is-quest-empty"><strong>Quest log clear</strong><span>No active objectives assigned.</span></div>';
     return (
       '<div class="ws-cmd-map-window-section is-objectives">' +
       this.mapZoneHeaderHTML('Objectives', 'Active Tasks', tasks.length) +
@@ -2879,6 +2889,7 @@ export class WorkspaceCommandView {
         const entryBadge = agent.entry
           ? '<span class="ws-cmd-map-entry-badge" title="Entry Agent"><i class="bi bi-star-fill" aria-hidden="true"></i><span>Entry</span></span>'
           : '';
+        const statusLabel = agent.status?.label || 'Idle';
         return (
           '<button type="button" class="ws-cmd-map-agent ' +
           escapeHtml(agent.tone) +
@@ -2897,9 +2908,14 @@ export class WorkspaceCommandView {
           escapeHtml(agent.name) +
           ', ' +
           (agent.entry ? 'Entry Agent, ' : '') +
-          escapeHtml(agent.status?.label || 'Idle') +
+          escapeHtml(statusLabel) +
           '">' +
           '<span class="ws-cmd-map-agent-path" aria-hidden="true"></span>' +
+          '<span class="ws-cmd-map-agent-status" aria-hidden="true" title="' +
+          escapeHtml(statusLabel) +
+          '"><span class="ws-cmd-led ' +
+          escapeHtml(agent.tone) +
+          '"></span></span>' +
           entryBadge +
           this.agentCharacterHTML(agent, 'roster') +
           '<span class="ws-cmd-map-agent-copy"><strong>' +
@@ -2907,7 +2923,7 @@ export class WorkspaceCommandView {
           '</strong><span>' +
           escapeHtml(agent.role?.label || 'Agent') +
           '</span><em>' +
-          escapeHtml(agent.status?.label || 'Idle') +
+          escapeHtml(statusLabel) +
           '</em></span></button>'
         );
       })
@@ -2920,6 +2936,40 @@ export class WorkspaceCommandView {
       '<div class="ws-cmd-map-floor" aria-hidden="true"></div>' +
       '<div class="ws-cmd-map-agent-field">' +
       this.renderMapAgentUnits(agents) +
+      '</div></section>'
+    );
+  }
+
+  renderMapAgentLoadout(agent) {
+    const skills = Array.isArray(agent?.skills?.names) ? agent.skills.names : [];
+    const tools = Array.isArray(agent?.mcpNames) ? agent.mcpNames : [];
+    const chips = [
+      ...skills.map(name => ({ kind: 'Skill', label: name })),
+      ...tools.map(name => ({ kind: 'Tool', label: name }))
+    ];
+    if (!agent?.model?.empty && agent?.model?.label) {
+      chips.unshift({ kind: 'Model', label: agent.model.label });
+    }
+    const shown = chips
+      .map(chip => ({
+        kind: String(chip.kind || '').trim(),
+        label: String(chip.label || '').trim()
+      }))
+      .filter(chip => chip.kind && chip.label)
+      .slice(0, 6);
+    if (!shown.length) {
+      return '<section class="ws-cmd-rpg-loadout is-empty"><span>Loadout</span><strong>No skills or tools configured</strong></section>';
+    }
+    const remaining = Math.max(0, chips.length - shown.length);
+    return (
+      '<section class="ws-cmd-rpg-loadout"><span>Loadout</span><div>' +
+      shown
+        .map(
+          chip =>
+            '<em><small>' + escapeHtml(chip.kind) + '</small>' + escapeHtml(chip.label) + '</em>'
+        )
+        .join('') +
+      (remaining ? '<em><small>More</small>+' + escapeHtml(remaining) + '</em>' : '') +
       '</div></section>'
     );
   }
@@ -2938,6 +2988,8 @@ export class WorkspaceCommandView {
     const detailAction = detailTarget
       ? '<a class="ws-cmd-agent-action" href="' + escapeHtml(detailTarget.href) + '">Open Agent</a>'
       : '';
+    const classLabel = agent.role?.detail || agent.role?.label || 'Agent';
+    const modelLabel = agent.model?.empty ? 'Model not set' : agent.model?.label || 'Model not set';
     const statCards = [
       { label: 'Quests', value: openTaskCount },
       { label: 'Skills', value: Number(agent.skills?.count || 0) },
@@ -2950,17 +3002,27 @@ export class WorkspaceCommandView {
       agent.model?.empty ? '' : agent.model?.label || ''
     ].filter(Boolean);
     return (
-      '<div class="ws-cmd-map-inspector-card" aria-label="' +
+      '<div class="ws-cmd-map-inspector-card ' +
+      escapeHtml(agent.tone) +
+      '" aria-label="' +
       escapeHtml(agent.name) +
       ' sheet">' +
       '<div class="ws-cmd-map-agent-sheet-head">' +
       this.agentCharacterHTML(agent, 'roster') +
-      '<div><span>Unit Sheet</span><strong>' +
+      '<div class="ws-cmd-map-agent-sheet-title"><span>Unit Sheet</span><strong>' +
       escapeHtml(agent.name) +
       '</strong><p>' +
       escapeHtml(agent.role?.label || 'Agent') +
       '</p></div></div>' +
       '<div class="ws-cmd-rpg-sheet">' +
+      '<div class="ws-cmd-rpg-class-grid">' +
+      '<div class="ws-cmd-rpg-class-card"><span>Class</span><strong>' +
+      escapeHtml(classLabel) +
+      '</strong></div>' +
+      '<div class="ws-cmd-rpg-class-card"><span>Model</span><strong>' +
+      escapeHtml(modelLabel) +
+      '</strong></div>' +
+      '</div>' +
       '<div class="ws-cmd-rpg-status-strip"><span class="ws-cmd-led ' +
       escapeHtml(agent.tone) +
       '"></span><strong>' +
@@ -2987,6 +3049,7 @@ export class WorkspaceCommandView {
       (summary?.activityLabel ? ' · ' + escapeHtml(summary.activityLabel) : '') +
       (summary?.whenLabel ? ' · ' + escapeHtml(summary.whenLabel) : '') +
       '</p></section>' +
+      this.renderMapAgentLoadout(agent) +
       '<div class="ws-cmd-rpg-sheet-row"><span>Recent Activity</span><strong>' +
       escapeHtml(summary?.activityLabel || 'No recent activity') +
       (summary?.whenLabel ? ' · ' + escapeHtml(summary.whenLabel) : '') +
@@ -3014,7 +3077,7 @@ export class WorkspaceCommandView {
         icon: 'bi-journal-text',
         count: Array.isArray(page.notes) ? page.notes.length : 0,
         action: 'New Note',
-        empty: 'No notes yet.',
+        slotLabel: 'Note',
         items: (Array.isArray(page.notes) ? page.notes : []).map(note => ({
           label: note.name || note.title || 'Untitled Note',
           meta: '',
@@ -3028,7 +3091,7 @@ export class WorkspaceCommandView {
         icon: 'bi-calendar2-week',
         count: Array.isArray(page.schedules) ? page.schedules.length : 0,
         action: 'Open Schedules',
-        empty: 'No schedules yet.',
+        slotLabel: 'Schedule',
         items: (Array.isArray(page.schedules) ? page.schedules : []).map(schedule => ({
           label: schedule.name || schedule.task_description || 'Unnamed Schedule',
           meta: '',
@@ -3042,7 +3105,7 @@ export class WorkspaceCommandView {
         icon: 'bi-chat-dots',
         count: Array.isArray(page.sessions) ? page.sessions.length : 0,
         action: 'New Session',
-        empty: 'No sessions yet.',
+        slotLabel: 'Session',
         items: (Array.isArray(page.sessions) ? page.sessions : []).map(session => ({
           label: session.title || session.name || 'Untitled Session',
           meta: session.agent_name || '',
@@ -3056,7 +3119,7 @@ export class WorkspaceCommandView {
         icon: 'bi-folder2-open',
         count: folders.length,
         action: 'Link Folder',
-        empty: 'No linked folders yet.',
+        slotLabel: 'Folder',
         items: folders.map(folder => ({
           label: folder.title || folder.name || folder.path || 'Unnamed Directory',
           meta: folder.path || '',
@@ -3071,7 +3134,7 @@ export class WorkspaceCommandView {
         icon: 'bi-file-earmark-text',
         count: files.length,
         action: 'Upload',
-        empty: 'No files yet.',
+        slotLabel: 'File',
         items: files.map(file => ({
           label: this.fileTitle(file),
           meta: this.fileMeta(file),
@@ -3085,7 +3148,7 @@ export class WorkspaceCommandView {
         icon: 'bi-cpu',
         count: this.systemTabs().length,
         action: 'Open Systems',
-        empty: 'No systems configured.',
+        slotLabel: 'System',
         items: this.systemTabs().map(tab => ({
           label: tab.label,
           meta: 'Workspace system',
@@ -3098,6 +3161,10 @@ export class WorkspaceCommandView {
 
   renderMapInventoryItems(group) {
     const items = Array.isArray(group?.items) ? group.items : [];
+    const groupKey = String(group?.key || 'item')
+      .trim()
+      .toLowerCase();
+    const slotType = String(group?.slotLabel || group?.label || 'Item').trim();
     const visibleItems = items.slice(0, 11);
     const slotCount = Math.max(
       8,
@@ -3115,11 +3182,15 @@ export class WorkspaceCommandView {
             escapeHtml(item.source || '') +
             '"';
       return (
-        '<button type="button" class="ws-cmd-map-inventory-slot" ' +
+        '<button type="button" class="ws-cmd-map-inventory-slot is-' +
+        escapeHtml(groupKey) +
+        '" ' +
         attrs +
         ' aria-label="Open ' +
         escapeHtml(item.label) +
-        '"><span class="ws-cmd-map-slot-icon"><i class="bi ' +
+        '"><span class="ws-cmd-map-slot-type">' +
+        escapeHtml(slotType) +
+        '</span><span class="ws-cmd-map-slot-icon"><i class="bi ' +
         escapeHtml(group?.icon || 'bi-box') +
         '" aria-hidden="true"></i></span><span class="ws-cmd-map-slot-name">' +
         escapeHtml(item.label) +
@@ -3131,10 +3202,17 @@ export class WorkspaceCommandView {
       );
     });
     while (slots.length < slotCount) {
+      const emptyLabel = slots.length === 0 ? 'Open Slot' : 'Empty Slot';
       slots.push(
-        '<div class="ws-cmd-map-inventory-slot is-empty"><span class="ws-cmd-map-slot-icon">+</span><span class="ws-cmd-map-slot-name">' +
-          escapeHtml(slots.length === 0 ? group?.empty || 'Empty slot' : 'Empty') +
-          '</span></div>'
+        '<div class="ws-cmd-map-inventory-slot is-empty is-' +
+          escapeHtml(groupKey) +
+          '"><span class="ws-cmd-map-slot-type">' +
+          escapeHtml(slotType) +
+          '</span><span class="ws-cmd-map-slot-icon"><i class="bi bi-plus-lg" aria-hidden="true"></i></span><span class="ws-cmd-map-slot-name">' +
+          escapeHtml(emptyLabel) +
+          '</span><em>' +
+          escapeHtml(group?.label || 'Item') +
+          '</em></div>'
       );
     }
     return '<div class="ws-cmd-map-inventory-grid">' + slots.join('') + '</div>';

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2087,11 +2087,6 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
 
   const tray = commandView.renderMapToolTray();
   assert.match(tray, /data-cmd-map-window="inventory" aria-label="Inventory" aria-pressed="true"/);
-  const stations = commandView.renderMapStationNodes([]);
-  assert.match(stations, /ws-cmd-map-station-node is-objective/);
-  assert.match(stations, /data-cmd-map-window="objective"/);
-  assert.match(stations, /data-cmd-map-inventory-section="notes"/);
-  assert.match(stations, /data-cmd-map-inventory-section="sessions"/);
 
   const windowHTML = commandView.renderMapWindow(null);
   assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Inventory"/);
@@ -2099,43 +2094,6 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
   assert.match(windowHTML, /ws-cmd-map-inventory-slot is-empty/);
   assert.match(windowHTML, /ws-cmd-map-slot-type">Note/);
   assert.match(windowHTML, /Open Slot/);
-});
-
-test('Operations Map station nodes open windows and inventory sections', () => {
-  const mapRoot = makeListenerRoot();
-  const calls = [];
-  const commandView = Object.create(WorkspaceCommandView.prototype);
-  Object.assign(commandView, {
-    activeMapWindow: '',
-    mapInventorySection: '',
-    container: {
-      querySelector(selector) {
-        return selector === '.ws-cmd-map-shell' ? mapRoot : null;
-      }
-    },
-    page: {},
-    render() {
-      calls.push([this.activeMapWindow, this.mapInventorySection]);
-    }
-  });
-
-  commandView.bindOperationsMap();
-
-  mapRoot.listener({
-    target: makeAttributeClickTarget({ 'data-cmd-map-window': 'objective' })
-  });
-  mapRoot.listener({
-    target: makeAttributeClickTarget({ 'data-cmd-map-inventory-section': 'sessions' })
-  });
-  mapRoot.listener({
-    target: makeAttributeClickTarget({ 'data-cmd-map-inventory-section': 'notes' })
-  });
-
-  assert.deepEqual(calls, [
-    ['objective', ''],
-    ['inventory', 'sessions'],
-    ['inventory', 'notes']
-  ]);
 });
 
 test('Operations Map agent command menu delegates to existing workspace flows', () => {
@@ -2268,11 +2226,8 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     assert.match(html, /ws-cmd-map-shell/);
     assert.match(html, /data-map-zone="agents"/);
     assert.match(html, /data-cmd-map-window="inventory"/);
-    assert.match(html, /ws-cmd-map-stations/);
-    assert.match(html, /Objective/);
-    assert.match(html, /Quests/);
-    assert.match(html, /Sessions/);
-    assert.match(html, /Systems/);
+    assert.doesNotMatch(html, /ws-cmd-map-stations/);
+    assert.doesNotMatch(html, /ws-cmd-map-station-node/);
     assert.match(html, /Researcher/);
     assert.match(html, /ws-cmd-map-entry-badge/);
     assert.match(html, /Entry Agent/);

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -7,6 +7,11 @@ import { WorkspaceCommandView } from './workspace-command.js';
 // setup() when there's no container — a null-returning stub is enough to build
 // an instance whose pure format helpers we can exercise.
 globalThis.document = { getElementById: () => null };
+globalThis.localStorage = {
+  getItem: () => null,
+  setItem() {},
+  removeItem() {}
+};
 const view = new WorkspaceCommandView(null);
 
 function makeToggleButton() {
@@ -1969,6 +1974,178 @@ test('setup always activates Command view', () => {
   } finally {
     globalThis.document = originalDocument;
     globalThis.window = originalWindow;
+    globalThis.localStorage = originalLocalStorage;
+  }
+});
+
+test('command view mode preference defaults to details and persists map globally', () => {
+  const originalLocalStorage = globalThis.localStorage;
+  const store = new Map();
+  try {
+    globalThis.localStorage = {
+      getItem(key) {
+        return store.has(key) ? store.get(key) : null;
+      },
+      setItem(key, value) {
+        store.set(key, String(value));
+      }
+    };
+    const commandView = Object.create(WorkspaceCommandView.prototype);
+
+    assert.equal(commandView.readCommandViewModePreference(), 'details');
+    commandView.persistCommandViewMode('map');
+    assert.equal(store.get('oriWorkspaceCommandViewMode'), 'map');
+    assert.equal(commandView.readCommandViewModePreference(), 'map');
+
+    commandView.persistCommandViewMode('bad-value');
+    assert.equal(commandView.readCommandViewModePreference(), 'details');
+  } finally {
+    globalThis.localStorage = originalLocalStorage;
+  }
+});
+
+test('Operations Map agent status prioritizes attention states before working', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  const agent = {
+    status: { key: 'idle', label: 'Idle', detail: 'No active tasks' },
+    tasks: [
+      { id: 'task-1', status: 'in_progress' },
+      { id: 'task-2', status: 'blocked' }
+    ]
+  };
+
+  assert.equal(commandView.mapAgentStatus(agent).key, 'blocked');
+
+  agent.tasks = [
+    { id: 'task-1', status: 'in_progress' },
+    { id: 'task-2', status: 'waiting_for_choice' }
+  ];
+  assert.equal(commandView.mapAgentStatus(agent).key, 'needs-input');
+
+  agent.tasks = [{ id: 'task-1', status: 'in_progress' }];
+  assert.equal(commandView.mapAgentStatus(agent).key, 'working');
+
+  agent.tasks = [{ id: 'task-1', status: 'pending' }];
+  assert.equal(commandView.mapAgentStatus(agent).key, 'waiting');
+});
+
+test('Operations Map inventory derives counts from existing page data', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      notes: [{ id: 'n1', title: 'Note' }],
+      schedules: [{ id: 'sch1', name: 'Daily' }],
+      sessions: [{ id: 's1', title: 'Session' }],
+      directories: [{ id: 'd1', name: 'Project', path: '/tmp/project' }],
+      files: [{ id: 'f1', title: 'Brief.md' }]
+    },
+    activeSystemTab: 'memory'
+  });
+
+  const counts = Object.fromEntries(
+    commandView.mapInventoryGroups().map(group => [group.key, group.count])
+  );
+
+  assert.equal(counts.notes, 1);
+  assert.equal(counts.schedules, 1);
+  assert.equal(counts.sessions, 1);
+  assert.equal(counts.folders, 1);
+  assert.equal(counts.files, 1);
+  assert.equal(counts.systems, 2);
+});
+
+test('Operations Map controls expose accessible pressed and dialog state', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    viewMode: 'map',
+    page: { notes: [], schedules: [], sessions: [], directories: [], files: [] },
+    activeMapWindow: 'inventory',
+    mapInventorySection: 'notes',
+    activeSystemTab: 'memory'
+  });
+
+  const switcher = commandView.commandViewSwitchHTML();
+  assert.match(switcher, /role="group" aria-label="Workspace view"/);
+  assert.match(switcher, /data-cmd-view-mode="map" aria-pressed="true"/);
+
+  const tray = commandView.renderMapToolTray();
+  assert.match(tray, /data-cmd-map-window="inventory" aria-label="Inventory" aria-pressed="true"/);
+
+  const windowHTML = commandView.renderMapWindow(null);
+  assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Inventory"/);
+  assert.match(windowHTML, /ws-cmd-map-inventory-grid/);
+  assert.match(windowHTML, /ws-cmd-map-inventory-slot is-empty/);
+});
+
+test('Operations Map renders units first and keeps support panels hidden by default', () => {
+  const originalLocalStorage = globalThis.localStorage;
+  try {
+    globalThis.localStorage = { getItem: () => null, setItem() {} };
+    const commandView = Object.create(WorkspaceCommandView.prototype);
+    Object.assign(commandView, {
+      page: {
+        workspace: { id: 'ws-1', name: 'Research', mcp_bindings: [], skill_bindings: [] },
+        buildAgentGroups() {
+          return [
+            {
+              key: 'researcher',
+              name: 'Researcher',
+              isWorkspaceAgent: true,
+              instanceCount: 1,
+              roles: ['Agent'],
+              tasks: [
+                {
+                  id: 'task-1',
+                  status: 'in_progress',
+                  description: 'Collect sources'
+                }
+              ]
+            }
+          ];
+        },
+        getAgentRosterStatus() {
+          return { key: 'working', label: 'Working', detail: 'Task in progress' };
+        },
+        getAgentSkillSummary() {
+          return { count: 0, names: [] };
+        },
+        getEffectiveWorkspaceMCPServerNames() {
+          return [];
+        },
+        getAgentModelPresentation() {
+          return { model: '', label: 'Model not set', empty: true };
+        },
+        tasks: [{ id: 'task-1', status: 'in_progress', description: 'Collect sources' }]
+      },
+      selectedAgentKey: '',
+      agentSelectionInitialized: true,
+      activeMapWindow: '',
+      mapInventorySection: '',
+      activeSystemTab: 'memory'
+    });
+
+    const html = commandView.renderOperationsMap();
+
+    assert.match(html, /ws-cmd-map-shell/);
+    assert.match(html, /data-map-zone="agents"/);
+    assert.match(html, /data-cmd-map-window="inventory"/);
+    assert.match(html, /Researcher/);
+    assert.doesNotMatch(html, /data-map-zone="mission"/);
+    assert.doesNotMatch(html, /data-map-zone="tasks"/);
+    assert.doesNotMatch(html, /data-map-zone="tools"/);
+    assert.doesNotMatch(html, /role="dialog"/);
+
+    commandView.activeMapWindow = 'objectives';
+    const windowHTML = commandView.renderOperationsMap();
+    assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Objectives"/);
+    assert.match(windowHTML, /Collect sources/);
+
+    commandView.activeMapWindow = 'inspector';
+    const agentSheetHTML = commandView.renderOperationsMap();
+    assert.match(agentSheetHTML, /Unit Sheet/);
+    assert.match(agentSheetHTML, /ws-cmd-rpg-stat-grid/);
+    assert.match(agentSheetHTML, /Current Quest/);
+  } finally {
     globalThis.localStorage = originalLocalStorage;
   }
 });

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2106,6 +2106,9 @@ test('Operations Map renders units first and keeps support panels hidden by defa
         getAgentRosterStatus() {
           return { key: 'working', label: 'Working', detail: 'Task in progress' };
         },
+        isWorkspaceEntryAgent(name) {
+          return name === 'Researcher';
+        },
         getAgentSkillSummary() {
           return { count: 0, names: [] };
         },
@@ -2130,6 +2133,8 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     assert.match(html, /data-map-zone="agents"/);
     assert.match(html, /data-cmd-map-window="inventory"/);
     assert.match(html, /Researcher/);
+    assert.match(html, /ws-cmd-map-entry-badge/);
+    assert.match(html, /Entry Agent/);
     assert.doesNotMatch(html, /data-map-zone="mission"/);
     assert.doesNotMatch(html, /data-map-zone="tasks"/);
     assert.doesNotMatch(html, /data-map-zone="tools"/);

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -77,6 +77,14 @@ function makeAttributeClickTarget(attrs) {
           }
         };
       }
+      const matchedAttr = Object.keys(attrs).find(attr => selector.includes(attr));
+      if (matchedAttr) {
+        return {
+          getAttribute(name) {
+            return attrs[name] || '';
+          }
+        };
+      }
       if (
         selector.includes('data-cmd-open-section') &&
         selector.includes('data-cmd-item-id') &&
@@ -2082,6 +2090,73 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
   assert.match(windowHTML, /Open Slot/);
 });
 
+test('Operations Map agent command menu delegates to existing workspace flows', () => {
+  const mapRoot = makeListenerRoot();
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-map-shell' ? mapRoot : null;
+      }
+    },
+    page: {
+      showAddTaskModalForAgent(encodedName) {
+        calls.push(['add-task', encodedName]);
+      },
+      createNewSessionForAgent(encodedName) {
+        calls.push(['new-session', encodedName]);
+      },
+      openSession(id) {
+        calls.push(['open-session', id]);
+      },
+      openTask(id) {
+        calls.push(['open-task', id]);
+      }
+    },
+    selectAgent(encodedName, options) {
+      calls.push(['select-agent', encodedName, options.focus]);
+    },
+    setCommandViewMode(mode, options) {
+      calls.push(['view-mode', mode, options.focus]);
+    },
+    setActiveAgentTab(tab) {
+      calls.push(['agent-tab', tab]);
+    }
+  });
+
+  commandView.bindOperationsMap();
+
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-add-task': 'Researcher' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-map-new-session': 'Researcher' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-open-session': 'session-1' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-open-task': 'task-1' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({
+      'data-cmd-map-agent-tab': 'loadout',
+      'data-cmd-agent-name': 'Researcher'
+    })
+  });
+
+  assert.deepEqual(calls, [
+    ['add-task', 'Researcher'],
+    ['new-session', 'Researcher'],
+    ['open-session', 'session-1'],
+    ['open-task', 'task-1'],
+    ['select-agent', 'Researcher', false],
+    ['view-mode', 'details', false],
+    ['agent-tab', 'loadout']
+  ]);
+});
+
 test('Operations Map renders units first and keeps support panels hidden by default', () => {
   const originalLocalStorage = globalThis.localStorage;
   try {
@@ -2123,7 +2198,15 @@ test('Operations Map renders units first and keeps support panels hidden by defa
         getAgentModelPresentation() {
           return { model: '', label: 'Model not set', empty: true };
         },
-        tasks: [{ id: 'task-1', status: 'in_progress', description: 'Collect sources' }]
+        tasks: [{ id: 'task-1', status: 'in_progress', description: 'Collect sources' }],
+        sessions: [
+          {
+            id: 'session-1',
+            title: 'Research chat',
+            agent_name: 'Researcher',
+            updated_at: '2026-07-09T12:00:00Z'
+          }
+        ]
       },
       selectedAgentKey: '',
       agentSelectionInitialized: true,
@@ -2159,6 +2242,10 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     assert.match(agentSheetHTML, /filesystem/);
     assert.match(agentSheetHTML, /ws-cmd-rpg-stat-grid/);
     assert.match(agentSheetHTML, /Current Quest/);
+    assert.match(agentSheetHTML, /Command Menu/);
+    assert.match(agentSheetHTML, /Track Quest/);
+    assert.match(agentSheetHTML, /Continue Session/);
+    assert.match(agentSheetHTML, /Configure Loadout/);
   } finally {
     globalThis.localStorage = originalLocalStorage;
   }

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -77,7 +77,13 @@ function makeAttributeClickTarget(attrs) {
           }
         };
       }
-      const matchedAttr = Object.keys(attrs).find(attr => selector.includes(attr));
+      const matchedAttr = Object.keys(attrs).find(
+        attr =>
+          selector === '[' + attr + ']' ||
+          selector.startsWith('[' + attr + '=') ||
+          selector.includes('][' + attr + ']') ||
+          selector.includes('][' + attr + '=')
+      );
       if (matchedAttr) {
         return {
           getAttribute(name) {
@@ -2081,6 +2087,11 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
 
   const tray = commandView.renderMapToolTray();
   assert.match(tray, /data-cmd-map-window="inventory" aria-label="Inventory" aria-pressed="true"/);
+  const stations = commandView.renderMapStationNodes([]);
+  assert.match(stations, /ws-cmd-map-station-node is-objective/);
+  assert.match(stations, /data-cmd-map-window="objective"/);
+  assert.match(stations, /data-cmd-map-inventory-section="notes"/);
+  assert.match(stations, /data-cmd-map-inventory-section="sessions"/);
 
   const windowHTML = commandView.renderMapWindow(null);
   assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Inventory"/);
@@ -2088,6 +2099,43 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
   assert.match(windowHTML, /ws-cmd-map-inventory-slot is-empty/);
   assert.match(windowHTML, /ws-cmd-map-slot-type">Note/);
   assert.match(windowHTML, /Open Slot/);
+});
+
+test('Operations Map station nodes open windows and inventory sections', () => {
+  const mapRoot = makeListenerRoot();
+  const calls = [];
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    activeMapWindow: '',
+    mapInventorySection: '',
+    container: {
+      querySelector(selector) {
+        return selector === '.ws-cmd-map-shell' ? mapRoot : null;
+      }
+    },
+    page: {},
+    render() {
+      calls.push([this.activeMapWindow, this.mapInventorySection]);
+    }
+  });
+
+  commandView.bindOperationsMap();
+
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-map-window': 'objective' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-map-inventory-section': 'sessions' })
+  });
+  mapRoot.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-map-inventory-section': 'notes' })
+  });
+
+  assert.deepEqual(calls, [
+    ['objective', ''],
+    ['inventory', 'sessions'],
+    ['inventory', 'notes']
+  ]);
 });
 
 test('Operations Map agent command menu delegates to existing workspace flows', () => {
@@ -2220,6 +2268,11 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     assert.match(html, /ws-cmd-map-shell/);
     assert.match(html, /data-map-zone="agents"/);
     assert.match(html, /data-cmd-map-window="inventory"/);
+    assert.match(html, /ws-cmd-map-stations/);
+    assert.match(html, /Objective/);
+    assert.match(html, /Quests/);
+    assert.match(html, /Sessions/);
+    assert.match(html, /Systems/);
     assert.match(html, /Researcher/);
     assert.match(html, /ws-cmd-map-entry-badge/);
     assert.match(html, /Entry Agent/);

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -100,6 +100,9 @@ test('statusTone maps an agent status to a visual tone', () => {
   assert.equal(view.statusTone('busy', ''), 'working');
   assert.equal(view.statusTone('error', ''), 'alert');
   assert.equal(view.statusTone('failed', ''), 'alert');
+  assert.equal(view.statusTone('waiting', ''), 'waiting');
+  assert.equal(view.statusTone('needs-input', ''), 'needs-input');
+  assert.equal(view.statusTone('completed', ''), 'done');
   assert.equal(view.statusTone('idle', ''), 'idle');
   assert.equal(view.statusTone('', ''), 'idle');
 });
@@ -2075,6 +2078,8 @@ test('Operations Map controls expose accessible pressed and dialog state', () =>
   assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Inventory"/);
   assert.match(windowHTML, /ws-cmd-map-inventory-grid/);
   assert.match(windowHTML, /ws-cmd-map-inventory-slot is-empty/);
+  assert.match(windowHTML, /ws-cmd-map-slot-type">Note/);
+  assert.match(windowHTML, /Open Slot/);
 });
 
 test('Operations Map renders units first and keeps support panels hidden by default', () => {
@@ -2110,10 +2115,10 @@ test('Operations Map renders units first and keeps support panels hidden by defa
           return name === 'Researcher';
         },
         getAgentSkillSummary() {
-          return { count: 0, names: [] };
+          return { count: 1, names: ['workspace-planning'] };
         },
         getEffectiveWorkspaceMCPServerNames() {
-          return [];
+          return ['filesystem'];
         },
         getAgentModelPresentation() {
           return { model: '', label: 'Model not set', empty: true };
@@ -2148,6 +2153,10 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     commandView.activeMapWindow = 'inspector';
     const agentSheetHTML = commandView.renderOperationsMap();
     assert.match(agentSheetHTML, /Unit Sheet/);
+    assert.match(agentSheetHTML, /Class/);
+    assert.match(agentSheetHTML, /Loadout/);
+    assert.match(agentSheetHTML, /workspace-planning/);
+    assert.match(agentSheetHTML, /filesystem/);
     assert.match(agentSheetHTML, /ws-cmd-rpg-stat-grid/);
     assert.match(agentSheetHTML, /Current Quest/);
   } finally {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -776,6 +776,49 @@ test.describe('Workspace Agent Character Roster', () => {
           item.labelOverflow === 'hidden'
       )
     ).toBeTruthy();
+    const stationNodes = page.locator('#workspaceCommandView .ws-cmd-map-station-node');
+    await expect(stationNodes).toHaveCount(5);
+    await expect(stationNodes).toContainText([
+      'Objective',
+      'Quests',
+      'Inventory',
+      'Sessions',
+      'Systems'
+    ]);
+    const stationGeometry = await stationNodes.evaluateAll(nodes =>
+      nodes.map(node => {
+        const rect = node.getBoundingClientRect();
+        const mapRect = node.closest('.ws-cmd-opmap')?.getBoundingClientRect();
+        return {
+          bottom: Math.round(rect.bottom),
+          left: Math.round(rect.left),
+          mapBottom: mapRect ? Math.round(mapRect.bottom) : 0,
+          mapLeft: mapRect ? Math.round(mapRect.left) : 0,
+          mapRight: mapRect ? Math.round(mapRect.right) : 0,
+          mapTop: mapRect ? Math.round(mapRect.top) : 0,
+          right: Math.round(rect.right),
+          top: Math.round(rect.top)
+        };
+      })
+    );
+    expect(
+      stationGeometry.every(
+        item =>
+          item.left >= item.mapLeft &&
+          item.top >= item.mapTop &&
+          item.right <= item.mapRight &&
+          item.bottom <= item.mapBottom
+      )
+    ).toBeTruthy();
+    await page.locator('#workspaceCommandView [data-cmd-map-station-key="sessions"]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toContainText(
+      'Inventory'
+    );
+    await expect(
+      page.locator('#workspaceCommandView .ws-cmd-map-inventory-group.is-active')
+    ).toContainText('Sessions');
+    await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
     const entryUnit = page
       .locator('#workspaceCommandView .ws-cmd-map-agent')
       .filter({ hasText: 'Roster Manager' });
@@ -784,19 +827,17 @@ test.describe('Workspace Agent Character Roster', () => {
     await expect(entryUnit).toHaveClass(/waiting/);
     await expect(entryUnit).toHaveAttribute('aria-label', /Entry Agent/);
 
-    await page.locator('#workspaceCommandView [data-cmd-map-window="inventory"]').click();
+    await page.locator('#workspaceCommandView [data-cmd-map-station-key="inventory"]').click();
     const inventoryWindow = page.locator('#workspaceCommandView .ws-cmd-map-window');
+    const activeInventoryGroup = page.locator(
+      '#workspaceCommandView .ws-cmd-map-inventory-group.is-active'
+    );
     await expect(inventoryWindow).toBeVisible();
     await expect(inventoryWindow).toContainText('Inventory');
-    await expect(
-      page.locator(
-        '#workspaceCommandView .ws-cmd-map-inventory-group.is-active .ws-cmd-map-inventory-grid'
-      )
-    ).toBeVisible();
-    await expect(
-      page.locator('#workspaceCommandView .ws-cmd-map-inventory-slot').first()
-    ).toBeVisible();
-    await expect(page.locator('#workspaceCommandView .ws-cmd-map-slot-type').first()).toContainText(
+    await expect(activeInventoryGroup).toContainText('Notes');
+    await expect(activeInventoryGroup.locator('.ws-cmd-map-inventory-grid')).toBeVisible();
+    await expect(activeInventoryGroup.locator('.ws-cmd-map-inventory-slot').first()).toBeVisible();
+    await expect(activeInventoryGroup.locator('.ws-cmd-map-slot-type').first()).toContainText(
       'Note'
     );
     const inventoryGeometry = await inventoryWindow.evaluate(node => {
@@ -820,7 +861,9 @@ test.describe('Workspace Agent Character Roster', () => {
     await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
     await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
 
-    await page.locator('#workspaceCommandView [data-cmd-map-window="objectives"]').click();
+    await page
+      .locator('#workspaceCommandView .ws-cmd-map-belt-btn[data-cmd-map-window="objectives"]')
+      .click();
     await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toContainText(
       'Plan the work'
     );

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -776,49 +776,8 @@ test.describe('Workspace Agent Character Roster', () => {
           item.labelOverflow === 'hidden'
       )
     ).toBeTruthy();
-    const stationNodes = page.locator('#workspaceCommandView .ws-cmd-map-station-node');
-    await expect(stationNodes).toHaveCount(5);
-    await expect(stationNodes).toContainText([
-      'Objective',
-      'Quests',
-      'Inventory',
-      'Sessions',
-      'Systems'
-    ]);
-    const stationGeometry = await stationNodes.evaluateAll(nodes =>
-      nodes.map(node => {
-        const rect = node.getBoundingClientRect();
-        const mapRect = node.closest('.ws-cmd-opmap')?.getBoundingClientRect();
-        return {
-          bottom: Math.round(rect.bottom),
-          left: Math.round(rect.left),
-          mapBottom: mapRect ? Math.round(mapRect.bottom) : 0,
-          mapLeft: mapRect ? Math.round(mapRect.left) : 0,
-          mapRight: mapRect ? Math.round(mapRect.right) : 0,
-          mapTop: mapRect ? Math.round(mapRect.top) : 0,
-          right: Math.round(rect.right),
-          top: Math.round(rect.top)
-        };
-      })
-    );
-    expect(
-      stationGeometry.every(
-        item =>
-          item.left >= item.mapLeft &&
-          item.top >= item.mapTop &&
-          item.right <= item.mapRight &&
-          item.bottom <= item.mapBottom
-      )
-    ).toBeTruthy();
-    await page.locator('#workspaceCommandView [data-cmd-map-station-key="sessions"]').click();
-    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toContainText(
-      'Inventory'
-    );
-    await expect(
-      page.locator('#workspaceCommandView .ws-cmd-map-inventory-group.is-active')
-    ).toContainText('Sessions');
-    await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
-    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-station-node')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-station-route')).toHaveCount(0);
     const entryUnit = page
       .locator('#workspaceCommandView .ws-cmd-map-agent')
       .filter({ hasText: 'Roster Manager' });
@@ -827,7 +786,9 @@ test.describe('Workspace Agent Character Roster', () => {
     await expect(entryUnit).toHaveClass(/waiting/);
     await expect(entryUnit).toHaveAttribute('aria-label', /Entry Agent/);
 
-    await page.locator('#workspaceCommandView [data-cmd-map-station-key="inventory"]').click();
+    await page
+      .locator('#workspaceCommandView .ws-cmd-map-belt-btn[data-cmd-map-window="inventory"]')
+      .click();
     const inventoryWindow = page.locator('#workspaceCommandView .ws-cmd-map-window');
     const activeInventoryGroup = page.locator(
       '#workspaceCommandView .ws-cmd-map-inventory-group.is-active'

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -836,8 +836,30 @@ test.describe('Workspace Agent Character Roster', () => {
     await expect(inspector).toContainText('Class');
     await expect(inspector).toContainText('Loadout');
     await expect(inspector).toContainText('Current Quest');
+    await expect(inspector).toContainText('Command Menu');
+    await expect(inspector).toContainText('Resolve Quest');
+    await expect(inspector).toContainText('Start Session');
+    await expect(inspector).toContainText('Configure Loadout');
     await expect(inspector).toContainText('Quests');
     await expect(inspector).toContainText('Skills');
+    const inspectorGeometry = await inspector.evaluate(node => {
+      const rect = node.getBoundingClientRect();
+      const body = node.querySelector('.ws-cmd-map-window-body')?.getBoundingClientRect();
+      const menu = node.querySelector('.ws-cmd-rpg-command-panel')?.getBoundingClientRect();
+      return {
+        bottom: Math.round(rect.bottom),
+        bodyBottom: body ? Math.round(body.bottom) : 0,
+        bodyTop: body ? Math.round(body.top) : 0,
+        menuBottom: menu ? Math.round(menu.bottom) : 0,
+        menuTop: menu ? Math.round(menu.top) : 0,
+        top: Math.round(rect.top),
+        viewportHeight: window.innerHeight
+      };
+    });
+    expect(inspectorGeometry.top).toBeGreaterThanOrEqual(0);
+    expect(inspectorGeometry.bottom).toBeLessThanOrEqual(inspectorGeometry.viewportHeight);
+    expect(inspectorGeometry.menuTop).toBeGreaterThanOrEqual(inspectorGeometry.bodyTop);
+    expect(inspectorGeometry.menuBottom).toBeLessThanOrEqual(inspectorGeometry.bodyBottom);
     await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
     await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -724,6 +724,26 @@ test.describe('Workspace Agent Character Roster', () => {
     await expect(page.locator('#workspaceCommandView [data-map-zone="agents"]')).toContainText(
       'Research Analyst'
     );
+    const beltGeometry = await page
+      .locator('#workspaceCommandView .ws-cmd-map-belt')
+      .evaluate(node => {
+        const style = window.getComputedStyle(node);
+        const rect = node.getBoundingClientRect();
+        const mapRect = node.closest('.ws-cmd-opmap').getBoundingClientRect();
+        return {
+          flexDirection: style.flexDirection,
+          rightGap: Math.round(mapRect.right - rect.right),
+          topGap: Math.round(rect.top - mapRect.top)
+        };
+      });
+    expect(beltGeometry.flexDirection).toBe('row');
+    expect(beltGeometry.rightGap).toBeLessThanOrEqual(24);
+    expect(beltGeometry.topGap).toBeLessThanOrEqual(24);
+    const entryUnit = page
+      .locator('#workspaceCommandView .ws-cmd-map-agent')
+      .filter({ hasText: 'Roster Manager' });
+    await expect(entryUnit.locator('.ws-cmd-map-entry-badge')).toBeVisible();
+    await expect(entryUnit).toHaveAttribute('aria-label', /Entry Agent/);
 
     await page.locator('#workspaceCommandView [data-cmd-map-window="inventory"]').click();
     const inventoryWindow = page.locator('#workspaceCommandView .ws-cmd-map-window');

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -739,6 +739,43 @@ test.describe('Workspace Agent Character Roster', () => {
     expect(beltGeometry.flexDirection).toBe('row');
     expect(beltGeometry.rightGap).toBeLessThanOrEqual(24);
     expect(beltGeometry.topGap).toBeLessThanOrEqual(24);
+    const beltLabelGeometry = await page
+      .locator('#workspaceCommandView .ws-cmd-map-belt-btn')
+      .evaluateAll(buttons =>
+        buttons.map(button => {
+          const label = button.querySelector('.sr-only');
+          const labelStyle = label ? window.getComputedStyle(label) : null;
+          const labelRect = label ? label.getBoundingClientRect() : null;
+          const buttonRect = button.getBoundingClientRect();
+          return {
+            ariaLabel: button.getAttribute('aria-label'),
+            buttonHeight: Math.round(buttonRect.height),
+            buttonWidth: Math.round(buttonRect.width),
+            labelHeight: labelRect ? Math.round(labelRect.height) : 0,
+            labelOverflow: labelStyle?.overflow || '',
+            labelText: label?.textContent?.trim() || '',
+            labelWidth: labelRect ? Math.round(labelRect.width) : 0
+          };
+        })
+      );
+    expect(beltLabelGeometry).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ariaLabel: 'Workspace Objective',
+          labelText: 'Workspace Objective'
+        })
+      ])
+    );
+    expect(
+      beltLabelGeometry.every(
+        item =>
+          item.buttonHeight >= 44 &&
+          item.buttonWidth >= 44 &&
+          item.labelHeight <= 1 &&
+          item.labelWidth <= 1 &&
+          item.labelOverflow === 'hidden'
+      )
+    ).toBeTruthy();
     const entryUnit = page
       .locator('#workspaceCommandView .ws-cmd-map-agent')
       .filter({ hasText: 'Roster Manager' });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -704,6 +704,93 @@ test.describe('Workspace Agent Character Roster', () => {
     expect(mobileGeometry.stageBottom).toBeLessThanOrEqual(mobileGeometry.overviewTop || 0);
     expect(mobileGeometry.pageWidth).toBeLessThanOrEqual(mobileGeometry.viewportWidth);
   });
+
+  test('operations map switches from details, selects agents, and opens inventory', async ({
+    page
+  }) => {
+    await installRosterRoutes(page);
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('oriWorkspaceCommandViewMode');
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/workspaces/roster-ws');
+
+    await page.locator('#workspaceCommandView [data-cmd-view-mode="map"]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-opmap')).toBeVisible();
+    await expect(page.locator('#workspaceCommandView [data-map-zone="mission"]')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView [data-map-zone="tasks"]')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView [data-map-zone="tools"]')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
+    await expect(page.locator('#workspaceCommandView [data-map-zone="agents"]')).toContainText(
+      'Research Analyst'
+    );
+
+    await page.locator('#workspaceCommandView [data-cmd-map-window="inventory"]').click();
+    const inventoryWindow = page.locator('#workspaceCommandView .ws-cmd-map-window');
+    await expect(inventoryWindow).toBeVisible();
+    await expect(inventoryWindow).toContainText('Inventory');
+    await expect(
+      page.locator(
+        '#workspaceCommandView .ws-cmd-map-inventory-group.is-active .ws-cmd-map-inventory-grid'
+      )
+    ).toBeVisible();
+    await expect(
+      page.locator('#workspaceCommandView .ws-cmd-map-inventory-slot').first()
+    ).toBeVisible();
+    const inventoryGeometry = await inventoryWindow.evaluate(node => {
+      const rect = node.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        viewportHeight: window.innerHeight
+      };
+    });
+    expect(inventoryGeometry.top).toBeGreaterThanOrEqual(0);
+    expect(inventoryGeometry.bottom).toBeLessThanOrEqual(inventoryGeometry.viewportHeight);
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-inventory-badge')).toContainText([
+      'Notes',
+      'Schedules',
+      'Sessions',
+      'Linked Folders',
+      'Files',
+      'Systems'
+    ]);
+    await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
+
+    await page.locator('#workspaceCommandView [data-cmd-map-window="objectives"]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toContainText(
+      'Plan the work'
+    );
+    await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
+
+    await page
+      .locator('#workspaceCommandView .ws-cmd-map-agent')
+      .filter({ hasText: 'Research Analyst' })
+      .click();
+    const inspector = page.locator('#workspaceCommandView .ws-cmd-map-window');
+    await expect(inspector).toContainText('Research Analyst');
+    await expect(inspector).toContainText('Needs input');
+    await expect(inspector).toContainText('Current Quest');
+    await expect(inspector).toContainText('Quests');
+    await expect(inspector).toContainText('Skills');
+    await page.locator('#workspaceCommandView [data-cmd-map-window-close]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-window')).toHaveCount(0);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    const mobileGeometry = await page
+      .locator('#workspaceCommandView .ws-cmd-opmap')
+      .evaluate(() => {
+        return {
+          pageWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth
+        };
+      });
+    expect(mobileGeometry.pageWidth).toBeLessThanOrEqual(mobileGeometry.viewportWidth);
+
+    await page.locator('#workspaceCommandView [data-cmd-view-mode="details"]').click();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-deck')).toBeVisible();
+  });
 });
 
 test.describe('Task Output Contracts', () => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -780,6 +780,8 @@ test.describe('Workspace Agent Character Roster', () => {
       .locator('#workspaceCommandView .ws-cmd-map-agent')
       .filter({ hasText: 'Roster Manager' });
     await expect(entryUnit.locator('.ws-cmd-map-entry-badge')).toBeVisible();
+    await expect(entryUnit.locator('.ws-cmd-map-agent-status')).toBeVisible();
+    await expect(entryUnit).toHaveClass(/waiting/);
     await expect(entryUnit).toHaveAttribute('aria-label', /Entry Agent/);
 
     await page.locator('#workspaceCommandView [data-cmd-map-window="inventory"]').click();
@@ -794,6 +796,9 @@ test.describe('Workspace Agent Character Roster', () => {
     await expect(
       page.locator('#workspaceCommandView .ws-cmd-map-inventory-slot').first()
     ).toBeVisible();
+    await expect(page.locator('#workspaceCommandView .ws-cmd-map-slot-type').first()).toContainText(
+      'Note'
+    );
     const inventoryGeometry = await inventoryWindow.evaluate(node => {
       const rect = node.getBoundingClientRect();
       return {
@@ -828,6 +833,8 @@ test.describe('Workspace Agent Character Roster', () => {
     const inspector = page.locator('#workspaceCommandView .ws-cmd-map-window');
     await expect(inspector).toContainText('Research Analyst');
     await expect(inspector).toContainText('Needs input');
+    await expect(inspector).toContainText('Class');
+    await expect(inspector).toContainText('Loadout');
     await expect(inspector).toContainText('Current Quest');
     await expect(inspector).toContainText('Quests');
     await expect(inspector).toContainText('Skills');


### PR DESCRIPTION
## Summary
- add a persistent RPG-style operations map view for workspace details
- move objective, objectives, inventory, and stations into compact tray-driven modals while keeping the map focused on agent units
- add RPG agent sheet, command menu, visual inventory grid, entry-agent indicator, and clipping/layout fixes

## Validation
- npx prettier --check internal/web/static/js/modules/workspace-command.js internal/web/static/js/modules/workspace-command.test.js internal/web/static/css/workspace-command.css tests/smoke.spec.ts
- npm run lint
- node --test internal/web/static/js/modules/workspace-command.test.js
- PLAYWRIGHT_BASE_URL=http://localhost:32123 npx playwright test tests/smoke.spec.ts --grep "operations map"