### PR TITLE
feat(wt): PRD-driven worktree workflow + interactive REPL

### DIFF
--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -2,12 +2,21 @@
 # wt - worktree manager for parallel agent workflows
 #
 # Usage:
-#   source scripts/wt.sh   # Load the function (cd works directly)
-#   wt                     # Interactive mode - select worktree to navigate
-#   wt new <name>          # Create new worktree
-#   wt rm <name>           # Remove worktree
-#   wt ls                  # List worktrees
-#   wt cd <name>           # Navigate to worktree
+#   source scripts/wt.sh    # Load the function (cd works directly)
+#   wt                      # Interactive mode - select worktree to navigate
+#   wt start [prd]          # Create a worktree from a PRD in the dev tasks/ folder
+#   wt new <name>           # Create a clean worktree (no PRD/tasks)
+#   wt pr [name]            # Push branch and open a PR against dev
+#   wt done [name]          # Archive tasks back to dev, then remove worktree+branch
+#   wt rm [name]            # Remove worktree and its branch
+#   wt ls                   # List worktrees
+#   wt status               # Show ahead/behind/merged vs dev for all worktrees
+#   wt cd <name>            # Navigate to a worktree
+#   wt merge [name]         # Local merge into dev (legacy; prefer wt pr)
+#
+# Planning docs live in the dev worktree's tasks/ folder (gitignored). Create
+# each PRD + task list there, then `wt start` fans a single PRD out into its
+# own worktree so one PRD = one branch = one PR.
 
 WORKTREE_DIR="../"
 BASE_BRANCH="dev"
@@ -36,6 +45,48 @@ function wt_is_protected_worktree {
   return 1
 }
 
+function wt_get_dev_worktree {
+  local line wt_path=""
+  while IFS= read -r line; do
+    if [[ "$line" == worktree\ * ]]; then
+      wt_path="${line#worktree }"
+    elif [[ "$line" == "branch refs/heads/$BASE_BRANCH" ]]; then
+      print -r -- "$wt_path"
+      return 0
+    fi
+  done < <(git worktree list --porcelain)
+  return 1
+}
+
+function wt_new_worktree_dir {
+  # Directory that new worktrees are created in: the dev worktree's parent, so
+  # placement does not depend on the current working directory. Falls back to
+  # the CWD-relative WORKTREE_DIR only when the dev worktree can't be found.
+  local dev_path
+  dev_path="$(wt_get_dev_worktree)"
+  if [[ -n "$dev_path" ]]; then
+    print -r -- "${dev_path:h}"
+  else
+    print -r -- "${WORKTREE_DIR%/}"
+  fi
+}
+
+function wt_parse_name {
+  # Splits a user-supplied name into a branch and a worktree directory name.
+  #   foo                -> branch feature/foo, dir foo
+  #   fix/foo            -> branch fix/foo,     dir foo   (honors intent prefix)
+  # Sets globals WT_BRANCH_NAME and WT_DIR_NAME.
+  typeset -g WT_BRANCH_NAME WT_DIR_NAME
+  local raw="$1"
+  if [[ "$raw" == */* ]]; then
+    WT_BRANCH_NAME="$raw"
+    WT_DIR_NAME="${raw:t}"
+  else
+    WT_BRANCH_NAME="feature/$raw"
+    WT_DIR_NAME="$raw"
+  fi
+}
+
 function wt_resolve_worktree_path {
   local name="$1"
   local absolute_name="${name:A}"
@@ -51,17 +102,23 @@ function wt_resolve_worktree_path {
     fi
   done < <(git worktree list --porcelain)
 
-  print -r -- "${WORKTREE_DIR}${name}"
+  print -r -- "$(wt_new_worktree_dir)/${name}"
 }
 
-function wt_get_dev_worktree {
+function wt_resolve_worktree_branch {
+  # Echoes the branch checked out in the worktree named/pathed by $1, or nothing.
+  local name="$1"
+  local target_path
+  target_path="$(wt_resolve_worktree_path "$name")"
   local line wt_path=""
   while IFS= read -r line; do
     if [[ "$line" == worktree\ * ]]; then
       wt_path="${line#worktree }"
-    elif [[ "$line" == "branch refs/heads/$BASE_BRANCH" ]]; then
-      print -r -- "$wt_path"
-      return 0
+    elif [[ "$line" == branch\ refs/heads/* ]]; then
+      if [[ "${wt_path:t}" == "$name" || "$wt_path" == "$target_path" ]]; then
+        print -r -- "${line#branch refs/heads/}"
+        return 0
+      fi
     fi
   done < <(git worktree list --porcelain)
   return 1
@@ -91,6 +148,22 @@ function wt_load_worktrees {
   fi
 }
 
+function wt_load_merged_set {
+  # Populates WT_MERGED_SET with branches that were merged via a (squash) PR on
+  # GitHub. Best-effort: needs gh and only runs once per shell session. Because
+  # we squash-merge, merged branch commits are never ancestors of dev, so
+  # merge-base alone can't detect them - this closes that gap.
+  typeset -gA WT_MERGED_SET
+  [[ -n "${WT_MERGED_LOADED:-}" ]] && return 0
+  typeset -g WT_MERGED_LOADED=1
+  command -v gh >/dev/null 2>&1 || return 0
+  local ref
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] && WT_MERGED_SET[$ref]=1
+  done < <(gh pr list --state merged --base "$BASE_BRANCH" --limit 100 \
+             --json headRefName --jq '.[].headRefName' 2>/dev/null)
+}
+
 function wt_branch_status {
   # Echoes "ahead behind label" for branch vs BASE_BRANCH.
   local branch="$1"
@@ -100,6 +173,8 @@ function wt_branch_status {
   if [[ "$branch" == "$BASE_BRANCH" ]]; then
     label="(base)"
   elif git merge-base --is-ancestor "$branch" "$BASE_BRANCH" 2>/dev/null; then
+    label="merged"
+  elif [[ -n "${WT_MERGED_SET[$branch]:-}" ]]; then
     label="merged"
   elif [[ "$ahead" == "0" ]]; then
     label="empty"
@@ -182,38 +257,43 @@ function wt_render_header {
   print -r -- "${WT_C_DIM}${prefix}${name_pad}  ${branch_pad}  AHEAD BEHIND  STATUS${WT_C_RESET}"
 }
 
-function wt {
-  local script_dir="${0:A:h}"
+function wt_provision_worktree {
+  # Creates a worktree for $1 (branch) at dir $2 (name), based on an up-to-date
+  # origin/dev, and sets it up: Claude permission profile, folder picker, npm.
+  # Sets global WT_PROVISIONED_TARGET to the created path. Returns non-zero on
+  # failure to create the worktree.
+  local branch="$1" dir_name="$2"
+  typeset -g WT_PROVISIONED_TARGET=""
+  local base_dir target
+  base_dir="$(wt_new_worktree_dir)"
+  target="${base_dir}/${dir_name}"
 
-  case "$1" in
-  new)
-    local name="$2"
-    if [[ -z "$name" ]]; then
-      echo "Usage: wt new <name>"
-      return 1
-    fi
-    git worktree add -b "feature/$name" "$WORKTREE_DIR$name" "$BASE_BRANCH"
-    echo "Created worktree: $WORKTREE_DIR$name (branch: feature/$name, based on $BASE_BRANCH)"
-    # Copy the tasks/ folder into the new worktree. tasks/ is gitignored (it
-    # holds PRDs and task lists), so a fresh worktree starts without it.
-    local source_root
-    source_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-    if [[ -n "$source_root" && -d "$source_root/tasks" ]]; then
-      echo "Copying tasks/ into new worktree..."
-      mkdir -p "$WORKTREE_DIR$name/tasks"
-      cp -R "$source_root/tasks/." "$WORKTREE_DIR$name/tasks/"
-    fi
-    # Give the feature worktree its own Claude Code permission profile. It runs
-    # hotter than dev (see FEATURE_WORKTREE_PERMISSION_MODE): edits auto-apply
-    # because the worktree is isolated and reviewed at merge, while a deny floor
-    # still blocks destructive commands. settings.local.json is gitignored, so it
-    # stays in this worktree and never touches dev/main; the shared allow/deny in
-    # the checked-in .claude/settings.json still applies on top.
-    local claude_local="$WORKTREE_DIR$name/.claude/settings.local.json"
-    if [[ ! -f "$claude_local" ]]; then
-      echo "Writing feature-worktree Claude profile ($FEATURE_WORKTREE_PERMISSION_MODE)..."
-      mkdir -p "$WORKTREE_DIR$name/.claude"
-      cat > "$claude_local" <<JSON
+  # Base on origin/dev so parallel work landing on dev is picked up. Fall back
+  # to the local base branch if the remote ref isn't available (offline).
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null
+  local start_point="origin/$BASE_BRANCH"
+  if ! git rev-parse --verify "$start_point" >/dev/null 2>&1; then
+    echo "Warning: origin/$BASE_BRANCH unavailable; basing on local $BASE_BRANCH"
+    start_point="$BASE_BRANCH"
+  fi
+
+  if ! git worktree add -b "$branch" "$target" "$start_point"; then
+    return 1
+  fi
+  echo "Created worktree: $target (branch: $branch, based on $start_point)"
+  WT_PROVISIONED_TARGET="$target"
+
+  # Give the feature worktree its own Claude Code permission profile. It runs
+  # hotter than dev (see FEATURE_WORKTREE_PERMISSION_MODE): edits auto-apply
+  # because the worktree is isolated and reviewed at merge, while a deny floor
+  # still blocks destructive commands. settings.local.json is gitignored, so it
+  # stays in this worktree and never touches dev/main; the shared allow/deny in
+  # the checked-in .claude/settings.json still applies on top.
+  local claude_local="$target/.claude/settings.local.json"
+  if [[ ! -f "$claude_local" ]]; then
+    echo "Writing feature-worktree Claude profile ($FEATURE_WORKTREE_PERMISSION_MODE)..."
+    mkdir -p "$target/.claude"
+    cat > "$claude_local" <<JSON
 {
   "permissions": {
     "defaultMode": "$FEATURE_WORKTREE_PERMISSION_MODE",
@@ -228,43 +308,236 @@ function wt {
   }
 }
 JSON
+  fi
+
+  # Build folder picker in the new worktree
+  local picker_script="$target/scripts/build-folder-picker.sh"
+  if [[ -f "$picker_script" ]]; then
+    echo "Building folder picker in new worktree..."
+    (cd "$target" && bash scripts/build-folder-picker.sh)
+  fi
+
+  # Install npm dependencies. node_modules is gitignored and not shared
+  # between worktrees, so a fresh worktree starts without it and tooling
+  # like eslint/prettier/playwright won't run until this completes.
+  if [[ -f "$target/package.json" ]] && command -v npm >/dev/null 2>&1; then
+    echo "Installing npm dependencies in new worktree..."
+    (cd "$target" && npm install)
+  fi
+
+  return 0
+}
+
+function wt {
+  case "$1" in
+  start)
+    # PRD-driven creation: pick a prd-*.md from the dev worktree's tasks/ folder
+    # and fan it (plus its matching tasks- list) out into a dedicated worktree.
+    wt_color_init
+    local dev_path tasks_dir
+    dev_path="$(wt_get_dev_worktree)"
+    if [[ -z "$dev_path" ]]; then
+      echo "Could not find $BASE_BRANCH worktree"
+      return 1
     fi
-    # Build folder picker in the new worktree
-    local picker_script="$WORKTREE_DIR$name/scripts/build-folder-picker.sh"
-    if [[ -f "$picker_script" ]]; then
-      echo "Building folder picker in new worktree..."
-      (cd "$WORKTREE_DIR$name" && bash scripts/build-folder-picker.sh)
+    tasks_dir="$dev_path/tasks"
+
+    local -a prd_files
+    local f
+    for f in "$tasks_dir"/prd-*.md(N); do
+      prd_files+=("${f:t}")
+    done
+    if [[ ${#prd_files[@]} -eq 0 ]]; then
+      echo "No PRDs found in $tasks_dir (expected prd-*.md)."
+      echo "Create a PRD there first, then re-run 'wt start'."
+      return 1
     fi
-    # Install npm dependencies. node_modules is gitignored and not shared
-    # between worktrees, so a fresh worktree starts without it and tooling
-    # like eslint/prettier/playwright won't run until this completes.
-    if [[ -f "$WORKTREE_DIR$name/package.json" ]] && command -v npm >/dev/null 2>&1; then
-      echo "Installing npm dependencies in new worktree..."
-      (cd "$WORKTREE_DIR$name" && npm install)
+
+    local chosen="$2"
+    if [[ -z "$chosen" ]]; then
+      echo "Select a PRD to start (from ${WT_C_CYAN}$tasks_dir${WT_C_RESET}):"
+      local i
+      for i in {1..${#prd_files[@]}}; do
+        local feat="${prd_files[$i]#prd-}"; feat="${feat%.md}"
+        local has_tasks="  (no task list yet)"
+        [[ -f "$tasks_dir/tasks-$feat.md" ]] && has_tasks=""
+        echo "  $i) ${prd_files[$i]}${has_tasks}"
+      done
+      echo "  q) Quit"
+      echo
+      read "choice?Choice: "
+      if [[ "$choice" == "q" || -z "$choice" ]]; then
+        return 0
+      fi
+      if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#prd_files[@]} )); then
+        echo "Invalid choice"
+        return 1
+      fi
+      chosen="${prd_files[$choice]}"
+    else
+      # Accept "prd-foo.md", "prd-foo", or "foo".
+      [[ "$chosen" == *.md ]] || chosen="$chosen.md"
+      [[ "$chosen" == prd-* ]] || chosen="prd-$chosen"
+      if [[ ! -f "$tasks_dir/$chosen" ]]; then
+        echo "PRD not found: $tasks_dir/$chosen"
+        return 1
+      fi
+    fi
+
+    local feature="${chosen#prd-}"; feature="${feature%.md}"
+    local branch="feature/$feature"
+
+    if ! wt_provision_worktree "$branch" "$feature"; then
+      return 1
+    fi
+    local target="$WT_PROVISIONED_TARGET"
+
+    echo "Copying PRD and task list into new worktree..."
+    mkdir -p "$target/tasks"
+    cp "$tasks_dir/$chosen" "$target/tasks/"
+    if [[ -f "$tasks_dir/tasks-$feature.md" ]]; then
+      cp "$tasks_dir/tasks-$feature.md" "$target/tasks/"
+    else
+      echo "Note: no tasks-$feature.md yet - generate the task list in this worktree."
+    fi
+
+    cd "$target"
+    echo "Changed to: $target"
+    ;;
+  new)
+    local name="$2"
+    if [[ -z "$name" ]]; then
+      echo "Usage: wt new <name>            (branch feature/<name>)"
+      echo "       wt new <type>/<name>     (e.g. fix/foo -> branch fix/foo)"
+      echo "For PRD-driven work, prefer: wt start"
+      return 1
+    fi
+    wt_parse_name "$name"
+    if ! wt_provision_worktree "$WT_BRANCH_NAME" "$WT_DIR_NAME"; then
+      return 1
+    fi
+    echo "Clean worktree ready (no tasks copied). For PRD-driven work use 'wt start'."
+    ;;
+  pr)
+    # Push the current (or named) worktree's branch and open a PR against dev.
+    local name="$2" branch target_path
+    if [[ -n "$name" ]]; then
+      target_path="$(wt_resolve_worktree_path "$name")"
+      branch="$(wt_resolve_worktree_branch "$name")"
+    else
+      target_path="$(git rev-parse --show-toplevel 2>/dev/null)"
+      branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    fi
+    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
+      echo "Could not determine a branch to open a PR for"
+      return 1
+    fi
+    if [[ "$branch" == "$BASE_BRANCH" || "$branch" == "main" ]]; then
+      echo "Refusing to open a PR from protected branch: $branch"
+      return 1
+    fi
+    if ! command -v gh >/dev/null 2>&1; then
+      echo "gh CLI not found; install it or push and open the PR manually."
+      return 1
+    fi
+    echo "Pushing $branch and opening a PR against $BASE_BRANCH..."
+    git -C "$target_path" push -u origin "$branch" || return 1
+    (cd "$target_path" && gh pr create --base "$BASE_BRANCH" --head "$branch" --fill)
+    ;;
+  done)
+    # Post-merge cleanup: archive the (completed) task list back to dev, remove
+    # the worktree + local/remote branch, then rebase the dev worktree onto
+    # origin/dev. Meant to run after the feature's PR has been squash-merged.
+    local name="$2" target_path branch
+    if [[ -z "$name" ]]; then
+      target_path="$(git rev-parse --show-toplevel 2>/dev/null)"
+      name="${target_path:t}"
+      branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    else
+      target_path="$(wt_resolve_worktree_path "$name")"
+      branch="$(wt_resolve_worktree_branch "$name")"
+      [[ -z "$branch" ]] && branch="feature/$name"
+    fi
+
+    if wt_is_protected_worktree "$target_path"; then
+      echo "Refusing to clean up protected worktree: ${target_path:t}"
+      return 1
+    fi
+
+    local dev_path
+    dev_path="$(wt_get_dev_worktree)"
+    if [[ -z "$dev_path" ]]; then
+      echo "Could not find $BASE_BRANCH worktree"
+      return 1
+    fi
+
+    # Best-effort merged check so we don't discard unmerged work by accident.
+    if command -v gh >/dev/null 2>&1; then
+      local merged_num
+      merged_num="$(gh pr list --head "$branch" --state merged --limit 1 \
+                 --json number --jq '.[0].number' 2>/dev/null)"
+      if [[ -z "$merged_num" ]]; then
+        echo "Warning: no merged PR found for '$branch'."
+        read "cont?Continue cleaning up anyway? [y/N]: "
+        [[ "$cont" == y* ]] || { echo "Aborted"; return 0; }
+      fi
+    fi
+
+    # Archive tasks/ (with ticked checkboxes) back into the dev worktree.
+    if [[ -d "$target_path/tasks" ]]; then
+      echo "Archiving tasks/ back into $dev_path/tasks/ ..."
+      mkdir -p "$dev_path/tasks"
+      cp -R "$target_path/tasks/." "$dev_path/tasks/"
+    fi
+
+    # Warn on any uncommitted tracked changes before a forced removal.
+    local dirty
+    dirty="$(git -C "$target_path" status --porcelain 2>/dev/null)"
+    if [[ -n "$dirty" ]]; then
+      echo "Worktree has uncommitted changes:"
+      echo "$dirty"
+      read "force?Remove anyway (discards these changes)? [y/N]: "
+      [[ "$force" == y* ]] || { echo "Aborted"; return 1; }
+    fi
+
+    git worktree remove "$target_path" --force || return 1
+    git branch -D "$branch" 2>/dev/null
+    echo "Removed worktree and local branch: $name ($branch)"
+
+    read "delremote?Delete remote branch origin/$branch too? [y/N]: "
+    if [[ "$delremote" == y* ]]; then
+      git push origin --delete "$branch" 2>/dev/null \
+        && echo "Deleted remote branch: origin/$branch" \
+        || echo "Could not delete origin/$branch (already gone?)"
+    fi
+
+    # Rebase the dev worktree onto origin/dev to pick up the squashed commit.
+    # Never hard-reset - preserve any unpushed dev commits.
+    if [[ -n "$(git -C "$dev_path" status --porcelain)" ]]; then
+      echo "Dev worktree has uncommitted changes; skipping rebase. Sync it manually:"
+      echo "  git -C '$dev_path' fetch origin $BASE_BRANCH && git -C '$dev_path' rebase origin/$BASE_BRANCH"
+    else
+      echo "Rebasing dev worktree onto origin/$BASE_BRANCH ..."
+      git -C "$dev_path" fetch origin "$BASE_BRANCH" --quiet
+      git -C "$dev_path" rebase "origin/$BASE_BRANCH" \
+        || echo "Rebase hit conflicts; resolve them in $dev_path"
     fi
     ;;
   rm)
     local name="$2"
-    local target_path
+    local target_path branch
 
     if [[ -z "$name" ]]; then
-      # Interactive selection
+      # Interactive selection (porcelain-parsed, protected worktrees skipped).
+      wt_load_worktrees
       local -a rm_names rm_paths rm_branches
-      local line
-      while IFS= read -r line; do
-        local parts=("${(@s/ /)line}")
-        local wt_path="${parts[1]}"
-        local branch="${parts[3]}"
-        branch="${branch#\[}"
-        branch="${branch%\]}"
-        local wt_name="${wt_path:t}"
-        if wt_is_protected_worktree "$wt_path"; then
-          continue
-        fi
-        rm_names+=("$wt_name")
-        rm_paths+=("$wt_path")
-        rm_branches+=("$branch")
-      done < <(git worktree list)
+      local i
+      for i in {1..${#WT_PATHS[@]}}; do
+        wt_is_protected_worktree "${WT_PATHS[$i]}" && continue
+        rm_names+=("${WT_PATHS[$i]:t}")
+        rm_paths+=("${WT_PATHS[$i]}")
+        rm_branches+=("${WT_BRANCHES[$i]:-detached}")
+      done
 
       if [[ ${#rm_names[@]} -eq 0 ]]; then
         echo "No removable worktrees found"
@@ -272,7 +545,6 @@ JSON
       fi
 
       echo "Select worktree to remove:"
-      local i
       for i in {1..${#rm_names[@]}}; do
         echo "  $i) ${rm_names[$i]} (${rm_branches[$i]})"
       done
@@ -292,8 +564,11 @@ JSON
 
       name="${rm_names[$choice]}"
       target_path="${rm_paths[$choice]}"
+      branch="${rm_branches[$choice]}"
     else
       target_path="$(wt_resolve_worktree_path "$name")"
+      branch="$(wt_resolve_worktree_branch "$name")"
+      [[ -z "$branch" ]] && branch="feature/$name"
     fi
 
     if wt_is_protected_worktree "$target_path"; then
@@ -301,8 +576,10 @@ JSON
       return 1
     fi
     git worktree remove "$target_path" --force
-    git branch -D "feature/$name" 2>/dev/null
-    echo "Removed worktree and branch: $name"
+    if [[ -n "$branch" && "$branch" != "detached" ]]; then
+      git branch -D "$branch" 2>/dev/null
+    fi
+    echo "Removed worktree and branch: $name ($branch)"
     ;;
   ls)
     git worktree list
@@ -314,7 +591,8 @@ JSON
       wt go
       return $?
     fi
-    local target="${script_dir}/../../$name"
+    local target
+    target="$(wt_resolve_worktree_path "$name")"
     if [[ -d "$target" ]]; then
       cd "$target"
       echo "Changed to worktree: $target"
@@ -325,6 +603,8 @@ JSON
     ;;
   ""|go)
     # Interactive mode - show menu of worktrees with status vs $BASE_BRANCH.
+    # No gh lookup here so navigation stays network-free; use `wt status` for
+    # the squash-merge-aware view.
     wt_color_init
     wt_load_worktrees
     if [[ ${#WT_PATHS[@]} -eq 0 ]]; then
@@ -368,6 +648,7 @@ JSON
     ;;
   status)
     wt_color_init
+    wt_load_merged_set
     wt_load_worktrees
     if [[ ${#WT_PATHS[@]} -eq 0 ]]; then
       echo "No worktrees found"
@@ -525,12 +806,15 @@ JSON
   *)
     echo "Usage: wt [command] [args]"
     echo "  wt               - Interactive mode (select worktree to navigate)"
-    echo "  wt new <name>    - Create worktree (always based on $BASE_BRANCH)"
+    echo "  wt start [prd]   - Create worktree from a PRD in the dev tasks/ folder"
+    echo "  wt new <name>    - Create a clean worktree (feature/<name>, or <type>/<name>)"
+    echo "  wt pr [name]     - Push branch and open a PR against $BASE_BRANCH"
+    echo "  wt done [name]   - Archive tasks to dev, remove worktree+branch, rebase dev"
     echo "  wt rm [name]     - Remove worktree and branch (interactive if no name)"
     echo "  wt ls            - List worktrees"
-    echo "  wt cd <name>     - Navigate to worktree"
     echo "  wt status        - Show ahead/behind/merged vs $BASE_BRANCH for all worktrees"
-    echo "  wt merge [name]  - Merge worktree branch into $BASE_BRANCH (interactive if no name)"
+    echo "  wt cd <name>     - Navigate to worktree"
+    echo "  wt merge [name]  - Local merge into $BASE_BRANCH (legacy; prefer wt pr)"
     ;;
   esac
 }

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -3,7 +3,8 @@
 #
 # Usage:
 #   source scripts/wt.sh    # Load the function (cd works directly)
-#   wt                      # Interactive mode - select worktree to navigate
+#   wt                      # Interactive REPL (type: go, status, start, ...)
+#   wt go                   # One-shot worktree picker (navigate + cd)
 #   wt start [prd]          # Create a worktree from a PRD in the dev tasks/ folder
 #   wt new <name>           # Create a clean worktree (no PRD/tasks)
 #   wt pr [name]            # Push branch and open a PR against dev
@@ -328,8 +329,44 @@ JSON
   return 0
 }
 
+function wt_repl {
+  # Persistent prompt: read a line and dispatch it as `wt <words>`. Runs in the
+  # current shell (wt is sourced), so cd/start still change the shell's dir; the
+  # prompt shows the current directory's basename so you can see where you are.
+  wt_color_init
+  echo "wt REPL - commands: go, status, start, new, pr, done, cd, ls, rm, merge, help  (q to quit)"
+  local line
+  local -a words
+  while true; do
+    if ! read -r "line?${WT_C_BOLD}wt${WT_C_RESET} ${WT_C_CYAN}${PWD:t}${WT_C_RESET}> "; then
+      echo
+      break
+    fi
+    line="${line## }"; line="${line%% }"
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      q|quit|exit) break ;;
+      h|help|'?')  wt_dispatch help; continue ;;
+    esac
+    words=(${(z)line})
+    wt_dispatch "${words[@]}"
+  done
+}
+
 function wt {
+  # No args -> interactive REPL. With args -> one-shot dispatch.
+  if [[ $# -eq 0 ]]; then
+    wt_repl
+    return $?
+  fi
+  wt_dispatch "$@"
+}
+
+function wt_dispatch {
   case "$1" in
+  repl)
+    wt_repl
+    ;;
   start)
     # PRD-driven creation: pick a prd-*.md from the dev worktree's tasks/ folder
     # and fan it (plus its matching tasks- list) out into a dedicated worktree.
@@ -601,7 +638,7 @@ function wt {
       return 1
     fi
     ;;
-  ""|go)
+  go)
     # Interactive mode - show menu of worktrees with status vs $BASE_BRANCH.
     # No gh lookup here so navigation stays network-free; use `wt status` for
     # the squash-merge-aware view.
@@ -805,7 +842,8 @@ function wt {
     ;;
   *)
     echo "Usage: wt [command] [args]"
-    echo "  wt               - Interactive mode (select worktree to navigate)"
+    echo "  wt               - Interactive REPL (bare 'wt'; type commands, q to quit)"
+    echo "  wt go            - One-shot worktree picker (navigate + cd)"
     echo "  wt start [prd]   - Create worktree from a PRD in the dev tasks/ folder"
     echo "  wt new <name>    - Create a clean worktree (feature/<name>, or <type>/<name>)"
     echo "  wt pr [name]     - Push branch and open a PR against $BASE_BRANCH"


### PR DESCRIPTION
Reworks `scripts/wt.sh` (the sourced worktree helper) around a PRD-driven flow and turns bare `wt` into an interactive REPL.

## Workflow
Planning docs (`prd-*.md` + `tasks-*.md`) now live in the **dev worktree's `tasks/`** as the single source of truth (it's gitignored, so it doesn't sync between worktrees — dev is canonical). Instead of copying the whole drift-prone `tasks/` folder into every new worktree, a single PRD is fanned out one-per-worktree.

**New commands**
- `wt start [prd]` — pick a `prd-*.md` from dev's `tasks/`, derive `feature/<name>`, provision the worktree, and copy in **only** that PRD + its matching `tasks-<name>.md`. Ends by cd-ing in.
- `wt pr [name]` — push the branch and open a PR against `dev`.
- `wt done [name]` — archive the completed (ticked) task list back to dev, remove the worktree + local/remote branch, then rebase the dev worktree onto `origin/dev` (skips if dev is dirty; never hard-resets). Best-effort merged-PR check before destroying anything.

## Interactive REPL
Bare `wt` now opens a persistent `wt>` prompt that dispatches each typed line as a wt command; the old one-shot nav picker moved to `wt go`. `wt <cmd>` one-shot invocation is unchanged. Split into `wt_dispatch()` + `wt_repl()`; wt stays a sourced function so `cd`/`start` inside the loop move the shell and persist after `q`.

## Fixes bundled
- Base new worktrees on `origin/dev` (fetch first), not stale local dev.
- Anchor new-worktree placement to the dev worktree's parent instead of the CWD-relative `WORKTREE_DIR`; `wt cd` resolves via git porcelain (old `${0:A:h}` was just `$PWD`).
- `wt new` honors an intent prefix (`fix/foo` → branch `fix/foo`) and no longer copies `tasks/`.
- `wt rm` resolves the real branch (not just `feature/<name>`) and parses via porcelain.
- `wt status` detects squash-merged branches via `gh` (merge-base can't, since we squash).
- Removed the dead `alias wt=` line from `~/.zshrc` (not in this repo; done locally).

## Testing
Verified end-to-end with a throwaway PRD: `wt start` → correct path, at `origin/dev` tip, only the one PRD copied, Claude profile written. `wt done` → task list archived back to dev, worktree + branch removed, dev rebase safely skipped (dev was dirty). REPL driven via piped input: `cd` inside the loop persists after `q`; one-shot `wt <cmd>` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)