### PR TITLE
feat(workspace): map quick-task composer + Give Task agent fix

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -584,6 +584,145 @@
 .ws-cmd-map-belt-btn:last-child:focus-visible::after {
   transform: translate(0, 0);
 }
+/* Quick "New Quest" composer: floating dock at the map's bottom-right. */
+.ws-cmd-map-quest-dock {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  z-index: 6;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+  gap: 10px;
+}
+.ws-cmd-map-quest-fab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px solid var(--ws-faction);
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.2), rgba(15, 59, 48, 0.9));
+  color: var(--ws-ink);
+  font-family: var(--ws-font-display);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  cursor: pointer;
+  clip-path: polygon(0 0, calc(100% - 10px) 0, 100% 10px, 100% 100%, 10px 100%, 0 calc(100% - 10px));
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.34);
+}
+.ws-cmd-map-quest-fab i {
+  font-size: 15px;
+  color: var(--ws-faction);
+}
+.ws-cmd-map-quest-fab:hover,
+.ws-cmd-map-quest-fab.is-open {
+  border-color: var(--ws-faction);
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.3), rgba(15, 59, 48, 0.95));
+}
+.ws-cmd-map-quest-fab:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-map-quest-composer {
+  width: min(340px, calc(100vw - 48px));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--ws-line-bright);
+  background: linear-gradient(180deg, #15171c, #0b0c10);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5), var(--ws-glow);
+  clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+}
+.ws-cmd-map-quest-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--ws-font-display);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--ws-faction);
+}
+.ws-cmd-map-quest-close {
+  border: none;
+  background: none;
+  color: var(--ws-ink-dim);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.ws-cmd-map-quest-close:hover {
+  color: var(--ws-ink);
+}
+.ws-cmd-map-quest-input {
+  width: 100%;
+  resize: vertical;
+  min-height: 46px;
+  padding: 8px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.9);
+  color: var(--ws-ink);
+  font-family: var(--ws-font-mono);
+  font-size: 13px;
+  line-height: 1.4;
+}
+.ws-cmd-map-quest-input:focus-visible {
+  outline: 1px solid var(--ws-faction);
+  outline-offset: 0;
+  border-color: var(--ws-faction);
+}
+.ws-cmd-map-quest-error {
+  margin: 0;
+  color: var(--ws-alert);
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+}
+.ws-cmd-map-quest-actions {
+  display: flex;
+  gap: 8px;
+}
+.ws-cmd-map-quest-btn {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.84);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-display);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+}
+.ws-cmd-map-quest-btn:hover:not([disabled]) {
+  color: var(--ws-ink);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-map-quest-btn.is-primary {
+  border-color: var(--ws-faction);
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.22), rgba(15, 59, 48, 0.9));
+  color: var(--ws-ink);
+}
+.ws-cmd-map-quest-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-map-quest-btn[disabled] {
+  opacity: 0.6;
+  cursor: progress;
+}
+.ws-cmd-map-quest-hint {
+  margin: 0;
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2px;
+}
+
 .ws-cmd-map-window-backdrop {
   position: fixed;
   inset: clamp(76px, 10vh, 112px) 16px 16px;
@@ -3920,6 +4059,18 @@
   .ws-cmd-map-belt-btn {
     width: 44px;
     height: 44px;
+  }
+  .ws-cmd-map-quest-dock {
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+    align-items: stretch;
+  }
+  .ws-cmd-map-quest-fab {
+    align-self: flex-end;
+  }
+  .ws-cmd-map-quest-composer {
+    width: 100%;
   }
   .ws-cmd-map-window-backdrop {
     padding: 12px;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -36,6 +36,11 @@ export class WorkspaceCommandView {
     this.statModalTrigger = null;
     this.taskModalShowAll = false;
     this.taskModalBoardMode = false;
+    // Quick "New Quest" composer on the operations map (create task → entry-agent default).
+    this.taskComposerOpen = false;
+    this.taskComposerDraft = '';
+    this.taskComposerError = '';
+    this.taskComposerSubmitting = false;
     this.identityExpanded = false;
     this.identityEditMode = '';
     this.identitySaving = false;
@@ -145,6 +150,10 @@ export class WorkspaceCommandView {
   handleGlobalKeydown(event) {
     if (!this.active || !event || event.key !== 'Escape') return;
     if (this.statModalSection || this.identityEditMode) return;
+    if (this.viewMode === 'map' && this.taskComposerOpen) {
+      this.closeTaskComposer();
+      return;
+    }
     if (this.viewMode === 'map' && this.activeMapWindow) {
       this.activeMapWindow = '';
       this.render();
@@ -3438,9 +3447,126 @@ export class WorkspaceCommandView {
       this.renderMapAgentsZone(agents) +
       this.renderMapToolTray() +
       '</div>' +
+      this.renderMapQuickTask() +
       this.renderMapWindow(selected) +
       '</div>'
     );
+  }
+
+  // Floating "New Quest" button + inline composer. Creating with no assignee lets the
+  // server stamp the task onto the workspace's entry agent (entry_agent_default).
+  renderMapQuickTask() {
+    const open = this.taskComposerOpen;
+    const submitting = this.taskComposerSubmitting;
+    const button =
+      '<button type="button" class="ws-cmd-map-quest-fab' +
+      (open ? ' is-open' : '') +
+      '" data-cmd-map-quest-toggle aria-haspopup="dialog" aria-expanded="' +
+      (open ? 'true' : 'false') +
+      '" aria-label="New quest"><i class="bi bi-plus-lg" aria-hidden="true"></i><span>New Quest</span></button>';
+    if (!open) {
+      return '<div class="ws-cmd-map-quest-dock">' + button + '</div>';
+    }
+    const draft = escapeHtml(this.taskComposerDraft || '');
+    const error = this.taskComposerError
+      ? '<p class="ws-cmd-map-quest-error" role="alert">' +
+        escapeHtml(this.taskComposerError) +
+        '</p>'
+      : '';
+    const disabledAttr = submitting ? ' disabled' : '';
+    return (
+      '<div class="ws-cmd-map-quest-dock is-open">' +
+      button +
+      '<section class="ws-cmd-map-quest-composer" role="dialog" aria-modal="false" aria-label="New quest">' +
+      '<header class="ws-cmd-map-quest-head"><span>New Quest</span>' +
+      '<button type="button" class="ws-cmd-map-quest-close" data-cmd-map-quest-cancel aria-label="Close new quest">×</button></header>' +
+      '<textarea class="ws-cmd-map-quest-input" data-cmd-map-quest-input rows="2" ' +
+      'placeholder="Describe the quest… (assigned to the entry agent)"' +
+      disabledAttr +
+      '>' +
+      draft +
+      '</textarea>' +
+      error +
+      '<div class="ws-cmd-map-quest-actions">' +
+      '<button type="button" class="ws-cmd-map-quest-btn is-primary" data-cmd-map-quest-create' +
+      disabledAttr +
+      '>' +
+      (submitting ? 'Creating…' : 'Create') +
+      '</button>' +
+      '<button type="button" class="ws-cmd-map-quest-btn" data-cmd-map-quest-start' +
+      disabledAttr +
+      '>Create &amp; Start</button>' +
+      '</div>' +
+      '<p class="ws-cmd-map-quest-hint">Enter to create · ⌘/Ctrl+Enter to create &amp; start</p>' +
+      '</section></div>'
+    );
+  }
+
+  openTaskComposer() {
+    this.taskComposerOpen = true;
+    this.taskComposerError = '';
+    this.render();
+  }
+
+  closeTaskComposer({ clearDraft = true } = {}) {
+    this.taskComposerOpen = false;
+    this.taskComposerError = '';
+    this.taskComposerSubmitting = false;
+    if (clearDraft) this.taskComposerDraft = '';
+    this.render();
+  }
+
+  async submitTaskComposer({ start = false } = {}) {
+    if (this.taskComposerSubmitting) return;
+    const description = String(this.taskComposerDraft || '').trim();
+    if (!description) {
+      this.taskComposerError = 'Enter a quest description.';
+      this.render();
+      return;
+    }
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || typeof page.createTask !== 'function') return;
+
+    this.taskComposerSubmitting = true;
+    this.taskComposerError = '';
+    this.render();
+
+    let created = null;
+    try {
+      // No assignee → server applies the entry-agent default; suppress the generic
+      // "Task created" toast so we can name the resolved assignee instead.
+      created = await page.createTask(description, '', '', { successToast: false });
+    } catch (_error) {
+      created = null;
+    }
+
+    if (!created || !created.id) {
+      this.taskComposerSubmitting = false;
+      this.taskComposerError = 'Could not create the quest. Try again.';
+      this.render();
+      return;
+    }
+
+    const assignee = String(created.to || '').trim();
+    if (start && typeof page.executeTask === 'function') {
+      try {
+        await page.executeTask(created.id, { skipConfirm: true });
+      } catch (_error) {
+        /* execution failures surface via executeTask's own toast */
+      }
+    }
+    if (window.Toast) {
+      const target = assignee || 'the entry agent';
+      window.Toast.success(
+        (start ? 'Quest started · assigned to ' : 'Quest assigned to ') + target
+      );
+    }
+    // loadTasks() (via createTask/executeTask) already refreshed the view; close cleanly.
+    this.taskComposerDraft = '';
+    this.taskComposerOpen = false;
+    this.taskComposerSubmitting = false;
+    this.taskComposerError = '';
+    this.render();
   }
 
   runMapInventoryAction(sectionKey, triggerButton) {
@@ -3458,6 +3584,29 @@ export class WorkspaceCommandView {
     if (!root) return;
     root.addEventListener('click', event => {
       const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      const questToggle = event.target.closest('[data-cmd-map-quest-toggle]');
+      if (questToggle) {
+        if (this.taskComposerOpen) this.closeTaskComposer();
+        else this.openTaskComposer();
+        return;
+      }
+      if (event.target.closest('[data-cmd-map-quest-cancel]')) {
+        this.closeTaskComposer();
+        return;
+      }
+      if (event.target.closest('[data-cmd-map-quest-create]')) {
+        this.submitTaskComposer({ start: false });
+        return;
+      }
+      if (event.target.closest('[data-cmd-map-quest-start]')) {
+        this.submitTaskComposer({ start: true });
+        return;
+      }
+      // Click outside the composer (but still on the map) dismisses it, keeping the draft.
+      if (this.taskComposerOpen && !event.target.closest('.ws-cmd-map-quest-dock')) {
+        this.closeTaskComposer({ clearDraft: false });
+        return;
+      }
       const closeWindow = event.target.closest('[data-cmd-map-window-close]');
       if (closeWindow) {
         this.activeMapWindow = '';
@@ -3567,6 +3716,44 @@ export class WorkspaceCommandView {
         );
       }
     });
+    this.bindTaskComposer(root);
+  }
+
+  // Wire the quest composer's textarea: track the draft and handle keyboard submits.
+  // The composer only exists in the DOM while open, so this re-binds on each render.
+  bindTaskComposer(root) {
+    if (!root || !this.taskComposerOpen) return;
+    const input = root.querySelector('[data-cmd-map-quest-input]');
+    if (!input) return;
+    input.addEventListener('input', event => {
+      this.taskComposerDraft = event.target.value;
+      if (this.taskComposerError) this.taskComposerError = '';
+    });
+    input.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        this.closeTaskComposer();
+        return;
+      }
+      if (event.key === 'Enter') {
+        // Newlines are not needed for a one-line quest; Enter submits.
+        event.preventDefault();
+        this.taskComposerDraft = event.target.value;
+        this.submitTaskComposer({ start: event.metaKey || event.ctrlKey });
+      }
+    });
+    // Restore focus + caret after the re-render that opened/updated the composer.
+    if (!this.taskComposerSubmitting && typeof input.focus === 'function') {
+      input.focus();
+      const end = input.value.length;
+      if (typeof input.setSelectionRange === 'function') {
+        try {
+          input.setSelectionRange(end, end);
+        } catch (_error) {
+          /* setSelectionRange unsupported on some inputs */
+        }
+      }
+    }
   }
 
   captureAgentDeckViewState() {

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2258,3 +2258,145 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     globalThis.localStorage = originalLocalStorage;
   }
 });
+
+function makeQuestComposerView(overrides = {}) {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(
+    commandView,
+    {
+      taskComposerOpen: false,
+      taskComposerDraft: '',
+      taskComposerError: '',
+      taskComposerSubmitting: false,
+      renderCalls: 0,
+      render() {
+        this.renderCalls += 1;
+      }
+    },
+    overrides
+  );
+  return commandView;
+}
+
+test('operations map shows a New Quest button and reveals the composer when open', () => {
+  const closed = makeQuestComposerView();
+  const closedHTML = closed.renderMapQuickTask();
+  assert.match(closedHTML, /data-cmd-map-quest-toggle/);
+  assert.match(closedHTML, /New Quest/);
+  assert.match(closedHTML, /aria-expanded="false"/);
+  assert.doesNotMatch(closedHTML, /data-cmd-map-quest-input/);
+
+  const open = makeQuestComposerView({ taskComposerOpen: true, taskComposerDraft: 'Draft copy edits' });
+  const openHTML = open.renderMapQuickTask();
+  assert.match(openHTML, /aria-expanded="true"/);
+  assert.match(openHTML, /data-cmd-map-quest-input/);
+  assert.match(openHTML, /Draft copy edits/);
+  assert.match(openHTML, /data-cmd-map-quest-create/);
+  assert.match(openHTML, /data-cmd-map-quest-start/);
+});
+
+test('quest composer Create posts with no assignee so the entry-agent default applies', async () => {
+  const originalWindow = globalThis.window;
+  const toasts = [];
+  globalThis.window = { Toast: { success: msg => toasts.push(msg) } };
+  try {
+    const createArgs = [];
+    const view = makeQuestComposerView({
+      taskComposerOpen: true,
+      taskComposerDraft: 'Summarize the weekly report',
+      page: {
+        async createTask(name, description, columnId, options) {
+          createArgs.push([name, description, columnId, options]);
+          return { id: 't-42', to: 'Atlas' };
+        }
+      }
+    });
+
+    await view.submitTaskComposer({ start: false });
+
+    assert.equal(createArgs.length, 1);
+    const [name, , columnId, options] = createArgs[0];
+    assert.equal(name, 'Summarize the weekly report');
+    assert.equal(columnId, '');
+    assert.equal(options.successToast, false);
+    assert.ok(!('to' in options) && !('assignee' in options), 'no assignee is sent');
+    assert.deepEqual(toasts, ['Quest assigned to Atlas']);
+    assert.equal(view.taskComposerOpen, false);
+    assert.equal(view.taskComposerDraft, '');
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('quest composer Create & Start executes the created task and names the assignee', async () => {
+  const originalWindow = globalThis.window;
+  const toasts = [];
+  globalThis.window = { Toast: { success: msg => toasts.push(msg) } };
+  try {
+    const executed = [];
+    const view = makeQuestComposerView({
+      taskComposerOpen: true,
+      taskComposerDraft: 'Kick off ingest',
+      page: {
+        async createTask() {
+          return { id: 't-9', to: 'Scribe' };
+        },
+        async executeTask(id, options) {
+          executed.push([id, options]);
+        }
+      }
+    });
+
+    await view.submitTaskComposer({ start: true });
+
+    assert.deepEqual(executed, [['t-9', { skipConfirm: true }]]);
+    assert.deepEqual(toasts, ['Quest started · assigned to Scribe']);
+    assert.equal(view.taskComposerOpen, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('quest composer keeps the draft and shows an error when creation fails', async () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = { Toast: { success() {} } };
+  try {
+    const view = makeQuestComposerView({
+      taskComposerOpen: true,
+      taskComposerDraft: 'Retryable quest',
+      page: {
+        async createTask() {
+          return null;
+        }
+      }
+    });
+
+    await view.submitTaskComposer({ start: false });
+
+    assert.equal(view.taskComposerOpen, true);
+    assert.equal(view.taskComposerDraft, 'Retryable quest');
+    assert.equal(view.taskComposerSubmitting, false);
+    assert.match(view.taskComposerError, /could not create/i);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('quest composer rejects an empty draft without calling the page', async () => {
+  let called = false;
+  const view = makeQuestComposerView({
+    taskComposerOpen: true,
+    taskComposerDraft: '   ',
+    page: {
+      async createTask() {
+        called = true;
+        return { id: 'x' };
+      }
+    }
+  });
+
+  await view.submitTaskComposer({ start: false });
+
+  assert.equal(called, false);
+  assert.match(view.taskComposerError, /enter a quest/i);
+});

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -15481,13 +15481,19 @@ export class WorkspaceDetailPage {
   /**
    * Show add task modal
    */
-  showAddTaskModal() {
+  showAddTaskModal(options = {}) {
     // Use existing task modal controller
     if (
       window.taskModalController &&
       typeof window.taskModalController.openForCreate === 'function'
     ) {
-      window.taskModalController.openForCreate(this.workspaceId, '', () => this.loadTasks());
+      const createOptions = options && typeof options === 'object' ? options : {};
+      window.taskModalController.openForCreate(
+        this.workspaceId,
+        '',
+        () => this.loadTasks(),
+        createOptions
+      );
     } else {
       // Fallback to prompt
       const name = prompt('Enter task name:');
@@ -15496,10 +15502,21 @@ export class WorkspaceDetailPage {
   }
 
   showAddTaskModalForAgent(encodedAgentName = '') {
-    // Keep current behavior (workspace task modal), but route from per-agent section actions.
-    // Future enhancement can preselect agent assignment in the task modal.
-    void encodedAgentName;
-    this.showAddTaskModal();
+    // Route from per-agent section actions with the assignee preselected, so a task
+    // given to a specific agent lands on that agent instead of the entry-agent default.
+    let agentName = '';
+    try {
+      agentName = decodeURIComponent(String(encodedAgentName || '')).trim();
+    } catch (_error) {
+      agentName = String(encodedAgentName || '').trim();
+    }
+    if (!agentName) {
+      this.showAddTaskModal();
+      return;
+    }
+    // The assignment dropdown keys agents as `node:<name>-node-1` (see task modal
+    // populateAgentDropdown); draftAssignmentValue is applied after it populates.
+    this.showAddTaskModal({ draftAssignmentValue: `node:${agentName}-node-1` });
   }
 
   /**

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -768,3 +768,45 @@ test('workspace-local model save posts to the workspace-scoped endpoint', async 
   assert.equal(body.model, 'claude-opus-4');
   assert.equal(body.llm_provider, 'claude');
 });
+
+test('showAddTaskModalForAgent preselects the chosen agent as the task assignee', () => {
+  const page = new WorkspaceDetailPage('ws-7');
+  const calls = [];
+  const originalController = global.window.taskModalController;
+  global.window.taskModalController = {
+    openForCreate(workspaceId, prefill, onSave, options) {
+      calls.push({ workspaceId, prefill, options });
+    }
+  };
+  try {
+    page.showAddTaskModalForAgent(encodeURIComponent('Atlas Prime'));
+  } finally {
+    global.window.taskModalController = originalController;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].workspaceId, 'ws-7');
+  assert.equal(calls[0].options.draftAssignmentValue, 'node:Atlas Prime-node-1');
+});
+
+test('showAddTaskModalForAgent with no agent opens the modal without an assignee', () => {
+  const page = new WorkspaceDetailPage('ws-7');
+  const calls = [];
+  const originalController = global.window.taskModalController;
+  global.window.taskModalController = {
+    openForCreate(workspaceId, prefill, onSave, options) {
+      calls.push({ options });
+    }
+  };
+  try {
+    page.showAddTaskModalForAgent('');
+  } finally {
+    global.window.taskModalController = originalController;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.ok(
+    !calls[0].options || !('draftAssignmentValue' in calls[0].options),
+    'no assignment value is forced when no agent is given'
+  );
+});


### PR DESCRIPTION
First seam-PR of the *Map Task Execution + Unit Sheet Loadout* epic (PRD: `tasks/prd-map-task-execution-unit-sheet-loadout.md`). Covers Req A + B; loadout editing (C) and start-in-place (D) follow as separate PRs.

## What this delivers

**A — Quick task creation on the map**
- Always-visible "New Quest" button on the operations map (bottom-right dock).
- Single-field composer: **Create** posts with *no assignee*, so the server stamps the task onto the workspace entry agent (`entry_agent_default`). **Create & Start** chains `executeTask(id, { skipConfirm: true })`.
- Keyboard: Enter = create, ⌘/Ctrl+Enter = create & start, Escape / click-outside dismiss (keeping the draft on failure). Textarea auto-focuses on open.
- Success toast names the resolved assignee from the create response's `to` field.

**B — Give Task agent fix**
- `showAddTaskModalForAgent` previously discarded the agent (`void encodedAgentName`) and opened the generic modal, so a task "given" to a specialist agent silently fell back to the entry agent.
- It now decodes the name and passes `draftAssignmentValue: node:<name>-node-1`, which the task modal already applies to the assignment dropdown after it populates (no change needed in `openForCreate` — reuse win).

## Verification
- **7 new module tests** (5 composer behavior/render + 2 Give Task); full `workspace-command.test.js` / `workspace-detail.test.js` suites green. eslint clean.
- Server builds (embedded assets); `go test ./...` clean except the pre-existing live-OpenAI integration test (429 quota, unrelated).
- **Real-browser smoke on an isolated server:** New Quest button renders, composer opens + auto-focuses, submit created a task with `to: "Claude Code"`, `assignment_mode: "entry_agent_default"`, toast "Quest assigned to Claude Code". Give Task opened the modal preselected to "Claude Code".

## Scope notes
- Frontend-only; no backend/endpoint changes.
- Targets `dev`. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)