### PR TITLE
feat(workspace): edit agent Skills + MCP loadout from the Unit Sheet

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -3304,6 +3304,151 @@
   font-size: 10px;
   font-style: italic;
 }
+
+/* Interactive loadout editor (map Unit Sheet + details Loadout tab). */
+.ws-cmd-loadout-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ws-cmd-loadout-editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ws-cmd-loadout-editor-section header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.ws-cmd-loadout-add-btn {
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.84);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-display);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+.ws-cmd-loadout-add-btn:hover,
+.ws-cmd-loadout-add-btn.is-open {
+  color: var(--ws-ink);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-loadout-add-btn:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-loadout-chip.is-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  background: transparent;
+  font-size: 10px;
+  transition: border-color 0.12s ease, color 0.12s ease;
+}
+.ws-cmd-loadout-chip-mark {
+  font-weight: 700;
+}
+.ws-cmd-loadout-chip.is-toggle.is-on {
+  color: var(--ws-faction);
+  border-color: var(--ws-faction);
+  background: rgba(70, 211, 154, 0.1);
+}
+.ws-cmd-loadout-chip.is-toggle.is-off {
+  color: var(--ws-ink-faint);
+  border-color: var(--ws-line);
+}
+.ws-cmd-loadout-chip.is-toggle:hover:not([disabled]) {
+  color: var(--ws-ink);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-loadout-chip.is-toggle:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-loadout-chip.is-toggle.is-busy,
+.ws-cmd-loadout-chip.is-toggle[disabled] {
+  opacity: 0.55;
+  cursor: progress;
+}
+.ws-cmd-loadout-chip.is-locked {
+  color: var(--ws-ink-faint);
+  border-style: dashed;
+}
+.ws-cmd-loadout-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 8px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.7);
+}
+.ws-cmd-loadout-picker.is-loading,
+.ws-cmd-loadout-picker.is-empty {
+  color: var(--ws-ink-faint);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  font-style: italic;
+}
+.ws-cmd-loadout-picker-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px solid var(--ws-line-bright);
+  background: rgba(9, 11, 15, 0.84);
+  color: var(--ws-ink-dim);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+.ws-cmd-loadout-picker-item i {
+  font-size: 9px;
+  color: var(--ws-faction);
+}
+.ws-cmd-loadout-picker-item:hover:not([disabled]) {
+  color: var(--ws-ink);
+  border-color: var(--ws-faction);
+}
+.ws-cmd-loadout-picker-item:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
+.ws-cmd-loadout-picker-item.is-busy,
+.ws-cmd-loadout-picker-item[disabled] {
+  opacity: 0.55;
+  cursor: progress;
+}
+.ws-cmd-loadout-editor-error {
+  margin: 0;
+  color: var(--ws-alert);
+  font-family: var(--ws-font-mono);
+  font-size: 10px;
+}
+.ws-cmd-rpg-loadout.is-editable {
+  display: block;
+}
+.ws-cmd-rpg-loadout-model {
+  margin-bottom: 8px;
+  color: var(--ws-ink);
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+}
+.ws-cmd-rpg-loadout-model small {
+  display: block;
+  color: var(--ws-ink-faint);
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.ws-cmd-loadout-card.is-editor {
+  display: block;
+}
 .ws-cmd-loadout-prompt {
   display: flex;
   justify-content: space-between;

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -58,6 +58,12 @@ export class WorkspaceCommandView {
     this.pendingAgentTabFocus = '';
     this.agentPromptLoadingKey = '';
     this.lastAnnouncedAgentStatus = '';
+    // Interactive loadout editing (shared by map Unit Sheet + details Loadout tab).
+    this.loadoutAddOpen = ''; // '' | 'skill' | 'mcp' — which "Add" picker is open
+    this.loadoutAddOptions = [];
+    this.loadoutAddLoading = false;
+    this.loadoutBusyKey = ''; // "<kind>:<bindingId>" or "<kind>:add:<name>" while mutating
+    this.loadoutError = '';
     this.sharedSurfaceAnchors = {};
     this.boundGlobalKeydown = event => this.handleGlobalKeydown(event);
     this.setup();
@@ -2249,23 +2255,6 @@ export class WorkspaceCommandView {
     return this.questLogHTML(agent.group, agent.encodedName);
   }
 
-  chipListHTML(items, emptyText, tone = '') {
-    const values = Array.isArray(items) ? items.filter(Boolean) : [];
-    if (!values.length) {
-      return '<span class="ws-cmd-loadout-empty">' + escapeHtml(emptyText) + '</span>';
-    }
-    return values
-      .map(
-        item =>
-          '<span class="ws-cmd-loadout-chip ' +
-          escapeHtml(tone) +
-          '">' +
-          escapeHtml(item) +
-          '</span>'
-      )
-      .join('');
-  }
-
   promptCacheEntry(agent) {
     const cache = this.page && this.page.agentPromptCache;
     if (!cache || typeof cache.get !== 'function' || !agent) return null;
@@ -2328,7 +2317,6 @@ export class WorkspaceCommandView {
         escapeHtml(agent.encodedName) +
         '">Change</button>'
       : '<span class="ws-cmd-loadout-readonly">Read only</span>';
-    const skillNames = Array.isArray(agent.skills?.names) ? agent.skills.names : [];
     return (
       '<div class="ws-cmd-loadout-grid">' +
       '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">Model</span>' +
@@ -2336,18 +2324,9 @@ export class WorkspaceCommandView {
       '</header><strong>' +
       escapeHtml(model) +
       '</strong></section>' +
-      '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">Skills</span>' +
-      '<span>' +
-      skillNames.length +
-      '</span></header><div class="ws-cmd-loadout-chips">' +
-      this.chipListHTML(skillNames, 'No workspace skills attached.', 'skill') +
-      '</div></section>' +
-      '<section class="ws-cmd-loadout-card"><header><span class="ws-cmd-loadout-kicker">MCP tools</span>' +
-      '<span>' +
-      agent.mcpNames.length +
-      '</span></header><div class="ws-cmd-loadout-chips">' +
-      this.chipListHTML(agent.mcpNames, 'No MCP tools attached.', 'mcp') +
-      '</div></section>' +
+      '<section class="ws-cmd-loadout-card is-editor">' +
+      this.renderLoadoutEditor(agent) +
+      '</section>' +
       '</div>' +
       this.promptLoadoutHTML(agent)
     );
@@ -2950,37 +2929,252 @@ export class WorkspaceCommandView {
   }
 
   renderMapAgentLoadout(agent) {
-    const skills = Array.isArray(agent?.skills?.names) ? agent.skills.names : [];
-    const tools = Array.isArray(agent?.mcpNames) ? agent.mcpNames : [];
-    const chips = [
-      ...skills.map(name => ({ kind: 'Skill', label: name })),
-      ...tools.map(name => ({ kind: 'Tool', label: name }))
-    ];
-    if (!agent?.model?.empty && agent?.model?.label) {
-      chips.unshift({ kind: 'Model', label: agent.model.label });
-    }
-    const shown = chips
-      .map(chip => ({
-        kind: String(chip.kind || '').trim(),
-        label: String(chip.label || '').trim()
-      }))
-      .filter(chip => chip.kind && chip.label)
-      .slice(0, 6);
-    if (!shown.length) {
-      return '<section class="ws-cmd-rpg-loadout is-empty"><span>Loadout</span><strong>No skills or tools configured</strong></section>';
-    }
-    const remaining = Math.max(0, chips.length - shown.length);
+    const modelLine =
+      !agent?.model?.empty && agent?.model?.label
+        ? '<div class="ws-cmd-rpg-loadout-model"><small>Model</small>' +
+          escapeHtml(agent.model.label) +
+          '</div>'
+        : '';
     return (
-      '<section class="ws-cmd-rpg-loadout"><span>Loadout</span><div>' +
-      shown
-        .map(
-          chip =>
-            '<em><small>' + escapeHtml(chip.kind) + '</small>' + escapeHtml(chip.label) + '</em>'
-        )
-        .join('') +
-      (remaining ? '<em><small>More</small>+' + escapeHtml(remaining) + '</em>' : '') +
-      '</div></section>'
+      '<section class="ws-cmd-rpg-loadout is-editable"><span>Loadout</span>' +
+      modelLine +
+      this.renderLoadoutEditor(agent) +
+      '</section>'
     );
+  }
+
+  // Interactive Skills + MCP editor shared by the map Unit Sheet and the
+  // details-mode Loadout tab, so both surfaces agree on what is editable.
+  renderLoadoutEditor(agent) {
+    if (!agent) return '';
+    const page = this.page || {};
+    const enc = agent.encodedName;
+    const skills =
+      typeof page.getAgentWorkspaceSkillLoadout === 'function'
+        ? page.getAgentWorkspaceSkillLoadout(agent.name)
+        : [];
+    const mcps =
+      typeof page.getAgentWorkspaceMCPLoadout === 'function'
+        ? page.getAgentWorkspaceMCPLoadout(agent.name)
+        : [];
+    return (
+      '<div class="ws-cmd-loadout-editor">' +
+      this.loadoutSectionHTML('skill', 'Skills', skills, enc) +
+      this.loadoutSectionHTML('mcp', 'MCP Tools', mcps, enc) +
+      (this.loadoutError
+        ? '<p class="ws-cmd-loadout-editor-error" role="alert">' +
+          escapeHtml(this.loadoutError) +
+          '</p>'
+        : '') +
+      '</div>'
+    );
+  }
+
+  loadoutSectionHTML(kind, label, items, encodedAgent) {
+    const list = Array.isArray(items) ? items : [];
+    const chips = list.length
+      ? list
+          .map(item => {
+            if (item.locked) {
+              return (
+                '<span class="ws-cmd-loadout-chip is-locked" title="Always available in this workspace">' +
+                escapeHtml(item.name) +
+                '</span>'
+              );
+            }
+            const busy = this.loadoutBusyKey === kind + ':' + item.bindingId;
+            return (
+              '<button type="button" class="ws-cmd-loadout-chip is-toggle ' +
+              (item.enabled ? 'is-on' : 'is-off') +
+              (busy ? ' is-busy' : '') +
+              '" role="switch" aria-checked="' +
+              (item.enabled ? 'true' : 'false') +
+              '" data-cmd-loadout-toggle="' +
+              escapeHtml(kind) +
+              '" data-cmd-loadout-binding="' +
+              escapeHtml(item.bindingId) +
+              '" data-cmd-loadout-agent="' +
+              escapeHtml(encodedAgent) +
+              '"' +
+              (busy ? ' disabled' : '') +
+              '><span class="ws-cmd-loadout-chip-mark" aria-hidden="true">' +
+              (item.enabled ? '✓' : '+') +
+              '</span>' +
+              escapeHtml(item.name) +
+              '</button>'
+            );
+          })
+          .join('')
+      : '<span class="ws-cmd-loadout-empty">None bound to this workspace.</span>';
+    const addOpen = this.loadoutAddOpen === kind;
+    return (
+      '<section class="ws-cmd-loadout-editor-section">' +
+      '<header><span class="ws-cmd-loadout-kicker">' +
+      escapeHtml(label) +
+      '</span><button type="button" class="ws-cmd-loadout-add-btn' +
+      (addOpen ? ' is-open' : '') +
+      '" data-cmd-loadout-add="' +
+      escapeHtml(kind) +
+      '" data-cmd-loadout-agent="' +
+      escapeHtml(encodedAgent) +
+      '" aria-expanded="' +
+      (addOpen ? 'true' : 'false') +
+      '">' +
+      (kind === 'mcp' ? 'Add Tool' : 'Add Skill') +
+      '</button></header>' +
+      '<div class="ws-cmd-loadout-chips">' +
+      chips +
+      '</div>' +
+      (addOpen ? this.loadoutPickerHTML(kind, encodedAgent) : '') +
+      '</section>'
+    );
+  }
+
+  loadoutPickerHTML(kind, encodedAgent) {
+    if (this.loadoutAddLoading) {
+      return '<div class="ws-cmd-loadout-picker is-loading" aria-live="polite">Loading…</div>';
+    }
+    const options = Array.isArray(this.loadoutAddOptions) ? this.loadoutAddOptions : [];
+    if (!options.length) {
+      return '<div class="ws-cmd-loadout-picker is-empty">Nothing new to add.</div>';
+    }
+    return (
+      '<div class="ws-cmd-loadout-picker" role="listbox" aria-label="Add ' +
+      (kind === 'mcp' ? 'tool' : 'skill') +
+      '">' +
+      options
+        .map(name => {
+          const busy = this.loadoutBusyKey === kind + ':add:' + name;
+          return (
+            '<button type="button" class="ws-cmd-loadout-picker-item' +
+            (busy ? ' is-busy' : '') +
+            '" role="option" data-cmd-loadout-bind="' +
+            escapeHtml(kind) +
+            '" data-cmd-loadout-name="' +
+            escapeHtml(name) +
+            '" data-cmd-loadout-agent="' +
+            escapeHtml(encodedAgent) +
+            '"' +
+            (busy ? ' disabled' : '') +
+            '><i class="bi bi-plus-lg" aria-hidden="true"></i>' +
+            escapeHtml(name) +
+            '</button>'
+          );
+        })
+        .join('') +
+      '</div>'
+    );
+  }
+
+  decodeAgentName(encodedName) {
+    try {
+      return decodeURIComponent(String(encodedName || '')).trim();
+    } catch (_error) {
+      return String(encodedName || '').trim();
+    }
+  }
+
+  // Delegated handler for loadout chip toggles, Add buttons, and picker items.
+  // Returns true if it handled the event (shared by map + garrison listeners).
+  handleLoadoutClick(event) {
+    const toggle = event.target.closest('[data-cmd-loadout-toggle]');
+    if (toggle) {
+      this.toggleLoadoutBinding(
+        toggle.getAttribute('data-cmd-loadout-toggle'),
+        toggle.getAttribute('data-cmd-loadout-agent'),
+        toggle.getAttribute('data-cmd-loadout-binding'),
+        toggle.getAttribute('aria-checked') !== 'true'
+      );
+      return true;
+    }
+    const add = event.target.closest('[data-cmd-loadout-add]');
+    if (add) {
+      this.openLoadoutPicker(
+        add.getAttribute('data-cmd-loadout-add'),
+        add.getAttribute('data-cmd-loadout-agent')
+      );
+      return true;
+    }
+    const bind = event.target.closest('[data-cmd-loadout-bind]');
+    if (bind) {
+      this.bindLoadoutCapability(
+        bind.getAttribute('data-cmd-loadout-bind'),
+        bind.getAttribute('data-cmd-loadout-agent'),
+        bind.getAttribute('data-cmd-loadout-name')
+      );
+      return true;
+    }
+    return false;
+  }
+
+  async toggleLoadoutBinding(kind, encodedAgent, bindingId, enable) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || typeof page.setAgentWorkspaceCapabilityEnabled !== 'function') return;
+    const agentName = this.decodeAgentName(encodedAgent);
+    this.loadoutError = '';
+    this.loadoutBusyKey = kind + ':' + bindingId;
+    this.render();
+    try {
+      await page.setAgentWorkspaceCapabilityEnabled(kind, agentName, bindingId, enable);
+    } catch (error) {
+      this.loadoutError =
+        (kind === 'mcp' ? 'Tool' : 'Skill') + ' update failed: ' + (error?.message || 'error');
+      if (window.Toast) window.Toast.error(this.loadoutError);
+    } finally {
+      this.loadoutBusyKey = '';
+      this.render();
+    }
+  }
+
+  async openLoadoutPicker(kind, _encodedAgent) {
+    if (this.loadoutAddOpen === kind) {
+      this.loadoutAddOpen = '';
+      this.loadoutAddOptions = [];
+      this.render();
+      return;
+    }
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    this.loadoutAddOpen = kind;
+    this.loadoutAddLoading = true;
+    this.loadoutAddOptions = [];
+    this.loadoutError = '';
+    this.render();
+    try {
+      this.loadoutAddOptions =
+        page && typeof page.listAgentLoadoutAdditions === 'function'
+          ? await page.listAgentLoadoutAdditions(kind)
+          : [];
+    } catch (_error) {
+      this.loadoutAddOptions = [];
+    } finally {
+      this.loadoutAddLoading = false;
+      // Only re-render if this picker is still the open one.
+      if (this.loadoutAddOpen === kind) this.render();
+    }
+  }
+
+  async bindLoadoutCapability(kind, encodedAgent, name) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || typeof page.addAgentWorkspaceCapability !== 'function') return;
+    const agentName = this.decodeAgentName(encodedAgent);
+    const capName = String(name || '').trim();
+    this.loadoutError = '';
+    this.loadoutBusyKey = kind + ':add:' + capName;
+    this.render();
+    try {
+      await page.addAgentWorkspaceCapability(kind, agentName, capName);
+      this.loadoutAddOpen = '';
+      this.loadoutAddOptions = [];
+      if (window.Toast) {
+        window.Toast.success((kind === 'mcp' ? 'Tool' : 'Skill') + ' "' + capName + '" added');
+      }
+    } catch (error) {
+      this.loadoutError = 'Could not add ' + capName + ': ' + (error?.message || 'error');
+      if (window.Toast) window.Toast.error(this.loadoutError);
+    } finally {
+      this.loadoutBusyKey = '';
+      this.render();
+    }
   }
 
   latestAgentSession(agent) {
@@ -3584,6 +3778,7 @@ export class WorkspaceCommandView {
     if (!root) return;
     root.addEventListener('click', event => {
       const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      if (this.handleLoadoutClick(event)) return;
       const questToggle = event.target.closest('[data-cmd-map-quest-toggle]');
       if (questToggle) {
         if (this.taskComposerOpen) this.closeTaskComposer();
@@ -3876,6 +4071,7 @@ export class WorkspaceCommandView {
     root.addEventListener('keydown', event => this.handleAgentTabKeydown(event));
     root.addEventListener('click', event => {
       const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+      if (this.handleLoadoutClick(event)) return;
       const selectBtn = event.target.closest('[data-cmd-select-agent]');
       if (selectBtn) {
         this.selectAgent(selectBtn.getAttribute('data-cmd-select-agent'));

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2201,6 +2201,12 @@ test('Operations Map renders units first and keeps support panels hidden by defa
         getEffectiveWorkspaceMCPServerNames() {
           return ['filesystem'];
         },
+        getAgentWorkspaceSkillLoadout() {
+          return [{ bindingId: 'sk-1', name: 'workspace-planning', enabled: true, locked: false }];
+        },
+        getAgentWorkspaceMCPLoadout() {
+          return [{ bindingId: 'mcp-1', name: 'filesystem', enabled: true, locked: false }];
+        },
         getAgentModelPresentation() {
           return { model: '', label: 'Model not set', empty: true };
         },
@@ -2399,4 +2405,162 @@ test('quest composer rejects an empty draft without calling the page', async () 
 
   assert.equal(called, false);
   assert.match(view.taskComposerError, /enter a quest/i);
+});
+
+function makeLoadoutView(overrides = {}) {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(
+    view,
+    {
+      loadoutAddOpen: '',
+      loadoutAddOptions: [],
+      loadoutAddLoading: false,
+      loadoutBusyKey: '',
+      loadoutError: '',
+      renderCalls: 0,
+      render() {
+        this.renderCalls += 1;
+      }
+    },
+    overrides
+  );
+  return view;
+}
+
+test('loadout editor renders interactive toggles, locked chips, and add buttons', () => {
+  const view = makeLoadoutView({
+    page: {
+      getAgentWorkspaceSkillLoadout() {
+        return [
+          { bindingId: 'sk-1', name: 'planner', enabled: true, locked: false },
+          { bindingId: 'sk-2', name: 'writer', enabled: false, locked: false }
+        ];
+      },
+      getAgentWorkspaceMCPLoadout() {
+        return [{ bindingId: 'fs', name: 'filesystem', enabled: true, locked: true }];
+      }
+    }
+  });
+
+  const html = view.renderLoadoutEditor({ name: 'Atlas', encodedName: 'Atlas' });
+  assert.match(html, /data-cmd-loadout-toggle="skill" data-cmd-loadout-binding="sk-1"/);
+  assert.match(html, /aria-checked="true"[^>]*data-cmd-loadout-binding="sk-1"|data-cmd-loadout-binding="sk-1"[^>]*aria-checked="true"/);
+  assert.match(html, /data-cmd-loadout-binding="sk-2"/);
+  assert.match(html, /ws-cmd-loadout-chip is-locked/);
+  assert.doesNotMatch(html, /data-cmd-loadout-toggle="mcp" data-cmd-loadout-binding="fs"/);
+  assert.match(html, /data-cmd-loadout-add="skill"/);
+  assert.match(html, /data-cmd-loadout-add="mcp"/);
+});
+
+test('toggling a loadout chip delegates to the page with decoded agent and inverted state', async () => {
+  const calls = [];
+  const view = makeLoadoutView({
+    page: {
+      async setAgentWorkspaceCapabilityEnabled(kind, agentName, bindingId, enabled) {
+        calls.push([kind, agentName, bindingId, enabled]);
+        return true;
+      }
+    }
+  });
+
+  await view.toggleLoadoutBinding('skill', encodeURIComponent('Atlas Prime'), 'sk-9', false);
+
+  assert.deepEqual(calls, [['skill', 'Atlas Prime', 'sk-9', false]]);
+  assert.equal(view.loadoutBusyKey, '');
+});
+
+test('handleLoadoutClick routes a toggle target to toggleLoadoutBinding', () => {
+  const args = [];
+  const view = makeLoadoutView();
+  view.toggleLoadoutBinding = (...a) => args.push(a);
+  const target = {
+    closest(selector) {
+      if (selector === '[data-cmd-loadout-toggle]') {
+        return {
+          getAttribute(name) {
+            return {
+              'data-cmd-loadout-toggle': 'mcp',
+              'data-cmd-loadout-agent': 'Atlas',
+              'data-cmd-loadout-binding': 'mcp-3',
+              'aria-checked': 'false'
+            }[name];
+          }
+        };
+      }
+      return null;
+    }
+  };
+
+  const handled = view.handleLoadoutClick({ target });
+
+  assert.equal(handled, true);
+  assert.deepEqual(args, [['mcp', 'Atlas', 'mcp-3', true]]);
+});
+
+test('opening a loadout picker loads registry additions; reopening the same kind closes it', async () => {
+  const view = makeLoadoutView({
+    page: {
+      async listAgentLoadoutAdditions(kind) {
+        return kind === 'skill' ? ['reviewer', 'summarizer'] : [];
+      }
+    }
+  });
+
+  await view.openLoadoutPicker('skill', 'Atlas');
+  assert.equal(view.loadoutAddOpen, 'skill');
+  assert.deepEqual(view.loadoutAddOptions, ['reviewer', 'summarizer']);
+  assert.equal(view.loadoutAddLoading, false);
+
+  await view.openLoadoutPicker('skill', 'Atlas');
+  assert.equal(view.loadoutAddOpen, '');
+});
+
+test('binding a loadout capability delegates to the page and closes the picker on success', async () => {
+  const originalWindow = globalThis.window;
+  const toasts = [];
+  globalThis.window = { Toast: { success: m => toasts.push(m), error() {} } };
+  try {
+    const calls = [];
+    const view = makeLoadoutView({
+      loadoutAddOpen: 'mcp',
+      loadoutAddOptions: ['filesystem'],
+      page: {
+        async addAgentWorkspaceCapability(kind, agentName, name) {
+          calls.push([kind, agentName, name]);
+          return true;
+        }
+      }
+    });
+
+    await view.bindLoadoutCapability('mcp', encodeURIComponent('Atlas'), 'filesystem');
+
+    assert.deepEqual(calls, [['mcp', 'Atlas', 'filesystem']]);
+    assert.equal(view.loadoutAddOpen, '');
+    assert.deepEqual(toasts, ['Tool "filesystem" added']);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('a failed loadout binding surfaces an error and preserves the picker', async () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = { Toast: { success() {}, error() {} } };
+  try {
+    const view = makeLoadoutView({
+      loadoutAddOpen: 'skill',
+      page: {
+        async addAgentWorkspaceCapability() {
+          throw new Error('registry offline');
+        }
+      }
+    });
+
+    await view.bindLoadoutCapability('skill', 'Atlas', 'reviewer');
+
+    assert.equal(view.loadoutAddOpen, 'skill');
+    assert.match(view.loadoutError, /could not add reviewer/i);
+    assert.match(view.loadoutError, /registry offline/);
+  } finally {
+    globalThis.window = originalWindow;
+  }
 });

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -11376,6 +11376,177 @@ export class WorkspaceDetailPage {
     return ids;
   }
 
+  // ---------------------------------------------------------------------------
+  // Shared agent loadout editing (map Unit Sheet + details Loadout tab)
+  //
+  // These reuse the skills/MCP managers' access primitives so both surfaces
+  // agree on the "no access entry = all workspace bindings enabled" convention
+  // and its default-collapse behavior. Synthesized bindings (e.g. the implicit
+  // workspace filesystem server) have no persisted row and are reported locked.
+  // ---------------------------------------------------------------------------
+
+  getAgentWorkspaceSkillLoadout(agentName) {
+    const mgr = this.skillsManager;
+    if (!mgr) return [];
+    const effective = new Set(
+      mgr
+        .getEffectiveWorkspaceSkillBindingsForAgent(agentName)
+        .map(binding => String(binding?.id || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
+    return mgr
+      .getWorkspaceSkillBindings()
+      .map(binding => {
+        const bindingId = String(binding?.id || '').trim();
+        return {
+          bindingId,
+          name: String(binding?.skillName || '').trim(),
+          enabled: effective.has(bindingId.toLowerCase()),
+          locked: binding?.source === 'synthesized'
+        };
+      })
+      .filter(item => item.bindingId && item.name);
+  }
+
+  getAgentWorkspaceMCPLoadout(agentName) {
+    const mgr = this.mcpManager;
+    if (!mgr) return [];
+    const effective = new Set(
+      mgr
+        .getEffectiveWorkspaceMCPBindingsForAgent(agentName)
+        .map(binding => String(binding?.id || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
+    return mgr
+      .getWorkspaceMCPBindings()
+      .map(binding => {
+        const bindingId = String(binding?.id || '').trim();
+        return {
+          bindingId,
+          name: String(binding?.serverName || '').trim(),
+          enabled: effective.has(bindingId.toLowerCase()),
+          locked: binding?.source === 'synthesized'
+        };
+      })
+      .filter(item => item.bindingId && item.name);
+  }
+
+  // Registry capabilities of `kind` ('skill'|'mcp') not yet present as an
+  // enabled workspace binding — the candidates a "bind new" picker should list.
+  async listAgentLoadoutAdditions(kind) {
+    const isMCP = kind === 'mcp';
+    const mgr = isMCP ? this.mcpManager : this.skillsManager;
+    if (!mgr) return [];
+    let registry = [];
+    try {
+      registry = isMCP
+        ? await mgr.loadAvailableMCPServers()
+        : await mgr.loadAvailableSkills();
+    } catch (_error) {
+      registry = [];
+    }
+    const bound = new Set(
+      (isMCP ? mgr.getWorkspaceMCPBindings() : mgr.getWorkspaceSkillBindings())
+        .map(binding => String(isMCP ? binding?.serverName : binding?.skillName || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
+    return (Array.isArray(registry) ? registry : [])
+      .map(entry => String(entry?.name || '').trim())
+      .filter(name => name && !bound.has(name.toLowerCase()));
+  }
+
+  async setAgentWorkspaceCapabilityEnabled(kind, agentName, bindingId, enabled) {
+    const id = String(bindingId || '').trim();
+    const name = String(agentName || '').trim();
+    if (!id || !name) return false;
+    const isMCP = kind === 'mcp';
+    const mgr = isMCP ? this.mcpManager : this.skillsManager;
+    if (!mgr) return false;
+
+    const selections = isMCP
+      ? mgr.getWorkspaceMCPAgentAccessSelections(id)
+      : mgr.getWorkspaceSkillAgentAccessSelections(id);
+    const enabledInstanceIds = new Set(
+      selections
+        .filter(selection => selection.checked)
+        .map(selection => String(selection.id || '').trim())
+        .filter(Boolean)
+    );
+    const instanceIds = this.getAgentInstanceIdsForName(name);
+    if (instanceIds.length === 0) return false;
+    instanceIds.forEach(instanceId => {
+      if (enabled) enabledInstanceIds.add(instanceId);
+      else enabledInstanceIds.delete(instanceId);
+    });
+
+    if (isMCP) {
+      await mgr.persistWorkspaceMCPAgentAccess(id, Array.from(enabledInstanceIds));
+    } else {
+      await mgr.persistWorkspaceSkillAgentAccess(id, Array.from(enabledInstanceIds));
+    }
+    await this.loadWorkspace();
+    return true;
+  }
+
+  // Bind a registry capability into the workspace (create or enable), then
+  // enable it for the agent. Mirrors the create-or-enable-then-merge flow used
+  // by agent creation, but scoped to a single agent + capability.
+  async addAgentWorkspaceCapability(kind, agentName, capabilityName) {
+    const name = String(capabilityName || '').trim();
+    const agent = String(agentName || '').trim();
+    if (!name || !agent) return false;
+    const isMCP = kind === 'mcp';
+    const mgr = isMCP ? this.mcpManager : this.skillsManager;
+    if (!mgr) return false;
+
+    const bindingName = binding =>
+      String(isMCP ? binding?.serverName : binding?.skillName || '').trim();
+    const findBinding = () =>
+      (isMCP
+        ? mgr.getWorkspaceMCPBindings({ includeDisabled: true })
+        : mgr.getWorkspaceSkillBindings({ includeDisabled: true })
+      ).find(
+        binding =>
+          binding?.source !== 'synthesized' &&
+          bindingName(binding).toLowerCase() === name.toLowerCase()
+      );
+
+    const collection = isMCP ? 'mcp-bindings' : 'skill-bindings';
+    const base = `/api/workspaces/${encodeURIComponent(this.workspaceId)}/${collection}`;
+    let match = findBinding();
+    let bindingId = match ? String(match.id || '').trim() : '';
+
+    if (!bindingId) {
+      const payload = isMCP
+        ? { server_name: name, enabled: true }
+        : { skill_name: name, enabled: true, config: {} };
+      const response = await fetch(base, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) throw new Error((await response.text()) || `Failed to bind ${name}`);
+      const data = await response.json().catch(() => ({}));
+      bindingId = String(data?.binding?.id || data?.id || '').trim();
+      await this.loadWorkspace();
+      if (!bindingId) {
+        match = findBinding();
+        bindingId = match ? String(match.id || '').trim() : '';
+      }
+    } else if (match && match.enabled === false) {
+      const response = await fetch(`${base}/${encodeURIComponent(bindingId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true })
+      });
+      if (!response.ok) throw new Error((await response.text()) || `Failed to enable ${name}`);
+      await this.loadWorkspace();
+    }
+
+    if (!bindingId) throw new Error(`Could not resolve a workspace binding for ${name}`);
+    return this.setAgentWorkspaceCapabilityEnabled(kind, agent, bindingId, true);
+  }
+
   async loadWorkspaceAgentSnapshots() {
     this.workspaceAgentSnapshots = new Set();
     this.workspaceAgentProfiles = new Map();

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -810,3 +810,99 @@ test('showAddTaskModalForAgent with no agent opens the modal without an assignee
     'no assignment value is forced when no agent is given'
   );
 });
+
+test('setAgentWorkspaceCapabilityEnabled merges the agent into the binding access set', async () => {
+  const page = new WorkspaceDetailPage('ws-1');
+  page.workspace = { agent_instances: [{ id: 'inst-A', name: 'Atlas' }, { id: 'inst-B', name: 'Bolt' }] };
+  const persisted = [];
+  page.skillsManager.getWorkspaceSkillAgentAccessSelections = () => [
+    { id: 'inst-A', checked: false },
+    { id: 'inst-B', checked: true }
+  ];
+  page.skillsManager.persistWorkspaceSkillAgentAccess = async (bindingId, ids) => {
+    persisted.push([bindingId, ids]);
+  };
+  page.loadWorkspace = async () => {};
+
+  const ok = await page.setAgentWorkspaceCapabilityEnabled('skill', 'Atlas', 'sk-1', true);
+
+  assert.equal(ok, true);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0][0], 'sk-1');
+  assert.deepEqual([...persisted[0][1]].sort(), ['inst-A', 'inst-B']);
+});
+
+test('setAgentWorkspaceCapabilityEnabled removes the agent when disabling', async () => {
+  const page = new WorkspaceDetailPage('ws-1');
+  page.workspace = { agent_instances: [{ id: 'inst-A', name: 'Atlas' }, { id: 'inst-B', name: 'Bolt' }] };
+  const persisted = [];
+  page.mcpManager.getWorkspaceMCPAgentAccessSelections = () => [
+    { id: 'inst-A', checked: true },
+    { id: 'inst-B', checked: true }
+  ];
+  page.mcpManager.persistWorkspaceMCPAgentAccess = async (bindingId, ids) => {
+    persisted.push([bindingId, ids]);
+  };
+  page.loadWorkspace = async () => {};
+
+  await page.setAgentWorkspaceCapabilityEnabled('mcp', 'Atlas', 'mcp-1', false);
+
+  assert.deepEqual(persisted[0][1], ['inst-B']);
+});
+
+test('addAgentWorkspaceCapability creates a workspace MCP binding then enables it for the agent', async () => {
+  const page = new WorkspaceDetailPage('ws-1');
+  page.workspace = { agent_instances: [{ id: 'inst-A', name: 'Atlas' }] };
+  page.mcpManager.getWorkspaceMCPBindings = () => [];
+  page.loadWorkspace = async () => {};
+  const enableCalls = [];
+  page.setAgentWorkspaceCapabilityEnabled = async (...a) => {
+    enableCalls.push(a);
+    return true;
+  };
+  const fetchCalls = [];
+  const origFetch = global.fetch;
+  global.fetch = async (url, opts) => {
+    fetchCalls.push([url, opts]);
+    return { ok: true, json: async () => ({ binding: { id: 'b1' } }), text: async () => '' };
+  };
+  try {
+    const ok = await page.addAgentWorkspaceCapability('mcp', 'Atlas', 'weather');
+    assert.equal(ok, true);
+  } finally {
+    global.fetch = origFetch;
+  }
+
+  assert.equal(fetchCalls.length, 1);
+  assert.match(fetchCalls[0][0], /\/api\/workspaces\/ws-1\/mcp-bindings$/);
+  assert.equal(fetchCalls[0][1].method, 'POST');
+  assert.deepEqual(JSON.parse(fetchCalls[0][1].body), { server_name: 'weather', enabled: true });
+  assert.deepEqual(enableCalls, [['mcp', 'Atlas', 'b1', true]]);
+});
+
+test('addAgentWorkspaceCapability reuses an existing enabled binding without a POST', async () => {
+  const page = new WorkspaceDetailPage('ws-1');
+  page.workspace = { agent_instances: [{ id: 'inst-A', name: 'Atlas' }] };
+  page.skillsManager.getWorkspaceSkillBindings = () => [
+    { id: 'sk-existing', skillName: 'planner', enabled: true }
+  ];
+  const enableCalls = [];
+  page.setAgentWorkspaceCapabilityEnabled = async (...a) => {
+    enableCalls.push(a);
+    return true;
+  };
+  const origFetch = global.fetch;
+  let fetched = false;
+  global.fetch = async () => {
+    fetched = true;
+    return { ok: true, json: async () => ({}), text: async () => '' };
+  };
+  try {
+    await page.addAgentWorkspaceCapability('skill', 'Atlas', 'planner');
+  } finally {
+    global.fetch = origFetch;
+  }
+
+  assert.equal(fetched, false, 'no binding is created when one already exists enabled');
+  assert.deepEqual(enableCalls, [['skill', 'Atlas', 'sk-existing', true]]);
+});


### PR DESCRIPTION
Second seam-PR of the *Map Task Execution + Unit Sheet Loadout* epic (PRD: `tasks/prd-map-task-execution-unit-sheet-loadout.md`). Covers Req C. Branches independently from `origin/dev` (does not depend on #189).

## What this delivers

The read-only loadout chips become an interactive editor, shared by the **map Unit Sheet** and the **details-mode Loadout tab**:
- **Toggle chips** (`role="switch"`) enable/disable each Skill and MCP tool per-agent. Synthesized bindings (the implicit workspace filesystem server) render locked.
- **Add Skill / Add Tool** pickers list registry capabilities not yet bound to the workspace; selecting one creates the workspace binding and enables it for the agent in a single step.
- Every change refreshes both surfaces and the roster Skills/Tools counts (via `loadWorkspace()`), no page reload. Failures surface an inline error + toast and leave prior state intact.

## Architecture

The mutation layer lives on `WorkspaceDetailPage` (`setAgentWorkspaceCapabilityEnabled`, `addAgentWorkspaceCapability`, `listAgentLoadoutAdditions`, `getAgentWorkspace{Skill,MCP}Loadout`) and **reuses the skills/MCP managers' existing access primitives** — `getWorkspace*AgentAccessSelections` + `persistWorkspace*AgentAccess`. That preserves the subtle "no access entry = all workspace bindings enabled" convention and its default-collapse behavior (the highest-risk part of this work), rather than reimplementing it. Bind-new uses the same create-or-enable-then-merge REST flow as agent creation. Both surfaces render through one shared `renderLoadoutEditor`, so map and details can't disagree about editability.

## Verification
- **10 new tests** (6 command-view + 4 page-level: toggle merge/remove, create-then-enable, reuse-existing-binding); all suites green. eslint clean. Server builds.
- `go test ./...` clean except the pre-existing live-OpenAI integration test (429 quota, unrelated).
- **Real-browser smoke on an isolated server:**
  - Toggling an MCP chip off created a restrictive `agent-mcp-access` entry excluding exactly that binding.
  - "Add Tool" listed `fetch` (registry minus bound); binding it created the workspace binding and a new toggle chip appeared.
  - Details-mode Loadout tab showed identical chips with matching toggle state.

## Scope notes
- Frontend-only; no backend/endpoint changes.
- Reuse wins: instance-ID resolution reused `getAgentInstanceIdsForName` (no new field); the empty "Add" picker for globally-disabled registry servers is correct behavior inherited from the shared `loadAvailableMCPServers` loader.
- Targets `dev`. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)