### PR TITLE
feat(workspace): start pending quests in place from the operations map

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -896,6 +896,40 @@
   display: grid;
   gap: 8px;
 }
+.ws-cmd-map-task-row-wrap {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  min-width: 0;
+}
+.ws-cmd-map-task-row-wrap .ws-cmd-map-task-row {
+  flex: 1 1 auto;
+}
+.ws-cmd-map-task-start {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px;
+  border: 1px solid var(--ws-faction);
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.18), rgba(15, 59, 48, 0.85));
+  color: var(--ws-ink);
+  font-family: var(--ws-font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+}
+.ws-cmd-map-task-start i {
+  color: var(--ws-faction);
+}
+.ws-cmd-map-task-start:hover {
+  background: linear-gradient(180deg, rgba(70, 211, 154, 0.28), rgba(15, 59, 48, 0.92));
+}
+.ws-cmd-map-task-start:focus-visible {
+  outline: 2px solid var(--ws-faction);
+  outline-offset: 2px;
+}
 .ws-cmd-map-task-row,
 .ws-cmd-map-station,
 .ws-cmd-map-inventory-slot {

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2814,7 +2814,8 @@ export class WorkspaceCommandView {
               .trim()
               .toLowerCase();
             const questNumber = String(index + 1).padStart(2, '0');
-            return (
+            const startable = this.isQueuedTask(task);
+            const openButton =
               '<button type="button" class="ws-cmd-map-task-row ' +
               escapeHtml(this.taskTone(status)) +
               '" data-cmd-open-task="' +
@@ -2826,7 +2827,16 @@ export class WorkspaceCommandView {
               escapeHtml(label) +
               '</span><span class="ws-cmd-map-task-status">' +
               escapeHtml(this.taskStatusLabel(status)) +
-              '</span></button>'
+              '</span></button>';
+            const startButton = startable
+              ? '<button type="button" class="ws-cmd-map-task-start" data-cmd-map-start-task="' +
+                escapeHtml(id) +
+                '" aria-label="Start ' +
+                escapeHtml(label) +
+                '"><i class="bi bi-play-fill" aria-hidden="true"></i><span>Start</span></button>'
+              : '';
+            return (
+              '<div class="ws-cmd-map-task-row-wrap">' + openButton + startButton + '</div>'
             );
           })
           .join('')
@@ -3193,6 +3203,30 @@ export class WorkspaceCommandView {
     return 'Open Quest';
   }
 
+  // Dispatch a pending quest in place. executeTask owns the live-execution
+  // monitor and already guards against already-running tasks; we add a
+  // deterministic raced-state check so a quest that stopped being pending
+  // (started elsewhere, deleted) reports cleanly and refreshes.
+  async startMapQuest(taskId) {
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (!page || typeof page.executeTask !== 'function') return;
+    const id = String(taskId || '').trim();
+    if (!id) return;
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    const task = tasks.find(item => String(item?.id || '') === id);
+    if (!task || !this.isQueuedTask(task)) {
+      if (window.Toast) window.Toast.info('That quest is no longer pending.');
+      if (typeof page.loadTasks === 'function') await page.loadTasks();
+      return;
+    }
+    try {
+      await page.executeTask(id, { skipConfirm: true });
+    } catch (_error) {
+      if (window.Toast) window.Toast.error('Could not start the quest.');
+      if (typeof page.loadTasks === 'function') await page.loadTasks();
+    }
+  }
+
   renderMapAgentCommandMenu(agent, detailTarget) {
     const task = this.priorityTaskForAgent(agent) || agent?.currentTask;
     const taskId = String(task?.id || '').trim();
@@ -3241,15 +3275,29 @@ export class WorkspaceCommandView {
     const actions = [];
     if (taskId) {
       const urgent = this.isBlockedTask(task) || this.isNeedsInputTask(task);
-      actions.push(
-        action({
-          label: taskLabel,
-          detail: taskDetail,
-          icon: urgent ? 'bi-exclamation-triangle' : 'bi-journal-check',
-          className: urgent ? 'is-primary is-' + taskTone : 'is-' + taskTone,
-          attrs: 'data-cmd-open-task="' + escapeHtml(taskId) + '"'
-        })
-      );
+      const startable = this.isQueuedTask(task);
+      if (startable) {
+        // A pending quest can be dispatched in place instead of only opened.
+        actions.push(
+          action({
+            label: 'Start Quest',
+            detail: taskDetail,
+            icon: 'bi-play-fill',
+            className: 'is-primary is-' + taskTone,
+            attrs: 'data-cmd-map-start-task="' + escapeHtml(taskId) + '"'
+          })
+        );
+      } else {
+        actions.push(
+          action({
+            label: taskLabel,
+            detail: taskDetail,
+            icon: urgent ? 'bi-exclamation-triangle' : 'bi-journal-check',
+            className: urgent ? 'is-primary is-' + taskTone : 'is-' + taskTone,
+            attrs: 'data-cmd-open-task="' + escapeHtml(taskId) + '"'
+          })
+        );
+      }
     }
     actions.push(
       action({
@@ -3847,6 +3895,11 @@ export class WorkspaceCommandView {
         } else if (typeof page.createNewSession === 'function') {
           page.createNewSession();
         }
+        return;
+      }
+      const startTaskBtn = event.target.closest('[data-cmd-map-start-task]');
+      if (startTaskBtn) {
+        this.startMapQuest(startTaskBtn.getAttribute('data-cmd-map-start-task'));
         return;
       }
       const openTaskBtn = event.target.closest('[data-cmd-open-task]');

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2564,3 +2564,92 @@ test('a failed loadout binding surfaces an error and preserves the picker', asyn
     globalThis.window = originalWindow;
   }
 });
+
+test('objectives panel adds a Start action to pending quest rows only', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.openMapTasks = () => [
+    { id: 't-pending', status: 'pending', description: 'Draft report' },
+    { id: 't-running', status: 'in_progress', description: 'Compile data' }
+  ];
+
+  const html = view.renderMapTasksPanel();
+
+  assert.match(html, /data-cmd-map-start-task="t-pending"/);
+  assert.match(html, /ws-cmd-map-task-row-wrap/);
+  assert.doesNotMatch(html, /data-cmd-map-start-task="t-running"/);
+  assert.match(html, /data-cmd-open-task="t-pending"/);
+  assert.match(html, /data-cmd-open-task="t-running"/);
+});
+
+test('agent command menu offers Start Quest for a pending priority task', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.priorityTaskForAgent = () => ({ id: 'q1', status: 'pending', description: 'Draft' });
+  view.latestAgentSession = () => null;
+  const agent = {
+    skills: { count: 0 },
+    mcpNames: [],
+    encodedName: 'Atlas',
+    status: { label: 'Idle' }
+  };
+
+  const html = view.renderMapAgentCommandMenu(agent, null);
+
+  assert.match(html, /Start Quest/);
+  assert.match(html, /data-cmd-map-start-task="q1"/);
+  assert.doesNotMatch(html, /data-cmd-open-task="q1"/);
+});
+
+test('agent command menu keeps Track Quest (open) for an in-progress task', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.priorityTaskForAgent = () => ({ id: 'q2', status: 'in_progress', description: 'Run' });
+  view.latestAgentSession = () => null;
+  const agent = { skills: { count: 0 }, mcpNames: [], encodedName: 'Atlas', status: { label: 'Working' } };
+
+  const html = view.renderMapAgentCommandMenu(agent, null);
+
+  assert.match(html, /data-cmd-open-task="q2"/);
+  assert.doesNotMatch(html, /data-cmd-map-start-task="q2"/);
+});
+
+test('startMapQuest executes a pending task via the page with skipConfirm', async () => {
+  const calls = [];
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.page = {
+    tasks: [{ id: 'q1', status: 'pending' }],
+    async executeTask(id, options) {
+      calls.push([id, options]);
+    }
+  };
+
+  await view.startMapQuest('q1');
+
+  assert.deepEqual(calls, [['q1', { skipConfirm: true }]]);
+});
+
+test('startMapQuest reports and refreshes when the quest is no longer pending', async () => {
+  const originalWindow = globalThis.window;
+  const infos = [];
+  globalThis.window = { Toast: { info: m => infos.push(m) } };
+  try {
+    let executed = false;
+    let refreshed = false;
+    const view = Object.create(WorkspaceCommandView.prototype);
+    view.page = {
+      tasks: [{ id: 'q1', status: 'in_progress' }],
+      async executeTask() {
+        executed = true;
+      },
+      async loadTasks() {
+        refreshed = true;
+      }
+    };
+
+    await view.startMapQuest('q1');
+
+    assert.equal(executed, false);
+    assert.equal(refreshed, true);
+    assert.match(infos[0], /no longer pending/i);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});


### PR DESCRIPTION
Final seam-PR of the *Map Task Execution + Unit Sheet Loadout* epic (PRD: `tasks/prd-map-task-execution-unit-sheet-loadout.md`). Covers Req D. Branches independently from `origin/dev` (does not depend on #189 / #190).

## What this delivers

Pending quests can be dispatched without leaving the map:
- **Objectives window** — pending quest rows gain a "Start" action (the row is wrapped so the open button and Start sit side by side). Only pending (`isQueuedTask`) tasks get it.
- **Unit Sheet command menu** — a pending priority task shows **Start Quest** (play icon) instead of "Open Queue".
- Both dispatch through the existing `executeTask(id, { skipConfirm: true })`, so its live-execution monitor and `loadTasks` refresh apply — no new realtime transport. The Start affordance disappears once the task leaves pending.
- `startMapQuest` adds a deterministic raced-state guard: a quest that is no longer pending (started elsewhere, deleted) skips execution, shows an info toast, and refreshes. executeTask's own "already running" guard still applies.

## Verification
- **5 new tests** (Start renders for pending rows only; command-menu Start Quest vs Track Quest for in-progress; executeTask routing; raced guard skips execute + toasts + refreshes); all suites green. eslint clean. Server builds.
- `go test ./...` clean except the pre-existing live-OpenAI integration test (429 quota, unrelated).
- **Real-browser smoke on an isolated server:**
  - Objectives "Start" dispatched `executeTask(id, { skipConfirm: true })`.
  - Unit Sheet "Start Quest" routed identically.
  - After transitioning the task to in_progress out-of-band, the Start button disappeared.
  - The raced path skipped execute, toasted "That quest is no longer pending.", and refreshed.

## Scope notes
- Frontend-only; no backend/endpoint changes.
- Targets `dev`. Squash-merge. Completes the 4-group epic (with #189 and #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)