### PR TITLE
feat(templates): launch project entries with default apps

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -863,14 +863,18 @@ GET /api/project-templates
     },
     {
       "id": "reaper-song", "name": "Reaper Song", "description": "A minimal REAPER project...",
-      "icon": "🎵", "behavior_profile": "general", "builtin": true, "has_skeleton": true
+      "icon": "🎵", "behavior_profile": "general", "builtin": true, "has_skeleton": true,
+      "project_entry": {
+        "relative_path": "{{name}}.rpp",
+        "open_after_create_default": true
+      }
     }
   ],
   "templates_root": "/path/to/templates"
 }
 ```
 
-The library directory is configurable via the `templates_root` setting (then the `ORI_TEMPLATES_DIR` environment variable, then `<data dir>/templates`). Every immediate subfolder is a template. The optional `template.json` carries declarative metadata: `name`, `description`, `tags`, `icon`, `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (each task may set `setup: true`; at most one per template — it auto-starts on the workspace's first open), `tools`, `agents`, and `builtin`. A legacy `onboarding` block from the removed intake engine is ignored, surfaced as a load-time warning, and stripped on the next authoring save. `has_skeleton` is derived (false ⇒ a metadata-only template that scaffolds no project folder). Built-ins (`builtin: true`) are read-only.
+The library directory is configurable via the `templates_root` setting (then the `ORI_TEMPLATES_DIR` environment variable, then `<data dir>/templates`). Every immediate subfolder is a template. The optional `template.json` carries declarative metadata: `name`, `description`, `tags`, `icon`, `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (each task may set `setup: true`; at most one per template — it auto-starts on the workspace's first open), `tools`, `agents`, `project_entry`, `builtin`, and `builtin_version`. `project_entry.relative_path` must be a portable path to a regular scaffold file and may use only `{{name}}` and `{{date}}`; `open_after_create_default` controls the initial Create Workspace checkbox state. Invalid hand-authored entry metadata is warned and omitted from normalized output. A legacy `onboarding` block from the removed intake engine is ignored, surfaced as a load-time warning, and stripped on the next authoring save. `has_skeleton` is derived (false ⇒ a metadata-only template that scaffolds no project folder). Built-ins (`builtin: true`) are read-only.
 
 **Create a workspace with a project** — `POST /api/workspaces` accepts three additional optional fields:
 
@@ -884,7 +888,7 @@ The library directory is configurable via the `templates_root` setting (then the
 }
 ```
 
-The project folder is created inside the workspace folder as a sibling of `files/` and `notes/`, and `project_path` is persisted in `workspace.json` (its canonical store). Instantiation failures are **non-fatal**: the workspace is still created and the response carries a `project_warning` string. Group workspaces reject template fields with `400`. A `project.created` event is published on success.
+The project folder is created inside the workspace folder as a sibling of `files/` and `notes/`, and `project_path` is persisted in `workspace.json` (its canonical store). A verified entry is resolved with the same filename tokens and stored as the portable relative value `shared_data.project_entry_path` in that same canonical workspace record. Instantiation failures are **non-fatal**: the workspace is still created and the response carries a `project_warning` string. An entry-only verification or persistence failure also returns `project_warning` but keeps the successfully scaffolded project. The field is absent when there is no warning. Group workspaces reject template fields with `400`. A `project.created` event is published on success.
 
 **Chat tools** — workspace chats expose `workspace_project_templates` (list) and `workspace_create_project` (`template_id`, optional `name`), which instantiate into the *current* workspace through the same engine. The create tool refuses when the workspace is a group or already has a project.
 
@@ -895,7 +899,17 @@ POST /api/workspaces/:id/project
 { "template_id": "reaper-song", "project_name": "Midnight" }   // or "template_path"
 ```
 
-Responds `201` with `project_path` and the refreshed workspace; `409` when the workspace already has a project, `400` for groups/invalid templates. The created project is also registered as the workspace's primary linked directory.
+Responds `201` with `project_path` and the refreshed workspace; when entry-only verification fails, the successful response also includes `project_warning`. Returns `409` when the workspace already has a project and `400` for groups/invalid templates. The created project is also registered as the workspace's primary linked directory. This endpoint records entry metadata but never launches an application.
+
+**Open the persisted project entry in the system default application:**
+
+```http
+POST /api/workspaces/:id/project/open
+```
+
+The request must come from a direct IPv4 or IPv6 loopback peer and must have no request body or caller-supplied path. Forwarded headers cannot turn a remote request into a local one; a loopback proxy that explicitly identifies a remote client is rejected. The server reads only canonical `project_path` and `shared_data.project_entry_path`, resolves the workspace folder through workspace storage, and immediately revalidates relative paths, containment, regular-file type, and symlink boundaries before invoking the operating-system file opener.
+
+A successful request returns `200` with an acceptance message. Acceptance means the OS open request was issued; it does not prove the target application finished loading or that its automation/control interface is ready. Common errors are `400` for a body or unsafe/malformed persisted metadata, `403` for a non-local peer, `404` for missing workspace/project/entry data or file, `405` for another method, `503` when folder/opening support is unavailable, and `500` when the operating-system opener fails. Errors never mutate or delete the workspace.
 
 **Template setup task (first-open auto-start):**
 
@@ -911,12 +925,12 @@ Called by the workspace detail page on load. Finds the seeded starter task marke
 POST   /api/project-templates                 { "name": "Display Name" }   // create a blank (metadata-only) template
 POST   /api/project-templates/import          { "path": "/any/folder", "name": "Display Name" }
 POST   /api/project-templates/:id/duplicate   { "name": "..." }   // editable copy (a built-in's copy is never builtin)
-PUT    /api/project-templates/:id             { "name", "description", "tags", "icon", "behavior_profile", "starter_tasks" }
+PUT    /api/project-templates/:id             { "name", "description", "tags", "icon", "behavior_profile", "starter_tasks", "project_entry" }
 DELETE /api/project-templates/:id             → { "success": true, "trashed": true|false }
 POST   /api/project-templates/reveal          { "id": "..." }   // empty id opens the library root (local-first)
 ```
 
-Mutating a built-in template (`PUT`/`DELETE`, file edits, tools/agents) is rejected with `403` — duplicate it first. The same `template.json` config (`behavior_profile`, `starter_tasks`, `tools`, `agents`) is also editable via the `/templates` page; see [Project Templates](../features/project-templates.md).
+Mutating a built-in template (`PUT`/`DELETE`, file edits, tools/agents) is rejected with `403` — duplicate it first. For `project_entry`, omission preserves the current value, an object validates/replaces it, and `null` clears it; invalid values return `400`. The same `template.json` config (`behavior_profile`, `starter_tasks`, `tools`, `agents`, `project_entry`) is also editable via the `/templates` page; see [Project Templates](../features/project-templates.md).
 
 Import copies the folder **verbatim** (no token substitution — `{{name}}` in file names is preserved for instantiation time; symlinks skipped). Delete prefers the system Trash; deleted starter templates are re-materialized on the next server start. Metadata updates preserve unknown `template.json` fields.
 

--- a/docs/features/project-templates.md
+++ b/docs/features/project-templates.md
@@ -7,7 +7,7 @@ A **template** describes how a workspace starts. It is presented as a single **T
 - **starter tasks** seeded into the new workspace and assigned to the entry agent (at most one may be marked `setup: true` — it auto-starts once, when the workspace is first opened),
 - default **tools** (skills / MCP servers / plugins, applied if present),
 - an **agent roster** — the agents created on the new workspace (entry agent + specialists), and
-- a **project folder skeleton** — a Reaper song, a writing project, a code scaffold, anything.
+- a **project folder skeleton** — a Reaper song, a writing project, a code scaffold, anything, with an optional **project entry file** Ori can offer to open in the system default application.
 
 A template that ships a skeleton scaffolds it into the workspace and records the result as the workspace's `project_path`. A **metadata-only** template (no files beyond `template.json`) contributes behavior/tasks/tools but creates no project folder. Either way, Ori contains no domain-specific code: a template is just a folder, and all domain specificity lives in template data.
 
@@ -15,9 +15,9 @@ A template that ships a skeleton scaffolds it into the workspace and records the
 
 Ori's capabilities come from MCP servers and skills, not built-in integrations. Project templates follow the same philosophy:
 
-- **The app ships one mechanism** — copy a folder skeleton, substitute names, set `project_path`.
+- **The app ships one mechanism** — copy a folder skeleton, substitute names, set `project_path`, and optionally remember one verified entry file.
 - **Templates carry the domain** — a `reaper-song` template makes Ori useful for music; a `novel` template makes it useful for writing. Supporting a new domain requires zero changes to Ori.
-- **Behavior stays in MCP/skills** — anything that should happen *after* instantiation ("open it in Reaper, set the tempo") belongs to a domain MCP or skill, never to the template manifest.
+- **Behavior stays in MCP/skills** — `project_entry` may identify a file and default the user's one-time **Open project after creation** choice, but it cannot name an application or perform domain work. Actions such as setting tempo, confirming that REAPER is ready, or editing a live session still belong to a domain MCP or skill.
 
 ## Where templates live
 
@@ -43,11 +43,29 @@ templates/
     assets/
 ```
 
-- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create actions. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details", "setup" }]`; at most one task may set `setup: true`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `agents` (agent roster — see below), `builtin`, and `builtin_version` (shipped manifest revision for built-ins — see "Keeping built-ins current"). Unknown keys are preserved untouched.
+```json
+{
+  "name": "My REAPER Template",
+  "project_entry": {
+    "relative_path": "{{name}}.rpp",
+    "open_after_create_default": true
+  }
+}
+```
+
+- `template.json` carries **declarative metadata only** — never executable hooks, scripts, or post-create commands. Recognized keys: `name`, `description`, `tags`, `icon` (emoji shown on the picker card), `behavior_profile` (`general` | `research` | `software_project`), `starter_tasks` (`[{ "description", "details", "setup" }]`; at most one task may set `setup: true`), `tools` (`{ "skills", "mcp_servers", "plugins" }`), `agents` (agent roster — see below), `project_entry`, `builtin`, and `builtin_version` (shipped manifest revision for built-ins — see "Keeping built-ins current"). Unknown keys are preserved untouched.
 - A folder containing **only** `template.json` is a valid metadata-only template (it scaffolds no files).
 - `{{name}}` becomes the slugified project name; `{{date}}` becomes `YYYY-MM-DD`. Substitution applies to file and folder **names only**; file contents are byte-copied untouched, so binary files are always safe.
 - Symlinks are skipped during instantiation (they would break portability or reach outside the template).
 - Keep templates small: instantiation is synchronous, and seeds are meant to be starting points, not finished projects.
+
+`project_entry` rules:
+
+- `relative_path` is relative to the generated project folder, uses `/` separators, and must name a regular, non-symlink scaffold file. Absolute paths, drive letters, traversal, malformed tokens, and symlinked components are rejected.
+- Only `{{name}}` and `{{date}}` are supported, using the same values as scaffold filename substitution. The literal source file must exist in the template (for example, `{{name}}.rpp`).
+- `open_after_create_default` defaults the Create Workspace checkbox; `false` still means the template has an entry and shows the checkbox unchecked. Omitting `project_entry` means there is no launch action.
+- A hand-edited invalid entry produces a template warning and is omitted from normalized API output. The authoring API rejects an invalid update with `400`. Entry verification problems during instantiation are non-fatal: the project remains created and the response carries `project_warning`.
+- The `/templates` **Overview** tab exposes **Project entry file** and **Open project after creation by default** controls. Leaving the path blank removes the entry.
 
 ## Agents
 
@@ -110,13 +128,24 @@ song-x/                  ← workspace folder
 
 This placement matters: the workspace's auto-provisioned filesystem MCP is rooted at the workspace folder, so agents can read and edit the project immediately — while the attachment reconcile that runs on file-tree loads only walks `files/`, keeping potentially large project media out of that scan.
 
-Because `project_path` is relative and stored in `workspace.json` (its canonical store — there is no SQLite column; reads hydrate from disk), the project travels with the workspace through renames, moves, grouping, and machine migrations.
+Because `project_path` is relative and stored in `workspace.json` (its canonical store — there is no SQLite column; reads hydrate from disk), the project travels with the workspace through renames, moves, grouping, and machine migrations. When an entry verifies successfully, its resolved portable path is stored relative to that project as `shared_data.project_entry_path`; session metadata is only a best-effort mirror.
+
+For a library template with a valid entry, Create Workspace shows **Open project after creation** and initializes it from `open_after_create_default`. The user can opt in or out before creating. An opted-in create sends one bodyless request to the fixed local open endpoint, then navigates to the new workspace. Opening failure never rolls back workspace/project creation; the destination shows a one-time warning and the persistent **Open Project** command remains available for retry. Ordinary workspace loads, reloads, chat-created projects, and adding a project to an existing workspace do not launch an application.
+
+**Open Project** asks the operating system to use the file type's default application. Acceptance means only that the OS request was issued; it does not prove that a domain application finished loading the file or that an automation interface such as REAPER Web Remote is ready. Domain skills must verify live state before claiming live changes.
+
+## Project-entry non-goals
+
+- Binding a template to a named application, executable, bundle path, command, arguments, environment variables, or shell hook.
+- Running arbitrary post-create scripts or launching on ordinary page load, reload, server start, chat tool use, or background workspace creation.
+- Treating an OS-open response as application readiness or bypassing the confirmation/safety behavior of a domain skill.
+- Persisting absolute machine paths. Both `project_path` and `shared_data.project_entry_path` remain portable relative paths.
 
 ## Managing the library
 
 The filesystem is the primary management surface — but the app provides a full authoring UI over it:
 
-- **`/templates` page** — the dedicated authoring surface. Per template: edit the Overview (name, description, tags, **icon**, **agent behavior**, **starter tasks**), browse/edit Files, configure Tools and Agents, **Duplicate**, **Reveal**, and **Delete**. Built-ins show a read-only badge and disable the mutating controls; **Duplicate to customize** makes an editable copy (the copy is never marked built-in). Mutating a built-in is also rejected server-side with `403` (defense in depth), so the read-only guarantee does not depend on the UI.
+- **`/templates` page** — the dedicated authoring surface. Per template: edit the Overview (name, description, tags, **icon**, **agent behavior**, **project entry**, **starter tasks**), browse/edit Files, configure Tools and Agents, **Duplicate**, **Reveal**, and **Delete**. Built-ins show a read-only badge and disable the mutating controls; **Duplicate to customize** makes an editable copy (the copy is never marked built-in). Mutating a built-in is also rejected server-side with `403` (defense in depth), so the read-only guarantee does not depend on the UI.
 - **Manage modal** (reachable from the create-workspace modal and Settings → Project Templates): a lighter list/import/edit/delete/reveal veneer over the same library.
 - **Settings → Project Templates**: configure `templates_root` (Browse/Save/Clear), open the library folder, and launch the authoring page. Changing the directory materializes the library there, including any absent built-ins.
 - Deleting a built-in lasts until the next server start, which re-adds absent built-ins; duplicate-and-edit instead if you want one gone-but-different.
@@ -126,5 +155,7 @@ The filesystem is the primary management surface — but the app provides a full
 - One project per workspace (v1). The chat tool and API refuse when `project_path` is already set.
 - Group workspaces cannot hold projects (their MCP roots are scoped to `files/` + `notes/`, so a sibling project would be invisible to group agents).
 - Instantiation failures never break workspace creation: the workspace is created without a project and the response carries `project_warning`.
+- Entry-only failures never remove a successfully scaffolded project: `project_warning` explains the missing entry and no `project_entry_path` is persisted.
+- The project-open endpoint accepts no caller path or request body, is limited to direct loopback requests, and revalidates the persisted workspace/project paths, containment, file type, and every symlink boundary immediately before invoking the system opener.
 - A failed copy removes the partial project folder; reserved names (`files`, `notes`, `outputs`, `agents`, `sub-workspaces`, `tasks`, `sessions`) and path traversal are rejected.
 - A `project.created` workspace event is published after successful instantiation.

--- a/internal/chathttp/workspace_project_tools.go
+++ b/internal/chathttp/workspace_project_tools.go
@@ -134,10 +134,11 @@ func (p *WorkspaceToolProvider) createProjectTool() toolapi.Tool {
 				projectName = ws.Name
 			}
 
-			relPath, err := projecttemplates.Instantiate(tpl.Path, folderPath, projectName)
+			result, err := projecttemplates.InstantiateTemplate(tpl, folderPath, projectName)
 			if err != nil {
 				return "", err
 			}
+			relPath := result.ProjectPath
 
 			projectDirID, err := projecttemplates.EnsureProjectDirectoryReference(folderWS, projectName, folderPath, relPath)
 			if err != nil {
@@ -154,6 +155,10 @@ func (p *WorkspaceToolProvider) createProjectTool() toolapi.Tool {
 				folderWS.SharedData = make(map[string]any)
 			}
 			projecttemplates.SetPrimaryDirectoryID(folderWS.SharedData, projectDirID)
+			if err := projecttemplates.SetProjectEntryPath(folderWS.SharedData, result.ProjectEntryPath); err != nil {
+				result.ProjectEntryPath = ""
+				result.ProjectWarning = joinProjectWarning(result.ProjectWarning, fmt.Sprintf("project entry metadata could not be persisted: %v", err))
+			}
 			folderWS.UpdatedAt = now
 			if err := p.fileStore.Save(folderWS); err != nil {
 				_ = os.RemoveAll(filepath.Join(folderPath, relPath))
@@ -167,6 +172,7 @@ func (p *WorkspaceToolProvider) createProjectTool() toolapi.Tool {
 				ws.SharedData = make(map[string]any)
 			}
 			projecttemplates.SetPrimaryDirectoryID(ws.SharedData, projectDirID)
+			_ = projecttemplates.SetProjectEntryPath(ws.SharedData, result.ProjectEntryPath)
 			if refsJSON, err := json.Marshal(folderWS.DirectoryReferences); err == nil {
 				ws.DirectoryReferencesJSON = refsJSON
 			}
@@ -176,28 +182,57 @@ func (p *WorkspaceToolProvider) createProjectTool() toolapi.Tool {
 			}
 
 			if p.projectEventBus != nil {
+				data := map[string]any{
+					"project_path": relPath,
+					"template_id":  tpl.ID,
+				}
+				if result.ProjectEntryPath != "" {
+					data[projecttemplates.ProjectEntryPathKey] = result.ProjectEntryPath
+				}
+				if result.ProjectWarning != "" {
+					data["project_warning"] = result.ProjectWarning
+				}
 				p.projectEventBus.Publish(workspace.Event{
 					Type:        workspace.EventProjectCreated,
 					WorkspaceID: p.workspaceID,
 					Source:      "workspace_create_project",
-					Data: map[string]any{
-						"project_path": relPath,
-						"template_id":  tpl.ID,
-					},
+					Data:        data,
 				})
 			}
 
 			logger.Info("Workspace tool created project from template", logger.Fields{
-				"workspace_id": p.workspaceID,
-				"template":     tpl.ID,
-				"project_path": relPath,
+				"workspace_id":  p.workspaceID,
+				"template":      tpl.ID,
+				"project_path":  relPath,
+				"project_entry": result.ProjectEntryPath,
 			})
-			return marshalToolResponse(map[string]any{
+			message := fmt.Sprintf("Project created at %q inside the workspace folder (template %q). It is recorded as the workspace's project_path and is readable through the workspace filesystem tools.", relPath, tpl.ID)
+			response := map[string]any{
 				"project_path": relPath,
 				"template_id":  tpl.ID,
 				"tags":         ws.Tags,
-				"message":      fmt.Sprintf("Project created at %q inside the workspace folder (template %q). It is recorded as the workspace's project_path and is readable through the workspace filesystem tools.", relPath, tpl.ID),
-			})
+				"message":      message,
+			}
+			if result.ProjectEntryPath != "" {
+				response[projecttemplates.ProjectEntryPathKey] = result.ProjectEntryPath
+			}
+			if result.ProjectWarning != "" {
+				response["project_warning"] = result.ProjectWarning
+				response["message"] = message + " Warning: " + result.ProjectWarning
+			}
+			return marshalToolResponse(response)
 		},
 	}
+}
+
+func joinProjectWarning(existing, warning string) string {
+	existing = strings.TrimSpace(existing)
+	warning = strings.TrimSpace(warning)
+	if existing == "" {
+		return warning
+	}
+	if warning == "" {
+		return existing
+	}
+	return existing + "; " + warning
 }

--- a/internal/chathttp/workspace_project_tools_test.go
+++ b/internal/chathttp/workspace_project_tools_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
@@ -47,7 +48,7 @@ func setupProjectToolProvider(t *testing.T, ws *session.Workspace) (*WorkspaceTo
 		cleanup()
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(libDir, "demo", "template.json"), []byte(`{"name":"Demo","description":"demo template","tags":[" Music ","reaper","music"]}`), 0o640); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "demo", "template.json"), []byte(`{"name":"Demo","description":"demo template","tags":[" Music ","reaper","music"],"project_entry":{"relative_path":"{{name}}.rpp","open_after_create_default":true}}`), 0o640); err != nil {
 		cleanup()
 		t.Fatal(err)
 	}
@@ -112,14 +113,15 @@ func TestWorkspaceCreateProjectTool(t *testing.T) {
 		t.Fatalf("create tool: %v", err)
 	}
 	var payload struct {
-		ProjectPath string   `json:"project_path"`
-		TemplateID  string   `json:"template_id"`
-		Tags        []string `json:"tags"`
+		ProjectPath      string   `json:"project_path"`
+		ProjectEntryPath string   `json:"project_entry_path"`
+		TemplateID       string   `json:"template_id"`
+		Tags             []string `json:"tags"`
 	}
 	if err := json.Unmarshal([]byte(result), &payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if payload.ProjectPath != "song-x" || payload.TemplateID != "demo" {
+	if payload.ProjectPath != "song-x" || payload.ProjectEntryPath != "song-x.rpp" || payload.TemplateID != "demo" {
 		t.Fatalf("unexpected payload: %+v", payload)
 	}
 	if len(payload.Tags) != 2 || payload.Tags[0] != "music" || payload.Tags[1] != "reaper" {
@@ -162,10 +164,16 @@ func TestWorkspaceCreateProjectTool(t *testing.T) {
 	if folderWS.SharedData["project_directory_id"] != folderWS.DirectoryReferences[0].ID {
 		t.Fatalf("project directory = %v, want %q", folderWS.SharedData["project_directory_id"], folderWS.DirectoryReferences[0].ID)
 	}
+	if folderWS.SharedData[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
+		t.Fatalf("folder project entry = %v, want song-x.rpp", folderWS.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
+	if sessionWS.SharedData[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
+		t.Fatalf("session project entry = %v, want song-x.rpp", sessionWS.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
 
 	select {
 	case event := <-events:
-		if event.Data["project_path"] != "song-x" {
+		if event.Data["project_path"] != "song-x" || event.Data[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
 			t.Fatalf("unexpected event payload: %+v", event)
 		}
 	case <-time.After(2 * time.Second):

--- a/internal/projecttemplates/instantiate.go
+++ b/internal/projecttemplates/instantiate.go
@@ -78,13 +78,38 @@ func ValidateTarget(isGroup bool, existingProjectPath string) error {
 // nowFunc is stubbed in tests to pin {{date}} substitution.
 var nowFunc = time.Now
 
+type templateTokenValues struct {
+	projectSlug string
+	date        string
+}
+
+func newTemplateTokenValues(projectSlug string) templateTokenValues {
+	return templateTokenValues{
+		projectSlug: projectSlug,
+		date:        nowFunc().Format("2006-01-02"),
+	}
+}
+
+func (values templateTokenValues) substitute(name string) string {
+	name = strings.ReplaceAll(name, "{{name}}", values.projectSlug)
+	name = strings.ReplaceAll(name, "{{date}}", values.date)
+	return name
+}
+
 // substituteTokens replaces the supported tokens in a path name. Replacement
 // values are slug/date strings (lowercase alphanumerics and hyphens), so
 // substitution can never introduce path separators.
 func substituteTokens(name, projectSlug string) string {
-	name = strings.ReplaceAll(name, "{{name}}", projectSlug)
-	name = strings.ReplaceAll(name, "{{date}}", nowFunc().Format("2006-01-02"))
-	return name
+	return newTemplateTokenValues(projectSlug).substitute(name)
+}
+
+// InstantiationResult carries the fatal scaffold result separately from the
+// optional project-entry warning. A project can be fully created even when its
+// declared entry file cannot be verified.
+type InstantiationResult struct {
+	ProjectPath      string
+	ProjectEntryPath string
+	ProjectWarning   string
 }
 
 // Instantiate copies the template at templatePath into a new project folder
@@ -94,42 +119,63 @@ func substituteTokens(name, projectSlug string) string {
 // skipped, the root template.json is excluded, and any failure removes the
 // partially created project folder.
 func Instantiate(templatePath, workspaceFolder, projectName string) (string, error) {
+	result, err := instantiateTemplate(templatePath, workspaceFolder, projectName, nil)
+	return result.ProjectPath, err
+}
+
+// InstantiateTemplate copies a normalized Template and resolves its optional
+// project entry with the exact same token values used for scaffold filenames.
+func InstantiateTemplate(tpl Template, workspaceFolder, projectName string) (InstantiationResult, error) {
+	return instantiateTemplate(tpl.Path, workspaceFolder, projectName, tpl.ProjectEntry)
+}
+
+func instantiateTemplate(templatePath, workspaceFolder, projectName string, entry *ProjectEntry) (InstantiationResult, error) {
 	slug, err := SanitizeProjectName(projectName)
 	if err != nil {
-		return "", err
+		return InstantiationResult{}, err
 	}
+	values := newTemplateTokenValues(slug)
 
 	srcInfo, err := os.Stat(templatePath)
 	if err != nil || !srcInfo.IsDir() {
-		return "", fmt.Errorf("%w: %q is not a folder", ErrTemplateNotFound, templatePath)
+		return InstantiationResult{}, fmt.Errorf("%w: %q is not a folder", ErrTemplateNotFound, templatePath)
 	}
 	if !hasSkeletonFiles(templatePath) {
-		return "", fmt.Errorf("%w: %q", ErrNoSkeleton, templatePath)
+		return InstantiationResult{}, fmt.Errorf("%w: %q", ErrNoSkeleton, templatePath)
 	}
 	wsInfo, err := os.Stat(workspaceFolder)
 	if err != nil || !wsInfo.IsDir() {
-		return "", fmt.Errorf("workspace folder %q is not accessible", workspaceFolder)
+		return InstantiationResult{}, fmt.Errorf("workspace folder %q is not accessible", workspaceFolder)
 	}
 
 	destRoot := filepath.Join(workspaceFolder, slug)
 	if _, err := os.Lstat(destRoot); err == nil {
-		return "", fmt.Errorf("%w: %q already exists in the workspace folder", ErrProjectExists, slug)
+		return InstantiationResult{}, fmt.Errorf("%w: %q already exists in the workspace folder", ErrProjectExists, slug)
 	} else if !os.IsNotExist(err) {
-		return "", fmt.Errorf("failed to inspect project folder %q: %w", destRoot, err)
+		return InstantiationResult{}, fmt.Errorf("failed to inspect project folder %q: %w", destRoot, err)
 	}
 
-	if err := copyTemplateTree(templatePath, destRoot, slug, srcInfo.Mode().Perm()); err != nil {
+	if err := copyTemplateTree(templatePath, destRoot, values, srcInfo.Mode().Perm()); err != nil {
 		// Best-effort cleanup so a failed instantiation leaves no partial
 		// project folder behind (and the caller never persists ProjectPath).
 		_ = os.RemoveAll(destRoot)
-		return "", err
+		return InstantiationResult{}, err
 	}
 
-	return slug, nil
+	result := InstantiationResult{ProjectPath: slug}
+	if entry != nil {
+		entryPath, err := resolveInstantiatedProjectEntry(destRoot, entry, values)
+		if err != nil {
+			result.ProjectWarning = fmt.Sprintf("project was created, but its entry file is unavailable: %v", err)
+		} else {
+			result.ProjectEntryPath = entryPath
+		}
+	}
+	return result, nil
 }
 
 // copyTemplateTree walks the template and materializes it under destRoot.
-func copyTemplateTree(templatePath, destRoot, slug string, rootPerm fs.FileMode) error {
+func copyTemplateTree(templatePath, destRoot string, values templateTokenValues, rootPerm fs.FileMode) error {
 	if err := os.MkdirAll(destRoot, normalizeDirPerm(rootPerm)); err != nil {
 		return fmt.Errorf("failed to create project folder: %w", err)
 	}
@@ -157,7 +203,7 @@ func copyTemplateTree(templatePath, destRoot, slug string, rootPerm fs.FileMode)
 			return nil
 		}
 
-		destRel, err := substituteRelPath(relPath, slug)
+		destRel, err := substituteRelPathWithValues(relPath, values)
 		if err != nil {
 			return err
 		}
@@ -190,9 +236,13 @@ func copyTemplateTree(templatePath, destRoot, slug string, rootPerm fs.FileMode)
 // slash-separated fs.WalkDir path and re-validates the result so a template
 // cannot smuggle in traversal segments.
 func substituteRelPath(relPath, slug string) (string, error) {
+	return substituteRelPathWithValues(relPath, newTemplateTokenValues(slug))
+}
+
+func substituteRelPathWithValues(relPath string, values templateTokenValues) (string, error) {
 	segments := strings.Split(relPath, "/")
 	for i, segment := range segments {
-		substituted := substituteTokens(segment, slug)
+		substituted := values.substitute(segment)
 		if strings.Contains(substituted, "{{fields.") {
 			return "", fmt.Errorf("template entry %q references an unknown field token", relPath)
 		}

--- a/internal/projecttemplates/instantiate_test.go
+++ b/internal/projecttemplates/instantiate_test.go
@@ -87,6 +87,67 @@ func TestInstantiateSubstitutesNamesAndCopiesBytes(t *testing.T) {
 	}
 }
 
+func TestInstantiateTemplateResolvesProjectEntryWithScaffoldTokens(t *testing.T) {
+	date := pinnedDate(t)
+	tplDir := t.TempDir()
+	wsDir := t.TempDir()
+	writeFile(t, filepath.Join(tplDir, "sessions", "{{name}}-{{date}}.rpp"), "project")
+	writeFile(t, filepath.Join(tplDir, ManifestFileName), `{
+  "name":"Song",
+  "project_entry":{"relative_path":"sessions/{{name}}-{{date}}.rpp","open_after_create_default":true},
+  "agents":[{"name":"Producer","role":"orchestrator"}]
+}`)
+
+	tpl, err := LoadFolder(tplDir)
+	if err != nil {
+		t.Fatalf("LoadFolder: %v", err)
+	}
+	result, err := InstantiateTemplate(tpl, wsDir, "Midnight Song")
+	if err != nil {
+		t.Fatalf("InstantiateTemplate: %v", err)
+	}
+	if result.ProjectPath != "midnight-song" {
+		t.Fatalf("ProjectPath = %q", result.ProjectPath)
+	}
+	wantEntry := "sessions/midnight-song-" + date + ".rpp"
+	if result.ProjectEntryPath != wantEntry || result.ProjectWarning != "" {
+		t.Fatalf("unexpected entry result: %+v, want %q", result, wantEntry)
+	}
+	if _, err := os.Stat(filepath.Join(wsDir, result.ProjectPath, filepath.FromSlash(result.ProjectEntryPath))); err != nil {
+		t.Fatalf("resolved project entry does not exist: %v", err)
+	}
+}
+
+func TestInstantiateTemplateEntryFailureIsNonFatal(t *testing.T) {
+	tplDir := t.TempDir()
+	wsDir := t.TempDir()
+	entrySource := filepath.Join(tplDir, "{{name}}.rpp")
+	writeFile(t, entrySource, "project")
+	writeFile(t, filepath.Join(tplDir, "keep.txt"), "keep")
+	writeFile(t, filepath.Join(tplDir, ManifestFileName), `{
+  "project_entry":{"relative_path":"{{name}}.rpp","open_after_create_default":true},
+  "agents":[{"name":"Producer","role":"orchestrator"}]
+}`)
+	tpl, err := LoadFolder(tplDir)
+	if err != nil || tpl.ProjectEntry == nil {
+		t.Fatalf("LoadFolder entry = %#v, err = %v", tpl.ProjectEntry, err)
+	}
+	if err := os.Remove(entrySource); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := InstantiateTemplate(tpl, wsDir, "Song")
+	if err != nil {
+		t.Fatalf("entry failure should not fail instantiation: %v", err)
+	}
+	if result.ProjectPath != "song" || result.ProjectEntryPath != "" || result.ProjectWarning == "" {
+		t.Fatalf("unexpected non-fatal result: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(wsDir, "song", "keep.txt")); err != nil {
+		t.Fatalf("project was rolled back after entry warning: %v", err)
+	}
+}
+
 // Field-token substitution left with the intake engine: any leftover
 // {{fields.<id>}} token in a template entry name is a clear error instead of a
 // silently-literal folder name.

--- a/internal/projecttemplates/manage.go
+++ b/internal/projecttemplates/manage.go
@@ -258,6 +258,7 @@ type ManifestEdit struct {
 	Icon            *string
 	BehaviorProfile *string
 	StarterTasks    *[]StarterTask
+	ProjectEntry    *ProjectEntryEdit
 }
 
 // UpdateManifest writes display metadata into a library template's
@@ -322,6 +323,17 @@ func UpdateManifest(libDir, id, name, description string, tags *[]string, edit *
 				raw["starter_tasks"] = tasks
 			} else {
 				delete(raw, "starter_tasks")
+			}
+		}
+		if edit.ProjectEntry != nil && edit.ProjectEntry.Set {
+			if edit.ProjectEntry.Value == nil {
+				delete(raw, "project_entry")
+			} else {
+				entry, err := normalizeProjectEntry(tpl.Path, edit.ProjectEntry.Value)
+				if err != nil {
+					return Template{}, err
+				}
+				raw["project_entry"] = entry
 			}
 		}
 	}

--- a/internal/projecttemplates/manage_unified_test.go
+++ b/internal/projecttemplates/manage_unified_test.go
@@ -157,3 +157,72 @@ func TestUpdateManifestStripsLegacyOnboarding(t *testing.T) {
 		t.Errorf("unknown keys should survive the save: %s", data)
 	}
 }
+
+func TestUpdateManifestProjectEntryTriState(t *testing.T) {
+	dir := t.TempDir()
+	templateDir := filepath.Join(dir, "demo")
+	writeFile(t, filepath.Join(templateDir, ManifestFileName), `{"name":"Demo","custom_key":"kept"}`)
+	writeFile(t, filepath.Join(templateDir, "{{name}}.rpp"), "project")
+
+	entry := &ProjectEntry{RelativePath: "{{name}}.rpp", OpenAfterCreateDefault: false}
+	tpl, err := UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{
+		ProjectEntry: &ProjectEntryEdit{Set: true, Value: entry},
+	})
+	if err != nil {
+		t.Fatalf("UpdateManifest(set project entry): %v", err)
+	}
+	if tpl.ProjectEntry == nil || tpl.ProjectEntry.RelativePath != "{{name}}.rpp" || tpl.ProjectEntry.OpenAfterCreateDefault {
+		t.Fatalf("project entry did not persist: %#v", tpl.ProjectEntry)
+	}
+
+	data, err := os.ReadFile(filepath.Join(templateDir, ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"open_after_create_default": false`) || !strings.Contains(string(data), `"custom_key": "kept"`) {
+		t.Fatalf("manifest lost false default or unknown field: %s", data)
+	}
+
+	// An unrelated edit preserves the current object.
+	icon := "🎵"
+	tpl, err = UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{Icon: &icon})
+	if err != nil {
+		t.Fatalf("UpdateManifest(preserve project entry): %v", err)
+	}
+	if tpl.ProjectEntry == nil || tpl.ProjectEntry.RelativePath != "{{name}}.rpp" {
+		t.Fatalf("omitted project entry was not preserved: %#v", tpl.ProjectEntry)
+	}
+
+	// A present edit with a nil value clears the object.
+	tpl, err = UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{
+		ProjectEntry: &ProjectEntryEdit{Set: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateManifest(clear project entry): %v", err)
+	}
+	if tpl.ProjectEntry != nil {
+		t.Fatalf("project entry was not cleared: %#v", tpl.ProjectEntry)
+	}
+	data, err = os.ReadFile(filepath.Join(templateDir, ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"project_entry"`) {
+		t.Fatalf("cleared project_entry key remains in manifest: %s", data)
+	}
+}
+
+func TestUpdateManifestRejectsInvalidProjectEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "demo", ManifestFileName), `{"name":"Demo"}`)
+	writeFile(t, filepath.Join(dir, "demo", "seed.txt"), "seed")
+
+	for _, relativePath := range []string{"../escape.rpp", "{{other}}.rpp", "missing.rpp", "seed.txt/child"} {
+		_, err := UpdateManifest(dir, "demo", "Demo", "", nil, &ManifestEdit{
+			ProjectEntry: &ProjectEntryEdit{Set: true, Value: &ProjectEntry{RelativePath: relativePath}},
+		})
+		if !errors.Is(err, ErrInvalidProjectEntry) {
+			t.Errorf("UpdateManifest(project_entry %q) error = %v, want ErrInvalidProjectEntry", relativePath, err)
+		}
+	}
+}

--- a/internal/projecttemplates/project_entry.go
+++ b/internal/projecttemplates/project_entry.go
@@ -1,0 +1,142 @@
+package projecttemplates
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ProjectEntry identifies the one scaffolded file that represents a template
+// project. RelativePath is portable manifest data, not an executable hook or
+// application name.
+type ProjectEntry struct {
+	RelativePath           string `json:"relative_path"`
+	OpenAfterCreateDefault bool   `json:"open_after_create_default"`
+}
+
+// ProjectEntryEdit gives manifest updates tri-state semantics: an omitted edit
+// preserves the current value, Set with a nil Value clears it, and Set with a
+// Value validates and replaces it.
+type ProjectEntryEdit struct {
+	Set   bool
+	Value *ProjectEntry
+}
+
+// ErrInvalidProjectEntry reports unsafe or unusable project-entry metadata.
+var ErrInvalidProjectEntry = errors.New("invalid project entry")
+
+var projectEntryTokenPattern = regexp.MustCompile(`\{\{[^{}]*\}\}`)
+
+// ValidateProjectEntryPath validates and normalizes the portable, slash-based
+// path stored in template manifests. It deliberately does not use host-only
+// filepath rules so a manifest accepted on macOS cannot become an absolute or
+// traversing path on Windows.
+func ValidateProjectEntryPath(relativePath string) (string, error) {
+	relativePath = strings.TrimSpace(relativePath)
+	if relativePath == "" {
+		return "", fmt.Errorf("%w: relative_path is required", ErrInvalidProjectEntry)
+	}
+	if strings.ContainsRune(relativePath, '\x00') {
+		return "", fmt.Errorf("%w: relative_path contains a NUL byte", ErrInvalidProjectEntry)
+	}
+	if strings.Contains(relativePath, `\`) {
+		return "", fmt.Errorf("%w: relative_path must use forward slashes", ErrInvalidProjectEntry)
+	}
+	if path.IsAbs(relativePath) || strings.HasPrefix(relativePath, "//") || hasWindowsVolumePrefix(relativePath) {
+		return "", fmt.Errorf("%w: relative_path must be relative to the generated project", ErrInvalidProjectEntry)
+	}
+
+	for _, segment := range strings.Split(relativePath, "/") {
+		if segment == "." || segment == ".." {
+			return "", fmt.Errorf("%w: relative_path cannot contain traversal segments", ErrInvalidProjectEntry)
+		}
+	}
+
+	for _, token := range projectEntryTokenPattern.FindAllString(relativePath, -1) {
+		if token != "{{name}}" && token != "{{date}}" {
+			return "", fmt.Errorf("%w: unsupported token %q (use only {{name}} or {{date}})", ErrInvalidProjectEntry, token)
+		}
+	}
+	withoutSupported := strings.NewReplacer("{{name}}", "", "{{date}}", "").Replace(relativePath)
+	if strings.Contains(withoutSupported, "{{") || strings.Contains(withoutSupported, "}}") {
+		return "", fmt.Errorf("%w: malformed or unsupported filename token", ErrInvalidProjectEntry)
+	}
+
+	clean := path.Clean(relativePath)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("%w: relative_path must name a file inside the generated project", ErrInvalidProjectEntry)
+	}
+	return clean, nil
+}
+
+func hasWindowsVolumePrefix(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
+}
+
+// normalizeManifestProjectEntry decodes and verifies a hand-authored manifest
+// entry. Invalid metadata is returned as a warning by the caller and is never
+// exposed through the template API.
+func normalizeManifestProjectEntry(templateDir string, raw json.RawMessage) (*ProjectEntry, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+
+	var entry ProjectEntry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return nil, fmt.Errorf("%w: project_entry must be an object: %v", ErrInvalidProjectEntry, err)
+	}
+	return normalizeProjectEntry(templateDir, &entry)
+}
+
+// normalizeProjectEntry validates an authoring value and confirms that its
+// literal manifest path names a regular, non-symlink scaffold source file.
+func normalizeProjectEntry(templateDir string, entry *ProjectEntry) (*ProjectEntry, error) {
+	if entry == nil {
+		return nil, nil
+	}
+	clean, err := ValidateProjectEntryPath(entry.RelativePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyTemplateEntrySource(templateDir, clean); err != nil {
+		return nil, err
+	}
+	return &ProjectEntry{
+		RelativePath:           clean,
+		OpenAfterCreateDefault: entry.OpenAfterCreateDefault,
+	}, nil
+}
+
+func verifyTemplateEntrySource(templateDir, portablePath string) error {
+	current := filepath.Clean(templateDir)
+	segments := strings.Split(portablePath, "/")
+	for index, segment := range segments {
+		current = filepath.Join(current, filepath.FromSlash(segment))
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("%w: relative_path %q does not name a scaffolded file", ErrInvalidProjectEntry, portablePath)
+			}
+			return fmt.Errorf("%w: failed to inspect relative_path %q: %v", ErrInvalidProjectEntry, portablePath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: relative_path %q cannot contain symlinks", ErrInvalidProjectEntry, portablePath)
+		}
+		if index < len(segments)-1 {
+			if !info.IsDir() {
+				return fmt.Errorf("%w: relative_path %q has a non-directory parent", ErrInvalidProjectEntry, portablePath)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: relative_path %q must name a regular file", ErrInvalidProjectEntry, portablePath)
+		}
+	}
+	return nil
+}

--- a/internal/projecttemplates/project_entry.go
+++ b/internal/projecttemplates/project_entry.go
@@ -30,6 +30,10 @@ type ProjectEntryEdit struct {
 // ErrInvalidProjectEntry reports unsafe or unusable project-entry metadata.
 var ErrInvalidProjectEntry = errors.New("invalid project entry")
 
+// ProjectEntryPathKey is the stable workspace shared_data key containing the
+// resolved entry path relative to project_path.
+const ProjectEntryPathKey = "project_entry_path"
+
 var projectEntryTokenPattern = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
 // ValidateProjectEntryPath validates and normalizes the portable, slash-based
@@ -139,4 +143,87 @@ func verifyTemplateEntrySource(templateDir, portablePath string) error {
 		}
 	}
 	return nil
+}
+
+func resolveInstantiatedProjectEntry(projectRoot string, entry *ProjectEntry, values templateTokenValues) (string, error) {
+	if entry == nil {
+		return "", nil
+	}
+	clean, err := ValidateProjectEntryPath(entry.RelativePath)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := substituteRelPathWithValues(clean, values)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidProjectEntry, err)
+	}
+	portable := filepath.ToSlash(resolved)
+	if strings.Contains(portable, "{{") || strings.Contains(portable, "}}") {
+		return "", fmt.Errorf("%w: project entry contains an unresolved token", ErrInvalidProjectEntry)
+	}
+
+	root := filepath.Clean(projectRoot)
+	target := filepath.Clean(filepath.Join(root, filepath.FromSlash(portable)))
+	if target == root || !strings.HasPrefix(target, root+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: resolved project entry escapes the generated project", ErrInvalidProjectEntry)
+	}
+	if err := verifyTemplateEntrySource(root, portable); err != nil {
+		return "", err
+	}
+	return portable, nil
+}
+
+// SetProjectEntryPath validates and stores a resolved portable entry path. An
+// empty value clears the key. The map is intentionally supplied by callers so
+// canonical folder and mirrored session metadata use the same implementation.
+func SetProjectEntryPath(sharedData map[string]any, relativePath string) error {
+	relativePath = strings.TrimSpace(relativePath)
+	if relativePath == "" {
+		ClearProjectEntryPath(sharedData)
+		return nil
+	}
+	if sharedData == nil {
+		return fmt.Errorf("%w: workspace shared_data is unavailable", ErrInvalidProjectEntry)
+	}
+	clean, err := validateResolvedProjectEntryPath(relativePath)
+	if err != nil {
+		return err
+	}
+	sharedData[ProjectEntryPathKey] = clean
+	return nil
+}
+
+// GetProjectEntryPath returns a validated resolved path from shared_data. A
+// missing key is not an error; a malformed/wrongly typed stored value is.
+func GetProjectEntryPath(sharedData map[string]any) (string, error) {
+	if sharedData == nil {
+		return "", nil
+	}
+	raw, ok := sharedData[ProjectEntryPathKey]
+	if !ok || raw == nil {
+		return "", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: stored %s must be a string", ErrInvalidProjectEntry, ProjectEntryPathKey)
+	}
+	return validateResolvedProjectEntryPath(value)
+}
+
+// ClearProjectEntryPath removes persisted project-entry metadata.
+func ClearProjectEntryPath(sharedData map[string]any) {
+	if sharedData != nil {
+		delete(sharedData, ProjectEntryPathKey)
+	}
+}
+
+func validateResolvedProjectEntryPath(relativePath string) (string, error) {
+	clean, err := ValidateProjectEntryPath(relativePath)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(clean, "{{") || strings.Contains(clean, "}}") {
+		return "", fmt.Errorf("%w: persisted project entry cannot contain template tokens", ErrInvalidProjectEntry)
+	}
+	return clean, nil
 }

--- a/internal/projecttemplates/project_entry.go
+++ b/internal/projecttemplates/project_entry.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
 // ProjectEntry identifies the one scaffolded file that represents a template
@@ -30,9 +32,9 @@ type ProjectEntryEdit struct {
 // ErrInvalidProjectEntry reports unsafe or unusable project-entry metadata.
 var ErrInvalidProjectEntry = errors.New("invalid project entry")
 
-// ProjectEntryPathKey is the stable workspace shared_data key containing the
-// resolved entry path relative to project_path.
-const ProjectEntryPathKey = "project_entry_path"
+// ProjectEntryPathKey aliases the canonical workspace shared_data key so older
+// callers importing projecttemplates keep one stable metadata contract.
+const ProjectEntryPathKey = workspace.ProjectEntryPathKey
 
 var projectEntryTokenPattern = regexp.MustCompile(`\{\{[^{}]*\}\}`)
 
@@ -177,53 +179,23 @@ func resolveInstantiatedProjectEntry(projectRoot string, entry *ProjectEntry, va
 // empty value clears the key. The map is intentionally supplied by callers so
 // canonical folder and mirrored session metadata use the same implementation.
 func SetProjectEntryPath(sharedData map[string]any, relativePath string) error {
-	relativePath = strings.TrimSpace(relativePath)
-	if relativePath == "" {
-		ClearProjectEntryPath(sharedData)
-		return nil
+	if err := workspace.SetProjectEntryPath(sharedData, relativePath); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidProjectEntry, err)
 	}
-	if sharedData == nil {
-		return fmt.Errorf("%w: workspace shared_data is unavailable", ErrInvalidProjectEntry)
-	}
-	clean, err := validateResolvedProjectEntryPath(relativePath)
-	if err != nil {
-		return err
-	}
-	sharedData[ProjectEntryPathKey] = clean
 	return nil
 }
 
 // GetProjectEntryPath returns a validated resolved path from shared_data. A
 // missing key is not an error; a malformed/wrongly typed stored value is.
 func GetProjectEntryPath(sharedData map[string]any) (string, error) {
-	if sharedData == nil {
-		return "", nil
+	value, err := workspace.GetProjectEntryPath(sharedData)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidProjectEntry, err)
 	}
-	raw, ok := sharedData[ProjectEntryPathKey]
-	if !ok || raw == nil {
-		return "", nil
-	}
-	value, ok := raw.(string)
-	if !ok {
-		return "", fmt.Errorf("%w: stored %s must be a string", ErrInvalidProjectEntry, ProjectEntryPathKey)
-	}
-	return validateResolvedProjectEntryPath(value)
+	return value, nil
 }
 
 // ClearProjectEntryPath removes persisted project-entry metadata.
 func ClearProjectEntryPath(sharedData map[string]any) {
-	if sharedData != nil {
-		delete(sharedData, ProjectEntryPathKey)
-	}
-}
-
-func validateResolvedProjectEntryPath(relativePath string) (string, error) {
-	clean, err := ValidateProjectEntryPath(relativePath)
-	if err != nil {
-		return "", err
-	}
-	if strings.Contains(clean, "{{") || strings.Contains(clean, "}}") {
-		return "", fmt.Errorf("%w: persisted project entry cannot contain template tokens", ErrInvalidProjectEntry)
-	}
-	return clean, nil
+	workspace.ClearProjectEntryPath(sharedData)
 }

--- a/internal/projecttemplates/project_entry_test.go
+++ b/internal/projecttemplates/project_entry_test.go
@@ -1,0 +1,164 @@
+package projecttemplates
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateProjectEntryPath(t *testing.T) {
+	t.Parallel()
+
+	valid := map[string]string{
+		"{{name}}.rpp":            "{{name}}.rpp",
+		"sessions/{{date}}.rpp":   "sessions/{{date}}.rpp",
+		"  nested//project.rpp  ": "nested/project.rpp",
+	}
+	for input, want := range valid {
+		input, want := input, want
+		t.Run("valid_"+strings.ReplaceAll(input, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateProjectEntryPath(input)
+			if err != nil {
+				t.Fatalf("ValidateProjectEntryPath(%q): %v", input, err)
+			}
+			if got != want {
+				t.Fatalf("ValidateProjectEntryPath(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+
+	invalid := []string{
+		"",
+		" ",
+		"/absolute.rpp",
+		"//server/share.rpp",
+		`C:\song.rpp`,
+		`folder\song.rpp`,
+		"../escape.rpp",
+		"folder/../escape.rpp",
+		"./song.rpp",
+		"{{workspace}}.rpp",
+		"{{name.rpp",
+		"song}}.rpp",
+		"song\x00.rpp",
+	}
+	for _, input := range invalid {
+		input := input
+		t.Run("invalid_"+strings.ReplaceAll(input, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+			if _, err := ValidateProjectEntryPath(input); !errors.Is(err, ErrInvalidProjectEntry) {
+				t.Fatalf("ValidateProjectEntryPath(%q) error = %v, want ErrInvalidProjectEntry", input, err)
+			}
+		})
+	}
+}
+
+func TestLoadFolderNormalizesValidProjectEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "{{name}}.rpp"), []byte("project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+  "name": "Song",
+  "project_entry": {
+    "relative_path": "{{name}}.rpp",
+    "open_after_create_default": false
+  },
+  "agents": [{"name":"Producer","role":"orchestrator"}]
+}`
+	if err := os.WriteFile(filepath.Join(dir, ManifestFileName), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	tpl, err := LoadFolder(dir)
+	if err != nil {
+		t.Fatalf("LoadFolder: %v", err)
+	}
+	if tpl.ProjectEntry == nil {
+		t.Fatal("expected normalized project entry")
+	}
+	if tpl.ProjectEntry.RelativePath != "{{name}}.rpp" || tpl.ProjectEntry.OpenAfterCreateDefault {
+		t.Fatalf("unexpected project entry: %#v", tpl.ProjectEntry)
+	}
+	if len(tpl.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", tpl.Warnings)
+	}
+
+	data, err := json.Marshal(tpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"open_after_create_default":false`) {
+		t.Fatalf("explicit false default missing from API JSON: %s", data)
+	}
+}
+
+func TestLoadFolderWarnsAndOmitsInvalidProjectEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"traversal":      `{"relative_path":"../escape.rpp","open_after_create_default":true}`,
+		"unknown token":  `{"relative_path":"{{workspace}}.rpp","open_after_create_default":true}`,
+		"missing source": `{"relative_path":"missing.rpp","open_after_create_default":true}`,
+		"wrong type":     `"song.rpp"`,
+	}
+	for name, rawEntry := range tests {
+		name, rawEntry := name, rawEntry
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			manifest := `{"agents":[{"name":"Producer","role":"orchestrator"}],"project_entry":` + rawEntry + `}`
+			if err := os.WriteFile(filepath.Join(dir, ManifestFileName), []byte(manifest), 0o640); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed"), 0o640); err != nil {
+				t.Fatal(err)
+			}
+
+			tpl, err := LoadFolder(dir)
+			if err != nil {
+				t.Fatalf("LoadFolder: %v", err)
+			}
+			if tpl.ProjectEntry != nil {
+				t.Fatalf("invalid project entry was exposed: %#v", tpl.ProjectEntry)
+			}
+			if len(tpl.Warnings) != 1 || !strings.Contains(tpl.Warnings[0], "project_entry") {
+				t.Fatalf("expected project_entry warning, got %v", tpl.Warnings)
+			}
+		})
+	}
+}
+
+func TestLoadFolderRejectsSymlinkProjectEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.rpp")
+	if err := os.WriteFile(target, []byte("project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "entry.rpp")); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"agents":[{"name":"Producer","role":"orchestrator"}],"project_entry":{"relative_path":"entry.rpp","open_after_create_default":true}}`
+	if err := os.WriteFile(filepath.Join(dir, ManifestFileName), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	tpl, err := LoadFolder(dir)
+	if err != nil {
+		t.Fatalf("LoadFolder: %v", err)
+	}
+	if tpl.ProjectEntry != nil || len(tpl.Warnings) != 1 || !strings.Contains(tpl.Warnings[0], "symlink") {
+		t.Fatalf("expected symlink entry to be warned and omitted, got entry=%#v warnings=%v", tpl.ProjectEntry, tpl.Warnings)
+	}
+}

--- a/internal/projecttemplates/project_entry_test.go
+++ b/internal/projecttemplates/project_entry_test.go
@@ -162,3 +162,40 @@ func TestLoadFolderRejectsSymlinkProjectEntry(t *testing.T) {
 		t.Fatalf("expected symlink entry to be warned and omitted, got entry=%#v warnings=%v", tpl.ProjectEntry, tpl.Warnings)
 	}
 }
+
+func TestProjectEntrySharedDataHelpers(t *testing.T) {
+	t.Parallel()
+
+	shared := map[string]any{}
+	if err := SetProjectEntryPath(shared, "sessions/song.rpp"); err != nil {
+		t.Fatalf("SetProjectEntryPath: %v", err)
+	}
+	if got, err := GetProjectEntryPath(shared); err != nil || got != "sessions/song.rpp" {
+		t.Fatalf("GetProjectEntryPath = %q, %v", got, err)
+	}
+
+	ClearProjectEntryPath(shared)
+	if got, err := GetProjectEntryPath(shared); err != nil || got != "" {
+		t.Fatalf("GetProjectEntryPath after clear = %q, %v", got, err)
+	}
+
+	for name, value := range map[string]any{
+		"wrong type": 123,
+		"absolute":   "/tmp/song.rpp",
+		"traversal":  "../song.rpp",
+		"token":      "{{name}}.rpp",
+		"backslash":  `sessions\song.rpp`,
+	} {
+		shared[ProjectEntryPathKey] = value
+		if _, err := GetProjectEntryPath(shared); !errors.Is(err, ErrInvalidProjectEntry) {
+			t.Errorf("%s: GetProjectEntryPath error = %v, want ErrInvalidProjectEntry", name, err)
+		}
+	}
+
+	if err := SetProjectEntryPath(nil, "song.rpp"); !errors.Is(err, ErrInvalidProjectEntry) {
+		t.Fatalf("SetProjectEntryPath(nil) error = %v, want ErrInvalidProjectEntry", err)
+	}
+	if err := SetProjectEntryPath(shared, ""); err != nil {
+		t.Fatalf("empty SetProjectEntryPath should clear: %v", err)
+	}
+}

--- a/internal/projecttemplates/starter/reaper-song/template.json
+++ b/internal/projecttemplates/starter/reaper-song/template.json
@@ -4,7 +4,11 @@
   "icon": "🎵",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 2,
+  "builtin_version": 3,
+  "project_entry": {
+    "relative_path": "{{name}}.rpp",
+    "open_after_create_default": true
+  },
   "tags": [
     "music",
     "reaper"
@@ -12,7 +16,7 @@
   "starter_tasks": [
     {
       "description": "Adjust the new REAPER session to the user's preferences",
-      "details": "## Created defaults\nThe project scaffold already created a valid REAPER session file, `<project name>.rpp`, in the workspace project folder. It is set to 120 BPM in 4/4, with no tracks yet. The song is named after the workspace — there is nothing to create, only defaults to adjust.\n\n## Questions to ask\nTell the user what was created, then ask whether they want to change:\n- Tempo (BPM)\n- Musical key\nIf they are happy with the defaults, confirm and finish without changing anything.\n\n## Validation\n- Tempo must be between 40 and 240 BPM. If the user asks for something outside that range, say why and ask again.\n- Accept any conventional key spelling (e.g. \"A minor\", \"F# major\").\n\n## How to apply changes\nPrefer the reaper-session-setup skill to drive REAPER when it is running. Otherwise edit the .rpp file directly: the tempo lives on its `TEMPO <bpm> 4 4` line. Record the chosen key in your summary (and in the session notes if asked) — the .rpp format has no key field.",
+      "details": "## Created defaults\nThe project scaffold already created the workspace's one authoritative REAPER session file, `<project name>.rpp`, in the workspace project folder. It is set to 120 BPM in 4/4, with no tracks yet. Treat that existing scaffolded file as the song project and never create or initialize a second .rpp file.\n\n## Questions to ask\nTell the user what was created, then ask whether they want to change:\n- Tempo (BPM)\n- Musical key\nIf they are happy with the defaults, confirm and finish without changing anything.\n\n## Validation\n- Tempo must be between 40 and 240 BPM. If the user asks for something outside that range, say why and ask again.\n- Accept any conventional key spelling (e.g. \"A minor\", \"F# major\").\n\n## How to apply changes\nPrefer the reaper-session-setup skill only after live REAPER state and the required control interface are verified. An operating-system open request only asks the default application to open the project file; it does not prove that REAPER has finished opening it or that Web Remote is ready. If live control cannot be verified, say what is unavailable and ask the user to open or wait for REAPER, or enable the required Web Remote interface. Do not claim that live changes were applied.\n\nBefore falling back to direct file edits, explain that live REAPER state could not be verified and ask for the user's explicit confirmation. If they confirm, edit only the existing authoritative .rpp file (the tempo lives on its `TEMPO <bpm> 4 4` line), never create another project, and clearly describe the result as a file change rather than a verified live-session change. Record the chosen key in your summary (and in the session notes if asked) — the .rpp format has no key field.",
       "setup": true
     },
     {
@@ -24,7 +28,7 @@
     {
       "name": "Reaper Producer",
       "role": "orchestrator",
-      "system_prompt": "You are the music producer for this workspace. It was created from the Reaper Song template, so a REAPER session file named after the project already exists in the project folder at 120 BPM. Help the user shape the song: adjust session settings, plan arrangements, and drive REAPER through the reaper-session-setup skill when it is available. Keep answers practical and studio-minded.",
+      "system_prompt": "You are the music producer for this workspace. It was created from the Reaper Song template, so one scaffolded REAPER session file named after the project already exists in the project folder at 120 BPM. Treat that persisted project entry as the only authoritative song project and never create or initialize a second .rpp file. Help the user shape the song: adjust session settings, plan arrangements, and drive REAPER through the reaper-session-setup skill only after live REAPER state and its required control interface are verified. An operating-system open request does not prove that REAPER or Web Remote is ready. If live control is unavailable, ask the user to open or wait for REAPER or enable the required interface, and never claim live changes were applied. Before editing the .rpp file directly as a fallback, explain that live state is unverified and obtain the user's explicit confirmation; then edit only the existing authoritative file and distinguish file changes from verified live-session changes. Keep answers practical, truthful, and studio-minded.",
       "tools": {
         "skills": [
           "reaper-session-setup"

--- a/internal/projecttemplates/starter_onboarding_test.go
+++ b/internal/projecttemplates/starter_onboarding_test.go
@@ -27,6 +27,12 @@ func TestReaperStarterSetupTask(t *testing.T) {
 	if len(tpl.Warnings) != 0 {
 		t.Fatalf("reaper-song should load without warnings, got %v", tpl.Warnings)
 	}
+	if tpl.BuiltinVersion < 3 {
+		t.Fatalf("reaper-song builtin_version = %d, want at least 3", tpl.BuiltinVersion)
+	}
+	if tpl.ProjectEntry == nil || tpl.ProjectEntry.RelativePath != "{{name}}.rpp" || !tpl.ProjectEntry.OpenAfterCreateDefault {
+		t.Fatalf("reaper-song project entry = %#v", tpl.ProjectEntry)
+	}
 
 	// Roster: exactly one producer entry agent with the REAPER skill bound.
 	if len(tpl.Agents) != 1 || tpl.Agents[0].Name != "Reaper Producer" {
@@ -53,6 +59,35 @@ func TestReaperStarterSetupTask(t *testing.T) {
 	for _, want := range []string{"120 BPM", "40 and 240", "reaper-session-setup"} {
 		if !strings.Contains(setup.Details, want) {
 			t.Errorf("setup details missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"one authoritative REAPER session file",
+		"never create or initialize a second .rpp file",
+		"does not prove that REAPER has finished opening it or that Web Remote is ready",
+		"Do not claim that live changes were applied",
+		"ask for the user's explicit confirmation",
+		"file change rather than a verified live-session change",
+	} {
+		if !strings.Contains(setup.Details, want) {
+			t.Errorf("setup details missing truthful project-control guidance %q", want)
+		}
+	}
+	if strings.Contains(setup.Details, "Otherwise edit the .rpp file directly") {
+		t.Error("setup task must not silently fall back to direct .rpp edits")
+	}
+
+	prompt := tpl.Agents[0].SystemPrompt
+	for _, want := range []string{
+		"only authoritative song project",
+		"never create or initialize a second .rpp file",
+		"does not prove that REAPER or Web Remote is ready",
+		"never claim live changes were applied",
+		"obtain the user's explicit confirmation",
+		"distinguish file changes from verified live-session changes",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("Reaper Producer prompt missing %q", want)
 		}
 	}
 

--- a/internal/projecttemplates/starter_test.go
+++ b/internal/projecttemplates/starter_test.go
@@ -47,6 +47,12 @@ func TestEnsureLibraryMaterializesStarters(t *testing.T) {
 	if len(reaper.StarterTasks) == 0 || !reaper.StarterTasks[0].Setup {
 		t.Errorf("reaper starter should lead with a setup starter task: %+v", reaper.StarterTasks)
 	}
+	if reaper.BuiltinVersion < 3 {
+		t.Errorf("reaper starter builtin_version = %d, want at least 3", reaper.BuiltinVersion)
+	}
+	if reaper.ProjectEntry == nil || reaper.ProjectEntry.RelativePath != "{{name}}.rpp" || !reaper.ProjectEntry.OpenAfterCreateDefault {
+		t.Errorf("reaper starter project entry is not configured for default launch: %#v", reaper.ProjectEntry)
+	}
 	if writing := byID["writing-project"]; !writing.Builtin || !writing.HasSkeleton ||
 		len(writing.Tags) != 1 || writing.Tags[0] != "writing" {
 		t.Errorf("writing-project: %+v", writing)
@@ -157,6 +163,41 @@ func TestEnsureLibraryRefreshesBuiltinManifestOnVersionBump(t *testing.T) {
 	}
 }
 
+func TestEnsureLibraryRefreshesReaperProjectEntryOnVersionBump(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "templates")
+	if err := EnsureLibrary(dir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	reaperDir := filepath.Join(dir, "reaper-song")
+	manifestPath := filepath.Join(reaperDir, ManifestFileName)
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"Reaper Song","builtin":true,"builtin_version":2}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	seed := filepath.Join(reaperDir, "{{name}}.rpp")
+	if err := os.WriteFile(seed, []byte("user-edited reaper project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureLibrary(dir); err != nil {
+		t.Fatalf("EnsureLibrary (refresh): %v", err)
+	}
+	refreshed, err := FindLibraryTemplate(dir, "reaper-song")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if refreshed.BuiltinVersion < 3 {
+		t.Errorf("reaper builtin_version = %d, want at least 3", refreshed.BuiltinVersion)
+	}
+	if refreshed.ProjectEntry == nil || refreshed.ProjectEntry.RelativePath != "{{name}}.rpp" || !refreshed.ProjectEntry.OpenAfterCreateDefault {
+		t.Errorf("refreshed Reaper project entry = %#v", refreshed.ProjectEntry)
+	}
+	data, err := os.ReadFile(seed)
+	if err != nil || string(data) != "user-edited reaper project" {
+		t.Errorf("Reaper seed should survive manifest refresh, got %q err=%v", string(data), err)
+	}
+}
+
 func TestStarterInstantiatesEndToEnd(t *testing.T) {
 	// Generality gate (PRD success metric 2): both starters run through the
 	// identical engine path; the music template is in no way special.
@@ -166,24 +207,43 @@ func TestStarterInstantiatesEndToEnd(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		id       string
-		wantFile string
+		id        string
+		wantFile  string
+		wantEntry string
 	}{
-		{"reaper-song", "midnight.rpp"},
-		{"writing-project", "outline.md"},
+		{"reaper-song", "midnight.rpp", "midnight.rpp"},
+		{"writing-project", "outline.md", ""},
 	} {
 		wsDir := t.TempDir()
 		tpl, err := FindLibraryTemplate(libDir, tc.id)
 		if err != nil {
 			t.Fatalf("FindLibraryTemplate(%s): %v", tc.id, err)
 		}
-		rel, err := Instantiate(tpl.Path, wsDir, "Midnight")
+		result, err := InstantiateTemplate(tpl, wsDir, "Midnight")
 		if err != nil {
 			t.Fatalf("Instantiate(%s): %v", tc.id, err)
 		}
-		target := filepath.Join(wsDir, rel, tc.wantFile)
+		target := filepath.Join(wsDir, result.ProjectPath, tc.wantFile)
 		if _, err := os.Stat(target); err != nil {
 			t.Errorf("%s: expected %s: %v", tc.id, tc.wantFile, err)
+		}
+		if result.ProjectEntryPath != tc.wantEntry || result.ProjectWarning != "" {
+			t.Errorf("%s: project entry = %q warning = %q, want %q without warning", tc.id, result.ProjectEntryPath, result.ProjectWarning, tc.wantEntry)
+		}
+		if tc.id == "reaper-song" {
+			entries, err := os.ReadDir(filepath.Join(wsDir, result.ProjectPath))
+			if err != nil {
+				t.Fatal(err)
+			}
+			rppCount := 0
+			for _, entry := range entries {
+				if !entry.IsDir() && strings.EqualFold(filepath.Ext(entry.Name()), ".rpp") {
+					rppCount++
+				}
+			}
+			if rppCount != 1 {
+				t.Errorf("reaper-song scaffold contains %d .rpp files, want exactly one", rppCount)
+			}
 		}
 	}
 }

--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -20,7 +20,8 @@ import (
 )
 
 // ManifestFileName is the optional per-template metadata file. It carries
-// display metadata only — never behavior — and is excluded from instantiation.
+// constrained declarative metadata, never executable behavior, and is excluded
+// from instantiation.
 const ManifestFileName = "template.json"
 
 // Behavior profiles understood by the workspace-creation flow (sent as
@@ -105,6 +106,9 @@ type Template struct {
 	BehaviorProfile string `json:"behavior_profile,omitempty"`
 	// StarterTasks are example tasks seeded into a new workspace.
 	StarterTasks []StarterTask `json:"starter_tasks,omitempty"`
+	// ProjectEntry is the optional scaffolded file Ori can offer to open after
+	// an explicit Create Workspace action. It is validated data only.
+	ProjectEntry *ProjectEntry `json:"project_entry,omitempty"`
 	// Builtin marks a template shipped with the app: read-only in the authoring
 	// UI and grouped as a built-in in the create-modal picker.
 	Builtin bool `json:"builtin"`
@@ -164,6 +168,7 @@ type manifest struct {
 	Icon            string          `json:"icon,omitempty"`
 	BehaviorProfile string          `json:"behavior_profile,omitempty"`
 	StarterTasks    []StarterTask   `json:"starter_tasks,omitempty"`
+	ProjectEntry    json.RawMessage `json:"project_entry,omitempty"`
 	Builtin         bool            `json:"builtin,omitempty"`
 	BuiltinVersion  int             `json:"builtin_version,omitempty"`
 	Onboarding      json.RawMessage `json:"onboarding,omitempty"`
@@ -209,11 +214,16 @@ func newTemplate(path string) Template {
 	t.BuiltinVersion = m.BuiltinVersion
 	t.HasSkeleton = hasSkeletonFiles(t.Path)
 	t.Onboarding = m.Onboarding
+	projectEntry, projectEntryErr := normalizeManifestProjectEntry(t.Path, m.ProjectEntry)
+	t.ProjectEntry = projectEntry
 	if m.Tools != nil {
 		t.Tools = normalizeToolDefaults(*m.Tools)
 	}
 	t.Agents = normalizeAgentSpecs(m.Agents)
 	t.Warnings = manifestWarnings(m, t.Agents)
+	if projectEntryErr != nil {
+		t.Warnings = append(t.Warnings, fmt.Sprintf("template.json project_entry is ignored: %v", projectEntryErr))
+	}
 	return t
 }
 

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -426,6 +426,9 @@ func (b *ServerBuilder) initializeWorkspaceOrchestrator() {
 	}
 
 	b.workspaceHandler = workspace.NewHTTPHandler(b.workspaceStore, b.workspaceOrchestrator, b.eventBus)
+	if b.workspaceFileStore != nil {
+		b.workspaceHandler.SetFolderStore(b.workspaceFileStore)
+	}
 	if verbose {
 		logger.Info("Workspace HTTP handler initialized", logger.Fields{})
 	}

--- a/internal/server/project_templates_routes.go
+++ b/internal/server/project_templates_routes.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -59,9 +62,9 @@ func (s *Server) handleProjectTemplateImport(w http.ResponseWriter, r *http.Requ
 }
 
 // handleProjectTemplateUpdate serves PUT /api/project-templates/{templateID}:
-// edit a template's display metadata (template.json). The optional `tags` field
-// is tri-state: omitted preserves existing tags, an explicit empty array clears
-// them — so the legacy manage modal (which never sends tags) can't wipe them.
+// edit a template's metadata (template.json). Optional tags and project_entry
+// fields are tri-state so older clients preserve values they do not send;
+// project_entry null explicitly clears that object.
 func (s *Server) handleProjectTemplateUpdate(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Name            string                          `json:"name"`
@@ -70,6 +73,7 @@ func (s *Server) handleProjectTemplateUpdate(w http.ResponseWriter, r *http.Requ
 		Icon            *string                         `json:"icon"`
 		BehaviorProfile *string                         `json:"behavior_profile"`
 		StarterTasks    *[]projecttemplates.StarterTask `json:"starter_tasks"`
+		ProjectEntry    json.RawMessage                 `json:"project_entry"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
@@ -78,10 +82,24 @@ func (s *Server) handleProjectTemplateUpdate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	var projectEntryEdit *projecttemplates.ProjectEntryEdit
+	if req.ProjectEntry != nil {
+		projectEntryEdit = &projecttemplates.ProjectEntryEdit{Set: true}
+		if !bytes.Equal(bytes.TrimSpace(req.ProjectEntry), []byte("null")) {
+			var entry projecttemplates.ProjectEntry
+			if err := json.Unmarshal(req.ProjectEntry, &entry); err != nil {
+				s.respondProjectTemplateError(w, fmt.Errorf("%w: project_entry must be an object: %v", projecttemplates.ErrInvalidProjectEntry, err))
+				return
+			}
+			projectEntryEdit.Value = &entry
+		}
+	}
+
 	edit := &projecttemplates.ManifestEdit{
 		Icon:            req.Icon,
 		BehaviorProfile: req.BehaviorProfile,
 		StarterTasks:    req.StarterTasks,
+		ProjectEntry:    projectEntryEdit,
 	}
 	tpl, err := projecttemplates.UpdateManifest(resolveTemplatesRoot(s.Core.ConfigManager), r.PathValue("templateID"), req.Name, req.Description, req.Tags, edit)
 	if err != nil {
@@ -349,7 +367,7 @@ func (s *Server) respondProjectTemplateError(w http.ResponseWriter, err error) {
 	case errors.Is(err, projecttemplates.ErrTemplateNotFound), errors.Is(err, projecttemplates.ErrFileNotFound):
 		_ = orihttp.RespondNotFound(w, err.Error())
 	case errors.Is(err, projecttemplates.ErrInvalidTemplateName), errors.Is(err, projecttemplates.ErrInvalidPath), errors.Is(err, projecttemplates.ErrInvalidPromptVariable),
-		errors.Is(err, projecttemplates.ErrInvalidStarterTasks), errors.Is(err, projecttemplates.ErrRosterRequired):
+		errors.Is(err, projecttemplates.ErrInvalidStarterTasks), errors.Is(err, projecttemplates.ErrInvalidProjectEntry), errors.Is(err, projecttemplates.ErrRosterRequired):
 		_ = orihttp.RespondBadRequest(w, err.Error())
 	case errors.Is(err, projecttemplates.ErrTemplateExists), errors.Is(err, projecttemplates.ErrFileExists):
 		_ = orihttp.RespondConflict(w, err.Error())

--- a/internal/server/project_templates_routes_test.go
+++ b/internal/server/project_templates_routes_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/config"
@@ -150,5 +151,79 @@ func TestProjectTemplateManagementRoutes(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(libDir, "imported-pack")); !os.IsNotExist(err) {
 		t.Fatalf("template still present after delete (err=%v)", err)
+	}
+}
+
+func TestHandleProjectTemplateUpdateProjectEntryTriState(t *testing.T) {
+	libDir := t.TempDir()
+	templateDir := filepath.Join(libDir, "song")
+	if err := os.MkdirAll(templateDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, "{{name}}.rpp"), []byte("project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, "template.json"), []byte(`{"name":"Song","custom_key":"kept"}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	s := newTemplateRoutesServer(t, libDir)
+
+	callUpdate := func(body string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/api/project-templates/song", bytes.NewBufferString(body))
+		req.SetPathValue("templateID", "song")
+		s.handleProjectTemplateUpdate(w, req)
+		return w
+	}
+
+	w := callUpdate(`{"name":"Song","project_entry":{"relative_path":"{{name}}.rpp","open_after_create_default":false}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("set project entry: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Template struct {
+			ProjectEntry *struct {
+				RelativePath           string `json:"relative_path"`
+				OpenAfterCreateDefault bool   `json:"open_after_create_default"`
+			} `json:"project_entry"`
+		} `json:"template"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Template.ProjectEntry == nil || response.Template.ProjectEntry.RelativePath != "{{name}}.rpp" || response.Template.ProjectEntry.OpenAfterCreateDefault {
+		t.Fatalf("unexpected project entry response: %+v", response.Template.ProjectEntry)
+	}
+
+	// Omitting the field preserves it for older clients.
+	w = callUpdate(`{"name":"Song","description":"preserved"}`)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"project_entry"`) {
+		t.Fatalf("omitted project entry was not preserved: %d %s", w.Code, w.Body.String())
+	}
+
+	// Explicit null clears it.
+	w = callUpdate(`{"name":"Song","project_entry":null}`)
+	if w.Code != http.StatusOK || strings.Contains(w.Body.String(), `"project_entry"`) {
+		t.Fatalf("project entry was not cleared: %d %s", w.Code, w.Body.String())
+	}
+
+	for _, body := range []string{
+		`{"name":"Song","project_entry":{"relative_path":"../escape.rpp","open_after_create_default":true}}`,
+		`{"name":"Song","project_entry":{"relative_path":"missing.rpp","open_after_create_default":true}}`,
+		`{"name":"Song","project_entry":"{{name}}.rpp"}`,
+	} {
+		w = callUpdate(body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("invalid project entry: expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(templateDir, "template.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"custom_key": "kept"`) {
+		t.Fatalf("unknown manifest field was lost: %s", data)
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -959,6 +959,14 @@ func (s *Server) routeWorkspaceRuntimeRequest(w http.ResponseWriter, r *http.Req
 	trimmed := strings.TrimPrefix(path, "/api/workspaces/")
 	parts := strings.Split(trimmed, "/")
 
+	// Fixed-target desktop project launch must be claimed before the session
+	// handler's broader /project creation route. The runtime handler enforces
+	// POST, loopback origin, persisted metadata, and filesystem containment.
+	if len(parts) == 3 && parts[1] == "project" && parts[2] == "open" {
+		s.Handlers.Workspace.OpenWorkspaceProject(w, r)
+		return true
+	}
+
 	if strings.HasSuffix(path, "/events") {
 		s.Handlers.Workspace.GetWorkspaceEvents(w, r)
 		return true

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -88,8 +88,8 @@ func TestWorkspaceProjectOpenRouteUsesRuntimeHandler(t *testing.T) {
 	req.RemoteAddr = "127.0.0.1:43210"
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected fixed project-open runtime route to require canonical folder storage, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected project-open runtime route to use canonical folder storage, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/missing/project/open", nil)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -88,8 +88,8 @@ func TestWorkspaceProjectOpenRouteUsesRuntimeHandler(t *testing.T) {
 	req.RemoteAddr = "127.0.0.1:43210"
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected fixed project-open runtime route to return 404 for missing workspace, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected fixed project-open runtime route to require canonical folder storage, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/missing/project/open", nil)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -81,6 +81,26 @@ func TestWorkspaceRunRoutesRegistered(t *testing.T) {
 	}
 }
 
+func TestWorkspaceProjectOpenRouteUsesRuntimeHandler(t *testing.T) {
+	handler := newRoutesTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/missing/project/open", nil)
+	req.RemoteAddr = "127.0.0.1:43210"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected fixed project-open runtime route to return 404 for missing workspace, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/missing/project/open", nil)
+	req.RemoteAddr = "127.0.0.1:43210"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected project-open GET to return 405, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestWorkspaceNotesRoutesServeNotePage(t *testing.T) {
 	handler := newRoutesTestHandler(t)
 

--- a/internal/sessionhttp/project_templates.go
+++ b/internal/sessionhttp/project_templates.go
@@ -83,23 +83,24 @@ func (h *Handler) handleTemplateAgentPlan(w http.ResponseWriter, r *http.Request
 // the workspace's folder, persists ProjectPath in both the session store and
 // the folder store, and publishes project.created. On any failure after the
 // copy it removes the project folder again so the workspace never ends up
-// with an orphaned project or a dangling ProjectPath.
-func (h *Handler) instantiateWorkspaceProject(ctx context.Context, ws *session.Workspace, folderWS *agentworkspace.Workspace, templateID, templatePath, projectName string) error {
+// with an orphaned project or a dangling ProjectPath. Entry-file verification
+// is deliberately non-fatal and is returned in InstantiationResult.
+func (h *Handler) instantiateWorkspaceProject(ctx context.Context, ws *session.Workspace, folderWS *agentworkspace.Workspace, templateID, templatePath, projectName string) (projecttemplates.InstantiationResult, error) {
 	if err := projecttemplates.ValidateTarget(ws.IsGroup(), ws.ProjectPath); err != nil {
-		return err
+		return projecttemplates.InstantiationResult{}, err
 	}
 	if h.workspaceStore == nil {
-		return fmt.Errorf("workspace folder storage is unavailable")
+		return projecttemplates.InstantiationResult{}, fmt.Errorf("workspace folder storage is unavailable")
 	}
 
 	folderPath, err := h.workspaceStore.GetFolderPath(ws.ID)
 	if err != nil {
-		return fmt.Errorf("workspace folder is unavailable: %w", err)
+		return projecttemplates.InstantiationResult{}, fmt.Errorf("workspace folder is unavailable: %w", err)
 	}
 
 	tpl, err := h.resolveProjectTemplate(templateID, templatePath)
 	if err != nil {
-		return err
+		return projecttemplates.InstantiationResult{}, err
 	}
 
 	if strings.TrimSpace(projectName) == "" {
@@ -107,15 +108,16 @@ func (h *Handler) instantiateWorkspaceProject(ctx context.Context, ws *session.W
 	}
 	displayProjectName := strings.TrimSpace(projectName)
 
-	relPath, err := projecttemplates.Instantiate(tpl.Path, folderPath, projectName)
+	result, err := projecttemplates.InstantiateTemplate(tpl, folderPath, projectName)
 	if err != nil {
-		return err
+		return projecttemplates.InstantiationResult{}, err
 	}
+	relPath := result.ProjectPath
 
 	projectDirID, err := projecttemplates.EnsureProjectDirectoryReference(folderWS, displayProjectName, folderPath, relPath)
 	if err != nil {
 		_ = os.RemoveAll(filepath.Join(folderPath, relPath))
-		return fmt.Errorf("failed to register project folder: %w", err)
+		return projecttemplates.InstantiationResult{}, fmt.Errorf("failed to register project folder: %w", err)
 	}
 
 	// workspace.json is the canonical store for project_path (there is no
@@ -125,22 +127,27 @@ func (h *Handler) instantiateWorkspaceProject(ctx context.Context, ws *session.W
 	folderWS.ProjectPath = relPath
 	folderWS.Tags = agentworkspace.MergeWorkspaceTags(folderWS.Tags, tpl.Tags)
 	setFileStoreWorkspacePrimaryDirectoryID(folderWS, projectDirID)
+	if err := projecttemplates.SetProjectEntryPath(folderWS.SharedData, result.ProjectEntryPath); err != nil {
+		result.ProjectEntryPath = ""
+		result.ProjectWarning = appendProjectWarning(result.ProjectWarning, fmt.Sprintf("project entry metadata could not be persisted: %v", err))
+	}
 	folderWS.UpdatedAt = now
 	if err := h.workspaceStore.Save(folderWS); err != nil {
 		_ = os.RemoveAll(filepath.Join(folderPath, relPath))
 		folderWS.ProjectPath = ""
-		return fmt.Errorf("failed to persist project path: %w", err)
+		return projecttemplates.InstantiationResult{}, fmt.Errorf("failed to persist project path: %w", err)
 	}
 
 	ws.ProjectPath = relPath
 	ws.Tags = agentworkspace.MergeWorkspaceTags(ws.Tags, tpl.Tags)
+	if ws.SharedData == nil {
+		ws.SharedData = make(map[string]any)
+	}
 	if projectDirID != "" {
 		setWorkspacePrimaryDirectoryID(ws, projectDirID)
-		if ws.SharedData == nil {
-			ws.SharedData = make(map[string]any)
-		}
 		ws.SharedData[workspaceSharedDataProjectDirectoryIDKey] = projectDirID
 	}
+	_ = projecttemplates.SetProjectEntryPath(ws.SharedData, result.ProjectEntryPath)
 	if refsJSON, err := json.Marshal(folderWS.DirectoryReferences); err == nil {
 		ws.DirectoryReferencesJSON = refsJSON
 	} else {
@@ -154,23 +161,43 @@ func (h *Handler) instantiateWorkspaceProject(ctx context.Context, ws *session.W
 	}
 
 	if h.eventBus != nil {
+		data := map[string]any{
+			"project_path": relPath,
+			"template_id":  tpl.ID,
+		}
+		if result.ProjectEntryPath != "" {
+			data[projecttemplates.ProjectEntryPathKey] = result.ProjectEntryPath
+		}
+		if result.ProjectWarning != "" {
+			data["project_warning"] = result.ProjectWarning
+		}
 		h.eventBus.Publish(agentworkspace.Event{
 			Type:        agentworkspace.EventProjectCreated,
 			WorkspaceID: ws.ID,
 			Source:      "sessionhttp",
-			Data: map[string]any{
-				"project_path": relPath,
-				"template_id":  tpl.ID,
-			},
+			Data:        data,
 		})
 	}
 
 	logger.Info("Project instantiated from template", logger.Fields{
-		"workspace_id": ws.ID,
-		"template":     tpl.ID,
-		"project_path": relPath,
+		"workspace_id":  ws.ID,
+		"template":      tpl.ID,
+		"project_path":  relPath,
+		"project_entry": result.ProjectEntryPath,
 	})
-	return nil
+	return result, nil
+}
+
+func appendProjectWarning(existing, warning string) string {
+	existing = strings.TrimSpace(existing)
+	warning = strings.TrimSpace(warning)
+	if existing == "" {
+		return warning
+	}
+	if warning == "" {
+		return existing
+	}
+	return existing + "; " + warning
 }
 
 func setFileStoreWorkspacePrimaryDirectoryID(ws *agentworkspace.Workspace, directoryID string) {
@@ -230,17 +257,22 @@ func (h *Handler) handleWorkspaceProject(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	if err := h.instantiateWorkspaceProject(r.Context(), workspace, folderWS, req.TemplateID, req.TemplatePath, req.ProjectName); err != nil {
+	result, err := h.instantiateWorkspaceProject(r.Context(), workspace, folderWS, req.TemplateID, req.TemplatePath, req.ProjectName)
+	if err != nil {
 		h.respondWorkspaceProjectError(w, err)
 		return
 	}
 
 	hydrated := h.hydrateWorkspaceMetadataFromFileStore(workspace)
-	_ = orihttp.RespondCreated(w, map[string]any{
+	response := map[string]any{
 		"success":      true,
 		"project_path": hydrated.ProjectPath,
 		"workspace":    h.buildWorkspaceDetailResponse(hydrated),
-	})
+	}
+	if result.ProjectWarning != "" {
+		response["project_warning"] = result.ProjectWarning
+	}
+	_ = orihttp.RespondCreated(w, response)
 }
 
 func (h *Handler) respondWorkspaceProjectError(w http.ResponseWriter, err error) {

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -153,6 +153,28 @@ func TestCreateWorkspaceWithTemplate(t *testing.T) {
 		t.Fatalf("project entry = %v, want song-x.rpp", diskWS.SharedData[projecttemplates.ProjectEntryPathKey])
 	}
 
+	// A task mutation reads through the SQLite-primary SyncStore, whose table
+	// does not carry project_path. Its write-through save must merge the
+	// disk-canonical value instead of erasing it immediately after creation.
+	taskWorkspace, err := handler.workspaceTaskStore.Get(wsID)
+	if err != nil {
+		t.Fatalf("workspaceTaskStore.Get: %v", err)
+	}
+	taskWorkspace.Tasks = append(taskWorkspace.Tasks, agentworkspace.Task{
+		ID:     "post-create-task-update",
+		Status: agentworkspace.TaskStatusCompleted,
+	})
+	if err := handler.workspaceTaskStore.Save(taskWorkspace); err != nil {
+		t.Fatalf("workspaceTaskStore.Save: %v", err)
+	}
+	diskWS, err = handler.workspaceStore.Get(wsID)
+	if err != nil {
+		t.Fatalf("workspaceStore.Get after task save: %v", err)
+	}
+	if diskWS.ProjectPath != "song-x" {
+		t.Fatalf("disk project_path after task save = %q, want song-x", diskWS.ProjectPath)
+	}
+
 	// Session reads hydrate project_path from workspace.json (it has no
 	// SQLite column), so a bare session row must come back with the path.
 	hydrated := handler.hydrateWorkspaceMetadataFromFileStore(&session.Workspace{ID: wsID})

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -46,7 +46,7 @@ func templateTestEnv(t *testing.T) (*Handler, string, <-chan agentworkspace.Even
 		cleanup()
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(libDir, "demo-template", "template.json"), []byte(`{"name":"Demo Template","tags":[" Music ","reaper","music"]}`), 0o640); err != nil {
+	if err := os.WriteFile(filepath.Join(libDir, "demo-template", "template.json"), []byte(`{"name":"Demo Template","tags":[" Music ","reaper","music"],"project_entry":{"relative_path":"{{name}}.rpp","open_after_create_default":true}}`), 0o640); err != nil {
 		cleanup()
 		t.Fatal(err)
 	}
@@ -149,6 +149,9 @@ func TestCreateWorkspaceWithTemplate(t *testing.T) {
 	if diskWS.SharedData[workspaceSharedDataProjectDirectoryIDKey] != projectRef.ID {
 		t.Fatalf("project directory = %v, want %q", diskWS.SharedData[workspaceSharedDataProjectDirectoryIDKey], projectRef.ID)
 	}
+	if diskWS.SharedData[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
+		t.Fatalf("project entry = %v, want song-x.rpp", diskWS.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
 
 	// Session reads hydrate project_path from workspace.json (it has no
 	// SQLite column), so a bare session row must come back with the path.
@@ -159,10 +162,13 @@ func TestCreateWorkspaceWithTemplate(t *testing.T) {
 	if len(hydrated.Tags) != 2 || hydrated.Tags[0] != "music" || hydrated.Tags[1] != "reaper" {
 		t.Fatalf("hydrated tags = %#v, want [music reaper]", hydrated.Tags)
 	}
+	if hydrated.SharedData[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
+		t.Fatalf("hydrated project entry = %v, want song-x.rpp", hydrated.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
 
 	select {
 	case event := <-events:
-		if event.WorkspaceID != wsID || event.Data["project_path"] != "song-x" {
+		if event.WorkspaceID != wsID || event.Data["project_path"] != "song-x" || event.Data[projecttemplates.ProjectEntryPathKey] != "song-x.rpp" {
 			t.Fatalf("unexpected project.created payload: %+v", event)
 		}
 	case <-time.After(2 * time.Second):
@@ -478,6 +484,9 @@ func TestCreateProjectForExistingWorkspace(t *testing.T) {
 	if projectResp["project_path"] != "first-song" {
 		t.Fatalf("project_path = %v, want first-song", projectResp["project_path"])
 	}
+	if warning, present := projectResp["project_warning"]; present {
+		t.Fatalf("unexpected project_warning: %v", warning)
+	}
 
 	diskWS, err := handler.workspaceStore.Get(wsID)
 	if err != nil {
@@ -503,6 +512,9 @@ func TestCreateProjectForExistingWorkspace(t *testing.T) {
 	if diskWS.SharedData[workspaceSharedDataProjectDirectoryIDKey] != projectRef.ID {
 		t.Fatalf("project directory = %v, want %q", diskWS.SharedData[workspaceSharedDataProjectDirectoryIDKey], projectRef.ID)
 	}
+	if diskWS.SharedData[projecttemplates.ProjectEntryPathKey] != "first-song.rpp" {
+		t.Fatalf("project entry = %v, want first-song.rpp", diskWS.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
 
 	sessionWS, err := handler.store.GetWorkspace(context.Background(), wsID)
 	if err != nil {
@@ -522,10 +534,13 @@ func TestCreateProjectForExistingWorkspace(t *testing.T) {
 	if len(hydrated.Tags) != 2 || hydrated.Tags[0] != "music" || hydrated.Tags[1] != "reaper" {
 		t.Fatalf("hydrated tags = %#v, want [music reaper]", hydrated.Tags)
 	}
+	if hydrated.SharedData[projecttemplates.ProjectEntryPathKey] != "first-song.rpp" {
+		t.Fatalf("hydrated project entry = %v, want first-song.rpp", hydrated.SharedData[projecttemplates.ProjectEntryPathKey])
+	}
 
 	select {
 	case event := <-events:
-		if event.WorkspaceID != wsID || event.Data["project_path"] != "first-song" {
+		if event.WorkspaceID != wsID || event.Data["project_path"] != "first-song" || event.Data[projecttemplates.ProjectEntryPathKey] != "first-song.rpp" {
 			t.Fatalf("unexpected project.created payload: %+v", event)
 		}
 	case <-time.After(time.Second):

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -571,12 +571,16 @@ func (h *Handler) applyCreateWorkspaceTemplate(ctx context.Context, req createWo
 	default:
 		// Non-fatal by design: a failed instantiation must not fail
 		// workspace creation. The warning is surfaced to the user.
-		if err := h.instantiateWorkspaceProject(ctx, ws, folderWS, req.TemplateID, req.TemplatePath, req.ProjectName); err != nil {
+		result, err := h.instantiateWorkspaceProject(ctx, ws, folderWS, req.TemplateID, req.TemplatePath, req.ProjectName)
+		if err != nil {
 			if tc.resolveErr != nil {
 				err = tc.resolveErr
 			}
 			projectWarning = fmt.Sprintf("workspace was created, but the project template was not applied: %v", err)
 			logger.Warn("Project template instantiation failed", logger.Fields{"id": ws.ID, "error": err})
+		} else if result.ProjectWarning != "" {
+			projectWarning = result.ProjectWarning
+			logger.Warn("Project entry was not persisted", logger.Fields{"id": ws.ID, "warning": result.ProjectWarning})
 		}
 	}
 

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -118,6 +118,10 @@
   outline: 2px solid var(--ws-faction);
   outline-offset: 2px;
 }
+.ws-cmd-nav-btn:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
 .ws-cmd-view-switch {
   margin-left: auto;
   display: inline-flex;

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -335,7 +335,9 @@ function ptcElements() {
     pathInput: document.getElementById('projectTemplatePathInput'),
     browseBtn: document.getElementById('projectTemplateBrowseBtn'),
     manageLink: document.getElementById('projectTemplateManageLink'),
-    importToggle: document.getElementById('folderImportToggle')
+    importToggle: document.getElementById('folderImportToggle'),
+    openAfterCreate: document.getElementById('projectTemplateOpenAfterCreate'),
+    openAfterCreateToggle: document.getElementById('projectTemplateOpenAfterCreateToggle')
   };
 }
 
@@ -443,6 +445,35 @@ function ptcUpdateUI() {
     els.description.textContent = showDesc ? ptcSelected.description : '';
     els.description.hidden = !showDesc;
   }
+
+  const templatePath = els.pathInput?.value?.trim() || '';
+  const importMode = Boolean(els.importToggle?.checked);
+  const entry = ptcSelected?.project_entry;
+  const hasEntry = Boolean(
+    !importMode &&
+    !templatePath &&
+    ptcSelected &&
+    !ptcSelected.blank &&
+    entry &&
+    typeof entry === 'object' &&
+    typeof entry.relative_path === 'string' &&
+    entry.relative_path.trim()
+  );
+  if (els.openAfterCreate) els.openAfterCreate.hidden = !hasEntry;
+  if (els.openAfterCreateToggle) {
+    els.openAfterCreateToggle.checked = hasEntry
+      ? Boolean(entry.open_after_create_default)
+      : false;
+  }
+}
+
+function ptcShouldOpenAfterCreate() {
+  const els = ptcElements();
+  return Boolean(
+    els.openAfterCreate &&
+    !els.openAfterCreate.hidden &&
+    els.openAfterCreateToggle?.checked
+  );
 }
 
 function ptcBlankCard() {
@@ -464,6 +495,7 @@ function ptcSyncImportVisibility() {
   if (importMode) {
     if (els.description) els.description.hidden = true;
   }
+  ptcUpdateUI();
 }
 
 async function ptcPopulate() {
@@ -577,8 +609,10 @@ function ptcInit() {
 window.ProjectTemplateCard = {
   populate: ptcPopulate,
   reset: ptcReset,
+  syncState: ptcUpdateUI,
   getPayloadFields: ptcGetPayloadFields,
-  getSelectedTemplate: ptcGetSelectedTemplate
+  getSelectedTemplate: ptcGetSelectedTemplate,
+  shouldOpenAfterCreate: ptcShouldOpenAfterCreate
 };
 
 function ptmInitListeners() {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3043,6 +3043,7 @@ const sessionManager = {
     } else {
       this.resetTemplateAgentReview();
     }
+    window.ProjectTemplateCard?.syncState?.();
   },
 
   clearImportDuplicateWarning() {
@@ -3765,6 +3766,40 @@ const sessionManager = {
     }
   },
 
+  projectOpenNoticeStorageKey(workspaceId) {
+    return `oriProjectOpenNotice:${String(workspaceId || '').trim()}`;
+  },
+
+  rememberProjectOpenFailure(workspaceId, error) {
+    const id = String(workspaceId || '').trim();
+    if (!id) return;
+    const detail = error && error.message ? String(error.message).trim() : '';
+    const message = detail
+      ? `Workspace created, but the project could not be opened. Use Open Project to try again. ${detail}`
+      : 'Workspace created, but the project could not be opened. Use Open Project to try again.';
+    try {
+      sessionStorage.setItem(
+        this.projectOpenNoticeStorageKey(id),
+        JSON.stringify({ workspace_id: id, message })
+      );
+    } catch (storageError) {
+      console.warn('Failed to preserve project-open notice:', storageError);
+    }
+  },
+
+  async openProjectAfterWorkspaceCreate(workspaceId) {
+    const id = String(workspaceId || '').trim();
+    if (!id) return;
+    const response = await fetch(
+      `/api/workspaces/${encodeURIComponent(id)}/project/open`,
+      { method: 'POST' }
+    );
+    const result = await response.json().catch(() => ({}));
+    if (!response.ok || result.error) {
+      throw new Error(result.error || result.message || 'The system default application did not accept the project file.');
+    }
+  },
+
   // Create folder
   async createFolder() {
     if (this.isCreatingFolder) return;
@@ -3780,6 +3815,9 @@ const sessionManager = {
     const workspaceBootstrap = this.getWorkspaceBootstrapFromModal();
 
     const importEnabled = this.importModeEnabled || Boolean(importToggle?.checked);
+    const openProjectAfterCreate = Boolean(
+      !importEnabled && window.ProjectTemplateCard?.shouldOpenAfterCreate?.()
+    );
     const importPath = importPathInput?.value?.trim() || '';
     const name = nameInput?.value.trim() || '';
     const description = descriptionInput?.value.trim() || '';
@@ -4036,6 +4074,15 @@ const sessionManager = {
         }
       } else {
         this.showToast(importEnabled ? 'Workspace imported successfully' : 'Workspace created successfully', 'success');
+      }
+
+      if (createdWorkspaceId && openProjectAfterCreate) {
+        try {
+          await this.openProjectAfterWorkspaceCreate(createdWorkspaceId);
+        } catch (error) {
+          console.warn('Workspace created but project open failed:', error);
+          this.rememberProjectOpenFailure(createdWorkspaceId, error);
+        }
       }
 
       // Close modal

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -74,7 +74,7 @@ function tplShowError(message) {
 }
 
 function tplSelected() {
-  return tplState.templates.find((t) => t.id === tplState.selectedId) || null;
+  return tplState.templates.find(t => t.id === tplState.selectedId) || null;
 }
 
 // --- Loading & list rendering ---
@@ -95,16 +95,18 @@ async function tplRefresh(selectId) {
   if (rootPath) rootPath.textContent = tplState.root;
 
   // Keep selection valid; default to the requested or first template.
-  if (selectId && tplState.templates.some((t) => t.id === selectId)) {
+  if (selectId && tplState.templates.some(t => t.id === selectId)) {
     tplState.selectedId = selectId;
-  } else if (!tplState.templates.some((t) => t.id === tplState.selectedId)) {
+  } else if (!tplState.templates.some(t => t.id === tplState.selectedId)) {
     tplState.selectedId = '';
   }
 
   // If the selected template changed out from under a loaded Files tree or
   // Tools editor, drop them so neither tab shows another template's data.
-  if ((tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) ||
-      (tplTools.templateId && tplTools.templateId !== tplState.selectedId)) {
+  if (
+    (tplFiles.templateId && tplFiles.templateId !== tplState.selectedId) ||
+    (tplTools.templateId && tplTools.templateId !== tplState.selectedId)
+  ) {
     tplFilesReset();
     tplToolsReset();
   }
@@ -118,12 +120,12 @@ function tplVisibleTemplates() {
   let items = tplState.templates;
   const fb = window.OriTagFilterBar;
   if (fb && tplState.activeTags.length) {
-    items = fb.filterItems(items, tplState.activeTags, (t) => t.tags || []);
+    items = fb.filterItems(items, tplState.activeTags, t => t.tags || []);
   }
   const q = tplState.search.trim().toLowerCase();
   if (q) {
-    items = items.filter((t) =>
-      [t.name, t.id, t.description].filter(Boolean).some((v) => v.toLowerCase().includes(q))
+    items = items.filter(t =>
+      [t.name, t.id, t.description].filter(Boolean).some(v => v.toLowerCase().includes(q))
     );
   }
   return items;
@@ -162,26 +164,31 @@ function tplBuildRow(template) {
   row.setAttribute('role', 'listitem');
   row.style.cssText =
     'border: 1px solid var(--border-color); background: var(--bg-secondary);' +
-    (template.id === tplState.selectedId ? ' outline: 2px solid var(--accent-color, #6366f1);' : '');
+    (template.id === tplState.selectedId
+      ? ' outline: 2px solid var(--accent-color, #6366f1);'
+      : '');
   row.addEventListener('click', () => {
     if (tplState.selectedId === template.id) return;
     tplGuardDirty(() => tplSelectTemplate(template.id));
   });
 
   const title = document.createElement('div');
-  title.style.cssText = 'color: var(--text-primary); font-size: 14px; font-weight: 600; word-break: break-word;';
+  title.style.cssText =
+    'color: var(--text-primary); font-size: 14px; font-weight: 600; word-break: break-word;';
   title.textContent = (template.icon ? `${template.icon} ` : '') + (template.name || template.id);
   if (template.builtin) {
     const badge = document.createElement('span');
     badge.className = 'badge ms-1';
-    badge.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 600; font-size: 9px; vertical-align: middle;';
+    badge.style.cssText =
+      'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 600; font-size: 9px; vertical-align: middle;';
     badge.textContent = 'BUILT-IN';
     title.appendChild(badge);
   }
   row.appendChild(title);
 
   const id = document.createElement('div');
-  id.style.cssText = 'font-size: 11px; color: var(--text-secondary); font-family: var(--font-mono, monospace);';
+  id.style.cssText =
+    'font-size: 11px; color: var(--text-secondary); font-family: var(--font-mono, monospace);';
   id.textContent = template.id;
   row.appendChild(id);
 
@@ -199,7 +206,8 @@ function tplBuildRow(template) {
     for (const tag of template.tags) {
       const chip = document.createElement('span');
       chip.className = 'badge';
-      chip.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 500; font-size: 10px;';
+      chip.style.cssText =
+        'background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 500; font-size: 10px;';
       chip.textContent = tag;
       tags.appendChild(chip);
     }
@@ -218,7 +226,7 @@ function tplEnsureFilterBar() {
   tplState.filterBar = window.OriTagFilterBar.createTagFilterBar({
     container,
     label: 'Tags',
-    onChange: (active) => {
+    onChange: active => {
       tplState.activeTags = active;
       tplRenderList();
     }
@@ -228,7 +236,7 @@ function tplEnsureFilterBar() {
 function tplSyncFilterTags() {
   tplEnsureFilterBar();
   if (!tplState.filterBar || !window.OriTagFilterBar) return;
-  const available = window.OriTagFilterBar.collectTags(tplState.templates, (t) => t.tags || []);
+  const available = window.OriTagFilterBar.collectTags(tplState.templates, t => t.tags || []);
   tplState.filterBar.setAvailableTags(available);
   tplState.activeTags = tplState.filterBar.getActiveTags();
 }
@@ -292,7 +300,8 @@ function tplStarterTaskRow(task) {
 
   const setupWrap = document.createElement('label');
   setupWrap.className = 'd-flex align-items-center gap-1 mb-0';
-  setupWrap.style.cssText = 'font-size: 12px; color: var(--text-secondary); white-space: nowrap; cursor: pointer;';
+  setupWrap.style.cssText =
+    'font-size: 12px; color: var(--text-secondary); white-space: nowrap; cursor: pointer;';
   const setup = document.createElement('input');
   setup.type = 'checkbox';
   setup.className = 'form-check-input mt-0';
@@ -302,7 +311,7 @@ function tplStarterTaskRow(task) {
   setup.addEventListener('change', () => {
     if (!setup.checked) return;
     // At most one setup task: checking this one unchecks the rest.
-    document.querySelectorAll('#tplStarterTasksList input[data-k="setup"]').forEach((other) => {
+    document.querySelectorAll('#tplStarterTasksList input[data-k="setup"]').forEach(other => {
       if (other !== setup) other.checked = false;
     });
   });
@@ -323,8 +332,10 @@ function tplStarterTaskRow(task) {
   details.className = 'form-control';
   details.rows = 3;
   details.dataset.k = 'details';
-  details.style.cssText = 'background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.85em; resize: vertical;';
-  details.placeholder = 'Details for the agent (Markdown). For a setup task, consider headings:\n## Created defaults\n## Questions to ask\n## Validation\n## How to apply changes';
+  details.style.cssText =
+    'background: var(--bg-tertiary); border: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.85em; resize: vertical;';
+  details.placeholder =
+    'Details for the agent (Markdown). For a setup task, consider headings:\n## Created defaults\n## Questions to ask\n## Validation\n## How to apply changes';
   details.value = task && task.details ? task.details : '';
   row.appendChild(details);
 
@@ -335,7 +346,7 @@ function tplStarterTasksRender(tasks) {
   const list = tplEl('tplStarterTasksList');
   if (!list) return;
   list.innerHTML = '';
-  (Array.isArray(tasks) ? tasks : []).forEach((t) => list.appendChild(tplStarterTaskRow(t)));
+  (Array.isArray(tasks) ? tasks : []).forEach(t => list.appendChild(tplStarterTaskRow(t)));
 }
 
 // tplStarterTasksCollect reads the rows back into starter-task objects,
@@ -345,8 +356,8 @@ function tplStarterTasksCollect() {
   const list = tplEl('tplStarterTasksList');
   if (!list) return [];
   return Array.from(list.querySelectorAll('[data-role="starter-task"]'))
-    .map((row) => {
-      const val = (k) => row.querySelector(`[data-k="${k}"]`);
+    .map(row => {
+      const val = k => row.querySelector(`[data-k="${k}"]`);
       const description = (val('description')?.value || '').trim();
       if (!description) return null;
       const task = { description, details: (val('details')?.value || '').trim() };
@@ -362,12 +373,21 @@ function tplResetOverviewFields() {
   const nameInput = tplEl('tplEditName');
   const descInput = tplEl('tplEditDescription');
   // A name equal to the id is a folder-name fallback, not an explicit name.
-  if (nameInput) nameInput.value = template.name && template.name !== template.id ? template.name : '';
+  if (nameInput)
+    nameInput.value = template.name && template.name !== template.id ? template.name : '';
   if (descInput) descInput.value = template.description || '';
   const iconInput = tplEl('tplEditIcon');
   if (iconInput) iconInput.value = template.icon || '';
   const behaviorSelect = tplEl('tplEditBehavior');
   if (behaviorSelect) behaviorSelect.value = template.behavior_profile || 'general';
+  const projectEntryPath = tplEl('tplEditProjectEntryPath');
+  const projectEntryDefault = tplEl('tplEditProjectEntryDefault');
+  const entry =
+    template.project_entry && typeof template.project_entry === 'object'
+      ? template.project_entry
+      : null;
+  if (projectEntryPath) projectEntryPath.value = entry?.relative_path || '';
+  if (projectEntryDefault) projectEntryDefault.checked = Boolean(entry?.open_after_create_default);
   tplStarterTasksRender(template.starter_tasks);
   tplEnsureTagsWidget();
   if (tplState.tagsWidget) tplState.tagsWidget.setTags(template.tags || []);
@@ -380,7 +400,10 @@ async function tplSaveOverview() {
   const descInput = tplEl('tplEditDescription');
   const iconInput = tplEl('tplEditIcon');
   const behaviorSelect = tplEl('tplEditBehavior');
-  const tags = tplState.tagsWidget ? tplState.tagsWidget.getTags() : (template.tags || []);
+  const projectEntryPath = tplEl('tplEditProjectEntryPath');
+  const projectEntryDefault = tplEl('tplEditProjectEntryDefault');
+  const entryPath = projectEntryPath ? projectEntryPath.value.trim() : '';
+  const tags = tplState.tagsWidget ? tplState.tagsWidget.getTags() : template.tags || [];
   try {
     await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, {
       method: 'PUT',
@@ -391,7 +414,13 @@ async function tplSaveOverview() {
         tags,
         icon: iconInput ? iconInput.value.trim() : '',
         behavior_profile: behaviorSelect ? behaviorSelect.value : 'general',
-        starter_tasks: tplStarterTasksCollect()
+        starter_tasks: tplStarterTasksCollect(),
+        project_entry: entryPath
+          ? {
+              relative_path: entryPath,
+              open_after_create_default: Boolean(projectEntryDefault?.checked)
+            }
+          : null
       })
     });
     tplToast('Template saved.', 'success');
@@ -412,22 +441,41 @@ function tplApplyReadOnly() {
   if (notice) notice.hidden = !builtin;
   const agentsNotice = tplEl('tplAgentsReadOnlyNotice');
   if (agentsNotice) agentsNotice.hidden = !builtin;
-  ['tplAgentsAddBtn', 'tplAgentsSaveBtn'].forEach((id) => {
+  ['tplAgentsAddBtn', 'tplAgentsSaveBtn'].forEach(id => {
     const el = tplEl(id);
     if (el) el.hidden = builtin;
   });
   [
-    'tplEditName', 'tplEditDescription', 'tplEditIcon', 'tplEditBehavior', 'tplStarterTaskAddBtn',
-    'tplSaveBtn', 'tplResetBtn', 'tplDeleteBtn',
-    'tplFileNewBtn', 'tplFolderNewBtn', 'tplFileRenameBtn', 'tplFileDeleteBtn', 'tplEditorSaveBtn',
-    'tplToolsSaveBtn', 'tplAgentsAddBtn', 'tplAgentsSaveBtn'
-  ].forEach((id) => {
+    'tplEditName',
+    'tplEditDescription',
+    'tplEditIcon',
+    'tplEditBehavior',
+    'tplEditProjectEntryPath',
+    'tplEditProjectEntryDefault',
+    'tplStarterTaskAddBtn',
+    'tplSaveBtn',
+    'tplResetBtn',
+    'tplDeleteBtn',
+    'tplFileNewBtn',
+    'tplFolderNewBtn',
+    'tplFileRenameBtn',
+    'tplFileDeleteBtn',
+    'tplEditorSaveBtn',
+    'tplToolsSaveBtn',
+    'tplAgentsAddBtn',
+    'tplAgentsSaveBtn'
+  ].forEach(id => {
     const el = tplEl(id);
     if (el) el.disabled = builtin;
   });
   // The starter-tasks row editor is built dynamically; disable its controls too.
-  document.querySelectorAll('#tplStarterTasksList input, #tplStarterTasksList textarea, #tplStarterTasksList button')
-    .forEach((el) => { el.disabled = builtin; });
+  document
+    .querySelectorAll(
+      '#tplStarterTasksList input, #tplStarterTasksList textarea, #tplStarterTasksList button'
+    )
+    .forEach(el => {
+      el.disabled = builtin;
+    });
   // The tags widget is a custom component; dim + block interaction for built-ins.
   const tagsWrap = tplEl('tplEditTags');
   if (tagsWrap) {
@@ -437,8 +485,12 @@ function tplApplyReadOnly() {
   // Agent cards are rendered dynamically; disable their controls + drag for built-ins.
   const agentsList = tplEl('tplAgentsList');
   if (agentsList) {
-    agentsList.querySelectorAll('input, select, textarea, button').forEach((el) => { el.disabled = builtin; });
-    agentsList.querySelectorAll('.tpl-agent-card').forEach((card) => { card.draggable = !builtin; });
+    agentsList.querySelectorAll('input, select, textarea, button').forEach(el => {
+      el.disabled = builtin;
+    });
+    agentsList.querySelectorAll('.tpl-agent-card').forEach(card => {
+      card.draggable = !builtin;
+    });
   }
 }
 
@@ -481,7 +533,7 @@ function tplCreate() {
     label: 'Template name',
     confirm: 'Create',
     initial: '',
-    run: async (name) => {
+    run: async name => {
       if (!name) throw new Error('Please enter a name.');
       const result = await tplFetchJSON('/api/project-templates', {
         method: 'POST',
@@ -503,12 +555,15 @@ function tplDuplicate() {
     label: 'New template name',
     confirm: 'Duplicate',
     initial: `${template.name || template.id} copy`,
-    run: async (name) => {
-      const result = await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}/duplicate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name })
-      });
+    run: async name => {
+      const result = await tplFetchJSON(
+        `/api/project-templates/${encodeURIComponent(template.id)}/duplicate`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name })
+        }
+      );
       const created = result.template || {};
       tplToast(`Duplicated to "${created.name || created.id}".`, 'success');
       await tplRefresh(created.id);
@@ -541,11 +596,15 @@ async function tplDelete() {
   const template = tplSelected();
   if (!template) return;
   const label = template.name || template.id;
-  if (!window.confirm(`Delete the template "${label}"? It will be moved to the Trash when possible.`)) {
+  if (
+    !window.confirm(`Delete the template "${label}"? It will be moved to the Trash when possible.`)
+  ) {
     return;
   }
   try {
-    const result = await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, { method: 'DELETE' });
+    const result = await tplFetchJSON(`/api/project-templates/${encodeURIComponent(template.id)}`, {
+      method: 'DELETE'
+    });
     tplToast(result.trashed ? `"${label}" moved to Trash.` : `"${label}" deleted.`, 'success');
     tplState.selectedId = '';
     await tplRefresh();
@@ -649,8 +708,12 @@ function tplBuildTreeRow(node) {
   row.className = 'd-flex align-items-center gap-2 px-2 py-1 text-start w-100';
   row.style.cssText =
     `border: none; border-radius: 4px; font-size: 13px; padding-left: ${8 + depth * 16}px !important;` +
-    (isDir ? ' background: transparent; color: var(--text-secondary);' : ' background: var(--bg-secondary); color: var(--text-primary);') +
-    (node.path === tplFiles.selectedPath ? ' outline: 2px solid var(--accent-color, #6366f1);' : '');
+    (isDir
+      ? ' background: transparent; color: var(--text-secondary);'
+      : ' background: var(--bg-secondary); color: var(--text-primary);') +
+    (node.path === tplFiles.selectedPath
+      ? ' outline: 2px solid var(--accent-color, #6366f1);'
+      : '');
   row.setAttribute('role', 'treeitem');
 
   const icon = document.createElement('span');
@@ -667,7 +730,8 @@ function tplBuildTreeRow(node) {
     const badge = document.createElement('span');
     badge.className = 'badge';
     badge.textContent = 'metadata';
-    badge.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 9px; font-weight: 500;';
+    badge.style.cssText =
+      'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 9px; font-weight: 500;';
     row.appendChild(badge);
   }
 
@@ -685,7 +749,12 @@ async function tplOpenFile(path) {
   try {
     const res = await fetch(`${tplApiBase()}/files/content?path=${encodeURIComponent(path)}`);
     if (res.status === 413) {
-      tplEditorShow(path, '', true, 'This file is larger than 512 KB and can’t be edited here. Use Reveal to open the template folder on disk.');
+      tplEditorShow(
+        path,
+        '',
+        true,
+        'This file is larger than 512 KB and can’t be edited here. Use Reveal to open the template folder on disk.'
+      );
       return;
     }
     const data = await res.json().catch(() => ({}));
@@ -804,7 +873,7 @@ function tplFileCreate(type) {
     label: 'Path (relative to the template)',
     confirm: 'Create',
     initial: '',
-    run: async (path) => {
+    run: async path => {
       if (!path) throw new Error('Please enter a path.');
       const result = await tplFetchJSON(`${tplApiBase()}/files`, {
         method: 'POST',
@@ -827,7 +896,7 @@ function tplFileRename() {
       label: 'New path (relative to the template)',
       confirm: 'Rename',
       initial: path,
-      run: async (to) => {
+      run: async to => {
         if (!to || to === path) return;
         const result = await tplFetchJSON(`${tplApiBase()}/files/rename`, {
           method: 'POST',
@@ -849,7 +918,9 @@ async function tplFileDelete() {
     return;
   }
   try {
-    await tplFetchJSON(`${tplApiBase()}/files?path=${encodeURIComponent(path)}`, { method: 'DELETE' });
+    await tplFetchJSON(`${tplApiBase()}/files?path=${encodeURIComponent(path)}`, {
+      method: 'DELETE'
+    });
     tplToast(`Deleted "${path}".`, 'success');
     tplClearDirty();
     tplFilesReset();
@@ -893,7 +964,12 @@ async function tplToolsLoad() {
   const declared = tplToolsDeclared();
   await Promise.all([
     tplToolsRenderSection('tplToolsSkills', '/api/skills', ['skills', 'items'], declared.skills),
-    tplToolsRenderSection('tplToolsMcp', '/api/mcp/servers', ['servers', 'items'], declared.mcp_servers),
+    tplToolsRenderSection(
+      'tplToolsMcp',
+      '/api/mcp/servers',
+      ['servers', 'items'],
+      declared.mcp_servers
+    ),
     tplToolsRenderSection('tplToolsPlugins', '/api/plugins', ['plugins', 'items'], declared.plugins)
   ]);
 }
@@ -911,7 +987,7 @@ async function tplToolsRenderSection(containerId, url, listKeys, declaredNames) 
     console.warn(`Failed to load ${url}:`, error);
   }
 
-  const declaredSet = new Set(declaredNames.map((n) => n.toLowerCase()));
+  const declaredSet = new Set(declaredNames.map(n => n.toLowerCase()));
   const seen = new Set();
   const rows = [];
   for (const name of installed) {
@@ -956,7 +1032,8 @@ function tplToolsRow(row) {
     const tag = document.createElement('span');
     tag.className = 'badge';
     tag.textContent = 'not installed';
-    tag.style.cssText = 'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 10px;';
+    tag.style.cssText =
+      'background: var(--bg-tertiary); color: var(--text-secondary); font-size: 10px;';
     label.appendChild(tag);
   }
   return label;
@@ -980,7 +1057,7 @@ function tplToolsCollect(containerId) {
   const container = tplEl(containerId);
   if (!container) return [];
   return Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
-    .map((cb) => cb.dataset.name)
+    .map(cb => cb.dataset.name)
     .filter(Boolean);
 }
 
@@ -1013,25 +1090,48 @@ async function tplToolsSave() {
 // with tplAgentsCollect() before any structural change (add/remove/reorder) so
 // in-progress input is never lost. The first card is the entry agent.
 
-const TPL_AGENT_ROLES = ['', 'orchestrator', 'specialist', 'researcher', 'analyzer', 'synthesizer', 'validator', 'general'];
+const TPL_AGENT_ROLES = [
+  '',
+  'orchestrator',
+  'specialist',
+  'researcher',
+  'analyzer',
+  'synthesizer',
+  'validator',
+  'general'
+];
 const TPL_AGENT_TYPES = ['', 'tool-calling', 'general', 'research'];
 
-const tplAgents = { templateId: '', dragIndex: -1, existingNames: [], existingLoaded: false, promptVars: [], promptVarsLoaded: false };
+const tplAgents = {
+  templateId: '',
+  dragIndex: -1,
+  existingNames: [],
+  existingLoaded: false,
+  promptVars: [],
+  promptVarsLoaded: false
+};
 
 function tplAgentsBlank() {
-  return { name: '', role: '', type: '', model: '', system_prompt: '', tools: { skills: [], mcp_servers: [] } };
+  return {
+    name: '',
+    role: '',
+    type: '',
+    model: '',
+    system_prompt: '',
+    tools: { skills: [], mcp_servers: [] }
+  };
 }
 
 function tplAgentsNormalizeList(agents) {
-  return (Array.isArray(agents) ? agents : []).map((a) => ({
+  return (Array.isArray(agents) ? agents : []).map(a => ({
     name: a.name || '',
     role: a.role || '',
     type: a.type || '',
     model: a.model || '',
     system_prompt: a.system_prompt || '',
     tools: {
-      skills: (a.tools && Array.isArray(a.tools.skills)) ? a.tools.skills : [],
-      mcp_servers: (a.tools && Array.isArray(a.tools.mcp_servers)) ? a.tools.mcp_servers : []
+      skills: a.tools && Array.isArray(a.tools.skills) ? a.tools.skills : [],
+      mcp_servers: a.tools && Array.isArray(a.tools.mcp_servers) ? a.tools.mcp_servers : []
     }
   }));
 }
@@ -1055,7 +1155,10 @@ function tplAgentsDisplayName(agent, index) {
 function tplAgentsInitials(name, index) {
   const cleaned = String(name || '').trim();
   const parts = cleaned.split(/\s+/).filter(Boolean);
-  const initials = parts.slice(0, 2).map((part) => part.charAt(0).toUpperCase()).join('');
+  const initials = parts
+    .slice(0, 2)
+    .map(part => part.charAt(0).toUpperCase())
+    .join('');
   return initials || String(index + 1).padStart(2, '0');
 }
 
@@ -1063,13 +1166,13 @@ function tplAgentsRoleLabel(agent, index) {
   if (index === 0) return 'Entry agent';
   const role = String(agent?.role || '').trim();
   if (!role) return 'Specialist';
-  return role.replace(/[_-]+/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+  return role.replace(/[_-]+/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase());
 }
 
 function tplAgentsTypeLabel(type) {
   const value = String(type || '').trim();
   if (!value) return 'Default type';
-  return value.replace(/[_-]+/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+  return value.replace(/[_-]+/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase());
 }
 
 function tplAgentsChip(text, kind = '') {
@@ -1082,12 +1185,14 @@ function tplAgentsChip(text, kind = '') {
 function tplAgentsChipList(values, emptyText, kind = '') {
   const list = document.createElement('div');
   list.className = 'tpl-agent-chip-list';
-  const items = (Array.isArray(values) ? values : []).map((item) => String(item || '').trim()).filter(Boolean);
+  const items = (Array.isArray(values) ? values : [])
+    .map(item => String(item || '').trim())
+    .filter(Boolean);
   if (items.length === 0) {
     list.appendChild(tplAgentsChip(emptyText, 'empty'));
     return list;
   }
-  items.slice(0, 3).forEach((item) => list.appendChild(tplAgentsChip(item, kind)));
+  items.slice(0, 3).forEach(item => list.appendChild(tplAgentsChip(item, kind)));
   if (items.length > 3) list.appendChild(tplAgentsChip(`+${items.length - 3}`, 'count'));
   return list;
 }
@@ -1113,7 +1218,7 @@ function tplAgentsCol(label, input) {
 function tplAgentsSelect(cls, values, selected) {
   const sel = document.createElement('select');
   sel.className = `modern-input w-100 ${cls}`;
-  values.forEach((v) => {
+  values.forEach(v => {
     const opt = document.createElement('option');
     opt.value = v;
     opt.textContent = v === '' ? 'Default' : v;
@@ -1144,7 +1249,7 @@ async function tplAgentsEnsureExistingNames() {
     const res = await fetch('/api/agents');
     const data = await res.json().catch(() => ({}));
     tplAgents.existingNames = Array.isArray(data.agents)
-      ? data.agents.map((a) => (a && typeof a === 'object' ? a.name : a)).filter(Boolean)
+      ? data.agents.map(a => (a && typeof a === 'object' ? a.name : a)).filter(Boolean)
       : [];
   } catch {
     tplAgents.existingNames = [];
@@ -1160,7 +1265,7 @@ function tplAgentsPopulateDatalist() {
     document.body.appendChild(dl);
   }
   dl.innerHTML = '';
-  (tplAgents.existingNames || []).forEach((name) => {
+  (tplAgents.existingNames || []).forEach(name => {
     const opt = document.createElement('option');
     opt.value = String(name);
     dl.appendChild(opt);
@@ -1168,9 +1273,11 @@ function tplAgentsPopulateDatalist() {
 }
 
 function tplAgentsNameMatchesExisting(value) {
-  const v = String(value || '').trim().toLowerCase();
+  const v = String(value || '')
+    .trim()
+    .toLowerCase();
   if (!v) return false;
-  return (tplAgents.existingNames || []).some((n) => String(n).toLowerCase() === v);
+  return (tplAgents.existingNames || []).some(n => String(n).toLowerCase() === v);
 }
 
 // tplAgentsEnsurePromptVars lazily loads the closed prompt-variable vocabulary
@@ -1192,8 +1299,12 @@ async function tplAgentsEnsurePromptVars() {
 // tplInsertAtCursor inserts text at the textarea's caret (or end), keeps focus,
 // and fires an input event so any dependent state updates.
 function tplInsertAtCursor(textarea, text) {
-  const start = Number.isInteger(textarea.selectionStart) ? textarea.selectionStart : textarea.value.length;
-  const end = Number.isInteger(textarea.selectionEnd) ? textarea.selectionEnd : textarea.value.length;
+  const start = Number.isInteger(textarea.selectionStart)
+    ? textarea.selectionStart
+    : textarea.value.length;
+  const end = Number.isInteger(textarea.selectionEnd)
+    ? textarea.selectionEnd
+    : textarea.value.length;
   textarea.value = textarea.value.slice(0, start) + text + textarea.value.slice(end);
   const pos = start + text.length;
   textarea.selectionStart = pos;
@@ -1234,9 +1345,9 @@ function tplAgentsPromptTools(textarea) {
   panel.hidden = true;
   wrap.appendChild(panel);
 
-  tplAgentsEnsurePromptVars().then((vars) => {
+  tplAgentsEnsurePromptVars().then(vars => {
     chips.innerHTML = '';
-    vars.forEach((v) => {
+    vars.forEach(v => {
       const chip = document.createElement('button');
       chip.type = 'button';
       chip.className = 'tpl-prompt-var-chip';
@@ -1254,7 +1365,7 @@ function tplAgentsPromptTools(textarea) {
       const res = await fetch('/api/prompt-variables/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: textarea.value }),
+        body: JSON.stringify({ prompt: textarea.value })
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
@@ -1281,8 +1392,8 @@ function tplAgentsCard(agent, index) {
   card.draggable = !readOnly;
 
   const displayName = tplAgentsDisplayName(agent, index);
-  const skills = (agent.tools && agent.tools.skills ? agent.tools.skills : []);
-  const mcpServers = (agent.tools && agent.tools.mcp_servers ? agent.tools.mcp_servers : []);
+  const skills = agent.tools && agent.tools.skills ? agent.tools.skills : [];
+  const mcpServers = agent.tools && agent.tools.mcp_servers ? agent.tools.mcp_servers : [];
 
   const header = document.createElement('div');
   header.className = 'tpl-agent-card-head';
@@ -1306,7 +1417,8 @@ function tplAgentsCard(agent, index) {
   identity.appendChild(name);
   const subtitle = document.createElement('div');
   subtitle.className = 'tpl-agent-subtitle';
-  subtitle.textContent = index === 0 ? 'Required workspace front door' : 'Seeded workspace specialist';
+  subtitle.textContent =
+    index === 0 ? 'Required workspace front door' : 'Seeded workspace specialist';
   identity.appendChild(subtitle);
   header.appendChild(identity);
 
@@ -1321,9 +1433,13 @@ function tplAgentsCard(agent, index) {
 
   const summary = document.createElement('div');
   summary.className = 'tpl-agent-summary';
-  summary.appendChild(tplAgentsChip(tplAgentsRoleLabel(agent, index), index === 0 ? 'entry' : 'role'));
+  summary.appendChild(
+    tplAgentsChip(tplAgentsRoleLabel(agent, index), index === 0 ? 'entry' : 'role')
+  );
   summary.appendChild(tplAgentsChip(tplAgentsTypeLabel(agent.type), 'type'));
-  summary.appendChild(tplAgentsChip(agent.model ? agent.model : 'Workspace model', agent.model ? 'model' : 'empty'));
+  summary.appendChild(
+    tplAgentsChip(agent.model ? agent.model : 'Workspace model', agent.model ? 'model' : 'empty')
+  );
   card.appendChild(summary);
 
   const promptPreview = document.createElement('p');
@@ -1363,12 +1479,20 @@ function tplAgentsCard(agent, index) {
 
     const form = document.createElement('div');
     form.className = 'tpl-agent-form';
-    const nameInput = tplAgentsInput('tpl-agent-name', agent.name, 'Agent name or pick an existing agent', 'tpl-existing-agents');
+    const nameInput = tplAgentsInput(
+      'tpl-agent-name',
+      agent.name,
+      'Agent name or pick an existing agent',
+      'tpl-existing-agents'
+    );
     const nameField = tplAgentsField('Name', nameInput);
     const reuseHint = document.createElement('div');
     reuseHint.className = 'tpl-agent-reuse-hint';
-    reuseHint.textContent = 'Matches an existing agent — its saved prompt, model, and tools will be reused.';
-    const syncReuseHint = () => { reuseHint.hidden = !tplAgentsNameMatchesExisting(nameInput.value); };
+    reuseHint.textContent =
+      'Matches an existing agent — its saved prompt, model, and tools will be reused.';
+    const syncReuseHint = () => {
+      reuseHint.hidden = !tplAgentsNameMatchesExisting(nameInput.value);
+    };
     nameInput.addEventListener('input', syncReuseHint);
     syncReuseHint();
     nameField.appendChild(reuseHint);
@@ -1376,41 +1500,57 @@ function tplAgentsCard(agent, index) {
 
     const rt = document.createElement('div');
     rt.className = 'tpl-agent-form-row';
-    rt.appendChild(tplAgentsCol('Role', tplAgentsSelect('tpl-agent-role', TPL_AGENT_ROLES, agent.role || '')));
-    rt.appendChild(tplAgentsCol('Type', tplAgentsSelect('tpl-agent-type', TPL_AGENT_TYPES, agent.type || '')));
+    rt.appendChild(
+      tplAgentsCol('Role', tplAgentsSelect('tpl-agent-role', TPL_AGENT_ROLES, agent.role || ''))
+    );
+    rt.appendChild(
+      tplAgentsCol('Type', tplAgentsSelect('tpl-agent-type', TPL_AGENT_TYPES, agent.type || ''))
+    );
     form.appendChild(rt);
 
-    form.appendChild(tplAgentsField('Model', tplAgentsInput('tpl-agent-model', agent.model, 'Defaults to the workspace model')));
+    form.appendChild(
+      tplAgentsField(
+        'Model',
+        tplAgentsInput('tpl-agent-model', agent.model, 'Defaults to the workspace model')
+      )
+    );
 
     const prompt = document.createElement('textarea');
     prompt.className = 'form-control tpl-agent-prompt';
     prompt.rows = 2;
     prompt.value = agent.system_prompt || '';
-    prompt.placeholder = "This agent's instructions. Use {{variables}} to weave in workspace context.";
+    prompt.placeholder =
+      "This agent's instructions. Use {{variables}} to weave in workspace context.";
     form.appendChild(tplAgentsField('System prompt', tplAgentsPromptTools(prompt)));
 
     const sm = document.createElement('div');
     sm.className = 'tpl-agent-form-row';
     const skillsVal = skills.join(', ');
     const mcpVal = mcpServers.join(', ');
-    sm.appendChild(tplAgentsCol('Skills', tplAgentsInput('tpl-agent-skills', skillsVal, 'comma-separated')));
-    sm.appendChild(tplAgentsCol('MCP servers', tplAgentsInput('tpl-agent-mcp', mcpVal, 'comma-separated')));
+    sm.appendChild(
+      tplAgentsCol('Skills', tplAgentsInput('tpl-agent-skills', skillsVal, 'comma-separated'))
+    );
+    sm.appendChild(
+      tplAgentsCol('MCP servers', tplAgentsInput('tpl-agent-mcp', mcpVal, 'comma-separated'))
+    );
     form.appendChild(sm);
     details.appendChild(form);
     card.appendChild(details);
   }
 
-  card.addEventListener('dragstart', (event) => {
+  card.addEventListener('dragstart', event => {
     if (readOnly) return;
     tplAgents.dragIndex = index;
     card.classList.add('is-dragging');
     if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
   });
-  card.addEventListener('dragend', () => { card.classList.remove('is-dragging'); });
-  card.addEventListener('dragover', (event) => {
+  card.addEventListener('dragend', () => {
+    card.classList.remove('is-dragging');
+  });
+  card.addEventListener('dragover', event => {
     if (!readOnly) event.preventDefault();
   });
-  card.addEventListener('drop', (event) => {
+  card.addEventListener('drop', event => {
     if (readOnly) return;
     event.preventDefault();
     tplAgentsReorder(tplAgents.dragIndex, index);
@@ -1426,7 +1566,7 @@ function tplAgentsRender(agents) {
   // Lazily load existing agent names so the roster name field can suggest /
   // flag reuse; re-syncs hints once names arrive.
   tplAgentsEnsureExistingNames().then(() => {
-    list.querySelectorAll('.tpl-agent-name').forEach((input) => {
+    list.querySelectorAll('.tpl-agent-name').forEach(input => {
       input.dispatchEvent(new Event('input'));
     });
   });
@@ -1438,13 +1578,16 @@ function tplAgentsRender(agents) {
 }
 
 function tplAgentsParseNames(value) {
-  return String(value || '').split(',').map((s) => s.trim()).filter(Boolean);
+  return String(value || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
 }
 
 function tplAgentsCollect() {
   const list = tplEl('tplAgentsList');
   if (!list) return [];
-  return Array.from(list.querySelectorAll('.tpl-agent-card')).map((card) => ({
+  return Array.from(list.querySelectorAll('.tpl-agent-card')).map(card => ({
     name: (card.querySelector('.tpl-agent-name')?.value || '').trim(),
     role: card.querySelector('.tpl-agent-role')?.value || '',
     type: card.querySelector('.tpl-agent-type')?.value || '',
@@ -1482,9 +1625,12 @@ function tplAgentsReorder(from, to) {
 async function tplAgentsSave() {
   const template = tplSelected();
   if (!template) return;
-  const agents = tplAgentsCollect().filter((a) => a.name);
+  const agents = tplAgentsCollect().filter(a => a.name);
   if (agents.length === 0) {
-    tplToast('A template needs at least one agent — the first is the workspace entry agent.', 'error');
+    tplToast(
+      'A template needs at least one agent — the first is the workspace entry agent.',
+      'error'
+    );
     return;
   }
   try {
@@ -1536,7 +1682,7 @@ function tplInit() {
   }
 
   tplEl('tplNameModalConfirm')?.addEventListener('click', () => void tplRunNameAction());
-  tplEl('tplNameModalInput')?.addEventListener('keydown', (event) => {
+  tplEl('tplNameModalInput')?.addEventListener('keydown', event => {
     if (event.key === 'Enter') {
       event.preventDefault();
       void tplRunNameAction();
@@ -1572,7 +1718,7 @@ function tplInit() {
   const filesTab = tplEl('tplTabFiles');
   if (filesTab) {
     filesTab.addEventListener('shown.bs.tab', () => tplFilesEnsureTree());
-    filesTab.addEventListener('hide.bs.tab', (event) => {
+    filesTab.addEventListener('hide.bs.tab', event => {
       if (!tplFiles.dirty) return;
       const target = event.relatedTarget;
       event.preventDefault();

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -333,6 +333,23 @@ export class WorkspaceCommandView {
     );
   }
 
+  projectOpenActionHTML() {
+    const page = this.page || {};
+    if (typeof page.hasProjectEntry !== 'function' || !page.hasProjectEntry()) return '';
+
+    const busy = page.projectOpenBusy === true;
+    return (
+      '<button type="button" class="ws-cmd-nav-btn" data-cmd-open-project ' +
+      'aria-label="Open project using the system default application" aria-busy="' +
+      (busy ? 'true' : 'false') +
+      '"' +
+      (busy ? ' disabled' : '') +
+      '>' +
+      (busy ? 'Opening Project...' : 'Open Project') +
+      '</button>'
+    );
+  }
+
   isGroupWorkspace() {
     const ws = (this.page && this.page.workspace) || {};
     return (
@@ -408,6 +425,7 @@ export class WorkspaceCommandView {
       '<a class="ws-cmd-nav-btn" href="' +
       escapeHtml(workflowHref) +
       '">Orchestration Skills</a>' +
+      this.projectOpenActionHTML() +
       this.commandViewSwitchHTML() +
       '</div>' +
       '<div class="ws-cmd-crest">' +
@@ -681,6 +699,14 @@ export class WorkspaceCommandView {
     if (!root) return;
 
     root.addEventListener('click', event => {
+      const openProjectBtn = event.target.closest('[data-cmd-open-project]');
+      if (openProjectBtn) {
+        const page = this.page || {};
+        if (!openProjectBtn.disabled && typeof page.openProject === 'function') {
+          void page.openProject();
+        }
+        return;
+      }
       const viewBtn = event.target.closest('[data-cmd-view-mode]');
       if (viewBtn) {
         this.setCommandViewMode(viewBtn.getAttribute('data-cmd-view-mode'), { focus: false });

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -302,6 +302,59 @@ test('command subtitle includes mission automation state when mission state is l
   }
 });
 
+test('project open command is conditional, path-free, and exposes its busy state', () => {
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    page: {
+      workspace: {
+        project_path: 'secret-project',
+        shared_data: { project_entry_path: 'private/song.rpp' }
+      },
+      hasProjectEntry: () => false,
+      projectOpenBusy: false
+    }
+  });
+
+  assert.equal(commandView.projectOpenActionHTML(), '');
+
+  commandView.page.hasProjectEntry = () => true;
+  const readyHTML = commandView.projectOpenActionHTML();
+  assert.match(readyHTML, /data-cmd-open-project/);
+  assert.match(readyHTML, />Open Project<\/button>/);
+  assert.match(readyHTML, /aria-label="Open project using the system default application"/);
+  assert.match(readyHTML, /aria-busy="false"/);
+  assert.doesNotMatch(readyHTML, /secret-project|private\/song\.rpp/);
+
+  commandView.page.projectOpenBusy = true;
+  const busyHTML = commandView.projectOpenActionHTML();
+  assert.match(busyHTML, /aria-busy="true"/);
+  assert.match(busyHTML, / disabled/);
+  assert.match(busyHTML, />Opening Project\.\.\.<\/button>/);
+});
+
+test('command bar delegates Open Project through the workspace detail action layer', () => {
+  const topbar = makeListenerRoot();
+  let openCount = 0;
+  const commandView = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(commandView, {
+    container: {
+      querySelector: selector => (selector === '.ws-cmd-topbar' ? topbar : null)
+    },
+    page: {
+      openProject() {
+        openCount += 1;
+      }
+    }
+  });
+
+  commandView.bindIdentityControls();
+  topbar.listener({
+    target: makeAttributeClickTarget({ 'data-cmd-open-project': 'true' })
+  });
+
+  assert.equal(openCount, 1);
+});
+
 test('mission panel renders loaded goal state and findings link', () => {
   const originalWindow = globalThis.window;
   globalThis.window = {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -309,6 +309,7 @@ export class WorkspaceDetailPage {
     this.setupNotesPanelVaultDrop();
     this.setupPageDragAndDrop();
     await this.loadWorkspace();
+    this.consumeProjectOpenFailureNotice();
     await this.loadAgentCatalog();
     await this.loadWorkspaceAgentSnapshots();
     await Promise.all([
@@ -338,6 +339,44 @@ export class WorkspaceDetailPage {
     if (!restoredBlockedTask) {
       await this.maybeStartTemplateSetup();
     }
+  }
+
+  projectOpenNoticeStorageKey() {
+    return `oriProjectOpenNotice:${String(this.workspaceId || '').trim()}`;
+  }
+
+  consumeProjectOpenFailureNotice() {
+    let raw = '';
+    try {
+      raw = window.sessionStorage?.getItem(this.projectOpenNoticeStorageKey()) || '';
+      if (raw) {
+        window.sessionStorage?.removeItem(this.projectOpenNoticeStorageKey());
+      }
+    } catch (error) {
+      console.warn('Failed to read project-open notice:', error);
+      return false;
+    }
+    if (!raw) return false;
+
+    let message = 'Workspace created, but the project could not be opened. Use Open Project to try again.';
+    try {
+      const notice = JSON.parse(raw);
+      if (notice?.workspace_id && String(notice.workspace_id) !== String(this.workspaceId)) {
+        return false;
+      }
+      if (typeof notice?.message === 'string' && notice.message.trim()) {
+        message = notice.message.trim();
+      }
+    } catch (error) {
+      console.warn('Failed to parse project-open notice:', error);
+    }
+
+    if (window.Toast?.warning) {
+      window.Toast.warning(message, { title: 'Project not opened', duration: 8000 });
+    } else if (typeof window.notifyToast === 'function') {
+      window.notifyToast(message, 'warning');
+    }
+    return true;
   }
 
   ensureScrollablePanelAccessibility() {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -288,6 +288,7 @@ export class WorkspaceDetailPage {
     this.projectTemplates = [];
     this.projectTemplatesRoot = '';
     this.projectTemplateSubmitting = false;
+    this.projectOpenBusy = false;
     this.workspaceTagDraft = [];
     this.workspaceTagsSaving = false;
 
@@ -14388,6 +14389,45 @@ export class WorkspaceDetailPage {
 
   workspaceHasProject() {
     return this.getWorkspaceProjectPath() !== '';
+  }
+
+  hasProjectEntry() {
+    const entryPath = this.workspace?.shared_data?.project_entry_path;
+    return (
+      this.workspaceHasProject() && typeof entryPath === 'string' && entryPath.trim() !== ''
+    );
+  }
+
+  async openProject() {
+    if (this.projectOpenBusy || !this.hasProjectEntry()) return false;
+
+    this.projectOpenBusy = true;
+    window.workspaceCommand?.refresh();
+    try {
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(this.workspaceId)}/project/open`,
+        { method: 'POST' }
+      );
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(result.error || result.message || 'The project open request failed');
+      }
+
+      if (window.Toast?.success) {
+        window.Toast.success('Open request sent to the system default application');
+      }
+      return true;
+    } catch (error) {
+      console.error('Failed to open workspace project:', error);
+      const detail = error?.message || 'The project open request failed';
+      if (window.Toast?.error) {
+        window.Toast.error(`Could not open project. ${detail}. Resolve the issue and try again.`);
+      }
+      return false;
+    } finally {
+      this.projectOpenBusy = false;
+      window.workspaceCommand?.refresh();
+    }
   }
 
   getProjectDirectoryId() {

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -99,6 +99,128 @@ test('workspace detail consumes a scoped project-open failure notice once', () =
   assert.equal(warnings[0].options.title, 'Project not opened');
 });
 
+test('workspace detail detects project entries only from complete persisted metadata', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  const cases = [
+    [{}, false],
+    [{ project_path: 'song' }, false],
+    [{ project_path: 'song', shared_data: {} }, false],
+    [{ project_path: 'song', shared_data: { project_entry_path: 42 } }, false],
+    [{ project_path: 'song', shared_data: { project_entry_path: '   ' } }, false],
+    [{ project_path: '', shared_data: { project_entry_path: 'song.rpp' } }, false],
+    [
+      { project_path: 'song', shared_data: { project_entry_path: 'song.rpp' } },
+      true
+    ]
+  ];
+
+  for (const [workspace, expected] of cases) {
+    page.workspace = workspace;
+    assert.equal(page.hasProjectEntry(), expected);
+  }
+});
+
+test('workspace detail sends a bodyless project-open request and reports success', async () => {
+  const page = new WorkspaceDetailPage('workspace / one');
+  page.workspace = {
+    project_path: 'song',
+    shared_data: { project_entry_path: 'secret/song.rpp' }
+  };
+
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+  const requests = [];
+  const successes = [];
+  let refreshCount = 0;
+  global.window = {
+    ...originalWindow,
+    Toast: { success: message => successes.push(message), error() {} },
+    workspaceCommand: { refresh: () => (refreshCount += 1) }
+  };
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url: String(url), options });
+    return {
+      ok: true,
+      json: async () => ({ message: 'Project open request accepted' })
+    };
+  };
+
+  try {
+    assert.equal(await page.openProject(), true);
+  } finally {
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+  }
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, '/api/workspaces/workspace%20%2F%20one/project/open');
+  assert.deepEqual(requests[0].options, { method: 'POST' });
+  assert.equal(Object.hasOwn(requests[0].options, 'body'), false);
+  assert.equal(requests[0].url.includes('secret'), false);
+  assert.equal(refreshCount, 2);
+  assert.equal(page.projectOpenBusy, false);
+  assert.match(successes[0], /system default application/);
+});
+
+test('workspace detail prevents duplicate project-open requests and remains retryable', async () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    project_path: 'song',
+    shared_data: { project_entry_path: 'song.rpp' }
+  };
+
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+  const originalConsoleError = console.error;
+  const errors = [];
+  const successes = [];
+  let refreshCount = 0;
+  let requestCount = 0;
+  let releaseFirst;
+  const firstResponse = new Promise(resolve => {
+    releaseFirst = resolve;
+  });
+  global.window = {
+    ...originalWindow,
+    Toast: {
+      success: message => successes.push(message),
+      error: message => errors.push(message)
+    },
+    workspaceCommand: { refresh: () => (refreshCount += 1) }
+  };
+  console.error = () => {};
+  global.fetch = async () => {
+    requestCount += 1;
+    if (requestCount === 1) return firstResponse;
+    return { ok: true, json: async () => ({}) };
+  };
+
+  try {
+    const firstOpen = page.openProject();
+    assert.equal(page.projectOpenBusy, true);
+    assert.equal(await page.openProject(), false);
+    assert.equal(requestCount, 1);
+
+    releaseFirst({
+      ok: false,
+      json: async () => ({ error: 'Project entry file was not found' })
+    });
+    assert.equal(await firstOpen, false);
+    assert.equal(page.projectOpenBusy, false);
+    assert.equal(await page.openProject(), true);
+  } finally {
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+    console.error = originalConsoleError;
+  }
+
+  assert.equal(requestCount, 2);
+  assert.equal(refreshCount, 4);
+  assert.match(errors[0], /Project entry file was not found/);
+  assert.match(errors[0], /try again/);
+  assert.equal(successes.length, 1);
+});
+
 test('workspace detail renders reference URL task indicators', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   const indicator = page.renderTaskReferenceURLIndicator({

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -62,6 +62,43 @@ test('workspace detail activateWorkspaceConfigTab clicks the requested tab', () 
   assert.equal(mcpTab.clickCount, 1);
 });
 
+test('workspace detail consumes a scoped project-open failure notice once', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  const storage = new Map([
+    [
+      'oriProjectOpenNotice:workspace-1',
+      JSON.stringify({
+        workspace_id: 'workspace-1',
+        message: 'Workspace created, but the project could not be opened. Use Open Project to try again.'
+      })
+    ]
+  ]);
+  const warnings = [];
+  const previousWindow = global.window;
+  global.window = {
+    ...previousWindow,
+    sessionStorage: {
+      getItem: key => storage.get(key) || null,
+      removeItem: key => storage.delete(key)
+    },
+    Toast: {
+      warning: (message, options) => warnings.push({ message, options })
+    }
+  };
+
+  try {
+    assert.equal(page.consumeProjectOpenFailureNotice(), true);
+    assert.equal(page.consumeProjectOpenFailureNotice(), false);
+  } finally {
+    global.window = previousWindow;
+  }
+
+  assert.equal(storage.has('oriProjectOpenNotice:workspace-1'), false);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0].message, /Use Open Project to try again/);
+  assert.equal(warnings[0].options.title, 'Project not opened');
+});
+
 test('workspace detail renders reference URL task indicators', () => {
   const page = new WorkspaceDetailPage('workspace-1');
   const indicator = page.renderTaskReferenceURLIndicator({

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -27,6 +27,16 @@
               Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
             </div>
 
+            <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
+              <label class="d-flex align-items-start gap-2 mb-0" for="projectTemplateOpenAfterCreateToggle" style="cursor: pointer;">
+                <input type="checkbox" id="projectTemplateOpenAfterCreateToggle" class="form-check-input mt-1">
+                <span>
+                  <span class="workspace-setup-title d-block">Open project after creation</span>
+                  <span class="workspace-setup-help d-block">Uses your system's default app for this file type.</span>
+                </span>
+              </label>
+            </div>
+
             <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
               <div class="workspace-template-agent-review-head">
                 <div>

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -145,6 +145,18 @@
                       </div>
                     </div>
                     <div class="mb-3">
+                      <label for="tplEditProjectEntryPath" class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Project entry file</label>
+                      <input id="tplEditProjectEntryPath" type="text" class="modern-input w-100" placeholder="{{`{{name}}`}}.rpp" autocomplete="off" aria-describedby="tplEditProjectEntryHelp">
+                      <div id="tplEditProjectEntryHelp" style="margin-top: 6px; font-size: 11px; color: var(--text-secondary);">
+                        Relative to the generated project folder. It must name a scaffolded file and may use only
+                        <code>{{`{{name}}`}}</code> or <code>{{`{{date}}`}}</code> in file names. Leave blank to remove it.
+                      </div>
+                      <label class="d-flex align-items-center gap-2 mt-2 mb-0" style="font-size: 12px; color: var(--text-secondary); cursor: pointer;">
+                        <input id="tplEditProjectEntryDefault" type="checkbox" class="form-check-input mt-0">
+                        <span>Open project after creation by default</span>
+                      </label>
+                    </div>
+                    <div class="mb-3">
                       <label class="form-label" style="color: var(--text-secondary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;">Tags</label>
                       <div id="tplEditTags"></div>
                     </div>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -88,6 +88,8 @@ func TestRenderTemplatesPage(t *testing.T) {
 		`id="tplDirtyModal"`,
 		`id="tplStarterTasksList"`,
 		`id="tplStarterTaskAddBtn"`,
+		`id="tplEditProjectEntryPath"`,
+		`id="tplEditProjectEntryDefault"`,
 		`id="tplToolsSkills"`,
 		`id="tplToolsMcp"`,
 		`id="tplToolsPlugins"`,

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -107,6 +107,28 @@ func TestRenderTemplatesPage(t *testing.T) {
 	}
 }
 
+func TestRenderCreateWorkspaceProjectOpenOption(t *testing.T) {
+	r := NewTemplateRenderer()
+	if err := r.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+
+	html, err := r.RenderTemplate("workspaces", TemplateData{Title: "Workspaces - Ori Agent"})
+	if err != nil {
+		t.Fatalf("RenderTemplate(workspaces) failed: %v", err)
+	}
+	for _, want := range []string{
+		`id="projectTemplateOpenAfterCreate"`,
+		`id="projectTemplateOpenAfterCreateToggle"`,
+		`Open project after creation`,
+		`Uses your system's default app for this file type.`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered Create Workspace modal missing %q", want)
+		}
+	}
+}
+
 func TestRenderAgentsDetailDefaultsSidebarHidden(t *testing.T) {
 	r := NewTemplateRenderer()
 	if err := r.LoadTemplates(); err != nil {

--- a/internal/workspace/http_handlers.go
+++ b/internal/workspace/http_handlers.go
@@ -54,6 +54,24 @@ func NewHTTPHandler(store Store, orchestrator *Orchestrator, eventBus *EventBus)
 	return handler
 }
 
+// SetFolderStore wires the canonical folder-backed workspace store used by
+// desktop side-effect handlers. Production wraps the primary workspace store
+// with decorators that do not necessarily expose optional folder capabilities,
+// so the FileStore must be injected explicitly rather than inferred only from
+// the outer Store value.
+func (h *HTTPHandler) SetFolderStore(store *FileStore) {
+	if h == nil {
+		return
+	}
+	if store == nil {
+		h.folderResolver = nil
+		h.folderWorkspaceResolver = nil
+		return
+	}
+	h.folderResolver = store
+	h.folderWorkspaceResolver = store
+}
+
 // SetScheduler wires the task scheduler so mission HTTP endpoints can fire
 // mission runs through the same MissionTrigger configured for cadence runs.
 func (h *HTTPHandler) SetScheduler(scheduler *TaskScheduler) {

--- a/internal/workspace/http_handlers.go
+++ b/internal/workspace/http_handlers.go
@@ -14,14 +14,22 @@ import (
 	"github.com/johnjallday/ori-agent/internal/platform"
 )
 
+// folderWorkspaceResolver loads the canonical workspace.json record for a
+// workspace. It is deliberately separate from Store.Get because production
+// may use a SQLite-primary SyncStore whose row is only a best-effort mirror.
+type folderWorkspaceResolver interface {
+	GetFolderWorkspace(workspaceID string) (*Workspace, error)
+}
+
 // HTTPHandler handles HTTP requests for Agent Workspaces
 type HTTPHandler struct {
-	store          Store
-	orchestrator   *Orchestrator
-	eventBus       *EventBus
-	emailAccounts  emailAccountStore
-	folderResolver FolderResolver
-	openFile       func(string) error
+	store                   Store
+	orchestrator            *Orchestrator
+	eventBus                *EventBus
+	emailAccounts           emailAccountStore
+	folderResolver          FolderResolver
+	folderWorkspaceResolver folderWorkspaceResolver
+	openFile                func(string) error
 	// scheduler is the TaskScheduler that owns the MissionTrigger reference.
 	// Mission-related HTTP endpoints route through it so they share the same
 	// trigger configuration as cadence-driven runs. Optional — handlers
@@ -39,6 +47,9 @@ func NewHTTPHandler(store Store, orchestrator *Orchestrator, eventBus *EventBus)
 	}
 	if resolver, ok := store.(FolderResolver); ok {
 		handler.folderResolver = resolver
+	}
+	if resolver, ok := store.(folderWorkspaceResolver); ok {
+		handler.folderWorkspaceResolver = resolver
 	}
 	return handler
 }

--- a/internal/workspace/http_handlers.go
+++ b/internal/workspace/http_handlers.go
@@ -11,14 +11,17 @@ import (
 	"github.com/google/uuid"
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/platform"
 )
 
 // HTTPHandler handles HTTP requests for Agent Workspaces
 type HTTPHandler struct {
-	store         Store
-	orchestrator  *Orchestrator
-	eventBus      *EventBus
-	emailAccounts emailAccountStore
+	store          Store
+	orchestrator   *Orchestrator
+	eventBus       *EventBus
+	emailAccounts  emailAccountStore
+	folderResolver FolderResolver
+	openFile       func(string) error
 	// scheduler is the TaskScheduler that owns the MissionTrigger reference.
 	// Mission-related HTTP endpoints route through it so they share the same
 	// trigger configuration as cadence-driven runs. Optional — handlers
@@ -28,11 +31,16 @@ type HTTPHandler struct {
 
 // NewHTTPHandler creates a new HTTP handler
 func NewHTTPHandler(store Store, orchestrator *Orchestrator, eventBus *EventBus) *HTTPHandler {
-	return &HTTPHandler{
+	handler := &HTTPHandler{
 		store:        store,
 		orchestrator: orchestrator,
 		eventBus:     eventBus,
+		openFile:     platform.OpenFile,
 	}
+	if resolver, ok := store.(FolderResolver); ok {
+		handler.folderResolver = resolver
+	}
+	return handler
 }
 
 // SetScheduler wires the task scheduler so mission HTTP endpoints can fire

--- a/internal/workspace/http_handlers_project_open.go
+++ b/internal/workspace/http_handlers_project_open.go
@@ -39,7 +39,11 @@ func (h *HTTPHandler) OpenWorkspaceProject(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	ws, err := h.store.Get(workspaceID)
+	if h.folderResolver == nil || h.folderWorkspaceResolver == nil {
+		orihttp.ServiceUnavailable(w, "Workspace folder storage is unavailable")
+		return
+	}
+	ws, err := h.folderWorkspaceResolver.GetFolderWorkspace(workspaceID)
 	if err != nil {
 		orihttp.NotFound(w, fmt.Sprintf("Workspace not found: %v", err))
 		return
@@ -63,11 +67,6 @@ func (h *HTTPHandler) OpenWorkspaceProject(w http.ResponseWriter, r *http.Reques
 		orihttp.NotFound(w, "Workspace has no project entry to open")
 		return
 	}
-	if h.folderResolver == nil {
-		orihttp.ServiceUnavailable(w, "Workspace folder storage is unavailable")
-		return
-	}
-
 	workspaceRoot, err := h.folderResolver.GetFolderPath(workspaceID)
 	if err != nil {
 		orihttp.NotFound(w, fmt.Sprintf("Workspace folder is unavailable: %v", err))

--- a/internal/workspace/http_handlers_project_open.go
+++ b/internal/workspace/http_handlers_project_open.go
@@ -1,0 +1,229 @@
+package workspace
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+)
+
+var errProjectEntryTargetMissing = errors.New("project entry target is missing")
+
+// OpenWorkspaceProject handles POST /api/workspaces/:id/project/open.
+//
+// The endpoint accepts no path. It opens only the entry already persisted in
+// workspace.json and is restricted to local peers because it causes a desktop
+// side effect on the server machine.
+func (h *HTTPHandler) OpenWorkspaceProject(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	if !projectOpenRequestIsLoopback(r) {
+		orihttp.Forbidden(w, "Opening a desktop project requires a local request")
+		return
+	}
+	if requestBodyHasContent(r) {
+		orihttp.BadRequest(w, "Project open does not accept a request body or file path")
+		return
+	}
+
+	workspaceID, ok := workspaceIDFromWorkspacePath(w, r)
+	if !ok {
+		return
+	}
+	ws, err := h.store.Get(workspaceID)
+	if err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace not found: %v", err))
+		return
+	}
+
+	projectPath, err := validatePersistedProjectPath(ws.ProjectPath)
+	if err != nil {
+		if strings.TrimSpace(ws.ProjectPath) == "" {
+			orihttp.NotFound(w, "Workspace has no project to open")
+		} else {
+			orihttp.BadRequest(w, fmt.Sprintf("Workspace project metadata is invalid: %v", err))
+		}
+		return
+	}
+	entryPath, err := GetProjectEntryPath(ws.SharedData)
+	if err != nil {
+		orihttp.BadRequest(w, fmt.Sprintf("Workspace project entry metadata is invalid: %v", err))
+		return
+	}
+	if entryPath == "" {
+		orihttp.NotFound(w, "Workspace has no project entry to open")
+		return
+	}
+	if h.folderResolver == nil {
+		orihttp.ServiceUnavailable(w, "Workspace folder storage is unavailable")
+		return
+	}
+
+	workspaceRoot, err := h.folderResolver.GetFolderPath(workspaceID)
+	if err != nil {
+		orihttp.NotFound(w, fmt.Sprintf("Workspace folder is unavailable: %v", err))
+		return
+	}
+	target, err := verifiedProjectEntryTarget(workspaceRoot, projectPath, entryPath)
+	if err != nil {
+		if errors.Is(err, errProjectEntryTargetMissing) {
+			orihttp.NotFound(w, "Project entry file was not found")
+		} else {
+			orihttp.BadRequest(w, fmt.Sprintf("Project entry cannot be opened safely: %v", err))
+		}
+		return
+	}
+	if h.openFile == nil {
+		orihttp.ServiceUnavailable(w, "Operating-system file opening is unavailable")
+		return
+	}
+	if err := h.openFile(target); err != nil {
+		orihttp.InternalError(w, fmt.Sprintf("Failed to open project entry: %v", err))
+		return
+	}
+
+	logger.Info("Opened workspace project entry via OS", logger.Fields{
+		"workspace_id": workspaceID,
+		"project_path": projectPath,
+		"entry_path":   entryPath,
+	})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"message":   "Project open request accepted",
+		"workspace": workspaceID,
+		"path":      entryPath,
+	})
+}
+
+func requestBodyHasContent(r *http.Request) bool {
+	if r.Body == nil || r.Body == http.NoBody {
+		return false
+	}
+	data, err := io.ReadAll(io.LimitReader(r.Body, 1025))
+	if err != nil {
+		return true
+	}
+	return len(bytes.TrimSpace(data)) > 0
+}
+
+func projectOpenRequestIsLoopback(r *http.Request) bool {
+	peer, ok := parseProjectOpenIP(r.RemoteAddr)
+	if !ok || !peer.IsLoopback() {
+		return false
+	}
+
+	for _, header := range []string{"X-Forwarded-For", "X-Real-IP"} {
+		for _, value := range r.Header.Values(header) {
+			for _, candidate := range strings.Split(value, ",") {
+				ip, ok := parseProjectOpenIP(candidate)
+				if !ok || !ip.IsLoopback() {
+					return false
+				}
+			}
+		}
+	}
+	for _, forwarded := range r.Header.Values("Forwarded") {
+		for _, element := range strings.Split(forwarded, ",") {
+			for _, directive := range strings.Split(element, ";") {
+				key, value, found := strings.Cut(strings.TrimSpace(directive), "=")
+				if !found || !strings.EqualFold(key, "for") {
+					continue
+				}
+				ip, ok := parseProjectOpenIP(strings.Trim(value, `"`))
+				if !ok || !ip.IsLoopback() {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func parseProjectOpenIP(value string) (net.IP, bool) {
+	value = strings.TrimSpace(strings.Trim(value, `"`))
+	if value == "" || strings.EqualFold(value, "unknown") || strings.HasPrefix(value, "_") {
+		return nil, false
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	}
+	value = strings.TrimPrefix(strings.TrimSuffix(value, "]"), "[")
+	ip := net.ParseIP(value)
+	return ip, ip != nil
+}
+
+func validatePersistedProjectPath(value string) (string, error) {
+	return validateResolvedProjectEntryPath(value)
+}
+
+func verifiedProjectEntryTarget(workspaceRoot, projectPath, entryPath string) (string, error) {
+	root, err := filepath.Abs(filepath.Clean(workspaceRoot))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve workspace root: %w", err)
+	}
+	rootInfo, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errProjectEntryTargetMissing
+		}
+		return "", fmt.Errorf("failed to inspect workspace root: %w", err)
+	}
+	if !rootInfo.IsDir() {
+		return "", fmt.Errorf("workspace root is not a directory")
+	}
+
+	projectRoot, err := inspectProjectRelativePath(root, projectPath, true)
+	if err != nil {
+		return "", err
+	}
+	target, err := inspectProjectRelativePath(projectRoot, entryPath, false)
+	if err != nil {
+		return "", err
+	}
+	if !pathWithinRootAfterSymlinks(projectRoot, root) ||
+		!pathWithinRootAfterSymlinks(target, projectRoot) {
+		return "", fmt.Errorf("resolved path escapes the workspace project")
+	}
+	return target, nil
+}
+
+func inspectProjectRelativePath(root, portablePath string, wantDirectory bool) (string, error) {
+	current := filepath.Clean(root)
+	segments := strings.Split(portablePath, "/")
+	for index, segment := range segments {
+		current = filepath.Join(current, filepath.FromSlash(segment))
+		if !isPathWithin(current, root) || current == root {
+			return "", fmt.Errorf("path escapes its allowed root")
+		}
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", errProjectEntryTargetMissing
+			}
+			return "", fmt.Errorf("failed to inspect path: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("path contains a symlink")
+		}
+		last := index == len(segments)-1
+		if !last && !info.IsDir() {
+			return "", fmt.Errorf("path has a non-directory parent")
+		}
+		if last && wantDirectory && !info.IsDir() {
+			return "", fmt.Errorf("project_path is not a directory")
+		}
+		if last && !wantDirectory && !info.Mode().IsRegular() {
+			return "", fmt.Errorf("project entry is not a regular file")
+		}
+	}
+	return current, nil
+}

--- a/internal/workspace/http_handlers_project_open.go
+++ b/internal/workspace/http_handlers_project_open.go
@@ -202,7 +202,10 @@ func inspectProjectRelativePath(root, portablePath string, wantDirectory bool) (
 		if !isPathWithin(current, root) || current == root {
 			return "", fmt.Errorf("path escapes its allowed root")
 		}
-		info, err := os.Lstat(current)
+		// current is built segment-by-segment from root and re-checked with
+		// isPathWithin on every iteration, and symlinks are rejected below, so
+		// the path cannot escape the workspace root. // #nosec G304
+		info, err := os.Lstat(current) // #nosec G304
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "", errProjectEntryTargetMissing

--- a/internal/workspace/http_handlers_project_open.go
+++ b/internal/workspace/http_handlers_project_open.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -108,11 +107,11 @@ func requestBodyHasContent(r *http.Request) bool {
 	if r.Body == nil || r.Body == http.NoBody {
 		return false
 	}
-	data, err := io.ReadAll(io.LimitReader(r.Body, 1025))
+	data, err := io.ReadAll(io.LimitReader(r.Body, 1))
 	if err != nil {
 		return true
 	}
-	return len(bytes.TrimSpace(data)) > 0
+	return len(data) > 0
 }
 
 func projectOpenRequestIsLoopback(r *http.Request) bool {

--- a/internal/workspace/http_handlers_project_open_test.go
+++ b/internal/workspace/http_handlers_project_open_test.go
@@ -1,0 +1,294 @@
+package workspace
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func setupProjectOpenTest(t *testing.T) (*FileStore, *Workspace, *HTTPHandler, string) {
+	t.Helper()
+	store, ws, handler := newFolderHandlerTest(t, "ws-project-open", "Project Open")
+	workspaceRoot, err := store.GetFolderPath(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectRoot := filepath.Join(workspaceRoot, "song")
+	if err := os.MkdirAll(projectRoot, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	entryPath := filepath.Join(projectRoot, "song.rpp")
+	if err := os.WriteFile(entryPath, []byte("project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(ws.ID, func(stored *Workspace) error {
+		stored.ProjectPath = "song"
+		if stored.SharedData == nil {
+			stored.SharedData = make(map[string]any)
+		}
+		return SetProjectEntryPath(stored.SharedData, "song.rpp")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return store, ws, handler, entryPath
+}
+
+func localProjectOpenRequest(method, workspaceID string, body *bytes.Reader) *http.Request {
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(method, "/api/workspaces/"+workspaceID+"/project/open", nil)
+	} else {
+		req = httptest.NewRequest(method, "/api/workspaces/"+workspaceID+"/project/open", body)
+	}
+	req.RemoteAddr = "127.0.0.1:43210"
+	return req
+}
+
+func TestOpenWorkspaceProjectUsesPersistedEntry(t *testing.T) {
+	_, ws, handler, wantPath := setupProjectOpenTest(t)
+	var opened string
+	handler.openFile = func(path string) error {
+		opened = path
+		return nil
+	}
+
+	req := localProjectOpenRequest(http.MethodPost, ws.ID, nil)
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if filepath.Clean(opened) != filepath.Clean(wantPath) {
+		t.Fatalf("opener path = %q, want %q", opened, wantPath)
+	}
+	if !strings.Contains(rr.Body.String(), `"path":"song.rpp"`) {
+		t.Fatalf("response missing portable path: %s", rr.Body.String())
+	}
+}
+
+func TestOpenWorkspaceProjectAllowsIPv6Loopback(t *testing.T) {
+	_, ws, handler, _ := setupProjectOpenTest(t)
+	called := false
+	handler.openFile = func(string) error { called = true; return nil }
+	req := localProjectOpenRequest(http.MethodPost, ws.ID, nil)
+	req.RemoteAddr = "[::1]:43210"
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, req)
+	if rr.Code != http.StatusOK || !called {
+		t.Fatalf("IPv6 loopback expected 200/call, got %d called=%v: %s", rr.Code, called, rr.Body.String())
+	}
+}
+
+func TestOpenWorkspaceProjectRejectsMethodAndBody(t *testing.T) {
+	_, ws, handler, _ := setupProjectOpenTest(t)
+	called := false
+	handler.openFile = func(string) error { called = true; return nil }
+
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodGet, ws.ID, nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET expected 405, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, bytes.NewReader([]byte(`{"path":"outside.rpp"}`))))
+	if rr.Code != http.StatusBadRequest || called {
+		t.Fatalf("caller path expected 400/no open, got %d called=%v: %s", rr.Code, called, rr.Body.String())
+	}
+}
+
+func TestOpenWorkspaceProjectRejectsRemotePeersAndForwarding(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+	}{
+		{name: "remote ipv4", remoteAddr: "192.168.1.44:1234"},
+		{name: "remote ipv6", remoteAddr: "[2001:db8::44]:1234"},
+		{name: "spoofed loopback forwarding", remoteAddr: "192.168.1.44:1234", headers: map[string]string{"X-Forwarded-For": "127.0.0.1"}},
+		{name: "proxy remote xff", remoteAddr: "127.0.0.1:1234", headers: map[string]string{"X-Forwarded-For": "203.0.113.5"}},
+		{name: "proxy remote real ip", remoteAddr: "127.0.0.1:1234", headers: map[string]string{"X-Real-IP": "203.0.113.5"}},
+		{name: "proxy remote forwarded", remoteAddr: "127.0.0.1:1234", headers: map[string]string{"Forwarded": "for=203.0.113.5;proto=https"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ws, handler, _ := setupProjectOpenTest(t)
+			called := false
+			handler.openFile = func(string) error { called = true; return nil }
+			req := localProjectOpenRequest(http.MethodPost, ws.ID, nil)
+			req.RemoteAddr = tt.remoteAddr
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+			rr := httptest.NewRecorder()
+			handler.OpenWorkspaceProject(rr, req)
+			if rr.Code != http.StatusForbidden || called {
+				t.Fatalf("expected 403/no open, got %d called=%v: %s", rr.Code, called, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestOpenWorkspaceProjectRejectsMissingAndMalformedMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Workspace)
+		status int
+	}{
+		{name: "no project", mutate: func(ws *Workspace) { ws.ProjectPath = "" }, status: http.StatusNotFound},
+		{name: "project traversal", mutate: func(ws *Workspace) { ws.ProjectPath = "../outside" }, status: http.StatusBadRequest},
+		{name: "no entry", mutate: func(ws *Workspace) { ClearProjectEntryPath(ws.SharedData) }, status: http.StatusNotFound},
+		{name: "entry traversal", mutate: func(ws *Workspace) { ws.SharedData[ProjectEntryPathKey] = "../outside.rpp" }, status: http.StatusBadRequest},
+		{name: "entry absolute", mutate: func(ws *Workspace) { ws.SharedData[ProjectEntryPathKey] = "/tmp/outside.rpp" }, status: http.StatusBadRequest},
+		{name: "entry wrong type", mutate: func(ws *Workspace) { ws.SharedData[ProjectEntryPathKey] = 123 }, status: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, ws, handler, _ := setupProjectOpenTest(t)
+			if err := store.Update(ws.ID, func(stored *Workspace) error { tt.mutate(stored); return nil }); err != nil {
+				t.Fatal(err)
+			}
+			called := false
+			handler.openFile = func(string) error { called = true; return nil }
+			rr := httptest.NewRecorder()
+			handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, nil))
+			if rr.Code != tt.status || called {
+				t.Fatalf("expected %d/no open, got %d called=%v: %s", tt.status, rr.Code, called, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestOpenWorkspaceProjectRejectsUnsafeFilesystemTargets(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, store *FileStore, ws *Workspace, entryPath string)
+		status int
+	}{
+		{name: "missing file", status: http.StatusNotFound, mutate: func(t *testing.T, _ *FileStore, _ *Workspace, entryPath string) {
+			if err := os.Remove(entryPath); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "entry is directory", status: http.StatusBadRequest, mutate: func(t *testing.T, _ *FileStore, _ *Workspace, entryPath string) {
+			if err := os.Remove(entryPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(entryPath, 0o750); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+	if runtime.GOOS != "windows" {
+		tests = append(tests,
+			struct {
+				name   string
+				mutate func(*testing.T, *FileStore, *Workspace, string)
+				status int
+			}{name: "entry symlink", status: http.StatusBadRequest, mutate: func(t *testing.T, _ *FileStore, _ *Workspace, entryPath string) {
+				outside := filepath.Join(t.TempDir(), "outside.rpp")
+				if err := os.WriteFile(outside, []byte("outside"), 0o640); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(entryPath); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, entryPath); err != nil {
+					t.Fatal(err)
+				}
+			}},
+			struct {
+				name   string
+				mutate func(*testing.T, *FileStore, *Workspace, string)
+				status int
+			}{name: "project symlink", status: http.StatusBadRequest, mutate: func(t *testing.T, _ *FileStore, _ *Workspace, entryPath string) {
+				projectRoot := filepath.Dir(entryPath)
+				outside := t.TempDir()
+				if err := os.WriteFile(filepath.Join(outside, "song.rpp"), []byte("outside"), 0o640); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.RemoveAll(projectRoot); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, projectRoot); err != nil {
+					t.Fatal(err)
+				}
+			}},
+			struct {
+				name   string
+				mutate func(*testing.T, *FileStore, *Workspace, string)
+				status int
+			}{name: "parent symlink", status: http.StatusBadRequest, mutate: func(t *testing.T, store *FileStore, ws *Workspace, entryPath string) {
+				outside := t.TempDir()
+				if err := os.WriteFile(filepath.Join(outside, "song.rpp"), []byte("outside"), 0o640); err != nil {
+					t.Fatal(err)
+				}
+				link := filepath.Join(filepath.Dir(entryPath), "linked")
+				if err := os.Symlink(outside, link); err != nil {
+					t.Fatal(err)
+				}
+				if err := store.Update(ws.ID, func(stored *Workspace) error {
+					stored.SharedData[ProjectEntryPathKey] = "linked/song.rpp"
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}},
+		)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, ws, handler, entryPath := setupProjectOpenTest(t)
+			tt.mutate(t, store, ws, entryPath)
+			called := false
+			handler.openFile = func(string) error { called = true; return nil }
+			rr := httptest.NewRecorder()
+			handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, nil))
+			if rr.Code != tt.status || called {
+				t.Fatalf("expected %d/no open, got %d called=%v: %s", tt.status, rr.Code, called, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestOpenWorkspaceProjectOpenerFailureDoesNotMutateWorkspace(t *testing.T) {
+	store, ws, handler, _ := setupProjectOpenTest(t)
+	handler.openFile = func(string) error { return errors.New("no file association") }
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, nil))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+	stored, err := store.Get(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ProjectPath != "song" || stored.SharedData[ProjectEntryPathKey] != "song.rpp" {
+		t.Fatalf("opener failure mutated workspace: %+v", stored)
+	}
+}
+
+func TestOpenWorkspaceProjectRequiresFolderResolver(t *testing.T) {
+	store := NewInMemoryStore()
+	ws := newTestWorkspace("ws-no-folder-resolver", "No Resolver")
+	ws.ProjectPath = "song"
+	ws.SharedData[ProjectEntryPathKey] = "song.rpp"
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHTTPHandler(store, nil, nil)
+	handler.openFile = func(string) error { t.Fatal("opener must not be called"); return nil }
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/workspace/http_handlers_project_open_test.go
+++ b/internal/workspace/http_handlers_project_open_test.go
@@ -97,10 +97,19 @@ func TestOpenWorkspaceProjectRejectsMethodAndBody(t *testing.T) {
 		t.Fatalf("GET expected 405, got %d", rr.Code)
 	}
 
-	rr = httptest.NewRecorder()
-	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, bytes.NewReader([]byte(`{"path":"outside.rpp"}`))))
-	if rr.Code != http.StatusBadRequest || called {
-		t.Fatalf("caller path expected 400/no open, got %d called=%v: %s", rr.Code, called, rr.Body.String())
+	for name, body := range map[string][]byte{
+		"caller path": []byte(`{"path":"outside.rpp"}`),
+		"whitespace":  []byte(" \n\t"),
+		"padded path": append(bytes.Repeat([]byte(" "), 2048), []byte(`{"path":"outside.rpp"}`)...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			called = false
+			rr = httptest.NewRecorder()
+			handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, ws.ID, bytes.NewReader(body)))
+			if rr.Code != http.StatusBadRequest || called {
+				t.Fatalf("body expected 400/no open, got %d called=%v: %s", rr.Code, called, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/workspace/http_handlers_project_open_test.go
+++ b/internal/workspace/http_handlers_project_open_test.go
@@ -73,6 +73,54 @@ func TestOpenWorkspaceProjectUsesPersistedEntry(t *testing.T) {
 	}
 }
 
+func TestOpenWorkspaceProjectReadsCanonicalFolderMetadata(t *testing.T) {
+	primary := NewInMemoryStore()
+	fileStore, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fileStore.Close() })
+
+	primaryWS := newTestWorkspace("ws-canonical-project-open", "Canonical Project Open")
+	primaryWS.ProjectPath = "stale-project"
+	primaryWS.SharedData[ProjectEntryPathKey] = "stale.rpp"
+	if err := primary.Save(primaryWS); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalWS := newTestWorkspace(primaryWS.ID, primaryWS.Name)
+	canonicalWS.ProjectPath = "song"
+	canonicalWS.SharedData[ProjectEntryPathKey] = "song.rpp"
+	if err := fileStore.Save(canonicalWS); err != nil {
+		t.Fatal(err)
+	}
+	workspaceRoot, err := fileStore.GetFolderPath(canonicalWS.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectRoot := filepath.Join(workspaceRoot, "song")
+	if err := os.MkdirAll(projectRoot, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(projectRoot, "song.rpp")
+	if err := os.WriteFile(wantPath, []byte("project"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewHTTPHandler(NewSyncStore(primary, fileStore), nil, nil)
+	var opened string
+	handler.openFile = func(path string) error { opened = path; return nil }
+	rr := httptest.NewRecorder()
+	handler.OpenWorkspaceProject(rr, localProjectOpenRequest(http.MethodPost, canonicalWS.ID, nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected canonical metadata open to return 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if filepath.Clean(opened) != filepath.Clean(wantPath) {
+		t.Fatalf("opened %q from stale mirror, want canonical %q", opened, wantPath)
+	}
+}
+
 func TestOpenWorkspaceProjectAllowsIPv6Loopback(t *testing.T) {
 	_, ws, handler, _ := setupProjectOpenTest(t)
 	called := false

--- a/internal/workspace/project_entry_metadata.go
+++ b/internal/workspace/project_entry_metadata.go
@@ -1,0 +1,88 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ProjectEntryPathKey is the stable shared_data key containing a resolved,
+// portable entry path relative to Workspace.ProjectPath.
+const ProjectEntryPathKey = "project_entry_path"
+
+// ErrInvalidProjectEntryPath reports malformed persisted entry metadata.
+var ErrInvalidProjectEntryPath = errors.New("invalid project entry path")
+
+// SetProjectEntryPath validates and stores a resolved portable entry path. An
+// empty value clears the key.
+func SetProjectEntryPath(sharedData map[string]any, relativePath string) error {
+	relativePath = strings.TrimSpace(relativePath)
+	if relativePath == "" {
+		ClearProjectEntryPath(sharedData)
+		return nil
+	}
+	if sharedData == nil {
+		return fmt.Errorf("%w: workspace shared_data is unavailable", ErrInvalidProjectEntryPath)
+	}
+	clean, err := validateResolvedProjectEntryPath(relativePath)
+	if err != nil {
+		return err
+	}
+	sharedData[ProjectEntryPathKey] = clean
+	return nil
+}
+
+// GetProjectEntryPath returns a validated path. A missing key is not an error;
+// malformed or wrongly typed stored data is rejected.
+func GetProjectEntryPath(sharedData map[string]any) (string, error) {
+	if sharedData == nil {
+		return "", nil
+	}
+	raw, ok := sharedData[ProjectEntryPathKey]
+	if !ok || raw == nil {
+		return "", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: stored %s must be a string", ErrInvalidProjectEntryPath, ProjectEntryPathKey)
+	}
+	return validateResolvedProjectEntryPath(value)
+}
+
+// ClearProjectEntryPath removes persisted entry metadata.
+func ClearProjectEntryPath(sharedData map[string]any) {
+	if sharedData != nil {
+		delete(sharedData, ProjectEntryPathKey)
+	}
+}
+
+func validateResolvedProjectEntryPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%w: path is empty", ErrInvalidProjectEntryPath)
+	}
+	if strings.ContainsRune(value, '\x00') || strings.Contains(value, `\`) {
+		return "", fmt.Errorf("%w: path must use portable forward-slash segments", ErrInvalidProjectEntryPath)
+	}
+	if path.IsAbs(value) || strings.HasPrefix(value, "//") || hasPortableWindowsVolumePrefix(value) {
+		return "", fmt.Errorf("%w: path must be relative", ErrInvalidProjectEntryPath)
+	}
+	if strings.Contains(value, "{{") || strings.Contains(value, "}}") {
+		return "", fmt.Errorf("%w: resolved path cannot contain template tokens", ErrInvalidProjectEntryPath)
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "." || segment == ".." {
+			return "", fmt.Errorf("%w: path cannot contain traversal segments", ErrInvalidProjectEntryPath)
+		}
+	}
+	clean := path.Clean(value)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("%w: path escapes its project", ErrInvalidProjectEntryPath)
+	}
+	return clean, nil
+}
+
+func hasPortableWindowsVolumePrefix(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
+}

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -587,6 +587,12 @@ func (s *FileStore) BasePath() string {
 	return s.basePath
 }
 
+// GetFolderWorkspace explicitly identifies FileStore.Get as a canonical
+// workspace.json read for handlers that must not trust a session-store mirror.
+func (s *FileStore) GetFolderWorkspace(id string) (*Workspace, error) {
+	return s.Get(id)
+}
+
 // Get retrieves a workspace by ID, reading the full record (including chat history
 // and tasks) from disk. The in-memory cache holds metadata only (item 2.0), so Get
 // reads through to disk for the complete workspace rather than serving heavy fields

--- a/internal/workspace/sync_store.go
+++ b/internal/workspace/sync_store.go
@@ -56,6 +56,18 @@ func (s *SyncStore) GetFolderWorkspace(workspaceID string) (*Workspace, error) {
 // the disk sync is best-effort.
 func (s *SyncStore) Save(ws *Workspace) error {
 	if s.fileSync != nil && ws != nil && ws.Status != StatusTrashed && ws.Status != StatusMissing {
+		// ProjectPath is canonical in workspace.json and is not represented by
+		// the SQLite workspace table. A workspace fetched before project
+		// instantiation (or fetched from SQLite afterward) can therefore carry an
+		// empty value and must not erase a project path that was written directly
+		// to the folder store. There is no generic "empty means clear" operation
+		// through SyncStore; an intentional project removal must update the
+		// canonical FileStore explicitly.
+		if ws.ProjectPath == "" {
+			if diskWorkspace, err := s.fileSync.Get(ws.ID); err == nil && diskWorkspace != nil {
+				ws.ProjectPath = diskWorkspace.ProjectPath
+			}
+		}
 		if err := s.fileSync.Save(ws); err != nil {
 			logger.Warn("Failed to sync workspace to disk", logger.Fields{
 				"workspace_id": ws.ID,

--- a/internal/workspace/sync_store.go
+++ b/internal/workspace/sync_store.go
@@ -36,6 +36,15 @@ func (s *SyncStore) GetFolderPath(workspaceID string) (string, error) {
 	return s.fileSync.GetFolderPath(workspaceID)
 }
 
+// GetFolderWorkspace reads the canonical workspace.json record rather than
+// the SQLite-primary mirror returned by Get.
+func (s *SyncStore) GetFolderWorkspace(workspaceID string) (*Workspace, error) {
+	if s.fileSync == nil {
+		return nil, fmt.Errorf("workspace folder storage is unavailable")
+	}
+	return s.fileSync.Get(workspaceID)
+}
+
 // Save persists the workspace.
 //
 // The FileStore runs first because it owns the monotonic Version counter and

--- a/internal/workspace/sync_store.go
+++ b/internal/workspace/sync_store.go
@@ -1,6 +1,8 @@
 package workspace
 
 import (
+	"fmt"
+
 	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/logger"
 )
@@ -23,6 +25,15 @@ func NewSyncStore(primary Store, fileSync *FileStore) *SyncStore {
 // FileStore returns the underlying FileStore used for disk sync.
 func (s *SyncStore) FileStore() *FileStore {
 	return s.fileSync
+}
+
+// GetFolderPath exposes the canonical disk folder when SyncStore is used by a
+// runtime handler that needs workspace-root containment rather than files/.
+func (s *SyncStore) GetFolderPath(workspaceID string) (string, error) {
+	if s.fileSync == nil {
+		return "", fmt.Errorf("workspace folder storage is unavailable")
+	}
+	return s.fileSync.GetFolderPath(workspaceID)
 }
 
 // Save persists the workspace.

--- a/internal/workspace/sync_store_test.go
+++ b/internal/workspace/sync_store_test.go
@@ -118,6 +118,60 @@ func TestSyncStore_SaveUpdatesWorkspaceJSON(t *testing.T) {
 	}
 }
 
+func TestSyncStore_SavePreservesCanonicalProjectPathFromStalePrimaryWorkspace(t *testing.T) {
+	primary := NewInMemoryStore()
+	fileSync, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = fileSync.Close() }()
+
+	store := NewSyncStore(primary, fileSync)
+	ws := newTestWorkspace("ws-project-path-sync", "Project Path Sync")
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reproduce Create Workspace: orchestration can retain a SQLite-backed
+	// workspace fetched before the template handler writes project_path directly
+	// to canonical workspace.json.
+	staleWorkspace, err := primary.Get(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalWorkspace, err := fileSync.Get(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalWorkspace.ProjectPath = "song"
+	if err := SetProjectEntryPath(canonicalWorkspace.SharedData, "song.rpp"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fileSync.Save(canonicalWorkspace); err != nil {
+		t.Fatal(err)
+	}
+
+	staleWorkspace.SharedData[ProjectEntryPathKey] = "song.rpp"
+	staleWorkspace.Tasks = append(staleWorkspace.Tasks, Task{ID: "setup-task", Status: TaskStatusCompleted})
+	if err := store.Save(staleWorkspace); err != nil {
+		t.Fatal(err)
+	}
+
+	diskWorkspace, err := fileSync.Get(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diskWorkspace.ProjectPath != "song" {
+		t.Fatalf("canonical project_path = %q, want song", diskWorkspace.ProjectPath)
+	}
+	if diskWorkspace.SharedData[ProjectEntryPathKey] != "song.rpp" {
+		t.Fatalf("canonical project entry = %v, want song.rpp", diskWorkspace.SharedData[ProjectEntryPathKey])
+	}
+	if len(diskWorkspace.Tasks) != 1 || diskWorkspace.Tasks[0].ID != "setup-task" {
+		t.Fatalf("task update was not written through: %+v", diskWorkspace.Tasks)
+	}
+}
+
 func TestSyncStore_SaveSkipsDiskForTrashedWorkspace(t *testing.T) {
 	primary := NewInMemoryStore()
 	dir := t.TempDir()

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -218,6 +218,30 @@ test('project-open option follows template defaults and resets for non-library f
   await expect(toggle).not.toBeChecked();
 });
 
+test('live Reaper Song defaults to launch, supports keyboard opt-out, and never opens on reload', async ({ page }) => {
+  let openCalls = 0;
+  await page.route('**/api/workspaces/**/project/open', async route => {
+    openCalls += 1;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
+  await openCreateModal(page);
+  await cardByLabel(page, 'Reaper Song').click();
+
+  const panel = page.locator('#projectTemplateOpenAfterCreate');
+  const toggle = page.locator('#projectTemplateOpenAfterCreateToggle');
+  await expect(panel).toBeVisible();
+  await expect(toggle).toBeChecked();
+
+  await toggle.focus();
+  await page.keyboard.press('Space');
+  await expect(toggle).not.toBeChecked();
+  await expect(toggle).toBeFocused();
+
+  await page.reload();
+  await expect.poll(() => openCalls).toBe(0);
+});
+
 test('checked project-open option posts exactly once after create and before navigation', async ({ page }) => {
   await routeProjectEntryTemplates(page);
   await openCreateModal(page);

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -35,6 +35,56 @@ function cardByLabel(page: Page, label: string) {
     .filter({ has: page.locator('.workspace-template-card-label', { hasText: new RegExp(`^${label}$`) }) });
 }
 
+async function routeProjectEntryTemplates(page: Page) {
+  await page.route('**/api/project-templates', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        templates_root: '/tmp/templates',
+        templates: [
+          { id: 'research-project', name: 'Research Project', builtin: true, behavior_profile: 'research' },
+          { id: 'travels', name: 'Travels', builtin: true, behavior_profile: 'general' },
+          { id: 'content-production', name: 'Content Production', builtin: true, behavior_profile: 'general' },
+          {
+            id: 'auto-project',
+            name: 'Auto Project',
+            description: 'Template with automatic project opening.',
+            builtin: true,
+            behavior_profile: 'general',
+            project_entry: { relative_path: '{{name}}.rpp', open_after_create_default: true }
+          },
+          {
+            id: 'manual-project',
+            name: 'Manual Project',
+            description: 'Template with optional project opening.',
+            builtin: true,
+            behavior_profile: 'general',
+            project_entry: { relative_path: '{{name}}.rpp', open_after_create_default: false }
+          },
+          { id: 'no-entry', name: 'No Entry', builtin: true, behavior_profile: 'general' }
+        ]
+      })
+    });
+  });
+  await page.route('**/api/workspaces/template-agent-plan', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ has_agents: false, agents: [], warnings: [] })
+    });
+  });
+}
+
+async function stubWorkspaceReview(page: Page) {
+  await page.evaluate(() => {
+    const w = window as unknown as { WorkspaceBootstrapReview?: Record<string, unknown> };
+    const r = (w.WorkspaceBootstrapReview = w.WorkspaceBootstrapReview || {});
+    r.ensureReviewed = async () => ({ ready: true });
+    r.applyPlan = async () => ({ invitedAgents: 0, boundMCPs: 0, attachedSkills: 0, addedPlugins: 0, failures: [] });
+  });
+}
+
 test.beforeEach(async ({ page }) => {
   // Skip the first-run onboarding server-side so its modal (a static-backdrop
   // overlay that animates in) can't intercept create-modal clicks.
@@ -111,6 +161,147 @@ test('switching starting points updates auto-filled name, but never typed input'
   await expect(name).toHaveValue('Travels');
   await cardByLabel(page, 'Blank').click();
   await expect(name).toHaveValue('');
+});
+
+test('project-open option follows template defaults and resets for non-library flows', async ({ page }) => {
+  await routeProjectEntryTemplates(page);
+  await openCreateModal(page);
+
+  const panel = page.locator('#projectTemplateOpenAfterCreate');
+  const toggle = page.locator('#projectTemplateOpenAfterCreateToggle');
+  await expect(panel).toBeHidden();
+  await expect(toggle).not.toBeChecked();
+
+  await cardByLabel(page, 'Auto Project').click();
+  await expect(panel).toBeVisible();
+  await expect(toggle).toBeChecked();
+
+  await toggle.uncheck();
+  await cardByLabel(page, 'Manual Project').click();
+  await expect(panel).toBeVisible();
+  await expect(toggle).not.toBeChecked();
+  await toggle.check();
+
+  // Every template change reapplies that template's own default.
+  await cardByLabel(page, 'Auto Project').click();
+  await expect(toggle).toBeChecked();
+  await cardByLabel(page, 'Manual Project').click();
+  await expect(toggle).not.toBeChecked();
+
+  await cardByLabel(page, 'No Entry').click();
+  await expect(panel).toBeHidden();
+  await expect(toggle).not.toBeChecked();
+
+  // An ad-hoc path overrides the selected library template and clears launch.
+  await cardByLabel(page, 'Auto Project').click();
+  await page.locator('#folderAdvancedDisclosure .workspace-advanced-summary').click();
+  await page.locator('#projectTemplatePathInput').fill('/tmp/ad-hoc-template');
+  await expect(panel).toBeHidden();
+  await expect(toggle).not.toBeChecked();
+
+  // Import mode never carries a launch choice.
+  await page.evaluate(() => {
+    (window as unknown as { sessionManager: { setImportModeEnabled: (enabled: boolean) => void } })
+      .sessionManager.setImportModeEnabled(true);
+  });
+  await expect(panel).toBeHidden();
+  await expect(toggle).not.toBeChecked();
+
+  await page.evaluate(() => {
+    const el = document.getElementById('addFolderModal');
+    // @ts-expect-error bootstrap is a page global
+    window.bootstrap.Modal.getInstance(el)?.hide();
+  });
+  await expect(page.locator('#addFolderModal')).toBeHidden();
+  await openCreateModal(page);
+  await expect(panel).toBeHidden();
+  await expect(toggle).not.toBeChecked();
+});
+
+test('checked project-open option posts exactly once after create and before navigation', async ({ page }) => {
+  await routeProjectEntryTemplates(page);
+  await openCreateModal(page);
+  await stubWorkspaceReview(page);
+
+  const calls: string[] = [];
+  await page.route('**/api/workspaces/created-open/project/open', async route => {
+    calls.push('open');
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ message: 'ok' }) });
+  });
+  await page.route('**/api/workspaces', async route => {
+    calls.push('create');
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ folder: { id: 'created-open' }, seeded_starter_tasks: 0 })
+    });
+  });
+
+  await cardByLabel(page, 'Auto Project').click();
+  await expect(page.locator('#projectTemplateOpenAfterCreateToggle')).toBeChecked();
+  await page.locator('#createFolderBtn').click();
+  await page.waitForURL('**/workspaces/created-open');
+
+  await expect.poll(() => calls).toEqual(['create', 'open']);
+});
+
+test('unchecked project-open option creates and navigates without an open request', async ({ page }) => {
+  await routeProjectEntryTemplates(page);
+  await openCreateModal(page);
+  await stubWorkspaceReview(page);
+
+  let openCalls = 0;
+  await page.route('**/api/workspaces/created-closed/project/open', async route => {
+    openCalls += 1;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  await page.route('**/api/workspaces', async route => {
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ folder: { id: 'created-closed' }, seeded_starter_tasks: 0 })
+    });
+  });
+
+  await cardByLabel(page, 'Manual Project').click();
+  await expect(page.locator('#projectTemplateOpenAfterCreateToggle')).not.toBeChecked();
+  await page.locator('#createFolderBtn').click();
+  await page.waitForURL('**/workspaces/created-closed');
+  await expect.poll(() => openCalls).toBe(0);
+});
+
+test('project-open failure still navigates and shows a one-time retry notice', async ({ page }) => {
+  await routeProjectEntryTemplates(page);
+  await openCreateModal(page);
+  await stubWorkspaceReview(page);
+
+  let openCalls = 0;
+  await page.route('**/api/workspaces/created-failure/project/open', async route => {
+    openCalls += 1;
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'No default app is available.' })
+    });
+  });
+  await page.route('**/api/workspaces', async route => {
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ folder: { id: 'created-failure' }, seeded_starter_tasks: 0 })
+    });
+  });
+
+  await cardByLabel(page, 'Auto Project').click();
+  await page.locator('#createFolderBtn').click();
+  await page.waitForURL('**/workspaces/created-failure');
+  const retryNotice = page.locator('.toast-message', { hasText: 'Use Open Project to try again' });
+  await expect(retryNotice).toHaveCount(1);
+  await expect.poll(() => openCalls).toBe(1);
+
+  await page.reload();
+  await expect(retryNotice).toHaveCount(0);
+  await expect.poll(() => openCalls).toBe(1);
 });
 
 test('createFolder submits workspace_preset for create and import', async ({ page }) => {

--- a/tests/workspace-detail.a11y.spec.js
+++ b/tests/workspace-detail.a11y.spec.js
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test';
 
 for (const theme of ['light', 'dark']) {
   test(`workspace detail accessibility (${theme})`, async ({ page }) => {
-    const baseUrl = process.env.BASE_URL || 'http://localhost:8765';
+    const baseUrl =
+      process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://localhost:8765';
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await page.addInitScript(selectedTheme => {
       window.localStorage.setItem('ori-theme', selectedTheme);
@@ -30,10 +31,35 @@ for (const theme of ['light', 'dark']) {
     )?.id;
     expect(workspaceId).toBeTruthy();
 
+    const workspaceActivated = page.waitForResponse(response =>
+      response.url().includes('/api/orchestration/workspace/activate?id=')
+    );
     await page.goto(`${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}`, {
       waitUntil: 'domcontentloaded'
     });
     await expect(page.locator('#workspaceCommandView .ws-cmd-title h2')).toBeVisible();
+    await workspaceActivated;
+    await page.evaluate(() => {
+      window.workspaceDetail.workspace.project_path = '';
+      window.workspaceDetail.workspace.shared_data = {};
+      window.workspaceCommand.refresh();
+    });
+    await expect(page.locator('[data-cmd-open-project]')).toHaveCount(0);
+
+    await page.evaluate(() => {
+      window.workspaceDetail.workspace.project_path = 'accessibility-project';
+      window.workspaceDetail.workspace.shared_data = { project_entry_path: 'project.rpp' };
+      window.workspaceCommand.refresh();
+    });
+    const openProject = page.getByRole('button', {
+      name: 'Open project using the system default application'
+    });
+    await expect(openProject).toBeVisible();
+    await expect(openProject).toHaveAttribute('aria-busy', 'false');
+    await page.getByRole('button', { name: 'Map' }).click();
+    await expect(openProject).toBeVisible();
+    await page.getByRole('button', { name: 'Details' }).click();
+    await expect(openProject).toBeVisible();
     await page.locator('#workspaceCommandView').evaluate(async root => {
       const finiteAnimations = root
         .getAnimations({ subtree: true })


### PR DESCRIPTION
## Motivation

Project templates can scaffold an authoritative project file, but users currently have to find and open it manually. This adds a generic, declarative project-entry contract so templates can offer one explicit OS-default launch after Create Workspace and a durable retry action without binding Ori to REAPER or any executable.

## Summary

- Add validated `project_entry` manifest metadata and authoring controls, preserving false defaults and unknown fields.
- Resolve scaffold tokens once, verify the generated file, and persist portable `shared_data.project_entry_path` metadata through UI, API, and chat creation paths.
- Add a loopback-only, bodyless fixed-target open endpoint that reads canonical `workspace.json`, rejects symlinks and containment escapes, and uses the injected system file opener.
- Add the conditional Create Workspace option, non-fatal one-time recovery notice, and persistent accessible Open Project command with busy, success, error, and retry states.
- Configure Reaper Song to default-open `{{name}}.rpp`, refresh existing built-ins, and keep its setup task truthful about REAPER and Web Remote readiness.
- Document the schema, API, persistence, security behavior, and non-goals.

## Security notes

- Browsers never supply a file path; the endpoint accepts no request-body bytes.
- Direct peers must be IPv4 or IPv6 loopback, and forwarding headers cannot elevate a remote client.
- Project and entry metadata come from canonical disk state and are revalidated at open time.
- Every filesystem component is checked for containment, regular-file type, and symlinks before launch.

## Validation

- `go test ./internal/projecttemplates ./internal/sessionhttp ./internal/chathttp ./internal/workspace ./internal/server ./internal/web`
- `go test ./internal/workspace ./internal/server`
- `go vet ./internal/workspace ./internal/server`
- `OPENAI_API_KEY= go test -short ./...`
- `npm run lint`
- `npm run test:modules` (562 passed)
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:32123 npx playwright test tests/create-workspace-behavior.spec.ts tests/workspace-detail.a11y.spec.js` (10 passed; opener calls intercepted)
- `make test` reached all packages; the only failure was the live `internal/llm` OpenAI integration returning `429 insufficient_quota`.
- `npm run format:check` remains blocked by the existing repository baseline of 189 unformatted files.

## UI evidence

The targeted rendered-browser run covers the live Reaper true default, keyboard opt-out, checked and unchecked creation paths, exact-one open ordering, non-fatal failure messaging, one-time notice consumption, no reload launch, both command modes, and light/dark accessibility with no real desktop application opened.