### PR TITLE
fix(workspace): clear gosec G703 path-traversal taint alert

### DIFF
--- a/internal/workspace/http_handlers_project_open.go
+++ b/internal/workspace/http_handlers_project_open.go
@@ -204,8 +204,8 @@ func inspectProjectRelativePath(root, portablePath string, wantDirectory bool) (
 		}
 		// current is built segment-by-segment from root and re-checked with
 		// isPathWithin on every iteration, and symlinks are rejected below, so
-		// the path cannot escape the workspace root. // #nosec G304
-		info, err := os.Lstat(current) // #nosec G304
+		// the path cannot escape the workspace root.
+		info, err := os.Lstat(current) // #nosec G304 G703
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "", errProjectEntryTargetMissing


### PR DESCRIPTION
## What

Adds `G703` to the existing `#nosec` directive on the `os.Lstat` call in `inspectProjectRelativePath` (`internal/workspace/http_handlers_project_open.go`).

## Why

PR #192 merged with only a `#nosec G304` directive. gosec's newer **taint analyzer (rule G703)**, surfaced via GitHub Advanced Security, is a separate rule from classic `G304`, so the code-scanning alert persists on `dev`.

The flagged path is built and re-validated **segment-by-segment** against the workspace root (`isPathWithin` on every iteration) and rejects symlinks, so it cannot escape — the finding is a false positive. This is the same `#nosec G304 G703` pattern already used elsewhere in the package (`memory.go`, `workspace_directories.go`).

## Verification

- `go build ./internal/workspace/` passes
- Confirmed locally with `gosec@master` that the taint finding on this file clears (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)