### PR TITLE
feat: REAPER workspace integration

### DIFF
--- a/internal/pluginhttp/handlers.go
+++ b/internal/pluginhttp/handlers.go
@@ -34,6 +34,12 @@ func newHandlerWithManager(mgr *plugin.Manager) *Handler {
 	return &Handler{mgr: mgr}
 }
 
+// Manager returns the underlying plugin manager so other subsystems (template
+// application, REAPER readiness, repair) inspect installed plugins and reconcile
+// workspace bindings through the same configured store the Plugins API uses,
+// rather than a separate hard-coded plugins/ lookup.
+func (h *Handler) Manager() *plugin.Manager { return h.mgr }
+
 // ListHandler handles GET /api/plugins.
 func (h *Handler) ListHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/pluginworkspace/reconciler.go
+++ b/internal/pluginworkspace/reconciler.go
@@ -282,6 +282,83 @@ func (r *Reconciler) Reconcile(req Request) (Result, error) {
 	return res, nil
 }
 
+// Inspect reports each requested plugin's state (missing / disabled / detached /
+// attached) and which recorded components are attached vs. missing, without
+// mutating the workspace or plugin store. Readiness uses it to describe state
+// truthfully; it never enables a plugin or writes bindings.
+func (r *Reconciler) Inspect(workspaceID string, plugins []string) ([]PluginResult, error) {
+	if r.store == nil {
+		return nil, nil
+	}
+	ws, err := r.store.Get(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if ws == nil {
+		return nil, nil
+	}
+	installed := map[string]plugin.InstalledPlugin{}
+	if r.plugins != nil {
+		list, err := r.plugins.List()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range list {
+			installed[strings.ToLower(strings.TrimSpace(p.Name))] = p
+		}
+	}
+	boundSkills := map[string]bool{}
+	for _, b := range ws.GetSkillBindings() {
+		boundSkills[strings.ToLower(strings.TrimSpace(b.SkillName))] = true
+	}
+	boundMCP := map[string]bool{}
+	for _, b := range ws.GetMCPBindings() {
+		boundMCP[strings.ToLower(strings.TrimSpace(b.ServerName))] = true
+	}
+
+	out := make([]PluginResult, 0, len(plugins))
+	for _, name := range plugins {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		pr := PluginResult{Name: name}
+		p, ok := installed[strings.ToLower(name)]
+		if !ok {
+			pr.State = PluginStateMissing
+			out = append(out, pr)
+			continue
+		}
+		pr.Installed = true
+		pr.Enabled = p.Enabled
+		pr.Components = componentsOf(p)
+		for _, c := range pr.Components {
+			bound := false
+			switch c.Kind {
+			case ComponentSkill:
+				bound = boundSkills[strings.ToLower(c.Name)]
+			case ComponentMCP:
+				bound = boundMCP[strings.ToLower(c.Name)]
+			}
+			if bound {
+				pr.Attached = append(pr.Attached, c)
+			} else {
+				pr.Missing = append(pr.Missing, c)
+			}
+		}
+		switch {
+		case !p.Enabled:
+			pr.State = PluginStateDisabled
+		case len(pr.Missing) == 0:
+			pr.State = PluginStateAttached
+		default:
+			pr.State = PluginStateDetached
+		}
+		out = append(out, pr)
+	}
+	return out, nil
+}
+
 // aggregate fills the Result-level Applied and Warnings from per-plugin results.
 func (res *Result) aggregate() {
 	for _, pr := range res.Plugins {

--- a/internal/pluginworkspace/reconciler.go
+++ b/internal/pluginworkspace/reconciler.go
@@ -1,0 +1,328 @@
+// Package pluginworkspace centralizes the one idempotent path that binds an
+// installed plugin's recorded components (skills + MCP servers) onto a workspace.
+//
+// Before this package, three paths inferred and mutated workspace plugin state
+// independently and disagreed:
+//
+//   - Template application (internal/server/template_tools.go) read installed
+//     plugins from a hard-coded plugins/ store, ignored the plugin's Enabled
+//     flag, and bound components directly. A globally-disabled plugin could end
+//     up "In this workspace" and "Globally disabled" at once.
+//   - The Plugins tab (internal/web/static/js/modules/workspace-detail-plugins.js)
+//     decided "attached" purely from workspace skill/MCP bindings, so an
+//     agent-level REAPER skill made the plugin look detached.
+//   - Manual "Add to workspace" and (new) repair need to optionally enable a
+//     disabled plugin, but only after explicit confirmation.
+//
+// Reconcile is that single service. It reads installed-plugin state through the
+// configured plugin Manager/store used by the Plugins API (not a test-only or
+// hard-coded registry), and writes bindings through the synchronized workspace
+// store so attachment is immediately visible on the read path and survives
+// restart. Binding is case-normalized and idempotent: repeating it never
+// duplicates a binding and never disturbs unrelated bindings. Save failures are
+// reported without leaving a contradictory "applied" success state.
+package pluginworkspace
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// PluginManager is the read/enable surface the reconciler needs from the
+// configured plugin manager (satisfied by *plugin.Manager).
+type PluginManager interface {
+	List() ([]plugin.InstalledPlugin, error)
+	SetEnabled(name string, enabled bool) error
+}
+
+// WorkspaceStore is the workspace read/write surface (satisfied by the SyncStore
+// via workspace.Store).
+type WorkspaceStore interface {
+	Get(id string) (*workspace.Workspace, error)
+	Save(ws *workspace.Workspace) error
+}
+
+// ComponentKind distinguishes a plugin's bindable component types.
+type ComponentKind string
+
+const (
+	ComponentSkill ComponentKind = "skill"
+	ComponentMCP   ComponentKind = "mcp"
+)
+
+// Component is one bindable unit recorded by an installed plugin.
+type Component struct {
+	Kind ComponentKind `json:"kind"`
+	Name string        `json:"name"`
+}
+
+// String renders a component as "skill:name" / "mcp:name" for warnings and logs.
+func (c Component) String() string { return string(c.Kind) + ":" + c.Name }
+
+// PluginState is the reconciled state of one requested plugin.
+type PluginState string
+
+const (
+	// PluginStateMissing: the plugin is not installed globally.
+	PluginStateMissing PluginState = "missing"
+	// PluginStateDisabled: installed but its global record is disabled, and the
+	// caller did not permit enabling it, so no components were attached.
+	PluginStateDisabled PluginState = "disabled"
+	// PluginStateDetached: installed and enabled, but one or more recorded
+	// components remain unattached (typically because a Save failed).
+	PluginStateDetached PluginState = "detached"
+	// PluginStateAttached: installed, enabled, and every recorded component is
+	// attached to the workspace.
+	PluginStateAttached PluginState = "attached"
+)
+
+// PluginResult reports the outcome of reconciling one plugin.
+type PluginResult struct {
+	Name       string      `json:"name"`
+	Installed  bool        `json:"installed"`
+	Enabled    bool        `json:"enabled"`
+	State      PluginState `json:"state"`
+	Components []Component `json:"components"`         // all components the plugin records
+	Attached   []Component `json:"attached"`           // components attached after reconcile
+	Missing    []Component `json:"missing,omitempty"`  // recorded but still unattached
+	Applied    []Component `json:"applied,omitempty"`  // newly attached in this pass
+	Warnings   []string    `json:"warnings,omitempty"` // non-fatal notes for this plugin
+}
+
+// Request describes a reconciliation over one workspace.
+type Request struct {
+	WorkspaceID string
+	// Plugins are the plugin names whose components should be attached.
+	Plugins []string
+	// AllowEnable permits enabling a globally-disabled plugin before attaching
+	// its components. Template application passes false (report, don't enable);
+	// manual "Add to workspace" and repair pass true only after explicit user
+	// confirmation.
+	AllowEnable bool
+}
+
+// Result aggregates a reconciliation pass.
+type Result struct {
+	Plugins  []PluginResult `json:"plugins"`
+	Applied  []string       `json:"applied,omitempty"`  // aggregate "skill:x"/"mcp:y" newly bound
+	Warnings []string       `json:"warnings,omitempty"` // aggregate non-fatal notes
+	// SaveErr is non-nil when persisting the new bindings failed. When set, no
+	// component is reported as Applied and affected plugins stay Detached.
+	SaveErr error `json:"-"`
+}
+
+// Reconciler binds plugin components onto workspaces idempotently.
+type Reconciler struct {
+	plugins PluginManager
+	store   WorkspaceStore
+}
+
+// New builds a Reconciler over the configured plugin manager and workspace store.
+func New(plugins PluginManager, store WorkspaceStore) *Reconciler {
+	return &Reconciler{plugins: plugins, store: store}
+}
+
+// Reconcile attaches the requested plugins' recorded components to the workspace.
+// It is idempotent, honors the plugin enabled flag, preserves unrelated
+// bindings, and reports (rather than hides) missing plugins, disabled plugins,
+// and save failures.
+func (r *Reconciler) Reconcile(req Request) (Result, error) {
+	var res Result
+	if r.store == nil {
+		return res, nil
+	}
+	ws, err := r.store.Get(req.WorkspaceID)
+	if err != nil {
+		return res, err
+	}
+	if ws == nil {
+		return res, nil
+	}
+
+	installed := map[string]plugin.InstalledPlugin{}
+	if r.plugins != nil {
+		list, err := r.plugins.List()
+		if err != nil {
+			return res, err
+		}
+		for _, p := range list {
+			installed[strings.ToLower(strings.TrimSpace(p.Name))] = p
+		}
+	}
+
+	// Case-normalized sets of what is already bound, so attachment is idempotent
+	// and preserves unrelated bindings.
+	boundSkills := map[string]bool{}
+	for _, b := range ws.GetSkillBindings() {
+		boundSkills[strings.ToLower(strings.TrimSpace(b.SkillName))] = true
+	}
+	boundMCP := map[string]bool{}
+	for _, b := range ws.GetMCPBindings() {
+		boundMCP[strings.ToLower(strings.TrimSpace(b.ServerName))] = true
+	}
+
+	now := time.Now()
+	var pending []Component // planned bindings not yet persisted (cleared on save failure)
+
+	attach := func(pr *PluginResult, comps []Component) {
+		for _, c := range comps {
+			key := strings.ToLower(c.Name)
+			switch c.Kind {
+			case ComponentSkill:
+				if boundSkills[key] {
+					pr.Attached = append(pr.Attached, c)
+					continue
+				}
+				if err := ws.UpsertSkillBinding(workspace.SkillBinding{
+					ID: uuid.NewString(), SkillName: c.Name, Enabled: true, CreatedAt: now, UpdatedAt: now,
+				}); err != nil {
+					pr.Missing = append(pr.Missing, c)
+					pr.Warnings = append(pr.Warnings, "could not bind "+c.String()+": "+err.Error())
+					continue
+				}
+				boundSkills[key] = true
+				pr.Attached = append(pr.Attached, c)
+				pr.Applied = append(pr.Applied, c)
+				pending = append(pending, c)
+			case ComponentMCP:
+				if boundMCP[key] {
+					pr.Attached = append(pr.Attached, c)
+					continue
+				}
+				if err := ws.UpsertMCPBinding(workspace.MCPBinding{
+					ID: uuid.NewString(), ServerName: c.Name, Enabled: true, CreatedAt: now, UpdatedAt: now,
+				}); err != nil {
+					pr.Missing = append(pr.Missing, c)
+					pr.Warnings = append(pr.Warnings, "could not bind "+c.String()+": "+err.Error())
+					continue
+				}
+				boundMCP[key] = true
+				pr.Attached = append(pr.Attached, c)
+				pr.Applied = append(pr.Applied, c)
+				pending = append(pending, c)
+			}
+		}
+	}
+
+	for _, name := range req.Plugins {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		pr := PluginResult{Name: name}
+		p, ok := installed[strings.ToLower(name)]
+		if !ok {
+			pr.State = PluginStateMissing
+			pr.Warnings = append(pr.Warnings, "plugin "+name+" is not installed")
+			res.Plugins = append(res.Plugins, pr)
+			continue
+		}
+		pr.Installed = true
+		pr.Enabled = p.Enabled
+		pr.Components = componentsOf(p)
+
+		if !p.Enabled {
+			if !req.AllowEnable {
+				pr.State = PluginStateDisabled
+				pr.Missing = pr.Components
+				pr.Warnings = append(pr.Warnings, "plugin "+name+" is installed but globally disabled")
+				res.Plugins = append(res.Plugins, pr)
+				continue
+			}
+			if err := r.plugins.SetEnabled(p.Name, true); err != nil {
+				pr.State = PluginStateDisabled
+				pr.Missing = pr.Components
+				pr.Warnings = append(pr.Warnings, "could not enable plugin "+name+": "+err.Error())
+				res.Plugins = append(res.Plugins, pr)
+				continue
+			}
+			pr.Enabled = true
+		}
+
+		attach(&pr, pr.Components)
+		if len(pr.Missing) == 0 {
+			pr.State = PluginStateAttached
+		} else {
+			pr.State = PluginStateDetached
+		}
+		res.Plugins = append(res.Plugins, pr)
+	}
+
+	if len(pending) == 0 {
+		res.aggregate()
+		return res, nil
+	}
+
+	if err := r.store.Save(ws); err != nil {
+		// Persist failed: nothing actually attached. Roll the reported state back
+		// so we never claim success we didn't persist.
+		res.SaveErr = err
+		for i := range res.Plugins {
+			pr := &res.Plugins[i]
+			if len(pr.Applied) == 0 {
+				continue
+			}
+			// Applied components were never saved: demote them to missing.
+			pr.Missing = append(pr.Missing, pr.Applied...)
+			pr.Attached = subtractComponents(pr.Attached, pr.Applied)
+			pr.Applied = nil
+			pr.State = PluginStateDetached
+			pr.Warnings = append(pr.Warnings, "workspace save failed; components not attached: "+err.Error())
+		}
+		res.aggregate()
+		return res, nil
+	}
+
+	res.aggregate()
+	return res, nil
+}
+
+// aggregate fills the Result-level Applied and Warnings from per-plugin results.
+func (res *Result) aggregate() {
+	for _, pr := range res.Plugins {
+		for _, c := range pr.Applied {
+			res.Applied = append(res.Applied, c.String())
+		}
+		res.Warnings = append(res.Warnings, pr.Warnings...)
+	}
+}
+
+// componentsOf returns a plugin's recorded skills then MCP servers as Components.
+func componentsOf(p plugin.InstalledPlugin) []Component {
+	out := make([]Component, 0, len(p.Skills)+len(p.MCPServers))
+	for _, s := range p.Skills {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, Component{Kind: ComponentSkill, Name: s})
+		}
+	}
+	for _, s := range p.MCPServers {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, Component{Kind: ComponentMCP, Name: s})
+		}
+	}
+	return out
+}
+
+// subtractComponents returns from minus any component (kind+name) in remove.
+func subtractComponents(from, remove []Component) []Component {
+	if len(remove) == 0 {
+		return from
+	}
+	drop := make(map[string]bool, len(remove))
+	for _, c := range remove {
+		drop[string(c.Kind)+"\x00"+strings.ToLower(c.Name)] = true
+	}
+	out := from[:0]
+	for _, c := range from {
+		if drop[string(c.Kind)+"\x00"+strings.ToLower(c.Name)] {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/pluginworkspace/reconciler_test.go
+++ b/internal/pluginworkspace/reconciler_test.go
@@ -1,0 +1,253 @@
+package pluginworkspace
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// fakePlugins is an in-memory PluginManager built from a temporary fixture set,
+// so tests never read the developer's ignored plugins/ registry.
+type fakePlugins struct {
+	list      []plugin.InstalledPlugin
+	enableErr error
+	enabled   map[string]bool
+}
+
+func (f *fakePlugins) List() ([]plugin.InstalledPlugin, error) { return f.list, nil }
+
+func (f *fakePlugins) SetEnabled(name string, enabled bool) error {
+	if f.enableErr != nil {
+		return f.enableErr
+	}
+	if f.enabled == nil {
+		f.enabled = map[string]bool{}
+	}
+	f.enabled[name] = enabled
+	for i := range f.list {
+		if f.list[i].Name == name {
+			f.list[i].Enabled = enabled
+		}
+	}
+	return nil
+}
+
+// fakeStore holds one workspace in memory and can be told to fail on Save.
+type fakeStore struct {
+	ws      *workspace.Workspace
+	saveErr error
+	saves   int
+}
+
+func (f *fakeStore) Get(id string) (*workspace.Workspace, error) {
+	if f.ws == nil || f.ws.ID != id {
+		return nil, nil
+	}
+	return f.ws, nil
+}
+
+func (f *fakeStore) Save(ws *workspace.Workspace) error {
+	f.saves++
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.ws = ws
+	return nil
+}
+
+func newWS() *workspace.Workspace {
+	return workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Test"})
+}
+
+func reaperPlugin(enabled bool) plugin.InstalledPlugin {
+	return plugin.InstalledPlugin{
+		Name:       "reaper-plugin",
+		Enabled:    enabled,
+		Skills:     []string{"reaper-session-setup", "reaper-web-remote"},
+		MCPServers: nil,
+	}
+}
+
+func skillNames(ws *workspace.Workspace) []string {
+	var out []string
+	for _, b := range ws.GetSkillBindings() {
+		out = append(out, strings.ToLower(b.SkillName))
+	}
+	return out
+}
+
+func hasSkill(ws *workspace.Workspace, name string) bool {
+	return slices.Contains(skillNames(ws), strings.ToLower(name))
+}
+
+func TestReconcile_MissingPlugin(t *testing.T) {
+	ws := newWS()
+	store := &fakeStore{ws: ws}
+	r := New(&fakePlugins{}, store)
+
+	res, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Plugins) != 1 || res.Plugins[0].State != PluginStateMissing {
+		t.Fatalf("expected missing state, got %+v", res.Plugins)
+	}
+	if store.saves != 0 {
+		t.Fatalf("missing plugin should not save, saves=%d", store.saves)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("nothing should be applied, got %v", res.Applied)
+	}
+}
+
+func TestReconcile_DisabledNotEnabledWithoutPermission(t *testing.T) {
+	ws := newWS()
+	store := &fakeStore{ws: ws}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(false)}}
+	r := New(pm, store)
+
+	res, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}, AllowEnable: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pr := res.Plugins[0]
+	if pr.State != PluginStateDisabled {
+		t.Fatalf("expected disabled state, got %s", pr.State)
+	}
+	if hasSkill(ws, "reaper-session-setup") {
+		t.Fatalf("disabled plugin must not attach components")
+	}
+	if pm.enabled["reaper-plugin"] {
+		t.Fatalf("template application must not enable a disabled plugin")
+	}
+	if len(pr.Missing) != 2 {
+		t.Fatalf("expected 2 missing components, got %d", len(pr.Missing))
+	}
+}
+
+func TestReconcile_DisabledEnabledWithPermission(t *testing.T) {
+	ws := newWS()
+	store := &fakeStore{ws: ws}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(false)}}
+	r := New(pm, store)
+
+	res, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}, AllowEnable: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Plugins[0].State; got != PluginStateAttached {
+		t.Fatalf("expected attached state after enable, got %s", got)
+	}
+	if !pm.enabled["reaper-plugin"] {
+		t.Fatalf("AllowEnable should have enabled the plugin")
+	}
+	if !hasSkill(ws, "reaper-session-setup") || !hasSkill(ws, "reaper-web-remote") {
+		t.Fatalf("both skills should be attached, got %v", skillNames(ws))
+	}
+}
+
+func TestReconcile_FullAttachAndIdempotent(t *testing.T) {
+	ws := newWS()
+	store := &fakeStore{ws: ws}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(true)}}
+	r := New(pm, store)
+
+	res1, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res1.Plugins[0].State != PluginStateAttached || len(res1.Applied) != 2 {
+		t.Fatalf("first pass should attach 2, got state=%s applied=%v", res1.Plugins[0].State, res1.Applied)
+	}
+
+	// Second pass: no new bindings, no duplicate, no save.
+	savesBefore := store.saves
+	res2, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res2.Applied) != 0 {
+		t.Fatalf("second pass should apply nothing, got %v", res2.Applied)
+	}
+	if res2.Plugins[0].State != PluginStateAttached {
+		t.Fatalf("second pass should be attached, got %s", res2.Plugins[0].State)
+	}
+	if store.saves != savesBefore {
+		t.Fatalf("idempotent pass should not save again: before=%d after=%d", savesBefore, store.saves)
+	}
+	if len(ws.GetSkillBindings()) != 2 {
+		t.Fatalf("expected exactly 2 skill bindings, got %d", len(ws.GetSkillBindings()))
+	}
+}
+
+func TestReconcile_PreservesUnrelatedBindings(t *testing.T) {
+	ws := newWS()
+	// Pre-existing unrelated binding.
+	if err := ws.UpsertSkillBinding(workspace.SkillBinding{ID: "keep", SkillName: "note-taking", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeStore{ws: ws}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(true)}}
+	r := New(pm, store)
+
+	if _, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasSkill(ws, "note-taking") {
+		t.Fatalf("unrelated binding must be preserved")
+	}
+	if len(ws.GetSkillBindings()) != 3 {
+		t.Fatalf("expected 3 bindings (1 unrelated + 2 plugin), got %d", len(ws.GetSkillBindings()))
+	}
+}
+
+func TestReconcile_CaseInsensitiveDedup(t *testing.T) {
+	ws := newWS()
+	// Existing binding in a different case than what the plugin records.
+	if err := ws.UpsertSkillBinding(workspace.SkillBinding{ID: "pre", SkillName: "Reaper-Session-Setup", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeStore{ws: ws}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(true)}}
+	r := New(pm, store)
+
+	res, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only reaper-web-remote should be newly applied; the case variant is deduped.
+	if len(res.Plugins[0].Applied) != 1 || res.Plugins[0].Applied[0].Name != "reaper-web-remote" {
+		t.Fatalf("expected only reaper-web-remote applied, got %+v", res.Plugins[0].Applied)
+	}
+	if len(ws.GetSkillBindings()) != 2 {
+		t.Fatalf("expected 2 bindings (no case-dup), got %d", len(ws.GetSkillBindings()))
+	}
+}
+
+func TestReconcile_SaveFailureReportsNoSuccess(t *testing.T) {
+	ws := newWS()
+	store := &fakeStore{ws: ws, saveErr: errors.New("disk full")}
+	pm := &fakePlugins{list: []plugin.InstalledPlugin{reaperPlugin(true)}}
+	r := New(pm, store)
+
+	res, err := r.Reconcile(Request{WorkspaceID: ws.ID, Plugins: []string{"reaper-plugin"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SaveErr == nil {
+		t.Fatalf("expected SaveErr to be reported")
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("save failure must not report applied components, got %v", res.Applied)
+	}
+	if res.Plugins[0].State != PluginStateDetached {
+		t.Fatalf("expected detached state after save failure, got %s", res.Plugins[0].State)
+	}
+	if len(res.Plugins[0].Missing) != 2 {
+		t.Fatalf("both components should be reported missing after save failure, got %d", len(res.Plugins[0].Missing))
+	}
+}

--- a/internal/projecttemplates/starter/reaper-song/template.json
+++ b/internal/projecttemplates/starter/reaper-song/template.json
@@ -4,7 +4,12 @@
   "icon": "🎵",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 3,
+  "builtin_version": 4,
+  "tools": {
+    "plugins": [
+      "reaper-plugin"
+    ]
+  },
   "project_entry": {
     "relative_path": "{{name}}.rpp",
     "open_after_create_default": true

--- a/internal/projecttemplates/starter/reaper-song/template.json
+++ b/internal/projecttemplates/starter/reaper-song/template.json
@@ -4,11 +4,14 @@
   "icon": "🎵",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 4,
+  "builtin_version": 5,
   "tools": {
     "plugins": [
       "reaper-plugin"
-    ]
+    ],
+    "plugin_sources": {
+      "reaper-plugin": "https://github.com/johnjallday/reaper-plugin.git"
+    }
   },
   "project_entry": {
     "relative_path": "{{name}}.rpp",

--- a/internal/projecttemplates/starter_test.go
+++ b/internal/projecttemplates/starter_test.go
@@ -47,8 +47,17 @@ func TestEnsureLibraryMaterializesStarters(t *testing.T) {
 	if len(reaper.StarterTasks) == 0 || !reaper.StarterTasks[0].Setup {
 		t.Errorf("reaper starter should lead with a setup starter task: %+v", reaper.StarterTasks)
 	}
-	if reaper.BuiltinVersion < 3 {
-		t.Errorf("reaper starter builtin_version = %d, want at least 3", reaper.BuiltinVersion)
+	if reaper.BuiltinVersion < 4 {
+		t.Errorf("reaper starter builtin_version = %d, want at least 4 (v4 declares reaper-plugin)", reaper.BuiltinVersion)
+	}
+	// v4: the manifest declares reaper-plugin under top-level workspace tool
+	// defaults so creation attaches its components when installed.
+	if len(reaper.Tools.Plugins) != 1 || reaper.Tools.Plugins[0] != "reaper-plugin" {
+		t.Errorf("reaper starter must declare reaper-plugin in tool defaults, got %+v", reaper.Tools.Plugins)
+	}
+	// One authoritative Reaper Producer agent; no extra default agents.
+	if len(reaper.Agents) != 1 || reaper.Agents[0].Name != "Reaper Producer" {
+		t.Errorf("reaper starter must keep exactly one Reaper Producer agent, got %+v", reaper.Agents)
 	}
 	if reaper.ProjectEntry == nil || reaper.ProjectEntry.RelativePath != "{{name}}.rpp" || !reaper.ProjectEntry.OpenAfterCreateDefault {
 		t.Errorf("reaper starter project entry is not configured for default launch: %#v", reaper.ProjectEntry)

--- a/internal/projecttemplates/starter_test.go
+++ b/internal/projecttemplates/starter_test.go
@@ -47,13 +47,18 @@ func TestEnsureLibraryMaterializesStarters(t *testing.T) {
 	if len(reaper.StarterTasks) == 0 || !reaper.StarterTasks[0].Setup {
 		t.Errorf("reaper starter should lead with a setup starter task: %+v", reaper.StarterTasks)
 	}
-	if reaper.BuiltinVersion < 4 {
-		t.Errorf("reaper starter builtin_version = %d, want at least 4 (v4 declares reaper-plugin)", reaper.BuiltinVersion)
+	if reaper.BuiltinVersion < 5 {
+		t.Errorf("reaper starter builtin_version = %d, want at least 5 (declares reaper-plugin + source)", reaper.BuiltinVersion)
 	}
-	// v4: the manifest declares reaper-plugin under top-level workspace tool
-	// defaults so creation attaches its components when installed.
+	// The manifest declares reaper-plugin under top-level workspace tool defaults
+	// so creation attaches its components when installed.
 	if len(reaper.Tools.Plugins) != 1 || reaper.Tools.Plugins[0] != "reaper-plugin" {
 		t.Errorf("reaper starter must declare reaper-plugin in tool defaults, got %+v", reaper.Tools.Plugins)
+	}
+	// It also declares the exact install source so the create UI can offer a
+	// one-click, trust-previewed install without resolving a marketplace.
+	if src := reaper.Tools.PluginSource("reaper-plugin"); src == "" || !strings.Contains(src, "reaper-plugin") {
+		t.Errorf("reaper starter must declare a reaper-plugin install source, got %q", src)
 	}
 	// One authoritative Reaper Producer agent; no extra default agents.
 	if len(reaper.Agents) != 1 || reaper.Agents[0].Name != "Reaper Producer" {

--- a/internal/projecttemplates/tools.go
+++ b/internal/projecttemplates/tools.go
@@ -17,19 +17,56 @@ type ToolDefaults struct {
 	Skills     []string `json:"skills,omitempty"`
 	MCPServers []string `json:"mcp_servers,omitempty"`
 	Plugins    []string `json:"plugins,omitempty"`
+	// PluginSources maps a declared plugin name to the exact source it installs
+	// from (a git URL or local path the plugin installer accepts). It lets the
+	// install UI offer a one-click, trust-previewed install without resolving a
+	// marketplace or asking the user to paste a source. Optional; a plugin
+	// without a declared source falls back to marketplace resolution / paste.
+	// Keys are matched case-insensitively against Plugins.
+	PluginSources map[string]string `json:"plugin_sources,omitempty"`
 }
 
-// IsEmpty reports whether no tools are declared.
+// IsEmpty reports whether no tools are declared. Plugin sources alone (with no
+// plugins) are not meaningful and do not count.
 func (t ToolDefaults) IsEmpty() bool {
 	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.Plugins) == 0
 }
 
+// PluginSource returns the declared install source for a plugin name
+// (case-insensitive), or "" when none is declared.
+func (t ToolDefaults) PluginSource(name string) string {
+	if len(t.PluginSources) == 0 {
+		return ""
+	}
+	want := strings.ToLower(strings.TrimSpace(name))
+	for k, v := range t.PluginSources {
+		if strings.ToLower(strings.TrimSpace(k)) == want {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
 func normalizeToolDefaults(t ToolDefaults) ToolDefaults {
-	return ToolDefaults{
+	out := ToolDefaults{
 		Skills:     normalizeNameList(t.Skills),
 		MCPServers: normalizeNameList(t.MCPServers),
 		Plugins:    normalizeNameList(t.Plugins),
 	}
+	if len(t.PluginSources) > 0 {
+		out.PluginSources = make(map[string]string, len(t.PluginSources))
+		for k, v := range t.PluginSources {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			if k != "" && v != "" {
+				out.PluginSources[k] = v
+			}
+		}
+		if len(out.PluginSources) == 0 {
+			out.PluginSources = nil
+		}
+	}
+	return out
 }
 
 // normalizeNameList trims, drops blanks, de-duplicates case-insensitively

--- a/internal/projecttemplates/tools_test.go
+++ b/internal/projecttemplates/tools_test.go
@@ -76,3 +76,26 @@ func TestSetTools(t *testing.T) {
 		t.Errorf("unknown template = %v, want ErrTemplateNotFound", err)
 	}
 }
+
+func TestToolDefaults_PluginSourceAndNormalize(t *testing.T) {
+	td := normalizeToolDefaults(ToolDefaults{
+		Plugins:       []string{"reaper-plugin"},
+		PluginSources: map[string]string{"  Reaper-Plugin ": "  https://example.com/x.git ", "blank": "  "},
+	})
+	// Case-insensitive lookup, trimmed value.
+	if got := td.PluginSource("reaper-plugin"); got != "https://example.com/x.git" {
+		t.Fatalf("PluginSource = %q", got)
+	}
+	// Blank-valued entries are dropped by normalize.
+	if _, ok := td.PluginSources["blank"]; ok {
+		t.Fatalf("blank-valued source should be dropped: %+v", td.PluginSources)
+	}
+	// Undeclared plugin returns empty.
+	if got := td.PluginSource("other"); got != "" {
+		t.Fatalf("undeclared plugin source = %q, want empty", got)
+	}
+	// Sources-only (no plugins) is still IsEmpty.
+	if !(ToolDefaults{PluginSources: map[string]string{"a": "b"}}).IsEmpty() {
+		t.Fatalf("plugin_sources without plugins must be IsEmpty")
+	}
+}

--- a/internal/reapersetup/readiness.go
+++ b/internal/reapersetup/readiness.go
@@ -1,0 +1,402 @@
+// Package reapersetup computes one normalized, truthful readiness model for
+// REAPER workspaces, shared by workspace-creation feedback, the workspace UI,
+// repair, and the setup-task auto-start decision. It exists so the frontend does
+// not independently guess readiness from several unrelated endpoints.
+//
+// A central rule: Ori-ready is not REAPER-connected. This resolver can verify
+// plugin components, agent provider compatibility, and explicit native-CLI
+// permissions. It must never report that REAPER, Web Remote, the open project,
+// or the runner is live — that is checked by the setup agent at execution time,
+// and is always reported here as not-yet-checked (LiveVerification).
+package reapersetup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// ReaperPluginName is the plugin whose components back live REAPER control.
+const ReaperPluginName = "reaper-plugin"
+
+// ReaperSongTemplateID is the built-in template id for REAPER song workspaces.
+const ReaperSongTemplateID = "reaper-song"
+
+// Task context markers written by the template seed / setup-start endpoint. These
+// live here so readiness and the setup-start endpoint agree on the same keys.
+const (
+	// TaskContextTemplateSetup marks a task as the template's first-open setup task.
+	TaskContextTemplateSetup = "template_setup"
+	// TaskContextSetupConsumedAt is stamped once the setup task's auto-start is
+	// consumed; its presence means auto-start must not run again.
+	TaskContextSetupConsumedAt = "template_setup_autostart_consumed_at"
+)
+
+// Status is the normalized readiness status code. Exactly one is returned per
+// resolution, chosen by deterministic precedence (see Resolve).
+type Status string
+
+const (
+	// StatusFileOnly: identified REAPER workspace that is usable as a file
+	// project but is not pursuing live control (no pending setup task to run and
+	// not fully Ori-ready). It is a supported mode, never an error.
+	StatusFileOnly Status = "file_only"
+	// StatusPluginMissing: reaper-plugin is not installed globally.
+	StatusPluginMissing Status = "plugin_missing"
+	// StatusPluginDisabled: reaper-plugin is installed but its global record is disabled.
+	StatusPluginDisabled Status = "plugin_disabled"
+	// StatusPluginDetached: installed and enabled, but recorded components are not all attached.
+	StatusPluginDetached Status = "plugin_detached"
+	// StatusCLIAgentRequired: the effective setup agent does not use Codex or Claude Code.
+	StatusCLIAgentRequired Status = "cli_agent_required"
+	// StatusNativeCLIAccessRequired: compatible agent, but workspace and/or agent native CLI access is off.
+	StatusNativeCLIAccessRequired Status = "native_cli_access_required"
+	// StatusOriReady: plugin components, a compatible agent, and both explicit
+	// native-CLI permissions are ready for the setup agent to check REAPER.
+	StatusOriReady Status = "ori_ready"
+)
+
+// Readiness is the normalized result. Every field is safe to expose to the UI.
+type Readiness struct {
+	// Identified reports whether this is a REAPER workspace at all. When false,
+	// the UI must render no REAPER readiness surface.
+	Identified   bool   `json:"identified"`
+	IdentifiedBy string `json:"identified_by,omitempty"` // provenance | setup_task | project_entry | reaper_evidence
+
+	Status      Status `json:"status"`
+	ProjectMode string `json:"project_mode"` // "file_only" until "ori_ready"
+	Explanation string `json:"explanation"`
+	NextAction  string `json:"next_action,omitempty"`
+
+	// Plugin state (from the shared reconciler's read-only inspection).
+	PluginInstalled    bool                        `json:"plugin_installed"`
+	PluginEnabled      bool                        `json:"plugin_enabled"`
+	PluginAttached     bool                        `json:"plugin_attached"`
+	MissingComponents  []pluginworkspace.Component `json:"missing_components,omitempty"`
+	AttachedComponents []pluginworkspace.Component `json:"attached_components,omitempty"`
+
+	// Effective setup agent.
+	SetupAgent         string `json:"setup_agent,omitempty"`
+	SetupAgentProvider string `json:"setup_agent_provider,omitempty"`
+	SetupAgentIsCLI    bool   `json:"setup_agent_is_cli"`
+
+	// Native CLI access gates (both must be on for live control).
+	WorkspaceNativeCLIEnabled bool `json:"workspace_native_cli_enabled"`
+	AgentNativeCLIEnabled     bool `json:"agent_native_cli_enabled"`
+
+	// Setup task.
+	HasPendingSetupTask bool   `json:"has_pending_setup_task"`
+	SetupTaskID         string `json:"setup_task_id,omitempty"`
+
+	// LiveVerification is always "not_checked" here: readiness never proves
+	// REAPER/Web Remote/runner are live. Only the setup agent verifies that at
+	// execution time.
+	LiveVerification string `json:"live_verification"`
+}
+
+// workspaceReader is the read surface the resolver needs (satisfied by the
+// workspace SyncStore).
+type workspaceReader interface {
+	Get(id string) (*workspace.Workspace, error)
+	GetWorkspaceAgent(workspaceID, agentName string) (*agent.Agent, bool, error)
+}
+
+// pluginInspector reports plugin attachment without mutating anything (satisfied
+// by *pluginworkspace.Reconciler).
+type pluginInspector interface {
+	Inspect(workspaceID string, plugins []string) ([]pluginworkspace.PluginResult, error)
+}
+
+// Resolver computes readiness for a workspace.
+type Resolver struct {
+	store   workspaceReader
+	plugins pluginInspector
+}
+
+// NewResolver builds a readiness resolver over the workspace store and the shared
+// plugin reconciler.
+func NewResolver(store workspaceReader, plugins pluginInspector) *Resolver {
+	return &Resolver{store: store, plugins: plugins}
+}
+
+// Resolve computes the normalized readiness for the workspace. A fresh Resolve
+// reflects the current plugin install/enable/attachment, binding, task, provider,
+// and permission state — it never caches a stale ready result.
+func (r *Resolver) Resolve(workspaceID string) (Readiness, error) {
+	out := Readiness{LiveVerification: "not_checked", ProjectMode: "file_only"}
+	if r.store == nil {
+		return out, nil
+	}
+	ws, err := r.store.Get(workspaceID)
+	if err != nil {
+		return out, err
+	}
+	if ws == nil {
+		return out, nil
+	}
+
+	out.Identified, out.IdentifiedBy = identify(ws)
+	if !out.Identified {
+		return out, nil
+	}
+
+	// Plugin state via the shared read-only inspection.
+	if r.plugins != nil {
+		results, ierr := r.plugins.Inspect(workspaceID, []string{ReaperPluginName})
+		if ierr != nil {
+			return out, ierr
+		}
+		if len(results) > 0 {
+			pr := results[0]
+			out.PluginInstalled = pr.Installed
+			out.PluginEnabled = pr.Enabled
+			out.PluginAttached = pr.Installed && pr.Enabled && len(pr.Missing) == 0
+			out.MissingComponents = pr.Missing
+			out.AttachedComponents = pr.Attached
+		}
+	}
+
+	// Effective setup agent + its provider and native-access opt-in.
+	setupTaskID, hasPending := pendingSetupTask(ws)
+	out.SetupTaskID = setupTaskID
+	out.HasPendingSetupTask = hasPending
+
+	out.SetupAgent = effectiveSetupAgent(ws)
+	out.WorkspaceNativeCLIEnabled = ws.AllowNativeMCPCLI
+	if out.SetupAgent != "" {
+		if ag, ok, aerr := r.store.GetWorkspaceAgent(workspaceID, out.SetupAgent); aerr == nil && ok && ag != nil {
+			out.SetupAgentProvider = ag.Settings.Provider
+			out.SetupAgentIsCLI = isCLIProvider(ag.Settings.Provider)
+			out.AgentNativeCLIEnabled = ag.Settings.IsNativeMCPToolsAllowed()
+		}
+	}
+
+	out.Status = classify(out)
+	out.ProjectMode = projectMode(out.Status)
+	out.Explanation, out.NextAction = describe(out)
+	return out, nil
+}
+
+// classify chooses the status by deterministic precedence: the most specific
+// fixable blocker wins; ori_ready when nothing blocks; file_only when the
+// workspace is usable but not pursuing live control (nothing pending, not ready).
+func classify(r Readiness) Status {
+	ready := r.PluginInstalled && r.PluginEnabled && r.PluginAttached &&
+		r.SetupAgentIsCLI && r.WorkspaceNativeCLIEnabled && r.AgentNativeCLIEnabled
+	if ready {
+		return StatusOriReady
+	}
+	if !r.HasPendingSetupTask {
+		return StatusFileOnly
+	}
+	switch {
+	case !r.PluginInstalled:
+		return StatusPluginMissing
+	case !r.PluginEnabled:
+		return StatusPluginDisabled
+	case !r.PluginAttached:
+		return StatusPluginDetached
+	case !r.SetupAgentIsCLI:
+		return StatusCLIAgentRequired
+	default: // compatible agent, but a native-access gate is off
+		return StatusNativeCLIAccessRequired
+	}
+}
+
+func projectMode(s Status) string {
+	if s == StatusOriReady {
+		return "ori_ready"
+	}
+	return "file_only"
+}
+
+// describe returns calm, outcome-oriented copy and a recommended next action.
+// It never equates ori_ready with a verified REAPER connection.
+func describe(r Readiness) (explanation, action string) {
+	switch r.Status {
+	case StatusOriReady:
+		return "Ori is configured to check REAPER. Live REAPER, Web Remote, and runner readiness are verified when setup runs.", ""
+	case StatusFileOnly:
+		return "This is a usable file-only REAPER project. Live control prerequisites are not configured.", "Repair REAPER setup to enable live control."
+	case StatusPluginMissing:
+		return "File-only project: the reaper-plugin is not installed. The project and its .rpp file are intact.", "Install reaper-plugin."
+	case StatusPluginDisabled:
+		return "reaper-plugin is installed but globally disabled.", "Enable reaper-plugin, then attach it to this workspace."
+	case StatusPluginDetached:
+		return "reaper-plugin is installed but some components are not attached to this workspace.", "Repair REAPER setup to attach the missing components."
+	case StatusCLIAgentRequired:
+		return "Live local REAPER control requires a Codex or Claude Code agent. File-only use remains available.", "Assign a Codex or Claude Code agent as the setup agent."
+	case StatusNativeCLIAccessRequired:
+		return "A compatible agent is set, but native CLI access is off. Native CLI tools run outside Ori's per-call confirmation gate.", "Enable native CLI access for the workspace and the setup agent."
+	default:
+		return "", ""
+	}
+}
+
+// identify determines whether the workspace is a REAPER workspace, conservatively.
+// Order: reaper-song template provenance, then Reaper Song setup-task provenance,
+// then a persisted .rpp project entry, then a reaper tag combined with .rpp
+// evidence. A workspace name or reaper tag alone is never sufficient.
+func identify(ws *workspace.Workspace) (bool, string) {
+	if ws.IsFromTemplate(ReaperSongTemplateID) {
+		return true, "provenance"
+	}
+	for _, t := range ws.Tasks {
+		if t.TemplateRef != nil && strings.EqualFold(strings.TrimSpace(t.TemplateRef.TemplateID), ReaperSongTemplateID) {
+			return true, "setup_task"
+		}
+	}
+	if hasReaperProjectEntry(ws) {
+		return true, "project_entry"
+	}
+	if hasTag(ws, "reaper") && hasReaperProjectEntry(ws) {
+		return true, "reaper_evidence"
+	}
+	return false, ""
+}
+
+// hasReaperProjectEntry reports whether the workspace has a persisted .rpp
+// project entry (the authoritative REAPER project file).
+func hasReaperProjectEntry(ws *workspace.Workspace) bool {
+	if entry, err := workspace.GetProjectEntryPath(ws.SharedData); err == nil && strings.HasSuffix(strings.ToLower(strings.TrimSpace(entry)), ".rpp") {
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(ws.ProjectPath)), ".rpp")
+}
+
+func hasTag(ws *workspace.Workspace, tag string) bool {
+	for _, t := range ws.Tags {
+		if strings.EqualFold(strings.TrimSpace(t), tag) {
+			return true
+		}
+	}
+	return false
+}
+
+// pendingSetupTask returns the id of an assigned-or-pending, unconsumed template
+// setup task and whether one exists. Consumed, running, completed, cancelled, or
+// absent setup tasks do not count as pending.
+func pendingSetupTask(ws *workspace.Workspace) (string, bool) {
+	for i := range ws.Tasks {
+		t := &ws.Tasks[i]
+		if t.Context == nil || t.Context[TaskContextTemplateSetup] != true {
+			continue
+		}
+		if consumed, ok := t.Context[TaskContextSetupConsumedAt]; ok {
+			if s, _ := consumed.(string); strings.TrimSpace(s) != "" {
+				continue
+			}
+		}
+		if t.Status != workspace.TaskStatusPending && t.Status != workspace.TaskStatusAssigned {
+			continue
+		}
+		return t.ID, true
+	}
+	return "", false
+}
+
+// effectiveSetupAgent resolves the pending setup task's assignee, falling back to
+// the workspace entry agent when the task uses the entry-agent default (no
+// explicit assignee).
+func effectiveSetupAgent(ws *workspace.Workspace) string {
+	for i := range ws.Tasks {
+		t := &ws.Tasks[i]
+		if t.Context == nil || t.Context[TaskContextTemplateSetup] != true {
+			continue
+		}
+		if to := strings.TrimSpace(t.To); to != "" {
+			return to
+		}
+		break
+	}
+	return strings.TrimSpace(ws.EntryAgentName())
+}
+
+// isCLIProvider reports whether provider is a native-CLI provider (Codex / Claude
+// Code) capable of live local REAPER control.
+func isCLIProvider(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex", "claude_code":
+		return true
+	default:
+		return false
+	}
+}
+
+// PluginLister is the read surface the pre-create preview needs (satisfied by
+// *plugin.Manager).
+type PluginLister interface {
+	List() ([]plugin.InstalledPlugin, error)
+}
+
+// CreatePreview describes what a Reaper Song workspace's plugin attachment will
+// look like at creation time, computed from the same plugin store the live
+// readiness resolver reads. It intentionally omits agent/native-access state:
+// those depend on the selected Template Agents plan and are decided in-workspace
+// after creation. Like readiness, it never claims REAPER is live.
+type CreatePreview struct {
+	PluginInstalled  bool                        `json:"plugin_installed"`
+	PluginEnabled    bool                        `json:"plugin_enabled"`
+	WouldAttach      []pluginworkspace.Component `json:"would_attach,omitempty"`
+	Status           string                      `json:"status"` // plugin_missing | plugin_disabled | ready_to_attach
+	Explanation      string                      `json:"explanation"`
+	NextAction       string                      `json:"next_action,omitempty"`
+	LiveVerification string                      `json:"live_verification"`
+}
+
+// PreviewCreate reports the pre-create plugin attachment state for a Reaper Song
+// workspace. Used by the Create Workspace REAPER Setup card so it does not
+// independently infer plugin state.
+func PreviewCreate(plugins PluginLister) (CreatePreview, error) {
+	out := CreatePreview{Status: "plugin_missing", LiveVerification: "not_checked"}
+	if plugins == nil {
+		out.Explanation = "File-only project: the reaper-plugin is not installed."
+		out.NextAction = "Install reaper-plugin."
+		return out, nil
+	}
+	list, err := plugins.List()
+	if err != nil {
+		return out, err
+	}
+	for _, p := range list {
+		if !strings.EqualFold(strings.TrimSpace(p.Name), ReaperPluginName) {
+			continue
+		}
+		out.PluginInstalled = true
+		out.PluginEnabled = p.Enabled
+		for _, s := range p.Skills {
+			if s = strings.TrimSpace(s); s != "" {
+				out.WouldAttach = append(out.WouldAttach, pluginworkspace.Component{Kind: pluginworkspace.ComponentSkill, Name: s})
+			}
+		}
+		for _, s := range p.MCPServers {
+			if s = strings.TrimSpace(s); s != "" {
+				out.WouldAttach = append(out.WouldAttach, pluginworkspace.Component{Kind: pluginworkspace.ComponentMCP, Name: s})
+			}
+		}
+		break
+	}
+	switch {
+	case !out.PluginInstalled:
+		out.Status = "plugin_missing"
+		out.Explanation = "File-only project: the reaper-plugin is not installed. Creation still succeeds; the project and its .rpp file are intact."
+		out.NextAction = "Install reaper-plugin."
+	case !out.PluginEnabled:
+		out.Status = "plugin_disabled"
+		out.Explanation = "reaper-plugin is installed but globally disabled. Enable it to attach its components on creation."
+		out.NextAction = "Enable reaper-plugin."
+	default:
+		out.Status = "ready_to_attach"
+		out.Explanation = "reaper-plugin components will be attached to this workspace when it is created. REAPER, Web Remote, and runner readiness are checked later, when setup runs."
+	}
+	return out, nil
+}
+
+// String renders a readiness for logs.
+func (r Readiness) String() string {
+	return fmt.Sprintf("reaper readiness: identified=%v status=%s mode=%s", r.Identified, r.Status, r.ProjectMode)
+}

--- a/internal/reapersetup/readiness_test.go
+++ b/internal/reapersetup/readiness_test.go
@@ -98,7 +98,6 @@ func TestResolve_IdentificationSignals(t *testing.T) {
 }
 
 func TestResolve_StatusPrecedence(t *testing.T) {
-	tt := true
 	cases := []struct {
 		name   string
 		plugin pluginworkspace.PluginResult
@@ -150,7 +149,6 @@ func TestResolve_StatusPrecedence(t *testing.T) {
 			want: StatusOriReady,
 		},
 	}
-	_ = tt
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ws := reaperWS(t)

--- a/internal/reapersetup/readiness_test.go
+++ b/internal/reapersetup/readiness_test.go
@@ -1,0 +1,230 @@
+package reapersetup
+
+import (
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// fakeReader serves one workspace and a per-agent snapshot.
+type fakeReader struct {
+	ws     *workspace.Workspace
+	agents map[string]*agent.Agent
+}
+
+func (f *fakeReader) Get(id string) (*workspace.Workspace, error) {
+	if f.ws == nil || f.ws.ID != id {
+		return nil, nil
+	}
+	return f.ws, nil
+}
+
+func (f *fakeReader) GetWorkspaceAgent(workspaceID, name string) (*agent.Agent, bool, error) {
+	ag, ok := f.agents[name]
+	return ag, ok, nil
+}
+
+// fakeInspector returns a canned plugin state.
+type fakeInspector struct{ result pluginworkspace.PluginResult }
+
+func (f *fakeInspector) Inspect(string, []string) ([]pluginworkspace.PluginResult, error) {
+	return []pluginworkspace.PluginResult{f.result}, nil
+}
+
+func cliAgent(provider string, native bool) *agent.Agent {
+	return &agent.Agent{Settings: types.Settings{Provider: provider, AllowNativeMCPTools: &native}}
+}
+
+// reaperWS builds a workspace identified as REAPER (via provenance) with an entry
+// agent and a pending setup task assigned to it.
+func reaperWS(t *testing.T) *workspace.Workspace {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: ReaperSongTemplateID, Builtin: true, Version: 4})
+	ws.Tasks = append(ws.Tasks, workspace.Task{
+		ID:      "setup-1",
+		To:      "Reaper Producer",
+		Status:  workspace.TaskStatusPending,
+		Context: map[string]any{TaskContextTemplateSetup: true},
+	})
+	return ws
+}
+
+func attachedPlugin() pluginworkspace.PluginResult {
+	return pluginworkspace.PluginResult{
+		Name: ReaperPluginName, Installed: true, Enabled: true,
+		State:    pluginworkspace.PluginStateAttached,
+		Attached: []pluginworkspace.Component{{Kind: "skill", Name: "reaper-session-setup"}},
+	}
+}
+
+func TestResolve_NotIdentified(t *testing.T) {
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Plain"})
+	r := NewResolver(&fakeReader{ws: ws}, &fakeInspector{result: attachedPlugin()})
+	got, err := r.Resolve(ws.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identified {
+		t.Fatalf("plain workspace must not be identified as REAPER")
+	}
+}
+
+func TestResolve_IdentificationSignals(t *testing.T) {
+	// setup-task provenance only.
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	ws.Tasks = append(ws.Tasks, workspace.Task{
+		ID:          "t1",
+		TemplateRef: &workspace.TaskTemplateRef{TemplateID: ReaperSongTemplateID},
+		Context:     map[string]any{},
+	})
+	r := NewResolver(&fakeReader{ws: ws}, &fakeInspector{result: attachedPlugin()})
+	got, _ := r.Resolve(ws.ID)
+	if !got.Identified || got.IdentifiedBy != "setup_task" {
+		t.Fatalf("expected setup_task identification, got %+v", got.IdentifiedBy)
+	}
+
+	// tag alone is NOT sufficient.
+	ws2 := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	ws2.Tags = []string{"reaper"}
+	r2 := NewResolver(&fakeReader{ws: ws2}, &fakeInspector{result: attachedPlugin()})
+	got2, _ := r2.Resolve(ws2.ID)
+	if got2.Identified {
+		t.Fatalf("reaper tag alone must not identify a REAPER workspace")
+	}
+}
+
+func TestResolve_StatusPrecedence(t *testing.T) {
+	tt := true
+	cases := []struct {
+		name   string
+		plugin pluginworkspace.PluginResult
+		agent  *agent.Agent
+		wsNCLI bool
+		want   Status
+	}{
+		{
+			name:   "missing beats all",
+			plugin: pluginworkspace.PluginResult{Name: ReaperPluginName, State: pluginworkspace.PluginStateMissing},
+			agent:  cliAgent("codex", true), wsNCLI: true,
+			want: StatusPluginMissing,
+		},
+		{
+			name:   "disabled",
+			plugin: pluginworkspace.PluginResult{Name: ReaperPluginName, Installed: true, Enabled: false, State: pluginworkspace.PluginStateDisabled},
+			agent:  cliAgent("codex", true), wsNCLI: true,
+			want: StatusPluginDisabled,
+		},
+		{
+			name: "detached",
+			plugin: pluginworkspace.PluginResult{Name: ReaperPluginName, Installed: true, Enabled: true, State: pluginworkspace.PluginStateDetached,
+				Missing: []pluginworkspace.Component{{Kind: "skill", Name: "reaper-web-remote"}}},
+			agent: cliAgent("codex", true), wsNCLI: true,
+			want: StatusPluginDetached,
+		},
+		{
+			name:   "cli agent required",
+			plugin: attachedPlugin(),
+			agent:  cliAgent("openai", true), wsNCLI: true,
+			want: StatusCLIAgentRequired,
+		},
+		{
+			name:   "native access required (workspace off)",
+			plugin: attachedPlugin(),
+			agent:  cliAgent("codex", true), wsNCLI: false,
+			want: StatusNativeCLIAccessRequired,
+		},
+		{
+			name:   "native access required (agent off)",
+			plugin: attachedPlugin(),
+			agent:  cliAgent("codex", false), wsNCLI: true,
+			want: StatusNativeCLIAccessRequired,
+		},
+		{
+			name:   "ori ready",
+			plugin: attachedPlugin(),
+			agent:  cliAgent("codex", true), wsNCLI: true,
+			want: StatusOriReady,
+		},
+	}
+	_ = tt
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := reaperWS(t)
+			ws.AllowNativeMCPCLI = tc.wsNCLI
+			r := NewResolver(
+				&fakeReader{ws: ws, agents: map[string]*agent.Agent{"Reaper Producer": tc.agent}},
+				&fakeInspector{result: tc.plugin},
+			)
+			got, err := r.Resolve(ws.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != tc.want {
+				t.Fatalf("want %s, got %s (%s)", tc.want, got.Status, got.Explanation)
+			}
+			// ori_ready must never claim a live REAPER connection.
+			if got.LiveVerification != "not_checked" {
+				t.Fatalf("LiveVerification must stay not_checked, got %q", got.LiveVerification)
+			}
+		})
+	}
+}
+
+func TestResolve_OriReadyIsNotReaperConnected(t *testing.T) {
+	ws := reaperWS(t)
+	ws.AllowNativeMCPCLI = true
+	r := NewResolver(
+		&fakeReader{ws: ws, agents: map[string]*agent.Agent{"Reaper Producer": cliAgent("claude_code", true)}},
+		&fakeInspector{result: attachedPlugin()},
+	)
+	got, _ := r.Resolve(ws.ID)
+	if got.Status != StatusOriReady {
+		t.Fatalf("expected ori_ready, got %s", got.Status)
+	}
+	if got.ProjectMode != "ori_ready" {
+		t.Fatalf("expected project mode ori_ready")
+	}
+	// Explanation must talk about checking REAPER when setup runs, never assert a live connection.
+	if got.LiveVerification != "not_checked" {
+		t.Fatalf("live verification must be not_checked")
+	}
+}
+
+func TestResolve_FileOnlyWhenNoPendingSetupTask(t *testing.T) {
+	ws := reaperWS(t)
+	// Consume the setup task so nothing is pending.
+	ws.Tasks[0].Context[TaskContextSetupConsumedAt] = "2026-07-11T00:00:00Z"
+	r := NewResolver(
+		&fakeReader{ws: ws, agents: map[string]*agent.Agent{"Reaper Producer": cliAgent("openai", false)}},
+		&fakeInspector{result: pluginworkspace.PluginResult{Name: ReaperPluginName, State: pluginworkspace.PluginStateMissing}},
+	)
+	got, _ := r.Resolve(ws.ID)
+	if got.Status != StatusFileOnly {
+		t.Fatalf("expected file_only when no pending setup task, got %s", got.Status)
+	}
+	if got.HasPendingSetupTask {
+		t.Fatalf("consumed setup task must not count as pending")
+	}
+}
+
+func TestResolve_EffectiveAssigneeEntryFallback(t *testing.T) {
+	ws := reaperWS(t)
+	// Unassigned setup task -> falls back to entry agent.
+	ws.Tasks[0].To = ""
+	ws.AllowNativeMCPCLI = true
+	r := NewResolver(
+		&fakeReader{ws: ws, agents: map[string]*agent.Agent{"Reaper Producer": cliAgent("codex", true)}},
+		&fakeInspector{result: attachedPlugin()},
+	)
+	got, _ := r.Resolve(ws.ID)
+	if got.SetupAgent != "Reaper Producer" {
+		t.Fatalf("expected entry-agent fallback assignee, got %q", got.SetupAgent)
+	}
+	if got.Status != StatusOriReady {
+		t.Fatalf("expected ori_ready with entry-agent fallback, got %s", got.Status)
+	}
+}

--- a/internal/reapersetup/repair.go
+++ b/internal/reapersetup/repair.go
@@ -1,0 +1,186 @@
+package reapersetup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+)
+
+// RepairPlan previews the changes repair would make to a conservatively
+// identified REAPER workspace, keeping plugin installation, plugin enablement,
+// and component attachment as separate, clearly-labeled steps. It never includes
+// native-CLI access, agent, task, or .rpp changes — repair does not touch those.
+type RepairPlan struct {
+	Identified      bool                        `json:"identified"`
+	PluginInstalled bool                        `json:"plugin_installed"`
+	NeedsInstall    bool                        `json:"needs_install"` // plugin missing: use the install/trust flow first
+	NeedsEnable     bool                        `json:"needs_enable"`  // installed but disabled: requires explicit confirmation
+	AttachPlan      []pluginworkspace.Component `json:"attach_plan,omitempty"`
+	NoOp            bool                        `json:"no_op"` // already fully repaired
+	Explanation     string                      `json:"explanation"`
+}
+
+// RepairResult reports what repair actually did and the resulting readiness.
+type RepairResult struct {
+	Identified   bool                        `json:"identified"`
+	Enabled      bool                        `json:"enabled"` // the plugin was enabled during this repair
+	Attached     []pluginworkspace.Component `json:"attached,omitempty"`
+	NeedsInstall bool                        `json:"needs_install"` // plugin missing: nothing attached
+	NeedsConfirm bool                        `json:"needs_confirm"` // disabled plugin, confirmation not given
+	NoOp         bool                        `json:"no_op"`
+	Status       Status                      `json:"status"` // post-repair normalized readiness
+	Warnings     []string                    `json:"warnings,omitempty"`
+	Explanation  string                      `json:"explanation"`
+}
+
+// Repairer reconciles an existing REAPER workspace's plugin bindings using the
+// same readiness resolver and reconciliation service as creation. It is
+// idempotent and structurally cannot enable native-CLI access, mutate an agent,
+// create a task, or touch an .rpp file: it only enables the plugin (on
+// confirmation) and attaches the plugin's recorded components.
+type Repairer struct {
+	store      workspaceReader
+	reconciler *pluginworkspace.Reconciler
+	resolver   *Resolver
+}
+
+// NewRepairer builds a repairer over the workspace store, the shared reconciler,
+// and the readiness resolver (used to report post-repair state).
+func NewRepairer(store workspaceReader, reconciler *pluginworkspace.Reconciler, resolver *Resolver) *Repairer {
+	return &Repairer{store: store, reconciler: reconciler, resolver: resolver}
+}
+
+// identifiedReaper returns whether the workspace is a conservatively-identified
+// REAPER workspace repair may operate on.
+func (rp *Repairer) identifiedReaper(workspaceID string) (bool, error) {
+	if rp.store == nil {
+		return false, nil
+	}
+	ws, err := rp.store.Get(workspaceID)
+	if err != nil {
+		return false, err
+	}
+	if ws == nil {
+		return false, nil
+	}
+	ok, _ := identify(ws)
+	return ok, nil
+}
+
+// Preview lists the changes repair would make without applying them.
+func (rp *Repairer) Preview(workspaceID string) (RepairPlan, error) {
+	var plan RepairPlan
+	identified, err := rp.identifiedReaper(workspaceID)
+	if err != nil {
+		return plan, err
+	}
+	if !identified {
+		plan.Explanation = "This workspace is not identified as a REAPER workspace, so there is nothing to repair."
+		return plan, nil
+	}
+	plan.Identified = true
+
+	results, err := rp.reconciler.Inspect(workspaceID, []string{ReaperPluginName})
+	if err != nil {
+		return plan, err
+	}
+	if len(results) == 0 {
+		return plan, nil
+	}
+	pr := results[0]
+	plan.PluginInstalled = pr.Installed
+	switch pr.State {
+	case pluginworkspace.PluginStateMissing:
+		plan.NeedsInstall = true
+		plan.Explanation = "reaper-plugin is not installed. Install it (with the trust preview) before repair can attach its components."
+	case pluginworkspace.PluginStateDisabled:
+		plan.NeedsEnable = true
+		plan.AttachPlan = pr.Components
+		plan.Explanation = "reaper-plugin is installed but globally disabled. Repair will enable it (after your confirmation) and attach its components."
+	case pluginworkspace.PluginStateDetached:
+		plan.AttachPlan = pr.Missing
+		plan.Explanation = fmt.Sprintf("Repair will attach %d missing reaper-plugin component(s) to this workspace.", len(pr.Missing))
+	default: // attached
+		plan.NoOp = true
+		plan.Explanation = "reaper-plugin is already fully attached. No repair is needed."
+	}
+	return plan, nil
+}
+
+// Apply performs the repair. It attaches the plugin's recorded components
+// idempotently and, only when confirmEnable is true, enables a globally-disabled
+// plugin first. A missing plugin is reported (install is a separate step) and a
+// fully-attached plugin is a no-op. It never enables native access, mutates an
+// agent, creates a task, or touches an .rpp file.
+func (rp *Repairer) Apply(workspaceID string, confirmEnable bool) (RepairResult, error) {
+	var res RepairResult
+	identified, err := rp.identifiedReaper(workspaceID)
+	if err != nil {
+		return res, err
+	}
+	if !identified {
+		res.Explanation = "This workspace is not identified as a REAPER workspace; repair did nothing."
+		return res, nil
+	}
+	res.Identified = true
+
+	// Inspect current state to decide the safe path.
+	results, err := rp.reconciler.Inspect(workspaceID, []string{ReaperPluginName})
+	if err != nil {
+		return res, err
+	}
+	var state pluginworkspace.PluginState
+	if len(results) > 0 {
+		state = results[0].State
+	}
+	switch state {
+	case pluginworkspace.PluginStateMissing:
+		res.NeedsInstall = true
+		res.Explanation = "reaper-plugin is not installed; install it first, then repair to attach its components."
+	case pluginworkspace.PluginStateDisabled:
+		if !confirmEnable {
+			res.NeedsConfirm = true
+			res.Explanation = "reaper-plugin is disabled. Confirm enabling it to attach its components."
+		}
+	}
+
+	// Attach (and, when confirmed, enable) via the shared reconciler. For a
+	// missing plugin or an unconfirmed disabled plugin, this is a safe no-op that
+	// attaches nothing.
+	if !res.NeedsInstall && !res.NeedsConfirm {
+		out, rerr := rp.reconciler.Reconcile(pluginworkspace.Request{
+			WorkspaceID: workspaceID,
+			Plugins:     []string{ReaperPluginName},
+			AllowEnable: confirmEnable,
+		})
+		if rerr != nil {
+			return res, rerr
+		}
+		if out.SaveErr != nil {
+			res.Warnings = append(res.Warnings, "workspace save failed: "+out.SaveErr.Error())
+		}
+		for _, pr := range out.Plugins {
+			res.Attached = append(res.Attached, pr.Applied...)
+			res.Warnings = append(res.Warnings, pr.Warnings...)
+			if pr.Enabled && state == pluginworkspace.PluginStateDisabled && confirmEnable {
+				res.Enabled = true
+			}
+		}
+		if len(res.Attached) == 0 && res.Explanation == "" {
+			res.NoOp = true
+			res.Explanation = "reaper-plugin is already fully attached; repair made no changes."
+		} else if res.Explanation == "" {
+			res.Explanation = fmt.Sprintf("Attached %d reaper-plugin component(s) to this workspace.", len(res.Attached))
+		}
+	}
+
+	// Report the resulting normalized readiness so the UI can refresh in place.
+	if rp.resolver != nil {
+		if readiness, rerr := rp.resolver.Resolve(workspaceID); rerr == nil {
+			res.Status = readiness.Status
+		}
+	}
+	res.Explanation = strings.TrimSpace(res.Explanation)
+	return res, nil
+}

--- a/internal/reapersetup/repair_test.go
+++ b/internal/reapersetup/repair_test.go
@@ -1,0 +1,150 @@
+package reapersetup
+
+import (
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// repairEnv wires a repairer over an in-memory workspace store and a fixture
+// plugin manager.
+func repairEnv(t *testing.T, plugins []plugin.InstalledPlugin) (*Repairer, *workspace.InMemoryStore, *fakePM) {
+	t.Helper()
+	store := workspace.NewInMemoryStore()
+	pm := &fakePM{list: plugins, enabled: map[string]bool{}}
+	rec := pluginworkspace.New(pm, store)
+	resolver := NewResolver(store, rec)
+	return NewRepairer(store, rec, resolver), store, pm
+}
+
+type fakePM struct {
+	list    []plugin.InstalledPlugin
+	enabled map[string]bool
+}
+
+func (f *fakePM) List() ([]plugin.InstalledPlugin, error) { return f.list, nil }
+func (f *fakePM) SetEnabled(name string, enabled bool) error {
+	f.enabled[name] = enabled
+	for i := range f.list {
+		if f.list[i].Name == name {
+			f.list[i].Enabled = enabled
+		}
+	}
+	return nil
+}
+
+func reaperRepairWS(t *testing.T, store *workspace.InMemoryStore) *workspace.Workspace {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: ReaperSongTemplateID})
+	_ = workspace.SetProjectEntryPath(ws.SharedData, "Song.rpp")
+	ws.Tasks = append(ws.Tasks, workspace.Task{ID: "s1", To: "Reaper Producer", Status: workspace.TaskStatusPending, Context: map[string]any{TaskContextTemplateSetup: true}})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	return ws
+}
+
+func TestRepair_DetachedAttachesMissing(t *testing.T) {
+	rp, store, _ := repairEnv(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup", "reaper-web-remote"}},
+	})
+	ws := reaperRepairWS(t, store)
+	// One of two components already attached => detached.
+	_ = ws.UpsertSkillBinding(workspace.SkillBinding{ID: "b1", SkillName: "reaper-session-setup", Enabled: true})
+	_ = store.Save(ws)
+
+	res, err := rp.Apply(ws.ID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Attached) != 1 || res.Attached[0].Name != "reaper-web-remote" {
+		t.Fatalf("expected reaper-web-remote attached, got %+v", res.Attached)
+	}
+	// Idempotent: second apply is a no-op.
+	res2, _ := rp.Apply(ws.ID, false)
+	if !res2.NoOp || len(res2.Attached) != 0 {
+		t.Fatalf("second repair should be a no-op, got %+v", res2)
+	}
+}
+
+func TestRepair_DisabledRequiresConfirmation(t *testing.T) {
+	rp, store, pm := repairEnv(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: false, Skills: []string{"reaper-session-setup"}},
+	})
+	ws := reaperRepairWS(t, store)
+
+	// Without confirmation: does not enable, does not attach.
+	res, _ := rp.Apply(ws.ID, false)
+	if !res.NeedsConfirm {
+		t.Fatalf("disabled plugin repair must require confirmation, got %+v", res)
+	}
+	if pm.enabled["reaper-plugin"] {
+		t.Fatalf("must not enable without confirmation")
+	}
+
+	// With confirmation: enables and attaches.
+	res2, _ := rp.Apply(ws.ID, true)
+	if !res2.Enabled || len(res2.Attached) != 1 {
+		t.Fatalf("confirmed repair should enable+attach, got %+v", res2)
+	}
+}
+
+func TestRepair_MissingPluginNeedsInstall(t *testing.T) {
+	rp, store, _ := repairEnv(t, nil)
+	ws := reaperRepairWS(t, store)
+	res, _ := rp.Apply(ws.ID, true)
+	if !res.NeedsInstall || len(res.Attached) != 0 {
+		t.Fatalf("missing plugin should report needs_install and attach nothing, got %+v", res)
+	}
+}
+
+func TestRepair_NotIdentifiedNoOp(t *testing.T) {
+	rp, store, _ := repairEnv(t, []plugin.InstalledPlugin{{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup"}}})
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Plain"})
+	_ = store.Save(ws)
+	res, _ := rp.Apply(ws.ID, true)
+	if res.Identified {
+		t.Fatalf("plain workspace must not be repairable")
+	}
+}
+
+// TestRepair_ForbiddenMutations proves repair never touches native access, the
+// agent definition, the task set, or the .rpp project entry.
+func TestRepair_ForbiddenMutations(t *testing.T) {
+	rp, store, _ := repairEnv(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup", "reaper-web-remote"}},
+	})
+	ws := reaperRepairWS(t, store)
+	no := false
+	_ = store.SaveWorkspaceAgent(ws.ID, "Reaper Producer", &agent.Agent{Type: "orchestrator", Settings: types.Settings{Provider: "openai", AllowNativeMCPTools: &no}})
+
+	before, _ := store.Get(ws.ID)
+	wsNativeBefore := before.AllowNativeMCPCLI
+	taskCountBefore := len(before.Tasks)
+	entryBefore, _ := workspace.GetProjectEntryPath(before.SharedData)
+
+	if _, err := rp.Apply(ws.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	after, _ := store.Get(ws.ID)
+	if after.AllowNativeMCPCLI != wsNativeBefore {
+		t.Fatalf("repair must not change workspace native-CLI access")
+	}
+	ag, _, _ := store.GetWorkspaceAgent(ws.ID, "Reaper Producer")
+	if ag.Settings.Provider != "openai" || ag.Settings.IsNativeMCPToolsAllowed() {
+		t.Fatalf("repair must not mutate the agent provider or native-access opt-in")
+	}
+	if len(after.Tasks) != taskCountBefore {
+		t.Fatalf("repair must not create or remove tasks")
+	}
+	entryAfter, _ := workspace.GetProjectEntryPath(after.SharedData)
+	if entryAfter != entryBefore {
+		t.Fatalf("repair must not touch the .rpp project entry")
+	}
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -354,16 +354,25 @@ func (b *ServerBuilder) initializeHandlers() {
 		b.sessionHandler.SetTemplateToolApplier(makeTemplateToolApplier(b))
 		b.sessionHandler.SetAgentToolApplier(makeAgentToolApplier(b))
 	}
+}
 
-	// Wire the normalized REAPER readiness resolver + shared reconciler so the
-	// workspace UI, pre-create preview, and repair all read one truthful model
-	// backed by the configured plugin manager and synchronized workspace store.
-	if b.sessionHandler != nil && b.pluginHandler != nil && b.workspaceStore != nil {
-		reconciler := pluginworkspace.New(b.pluginHandler.Manager(), b.workspaceStore)
-		resolver := reapersetup.NewResolver(b.workspaceStore, reconciler)
-		repairer := reapersetup.NewRepairer(b.workspaceStore, reconciler, resolver)
-		b.sessionHandler.SetReaperSetup(resolver, b.pluginHandler.Manager(), reconciler, repairer)
+// wireReaperSetup wires the normalized REAPER readiness resolver, pre-create
+// preview lister, shared reconciler, and repairer onto the session handler so the
+// create modal, workspace UI, and repair all read one truthful model backed by
+// the configured plugin manager and synchronized workspace store.
+//
+// It must be called AFTER the workspace store exists (Phase 18), not during
+// initializeHandlers (Phase 17) where b.workspaceStore is still nil — otherwise
+// every REAPER endpoint stays nil-guarded and the create preview always reports
+// plugin_missing.
+func (b *ServerBuilder) wireReaperSetup() {
+	if b.sessionHandler == nil || b.pluginHandler == nil || b.workspaceStore == nil {
+		return
 	}
+	reconciler := pluginworkspace.New(b.pluginHandler.Manager(), b.workspaceStore)
+	resolver := reapersetup.NewResolver(b.workspaceStore, reconciler)
+	repairer := reapersetup.NewRepairer(b.workspaceStore, reconciler, resolver)
+	b.sessionHandler.SetReaperSetup(resolver, b.pluginHandler.Manager(), reconciler, repairer)
 }
 
 func (b *ServerBuilder) registerWorkspaceRunTaskValidationMirror() {

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -32,6 +32,8 @@ import (
 	"github.com/johnjallday/ori-agent/internal/notehttp"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/pluginhttp"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
 	"github.com/johnjallday/ori-agent/internal/review"
 	"github.com/johnjallday/ori-agent/internal/reviewhttp"
 	"github.com/johnjallday/ori-agent/internal/session"
@@ -351,6 +353,15 @@ func (b *ServerBuilder) initializeHandlers() {
 	if b.sessionHandler != nil {
 		b.sessionHandler.SetTemplateToolApplier(makeTemplateToolApplier(b))
 		b.sessionHandler.SetAgentToolApplier(makeAgentToolApplier(b))
+	}
+
+	// Wire the normalized REAPER readiness resolver + shared reconciler so the
+	// workspace UI, pre-create preview, and repair all read one truthful model
+	// backed by the configured plugin manager and synchronized workspace store.
+	if b.sessionHandler != nil && b.pluginHandler != nil && b.workspaceStore != nil {
+		reconciler := pluginworkspace.New(b.pluginHandler.Manager(), b.workspaceStore)
+		resolver := reapersetup.NewResolver(b.workspaceStore, reconciler)
+		b.sessionHandler.SetReaperSetup(resolver, b.pluginHandler.Manager(), reconciler)
 	}
 }
 

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -361,7 +361,8 @@ func (b *ServerBuilder) initializeHandlers() {
 	if b.sessionHandler != nil && b.pluginHandler != nil && b.workspaceStore != nil {
 		reconciler := pluginworkspace.New(b.pluginHandler.Manager(), b.workspaceStore)
 		resolver := reapersetup.NewResolver(b.workspaceStore, reconciler)
-		b.sessionHandler.SetReaperSetup(resolver, b.pluginHandler.Manager(), reconciler)
+		repairer := reapersetup.NewRepairer(b.workspaceStore, reconciler, resolver)
+		b.sessionHandler.SetReaperSetup(resolver, b.pluginHandler.Manager(), reconciler, repairer)
 	}
 }
 

--- a/internal/server/builder_test.go
+++ b/internal/server/builder_test.go
@@ -101,6 +101,12 @@ func TestServerBuilder_Build_Integration(t *testing.T) {
 	if builder.runBackedTaskHandler == nil {
 		t.Error("run-backed task handler not initialized")
 	}
+	// REAPER readiness/preview/repair must be wired after the workspace store is
+	// created (Phase 18), not during handler init (Phase 17) when the store is
+	// still nil. If this regresses, the create preview is stuck on plugin_missing.
+	if server.Handlers.Session == nil || !server.Handlers.Session.ReaperSetupWired() {
+		t.Error("REAPER setup (resolver/preview/repair) not wired onto the session handler")
+	}
 }
 
 // TestNew_UsesBuilder verifies New() delegates to builder

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -228,6 +228,11 @@ func (b *ServerBuilder) initializeWorkspaceStore() error {
 		b.sessionHandler.SetWorkspaceTaskStore(ws)
 	}
 
+	// Now that the workspace store (SyncStore) exists, wire REAPER readiness /
+	// preview / repair. Done here rather than in initializeHandlers because the
+	// store is created in this phase (Phase 18), after the handlers.
+	b.wireReaperSetup()
+
 	return nil
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -580,6 +580,11 @@ func registerSessionRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("/api/sessions/stats", s.Handlers.Session.HandleStorageStats)
 		mux.HandleFunc("/api/sessions/bulk", s.Handlers.Session.HandleBulkDeleteSessions)
 
+		// Pre-create REAPER Setup preview for the Reaper Song template (no
+		// workspace id yet). Per-workspace readiness is dispatched under
+		// /api/workspaces/{id}/reaper-setup by the session handler.
+		mux.HandleFunc("/api/reaper-setup/preview", s.Handlers.Session.GetReaperCreatePreview)
+
 		// Auto-classify route (must be registered before the wildcard routes)
 		if s.Handlers.AutoClassify != nil {
 			mux.HandleFunc("/api/sessions/auto-classify", s.Handlers.AutoClassify.HandleAutoClassify)

--- a/internal/server/template_tools.go
+++ b/internal/server/template_tools.go
@@ -6,14 +6,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
 	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
-
-// templatePluginsDir is the managed plugins directory the plugin handler uses;
-// the applier reads installed.json from here to expand plugin references.
-const templatePluginsDir = "plugins"
 
 // makeTemplateToolApplier returns a function that binds a template's declared
 // default tools onto a freshly created workspace, applying only what resolves on
@@ -21,12 +17,19 @@ const templatePluginsDir = "plugins"
 //
 //   - skills bind by name (resolved downstream by the skill manager);
 //   - MCP servers bind when configured (else reported missing);
-//   - plugins expand to their installed component skills + MCP servers.
+//   - plugins expand to their installed component skills + MCP servers through
+//     the shared pluginworkspace reconciler, which reads installed-plugin state
+//     from the configured plugin manager/store used by the Plugins API and
+//     honors the plugin's enabled flag.
 //
 // It binds through the same workspace store the binding endpoints read from (the
 // SyncStore), Get→bind→Save by id, so the new bindings are immediately visible —
 // writing through the raw FileStore would land on disk but bypass the read path.
 // Builder fields are read at apply time (request time), so wiring order is moot.
+//
+// Skills/MCP are bound and saved first; plugin components are then reconciled as
+// a separate Get→bind→Save pass so the two writes never clobber each other
+// regardless of whether the store returns shared or cloned workspace values.
 func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.ToolDefaults) ([]string, []string) {
 	return func(workspaceID string, tools projecttemplates.ToolDefaults) (applied, missing []string) {
 		store := b.workspaceStore
@@ -48,6 +51,7 @@ func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.Too
 			boundMCP[strings.ToLower(strings.TrimSpace(bnd.ServerName))] = true
 		}
 
+		changed := false
 		bindSkill := func(name string) {
 			name = strings.TrimSpace(name)
 			key := strings.ToLower(name)
@@ -59,6 +63,7 @@ func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.Too
 				ID: uuid.NewString(), SkillName: name, Enabled: true, CreatedAt: now, UpdatedAt: now,
 			}); err == nil {
 				applied = append(applied, "skill:"+name)
+				changed = true
 			}
 		}
 		bindMCP := func(name string) {
@@ -72,6 +77,7 @@ func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.Too
 				ID: uuid.NewString(), ServerName: name, Enabled: true, CreatedAt: now, UpdatedAt: now,
 			}); err == nil {
 				applied = append(applied, "mcp:"+name)
+				changed = true
 			}
 		}
 
@@ -91,33 +97,40 @@ func makeTemplateToolApplier(b *ServerBuilder) func(string, projecttemplates.Too
 			bindMCP(srv)
 		}
 
-		// Plugins: expand each installed plugin to its component skills + servers.
-		if len(tools.Plugins) > 0 {
-			installed, _ := plugin.NewStore(templatePluginsDir).List()
-			byName := make(map[string]plugin.InstalledPlugin, len(installed))
-			for _, p := range installed {
-				byName[strings.ToLower(p.Name)] = p
-			}
-			for _, pl := range tools.Plugins {
-				p, ok := byName[strings.ToLower(strings.TrimSpace(pl))]
-				if !ok {
-					missing = append(missing, "plugin:"+pl)
-					continue
-				}
-				for _, s := range p.Skills {
-					bindSkill(s)
-				}
-				for _, srv := range p.MCPServers {
-					bindMCP(srv)
-				}
-			}
-		}
-
-		if len(applied) > 0 {
+		if changed {
 			if err := store.Save(ws); err != nil {
 				return nil, missing
 			}
 		}
+
+		// Plugins: reconcile each declared plugin's recorded components through the
+		// shared service. Template application reports a disabled plugin without
+		// enabling it (AllowEnable=false); enabling is an explicit user decision in
+		// manual attachment or repair.
+		if len(tools.Plugins) > 0 && b.pluginHandler != nil {
+			rec := pluginworkspace.New(b.pluginHandler.Manager(), store)
+			res, err := rec.Reconcile(pluginworkspace.Request{
+				WorkspaceID: workspaceID,
+				Plugins:     tools.Plugins,
+				AllowEnable: false,
+			})
+			if err == nil {
+				applied = append(applied, res.Applied...)
+				for _, pr := range res.Plugins {
+					switch pr.State {
+					case pluginworkspace.PluginStateMissing:
+						missing = append(missing, "plugin:"+pr.Name)
+					case pluginworkspace.PluginStateDisabled:
+						missing = append(missing, "plugin:"+pr.Name+" (globally disabled)")
+					case pluginworkspace.PluginStateDetached:
+						for _, c := range pr.Missing {
+							missing = append(missing, c.String())
+						}
+					}
+				}
+			}
+		}
+
 		return applied, missing
 	}
 }

--- a/internal/server/template_tools_test.go
+++ b/internal/server/template_tools_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/pluginhttp"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// writePluginFixture writes an isolated installed.json under dir so the applier
+// reads a temporary plugin registry, never the developer's ignored plugins/.
+func writePluginFixture(t *testing.T, dir, installedJSON string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "installed.json"), []byte(installedJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// applierBuilder wires a minimal ServerBuilder with an in-memory workspace store
+// and a plugin handler pointed at an isolated fixture dir.
+func applierBuilder(t *testing.T, pluginsDir string) (*ServerBuilder, workspace.Store) {
+	t.Helper()
+	b := &ServerBuilder{}
+	store := workspace.NewInMemoryStore()
+	b.workspaceStore = store
+	b.pluginHandler = pluginhttp.NewHandler(nil, nil, t.TempDir(), pluginsDir)
+	return b, store
+}
+
+func TestTemplateToolApplier_ConfiguredStoreAttachesEnabledPlugin(t *testing.T) {
+	pluginsDir := t.TempDir()
+	writePluginFixture(t, pluginsDir, `[
+	  {"name":"reaper-plugin","enabled":true,"skills":["reaper-session-setup","reaper-web-remote"]}
+	]`)
+	b, store := applierBuilder(t, pluginsDir)
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	apply := makeTemplateToolApplier(b)
+	applied, missing := apply(ws.ID, projecttemplates.ToolDefaults{Plugins: []string{"reaper-plugin"}})
+
+	sort.Strings(applied)
+	if len(applied) != 2 {
+		t.Fatalf("expected 2 applied components, got %v", applied)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("expected nothing missing, got %v", missing)
+	}
+	got, _ := store.Get(ws.ID)
+	if len(got.GetSkillBindings()) != 2 {
+		t.Fatalf("expected 2 workspace skill bindings, got %d", len(got.GetSkillBindings()))
+	}
+}
+
+func TestTemplateToolApplier_DisabledPluginReportedNotEnabled(t *testing.T) {
+	pluginsDir := t.TempDir()
+	writePluginFixture(t, pluginsDir, `[
+	  {"name":"reaper-plugin","enabled":false,"skills":["reaper-session-setup"]}
+	]`)
+	b, store := applierBuilder(t, pluginsDir)
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	apply := makeTemplateToolApplier(b)
+	applied, missing := apply(ws.ID, projecttemplates.ToolDefaults{Plugins: []string{"reaper-plugin"}})
+
+	if len(applied) != 0 {
+		t.Fatalf("disabled plugin must not attach components, applied=%v", applied)
+	}
+	if len(missing) != 1 {
+		t.Fatalf("expected one missing/disabled entry, got %v", missing)
+	}
+	got, _ := store.Get(ws.ID)
+	if len(got.GetSkillBindings()) != 0 {
+		t.Fatalf("disabled plugin must leave no bindings, got %d", len(got.GetSkillBindings()))
+	}
+}
+
+func TestTemplateToolApplier_MissingPluginReported(t *testing.T) {
+	pluginsDir := t.TempDir()
+	writePluginFixture(t, pluginsDir, `[]`)
+	b, store := applierBuilder(t, pluginsDir)
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	apply := makeTemplateToolApplier(b)
+	applied, missing := apply(ws.ID, projecttemplates.ToolDefaults{Plugins: []string{"reaper-plugin"}})
+
+	if len(applied) != 0 {
+		t.Fatalf("missing plugin must apply nothing, got %v", applied)
+	}
+	if len(missing) != 1 || missing[0] != "plugin:reaper-plugin" {
+		t.Fatalf("expected missing plugin:reaper-plugin, got %v", missing)
+	}
+}
+
+func TestTemplateToolApplier_IdempotentReapply(t *testing.T) {
+	pluginsDir := t.TempDir()
+	writePluginFixture(t, pluginsDir, `[
+	  {"name":"reaper-plugin","enabled":true,"skills":["reaper-session-setup","reaper-web-remote"]}
+	]`)
+	b, store := applierBuilder(t, pluginsDir)
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song"})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	apply := makeTemplateToolApplier(b)
+	tools := projecttemplates.ToolDefaults{
+		Skills:  []string{"note-taking"},
+		Plugins: []string{"reaper-plugin"},
+	}
+	apply(ws.ID, tools)
+	applied2, _ := apply(ws.ID, tools)
+
+	if len(applied2) != 0 {
+		t.Fatalf("second application should be a no-op, got %v", applied2)
+	}
+	got, _ := store.Get(ws.ID)
+	// note-taking + 2 plugin skills, no duplicates.
+	if len(got.GetSkillBindings()) != 3 {
+		t.Fatalf("expected 3 bindings after idempotent re-apply, got %d", len(got.GetSkillBindings()))
+	}
+}

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -12,7 +12,9 @@ import (
 
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
 	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/store"
 	"github.com/johnjallday/ori-agent/internal/types"
@@ -49,6 +51,14 @@ type Handler struct {
 	// orchestration task handler); used by the template-setup first-open
 	// auto-start after the consumed marker is stamped.
 	templateSetupStarter func(workspaceID, taskID string) error
+
+	// REAPER setup: the normalized readiness resolver, the plugin lister used for
+	// the pre-create preview, and the shared reconciler used by repair. Injected
+	// by the server, which holds the plugin manager; nil when plugins are
+	// unavailable (the endpoints then report an unidentified/empty result).
+	reaperResolver     *reapersetup.Resolver
+	reaperPluginLister reapersetup.PluginLister
+	reaperReconciler   *pluginworkspace.Reconciler
 
 	// rescanMu serializes disk reconciles so concurrent rescan requests
 	// (e.g. several hub tabs loading at once) don't run overlapping filesystem
@@ -108,6 +118,15 @@ func (h *Handler) SetTemplateToolApplier(fn func(workspaceID string, tools proje
 // per-agent tools (skills enabled on the agent; MCP servers on the workspace).
 func (h *Handler) SetAgentToolApplier(fn func(workspaceID, agentName string, tools projecttemplates.ToolDefaults) (applied, missing []string)) {
 	h.applyAgentTools = fn
+}
+
+// SetReaperSetup injects the normalized REAPER readiness resolver, the plugin
+// lister used for the pre-create preview, and the shared reconciler used by
+// repair. The server supplies these because the plugin manager lives there.
+func (h *Handler) SetReaperSetup(resolver *reapersetup.Resolver, lister reapersetup.PluginLister, reconciler *pluginworkspace.Reconciler) {
+	h.reaperResolver = resolver
+	h.reaperPluginLister = lister
+	h.reaperReconciler = reconciler
 }
 
 // SetTemplatesRootResolver sets the resolver used to locate the project

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -59,6 +59,7 @@ type Handler struct {
 	reaperResolver     *reapersetup.Resolver
 	reaperPluginLister reapersetup.PluginLister
 	reaperReconciler   *pluginworkspace.Reconciler
+	reaperRepairer     *reapersetup.Repairer
 
 	// rescanMu serializes disk reconciles so concurrent rescan requests
 	// (e.g. several hub tabs loading at once) don't run overlapping filesystem
@@ -123,10 +124,11 @@ func (h *Handler) SetAgentToolApplier(fn func(workspaceID, agentName string, too
 // SetReaperSetup injects the normalized REAPER readiness resolver, the plugin
 // lister used for the pre-create preview, and the shared reconciler used by
 // repair. The server supplies these because the plugin manager lives there.
-func (h *Handler) SetReaperSetup(resolver *reapersetup.Resolver, lister reapersetup.PluginLister, reconciler *pluginworkspace.Reconciler) {
+func (h *Handler) SetReaperSetup(resolver *reapersetup.Resolver, lister reapersetup.PluginLister, reconciler *pluginworkspace.Reconciler, repairer *reapersetup.Repairer) {
 	h.reaperResolver = resolver
 	h.reaperPluginLister = lister
 	h.reaperReconciler = reconciler
+	h.reaperRepairer = repairer
 }
 
 // SetTemplatesRootResolver sets the resolver used to locate the project

--- a/internal/sessionhttp/handler.go
+++ b/internal/sessionhttp/handler.go
@@ -131,6 +131,15 @@ func (h *Handler) SetReaperSetup(resolver *reapersetup.Resolver, lister reaperse
 	h.reaperRepairer = repairer
 }
 
+// ReaperSetupWired reports whether the REAPER readiness resolver, preview lister,
+// and repairer have been injected. Used by build wiring tests to catch the
+// ordering bug where wiring ran before the workspace store existed (which left
+// every REAPER endpoint nil-guarded and the create preview stuck on
+// plugin_missing).
+func (h *Handler) ReaperSetupWired() bool {
+	return h.reaperResolver != nil && h.reaperPluginLister != nil && h.reaperRepairer != nil
+}
+
 // SetTemplatesRootResolver sets the resolver used to locate the project
 // templates library directory.
 func (h *Handler) SetTemplatesRootResolver(fn func() string) {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -625,6 +625,26 @@ func (h *Handler) applyCreateWorkspaceTemplate(ctx context.Context, req createWo
 			}
 		}
 	}
+
+	// Persist portable template provenance so features (REAPER readiness, repair)
+	// can identify the originating built-in without scanning filenames or task
+	// prose. Best-effort: a failure here never fails creation.
+	if tc.resolved && tc.template.Builtin && strings.TrimSpace(tc.template.ID) != "" && h.workspaceTaskStore != nil {
+		prov := &agentworkspace.TemplateProvenance{
+			TemplateID:   tc.template.ID,
+			TemplateName: tc.template.Name,
+			Builtin:      true,
+			Version:      tc.template.BuiltinVersion,
+			AppliedAt:    time.Now(),
+		}
+		if err := h.workspaceTaskStore.Update(ws.ID, func(w *agentworkspace.Workspace) error {
+			w.SetTemplateProvenance(prov)
+			return nil
+		}); err != nil {
+			logger.Warn("Failed to persist template provenance", logger.Fields{"id": ws.ID, "template": tc.template.ID, "error": err})
+		}
+	}
+
 	return projectWarning
 }
 

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -281,6 +281,22 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Required-plugin gate: a template that declares plugins requires them
+	// installed and enabled before creation, so the workspace is never created
+	// missing its required tools. Reject with a structured 409 naming what to
+	// install/enable; the create modal surfaces this and offers the install/enable
+	// actions.
+	if templateResolved {
+		if missing, disabled := h.unsatisfiedRequiredPlugins(resolvedTemplate.Tools); len(missing)+len(disabled) > 0 {
+			_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+				"error":            "required plugins are not ready",
+				"missing_plugins":  missing,
+				"disabled_plugins": disabled,
+			})
+			return
+		}
+	}
+
 	ws := buildCreateWorkspace(req, kind, requestedTags, resolvedTemplate, templateResolved)
 
 	seed, ok := h.selectCreateWorkspaceEntryAgent(w, ws, req, kind, resolvedTemplate, templateResolved)

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -98,6 +98,9 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 				h.handleTemplateSetupStart(w, r, id)
 				return
 			}
+		case "reaper-setup":
+			h.handleReaperReadiness(w, r, id)
+			return
 		}
 	}
 

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -99,6 +99,10 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		case "reaper-setup":
+			if len(parts) == 3 && parts[2] == "repair" {
+				h.handleReaperRepair(w, r, id)
+				return
+			}
 			h.handleReaperReadiness(w, r, id)
 			return
 		}

--- a/internal/sessionhttp/workspace_reaper_setup.go
+++ b/internal/sessionhttp/workspace_reaper_setup.go
@@ -1,0 +1,55 @@
+package sessionhttp
+
+import (
+	"net/http"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
+)
+
+// handleReaperReadiness serves GET /api/workspaces/{id}/reaper-setup: the one
+// normalized REAPER readiness result reused by the workspace UI, repair, and
+// setup auto-start decisions. Each request recomputes from live plugin, binding,
+// task, provider, and permission state — it never returns a cached ready result.
+func (h *Handler) handleReaperReadiness(w http.ResponseWriter, r *http.Request, workspaceID string) {
+	if r.Method != http.MethodGet {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		orihttp.BadRequest(w, "workspace ID is required")
+		return
+	}
+	if h.reaperResolver == nil {
+		// Plugins unavailable: report an unidentified, file-only-safe result so the
+		// UI simply renders no REAPER surface rather than erroring.
+		orihttp.WriteJSON(w, reapersetup.Readiness{LiveVerification: "not_checked", ProjectMode: "file_only"})
+		return
+	}
+	readiness, err := h.reaperResolver.Resolve(workspaceID)
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, readiness)
+}
+
+// GetReaperCreatePreview serves GET /api/reaper-setup/preview: the pre-create
+// REAPER Setup card state for the Reaper Song template, computed from the same
+// plugin store the readiness resolver reads. There is no workspace yet, so it
+// reports plugin install/enable/would-attach only; agent and native-access
+// decisions happen in-workspace after creation.
+func (h *Handler) GetReaperCreatePreview(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+	preview, err := reapersetup.PreviewCreate(h.reaperPluginLister)
+	if err != nil {
+		orihttp.InternalError(w, err.Error())
+		return
+	}
+	orihttp.WriteJSON(w, preview)
+}

--- a/internal/sessionhttp/workspace_reaper_setup.go
+++ b/internal/sessionhttp/workspace_reaper_setup.go
@@ -1,6 +1,7 @@
 package sessionhttp
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -34,6 +35,51 @@ func (h *Handler) handleReaperReadiness(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	orihttp.WriteJSON(w, readiness)
+}
+
+// handleReaperRepair serves the existing-workspace repair endpoint at
+// /api/workspaces/{id}/reaper-setup/repair. GET previews the changes; POST
+// applies them (body {"confirm_enable": bool} to permit enabling a disabled
+// plugin). Repair only runs for conservatively identified REAPER workspaces and
+// never enables native access, mutates an agent, creates a task, or touches an
+// .rpp file. After a mutation, the response carries the refreshed readiness
+// status so the UI updates in place.
+func (h *Handler) handleReaperRepair(w http.ResponseWriter, r *http.Request, workspaceID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		orihttp.BadRequest(w, "workspace ID is required")
+		return
+	}
+	if h.reaperRepairer == nil {
+		orihttp.WriteJSON(w, reapersetup.RepairPlan{})
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		plan, err := h.reaperRepairer.Preview(workspaceID)
+		if err != nil {
+			orihttp.InternalError(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, plan)
+	case http.MethodPost:
+		var req struct {
+			ConfirmEnable bool `json:"confirm_enable"`
+		}
+		// Body is optional; decode leniently and default to no-confirm without
+		// erroring on an empty/absent body.
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&req)
+		}
+		result, err := h.reaperRepairer.Apply(workspaceID, req.ConfirmEnable)
+		if err != nil {
+			orihttp.InternalError(w, err.Error())
+			return
+		}
+		orihttp.WriteJSON(w, result)
+	default:
+		_ = orihttp.RespondMethodNotAllowed(w)
+	}
 }
 
 // GetReaperCreatePreview serves GET /api/reaper-setup/preview: the pre-create

--- a/internal/sessionhttp/workspace_reaper_setup.go
+++ b/internal/sessionhttp/workspace_reaper_setup.go
@@ -6,8 +6,50 @@ import (
 	"strings"
 
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/reapersetup"
 )
+
+// unsatisfiedRequiredPlugins reports the template-declared plugins that are not
+// installed (missing) and those installed but globally disabled (disabled).
+//
+// Product decision (overrides the earlier file-only-always default): a template
+// that declares plugins requires them installed AND enabled before a workspace
+// can be created, so the workspace never starts missing its required tools. The
+// create flow blocks on any missing/disabled required plugin. Reads through the
+// same plugin manager the Plugins API uses. Fails open (returns nothing) when
+// the plugin manager is unavailable or its store can't be read, so a transient
+// read error never permanently blocks creation.
+func (h *Handler) unsatisfiedRequiredPlugins(tools projecttemplates.ToolDefaults) (missing, disabled []string) {
+	if len(tools.Plugins) == 0 || h.reaperPluginLister == nil {
+		return nil, nil
+	}
+	installed, err := h.reaperPluginLister.List()
+	if err != nil {
+		return nil, nil
+	}
+	enabledByName := make(map[string]bool, len(installed))
+	present := make(map[string]bool, len(installed))
+	for _, p := range installed {
+		key := strings.ToLower(strings.TrimSpace(p.Name))
+		present[key] = true
+		enabledByName[key] = p.Enabled
+	}
+	for _, name := range tools.Plugins {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		switch {
+		case !present[key]:
+			missing = append(missing, name)
+		case !enabledByName[key]:
+			disabled = append(disabled, name)
+		}
+	}
+	return missing, disabled
+}
 
 // handleReaperReadiness serves GET /api/workspaces/{id}/reaper-setup: the one
 // normalized REAPER readiness result reused by the workspace UI, repair, and

--- a/internal/sessionhttp/workspace_reaper_setup_test.go
+++ b/internal/sessionhttp/workspace_reaper_setup_test.go
@@ -27,9 +27,10 @@ func reaperSetupHandler(t *testing.T, plugins []plugin.InstalledPlugin) (*Handle
 	pm := &fakePluginMgr{list: plugins}
 	rec := pluginworkspace.New(pm, store)
 	resolver := reapersetup.NewResolver(store, rec)
+	repairer := reapersetup.NewRepairer(store, rec, resolver)
 	h := New(nil)
 	h.SetWorkspaceTaskStore(store)
-	h.SetReaperSetup(resolver, pm, rec)
+	h.SetReaperSetup(resolver, pm, rec, repairer)
 	return h, store
 }
 

--- a/internal/sessionhttp/workspace_reaper_setup_test.go
+++ b/internal/sessionhttp/workspace_reaper_setup_test.go
@@ -28,6 +28,7 @@ func reaperSetupHandler(t *testing.T, plugins []plugin.InstalledPlugin) (*Handle
 	rec := pluginworkspace.New(pm, store)
 	resolver := reapersetup.NewResolver(store, rec)
 	h := New(nil)
+	h.SetWorkspaceTaskStore(store)
 	h.SetReaperSetup(resolver, pm, rec)
 	return h, store
 }

--- a/internal/sessionhttp/workspace_reaper_setup_test.go
+++ b/internal/sessionhttp/workspace_reaper_setup_test.go
@@ -97,6 +97,43 @@ func TestHandleReaperReadiness_PluginMissingStaysFileOnly(t *testing.T) {
 	}
 }
 
+func TestHandleReaperRepair_PreviewAndApply(t *testing.T) {
+	h, store := reaperSetupHandler(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup", "reaper-web-remote"}},
+	})
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: reapersetup.ReaperSongTemplateID})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	// Preview: detached -> plan to attach both components.
+	rr := httptest.NewRecorder()
+	h.handleReaperRepair(rr, httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID+"/reaper-setup/repair", nil), ws.ID)
+	var plan reapersetup.RepairPlan
+	if err := json.Unmarshal(rr.Body.Bytes(), &plan); err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Identified || len(plan.AttachPlan) != 2 {
+		t.Fatalf("expected a 2-component attach plan, got %+v", plan)
+	}
+
+	// Apply: attaches components.
+	rr2 := httptest.NewRecorder()
+	h.handleReaperRepair(rr2, httptest.NewRequest(http.MethodPost, "/api/workspaces/"+ws.ID+"/reaper-setup/repair", nil), ws.ID)
+	var res reapersetup.RepairResult
+	if err := json.Unmarshal(rr2.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Attached) != 2 {
+		t.Fatalf("expected 2 components attached, got %+v", res)
+	}
+	got, _ := store.Get(ws.ID)
+	if len(got.GetSkillBindings()) != 2 {
+		t.Fatalf("repair should leave 2 skill bindings, got %d", len(got.GetSkillBindings()))
+	}
+}
+
 func TestGetReaperCreatePreview(t *testing.T) {
 	h, _ := reaperSetupHandler(t, []plugin.InstalledPlugin{
 		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup", "reaper-web-remote"}},

--- a/internal/sessionhttp/workspace_reaper_setup_test.go
+++ b/internal/sessionhttp/workspace_reaper_setup_test.go
@@ -1,0 +1,116 @@
+package sessionhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+type fakePluginMgr struct{ list []plugin.InstalledPlugin }
+
+func (f *fakePluginMgr) List() ([]plugin.InstalledPlugin, error) { return f.list, nil }
+func (f *fakePluginMgr) SetEnabled(string, bool) error           { return nil }
+
+// reaperSetupHandler wires a session handler with an in-memory workspace store, a
+// reconciler over a fixture plugin manager, and the readiness resolver.
+func reaperSetupHandler(t *testing.T, plugins []plugin.InstalledPlugin) (*Handler, *workspace.InMemoryStore) {
+	t.Helper()
+	store := workspace.NewInMemoryStore()
+	pm := &fakePluginMgr{list: plugins}
+	rec := pluginworkspace.New(pm, store)
+	resolver := reapersetup.NewResolver(store, rec)
+	h := New(nil)
+	h.SetReaperSetup(resolver, pm, rec)
+	return h, store
+}
+
+func TestHandleReaperReadiness_OriReady(t *testing.T) {
+	h, store := reaperSetupHandler(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup"}},
+	})
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: reapersetup.ReaperSongTemplateID})
+	ws.AllowNativeMCPCLI = true
+	if err := ws.UpsertSkillBinding(workspace.SkillBinding{ID: "b1", SkillName: "reaper-session-setup", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	ws.Tasks = append(ws.Tasks, workspace.Task{ID: "s1", To: "Reaper Producer", Status: workspace.TaskStatusPending, Context: map[string]any{reapersetup.TaskContextTemplateSetup: true}})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	yes := true
+	if err := store.SaveWorkspaceAgent(ws.ID, "Reaper Producer", &agent.Agent{Type: "orchestrator", Settings: types.Settings{Provider: "codex", AllowNativeMCPTools: &yes}}); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID+"/reaper-setup", nil)
+	h.handleReaperReadiness(rr, req, ws.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rr.Code, rr.Body.String())
+	}
+	var got reapersetup.Readiness
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != reapersetup.StatusOriReady {
+		t.Fatalf("expected ori_ready, got %s", got.Status)
+	}
+	if got.LiveVerification != "not_checked" {
+		t.Fatalf("readiness must never claim REAPER connected; live_verification=%q", got.LiveVerification)
+	}
+}
+
+func TestHandleReaperReadiness_PluginMissingStaysFileOnly(t *testing.T) {
+	h, store := reaperSetupHandler(t, nil) // no plugins installed
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: reapersetup.ReaperSongTemplateID})
+	ws.Tasks = append(ws.Tasks, workspace.Task{ID: "s1", To: "Reaper Producer", Status: workspace.TaskStatusPending, Context: map[string]any{reapersetup.TaskContextTemplateSetup: true}})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID+"/reaper-setup", nil)
+	h.handleReaperReadiness(rr, req, ws.ID)
+
+	var got reapersetup.Readiness
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != reapersetup.StatusPluginMissing {
+		t.Fatalf("expected plugin_missing, got %s", got.Status)
+	}
+	if got.ProjectMode != "file_only" {
+		t.Fatalf("expected file_only project mode, got %s", got.ProjectMode)
+	}
+}
+
+func TestGetReaperCreatePreview(t *testing.T) {
+	h, _ := reaperSetupHandler(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup", "reaper-web-remote"}},
+	})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/reaper-setup/preview", nil)
+	h.GetReaperCreatePreview(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	var got reapersetup.CreatePreview
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "ready_to_attach" || len(got.WouldAttach) != 2 {
+		t.Fatalf("expected ready_to_attach with 2 components, got %s / %v", got.Status, got.WouldAttach)
+	}
+}

--- a/internal/sessionhttp/workspace_reaper_setup_test.go
+++ b/internal/sessionhttp/workspace_reaper_setup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/plugin"
 	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
 	"github.com/johnjallday/ori-agent/internal/reapersetup"
 	"github.com/johnjallday/ori-agent/internal/types"
 	"github.com/johnjallday/ori-agent/internal/workspace"
@@ -131,6 +132,33 @@ func TestHandleReaperRepair_PreviewAndApply(t *testing.T) {
 	got, _ := store.Get(ws.ID)
 	if len(got.GetSkillBindings()) != 2 {
 		t.Fatalf("repair should leave 2 skill bindings, got %d", len(got.GetSkillBindings()))
+	}
+}
+
+func TestUnsatisfiedRequiredPlugins(t *testing.T) {
+	tools := projecttemplates.ToolDefaults{Plugins: []string{"reaper-plugin"}}
+
+	// Missing plugin.
+	h, _ := reaperSetupHandler(t, nil)
+	if missing, disabled := h.unsatisfiedRequiredPlugins(tools); len(missing) != 1 || missing[0] != "reaper-plugin" || len(disabled) != 0 {
+		t.Fatalf("missing plugin: got missing=%v disabled=%v", missing, disabled)
+	}
+
+	// Installed but disabled.
+	h2, _ := reaperSetupHandler(t, []plugin.InstalledPlugin{{Name: "reaper-plugin", Enabled: false}})
+	if missing, disabled := h2.unsatisfiedRequiredPlugins(tools); len(disabled) != 1 || disabled[0] != "reaper-plugin" || len(missing) != 0 {
+		t.Fatalf("disabled plugin: got missing=%v disabled=%v", missing, disabled)
+	}
+
+	// Installed and enabled: satisfied.
+	h3, _ := reaperSetupHandler(t, []plugin.InstalledPlugin{{Name: "reaper-plugin", Enabled: true}})
+	if missing, disabled := h3.unsatisfiedRequiredPlugins(tools); len(missing)+len(disabled) != 0 {
+		t.Fatalf("enabled plugin should be satisfied: missing=%v disabled=%v", missing, disabled)
+	}
+
+	// Template declares no plugins: never blocks.
+	if missing, disabled := h.unsatisfiedRequiredPlugins(projecttemplates.ToolDefaults{}); len(missing)+len(disabled) != 0 {
+		t.Fatalf("no declared plugins should never block")
 	}
 }
 

--- a/internal/sessionhttp/workspace_setup_gate_test.go
+++ b/internal/sessionhttp/workspace_setup_gate_test.go
@@ -1,0 +1,119 @@
+package sessionhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	"github.com/johnjallday/ori-agent/internal/plugin"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// setupGateWS builds a REAPER workspace with an assigned pending setup task, an
+// entry agent snapshot, and native access wired per args.
+func setupGateWS(t *testing.T, store *workspace.InMemoryStore, provider string, wsNative, agentNative bool, attachSkill bool) *workspace.Workspace {
+	t.Helper()
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Song", Agents: []string{"Reaper Producer"}})
+	ws.SetTemplateProvenance(&workspace.TemplateProvenance{TemplateID: reapersetup.ReaperSongTemplateID})
+	ws.AllowNativeMCPCLI = wsNative
+	if attachSkill {
+		_ = ws.UpsertSkillBinding(workspace.SkillBinding{ID: "b1", SkillName: "reaper-session-setup", Enabled: true})
+	}
+	ws.Tasks = append(ws.Tasks, workspace.Task{
+		ID: "setup-1", WorkspaceID: ws.ID, To: "Reaper Producer",
+		Status: workspace.TaskStatusPending, Context: map[string]any{reapersetup.TaskContextTemplateSetup: true},
+	})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	_ = store.SaveWorkspaceAgent(ws.ID, "Reaper Producer", &agent.Agent{
+		Type: "orchestrator", Settings: types.Settings{Provider: provider, AllowNativeMCPTools: &agentNative},
+	})
+	return ws
+}
+
+func postSetupStart(t *testing.T, h *Handler, wsID string) map[string]any {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/"+wsID+"/template-setup/start", nil)
+	h.handleTemplateSetupStart(rr, req, wsID)
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("bad response %q: %v", rr.Body.String(), err)
+	}
+	return body
+}
+
+func TestSetupStart_BlockedWhenNotOriReady(t *testing.T) {
+	h, store := reaperSetupHandler(t, nil) // plugin missing => not ori_ready
+	var started int
+	h.templateSetupStarter = func(string, string) error { started++; return nil }
+	ws := setupGateWS(t, store, "codex", true, true, false)
+
+	body := postSetupStart(t, h, ws.ID)
+	if body["started"] != false {
+		t.Fatalf("must not start when not ori_ready: %+v", body)
+	}
+	if body["reason"] != "not_ready" || body["readiness_status"] != "plugin_missing" {
+		t.Fatalf("expected not_ready/plugin_missing blocker, got %+v", body)
+	}
+	if started != 0 {
+		t.Fatalf("starter must not run when blocked")
+	}
+	// Marker must NOT be written: task stays pending and unconsumed.
+	got, _ := store.Get(ws.ID)
+	if _, consumed := got.Tasks[0].Context[reapersetup.TaskContextSetupConsumedAt]; consumed {
+		t.Fatalf("consumed marker must not be written while blocked")
+	}
+}
+
+func TestSetupStart_StartsOnceWhenOriReady(t *testing.T) {
+	h, store := reaperSetupHandler(t, []plugin.InstalledPlugin{
+		{Name: "reaper-plugin", Enabled: true, Skills: []string{"reaper-session-setup"}},
+	})
+	var mu sync.Mutex
+	started := 0
+	h.templateSetupStarter = func(string, string) error { mu.Lock(); started++; mu.Unlock(); return nil }
+	ws := setupGateWS(t, store, "codex", true, true, true)
+
+	body := postSetupStart(t, h, ws.ID)
+	if body["started"] != true {
+		t.Fatalf("expected started when ori_ready: %+v", body)
+	}
+	// Idempotent: a second call (reload / concurrent tab) does not start again.
+	body2 := postSetupStart(t, h, ws.ID)
+	if body2["started"] != false || body2["reason"] != "already_consumed" {
+		t.Fatalf("second call should be already_consumed no-op, got %+v", body2)
+	}
+	if started != 1 {
+		t.Fatalf("setup task must start exactly once, started=%d", started)
+	}
+}
+
+func TestSetupStart_NonReaperTemplateUnaffected(t *testing.T) {
+	h, store := reaperSetupHandler(t, nil)
+	var started int
+	h.templateSetupStarter = func(string, string) error { started++; return nil }
+	// No REAPER provenance -> not identified -> gate does not apply.
+	ws := workspace.NewWorkspace(workspace.CreateWorkspaceParams{Name: "Notes", Agents: []string{"Writer"}})
+	ws.Tasks = append(ws.Tasks, workspace.Task{
+		ID: "s1", WorkspaceID: ws.ID, To: "Writer",
+		Status: workspace.TaskStatusPending, Context: map[string]any{reapersetup.TaskContextTemplateSetup: true},
+	})
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	body := postSetupStart(t, h, ws.ID)
+	if body["started"] != true {
+		t.Fatalf("non-REAPER setup task should start as before, got %+v", body)
+	}
+	if started != 1 {
+		t.Fatalf("non-REAPER starter should run once, started=%d", started)
+	}
+}

--- a/internal/sessionhttp/workspace_template_tasks.go
+++ b/internal/sessionhttp/workspace_template_tasks.go
@@ -10,6 +10,7 @@ import (
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+	"github.com/johnjallday/ori-agent/internal/reapersetup"
 	agentworkspace "github.com/johnjallday/ori-agent/internal/workspace"
 )
 
@@ -120,6 +121,25 @@ func (h *Handler) handleTemplateSetupStart(w http.ResponseWriter, r *http.Reques
 	if store == nil {
 		_ = orihttp.RespondSuccess(w, map[string]any{"success": true, "started": false, "reason": "no_task_store"})
 		return
+	}
+
+	// Gate on normalized readiness BEFORE reserving/writing the consumed marker.
+	// For a REAPER workspace, auto-start proceeds only when Ori is configured to
+	// attempt live control (ori_ready). Otherwise the setup task is left pending
+	// and unconsumed with a stable blocker reason, so a later readiness change
+	// (repair, enable, permission) still auto-starts it exactly once. Non-REAPER
+	// templates are not identified and keep the prior behavior.
+	if h.reaperResolver != nil {
+		if readiness, rerr := h.reaperResolver.Resolve(workspaceID); rerr == nil && readiness.Identified && readiness.Status != reapersetup.StatusOriReady {
+			_ = orihttp.RespondSuccess(w, map[string]any{
+				"success":          true,
+				"started":          false,
+				"reason":           "not_ready",
+				"readiness_status": string(readiness.Status),
+				"readiness":        readiness,
+			})
+			return
+		}
 	}
 
 	var (

--- a/internal/web/static/css/sessions.css
+++ b/internal/web/static/css/sessions.css
@@ -6956,3 +6956,56 @@ body.task-modal-open {
 .reaper-setup-card .reaper-setup-badge-checking {
   opacity: 0.7;
 }
+
+/* Durable REAPER Setup readiness card (workspace detail → Plugins). */
+.workspace-detail-reaper-card {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  background: var(--bg-secondary, rgba(127, 127, 127, 0.05));
+}
+.workspace-detail-reaper-card:focus {
+  outline: 2px solid var(--accent-color, #3b82f6);
+  outline-offset: 2px;
+}
+.workspace-detail-reaper-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+.workspace-detail-reaper-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.workspace-detail-reaper-status {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.workspace-detail-reaper-rows {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0;
+  display: grid;
+  gap: 4px;
+}
+.workspace-detail-reaper-row {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+.workspace-detail-reaper-row-mark {
+  width: 12px;
+  flex: 0 0 auto;
+  text-align: center;
+  color: var(--text-secondary);
+}
+.workspace-detail-reaper-row-label { color: var(--text-secondary); }
+.workspace-detail-reaper-row-value { color: var(--text-primary); }
+.reaper-setup-chip { cursor: pointer; }
+.reaper-setup-chip.reaper-setup-chip-ready { opacity: 0.85; }

--- a/internal/web/static/css/sessions.css
+++ b/internal/web/static/css/sessions.css
@@ -6927,3 +6927,32 @@ body.task-modal-open {
   font-size: 0.85rem;
   cursor: pointer;
 }
+
+/* REAPER Setup card (Create Workspace) — status uses text + badge, never color
+   alone, so state is legible without relying on hue. */
+.reaper-setup-card .reaper-setup-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.reaper-setup-card .reaper-setup-badge-ready {
+  border-color: #22c55e;
+  color: #16a34a;
+}
+.reaper-setup-card .reaper-setup-badge-disabled,
+.reaper-setup-card .reaper-setup-badge-file-only {
+  border-color: #f59e0b;
+  color: #d97706;
+}
+.reaper-setup-card .reaper-setup-badge-error {
+  border-color: #ef4444;
+  color: #dc2626;
+}
+.reaper-setup-card .reaper-setup-badge-checking {
+  opacity: 0.7;
+}

--- a/internal/web/static/js/modules/reaper-plugin-install.js
+++ b/internal/web/static/js/modules/reaper-plugin-install.js
@@ -1,0 +1,285 @@
+// reaper-plugin-install.js — the shared inline reaper-plugin install flow used by
+// both the Create Workspace REAPER Setup card and the workspace-detail repair
+// card. It owns a single host element, into which it renders a status line, the
+// trust disclosure, and the confirm/cancel (or source-input) controls, then
+// installs + enables the plugin and calls onComplete so the caller re-checks.
+//
+// Resolution order: a template-declared source (one click), else a configured
+// marketplace, else a pasted source. The trust preview is always shown before
+// anything installs — nothing installs silently.
+(function () {
+  'use strict';
+
+  const PLUGIN_NAME = 'reaper-plugin';
+  let busy = false;
+
+  async function fetchJSON(url, opts) {
+    const resp = await fetch(url, opts);
+    let data = {};
+    try {
+      data = await resp.json();
+    } catch (_) {
+      data = {};
+    }
+    if (!resp.ok) throw new Error(data.error || 'request failed: ' + resp.status);
+    return data;
+  }
+
+  function postJSON(body) {
+    return {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    };
+  }
+
+  // panel clears the host and returns a single column container to render into,
+  // so the install UI lays out cleanly regardless of the host's own flex rules
+  // (both cards' action rows are horizontal flex).
+  function panel(host) {
+    host.textContent = '';
+    const p = document.createElement('div');
+    p.className = 'reaper-install-panel';
+    p.style.cssText = 'display:flex;flex-direction:column;gap:6px;width:100%;';
+    host.appendChild(p);
+    return p;
+  }
+
+  function statusLine(c, text, primaryText) {
+    const d = document.createElement('div');
+    d.className = 'reaper-install-status';
+    d.style.cssText = primaryText
+      ? 'font-size:12px;color:var(--text-primary);'
+      : 'font-size:12px;color:var(--text-secondary);';
+    d.textContent = text;
+    c.appendChild(d);
+    return d;
+  }
+
+  function line(c, text) {
+    const d = document.createElement('div');
+    d.style.cssText = 'font-size:11px;color:var(--text-secondary);';
+    d.textContent = text;
+    c.appendChild(d);
+    return d;
+  }
+
+  function bar(c) {
+    const b = document.createElement('div');
+    b.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;';
+    c.appendChild(b);
+    return b;
+  }
+
+  function button(c, label, primary, onClick) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'modern-btn ' + (primary ? 'modern-btn-primary' : 'modern-btn-secondary');
+    b.style.fontSize = '12px';
+    b.textContent = label;
+    if (onClick) b.addEventListener('click', onClick);
+    c.appendChild(b);
+    return b;
+  }
+
+  async function resolveMarketplace() {
+    try {
+      const data = await fetchJSON('/api/plugins/marketplaces');
+      const list = Array.isArray(data.marketplaces) ? data.marketplaces : [];
+      for (const mp of list) {
+        const plugins = Array.isArray(mp.plugins) ? mp.plugins : [];
+        const hit = plugins.find(p => String(p.name || '').toLowerCase() === PLUGIN_NAME);
+        if (hit) return { marketplace: mp.name, plugin: hit.name || PLUGIN_NAME };
+      }
+    } catch (_) {
+      /* fall through */
+    }
+    return null;
+  }
+
+  function message(host, text) {
+    const c = panel(host);
+    statusLine(c, text);
+    return c;
+  }
+
+  // renderTrust shows the disclosure and an install confirm, so nothing installs
+  // without the user seeing what it registers.
+  function renderTrust(host, trust, sourceLabel, doInstall, opts) {
+    const t = trust || {};
+    const c = panel(host);
+    statusLine(c, 'Install ' + (t.Name || PLUGIN_NAME) + ' from ' + sourceLabel + '?', true);
+    const skills = Array.isArray(t.Skills) ? t.Skills : [];
+    const cmds = Array.isArray(t.MCPCommands) ? t.MCPCommands : [];
+    const warnings = Array.isArray(t.Warnings) ? t.Warnings : [];
+    if (skills.length) line(c, 'Skills: ' + skills.join(', '));
+    if (cmds.length) line(c, 'Runs: ' + cmds.join('; '));
+    if (!skills.length && !cmds.length) line(c, 'Registers reaper-plugin components.');
+    warnings.forEach(wtext => {
+      const wl = line(c, '⚠ ' + wtext);
+      wl.style.color = 'var(--warning-color, #d97706)';
+    });
+    const b = bar(c);
+    button(b, 'Install & enable', true, () => doInstall());
+    button(b, 'Cancel', false, () => finishCancel(opts));
+  }
+
+  function renderSourceInput(host, opts, keepStatus) {
+    const c = panel(host);
+    if (!keepStatus) {
+      statusLine(
+        c,
+        'No configured marketplace has reaper-plugin. Paste its source to install it here.'
+      );
+    }
+    line(
+      c,
+      'A GitHub repo URL or local path to reaper-plugin. The trust preview is shown before anything installs.'
+    );
+    const b = bar(c);
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'modern-input';
+    input.placeholder = 'e.g. https://github.com/owner/reaper-plugin.git';
+    input.style.cssText = 'flex:1 1 220px;font-size:12px;';
+    input.setAttribute('aria-label', 'reaper-plugin source');
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') previewSource(host, input.value, opts);
+    });
+    b.appendChild(input);
+    button(b, 'Preview install', true, () => previewSource(host, input.value, opts));
+    button(b, 'Open Plugins page', false, () =>
+      window.open('/plugins?install=' + encodeURIComponent(PLUGIN_NAME), '_blank', 'noopener')
+    );
+    input.focus?.();
+  }
+
+  async function previewSource(host, source, opts) {
+    source = String(source || '').trim();
+    if (!source || busy) return;
+    busy = true;
+    message(host, 'Checking ' + source + '…');
+    try {
+      const prev = await fetchJSON('/api/plugins/install', postJSON({ source, confirm: false }));
+      renderTrust(
+        host,
+        prev.trust,
+        source,
+        () =>
+          doInstall(
+            host,
+            () => fetchJSON('/api/plugins/install', postJSON({ source, confirm: true })),
+            opts
+          ),
+        opts
+      );
+    } catch (e) {
+      renderSourceInputWithError(
+        host,
+        opts,
+        'Could not read that source: ' + (e.message || 'unknown error')
+      );
+    } finally {
+      busy = false;
+    }
+  }
+
+  function renderSourceInputWithError(host, opts, msg) {
+    const c = panel(host);
+    const s = statusLine(c, msg);
+    s.style.color = 'var(--warning-color, #d97706)';
+    line(c, 'A GitHub repo URL or local path to reaper-plugin.');
+    const b = bar(c);
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'modern-input';
+    input.placeholder = 'e.g. https://github.com/owner/reaper-plugin.git';
+    input.style.cssText = 'flex:1 1 220px;font-size:12px;';
+    input.setAttribute('aria-label', 'reaper-plugin source');
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') previewSource(host, input.value, opts);
+    });
+    b.appendChild(input);
+    button(b, 'Preview install', true, () => previewSource(host, input.value, opts));
+  }
+
+  async function doInstall(host, installFn, opts) {
+    if (busy) return;
+    busy = true;
+    message(host, 'Installing reaper-plugin…');
+    try {
+      await installFn();
+      // Installs land disabled; enable so the plugin will attach.
+      try {
+        await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
+          method: 'POST'
+        });
+      } catch (_) {
+        /* best effort; the caller's re-check surfaces a disabled state */
+      }
+      finishComplete(opts);
+    } catch (e) {
+      const c = message(host, 'Install failed: ' + (e.message || 'unknown error'));
+      button(bar(c), 'Retry', false, () => begin(opts));
+    } finally {
+      busy = false;
+    }
+  }
+
+  function finishComplete(opts) {
+    if (opts && typeof opts.onComplete === 'function') opts.onComplete();
+  }
+  function finishCancel(opts) {
+    if (opts && typeof opts.onCancel === 'function') opts.onCancel();
+    else finishComplete(opts);
+  }
+
+  // begin starts the install flow into opts.host. opts:
+  //   host           element to render the flow into (required)
+  //   declaredSource optional exact source (template-declared) for one-click
+  //   onComplete     called after install+enable (caller re-checks readiness)
+  //   onCancel       called when the user cancels (defaults to onComplete)
+  async function begin(opts) {
+    const host = opts && opts.host;
+    if (!host || busy) return;
+    if (opts.declaredSource) {
+      await previewSource(host, opts.declaredSource, opts);
+      return;
+    }
+    busy = true;
+    message(host, 'Finding reaper-plugin…');
+    try {
+      const mp = await resolveMarketplace();
+      if (mp) {
+        const prev = await fetchJSON(
+          '/api/plugins/marketplaces/install',
+          postJSON({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: false })
+        );
+        renderTrust(
+          host,
+          prev.trust,
+          mp.plugin + ' · ' + mp.marketplace,
+          () =>
+            doInstall(
+              host,
+              () =>
+                fetchJSON(
+                  '/api/plugins/marketplaces/install',
+                  postJSON({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: true })
+                ),
+              opts
+            ),
+          opts
+        );
+      } else {
+        renderSourceInput(host, opts);
+      }
+    } catch (_) {
+      renderSourceInput(host, opts);
+    } finally {
+      busy = false;
+    }
+  }
+
+  window.ReaperPluginInstall = { begin };
+})();

--- a/internal/web/static/js/modules/reaper-plugin-install.test.js
+++ b/internal/web/static/js/modules/reaper-plugin-install.test.js
@@ -1,0 +1,154 @@
+// Tests for reaper-plugin-install.js — the shared inline install flow used by
+// both the create card and the workspace-detail repair card. Inline DOM stub.
+//
+// Run with: node --test internal/web/static/js/modules/reaper-plugin-install.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this._text = '';
+    this.className = '';
+    this.style = {};
+    this.disabled = false;
+    this.type = '';
+    this.placeholder = '';
+    this.value = '';
+    this.children = [];
+    this._listeners = {};
+    this._attrs = {};
+  }
+  get textContent() {
+    if (this.children.length) return this._text + this.children.map(c => c.textContent).join('');
+    return this._text;
+  }
+  set textContent(v) {
+    this._text = v;
+    if (v === '') this.children = [];
+  }
+  appendChild(el) {
+    this.children.push(el);
+    return el;
+  }
+  addEventListener(ev, fn) {
+    (this._listeners[ev] ||= []).push(fn);
+  }
+  click() {
+    (this._listeners.click || []).forEach(fn => fn());
+  }
+  setAttribute(k, v) {
+    this._attrs[k] = v;
+  }
+  focus() {}
+  querySelectorAll(sel) {
+    const want = String(sel).toUpperCase();
+    const out = [];
+    const walk = el =>
+      el.children.forEach(c => {
+        if (c.tagName === want) out.push(c);
+        walk(c);
+      });
+    walk(this);
+    return out;
+  }
+}
+
+class FakeDocument {
+  createElement(tag) {
+    return new FakeElement(tag);
+  }
+}
+
+globalThis.document = new FakeDocument();
+globalThis.window = globalThis;
+await import('./reaper-plugin-install.js');
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await new Promise(r => setTimeout(r, 0));
+};
+const buttons = host => host.querySelectorAll('button').map(b => b.textContent);
+
+test('marketplace path: trust preview then install + enable calls onComplete', async () => {
+  const host = new FakeElement('div');
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const method = (opts && opts.method) || 'GET';
+    calls.push(method + ' ' + url);
+    if (url === '/api/plugins/marketplaces') {
+      return {
+        ok: true,
+        json: async () => ({ marketplaces: [{ name: 'mp', plugins: [{ name: 'reaper-plugin' }] }] })
+      };
+    }
+    if (url === '/api/plugins/marketplaces/install') {
+      const body = JSON.parse(opts.body);
+      return body.confirm
+        ? { ok: true, json: async () => ({ installed: true }) }
+        : {
+            ok: true,
+            json: async () => ({
+              trust: { Name: 'reaper-plugin', Skills: ['reaper-session-setup'] }
+            })
+          };
+    }
+    if (url === '/api/plugins/reaper-plugin/enable')
+      return { ok: true, json: async () => ({ enabled: true }) };
+    throw new Error('unexpected ' + url);
+  };
+
+  let done = false;
+  window.ReaperPluginInstall.begin({ host, onComplete: () => (done = true) });
+  await flush();
+  assert.match(host.textContent, /Skills: reaper-session-setup/);
+  const confirm = host.querySelectorAll('button').find(b => b.textContent === 'Install & enable');
+  assert.ok(confirm, 'expected trust confirm');
+  confirm.click();
+  await flush();
+  assert.ok(done, 'onComplete should fire after install + enable');
+  assert.ok(calls.includes('POST /api/plugins/reaper-plugin/enable'), 'must enable after install');
+});
+
+test('declared source: installs straight from source, no marketplace call', async () => {
+  const host = new FakeElement('div');
+  const SRC = 'https://github.com/johnjallday/reaper-plugin.git';
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    calls.push(url);
+    if (url === '/api/plugins/install') {
+      const body = JSON.parse(opts.body);
+      assert.equal(body.source, SRC);
+      return body.confirm
+        ? { ok: true, json: async () => ({ installed: true }) }
+        : { ok: true, json: async () => ({ trust: { Name: 'reaper-plugin', Skills: [] } }) };
+    }
+    if (url === '/api/plugins/reaper-plugin/enable') return { ok: true, json: async () => ({}) };
+    throw new Error('unexpected ' + url);
+  };
+  let done = false;
+  window.ReaperPluginInstall.begin({ host, declaredSource: SRC, onComplete: () => (done = true) });
+  await flush();
+  host
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install & enable')
+    .click();
+  await flush();
+  assert.ok(done);
+  assert.ok(
+    !calls.includes('/api/plugins/marketplaces'),
+    'declared source must skip the marketplace'
+  );
+});
+
+test('no marketplace: falls back to a source input', async () => {
+  const host = new FakeElement('div');
+  globalThis.fetch = async url => {
+    if (url === '/api/plugins/marketplaces')
+      return { ok: true, json: async () => ({ marketplaces: [] }) };
+    throw new Error('unexpected ' + url);
+  };
+  window.ReaperPluginInstall.begin({ host, onComplete: () => {} });
+  await flush();
+  assert.ok(host.querySelectorAll('input').length > 0, 'expected a source input');
+  assert.ok(buttons(host).includes('Preview install'));
+});

--- a/internal/web/static/js/modules/reaper-readiness-panel.js
+++ b/internal/web/static/js/modules/reaper-readiness-panel.js
@@ -1,0 +1,246 @@
+// reaper-readiness-panel.js — the durable REAPER Setup readiness card on the
+// workspace detail page (Workspace Tools → Plugins), plus a compact
+// setup-needed indicator chip in the config summary.
+//
+// It reads one normalized readiness result from
+// GET /api/workspaces/{id}/reaper-setup and renders separate rows for project
+// mode, plugin install/enabled, workspace attachment, setup-agent compatibility,
+// native CLI access, setup-task state, and live REAPER verification — which is
+// always labeled not-yet-checked. It never claims REAPER is connected.
+//
+// Actions (repair, check-again-and-start-setup, deep-links) reuse the existing
+// idempotent backend endpoints and re-fetch readiness after every mutation.
+(function () {
+  'use strict';
+
+  const els = () => ({
+    card: document.getElementById('reaperReadinessCard'),
+    status: document.getElementById('reaperReadinessStatus'),
+    badge: document.getElementById('reaperReadinessBadge'),
+    rows: document.getElementById('reaperReadinessRows'),
+    actions: document.getElementById('reaperReadinessActions'),
+    chip: document.getElementById('reaperReadinessChip'),
+  });
+
+  let workspaceId = '';
+  let busy = false;
+
+  function wsId() {
+    return workspaceId || (typeof window !== 'undefined' && window.currentWorkspaceId) || '';
+  }
+
+  function setBadge(badge, label) {
+    if (!badge) return;
+    badge.textContent = label;
+    badge.className = 'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
+  }
+
+  function row(label, value, ok) {
+    const li = document.createElement('li');
+    li.className = 'workspace-detail-reaper-row';
+    const mark = document.createElement('span');
+    mark.className = 'workspace-detail-reaper-row-mark';
+    // Non-color status token in addition to any styling.
+    mark.textContent = ok === true ? '✓' : ok === false ? '•' : '–';
+    mark.setAttribute('aria-hidden', 'true');
+    const l = document.createElement('span');
+    l.className = 'workspace-detail-reaper-row-label';
+    l.textContent = label + ': ';
+    const v = document.createElement('span');
+    v.className = 'workspace-detail-reaper-row-value';
+    v.textContent = value;
+    li.appendChild(mark);
+    li.appendChild(l);
+    li.appendChild(v);
+    return li;
+  }
+
+  function button(label, opts = {}) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'modern-btn ' + (opts.primary ? 'modern-btn-primary' : 'modern-btn-secondary');
+    b.style.fontSize = '12px';
+    b.textContent = label;
+    if (opts.onClick) b.addEventListener('click', opts.onClick);
+    return b;
+  }
+
+  function setBusy(on) {
+    busy = on;
+    const { actions } = els();
+    if (actions) actions.querySelectorAll('button').forEach((b) => { b.disabled = on; });
+  }
+
+  function openPluginsTab() {
+    // Expand the (collapsed) config panel and switch to the Plugins tab, then
+    // bring the card into view — the readiness card lives inside that tab.
+    document.getElementById('workspace-detail-config-toggle')?.click?.();
+    document.getElementById('workspace-detail-config-plugins-tab')?.click?.();
+    const { card } = els();
+    card?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+    card?.focus?.();
+  }
+
+  async function post(url, body) {
+    const opts = { method: 'POST' };
+    if (body !== undefined) {
+      opts.headers = { 'Content-Type': 'application/json' };
+      opts.body = JSON.stringify(body);
+    }
+    const resp = await fetch(url, opts);
+    if (!resp.ok) throw new Error('request failed: ' + resp.status);
+    return resp.json();
+  }
+
+  async function repair(confirmEnable) {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const result = await post('/api/workspaces/' + encodeURIComponent(wsId()) + '/reaper-setup/repair',
+        { confirm_enable: !!confirmEnable });
+      if (result.needs_confirm) {
+        // Ask for explicit confirmation before enabling a disabled plugin.
+        renderConfirm('Enable reaper-plugin and attach its components to this workspace?', () => repair(true));
+        return;
+      }
+      if (result.needs_install) {
+        window.open('/plugins?install=reaper-plugin', '_blank', 'noopener');
+      }
+      await refresh();
+    } catch (_) {
+      renderError('Repair failed. Nothing was changed; you can try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function checkAgainAndStartSetup() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await post('/api/workspaces/' + encodeURIComponent(wsId()) + '/template-setup/start');
+      await refresh();
+    } catch (_) {
+      renderError('Could not start setup. Readiness is unchanged; you can try again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function renderConfirm(message, onConfirm) {
+    const { actions } = els();
+    if (!actions) return;
+    actions.textContent = '';
+    const msg = document.createElement('span');
+    msg.style.cssText = 'font-size:12px;color:var(--text-primary);align-self:center;';
+    msg.textContent = message;
+    actions.appendChild(msg);
+    actions.appendChild(button('Enable & attach', { primary: true, onClick: onConfirm }));
+    actions.appendChild(button('Cancel', { onClick: refresh }));
+  }
+
+  function renderError(message) {
+    const { status, actions, badge } = els();
+    setBadge(badge, 'Error');
+    if (status) status.textContent = message;
+    if (actions) {
+      actions.textContent = '';
+      actions.appendChild(button('Retry', { onClick: refresh }));
+    }
+  }
+
+  function statusLabel(r) {
+    switch (r.status) {
+      case 'ori_ready': return 'Ready';
+      case 'plugin_missing': return 'File-only';
+      case 'plugin_disabled': return 'Disabled';
+      case 'plugin_detached': return 'Detached';
+      case 'cli_agent_required': return 'Agent';
+      case 'native_cli_access_required': return 'Access';
+      case 'file_only': return 'File-only';
+      default: return 'Setup';
+    }
+  }
+
+  function render(r) {
+    const { card, status, badge, rows, actions, chip } = els();
+    if (!card) return;
+
+    if (!r || !r.identified) {
+      card.hidden = true;
+      if (chip) chip.hidden = true;
+      return;
+    }
+    card.hidden = false;
+    card.tabIndex = -1;
+
+    setBadge(badge, statusLabel(r));
+    if (status) status.textContent = r.explanation || '';
+
+    // Rows: separate, text-labeled status lines (color is never the only signal).
+    if (rows) {
+      rows.textContent = '';
+      rows.appendChild(row('Project mode', r.project_mode === 'ori_ready' ? 'Ori is ready to check REAPER' : 'File-only', r.project_mode === 'ori_ready'));
+      rows.appendChild(row('Plugin', r.plugin_installed ? (r.plugin_enabled ? 'Installed and enabled' : 'Installed but disabled') : 'Not installed', r.plugin_installed && r.plugin_enabled));
+      rows.appendChild(row('Workspace attachment', r.plugin_attached ? 'Components attached' : ((r.missing_components || []).map((c) => c.name).join(', ') || 'Not attached'), r.plugin_attached));
+      rows.appendChild(row('Setup agent', r.setup_agent ? (r.setup_agent + (r.setup_agent_is_cli ? ' (compatible)' : ' (needs Codex or Claude Code)')) : 'Not assigned', r.setup_agent_is_cli));
+      rows.appendChild(row('Native CLI access', (r.workspace_native_cli_enabled ? 'Workspace on' : 'Workspace off') + ' · ' + (r.agent_native_cli_enabled ? 'Agent on' : 'Agent off'), r.workspace_native_cli_enabled && r.agent_native_cli_enabled));
+      rows.appendChild(row('Setup task', r.has_pending_setup_task ? 'Pending' : 'None pending', null));
+      rows.appendChild(row('Live REAPER verification', 'Not checked yet — verified when setup runs', null));
+    }
+
+    // Actions.
+    if (actions) {
+      actions.textContent = '';
+      if (r.status !== 'ori_ready') {
+        actions.appendChild(button('Repair REAPER setup', { primary: true, onClick: () => repair(false) }));
+      }
+      if (r.status === 'ori_ready' && r.has_pending_setup_task) {
+        actions.appendChild(button('Check again and start setup', { primary: true, onClick: checkAgainAndStartSetup }));
+      }
+      if (!r.plugin_installed) {
+        actions.appendChild(button('Install plugin', { onClick: () => window.open('/plugins?install=reaper-plugin', '_blank', 'noopener') }));
+      }
+      if (r.status === 'cli_agent_required' || r.status === 'native_cli_access_required') {
+        actions.appendChild(button('Native CLI access', { onClick: () => document.getElementById('workspace-detail-config-native-mcp-tab')?.click?.() }));
+      }
+    }
+
+    // Compact chip: setup-needed vs. compact success.
+    if (chip) {
+      chip.hidden = false;
+      chip.textContent = r.status === 'ori_ready' ? 'REAPER: ready to check' : 'REAPER setup needed';
+      chip.classList.toggle('reaper-setup-chip-ready', r.status === 'ori_ready');
+      chip.setAttribute('aria-label', chip.textContent + '. Open REAPER Setup.');
+    }
+  }
+
+  async function refresh() {
+    const id = wsId();
+    if (!id) return;
+    try {
+      const resp = await fetch('/api/workspaces/' + encodeURIComponent(id) + '/reaper-setup');
+      if (!resp.ok) throw new Error('readiness failed');
+      render(await resp.json());
+    } catch (_) {
+      renderError('Could not load REAPER readiness.');
+    }
+  }
+
+  function init(id) {
+    workspaceId = id || wsId();
+    const { chip } = els();
+    chip?.addEventListener?.('click', openPluginsTab);
+    void refresh();
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => init(), { once: true });
+    } else {
+      init();
+    }
+  }
+
+  window.ReaperReadinessPanel = { init, refresh, render, _els: els };
+})();

--- a/internal/web/static/js/modules/reaper-readiness-panel.js
+++ b/internal/web/static/js/modules/reaper-readiness-panel.js
@@ -19,7 +19,7 @@
     badge: document.getElementById('reaperReadinessBadge'),
     rows: document.getElementById('reaperReadinessRows'),
     actions: document.getElementById('reaperReadinessActions'),
-    chip: document.getElementById('reaperReadinessChip'),
+    chip: document.getElementById('reaperReadinessChip')
   });
 
   let workspaceId = '';
@@ -32,7 +32,8 @@
   function setBadge(badge, label) {
     if (!badge) return;
     badge.textContent = label;
-    badge.className = 'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
+    badge.className =
+      'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
   }
 
   function row(label, value, ok) {
@@ -68,7 +69,10 @@
   function setBusy(on) {
     busy = on;
     const { actions } = els();
-    if (actions) actions.querySelectorAll('button').forEach((b) => { b.disabled = on; });
+    if (actions)
+      actions.querySelectorAll('button').forEach(b => {
+        b.disabled = on;
+      });
   }
 
   function openPluginsTab() {
@@ -96,11 +100,15 @@
     if (busy) return;
     setBusy(true);
     try {
-      const result = await post('/api/workspaces/' + encodeURIComponent(wsId()) + '/reaper-setup/repair',
-        { confirm_enable: !!confirmEnable });
+      const result = await post(
+        '/api/workspaces/' + encodeURIComponent(wsId()) + '/reaper-setup/repair',
+        { confirm_enable: !!confirmEnable }
+      );
       if (result.needs_confirm) {
         // Ask for explicit confirmation before enabling a disabled plugin.
-        renderConfirm('Enable reaper-plugin and attach its components to this workspace?', () => repair(true));
+        renderConfirm('Enable reaper-plugin and attach its components to this workspace?', () =>
+          repair(true)
+        );
         return;
       }
       if (result.needs_install) {
@@ -151,14 +159,22 @@
 
   function statusLabel(r) {
     switch (r.status) {
-      case 'ori_ready': return 'Ready';
-      case 'plugin_missing': return 'File-only';
-      case 'plugin_disabled': return 'Disabled';
-      case 'plugin_detached': return 'Detached';
-      case 'cli_agent_required': return 'Agent';
-      case 'native_cli_access_required': return 'Access';
-      case 'file_only': return 'File-only';
-      default: return 'Setup';
+      case 'ori_ready':
+        return 'Ready';
+      case 'plugin_missing':
+        return 'File-only';
+      case 'plugin_disabled':
+        return 'Disabled';
+      case 'plugin_detached':
+        return 'Detached';
+      case 'cli_agent_required':
+        return 'Agent';
+      case 'native_cli_access_required':
+        return 'Access';
+      case 'file_only':
+        return 'File-only';
+      default:
+        return 'Setup';
     }
   }
 
@@ -180,36 +196,95 @@
     // Rows: separate, text-labeled status lines (color is never the only signal).
     if (rows) {
       rows.textContent = '';
-      rows.appendChild(row('Project mode', r.project_mode === 'ori_ready' ? 'Ori is ready to check REAPER' : 'File-only', r.project_mode === 'ori_ready'));
-      rows.appendChild(row('Plugin', r.plugin_installed ? (r.plugin_enabled ? 'Installed and enabled' : 'Installed but disabled') : 'Not installed', r.plugin_installed && r.plugin_enabled));
-      rows.appendChild(row('Workspace attachment', r.plugin_attached ? 'Components attached' : ((r.missing_components || []).map((c) => c.name).join(', ') || 'Not attached'), r.plugin_attached));
-      rows.appendChild(row('Setup agent', r.setup_agent ? (r.setup_agent + (r.setup_agent_is_cli ? ' (compatible)' : ' (needs Codex or Claude Code)')) : 'Not assigned', r.setup_agent_is_cli));
-      rows.appendChild(row('Native CLI access', (r.workspace_native_cli_enabled ? 'Workspace on' : 'Workspace off') + ' · ' + (r.agent_native_cli_enabled ? 'Agent on' : 'Agent off'), r.workspace_native_cli_enabled && r.agent_native_cli_enabled));
-      rows.appendChild(row('Setup task', r.has_pending_setup_task ? 'Pending' : 'None pending', null));
-      rows.appendChild(row('Live REAPER verification', 'Not checked yet — verified when setup runs', null));
+      rows.appendChild(
+        row(
+          'Project mode',
+          r.project_mode === 'ori_ready' ? 'Ori is ready to check REAPER' : 'File-only',
+          r.project_mode === 'ori_ready'
+        )
+      );
+      rows.appendChild(
+        row(
+          'Plugin',
+          r.plugin_installed
+            ? r.plugin_enabled
+              ? 'Installed and enabled'
+              : 'Installed but disabled'
+            : 'Not installed',
+          r.plugin_installed && r.plugin_enabled
+        )
+      );
+      rows.appendChild(
+        row(
+          'Workspace attachment',
+          r.plugin_attached
+            ? 'Components attached'
+            : (r.missing_components || []).map(c => c.name).join(', ') || 'Not attached',
+          r.plugin_attached
+        )
+      );
+      rows.appendChild(
+        row(
+          'Setup agent',
+          r.setup_agent
+            ? r.setup_agent +
+                (r.setup_agent_is_cli ? ' (compatible)' : ' (needs Codex or Claude Code)')
+            : 'Not assigned',
+          r.setup_agent_is_cli
+        )
+      );
+      rows.appendChild(
+        row(
+          'Native CLI access',
+          (r.workspace_native_cli_enabled ? 'Workspace on' : 'Workspace off') +
+            ' · ' +
+            (r.agent_native_cli_enabled ? 'Agent on' : 'Agent off'),
+          r.workspace_native_cli_enabled && r.agent_native_cli_enabled
+        )
+      );
+      rows.appendChild(
+        row('Setup task', r.has_pending_setup_task ? 'Pending' : 'None pending', null)
+      );
+      rows.appendChild(
+        row('Live REAPER verification', 'Not checked yet — verified when setup runs', null)
+      );
     }
 
     // Actions.
     if (actions) {
       actions.textContent = '';
       if (r.status !== 'ori_ready') {
-        actions.appendChild(button('Repair REAPER setup', { primary: true, onClick: () => repair(false) }));
+        actions.appendChild(
+          button('Repair REAPER setup', { primary: true, onClick: () => repair(false) })
+        );
       }
       if (r.status === 'ori_ready' && r.has_pending_setup_task) {
-        actions.appendChild(button('Check again and start setup', { primary: true, onClick: checkAgainAndStartSetup }));
+        actions.appendChild(
+          button('Check again and start setup', { primary: true, onClick: checkAgainAndStartSetup })
+        );
       }
       if (!r.plugin_installed) {
-        actions.appendChild(button('Install plugin', { onClick: () => window.open('/plugins?install=reaper-plugin', '_blank', 'noopener') }));
+        actions.appendChild(
+          button('Install plugin', {
+            onClick: () => window.open('/plugins?install=reaper-plugin', '_blank', 'noopener')
+          })
+        );
       }
       if (r.status === 'cli_agent_required' || r.status === 'native_cli_access_required') {
-        actions.appendChild(button('Native CLI access', { onClick: () => document.getElementById('workspace-detail-config-native-mcp-tab')?.click?.() }));
+        actions.appendChild(
+          button('Native CLI access', {
+            onClick: () =>
+              document.getElementById('workspace-detail-config-native-mcp-tab')?.click?.()
+          })
+        );
       }
     }
 
     // Compact chip: setup-needed vs. compact success.
     if (chip) {
       chip.hidden = false;
-      chip.textContent = r.status === 'ori_ready' ? 'REAPER: ready to check' : 'REAPER setup needed';
+      chip.textContent =
+        r.status === 'ori_ready' ? 'REAPER: ready to check' : 'REAPER setup needed';
       chip.classList.toggle('reaper-setup-chip-ready', r.status === 'ori_ready');
       chip.setAttribute('aria-label', chip.textContent + '. Open REAPER Setup.');
     }

--- a/internal/web/static/js/modules/reaper-readiness-panel.js
+++ b/internal/web/static/js/modules/reaper-readiness-panel.js
@@ -112,7 +112,11 @@
         return;
       }
       if (result.needs_install) {
-        window.open('/plugins?install=reaper-plugin', '_blank', 'noopener');
+        // Plugin missing: run the inline install, then re-check (which will
+        // attach on the next repair once installed+enabled).
+        setBusy(false);
+        installPlugin();
+        return;
       }
       await refresh();
     } catch (_) {
@@ -120,6 +124,24 @@
     } finally {
       setBusy(false);
     }
+  }
+
+  // installPlugin runs the shared inline reaper-plugin install into the card's
+  // actions area, then re-checks readiness (existing workspaces have no
+  // template-declared source, so it resolves a marketplace or takes a paste).
+  function installPlugin() {
+    const { actions } = els();
+    if (!actions) return;
+    if (!window.ReaperPluginInstall) {
+      window.open('/plugins?install=reaper-plugin', '_blank', 'noopener');
+      return;
+    }
+    window.ReaperPluginInstall.begin({
+      host: actions,
+      declaredSource: '',
+      onComplete: refresh,
+      onCancel: refresh
+    });
   }
 
   async function checkAgainAndStartSetup() {
@@ -264,11 +286,7 @@
         );
       }
       if (!r.plugin_installed) {
-        actions.appendChild(
-          button('Install plugin', {
-            onClick: () => window.open('/plugins?install=reaper-plugin', '_blank', 'noopener')
-          })
-        );
+        actions.appendChild(button('Install plugin', { primary: true, onClick: installPlugin }));
       }
       if (r.status === 'cli_agent_required' || r.status === 'native_cli_access_required') {
         actions.appendChild(

--- a/internal/web/static/js/modules/reaper-readiness-panel.test.js
+++ b/internal/web/static/js/modules/reaper-readiness-panel.test.js
@@ -1,0 +1,119 @@
+// Tests for reaper-readiness-panel.js — the durable workspace-detail REAPER
+// readiness card + compact indicator. Inline DOM stub, no jsdom.
+//
+// Run with: node --test internal/web/static/js/modules/reaper-readiness-panel.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.hidden = false;
+    this._text = '';
+    this.className = '';
+    this.style = {};
+    this.disabled = false;
+    this.children = [];
+    this._attrs = {};
+    this._listeners = {};
+    this.classList = {
+      _set: new Set(),
+      toggle: (c, on) => { if (on) this.classList._set.add(c); else this.classList._set.delete(c); },
+      contains: (c) => this.classList._set.has(c),
+    };
+    this.tabIndex = 0;
+  }
+  get textContent() {
+    if (this.children.length) return this._text + this.children.map((c) => c.textContent).join('');
+    return this._text;
+  }
+  set textContent(v) { this._text = v; if (v === '') this.children = []; }
+  appendChild(el) { this.children.push(el); return el; }
+  addEventListener(ev, fn) { (this._listeners[ev] ||= []).push(fn); }
+  click() { (this._listeners.click || []).forEach((fn) => fn()); }
+  setAttribute(k, v) { this._attrs[k] = v; }
+  scrollIntoView() {}
+  focus() {}
+  querySelectorAll(sel) {
+    if (sel === 'button') return this.children.filter((c) => c.tagName === 'BUTTON');
+    return [];
+  }
+}
+
+class FakeDocument {
+  constructor() { this.byId = new Map(); this.readyState = 'complete'; }
+  register(id) { const el = new FakeElement('div'); el.id = id; this.byId.set(id, el); return el; }
+  getElementById(id) { return this.byId.get(id) || null; }
+  createElement(tag) { return new FakeElement(tag); }
+  addEventListener() {}
+}
+
+function setup() {
+  const doc = new FakeDocument();
+  ['reaperReadinessCard', 'reaperReadinessStatus', 'reaperReadinessBadge', 'reaperReadinessRows', 'reaperReadinessActions', 'reaperReadinessChip'].forEach((id) => doc.register(id));
+  globalThis.document = doc;
+  globalThis.window = globalThis;
+  globalThis.window.currentWorkspaceId = 'ws-1';
+  return doc;
+}
+
+const panel = await (async () => {
+  setup();
+  await import('./reaper-readiness-panel.js');
+  return globalThis.window.ReaperReadinessPanel;
+})();
+
+test('unidentified workspace hides card and chip', () => {
+  const doc = setup();
+  panel.render({ identified: false });
+  assert.equal(doc.getElementById('reaperReadinessCard').hidden, true);
+  assert.equal(doc.getElementById('reaperReadinessChip').hidden, true);
+});
+
+test('plugin_missing renders rows, repair action, and setup-needed chip', () => {
+  const doc = setup();
+  panel.render({
+    identified: true, status: 'plugin_missing', project_mode: 'file_only',
+    plugin_installed: false, plugin_enabled: false, plugin_attached: false,
+    setup_agent: 'Reaper Producer', setup_agent_is_cli: true,
+    workspace_native_cli_enabled: false, agent_native_cli_enabled: false,
+    has_pending_setup_task: true, explanation: 'File-only project',
+  });
+  const card = doc.getElementById('reaperReadinessCard');
+  const rows = doc.getElementById('reaperReadinessRows');
+  const actions = doc.getElementById('reaperReadinessActions');
+  const chip = doc.getElementById('reaperReadinessChip');
+  assert.equal(card.hidden, false);
+  assert.equal(rows.children.length, 7); // all readiness rows present
+  const labels = actions.querySelectorAll('button').map((b) => b.textContent);
+  assert.ok(labels.includes('Repair REAPER setup'));
+  assert.ok(labels.includes('Install plugin'));
+  assert.equal(chip.hidden, false);
+  assert.match(chip.textContent, /setup needed/i);
+});
+
+test('live verification row is always present and labeled not-checked', () => {
+  const doc = setup();
+  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: false });
+  const rows = doc.getElementById('reaperReadinessRows');
+  const liveRow = rows.children[rows.children.length - 1];
+  assert.match(liveRow.textContent, /not checked yet/i);
+});
+
+test('ori_ready shows a compact success chip, no repair button', () => {
+  const doc = setup();
+  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: false });
+  const chip = doc.getElementById('reaperReadinessChip');
+  assert.match(chip.textContent, /ready/i);
+  assert.ok(chip.classList.contains('reaper-setup-chip-ready'));
+  const labels = doc.getElementById('reaperReadinessActions').querySelectorAll('button').map((b) => b.textContent);
+  assert.ok(!labels.includes('Repair REAPER setup'));
+});
+
+test('ori_ready with a pending setup task offers Check again and start setup', () => {
+  const doc = setup();
+  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: true });
+  const labels = doc.getElementById('reaperReadinessActions').querySelectorAll('button').map((b) => b.textContent);
+  assert.ok(labels.includes('Check again and start setup'));
+});

--- a/internal/web/static/js/modules/reaper-readiness-panel.test.js
+++ b/internal/web/static/js/modules/reaper-readiness-panel.test.js
@@ -19,39 +19,73 @@ class FakeElement {
     this._listeners = {};
     this.classList = {
       _set: new Set(),
-      toggle: (c, on) => { if (on) this.classList._set.add(c); else this.classList._set.delete(c); },
-      contains: (c) => this.classList._set.has(c),
+      toggle: (c, on) => {
+        if (on) this.classList._set.add(c);
+        else this.classList._set.delete(c);
+      },
+      contains: c => this.classList._set.has(c)
     };
     this.tabIndex = 0;
   }
   get textContent() {
-    if (this.children.length) return this._text + this.children.map((c) => c.textContent).join('');
+    if (this.children.length) return this._text + this.children.map(c => c.textContent).join('');
     return this._text;
   }
-  set textContent(v) { this._text = v; if (v === '') this.children = []; }
-  appendChild(el) { this.children.push(el); return el; }
-  addEventListener(ev, fn) { (this._listeners[ev] ||= []).push(fn); }
-  click() { (this._listeners.click || []).forEach((fn) => fn()); }
-  setAttribute(k, v) { this._attrs[k] = v; }
+  set textContent(v) {
+    this._text = v;
+    if (v === '') this.children = [];
+  }
+  appendChild(el) {
+    this.children.push(el);
+    return el;
+  }
+  addEventListener(ev, fn) {
+    (this._listeners[ev] ||= []).push(fn);
+  }
+  click() {
+    (this._listeners.click || []).forEach(fn => fn());
+  }
+  setAttribute(k, v) {
+    this._attrs[k] = v;
+  }
   scrollIntoView() {}
   focus() {}
   querySelectorAll(sel) {
-    if (sel === 'button') return this.children.filter((c) => c.tagName === 'BUTTON');
+    if (sel === 'button') return this.children.filter(c => c.tagName === 'BUTTON');
     return [];
   }
 }
 
 class FakeDocument {
-  constructor() { this.byId = new Map(); this.readyState = 'complete'; }
-  register(id) { const el = new FakeElement('div'); el.id = id; this.byId.set(id, el); return el; }
-  getElementById(id) { return this.byId.get(id) || null; }
-  createElement(tag) { return new FakeElement(tag); }
+  constructor() {
+    this.byId = new Map();
+    this.readyState = 'complete';
+  }
+  register(id) {
+    const el = new FakeElement('div');
+    el.id = id;
+    this.byId.set(id, el);
+    return el;
+  }
+  getElementById(id) {
+    return this.byId.get(id) || null;
+  }
+  createElement(tag) {
+    return new FakeElement(tag);
+  }
   addEventListener() {}
 }
 
 function setup() {
   const doc = new FakeDocument();
-  ['reaperReadinessCard', 'reaperReadinessStatus', 'reaperReadinessBadge', 'reaperReadinessRows', 'reaperReadinessActions', 'reaperReadinessChip'].forEach((id) => doc.register(id));
+  [
+    'reaperReadinessCard',
+    'reaperReadinessStatus',
+    'reaperReadinessBadge',
+    'reaperReadinessRows',
+    'reaperReadinessActions',
+    'reaperReadinessChip'
+  ].forEach(id => doc.register(id));
   globalThis.document = doc;
   globalThis.window = globalThis;
   globalThis.window.currentWorkspaceId = 'ws-1';
@@ -74,11 +108,18 @@ test('unidentified workspace hides card and chip', () => {
 test('plugin_missing renders rows, repair action, and setup-needed chip', () => {
   const doc = setup();
   panel.render({
-    identified: true, status: 'plugin_missing', project_mode: 'file_only',
-    plugin_installed: false, plugin_enabled: false, plugin_attached: false,
-    setup_agent: 'Reaper Producer', setup_agent_is_cli: true,
-    workspace_native_cli_enabled: false, agent_native_cli_enabled: false,
-    has_pending_setup_task: true, explanation: 'File-only project',
+    identified: true,
+    status: 'plugin_missing',
+    project_mode: 'file_only',
+    plugin_installed: false,
+    plugin_enabled: false,
+    plugin_attached: false,
+    setup_agent: 'Reaper Producer',
+    setup_agent_is_cli: true,
+    workspace_native_cli_enabled: false,
+    agent_native_cli_enabled: false,
+    has_pending_setup_task: true,
+    explanation: 'File-only project'
   });
   const card = doc.getElementById('reaperReadinessCard');
   const rows = doc.getElementById('reaperReadinessRows');
@@ -86,7 +127,7 @@ test('plugin_missing renders rows, repair action, and setup-needed chip', () => 
   const chip = doc.getElementById('reaperReadinessChip');
   assert.equal(card.hidden, false);
   assert.equal(rows.children.length, 7); // all readiness rows present
-  const labels = actions.querySelectorAll('button').map((b) => b.textContent);
+  const labels = actions.querySelectorAll('button').map(b => b.textContent);
   assert.ok(labels.includes('Repair REAPER setup'));
   assert.ok(labels.includes('Install plugin'));
   assert.equal(chip.hidden, false);
@@ -95,7 +136,18 @@ test('plugin_missing renders rows, repair action, and setup-needed chip', () => 
 
 test('live verification row is always present and labeled not-checked', () => {
   const doc = setup();
-  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: false });
+  panel.render({
+    identified: true,
+    status: 'ori_ready',
+    project_mode: 'ori_ready',
+    plugin_installed: true,
+    plugin_enabled: true,
+    plugin_attached: true,
+    setup_agent_is_cli: true,
+    workspace_native_cli_enabled: true,
+    agent_native_cli_enabled: true,
+    has_pending_setup_task: false
+  });
   const rows = doc.getElementById('reaperReadinessRows');
   const liveRow = rows.children[rows.children.length - 1];
   assert.match(liveRow.textContent, /not checked yet/i);
@@ -103,17 +155,45 @@ test('live verification row is always present and labeled not-checked', () => {
 
 test('ori_ready shows a compact success chip, no repair button', () => {
   const doc = setup();
-  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: false });
+  panel.render({
+    identified: true,
+    status: 'ori_ready',
+    project_mode: 'ori_ready',
+    plugin_installed: true,
+    plugin_enabled: true,
+    plugin_attached: true,
+    setup_agent_is_cli: true,
+    workspace_native_cli_enabled: true,
+    agent_native_cli_enabled: true,
+    has_pending_setup_task: false
+  });
   const chip = doc.getElementById('reaperReadinessChip');
   assert.match(chip.textContent, /ready/i);
   assert.ok(chip.classList.contains('reaper-setup-chip-ready'));
-  const labels = doc.getElementById('reaperReadinessActions').querySelectorAll('button').map((b) => b.textContent);
+  const labels = doc
+    .getElementById('reaperReadinessActions')
+    .querySelectorAll('button')
+    .map(b => b.textContent);
   assert.ok(!labels.includes('Repair REAPER setup'));
 });
 
 test('ori_ready with a pending setup task offers Check again and start setup', () => {
   const doc = setup();
-  panel.render({ identified: true, status: 'ori_ready', project_mode: 'ori_ready', plugin_installed: true, plugin_enabled: true, plugin_attached: true, setup_agent_is_cli: true, workspace_native_cli_enabled: true, agent_native_cli_enabled: true, has_pending_setup_task: true });
-  const labels = doc.getElementById('reaperReadinessActions').querySelectorAll('button').map((b) => b.textContent);
+  panel.render({
+    identified: true,
+    status: 'ori_ready',
+    project_mode: 'ori_ready',
+    plugin_installed: true,
+    plugin_enabled: true,
+    plugin_attached: true,
+    setup_agent_is_cli: true,
+    workspace_native_cli_enabled: true,
+    agent_native_cli_enabled: true,
+    has_pending_setup_task: true
+  });
+  const labels = doc
+    .getElementById('reaperReadinessActions')
+    .querySelectorAll('button')
+    .map(b => b.textContent);
   assert.ok(labels.includes('Check again and start setup'));
 });

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -31,11 +31,26 @@
   });
 
   let busy = false;
+  // The exact install source the selected template declares for reaper-plugin
+  // (tools.plugin_sources). When set, Install is one click (trust-previewed) with
+  // no marketplace lookup or pasted source needed.
+  let declaredSource = '';
 
   function isReaperTemplate(template) {
     if (!template) return false;
     const id = String(template.id || template.ID || '').toLowerCase();
     return id === REAPER_SONG_TEMPLATE_ID;
+  }
+
+  // declaredPluginSource reads the template's declared source for reaper-plugin,
+  // matching the plugin name case-insensitively.
+  function declaredPluginSource(template) {
+    const sources = template && template.tools && template.tools.plugin_sources;
+    if (!sources || typeof sources !== 'object') return '';
+    for (const key of Object.keys(sources)) {
+      if (String(key).toLowerCase() === PLUGIN_NAME) return String(sources[key] || '').trim();
+    }
+    return '';
   }
 
   // setCreateBlocked disables/enables the shared Create Workspace button so a
@@ -121,6 +136,12 @@
 
   async function beginInstall() {
     if (busy) return;
+    // Preferred path: the template declares the exact source, so install is one
+    // click (still trust-previewed) with no marketplace lookup or paste.
+    if (declaredSource) {
+      await previewSourceInstall(declaredSource);
+      return;
+    }
     setBusy(true);
     renderMessage('Finding reaper-plugin…');
     try {
@@ -410,9 +431,11 @@
 
   function showForTemplate(template) {
     if (!isReaperTemplate(template)) {
+      declaredSource = '';
       hide();
       return;
     }
+    declaredSource = declaredPluginSource(template);
     void refresh();
   }
 

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -1,0 +1,161 @@
+// reaper-setup-card.js — the Create Workspace "REAPER Setup" card.
+//
+// Shown only when the Reaper Song template is selected. It reads the pre-create
+// preview from /api/reaper-setup/preview (the same backend the live readiness
+// resolver uses) and explains, with visible non-color text, whether the
+// installed reaper-plugin will attach, whether it must be enabled, or whether
+// the workspace will start as a usable file-only project. Workspace creation is
+// never blocked. Verification of REAPER/Web Remote/runner happens later, when
+// setup runs — the card never claims REAPER is connected.
+(function () {
+  'use strict';
+
+  const REAPER_SONG_TEMPLATE_ID = 'reaper-song';
+  const PLUGIN_NAME = 'reaper-plugin';
+
+  const els = () => ({
+    card: document.getElementById('reaperSetupCard'),
+    status: document.getElementById('reaperSetupStatusText'),
+    badge: document.getElementById('reaperSetupBadge'),
+    detail: document.getElementById('reaperSetupDetail'),
+    actions: document.getElementById('reaperSetupActions'),
+  });
+
+  let busy = false;
+
+  function isReaperTemplate(template) {
+    if (!template) return false;
+    const id = String(template.id || template.ID || '').toLowerCase();
+    return id === REAPER_SONG_TEMPLATE_ID;
+  }
+
+  function hide() {
+    const { card } = els();
+    if (card) card.hidden = true;
+  }
+
+  function setBadge(badge, label) {
+    if (!badge) return;
+    badge.textContent = label;
+    badge.className = 'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
+  }
+
+  function button(label, opts = {}) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'modern-btn ' + (opts.primary ? 'modern-btn-primary' : 'modern-btn-secondary');
+    b.style.fontSize = '12px';
+    b.textContent = label;
+    if (opts.onClick) b.addEventListener('click', opts.onClick);
+    if (opts.disabled) b.disabled = true;
+    return b;
+  }
+
+  function setBusy(on) {
+    busy = on;
+    const { actions } = els();
+    if (!actions) return;
+    actions.querySelectorAll('button').forEach((b) => { b.disabled = on; });
+  }
+
+  async function enablePlugin() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', { method: 'POST' });
+      if (!resp.ok) throw new Error('enable failed');
+      await refresh();
+    } catch (_) {
+      renderError('Could not enable reaper-plugin. You can still create a file-only workspace.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function openPluginsPage() {
+    // Fallback per PRD FR18: focus the existing Plugins installation surface with
+    // the exact plugin name when no marketplace resolves it inline.
+    window.open('/plugins?install=' + encodeURIComponent(PLUGIN_NAME), '_blank', 'noopener');
+  }
+
+  function renderError(message) {
+    const { card, status, detail, actions, badge } = els();
+    if (!card) return;
+    card.hidden = false;
+    setBadge(badge, 'Error');
+    if (status) status.textContent = message || 'Could not check reaper-plugin.';
+    if (detail) detail.textContent = 'File-only creation is still available.';
+    if (actions) {
+      actions.textContent = '';
+      actions.appendChild(button('Retry', { onClick: refresh }));
+    }
+  }
+
+  const verificationNote =
+    'You can create the workspace now. REAPER, Web Remote, and runner readiness are checked later, when setup runs.';
+
+  function render(preview) {
+    const { card, status, detail, actions, badge } = els();
+    if (!card) return;
+    card.hidden = false;
+    if (actions) actions.textContent = '';
+
+    const components = (preview.would_attach || []).map((c) => c.name).join(', ');
+
+    switch (preview.status) {
+      case 'ready_to_attach':
+        setBadge(badge, 'Ready');
+        status.textContent = 'reaper-plugin is installed. Its components will attach when you create this workspace.';
+        detail.textContent = (components ? 'Will attach: ' + components + '. ' : '') + verificationNote;
+        break;
+      case 'plugin_disabled':
+        setBadge(badge, 'Disabled');
+        status.textContent = 'reaper-plugin is installed but globally disabled.';
+        detail.textContent = 'Enable it to attach its components, or create a file-only project now. ' + verificationNote;
+        actions.appendChild(button('Enable plugin', { primary: true, onClick: enablePlugin }));
+        break;
+      case 'plugin_missing':
+      default:
+        setBadge(badge, 'File-only');
+        status.textContent = 'File-only project: reaper-plugin is not installed.';
+        detail.textContent =
+          'Creation still succeeds and your .rpp is intact. Install reaper-plugin (a global install; attachment is per-workspace) to enable live control later. ' +
+          verificationNote;
+        actions.appendChild(button('Install plugin', { primary: true, onClick: openPluginsPage }));
+        break;
+    }
+    // Live control also needs a Codex or Claude Code setup agent + explicit native
+    // CLI access, configured inside the workspace after creation (FR20/FR21).
+    const note = document.createElement('div');
+    note.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:6px;opacity:0.85;';
+    note.textContent =
+      'Live local REAPER control also needs a Codex or Claude Code agent and native CLI access, which you enable inside the workspace after creation.';
+    detail.appendChild(note);
+  }
+
+  async function refresh() {
+    const { card, status, badge } = els();
+    if (!card) return;
+    card.hidden = false;
+    setBadge(badge, 'Checking');
+    if (status) status.textContent = 'Checking reaper-plugin…';
+    try {
+      const resp = await fetch('/api/reaper-setup/preview');
+      if (!resp.ok) throw new Error('preview failed');
+      const preview = await resp.json();
+      render(preview);
+    } catch (_) {
+      renderError();
+    }
+  }
+
+  function showForTemplate(template) {
+    if (!isReaperTemplate(template)) {
+      hide();
+      return;
+    }
+    void refresh();
+  }
+
+  window.ReaperSetupCard = { showForTemplate, hide, refresh, isReaperTemplate };
+})();

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -10,12 +10,10 @@
 // never starts missing its required tools. While the plugin is missing or
 // disabled, this card disables the Create Workspace button.
 //
-// Installing is done inline, without leaving the modal: the card resolves
-// reaper-plugin from the configured marketplaces (or takes a source you paste),
-// shows the trust disclosure, installs on confirmation, enables it, and
-// re-checks — so a missing plugin becomes ready in a couple of clicks. The trust
-// preview is always shown; nothing is installed silently. Verification of
-// REAPER/Web Remote/runner still happens later, when setup runs.
+// Installing is done inline via the shared ReaperPluginInstall flow (trust
+// preview always shown, no tab switch); on completion the card re-checks and
+// unblocks creation. Verification of REAPER/Web Remote/runner happens later, when
+// setup runs — the card never claims REAPER is connected.
 (function () {
   'use strict';
 
@@ -94,234 +92,22 @@
     return b;
   }
 
-  function setBusy(on) {
-    busy = on;
-    const { actions } = els();
-    if (!actions) return;
-    actions.querySelectorAll('button, input').forEach(el => {
-      el.disabled = on;
-    });
-  }
-
-  async function fetchJSON(url, opts) {
-    const resp = await fetch(url, opts);
-    let data = {};
-    try {
-      data = await resp.json();
-    } catch (_) {
-      data = {};
-    }
-    if (!resp.ok) throw new Error(data.error || 'request failed: ' + resp.status);
-    return data;
-  }
-
-  // --- Inline install flow -------------------------------------------------
-
-  // resolveMarketplacePlugin scans the configured marketplaces for reaper-plugin
-  // so it can be installed with the trust preview and no hard-coded source.
-  async function resolveMarketplacePlugin() {
-    try {
-      const data = await fetchJSON('/api/plugins/marketplaces');
-      const list = Array.isArray(data.marketplaces) ? data.marketplaces : [];
-      for (const mp of list) {
-        const plugins = Array.isArray(mp.plugins) ? mp.plugins : [];
-        const hit = plugins.find(p => String(p.name || '').toLowerCase() === PLUGIN_NAME);
-        if (hit) return { marketplace: mp.name, plugin: hit.name || PLUGIN_NAME };
-      }
-    } catch (_) {
-      /* fall through to the source-paste path */
-    }
-    return null;
-  }
-
-  async function beginInstall() {
-    if (busy) return;
-    // Preferred path: the template declares the exact source, so install is one
-    // click (still trust-previewed) with no marketplace lookup or paste.
-    if (declaredSource) {
-      await previewSourceInstall(declaredSource);
+  // beginInstall runs the shared inline install into the actions area; on
+  // completion it re-checks readiness (which unblocks creation when ready).
+  function beginInstall() {
+    const { status, actions } = els();
+    if (!actions || !window.ReaperPluginInstall) {
+      // Fallback if the installer module is unavailable.
+      window.open('/plugins?install=' + encodeURIComponent(PLUGIN_NAME), '_blank', 'noopener');
       return;
     }
-    setBusy(true);
-    renderMessage('Finding reaper-plugin…');
-    try {
-      const mp = await resolveMarketplacePlugin();
-      if (mp) {
-        const prev = await fetchJSON('/api/plugins/marketplaces/install', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: false })
-        });
-        renderTrust(prev.trust, mp.plugin + ' · ' + mp.marketplace, () =>
-          confirmMarketplaceInstall(mp)
-        );
-      } else {
-        renderSourceInput();
-      }
-    } catch (e) {
-      renderError(
-        'Could not reach the plugin marketplaces. Paste a source instead, or open the Plugins page.'
-      );
-      renderSourceInput(true);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function confirmMarketplaceInstall(mp) {
-    if (busy) return;
-    setBusy(true);
-    renderMessage('Installing ' + PLUGIN_NAME + '…');
-    try {
-      await fetchJSON('/api/plugins/marketplaces/install', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: true })
-      });
-      await enableAndRefresh();
-    } catch (e) {
-      renderError('Install failed: ' + (e.message || 'unknown error'));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function previewSourceInstall(source) {
-    source = String(source || '').trim();
-    if (!source) return;
-    if (busy) return;
-    setBusy(true);
-    renderMessage('Checking ' + source + '…');
-    try {
-      const prev = await fetchJSON('/api/plugins/install', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ source, confirm: false })
-      });
-      renderTrust(prev.trust, source, () => confirmSourceInstall(source));
-    } catch (e) {
-      renderError('Could not read that source: ' + (e.message || 'unknown error'));
-      renderSourceInput(true);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function confirmSourceInstall(source) {
-    if (busy) return;
-    setBusy(true);
-    renderMessage('Installing ' + PLUGIN_NAME + '…');
-    try {
-      await fetchJSON('/api/plugins/install', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ source, confirm: true })
-      });
-      await enableAndRefresh();
-    } catch (e) {
-      renderError('Install failed: ' + (e.message || 'unknown error'));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // enableAndRefresh enables the freshly installed plugin (install records it
-  // disabled) and re-checks readiness, which unblocks creation when ready.
-  async function enableAndRefresh() {
-    try {
-      await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
-        method: 'POST'
-      });
-    } catch (_) {
-      /* best effort; refresh will show the disabled state and offer Enable */
-    }
-    await refresh();
-  }
-
-  // --- Inline panels -------------------------------------------------------
-
-  function renderMessage(message) {
-    const { status } = els();
-    if (status) status.textContent = message;
-    const { actions } = els();
-    if (actions) actions.textContent = '';
-  }
-
-  // renderTrust shows the install disclosure (what will be registered) so nothing
-  // installs without the user seeing it.
-  function renderTrust(trust, sourceLabel, onConfirm) {
-    const { detail, actions } = els();
-    if (!detail || !actions) return;
-    detail.textContent = '';
-    const t = trust || {};
-    const head = document.createElement('div');
-    head.style.cssText = 'font-size:12px;color:var(--text-primary);margin-bottom:4px;';
-    head.textContent = 'Install ' + (t.Name || PLUGIN_NAME) + ' from ' + sourceLabel + '?';
-    detail.appendChild(head);
-
-    const disclosure = document.createElement('div');
-    disclosure.style.cssText = 'font-size:11px;color:var(--text-secondary);';
-    const skills = Array.isArray(t.Skills) ? t.Skills : [];
-    const cmds = Array.isArray(t.MCPCommands) ? t.MCPCommands : [];
-    const warnings = Array.isArray(t.Warnings) ? t.Warnings : [];
-    if (skills.length) disclosure.appendChild(line('Skills: ' + skills.join(', ')));
-    if (cmds.length) disclosure.appendChild(line('Runs: ' + cmds.join('; ')));
-    if (!skills.length && !cmds.length)
-      disclosure.appendChild(line('Registers reaper-plugin components.'));
-    warnings.forEach(wtext => {
-      const wl = line('⚠ ' + wtext);
-      wl.style.color = 'var(--warning-color, #d97706)';
-      disclosure.appendChild(wl);
+    if (status) status.textContent = 'Installing reaper-plugin…';
+    window.ReaperPluginInstall.begin({
+      host: actions,
+      declaredSource,
+      onComplete: refresh,
+      onCancel: refresh
     });
-    detail.appendChild(disclosure);
-
-    actions.textContent = '';
-    actions.appendChild(button('Install & enable', { primary: true, onClick: onConfirm }));
-    actions.appendChild(button('Cancel', { onClick: refresh }));
-  }
-
-  function line(text) {
-    const d = document.createElement('div');
-    d.textContent = text;
-    return d;
-  }
-
-  // renderSourceInput lets the user paste a source when no marketplace resolves
-  // reaper-plugin, so install still happens inline (with the trust preview).
-  function renderSourceInput(keepMessage) {
-    const { status, detail, actions } = els();
-    if (!detail || !actions) return;
-    if (status && !keepMessage) {
-      status.textContent =
-        'No configured marketplace has reaper-plugin. Paste its source to install it here.';
-    }
-    detail.textContent = '';
-    const hint = line(
-      'A GitHub repo, owner/repo, or local path to reaper-plugin. The trust preview is shown before anything installs.'
-    );
-    hint.style.cssText = 'font-size:11px;color:var(--text-secondary);';
-    detail.appendChild(hint);
-
-    actions.textContent = '';
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.className = 'modern-input';
-    input.placeholder = 'e.g. johnjallday/reaper-plugin';
-    input.style.cssText = 'flex:1 1 220px;font-size:12px;';
-    input.setAttribute('aria-label', 'reaper-plugin source');
-    input.addEventListener('keydown', e => {
-      if (e.key === 'Enter') previewSourceInstall(input.value);
-    });
-    actions.appendChild(input);
-    actions.appendChild(
-      button('Preview install', { primary: true, onClick: () => previewSourceInstall(input.value) })
-    );
-    actions.appendChild(button('Open Plugins page', { onClick: openPluginsPage }));
-    input.focus?.();
-  }
-
-  function openPluginsPage() {
-    window.open('/plugins?install=' + encodeURIComponent(PLUGIN_NAME), '_blank', 'noopener');
   }
 
   function renderError(message) {
@@ -396,8 +182,9 @@
 
   async function enablePlugin() {
     if (busy) return;
-    setBusy(true);
-    renderMessage('Enabling reaper-plugin…');
+    busy = true;
+    const { status } = els();
+    if (status) status.textContent = 'Enabling reaper-plugin…';
     try {
       const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
         method: 'POST'
@@ -407,7 +194,7 @@
     } catch (_) {
       renderError('Could not enable reaper-plugin. Enable it, then Re-check.');
     } finally {
-      setBusy(false);
+      busy = false;
     }
   }
 

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -18,7 +18,7 @@
     status: document.getElementById('reaperSetupStatusText'),
     badge: document.getElementById('reaperSetupBadge'),
     detail: document.getElementById('reaperSetupDetail'),
-    actions: document.getElementById('reaperSetupActions'),
+    actions: document.getElementById('reaperSetupActions')
   });
 
   let busy = false;
@@ -37,7 +37,8 @@
   function setBadge(badge, label) {
     if (!badge) return;
     badge.textContent = label;
-    badge.className = 'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
+    badge.className =
+      'reaper-setup-badge reaper-setup-badge-' + label.toLowerCase().replace(/[^a-z]+/g, '-');
   }
 
   function button(label, opts = {}) {
@@ -55,14 +56,18 @@
     busy = on;
     const { actions } = els();
     if (!actions) return;
-    actions.querySelectorAll('button').forEach((b) => { b.disabled = on; });
+    actions.querySelectorAll('button').forEach(b => {
+      b.disabled = on;
+    });
   }
 
   async function enablePlugin() {
     if (busy) return;
     setBusy(true);
     try {
-      const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', { method: 'POST' });
+      const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
+        method: 'POST'
+      });
       if (!resp.ok) throw new Error('enable failed');
       await refresh();
     } catch (_) {
@@ -100,18 +105,22 @@
     card.hidden = false;
     if (actions) actions.textContent = '';
 
-    const components = (preview.would_attach || []).map((c) => c.name).join(', ');
+    const components = (preview.would_attach || []).map(c => c.name).join(', ');
 
     switch (preview.status) {
       case 'ready_to_attach':
         setBadge(badge, 'Ready');
-        status.textContent = 'reaper-plugin is installed. Its components will attach when you create this workspace.';
-        detail.textContent = (components ? 'Will attach: ' + components + '. ' : '') + verificationNote;
+        status.textContent =
+          'reaper-plugin is installed. Its components will attach when you create this workspace.';
+        detail.textContent =
+          (components ? 'Will attach: ' + components + '. ' : '') + verificationNote;
         break;
       case 'plugin_disabled':
         setBadge(badge, 'Disabled');
         status.textContent = 'reaper-plugin is installed but globally disabled.';
-        detail.textContent = 'Enable it to attach its components, or create a file-only project now. ' + verificationNote;
+        detail.textContent =
+          'Enable it to attach its components, or create a file-only project now. ' +
+          verificationNote;
         actions.appendChild(button('Enable plugin', { primary: true, onClick: enablePlugin }));
         break;
       case 'plugin_missing':

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -3,10 +3,15 @@
 // Shown only when the Reaper Song template is selected. It reads the pre-create
 // preview from /api/reaper-setup/preview (the same backend the live readiness
 // resolver uses) and explains, with visible non-color text, whether the
-// installed reaper-plugin will attach, whether it must be enabled, or whether
-// the workspace will start as a usable file-only project. Workspace creation is
-// never blocked. Verification of REAPER/Web Remote/runner happens later, when
-// setup runs — the card never claims REAPER is connected.
+// installed reaper-plugin will attach or must be installed/enabled first.
+//
+// Required-plugin gate (product decision): the Reaper Song template requires
+// reaper-plugin installed AND enabled before the workspace can be created, so it
+// never starts missing its required tools. While the plugin is missing or
+// disabled, this card disables the Create Workspace button and offers inline
+// Install/Enable actions; the backend enforces the same rule with a 409.
+// Verification of REAPER/Web Remote/runner still happens later, when setup runs —
+// the card never claims REAPER is connected.
 (function () {
   'use strict';
 
@@ -29,9 +34,27 @@
     return id === REAPER_SONG_TEMPLATE_ID;
   }
 
+  // setCreateBlocked disables/enables the shared Create Workspace button so a
+  // Reaper Song workspace cannot be created until reaper-plugin will attach.
+  function setCreateBlocked(blocked, reason) {
+    const btn = document.getElementById('createFolderBtn');
+    if (!btn) return;
+    btn.disabled = !!blocked;
+    btn.setAttribute('aria-disabled', blocked ? 'true' : 'false');
+    if (blocked) {
+      btn.dataset.reaperBlocked = '1';
+      if (reason) btn.title = reason;
+    } else if (btn.dataset.reaperBlocked) {
+      delete btn.dataset.reaperBlocked;
+      btn.removeAttribute('title');
+    }
+  }
+
   function hide() {
     const { card } = els();
     if (card) card.hidden = true;
+    // A non-REAPER template must never leave creation blocked.
+    setCreateBlocked(false);
   }
 
   function setBadge(badge, label) {
@@ -71,7 +94,7 @@
       if (!resp.ok) throw new Error('enable failed');
       await refresh();
     } catch (_) {
-      renderError('Could not enable reaper-plugin. You can still create a file-only workspace.');
+      renderError('Could not enable reaper-plugin. Enable it, then try again.');
     } finally {
       setBusy(false);
     }
@@ -89,15 +112,20 @@
     card.hidden = false;
     setBadge(badge, 'Error');
     if (status) status.textContent = message || 'Could not check reaper-plugin.';
-    if (detail) detail.textContent = 'File-only creation is still available.';
+    if (detail) detail.textContent = 'Try again; the backend re-checks the plugin when you create.';
     if (actions) {
       actions.textContent = '';
       actions.appendChild(button('Retry', { onClick: refresh }));
     }
+    // Don't hard-block on a transient preview error — the backend guard still
+    // enforces the requirement on create.
+    setCreateBlocked(false);
   }
 
   const verificationNote =
-    'You can create the workspace now. REAPER, Web Remote, and runner readiness are checked later, when setup runs.';
+    'REAPER, Web Remote, and runner readiness are checked later, when setup runs.';
+  const liveControlNote =
+    'Live local REAPER control also needs a Codex or Claude Code agent and native CLI access, which you enable inside the workspace after creation.';
 
   function render(preview) {
     const { card, status, detail, actions, badge } = els();
@@ -114,31 +142,34 @@
           'reaper-plugin is installed. Its components will attach when you create this workspace.';
         detail.textContent =
           (components ? 'Will attach: ' + components + '. ' : '') + verificationNote;
+        setCreateBlocked(false);
         break;
       case 'plugin_disabled':
-        setBadge(badge, 'Disabled');
-        status.textContent = 'reaper-plugin is installed but globally disabled.';
+        setBadge(badge, 'Required');
+        status.textContent =
+          'reaper-plugin is installed but globally disabled. Enable it to create this workspace.';
         detail.textContent =
-          'Enable it to attach its components, or create a file-only project now. ' +
+          'The Reaper Song template requires reaper-plugin. Creating is blocked until it is enabled. ' +
           verificationNote;
         actions.appendChild(button('Enable plugin', { primary: true, onClick: enablePlugin }));
+        setCreateBlocked(true, 'Enable reaper-plugin to create this workspace');
         break;
       case 'plugin_missing':
       default:
-        setBadge(badge, 'File-only');
-        status.textContent = 'File-only project: reaper-plugin is not installed.';
+        setBadge(badge, 'Required');
+        status.textContent =
+          'reaper-plugin is required and not installed. Install it to create this workspace.';
         detail.textContent =
-          'Creation still succeeds and your .rpp is intact. Install reaper-plugin (a global install; attachment is per-workspace) to enable live control later. ' +
+          'The Reaper Song template requires reaper-plugin (a global install; attachment is per-workspace). Creating is blocked until it is installed and enabled. ' +
           verificationNote;
         actions.appendChild(button('Install plugin', { primary: true, onClick: openPluginsPage }));
+        actions.appendChild(button('Re-check', { onClick: refresh }));
+        setCreateBlocked(true, 'Install reaper-plugin to create this workspace');
         break;
     }
-    // Live control also needs a Codex or Claude Code setup agent + explicit native
-    // CLI access, configured inside the workspace after creation (FR20/FR21).
     const note = document.createElement('div');
     note.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:6px;opacity:0.85;';
-    note.textContent =
-      'Live local REAPER control also needs a Codex or Claude Code agent and native CLI access, which you enable inside the workspace after creation.';
+    note.textContent = liveControlNote;
     detail.appendChild(note);
   }
 
@@ -148,6 +179,8 @@
     card.hidden = false;
     setBadge(badge, 'Checking');
     if (status) status.textContent = 'Checking reaper-plugin…';
+    // Block creation while we resolve state, to avoid a create during the gap.
+    setCreateBlocked(true, 'Checking reaper-plugin…');
     try {
       const resp = await fetch('/api/reaper-setup/preview');
       if (!resp.ok) throw new Error('preview failed');

--- a/internal/web/static/js/modules/reaper-setup-card.js
+++ b/internal/web/static/js/modules/reaper-setup-card.js
@@ -8,10 +8,14 @@
 // Required-plugin gate (product decision): the Reaper Song template requires
 // reaper-plugin installed AND enabled before the workspace can be created, so it
 // never starts missing its required tools. While the plugin is missing or
-// disabled, this card disables the Create Workspace button and offers inline
-// Install/Enable actions; the backend enforces the same rule with a 409.
-// Verification of REAPER/Web Remote/runner still happens later, when setup runs —
-// the card never claims REAPER is connected.
+// disabled, this card disables the Create Workspace button.
+//
+// Installing is done inline, without leaving the modal: the card resolves
+// reaper-plugin from the configured marketplaces (or takes a source you paste),
+// shows the trust disclosure, installs on confirmation, enables it, and
+// re-checks — so a missing plugin becomes ready in a couple of clicks. The trust
+// preview is always shown; nothing is installed silently. Verification of
+// REAPER/Web Remote/runner still happens later, when setup runs.
 (function () {
   'use strict';
 
@@ -79,46 +83,239 @@
     busy = on;
     const { actions } = els();
     if (!actions) return;
-    actions.querySelectorAll('button').forEach(b => {
-      b.disabled = on;
+    actions.querySelectorAll('button, input').forEach(el => {
+      el.disabled = on;
     });
   }
 
-  async function enablePlugin() {
+  async function fetchJSON(url, opts) {
+    const resp = await fetch(url, opts);
+    let data = {};
+    try {
+      data = await resp.json();
+    } catch (_) {
+      data = {};
+    }
+    if (!resp.ok) throw new Error(data.error || 'request failed: ' + resp.status);
+    return data;
+  }
+
+  // --- Inline install flow -------------------------------------------------
+
+  // resolveMarketplacePlugin scans the configured marketplaces for reaper-plugin
+  // so it can be installed with the trust preview and no hard-coded source.
+  async function resolveMarketplacePlugin() {
+    try {
+      const data = await fetchJSON('/api/plugins/marketplaces');
+      const list = Array.isArray(data.marketplaces) ? data.marketplaces : [];
+      for (const mp of list) {
+        const plugins = Array.isArray(mp.plugins) ? mp.plugins : [];
+        const hit = plugins.find(p => String(p.name || '').toLowerCase() === PLUGIN_NAME);
+        if (hit) return { marketplace: mp.name, plugin: hit.name || PLUGIN_NAME };
+      }
+    } catch (_) {
+      /* fall through to the source-paste path */
+    }
+    return null;
+  }
+
+  async function beginInstall() {
     if (busy) return;
     setBusy(true);
+    renderMessage('Finding reaper-plugin…');
     try {
-      const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
-        method: 'POST'
-      });
-      if (!resp.ok) throw new Error('enable failed');
-      await refresh();
-    } catch (_) {
-      renderError('Could not enable reaper-plugin. Enable it, then try again.');
+      const mp = await resolveMarketplacePlugin();
+      if (mp) {
+        const prev = await fetchJSON('/api/plugins/marketplaces/install', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: false })
+        });
+        renderTrust(prev.trust, mp.plugin + ' · ' + mp.marketplace, () =>
+          confirmMarketplaceInstall(mp)
+        );
+      } else {
+        renderSourceInput();
+      }
+    } catch (e) {
+      renderError(
+        'Could not reach the plugin marketplaces. Paste a source instead, or open the Plugins page.'
+      );
+      renderSourceInput(true);
     } finally {
       setBusy(false);
     }
   }
 
+  async function confirmMarketplaceInstall(mp) {
+    if (busy) return;
+    setBusy(true);
+    renderMessage('Installing ' + PLUGIN_NAME + '…');
+    try {
+      await fetchJSON('/api/plugins/marketplaces/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ marketplace: mp.marketplace, plugin: mp.plugin, confirm: true })
+      });
+      await enableAndRefresh();
+    } catch (e) {
+      renderError('Install failed: ' + (e.message || 'unknown error'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function previewSourceInstall(source) {
+    source = String(source || '').trim();
+    if (!source) return;
+    if (busy) return;
+    setBusy(true);
+    renderMessage('Checking ' + source + '…');
+    try {
+      const prev = await fetchJSON('/api/plugins/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source, confirm: false })
+      });
+      renderTrust(prev.trust, source, () => confirmSourceInstall(source));
+    } catch (e) {
+      renderError('Could not read that source: ' + (e.message || 'unknown error'));
+      renderSourceInput(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmSourceInstall(source) {
+    if (busy) return;
+    setBusy(true);
+    renderMessage('Installing ' + PLUGIN_NAME + '…');
+    try {
+      await fetchJSON('/api/plugins/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source, confirm: true })
+      });
+      await enableAndRefresh();
+    } catch (e) {
+      renderError('Install failed: ' + (e.message || 'unknown error'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // enableAndRefresh enables the freshly installed plugin (install records it
+  // disabled) and re-checks readiness, which unblocks creation when ready.
+  async function enableAndRefresh() {
+    try {
+      await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
+        method: 'POST'
+      });
+    } catch (_) {
+      /* best effort; refresh will show the disabled state and offer Enable */
+    }
+    await refresh();
+  }
+
+  // --- Inline panels -------------------------------------------------------
+
+  function renderMessage(message) {
+    const { status } = els();
+    if (status) status.textContent = message;
+    const { actions } = els();
+    if (actions) actions.textContent = '';
+  }
+
+  // renderTrust shows the install disclosure (what will be registered) so nothing
+  // installs without the user seeing it.
+  function renderTrust(trust, sourceLabel, onConfirm) {
+    const { detail, actions } = els();
+    if (!detail || !actions) return;
+    detail.textContent = '';
+    const t = trust || {};
+    const head = document.createElement('div');
+    head.style.cssText = 'font-size:12px;color:var(--text-primary);margin-bottom:4px;';
+    head.textContent = 'Install ' + (t.Name || PLUGIN_NAME) + ' from ' + sourceLabel + '?';
+    detail.appendChild(head);
+
+    const disclosure = document.createElement('div');
+    disclosure.style.cssText = 'font-size:11px;color:var(--text-secondary);';
+    const skills = Array.isArray(t.Skills) ? t.Skills : [];
+    const cmds = Array.isArray(t.MCPCommands) ? t.MCPCommands : [];
+    const warnings = Array.isArray(t.Warnings) ? t.Warnings : [];
+    if (skills.length) disclosure.appendChild(line('Skills: ' + skills.join(', ')));
+    if (cmds.length) disclosure.appendChild(line('Runs: ' + cmds.join('; ')));
+    if (!skills.length && !cmds.length)
+      disclosure.appendChild(line('Registers reaper-plugin components.'));
+    warnings.forEach(wtext => {
+      const wl = line('⚠ ' + wtext);
+      wl.style.color = 'var(--warning-color, #d97706)';
+      disclosure.appendChild(wl);
+    });
+    detail.appendChild(disclosure);
+
+    actions.textContent = '';
+    actions.appendChild(button('Install & enable', { primary: true, onClick: onConfirm }));
+    actions.appendChild(button('Cancel', { onClick: refresh }));
+  }
+
+  function line(text) {
+    const d = document.createElement('div');
+    d.textContent = text;
+    return d;
+  }
+
+  // renderSourceInput lets the user paste a source when no marketplace resolves
+  // reaper-plugin, so install still happens inline (with the trust preview).
+  function renderSourceInput(keepMessage) {
+    const { status, detail, actions } = els();
+    if (!detail || !actions) return;
+    if (status && !keepMessage) {
+      status.textContent =
+        'No configured marketplace has reaper-plugin. Paste its source to install it here.';
+    }
+    detail.textContent = '';
+    const hint = line(
+      'A GitHub repo, owner/repo, or local path to reaper-plugin. The trust preview is shown before anything installs.'
+    );
+    hint.style.cssText = 'font-size:11px;color:var(--text-secondary);';
+    detail.appendChild(hint);
+
+    actions.textContent = '';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'modern-input';
+    input.placeholder = 'e.g. johnjallday/reaper-plugin';
+    input.style.cssText = 'flex:1 1 220px;font-size:12px;';
+    input.setAttribute('aria-label', 'reaper-plugin source');
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') previewSourceInstall(input.value);
+    });
+    actions.appendChild(input);
+    actions.appendChild(
+      button('Preview install', { primary: true, onClick: () => previewSourceInstall(input.value) })
+    );
+    actions.appendChild(button('Open Plugins page', { onClick: openPluginsPage }));
+    input.focus?.();
+  }
+
   function openPluginsPage() {
-    // Fallback per PRD FR18: focus the existing Plugins installation surface with
-    // the exact plugin name when no marketplace resolves it inline.
     window.open('/plugins?install=' + encodeURIComponent(PLUGIN_NAME), '_blank', 'noopener');
   }
 
   function renderError(message) {
-    const { card, status, detail, actions, badge } = els();
+    const { card, status, badge, detail, actions } = els();
     if (!card) return;
     card.hidden = false;
     setBadge(badge, 'Error');
     if (status) status.textContent = message || 'Could not check reaper-plugin.';
-    if (detail) detail.textContent = 'Try again; the backend re-checks the plugin when you create.';
+    if (detail) detail.textContent = '';
     if (actions) {
       actions.textContent = '';
       actions.appendChild(button('Retry', { onClick: refresh }));
     }
-    // Don't hard-block on a transient preview error — the backend guard still
-    // enforces the requirement on create.
+    // Don't hard-block on a transient error — the backend guard still enforces
+    // the requirement on create.
     setCreateBlocked(false);
   }
 
@@ -158,19 +355,39 @@
       default:
         setBadge(badge, 'Required');
         status.textContent =
-          'reaper-plugin is required and not installed. Install it to create this workspace.';
+          'reaper-plugin is required and not installed. Install it below to create this workspace.';
         detail.textContent =
-          'The Reaper Song template requires reaper-plugin (a global install; attachment is per-workspace). Creating is blocked until it is installed and enabled. ' +
+          'The Reaper Song template requires reaper-plugin (a global install; attachment is per-workspace). ' +
           verificationNote;
-        actions.appendChild(button('Install plugin', { primary: true, onClick: openPluginsPage }));
+        actions.appendChild(button('Install plugin', { primary: true, onClick: beginInstall }));
         actions.appendChild(button('Re-check', { onClick: refresh }));
         setCreateBlocked(true, 'Install reaper-plugin to create this workspace');
         break;
     }
-    const note = document.createElement('div');
-    note.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:6px;opacity:0.85;';
-    note.textContent = liveControlNote;
-    detail.appendChild(note);
+    if (detail) {
+      const note = document.createElement('div');
+      note.style.cssText =
+        'font-size:11px;color:var(--text-secondary);margin-top:6px;opacity:0.85;';
+      note.textContent = liveControlNote;
+      detail.appendChild(note);
+    }
+  }
+
+  async function enablePlugin() {
+    if (busy) return;
+    setBusy(true);
+    renderMessage('Enabling reaper-plugin…');
+    try {
+      const resp = await fetch('/api/plugins/' + encodeURIComponent(PLUGIN_NAME) + '/enable', {
+        method: 'POST'
+      });
+      if (!resp.ok) throw new Error('enable failed');
+      await refresh();
+    } catch (_) {
+      renderError('Could not enable reaper-plugin. Enable it, then Re-check.');
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function refresh() {

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -46,8 +46,17 @@ class FakeElement {
     (this._listeners.click || []).forEach(fn => fn());
   }
   querySelectorAll(sel) {
-    if (sel === 'button') return this.children.filter(c => c.tagName === 'BUTTON');
-    return [];
+    // Recurse like the real DOM so nested buttons/inputs are found.
+    const want = String(sel).toUpperCase();
+    const out = [];
+    const walk = el => {
+      el.children.forEach(c => {
+        if (c.tagName === want) out.push(c);
+        walk(c);
+      });
+    };
+    walk(this);
+    return out;
   }
 }
 
@@ -87,6 +96,7 @@ function setup() {
 
 const mod = await (async () => {
   setup();
+  await import('./reaper-plugin-install.js'); // shared installer the card delegates to
   await import('./reaper-setup-card.js');
   return globalThis.window.ReaperSetupCard;
 })();
@@ -218,7 +228,11 @@ test('inline install: resolve from marketplace, show trust, install, enable, unb
     .querySelectorAll('button')
     .find(b => b.textContent === 'Install & enable');
   assert.ok(confirmBtn, 'expected an Install & enable confirm button');
-  assert.match(doc.getElementById('reaperSetupDetail').textContent, /Skills: reaper-session-setup/);
+  // The shared installer renders the trust disclosure into the actions host.
+  assert.match(
+    doc.getElementById('reaperSetupActions').textContent,
+    /Skills: reaper-session-setup/
+  );
 
   // Confirm install -> installs, enables, re-checks -> ready + unblocked.
   confirmBtn.click();
@@ -247,10 +261,7 @@ test('inline install: no marketplace match falls back to a source input', async 
     .click();
   await flush();
   const actions = doc.getElementById('reaperSetupActions');
-  assert.ok(
-    actions.children.some(c => c.tagName === 'INPUT'),
-    'expected a source input'
-  );
+  assert.ok(actions.querySelectorAll('input').length > 0, 'expected a source input');
   assert.ok(
     actions
       .querySelectorAll('button')

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -269,3 +269,68 @@ test('fetch failure renders Retry and does not hard-block creation', async () =>
   // the button is not left permanently disabled by the card.
   assert.equal(doc.getElementById('createFolderBtn').disabled, false);
 });
+
+// Placed last: it sets the module's declaredSource via showForTemplate, which
+// would otherwise steer earlier marketplace/paste tests down the source path.
+test('template-declared source: one-click install skips the marketplace', async () => {
+  const doc = setup();
+  const SRC = 'https://github.com/johnjallday/reaper-plugin.git';
+  let previewCall = 0;
+  const seen = [];
+  globalThis.fetch = async (url, opts) => {
+    const method = (opts && opts.method) || 'GET';
+    seen.push(method + ' ' + url);
+    if (url === '/api/reaper-setup/preview') {
+      previewCall += 1;
+      const status = previewCall === 1 ? 'plugin_missing' : 'ready_to_attach';
+      return {
+        ok: true,
+        json: async () => ({ status, would_attach: [{ name: 'reaper-session-setup' }] })
+      };
+    }
+    if (url === '/api/plugins/install' && method === 'POST') {
+      const body = JSON.parse(opts.body);
+      assert.equal(body.source, SRC);
+      if (!body.confirm) {
+        return {
+          ok: true,
+          json: async () => ({
+            installed: false,
+            trust: { Name: 'reaper-plugin', Skills: ['reaper-session-setup'], MCPCommands: [] }
+          })
+        };
+      }
+      return { ok: true, json: async () => ({ installed: true }) };
+    }
+    if (url === '/api/plugins/reaper-plugin/enable' && method === 'POST') {
+      return { ok: true, json: async () => ({ enabled: true }) };
+    }
+    throw new Error('unexpected fetch ' + method + ' ' + url);
+  };
+
+  mod.showForTemplate({ id: 'reaper-song', tools: { plugin_sources: { 'reaper-plugin': SRC } } });
+  await flush();
+
+  // Install uses the declared source directly — no marketplace lookup.
+  doc
+    .getElementById('reaperSetupActions')
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install plugin')
+    .click();
+  await flush();
+  assert.ok(
+    !seen.includes('GET /api/plugins/marketplaces'),
+    'must not consult the marketplace when a source is declared'
+  );
+
+  const confirmBtn = doc
+    .getElementById('reaperSetupActions')
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install & enable');
+  assert.ok(confirmBtn, 'expected the trust-preview confirm button');
+  confirmBtn.click();
+  await flush();
+  assert.equal(doc.getElementById('createFolderBtn').disabled, false);
+
+  mod.showForTemplate({ id: 'blank' }); // reset declaredSource for isolation
+});

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -17,6 +17,15 @@ class FakeElement {
     this.type = '';
     this.children = [];
     this._listeners = {};
+    this.dataset = {};
+    this._attrs = {};
+    this.title = '';
+  }
+  setAttribute(k, v) {
+    this._attrs[k] = v;
+  }
+  removeAttribute(k) {
+    delete this._attrs[k];
   }
   get textContent() {
     return this._text;
@@ -63,9 +72,10 @@ function setup() {
     'reaperSetupStatusText',
     'reaperSetupBadge',
     'reaperSetupDetail',
-    'reaperSetupActions'
+    'reaperSetupActions',
+    'createFolderBtn'
   ].forEach(id => {
-    const el = new FakeElement('div');
+    const el = new FakeElement(id === 'createFolderBtn' ? 'button' : 'div');
     el.id = id;
     doc.register(el);
   });
@@ -80,10 +90,12 @@ const mod = await (async () => {
   return globalThis.window.ReaperSetupCard;
 })();
 
-test('non-reaper template hides the card', () => {
+test('non-reaper template hides the card and never blocks creation', () => {
   const doc = setup();
+  doc.getElementById('createFolderBtn').disabled = true; // pretend a stale block
   mod.showForTemplate({ id: 'writing-project' });
   assert.equal(doc.getElementById('reaperSetupCard').hidden, true);
+  assert.equal(doc.getElementById('createFolderBtn').disabled, false);
 });
 
 test('ready_to_attach shows attach message and no action', async () => {
@@ -102,9 +114,11 @@ test('ready_to_attach shows attach message and no action', async () => {
   assert.equal(card.hidden, false);
   assert.match(status.textContent, /will attach/i);
   assert.equal(actions.querySelectorAll('button').length, 0);
+  // Plugin ready: creation is allowed.
+  assert.equal(doc.getElementById('createFolderBtn').disabled, false);
 });
 
-test('plugin_disabled offers an Enable action', async () => {
+test('plugin_disabled offers Enable and blocks creation', async () => {
   const doc = setup();
   globalThis.fetch = async () => ({
     ok: true,
@@ -112,12 +126,13 @@ test('plugin_disabled offers an Enable action', async () => {
   });
   await mod.refresh();
   const actions = doc.getElementById('reaperSetupActions');
-  const buttons = actions.querySelectorAll('button');
-  assert.equal(buttons.length, 1);
-  assert.equal(buttons[0].textContent, 'Enable plugin');
+  const labels = actions.querySelectorAll('button').map(b => b.textContent);
+  assert.ok(labels.includes('Enable plugin'));
+  // Required plugin disabled: creation is blocked until it's enabled.
+  assert.equal(doc.getElementById('createFolderBtn').disabled, true);
 });
 
-test('plugin_missing shows file-only + Install action, never blocks creation', async () => {
+test('plugin_missing shows Install and blocks creation', async () => {
   const doc = setup();
   globalThis.fetch = async () => ({
     ok: true,
@@ -126,14 +141,24 @@ test('plugin_missing shows file-only + Install action, never blocks creation', a
   await mod.refresh();
   const status = doc.getElementById('reaperSetupStatusText');
   const actions = doc.getElementById('reaperSetupActions');
-  assert.match(status.textContent, /file-only/i);
-  assert.equal(actions.querySelectorAll('button')[0].textContent, 'Install plugin');
+  assert.match(status.textContent, /required and not installed/i);
+  assert.ok(
+    actions
+      .querySelectorAll('button')
+      .map(b => b.textContent)
+      .includes('Install plugin')
+  );
+  // Required plugin missing: creation is blocked until it's installed.
+  assert.equal(doc.getElementById('createFolderBtn').disabled, true);
 });
 
-test('fetch failure renders a Retry control', async () => {
+test('fetch failure renders Retry and does not hard-block creation', async () => {
   const doc = setup();
   globalThis.fetch = async () => ({ ok: false });
   await mod.refresh();
   const actions = doc.getElementById('reaperSetupActions');
   assert.equal(actions.querySelectorAll('button')[0].textContent, 'Retry');
+  // On a transient preview error the backend guard still enforces the rule, so
+  // the button is not left permanently disabled by the card.
+  assert.equal(doc.getElementById('createFolderBtn').disabled, false);
 });

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -1,0 +1,104 @@
+// Tests for reaper-setup-card.js — the Create Workspace REAPER Setup card.
+// Uses a small inline DOM stub (no jsdom), matching the rest of the suite.
+//
+// Run with: node --test internal/web/static/js/modules/reaper-setup-card.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.hidden = false;
+    this._text = '';
+    this.className = '';
+    this.style = {};
+    this.disabled = false;
+    this.type = '';
+    this.children = [];
+    this._listeners = {};
+  }
+  get textContent() { return this._text; }
+  set textContent(v) { this._text = v; if (v === '') this.children = []; }
+  appendChild(el) { this.children.push(el); return el; }
+  addEventListener(ev, fn) { (this._listeners[ev] ||= []).push(fn); }
+  click() { (this._listeners.click || []).forEach((fn) => fn()); }
+  querySelectorAll(sel) {
+    if (sel === 'button') return this.children.filter((c) => c.tagName === 'BUTTON');
+    return [];
+  }
+}
+
+class FakeDocument {
+  constructor() { this.byId = new Map(); }
+  register(el) { this.byId.set(el.id, el); }
+  getElementById(id) { return this.byId.get(id) || null; }
+  createElement(tag) { return new FakeElement(tag); }
+}
+
+function setup() {
+  const doc = new FakeDocument();
+  ['reaperSetupCard', 'reaperSetupStatusText', 'reaperSetupBadge', 'reaperSetupDetail', 'reaperSetupActions'].forEach((id) => {
+    const el = new FakeElement('div');
+    el.id = id;
+    doc.register(el);
+  });
+  globalThis.document = doc;
+  globalThis.window = globalThis;
+  return doc;
+}
+
+const mod = await (async () => {
+  setup();
+  await import('./reaper-setup-card.js');
+  return globalThis.window.ReaperSetupCard;
+})();
+
+test('non-reaper template hides the card', () => {
+  const doc = setup();
+  mod.showForTemplate({ id: 'writing-project' });
+  assert.equal(doc.getElementById('reaperSetupCard').hidden, true);
+});
+
+test('ready_to_attach shows attach message and no action', async () => {
+  const doc = setup();
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({ status: 'ready_to_attach', would_attach: [{ name: 'reaper-session-setup' }, { name: 'reaper-web-remote' }] }),
+  });
+  await mod.refresh();
+  const card = doc.getElementById('reaperSetupCard');
+  const status = doc.getElementById('reaperSetupStatusText');
+  const actions = doc.getElementById('reaperSetupActions');
+  assert.equal(card.hidden, false);
+  assert.match(status.textContent, /will attach/i);
+  assert.equal(actions.querySelectorAll('button').length, 0);
+});
+
+test('plugin_disabled offers an Enable action', async () => {
+  const doc = setup();
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({ status: 'plugin_disabled', would_attach: [] }) });
+  await mod.refresh();
+  const actions = doc.getElementById('reaperSetupActions');
+  const buttons = actions.querySelectorAll('button');
+  assert.equal(buttons.length, 1);
+  assert.equal(buttons[0].textContent, 'Enable plugin');
+});
+
+test('plugin_missing shows file-only + Install action, never blocks creation', async () => {
+  const doc = setup();
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({ status: 'plugin_missing', would_attach: [] }) });
+  await mod.refresh();
+  const status = doc.getElementById('reaperSetupStatusText');
+  const actions = doc.getElementById('reaperSetupActions');
+  assert.match(status.textContent, /file-only/i);
+  assert.equal(actions.querySelectorAll('button')[0].textContent, 'Install plugin');
+});
+
+test('fetch failure renders a Retry control', async () => {
+  const doc = setup();
+  globalThis.fetch = async () => ({ ok: false });
+  await mod.refresh();
+  const actions = doc.getElementById('reaperSetupActions');
+  assert.equal(actions.querySelectorAll('button')[0].textContent, 'Retry');
+});

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -28,6 +28,7 @@ class FakeElement {
     delete this._attrs[k];
   }
   get textContent() {
+    if (this.children.length) return this._text + this.children.map(c => c.textContent).join('');
     return this._text;
   }
   set textContent(v) {
@@ -150,6 +151,112 @@ test('plugin_missing shows Install and blocks creation', async () => {
   );
   // Required plugin missing: creation is blocked until it's installed.
   assert.equal(doc.getElementById('createFolderBtn').disabled, true);
+});
+
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await new Promise(r => setTimeout(r, 0));
+};
+
+test('inline install: resolve from marketplace, show trust, install, enable, unblock', async () => {
+  const doc = setup();
+  let previewCall = 0;
+  globalThis.fetch = async (url, opts) => {
+    const method = (opts && opts.method) || 'GET';
+    if (url === '/api/reaper-setup/preview') {
+      previewCall += 1;
+      // First check: missing. After install+enable: ready.
+      const status = previewCall === 1 ? 'plugin_missing' : 'ready_to_attach';
+      return {
+        ok: true,
+        json: async () => ({ status, would_attach: [{ name: 'reaper-session-setup' }] })
+      };
+    }
+    if (url === '/api/plugins/marketplaces' && method === 'GET') {
+      return {
+        ok: true,
+        json: async () => ({
+          marketplaces: [{ name: 'my-mp', plugins: [{ name: 'reaper-plugin' }] }]
+        })
+      };
+    }
+    if (url === '/api/plugins/marketplaces/install' && method === 'POST') {
+      const body = JSON.parse(opts.body);
+      if (!body.confirm) {
+        return {
+          ok: true,
+          json: async () => ({
+            installed: false,
+            trust: { Name: 'reaper-plugin', Skills: ['reaper-session-setup'], MCPCommands: [] }
+          })
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ installed: true, plugin: { name: 'reaper-plugin' } })
+      };
+    }
+    if (url === '/api/plugins/reaper-plugin/enable' && method === 'POST') {
+      return { ok: true, json: async () => ({ enabled: true }) };
+    }
+    throw new Error('unexpected fetch ' + method + ' ' + url);
+  };
+
+  await mod.refresh(); // missing -> blocked, Install action present
+  assert.equal(doc.getElementById('createFolderBtn').disabled, true);
+
+  // Click Install plugin.
+  const actions = doc.getElementById('reaperSetupActions');
+  actions
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install plugin')
+    .click();
+  await flush();
+
+  // Trust disclosure is shown with an Install & enable confirm.
+  const confirmBtn = doc
+    .getElementById('reaperSetupActions')
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install & enable');
+  assert.ok(confirmBtn, 'expected an Install & enable confirm button');
+  assert.match(doc.getElementById('reaperSetupDetail').textContent, /Skills: reaper-session-setup/);
+
+  // Confirm install -> installs, enables, re-checks -> ready + unblocked.
+  confirmBtn.click();
+  await flush();
+  assert.match(doc.getElementById('reaperSetupStatusText').textContent, /will attach/i);
+  assert.equal(doc.getElementById('createFolderBtn').disabled, false);
+});
+
+test('inline install: no marketplace match falls back to a source input', async () => {
+  const doc = setup();
+  globalThis.fetch = async (url, opts) => {
+    const method = (opts && opts.method) || 'GET';
+    if (url === '/api/reaper-setup/preview') {
+      return { ok: true, json: async () => ({ status: 'plugin_missing', would_attach: [] }) };
+    }
+    if (url === '/api/plugins/marketplaces' && method === 'GET') {
+      return { ok: true, json: async () => ({ marketplaces: [{ name: 'empty', plugins: [] }] }) };
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+  await mod.refresh();
+  doc
+    .getElementById('reaperSetupActions')
+    .querySelectorAll('button')
+    .find(b => b.textContent === 'Install plugin')
+    .click();
+  await flush();
+  const actions = doc.getElementById('reaperSetupActions');
+  assert.ok(
+    actions.children.some(c => c.tagName === 'INPUT'),
+    'expected a source input'
+  );
+  assert.ok(
+    actions
+      .querySelectorAll('button')
+      .map(b => b.textContent)
+      .includes('Preview install')
+  );
 });
 
 test('fetch failure renders Retry and does not hard-block creation', async () => {

--- a/internal/web/static/js/modules/reaper-setup-card.test.js
+++ b/internal/web/static/js/modules/reaper-setup-card.test.js
@@ -18,27 +18,53 @@ class FakeElement {
     this.children = [];
     this._listeners = {};
   }
-  get textContent() { return this._text; }
-  set textContent(v) { this._text = v; if (v === '') this.children = []; }
-  appendChild(el) { this.children.push(el); return el; }
-  addEventListener(ev, fn) { (this._listeners[ev] ||= []).push(fn); }
-  click() { (this._listeners.click || []).forEach((fn) => fn()); }
+  get textContent() {
+    return this._text;
+  }
+  set textContent(v) {
+    this._text = v;
+    if (v === '') this.children = [];
+  }
+  appendChild(el) {
+    this.children.push(el);
+    return el;
+  }
+  addEventListener(ev, fn) {
+    (this._listeners[ev] ||= []).push(fn);
+  }
+  click() {
+    (this._listeners.click || []).forEach(fn => fn());
+  }
   querySelectorAll(sel) {
-    if (sel === 'button') return this.children.filter((c) => c.tagName === 'BUTTON');
+    if (sel === 'button') return this.children.filter(c => c.tagName === 'BUTTON');
     return [];
   }
 }
 
 class FakeDocument {
-  constructor() { this.byId = new Map(); }
-  register(el) { this.byId.set(el.id, el); }
-  getElementById(id) { return this.byId.get(id) || null; }
-  createElement(tag) { return new FakeElement(tag); }
+  constructor() {
+    this.byId = new Map();
+  }
+  register(el) {
+    this.byId.set(el.id, el);
+  }
+  getElementById(id) {
+    return this.byId.get(id) || null;
+  }
+  createElement(tag) {
+    return new FakeElement(tag);
+  }
 }
 
 function setup() {
   const doc = new FakeDocument();
-  ['reaperSetupCard', 'reaperSetupStatusText', 'reaperSetupBadge', 'reaperSetupDetail', 'reaperSetupActions'].forEach((id) => {
+  [
+    'reaperSetupCard',
+    'reaperSetupStatusText',
+    'reaperSetupBadge',
+    'reaperSetupDetail',
+    'reaperSetupActions'
+  ].forEach(id => {
     const el = new FakeElement('div');
     el.id = id;
     doc.register(el);
@@ -64,7 +90,10 @@ test('ready_to_attach shows attach message and no action', async () => {
   const doc = setup();
   globalThis.fetch = async () => ({
     ok: true,
-    json: async () => ({ status: 'ready_to_attach', would_attach: [{ name: 'reaper-session-setup' }, { name: 'reaper-web-remote' }] }),
+    json: async () => ({
+      status: 'ready_to_attach',
+      would_attach: [{ name: 'reaper-session-setup' }, { name: 'reaper-web-remote' }]
+    })
   });
   await mod.refresh();
   const card = doc.getElementById('reaperSetupCard');
@@ -77,7 +106,10 @@ test('ready_to_attach shows attach message and no action', async () => {
 
 test('plugin_disabled offers an Enable action', async () => {
   const doc = setup();
-  globalThis.fetch = async () => ({ ok: true, json: async () => ({ status: 'plugin_disabled', would_attach: [] }) });
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({ status: 'plugin_disabled', would_attach: [] })
+  });
   await mod.refresh();
   const actions = doc.getElementById('reaperSetupActions');
   const buttons = actions.querySelectorAll('button');
@@ -87,7 +119,10 @@ test('plugin_disabled offers an Enable action', async () => {
 
 test('plugin_missing shows file-only + Install action, never blocks creation', async () => {
   const doc = setup();
-  globalThis.fetch = async () => ({ ok: true, json: async () => ({ status: 'plugin_missing', would_attach: [] }) });
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({ status: 'plugin_missing', would_attach: [] })
+  });
   await mod.refresh();
   const status = doc.getElementById('reaperSetupStatusText');
   const actions = doc.getElementById('reaperSetupActions');

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3950,6 +3950,27 @@ const sessionManager = {
           continue;
         }
 
+        if (
+          response.status === 409 &&
+          !importEnabled &&
+          ((Array.isArray(result.missing_plugins) && result.missing_plugins.length) ||
+            (Array.isArray(result.disabled_plugins) && result.disabled_plugins.length))
+        ) {
+          // Required-plugin gate: the selected template needs plugins installed
+          // and enabled before creation. Surface exactly what to fix and refresh
+          // the REAPER Setup card so its inline Install/Enable actions are shown.
+          const parts = [];
+          if (result.missing_plugins?.length) {
+            parts.push(`Install required plugin(s): ${result.missing_plugins.join(', ')}`);
+          }
+          if (result.disabled_plugins?.length) {
+            parts.push(`Enable required plugin(s): ${result.disabled_plugins.join(', ')}`);
+          }
+          this.showToast(parts.join(' · ') || 'Required plugins are not ready', 'warning');
+          window.ReaperSetupCard?.refresh?.();
+          return;
+        }
+
         break;
       }
 

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -237,6 +237,8 @@ const sessionManager = {
       this.prefillTemplateValue(document.getElementById('folderDescriptionInput'), template?.description || '', 'autofillDescription');
       this.applyTemplateBehavior(template);
       void this.refreshTemplateAgentPlan();
+      // Show the REAPER Setup card only for the Reaper Song template.
+      window.ReaperSetupCard?.showForTemplate?.(template);
     });
 
     document.getElementById('templateAgentReviewToggle')?.addEventListener('change', () => {
@@ -3240,6 +3242,7 @@ const sessionManager = {
     this.workspaceTemplate = null;
     window.ProjectTemplateCard?.reset?.();
     this.resetTemplateAgentReview();
+    window.ReaperSetupCard?.hide?.();
     this.updateBehaviorHint();
   },
 

--- a/internal/web/static/js/modules/workspace-detail-plugins.js
+++ b/internal/web/static/js/modules/workspace-detail-plugins.js
@@ -313,6 +313,8 @@ export class WorkspacePluginsManager {
       });
 
       await this.host.loadWorkspace();
+      // Attachment changed: refresh the durable REAPER readiness card if present.
+      window.ReaperReadinessPanel?.refresh?.();
 
       const failures = Array.isArray(result?.failures) ? result.failures : [];
       if (failures.length > 0) {
@@ -392,6 +394,8 @@ export class WorkspacePluginsManager {
       }
 
       await this.host.loadWorkspace();
+      // Attachment changed: refresh the durable REAPER readiness card if present.
+      window.ReaperReadinessPanel?.refresh?.();
       if (window.Toast) window.Toast.success(`Removed ${label} from this workspace`);
     } catch (error) {
       console.error('Failed to remove plugin from workspace:', error);

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -53,6 +53,20 @@
               <div id="templateAgentReviewWarnings" class="workspace-template-agent-warnings" hidden></div>
             </div>
 
+            <!-- REAPER Setup card: shown only when the Reaper Song template is
+                 selected. Populated by sessions.js from /api/reaper-setup/preview. -->
+            <div id="reaperSetupCard" class="workspace-setup-card reaper-setup-card mb-2" role="group" aria-label="REAPER Setup" hidden>
+              <div class="workspace-setup-header" style="align-items: flex-start;">
+                <div>
+                  <div class="workspace-setup-title">REAPER Setup</div>
+                  <p id="reaperSetupStatusText" class="workspace-setup-help mb-0" aria-live="polite">Checking reaper-plugin…</p>
+                </div>
+                <span id="reaperSetupBadge" class="reaper-setup-badge" aria-hidden="true"></span>
+              </div>
+              <div id="reaperSetupDetail" class="reaper-setup-detail" style="font-size: 12px; color: var(--text-secondary); margin-top: 6px;"></div>
+              <div id="reaperSetupActions" class="reaper-setup-actions d-flex flex-wrap gap-2" style="margin-top: 8px;"></div>
+            </div>
+
             <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
             <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
             <div class="workspace-setup-card mb-2">

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -342,6 +342,7 @@
   <script type="module" src="/js/modules/note-rail-notes.js"></script>
   <script type="module" src="/js/modules/note-ai-assist.js"></script>
   <script type="module" src="/js/modules/search-palette.js"></script>
+  <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/project-templates-manage.js"></script>
   <script defer src="/js/modules/toast.js"></script>

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -342,6 +342,7 @@
   <script type="module" src="/js/modules/note-rail-notes.js"></script>
   <script type="module" src="/js/modules/note-ai-assist.js"></script>
   <script type="module" src="/js/modules/search-palette.js"></script>
+  <script defer src="/js/modules/reaper-plugin-install.js"></script>
   <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/project-templates-manage.js"></script>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1783,6 +1783,7 @@
     <script defer src="/js/modules/toast.js"></script>
     <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
     <script defer src="/js/modules/workspace-group-options.js"></script>
+    <script defer src="/js/modules/reaper-setup-card.js"></script>
     <script defer src="/js/modules/sessions.js"></script>
     <script defer src="/js/app.js"></script>
     <script defer src="/js/modules/agents.js"></script>

--- a/internal/web/templates/pages/agents.tmpl
+++ b/internal/web/templates/pages/agents.tmpl
@@ -1783,6 +1783,7 @@
     <script defer src="/js/modules/toast.js"></script>
     <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
     <script defer src="/js/modules/workspace-group-options.js"></script>
+    <script defer src="/js/modules/reaper-plugin-install.js"></script>
     <script defer src="/js/modules/reaper-setup-card.js"></script>
     <script defer src="/js/modules/sessions.js"></script>
     <script defer src="/js/app.js"></script>

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -706,6 +706,7 @@
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-plugin-install.js"></script>
   <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -706,6 +706,7 @@
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -8608,6 +8608,7 @@
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-tools.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-plugin-install.js"></script>
   <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/reaper-readiness-panel.js"></script>
   <script defer src="/js/modules/sessions.js"></script>

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -42,6 +42,10 @@
                   <span class="workspace-detail-config-chip" id="workspace-detail-config-connections-chip">MCP: 0</span>
                   <span class="workspace-detail-config-chip" id="workspace-detail-config-skills-chip">Skills: 0</span>
                   <span class="workspace-detail-config-chip" id="workspace-detail-config-reference-chip" hidden>Refs: 0</span>
+                  <!-- Compact REAPER setup-needed indicator; opens the readiness
+                       card in the Plugins tab. Hidden unless a REAPER workspace
+                       needs setup (or shows a compact success once ori_ready). -->
+                  <button type="button" class="workspace-detail-config-chip reaper-setup-chip" id="reaperReadinessChip" hidden></button>
                 </div>
               </div>
               <button
@@ -489,6 +493,21 @@
                   role="tabpanel"
                   aria-labelledby="workspace-detail-config-plugins-tab"
                   tabindex="0">
+                  <!-- Durable REAPER Setup readiness card. Hidden unless the
+                       workspace is identified as REAPER and not yet ori_ready
+                       (or collapsed to a compact success summary once ready).
+                       Populated by reaper-readiness-panel.js. -->
+                  <div id="reaperReadinessCard" class="workspace-detail-reaper-card" role="group" aria-label="REAPER Setup" hidden>
+                    <div class="workspace-detail-reaper-head">
+                      <div>
+                        <div class="workspace-detail-reaper-title">REAPER Setup</div>
+                        <div id="reaperReadinessStatus" class="workspace-detail-reaper-status" aria-live="polite"></div>
+                      </div>
+                      <span id="reaperReadinessBadge" class="reaper-setup-badge" aria-hidden="true"></span>
+                    </div>
+                    <ul id="reaperReadinessRows" class="workspace-detail-reaper-rows"></ul>
+                    <div id="reaperReadinessActions" class="workspace-detail-reaper-actions d-flex flex-wrap gap-2"></div>
+                  </div>
                   <div class="workspace-detail-config-pane-header">
                     <div>
                       <div class="workspace-detail-config-pane-title">Workspace Plugins</div>
@@ -8590,6 +8609,7 @@
   <script defer src="/js/modules/workspace-tools.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
   <script defer src="/js/modules/reaper-setup-card.js"></script>
+  <script defer src="/js/modules/reaper-readiness-panel.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>
   <script defer src="/js/modules/toast.js"></script>

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -8589,6 +8589,7 @@
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-tools.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>
   <script defer src="/js/modules/toast.js"></script>

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -50,6 +50,7 @@
   <script defer src="/js/modules/task-modal-controller.js"></script>
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-plugin-install.js"></script>
   <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -50,6 +50,7 @@
   <script defer src="/js/modules/task-modal-controller.js"></script>
   <script defer src="/js/modules/workspace-bootstrap-review.js"></script>
   <script defer src="/js/modules/workspace-group-options.js"></script>
+  <script defer src="/js/modules/reaper-setup-card.js"></script>
   <script defer src="/js/modules/sessions.js"></script>
   <script defer src="/js/modules/dashboard.js"></script>
   <script defer src="/js/modules/toast.js"></script>

--- a/internal/workspace/template_provenance.go
+++ b/internal/workspace/template_provenance.go
@@ -1,0 +1,64 @@
+package workspace
+
+import (
+	"strings"
+	"time"
+)
+
+// TemplateProvenance records the built-in template a workspace was created from,
+// in portable workspace metadata (persisted to workspace.json). Features such as
+// REAPER readiness and repair identify a workspace's origin from this rather than
+// scanning task descriptions or project filenames, which are brittle and can be
+// renamed by the user. It carries no executable hooks — it is pure provenance.
+type TemplateProvenance struct {
+	// TemplateID is the stable built-in identifier, e.g. "reaper-song".
+	TemplateID string `json:"template_id,omitempty"`
+	// TemplateName is the human-facing template name at creation time.
+	TemplateName string `json:"template_name,omitempty"`
+	// Builtin is true when the origin was a shipped built-in template.
+	Builtin bool `json:"builtin,omitempty"`
+	// Version is the template's builtin_version at creation time.
+	Version int `json:"version,omitempty"`
+	// AppliedAt records when the template was applied to the workspace.
+	AppliedAt time.Time `json:"applied_at,omitempty"`
+}
+
+// GetTemplateProvenance returns a copy of the workspace's template provenance, if
+// any.
+func (w *Workspace) GetTemplateProvenance() *TemplateProvenance {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.TemplateProvenance == nil {
+		return nil
+	}
+	cp := *w.TemplateProvenance
+	return &cp
+}
+
+// SetTemplateProvenance records the originating template. Passing nil clears it.
+func (w *Workspace) SetTemplateProvenance(p *TemplateProvenance) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if p == nil {
+		w.TemplateProvenance = nil
+		w.UpdatedAt = time.Now()
+		return
+	}
+	cp := *p
+	cp.TemplateID = strings.TrimSpace(cp.TemplateID)
+	if cp.AppliedAt.IsZero() {
+		cp.AppliedAt = time.Now()
+	}
+	w.TemplateProvenance = &cp
+	w.UpdatedAt = time.Now()
+}
+
+// IsFromTemplate reports whether the workspace was created from the given
+// built-in template ID (case-insensitive).
+func (w *Workspace) IsFromTemplate(templateID string) bool {
+	p := w.GetTemplateProvenance()
+	if p == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(p.TemplateID), strings.TrimSpace(templateID))
+}

--- a/internal/workspace/template_provenance_test.go
+++ b/internal/workspace/template_provenance_test.go
@@ -1,0 +1,66 @@
+package workspace
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTemplateProvenance_SetGetIsFrom(t *testing.T) {
+	ws := NewWorkspace(CreateWorkspaceParams{Name: "Song"})
+	if ws.GetTemplateProvenance() != nil {
+		t.Fatal("new workspace should have no provenance")
+	}
+	if ws.IsFromTemplate("reaper-song") {
+		t.Fatal("unset provenance must not match any template")
+	}
+
+	ws.SetTemplateProvenance(&TemplateProvenance{TemplateID: "  reaper-song  ", Builtin: true, Version: 4})
+	p := ws.GetTemplateProvenance()
+	if p == nil || p.TemplateID != "reaper-song" {
+		t.Fatalf("provenance not stored/trimmed: %+v", p)
+	}
+	if p.AppliedAt.IsZero() {
+		t.Fatal("AppliedAt should default to now")
+	}
+	if !ws.IsFromTemplate("Reaper-Song") {
+		t.Fatal("IsFromTemplate should be case-insensitive")
+	}
+	if ws.IsFromTemplate("writing-project") {
+		t.Fatal("must not match a different template")
+	}
+}
+
+func TestTemplateProvenance_GetReturnsCopy(t *testing.T) {
+	ws := NewWorkspace(CreateWorkspaceParams{Name: "Song"})
+	ws.SetTemplateProvenance(&TemplateProvenance{TemplateID: "reaper-song"})
+	got := ws.GetTemplateProvenance()
+	got.TemplateID = "mutated"
+	if ws.GetTemplateProvenance().TemplateID != "reaper-song" {
+		t.Fatal("GetTemplateProvenance must return a copy, not the internal pointer")
+	}
+}
+
+func TestTemplateProvenance_JSONRoundTrip(t *testing.T) {
+	ws := NewWorkspace(CreateWorkspaceParams{Name: "Song"})
+	ws.SetTemplateProvenance(&TemplateProvenance{TemplateID: "reaper-song", TemplateName: "Reaper Song", Builtin: true, Version: 4})
+	data, err := json.Marshal(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Workspace
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if !back.IsFromTemplate("reaper-song") {
+		t.Fatalf("provenance did not survive JSON round-trip: %+v", back.TemplateProvenance)
+	}
+}
+
+func TestTemplateProvenance_ClearWithNil(t *testing.T) {
+	ws := NewWorkspace(CreateWorkspaceParams{Name: "Song"})
+	ws.SetTemplateProvenance(&TemplateProvenance{TemplateID: "reaper-song"})
+	ws.SetTemplateProvenance(nil)
+	if ws.GetTemplateProvenance() != nil {
+		t.Fatal("nil should clear provenance")
+	}
+}

--- a/internal/workspace/workspace_types.go
+++ b/internal/workspace/workspace_types.go
@@ -129,6 +129,11 @@ type Workspace struct {
 	// defaults OFF; an agent must also opt in (Settings.AllowNativeMCPTools).
 	AllowNativeMCPCLI bool `json:"allow_native_mcp_cli,omitempty"`
 
+	// TemplateProvenance records the built-in template this workspace was created
+	// from (portable metadata; see template_provenance.go). Nil for workspaces
+	// created without a template or before provenance was recorded.
+	TemplateProvenance *TemplateProvenance `json:"template_provenance,omitempty"`
+
 	// Mission fields — workspace-level proactive goal carried out by the entry
 	// agent (Workspace Manager) on cadence. All fields are optional; a workspace
 	// with MissionEnabled = false (the zero value) behaves exactly as before.


### PR DESCRIPTION
Makes new and existing REAPER workspaces correctly configured, understandable, repairable, and truthful from template selection through first setup. Implements the PRD/task list in `tasks/prd-reaper-workspace-integration.md` (with two user-directed decisions layered on top — see below).

## What's in it

**Backend**
- `internal/pluginworkspace` — one idempotent reconciler that binds an installed plugin's recorded skill/MCP components onto a workspace through the configured plugin manager (honors the enabled flag) and the synchronized workspace store. Template application routes through it instead of a hard-coded `plugins/` lookup.
- `internal/reapersetup` — one normalized, truthful readiness resolver reused by the workspace UI, repair, and setup-gating. Conservative identification (template provenance → setup-task provenance → `.rpp` evidence; never name/tag alone), effective-assignee resolution, deterministic status precedence, and `ori_ready ≠ REAPER-connected` (live verification is always `not_checked`). Plus a pre-create preview and existing-workspace repair (idempotent; never touches native access, agents, tasks, or `.rpp`).
- Reaper Song template v5: declares `reaper-plugin` + its exact install source under `tools.plugin_sources`; portable `TemplateProvenance` persisted at creation.
- Setup auto-start is gated on `ori_ready` before the consumed marker is written (still exactly-once, non-REAPER templates unaffected).

**Frontend**
- Create Workspace **REAPER Setup card** — pre-create state with visible non-color text.
- Durable **readiness card + compact chip** on Workspace Tools → Plugins with repair, check-again-and-start-setup, and deep links.
- Shared **inline install** (`reaper-plugin-install.js`) used by both cards: trust-previewed install (template source → marketplace → pasted source), auto-enable, auto re-check — no tab switch.

## Two user-directed decisions (override the original PRD)
1. **Required-plugin gate:** a template that declares plugins now *blocks* creation until they're installed + enabled (backend 409 + disabled Create button), instead of the PRD's file-only-always. Reverses non-goal "blocking creation when the plugin is missing" and success metric #2.
2. Template declares the plugin's exact download source for one-click install.

## Testing
- Go: reconciler, readiness (identification + full status precedence + ori_ready≠connected), repair invariants (never enables native access / mutates agent / creates task / touches `.rpp`), setup-gating, required-plugin gate, provenance, template v5. `make test-unit` scope green (only pre-existing failure is the live-OpenAI `TestProviderIntegration` 429).
- JS: 578 tests incl. the shared installer flows and create-gate.
- Build-integration guard (`Handlers.Session.ReaperSetupWired`) catches the Phase-17/18 wiring bug that was found + fixed during review.
- Smoke-verified end-to-end: preview flips `plugin_missing → ready_to_attach` after inline install + enable.

## Not done (need a live env)
- Playwright suites and the full manual acceptance matrix (task 7.4/7.5) — left for reviewer sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)