### PR TITLE
fix: make wt start PRD glob work under non-interactive zsh

### DIFF
--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -379,6 +379,13 @@ function wt_dispatch {
     fi
     tasks_dir="$dev_path/tasks"
 
+    # The (N) glob qualifier below needs BARE_GLOB_QUAL, which is a zsh default
+    # but is off when this file is sourced from an `emulate sh`-style shell (e.g.
+    # a non-interactive/CI/headless agent). Without it, `prd-*.md(N)` aborts with
+    # "no matches found" before the loop runs. Force the option locally;
+    # local_options reverts it on return so the caller's shell is untouched.
+    setopt local_options bareglobqual
+
     local -a prd_files
     local f
     for f in "$tasks_dir"/prd-*.md(N); do


### PR DESCRIPTION
## Problem

`wt start` fails for any **non-interactive** caller (CI, headless/agent shells) with:

```
wt_dispatch:19: no matches found: /…/tasks/prd-*.md(N)
```

`wt_dispatch`'s `start` case globs the dev `tasks/` folder with the zsh `(N)` nullglob qualifier, which requires the `BARE_GLOB_QUAL` option. That option is a zsh default *interactively* but is **off** when `wt.sh` is sourced from an `emulate sh`-style shell. With it off, `prd-*.md(N)` is not treated as a nullglob and aborts with "no matches found" before the loop runs. It works from a normal terminal, which is why it only surfaced under automation.

## Fix

Force the option locally right before the glob:

```zsh
setopt local_options bareglobqual
```

`local_options` scopes the change to the function and reverts it on return, so the caller's interactive shell is never mutated. One-line change plus an explanatory comment; no behavior change for interactive users.

## Verification

All run in a shell with `bareglobqual` deliberately off (reproducing the failure):

- Raw `(N)` glob → `no matches found` (confirms the bug); **with the fix → matches correctly**.
- Empty tasks dir → 0 matches, **no error** (nullglob behavior preserved).
- `local_options` reverts the option to off after the function returns (caller untouched).
- `zsh -n` syntax OK; sourcing under the broken condition succeeds without mutating the caller.
- **End-to-end:** `wt start` under `bareglobqual` off now lists the PRDs instead of aborting.

Shell-only change — `dev`'s required checks (Unit Tests, Security Scan) have nothing to exercise here but still gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)