### PR TITLE
feat: home command bridge (status-first one-screen home)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,6 +225,11 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Extra["WorkspaceCount"] = workspaceCount
 	data.Extra["IsFirstRun"] = workspaceCount == 0
+	// Home is a dedicated command bridge rather than a second navigation shell.
+	// Keep sidebar behavior on every other page unchanged.
+	data.ShowSidebarToggle = false
+	data.Extra["HideSidebar"] = true
+	data.Extra["HomeCommandBridge"] = true
 
 	s.renderAndWritePage(w, "index", data)
 }

--- a/internal/web/static/css/home-command.css
+++ b/internal/web/static/css/home-command.css
@@ -1,0 +1,1015 @@
+/*
+ * home-command.css — the Home Command Bridge
+ *
+ * Scoped to the home body class so the tactical treatment stays an overview
+ * surface, not a global restyle. It intentionally shares the map view's
+ * Chakra Petch / JetBrains Mono vocabulary and signal colors.
+ */
+
+body.home-command-page {
+  --home-command-canvas: #0c0d10;
+  --hc-panel: #15181e;
+  --hc-panel-raised: #1a1e25;
+  --hc-panel-deep: #101217;
+  --hc-line: #2a2e38;
+  --hc-line-bright: #4a5160;
+  --hc-ink: #e4e9e7;
+  --hc-ink-dim: #a1a9b2;
+  --hc-ink-faint: #6e7783;
+  --hc-signal: #46d39a;
+  --hc-signal-deep: #0e4737;
+  --hc-amber: #e8b54b;
+  --hc-alert: #e2654d;
+  --hc-idle: #6f8695;
+  --hc-grid: rgba(133, 152, 165, 0.085);
+  --hc-grid-soft: rgba(133, 152, 165, 0.04);
+  --hc-shadow: 0 20px 38px -26px rgba(0, 0, 0, 0.9);
+  background-color: var(--home-command-canvas) !important;
+  background-image:
+    linear-gradient(var(--hc-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hc-grid-soft) 1px, transparent 1px) !important;
+  background-position: -1px -1px;
+  background-size:
+    24px 24px,
+    24px 24px;
+}
+
+[data-bs-theme="light"] body.home-command-page {
+  --home-command-canvas: #edf2ed;
+  --hc-panel: rgba(250, 252, 248, 0.94);
+  --hc-panel-raised: #ffffff;
+  --hc-panel-deep: #e5ece5;
+  --hc-line: #c8d2ca;
+  --hc-line-bright: #90a096;
+  --hc-ink: #17231b;
+  --hc-ink-dim: #526058;
+  --hc-ink-faint: #718076;
+  --hc-signal: #1f7a54;
+  --hc-signal-deep: #d8eee1;
+  --hc-amber: #98690a;
+  --hc-alert: #ba4939;
+  --hc-idle: #54798d;
+  --hc-grid: rgba(34, 57, 43, 0.09);
+  --hc-grid-soft: rgba(34, 57, 43, 0.045);
+  --hc-shadow: 0 18px 30px -26px rgba(28, 48, 35, 0.55);
+}
+
+body.home-command-page .home-command-main {
+  position: relative;
+  z-index: 0;
+  color: var(--hc-ink);
+}
+
+body.home-command-page .home-command-bridge,
+body.home-command-page .home-command-bridge * {
+  box-sizing: border-box;
+}
+
+.home-command-bridge {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 12px;
+  width: min(1680px, 100%);
+  margin: 0 auto;
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+}
+
+.home-command-strip,
+.home-section,
+.quest-log,
+.quest-log-restore-btn {
+  border: 1px solid var(--hc-line);
+  border-radius: 0;
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--hc-panel-raised) 78%, transparent),
+    var(--hc-panel)
+  );
+  box-shadow: var(--hc-shadow);
+}
+
+.home-command-strip {
+  position: relative;
+  overflow: hidden;
+  padding: 13px 16px 11px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
+}
+
+.home-command-strip::before,
+.home-section::before,
+.quest-log::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  content: "";
+  background: linear-gradient(112deg, rgba(70, 211, 154, 0.08), transparent 31%);
+}
+
+.home-command-strip-main,
+.home-section-header,
+.home-section-body,
+.quest-log-inner {
+  position: relative;
+  z-index: 1;
+}
+
+.home-command-strip-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
+}
+
+.home-command-kicker,
+.home-operations-eyebrow,
+.home-section-title,
+.home-section-link,
+.home-stat > span,
+.quest-log-eyebrow,
+.quest-log-progress-label,
+.quest-log-progress-count,
+.quest-log-dismiss,
+.quest-log-restore-copy,
+.home-workspace-card-meta,
+.home-status-text,
+.home-row-meta,
+.home-section-empty,
+.home-section-placeholder {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  letter-spacing: 1.15px;
+  text-transform: uppercase;
+}
+
+.home-command-kicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--hc-signal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 1.8px;
+}
+
+.home-command-kicker-led,
+.home-status-led {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--hc-signal);
+  box-shadow: 0 0 10px var(--hc-signal);
+}
+
+.home-command-shortcut {
+  margin-left: auto;
+  color: var(--hc-ink-faint);
+  font-size: 8px;
+  letter-spacing: 1px;
+}
+
+.home-command-form {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 44px;
+  border: 1px solid var(--hc-line-bright);
+  background: color-mix(in srgb, var(--hc-panel-deep) 88%, transparent);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.home-command-form:focus-within {
+  border-color: var(--hc-signal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hc-signal) 16%, transparent);
+}
+
+.home-command-prompt {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 100%;
+  color: var(--hc-signal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.home-command-input.modern-input {
+  min-width: 0;
+  min-height: 42px;
+  padding: 0 8px 0 0;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--hc-ink);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+}
+
+.home-command-input.modern-input::placeholder {
+  color: var(--hc-ink-faint);
+  opacity: 1;
+}
+
+.home-command-input.modern-input:focus {
+  border: 0;
+  box-shadow: none;
+}
+
+.home-command-input:not(:placeholder-shown) + .home-command-execute::before,
+.home-command-form:focus-within .home-command-prompt::after {
+  content: "";
+  width: 1px;
+  height: 15px;
+  margin-left: 2px;
+  background: var(--hc-signal);
+  animation: home-command-caret 1s steps(2, jump-none) infinite;
+}
+
+.home-command-execute.modern-btn {
+  align-self: stretch;
+  min-width: 92px;
+  border: 0;
+  border-left: 1px solid color-mix(in srgb, var(--hc-signal) 62%, var(--hc-line));
+  border-radius: 0;
+  padding: 0 15px;
+  background: color-mix(in srgb, var(--hc-signal-deep) 80%, var(--hc-panel));
+  color: var(--hc-signal);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.home-command-execute.modern-btn:hover,
+.home-command-execute.modern-btn:focus-visible {
+  background: var(--hc-signal);
+  color: #07140e;
+  outline: 0;
+}
+
+.home-command-chips {
+  gap: 6px;
+  margin: 0;
+}
+
+.home-command-page .home-prompt-chip {
+  border-color: var(--hc-line);
+  border-radius: 0;
+  padding: 4px 8px;
+  background: color-mix(in srgb, var(--hc-panel-deep) 54%, transparent);
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.home-command-page .home-prompt-chip:hover,
+.home-command-page .home-prompt-chip:focus-visible {
+  border-color: var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal) 10%, var(--hc-panel));
+  color: var(--hc-ink);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hc-signal) 16%, transparent);
+}
+
+.home-command-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(285px, 31%);
+  min-height: 0;
+  gap: 12px;
+}
+
+.home-operations-board {
+  display: grid;
+  grid-template-rows: auto minmax(132px, 0.85fr) minmax(0, 1fr);
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  max-width: none;
+  gap: 10px;
+}
+
+.home-operations-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 3px 2px 1px;
+}
+
+.home-operations-eyebrow {
+  display: block;
+  color: var(--hc-signal);
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.home-operations-title {
+  margin: 2px 0 0;
+  color: var(--hc-ink);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.95px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.home-stat-readout {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  min-width: 0;
+}
+
+.home-stat {
+  min-width: 70px;
+  padding: 5px 8px 4px;
+  border: 1px solid var(--hc-line);
+  background: color-mix(in srgb, var(--hc-panel-deep) 78%, transparent);
+  text-align: center;
+}
+
+.home-stat strong {
+  display: block;
+  color: var(--hc-ink);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.home-stat > span {
+  display: block;
+  margin-top: 3px;
+  color: var(--hc-ink-faint);
+  font-size: 7px;
+  letter-spacing: 0.8px;
+}
+
+.home-section {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 10px 11px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 10px) 0,
+    100% 10px,
+    100% 100%,
+    10px 100%,
+    0 calc(100% - 10px)
+  );
+}
+
+.home-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 18px;
+  margin-bottom: 8px;
+}
+
+.home-section-title {
+  margin: 0;
+  color: var(--hc-ink);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 1.65px;
+}
+
+.home-section-title::before {
+  margin-right: 6px;
+  color: var(--hc-signal);
+  content: "//";
+}
+
+.home-section-link {
+  color: var(--hc-signal);
+  font-size: 8px;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.home-section-link:hover,
+.home-section-link:focus-visible {
+  color: var(--hc-ink);
+  outline: 0;
+  text-decoration: none;
+}
+
+.home-section-body {
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  scrollbar-color: var(--hc-line-bright) transparent;
+  scrollbar-width: thin;
+}
+
+.home-section-placeholder,
+.home-section-empty {
+  padding: 8px 0;
+  color: var(--hc-ink-faint);
+  font-size: 9px;
+  line-height: 1.55;
+}
+
+.home-dashboard-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  min-height: 0;
+  gap: 10px;
+}
+
+.home-workspace-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+}
+
+.home-workspace-empty {
+  display: block;
+  height: 100%;
+}
+
+.home-workspace-empty-copy {
+  display: none;
+}
+
+.home-command-bridge[data-first-run="true"] .home-workspace-empty {
+  display: grid;
+  min-height: 100%;
+  place-items: center;
+}
+
+.home-command-bridge[data-first-run="true"] .home-workspace-card-new {
+  width: min(360px, 88%);
+  min-height: 94px;
+}
+
+.home-command-bridge[data-first-run="true"] .quest-log {
+  border-color: color-mix(in srgb, var(--hc-signal) 42%, var(--hc-line));
+  background: linear-gradient(
+    150deg,
+    color-mix(in srgb, var(--hc-signal) 11%, var(--hc-panel-raised)),
+    var(--hc-panel)
+  );
+}
+
+.home-workspace-card {
+  min-width: 0;
+  min-height: 76px;
+  max-width: none;
+  padding: 8px;
+  border: 1px solid var(--hc-line);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--hc-panel-deep) 56%, transparent);
+  color: var(--hc-ink);
+  box-shadow: none;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    transform 140ms ease;
+}
+
+.home-workspace-card:hover,
+.home-workspace-card:focus-visible {
+  border-color: var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal) 9%, var(--hc-panel));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hc-signal) 15%, transparent);
+  color: var(--hc-ink);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.home-workspace-card-head {
+  gap: 7px;
+}
+
+.home-workspace-card-avatar {
+  width: 25px;
+  height: 25px;
+  border: 1px solid hsl(var(--ws-hue, 160) 42% 56% / 0.8);
+  border-radius: 0;
+  background: hsl(var(--ws-hue, 160) 34% 24%);
+  color: hsl(var(--ws-hue, 160) 85% 86%);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.home-workspace-card-name {
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.55px;
+  text-transform: uppercase;
+}
+
+.home-workspace-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: auto;
+  color: var(--hc-ink-faint);
+  font-size: 8px;
+  letter-spacing: 0.4px;
+}
+
+.home-workspace-card-meta > span:not(.home-workspace-signal) {
+  white-space: nowrap;
+}
+
+.home-workspace-signal {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.home-status-led {
+  width: 6px;
+  height: 6px;
+  box-shadow: 0 0 7px currentColor;
+}
+
+.home-status-led.is-attention {
+  background: var(--hc-amber);
+  color: var(--hc-amber);
+}
+
+.home-status-led.is-working {
+  background: var(--hc-signal);
+  color: var(--hc-signal);
+  animation: home-command-signal 1.5s ease-in-out infinite;
+}
+
+.home-status-led.is-idle {
+  background: var(--hc-idle);
+  color: var(--hc-idle);
+  box-shadow: none;
+}
+
+.home-status-text {
+  overflow: hidden;
+  color: var(--hc-ink-dim);
+  font-size: 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-workspace-card-new {
+  align-items: center;
+  justify-content: center;
+  border-style: dashed;
+  background: color-mix(in srgb, var(--hc-signal) 4%, transparent);
+  text-align: center;
+}
+
+.home-workspace-card-new-icon {
+  color: var(--hc-signal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 19px;
+}
+
+.home-workspace-card-new-label {
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 8px;
+  letter-spacing: 0.85px;
+  text-transform: uppercase;
+}
+
+.home-row-list {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.home-row-link,
+.home-section-upcoming .home-row-link {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 7px;
+  padding: 7px 6px;
+  border: 1px solid transparent;
+  border-radius: 0;
+  color: var(--hc-ink);
+}
+
+.home-section-upcoming .home-row-link {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.home-row-link:hover,
+.home-row-link:focus-visible {
+  border-color: var(--hc-line-bright);
+  background: color-mix(in srgb, var(--hc-signal) 7%, transparent);
+  box-shadow: none;
+  color: var(--hc-ink);
+  outline: 0;
+}
+
+.home-row-icon {
+  width: 14px;
+  color: var(--hc-signal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.home-row-primary,
+.home-section-upcoming .home-row-primary {
+  min-width: 0;
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.home-row-meta,
+.home-section-upcoming .home-row-meta {
+  align-items: flex-end;
+  gap: 2px;
+  color: var(--hc-ink-faint);
+  font-size: 7px;
+  letter-spacing: 0.4px;
+}
+
+.home-row-workspace {
+  color: var(--hc-ink-dim);
+  font-weight: 500;
+}
+
+.home-row-agent,
+.home-row-time {
+  color: var(--hc-ink-faint);
+}
+
+.home-progression-zone {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+}
+
+.quest-log {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  padding: 13px;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 12px) 0,
+    100% 12px,
+    100% 100%,
+    12px 100%,
+    0 calc(100% - 12px)
+  );
+}
+
+.quest-log-inner {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.quest-log-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 10px;
+}
+
+.quest-log-insignia,
+.quest-log-restore-insignia {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal-deep) 75%, var(--hc-panel));
+  color: var(--hc-signal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 1px;
+}
+
+.quest-log-heading {
+  min-width: 0;
+}
+
+.quest-log-eyebrow {
+  display: block;
+  color: var(--hc-signal);
+  font-size: 8px;
+}
+
+.quest-log-tier {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.45px;
+  line-height: 1;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.quest-log-progress {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.quest-log-progress-label {
+  color: var(--hc-ink-faint);
+  font-size: 8px;
+  white-space: nowrap;
+}
+
+.quest-log-progress-count {
+  color: var(--hc-ink);
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.quest-log-dismiss {
+  margin-left: auto;
+  padding: 3px 5px;
+  border: 1px solid var(--hc-line);
+  border-radius: 0;
+  background: transparent;
+  color: var(--hc-ink-dim);
+  font-size: 8px;
+}
+
+.quest-log-dismiss:hover,
+.quest-log-dismiss:focus-visible {
+  border-color: var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal) 10%, transparent);
+  color: var(--hc-signal);
+  outline: 0;
+}
+
+.quest-log-meter {
+  width: 100%;
+  height: 6px;
+  overflow: hidden;
+  border: 1px solid var(--hc-line);
+  background: var(--hc-panel-deep);
+}
+
+.quest-log-meter-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: linear-gradient(90deg, var(--hc-signal-deep), var(--hc-signal));
+  transition: width 220ms ease;
+}
+
+.quest-log-list {
+  min-height: 0;
+  margin: 12px 0 0;
+  padding-right: 3px;
+  gap: 4px;
+  overflow: auto;
+  scrollbar-color: var(--hc-line-bright) transparent;
+  scrollbar-width: thin;
+}
+
+.quest-item {
+  gap: 7px;
+  padding: 5px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--hc-line) 72%, transparent);
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 12px;
+}
+
+.quest-mark {
+  width: 14px;
+  color: var(--hc-ink-faint);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.quest-item-done .quest-mark {
+  color: var(--hc-signal);
+}
+
+.quest-title {
+  color: inherit;
+}
+
+a.quest-title {
+  color: var(--hc-signal);
+}
+
+a.quest-title:hover,
+a.quest-title:focus-visible {
+  color: var(--hc-ink);
+  outline: 0;
+}
+
+.quest-log-why {
+  margin: 9px 0 0;
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 8px;
+  letter-spacing: 0.4px;
+  line-height: 1.55;
+}
+
+.quest-log-restore {
+  display: grid;
+  height: 100%;
+  place-items: start stretch;
+}
+
+.quest-log-restore-btn {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(72px, 0.75fr);
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  min-height: 60px;
+  padding: 10px;
+  color: var(--hc-ink);
+  cursor: pointer;
+  text-align: left;
+}
+
+.quest-log-restore-btn:hover,
+.quest-log-restore-btn:focus-visible {
+  border-color: var(--hc-signal);
+  outline: 0;
+}
+
+.quest-log-restore-copy {
+  display: grid;
+  gap: 3px;
+  color: var(--hc-ink);
+  font-size: 9px;
+}
+
+.quest-log-restore-copy span:last-child {
+  color: var(--hc-ink-faint);
+  font-size: 8px;
+}
+
+.quest-log-restore-meter {
+  display: block;
+  height: 5px;
+  overflow: hidden;
+  border: 1px solid var(--hc-line);
+  background: var(--hc-panel-deep);
+}
+
+.quest-log-restore-meter > span {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--hc-signal);
+}
+
+@keyframes home-command-caret {
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes home-command-signal {
+  50% {
+    box-shadow: 0 0 2px currentColor;
+    opacity: 0.65;
+  }
+}
+
+@media (min-width: 1200px) and (min-height: 680px) {
+  body.home-command-page .main-content-wrapper {
+    height: calc(100dvh - var(--navbar-offset, 76px));
+    min-height: 0;
+  }
+
+  body.home-command-page .home-command-main {
+    display: flex;
+    height: calc(100dvh - var(--navbar-offset, 76px));
+    min-height: 0;
+    padding: 12px clamp(12px, 1.35vw, 22px);
+    overflow: hidden;
+  }
+
+  .home-command-bridge {
+    min-height: 0;
+    flex: 1;
+  }
+}
+
+@media (max-width: 1199px), (max-height: 679px) {
+  body.home-command-page .home-command-main {
+    padding: 14px;
+  }
+
+  .home-command-bridge {
+    min-height: 0;
+  }
+
+  .home-command-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-operations-board {
+    grid-template-rows: auto auto auto;
+  }
+
+  .home-section-body,
+  .quest-log-list {
+    overflow: visible;
+  }
+
+  .quest-log {
+    height: auto;
+  }
+
+  .quest-log-restore {
+    height: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .home-command-strip {
+    padding: 11px;
+  }
+
+  .home-command-form {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .home-command-execute.modern-btn {
+    grid-column: 1 / -1;
+    min-height: 34px;
+    border-top: 1px solid color-mix(in srgb, var(--hc-signal) 50%, var(--hc-line));
+    border-left: 0;
+  }
+
+  .home-operations-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .home-stat-readout {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .home-stat {
+    flex: 1;
+  }
+
+  .home-dashboard-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-workspace-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-command-input:not(:placeholder-shown) + .home-command-execute::before,
+  .home-command-form:focus-within .home-command-prompt::after,
+  .home-status-led.is-working {
+    animation: none;
+  }
+}

--- a/internal/web/static/css/layout.css
+++ b/internal/web/static/css/layout.css
@@ -36,6 +36,18 @@ body::before {
   z-index: -1;
 }
 
+/* The Command Bridge owns its own grid-backed tactical canvas. Keep the
+   gradient and decorative particles on every other page. */
+body.home-command-page {
+  background: var(--home-command-canvas, var(--bg-primary)) !important;
+}
+
+body.home-command-page::before {
+  content: none;
+  display: none;
+  animation: none;
+}
+
 @keyframes float {
   0%, 100% { transform: translateY(0px) rotate(0deg); }
   50% { transform: translateY(-10px) rotate(180deg); }
@@ -202,6 +214,14 @@ body::before {
     margin-left: 0;
     max-width: 100vw;
     width: 100vw;
+  }
+
+  /* Home omits the sidebar from the DOM, so the sibling selector above cannot
+     reset its desktop offset. Scope this reset strictly to the bridge. */
+  body.home-command-page .main-content {
+    margin-left: 0;
+    max-width: 100vw;
+    width: 100%;
   }
 }
 

--- a/internal/web/static/js/modules/home-dashboard.js
+++ b/internal/web/static/js/modules/home-dashboard.js
@@ -19,31 +19,36 @@
   // Capture the page start time as soon as the script runs. The "first
   // action" is whichever qualifying interaction happens first (chip click,
   // card click, hero submit, skip click, etc.) — see fireTTFA callers.
-  const TTFA_START = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+  const TTFA_START =
+    typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
   let ttfaFired = false;
 
   function fireTTFA(source) {
     if (ttfaFired) return;
     ttfaFired = true;
-    const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    const now =
+      typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
     const ms = Math.round(now - TTFA_START);
     // Structured console marker — easy to grep, easy to swap for a real
     // analytics beacon (navigator.sendBeacon) once an endpoint exists.
     try {
       console.info('[home.ttfa]', { source, ms });
-    } catch (_) { /* ignore */ }
+    } catch (_) {
+      /* ignore */
+    }
   }
 
   // ----- HTML utilities -----
 
   function escapeHtml(s) {
-    return String(s ?? '').replace(/[&<>"']/g, (c) => (
-      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
-    ));
+    return String(s ?? '').replace(
+      /[&<>"']/g,
+      c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+    );
   }
 
   function relTime(ts) {
-    const fn = (typeof window !== 'undefined' && window.RelativeTime?.formatRelativeTime);
+    const fn = typeof window !== 'undefined' && window.RelativeTime?.formatRelativeTime;
     if (!fn) return ''; // utility not yet loaded; skip rather than crash
     return fn(ts);
   }
@@ -55,8 +60,8 @@
     if (!chips.length) return;
     const input = document.getElementById('homeAssistantInput');
     if (!input) return;
-    chips.forEach((chip) => {
-      chip.addEventListener('click', (e) => {
+    chips.forEach(chip => {
+      chip.addEventListener('click', e => {
         e.preventDefault();
         fireTTFA('chip');
         const prompt = (chip.getAttribute('data-prompt') || chip.textContent || '').trim();
@@ -66,7 +71,9 @@
         try {
           const len = input.value.length;
           input.setSelectionRange(len, len);
-        } catch (_) { /* ignore */ }
+        } catch (_) {
+          /* ignore */
+        }
       });
     });
 
@@ -80,7 +87,7 @@
   }
 
   function wireFocusShortcut() {
-    document.addEventListener('keydown', (e) => {
+    document.addEventListener('keydown', e => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== 'j' && e.key !== 'J') return;
 
@@ -88,7 +95,10 @@
       if (!input) return;
 
       const target = e.target;
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      ) {
         if (target !== input) return;
       }
 
@@ -98,7 +108,9 @@
       try {
         const len = input.value.length;
         input.setSelectionRange(len, len);
-      } catch (_) { /* ignore */ }
+      } catch (_) {
+        /* ignore */
+      }
     });
   }
 
@@ -115,18 +127,71 @@
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const data = await resp.json();
       const all = Array.isArray(data.workspaces) ? data.workspaces : [];
-      all.sort((a, b) => new Date(b.updated_at || b.created_at || 0) - new Date(a.updated_at || a.created_at || 0));
+      all.sort(
+        (a, b) =>
+          new Date(b.updated_at || b.created_at || 0) - new Date(a.updated_at || a.created_at || 0)
+      );
       const visible = all.slice(0, 6);
+      const isFirstRun = section.closest('#homeDashboardSections')?.dataset.firstRun === 'true';
 
       const viewAll = section.querySelector('[data-role="view-all"]');
       if (viewAll) viewAll.hidden = all.length <= 6;
 
-      body.innerHTML = renderWorkspaceCards(visible);
+      renderStatReadout(section, all);
+      body.innerHTML = renderWorkspaceCards(visible, isFirstRun);
       wireWorkspaceCardClicks(body);
     } catch (err) {
       console.error('home-dashboard: failed to load workspaces', err);
-      body.innerHTML = '<div class="home-section-placeholder">Could not load workspaces.</div>';
+      body.innerHTML = '<div class="home-section-placeholder">Workspace data unavailable.</div>';
     }
+  }
+
+  function count(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+  }
+
+  function workspaceAgentCount(workspace) {
+    if (workspace && workspace.agent_count !== undefined) return count(workspace.agent_count);
+    return Array.isArray(workspace?.agents) ? workspace.agents.length : 0;
+  }
+
+  function workspaceOpenTaskCount(workspace) {
+    return count(workspace?.open_task_count);
+  }
+
+  function workspaceStatus(workspace) {
+    if (count(workspace?.needs_attention_count) > 0) {
+      return { className: 'is-attention', label: 'Attention' };
+    }
+    if (workspaceOpenTaskCount(workspace) > 0) {
+      return { className: 'is-working', label: 'Active' };
+    }
+    return { className: 'is-idle', label: 'Idle' };
+  }
+
+  function renderStatReadout(section, workspaces) {
+    const readout = section
+      .closest('#homeDashboardSections')
+      ?.querySelector('[data-role="stat-readout"]');
+    if (!readout) return;
+
+    const values = {
+      'stat-workspaces': workspaces.length,
+      'stat-agents': workspaces.reduce(
+        (total, workspace) => total + workspaceAgentCount(workspace),
+        0
+      ),
+      'stat-open-tasks': workspaces.reduce(
+        (total, workspace) => total + workspaceOpenTaskCount(workspace),
+        0
+      )
+    };
+
+    Object.entries(values).forEach(([role, value]) => {
+      const target = readout.querySelector(`[data-role="${role}"]`);
+      if (target) target.textContent = String(value);
+    });
   }
 
   // Deterministic accent hue (0–359) derived from a workspace's id/name, so
@@ -142,54 +207,50 @@
 
   // 1–2 letter monogram from a workspace name for the card avatar.
   function wsInitials(name) {
-    const parts = String(name || '').trim().split(/[\s._-]+/).filter(Boolean);
+    const parts = String(name || '')
+      .trim()
+      .split(/[\s._-]+/)
+      .filter(Boolean);
     if (parts.length === 0) return '?';
     if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
     return (parts[0][0] + parts[1][0]).toUpperCase();
   }
 
-  function renderWorkspaceCards(workspaces) {
-    const cards = workspaces.map((ws) => {
-      const id = escapeHtml(ws.id || '');
-      const name = escapeHtml(ws.name || 'Untitled workspace');
-      const desc = escapeHtml(ws.description || '');
-      const updated = relTime(ws.updated_at || ws.created_at);
-      // `agent_instances` isn't on the list endpoint; fall back to `agents`.
-      const agentCount = Array.isArray(ws.agents) ? ws.agents.length : 0;
-      const countLabel = agentCount === 1 ? '1 agent' : `${agentCount} agents`;
-      const hue = wsHue(ws.id || ws.name || '');
-      const initials = escapeHtml(wsInitials(ws.name || ''));
-      return `
-        <a href="/workspaces/${id}" class="home-workspace-card" data-role="workspace-card" style="--ws-hue: ${hue};">
+  function renderWorkspaceCards(workspaces, isFirstRun) {
+    const cards = workspaces
+      .map(ws => {
+        const id = escapeHtml(ws.id || '');
+        const name = escapeHtml(ws.name || 'Untitled workspace');
+        const agentCount = workspaceAgentCount(ws);
+        const openTaskCount = workspaceOpenTaskCount(ws);
+        const status = workspaceStatus(ws);
+        const hue = wsHue(ws.id || ws.name || '');
+        const initials = escapeHtml(wsInitials(ws.name || ''));
+        return `
+        <a href="/workspaces/${id}" class="home-workspace-card home-workspace-status-chip" data-role="workspace-card" data-status="${status.label.toLowerCase()}" style="--ws-hue: ${hue};" aria-label="${name}: ${agentCount} agents, ${openTaskCount} open tasks, ${status.label}">
           <div class="home-workspace-card-head">
             <span class="home-workspace-card-avatar" aria-hidden="true">${initials}</span>
             <div class="home-workspace-card-name">${name}</div>
           </div>
-          ${desc ? `<div class="home-workspace-card-desc">${desc}</div>` : ''}
           <div class="home-workspace-card-meta">
-            <span class="home-workspace-card-agents">${escapeHtml(countLabel)}</span>
-            ${updated ? `<span class="home-workspace-card-time">${escapeHtml(updated)}</span>` : ''}
+            <span class="home-workspace-signal"><span class="home-status-led ${status.className}" aria-hidden="true"></span><span class="home-status-text">${status.label}</span></span>
+            <span class="home-workspace-card-agents">${agentCount} AG</span>
+            <span class="home-workspace-card-tasks">${openTaskCount} OPEN</span>
           </div>
         </a>
       `;
-    }).join('');
+      })
+      .join('');
 
     const newTile = `
-      <a href="/workspaces" class="home-workspace-card home-workspace-card-new" data-role="new-workspace">
-        <div class="home-workspace-card-new-icon" aria-hidden="true">+</div>
-        <div class="home-workspace-card-new-label">New workspace</div>
+      <a href="/workspaces?create=1"${isFirstRun ? ' id="homeFirstRunStart"' : ''} class="home-workspace-card home-workspace-card-new" data-role="new-workspace">
+        <div class="home-workspace-card-new-icon" aria-hidden="true">${isFirstRun ? '⊕' : '+'}</div>
+        <div class="home-workspace-card-new-label">${isFirstRun ? 'Establish first workspace' : 'New workspace'}</div>
       </a>
     `;
 
     if (workspaces.length === 0) {
-      return `
-        <div class="home-workspace-empty">
-          <div class="home-workspace-empty-copy">
-            Start with 1 workspace to keep tasks, notes, and files together.
-          </div>
-          ${newTile}
-        </div>
-      `;
+      return `<div class="home-workspace-empty">${newTile}</div>`;
     }
 
     return `<div class="home-workspace-strip">${cards}${newTile}</div>`;
@@ -210,15 +271,24 @@
   function wireDashboardActions() {
     const sections = document.getElementById('homeDashboardSections');
     if (!sections) return;
-    sections.addEventListener('click', (e) => {
+    sections.addEventListener('click', e => {
       const t = e.target;
       if (!t) return;
       const card = t.closest('[data-role="workspace-card"]');
-      if (card) { fireTTFA('workspace-card'); return; }
+      if (card) {
+        fireTTFA('workspace-card');
+        return;
+      }
       const newTile = t.closest('[data-role="new-workspace"]');
-      if (newTile) { fireTTFA('new-workspace'); return; }
+      if (newTile) {
+        fireTTFA(newTile.id === 'homeFirstRunStart' ? 'first-run-start' : 'new-workspace');
+        return;
+      }
       const viewAll = t.closest('[data-role="view-all"]');
-      if (viewAll) { fireTTFA('view-all'); return; }
+      if (viewAll) {
+        fireTTFA('view-all');
+        return;
+      }
       const rowLink = t.closest('.home-row-link');
       if (rowLink) {
         const inUpcoming = rowLink.closest('#homeUpcomingTasks');
@@ -244,7 +314,7 @@
       if (rows.length === 0) {
         body.innerHTML = `
           <div class="home-section-empty">
-            No tasks yet. <a href="/workspaces" class="home-section-link">Create a workspace to add your first task →</a>
+            No scheduled tasks.
           </div>
         `;
         return;
@@ -252,7 +322,7 @@
       body.innerHTML = `<ul class="home-row-list">${rows.map(renderUpcomingRow).join('')}</ul>`;
     } catch (err) {
       console.error('home-dashboard: failed to load upcoming tasks', err);
-      body.innerHTML = '<div class="home-section-placeholder">Could not load upcoming tasks.</div>';
+      body.innerHTML = '<div class="home-section-placeholder">Schedule data unavailable.</div>';
     }
   }
 
@@ -290,7 +360,7 @@
       if (events.length === 0) {
         body.innerHTML = `
           <div class="home-section-empty">
-            Recent work will appear here after you create a workspace and ask Ori to help.
+            Awaiting first operation.
           </div>
         `;
         return;
@@ -298,17 +368,22 @@
       body.innerHTML = `<ul class="home-row-list">${events.map(renderActivityRow).join('')}</ul>`;
     } catch (err) {
       console.error('home-dashboard: failed to load recent activity', err);
-      body.innerHTML = '<div class="home-section-placeholder">Could not load recent activity.</div>';
+      body.innerHTML = '<div class="home-section-placeholder">Activity data unavailable.</div>';
     }
   }
 
   function activityIcon(kind) {
     switch (kind) {
-      case 'note_edited':           return '✎';
-      case 'task_completed':        return '✓';
-      case 'scheduled_task_fired':  return '⏰';
-      case 'scheduled_task_failed': return '⚠';
-      default:                      return '•';
+      case 'note_edited':
+        return '✎';
+      case 'task_completed':
+        return '✓';
+      case 'scheduled_task_fired':
+        return '⏰';
+      case 'scheduled_task_failed':
+        return '⚠';
+      default:
+        return '•';
     }
   }
 

--- a/internal/web/static/js/modules/progression-widget.js
+++ b/internal/web/static/js/modules/progression-widget.js
@@ -14,9 +14,14 @@
   let restore = null;
   let knownCompleted = null; // Set of completed quest IDs; null until first load.
   let knownTierComplete = {}; // tier number -> bool, from the previous render.
+  let latestStatus = null;
 
   function el(role) {
     return widget ? widget.querySelector(`[data-role="${role}"]`) : null;
+  }
+
+  function restoreEl(role) {
+    return restore ? restore.querySelector(`[data-role="${role}"]`) : null;
   }
 
   async function fetchStatus() {
@@ -47,15 +52,15 @@
   // Skipped on the very first load so a returning user isn't flooded.
   function announceChanges(status) {
     const completedNow = new Set();
-    (status.tiers || []).forEach((t) => {
-      (t.quests || []).forEach((q) => {
+    (status.tiers || []).forEach(t => {
+      (t.quests || []).forEach(q => {
         if (q.status === 'completed') completedNow.add(q.id);
       });
     });
 
     if (knownCompleted !== null) {
-      (status.tiers || []).forEach((t) => {
-        (t.quests || []).forEach((q) => {
+      (status.tiers || []).forEach(t => {
+        (t.quests || []).forEach(q => {
           if (q.status === 'completed' && !knownCompleted.has(q.id)) {
             toast(q.title, 'Quest complete');
           }
@@ -68,13 +73,61 @@
 
     knownCompleted = completedNow;
     knownTierComplete = {};
-    (status.tiers || []).forEach((t) => { knownTierComplete[t.tier] = !!t.complete; });
+    (status.tiers || []).forEach(t => {
+      knownTierComplete[t.tier] = !!t.complete;
+    });
+  }
+
+  function currentTier(status) {
+    return (
+      (status.tiers || []).find(tier => tier.tier === status.current_tier) ||
+      (status.tiers || [])[0] ||
+      null
+    );
+  }
+
+  function completedCount(tier) {
+    return (tier?.quests || []).filter(quest => quest.status === 'completed').length;
+  }
+
+  function setMeter(bar, completed, total) {
+    if (!bar) return;
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+    bar.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+
+    const meter = bar.closest('[role="progressbar"]');
+    if (meter) meter.setAttribute('aria-valuenow', String(Math.max(0, Math.min(100, percent))));
+  }
+
+  function tierInsignia(tier) {
+    const value = Number(tier);
+    return Number.isFinite(value) && value > 0 ? String(value).padStart(2, '0') : '—';
+  }
+
+  function renderRestoreBadge(status, current) {
+    const completed = status.all_complete ? status.total_count : completedCount(current);
+    const total = status.all_complete ? status.total_count : (current?.quests || []).length;
+    const tierLabel = status.all_complete ? 'All tiers complete' : `Tier ${status.current_tier}`;
+
+    const insignia = restoreEl('restore-insignia');
+    const tier = restoreEl('restore-tier');
+    const progress = restoreEl('restore-progress');
+    const meter = restoreEl('restore-meter');
+    if (insignia)
+      insignia.textContent = status.all_complete ? '✓' : tierInsignia(status.current_tier);
+    if (tier) tier.textContent = tierLabel;
+    if (progress) progress.textContent = `${completed}/${total}`;
+    if (meter) meter.style.width = `${total > 0 ? Math.round((completed / total) * 100) : 0}%`;
   }
 
   function render(status) {
     if (!widget) return;
+    latestStatus = status;
+
+    const current = currentTier(status);
 
     if (status.dismissed) {
+      renderRestoreBadge(status, current);
       widget.hidden = true;
       if (restore) restore.hidden = false;
       return;
@@ -84,26 +137,32 @@
     // All quests complete: compact congratulatory state.
     if (status.all_complete) {
       el('tier-name').textContent = 'All quests complete';
-      el('progress-label').textContent = `${status.total_count}/${status.total_count}`;
+      el('tier-insignia').textContent = '✓';
+      el('progress-label').textContent = 'Tier complete';
+      el('progress-count').textContent = `${status.total_count}/${status.total_count}`;
+      setMeter(el('progress-bar'), status.total_count, status.total_count);
       el('quests').innerHTML = '';
       el('why').textContent = "You've mastered the basics — Ori is all yours.";
       widget.hidden = false;
       return;
     }
 
-    const current = (status.tiers || []).find((t) => t.tier === status.current_tier)
-      || (status.tiers || [])[0];
     if (!current) {
       widget.hidden = true;
       return;
     }
 
     el('tier-name').textContent = current.name;
+    el('tier-insignia').textContent = tierInsignia(status.current_tier);
     el('progress-label').textContent = `Tier ${status.current_tier} of ${status.total_tiers}`;
+    const complete = completedCount(current);
+    const total = current.quests.length;
+    el('progress-count').textContent = `${complete}/${total}`;
+    setMeter(el('progress-bar'), complete, total);
 
     const list = el('quests');
     list.innerHTML = '';
-    current.quests.forEach((q) => {
+    current.quests.forEach(q => {
       const done = q.status === 'completed';
       const li = document.createElement('li');
       li.className = 'quest-item' + (done ? ' quest-item-done' : '');
@@ -149,20 +208,26 @@
     const dismissBtn = el('dismiss');
     if (dismissBtn) {
       dismissBtn.addEventListener('click', async () => {
-        widget.hidden = true;
-        if (restore) restore.hidden = false;
-        try { await postJSON('/api/progression/dismiss', { dismissed: true }); } catch (_) { /* ignore */ }
+        const optimistic = latestStatus ? { ...latestStatus, dismissed: true } : null;
+        if (optimistic) render(optimistic);
+        try {
+          const status = await postJSON('/api/progression/dismiss', { dismissed: true });
+          render(status);
+        } catch (_) {
+          if (latestStatus) render({ ...latestStatus, dismissed: false });
+        }
       });
     }
     if (restore) {
       const restoreBtn = restore.querySelector('[data-role="restore"]');
       if (restoreBtn) {
         restoreBtn.addEventListener('click', async () => {
-          restore.hidden = true;
           try {
             const status = await postJSON('/api/progression/dismiss', { dismissed: false });
             render(status);
-          } catch (_) { /* ignore */ }
+          } catch (_) {
+            /* ignore */
+          }
         });
       }
     }

--- a/internal/web/static/js/modules/resizer.js
+++ b/internal/web/static/js/modules/resizer.js
@@ -13,6 +13,11 @@ class SidebarResizer {
   }
 
   init() {
+    // The Command Bridge deliberately omits the sidebar. Avoid mutating global
+    // sidebar dimensions or dispatching resize events on pages without one.
+    if (!document.getElementById('sidebarResizeHandle') || !document.getElementById('sidebar')) {
+      return;
+    }
     this.bindEvents();
     this.setSidebarWidth(this.sidebarWidth);
   }

--- a/internal/web/static/js/modules/sidebar.js
+++ b/internal/web/static/js/modules/sidebar.js
@@ -113,6 +113,9 @@ if (typeof EventBus !== 'undefined') {
 
 // Main sidebar setup function that coordinates all modules
 function setupSidebar() {
+  if (!document.getElementById('sidebar')) {
+    return;
+  }
   sidebarLog.debug('Setting up sidebar functionality...');
 
   // Add hover effects to interactive items
@@ -289,6 +292,9 @@ function setupSidebarToggle() {
 
 // Initialize all sidebar modules and load data
 async function initializeSidebar() {
+  if (!document.getElementById('sidebar')) {
+    return;
+  }
   try {
     sidebarLog.debug('Initializing sidebar modules...');
 

--- a/internal/web/templates/components/dashboard.tmpl
+++ b/internal/web/templates/components/dashboard.tmpl
@@ -1,97 +1,111 @@
-<!-- Ori Dashboard - Prompt-first layout -->
-<div class="container-fluid py-5 dashboard-shell dashboard-shell-minimal">
-  <div id="homeAssistantCard" class="modern-card p-4 p-md-5 mb-4 dashboard-home-card dashboard-home-card-minimal" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}">
-    <div class="home-assistant-minimal-wrap">
-      <div class="home-assistant-minimal-label">{{if .Extra.IsFirstRun}}Welcome{{else}}Ask Ori{{end}}</div>
-      <h1 class="home-assistant-minimal-title mb-0">{{if .Extra.IsFirstRun}}What do you want to get done?{{else}}What should Ori do?{{end}}</h1>
-      <p class="home-assistant-minimal-subtitle mb-0">
-        {{if .Extra.IsFirstRun}}Describe a task and Ori turns it into a plan — or create a workspace to keep a project's tasks, notes, and files together.{{else}}Enter a task and Ori plans it, then runs it — showing each step as it goes.{{end}}
-      </p>
-      <form id="homeAssistantForm" class="home-assistant-form home-assistant-form-minimal">
+<!-- Ori Dashboard — Command Bridge -->
+<div class="home-command-bridge" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}">
+  <section id="homeAssistantCard" class="modern-card home-command-strip" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}" aria-label="Ask Ori">
+    <div class="home-command-strip-main">
+      <div class="home-command-kicker">
+        <span class="home-command-kicker-led" aria-hidden="true"></span>
+        {{if .Extra.IsFirstRun}}FIRST COMMAND{{else}}COMMAND{{end}}
+        <span class="home-command-shortcut" aria-hidden="true">⌘J</span>
+      </div>
+      <form id="homeAssistantForm" class="home-assistant-form home-command-form">
+        <span class="home-command-prompt" aria-hidden="true">&gt;</span>
         <label for="homeAssistantInput" class="visually-hidden">Ask Ori</label>
-        <input id="homeAssistantInput" type="text" class="modern-input flex-grow-1" maxlength="800"
+        <input id="homeAssistantInput" type="text" class="modern-input home-command-input" maxlength="800"
                name="home_assistant_prompt"
                autocomplete="off"
-               placeholder="{{if .Extra.IsFirstRun}}Plan a product launch…{{else}}Ask Ori to do something…{{end}}"
-               style="min-height: 50px;">
-        <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn">Ask</button>
+               placeholder="{{if .Extra.IsFirstRun}}Plan a product launch…{{else}}Ask Ori to do something…{{end}}">
+        <button id="homeAssistantSendBtn" type="submit" class="modern-btn modern-btn-primary home-assistant-send-btn home-command-execute">Ask</button>
       </form>
-      <!-- Suggested prompt chips: populate the input on click (no auto-submit). -->
-      <div class="home-prompt-chips" role="group" aria-label="Suggested prompts">
+      <!-- Suggested prompt chips populate the input but never auto-submit. -->
+      <div class="home-prompt-chips home-command-chips" role="group" aria-label="Suggested commands">
         {{if .Extra.IsFirstRun}}
-        <button type="button" class="home-prompt-chip" data-prompt="Create a workspace for a project I'm working on">Create a workspace for a project I'm working on</button>
-        <button type="button" class="home-prompt-chip" data-prompt="Help me organize a research project">Help me organize a research project</button>
-        <button type="button" class="home-prompt-chip" data-prompt="Plan a product launch">Plan a product launch</button>
+        <button type="button" class="home-prompt-chip" data-prompt="Create a workspace for a project I'm working on">Create a workspace</button>
+        <button type="button" class="home-prompt-chip" data-prompt="Help me organize a research project">Organize research</button>
+        <button type="button" class="home-prompt-chip" data-prompt="Plan a product launch">Plan a launch</button>
         {{else}}
-        <button type="button" class="home-prompt-chip" data-prompt="Draft a weekly digest from my notes">Draft a weekly digest from my notes</button>
-        <button type="button" class="home-prompt-chip" data-prompt="Summarize this week's task activity">Summarize this week's task activity</button>
-        <button type="button" class="home-prompt-chip" data-prompt="What should I work on today?">What should I work on today?</button>
+        <button type="button" class="home-prompt-chip" data-prompt="Draft a weekly digest from my notes">Draft a weekly digest</button>
+        <button type="button" class="home-prompt-chip" data-prompt="Summarize this week's task activity">Summarize activity</button>
+        <button type="button" class="home-prompt-chip" data-prompt="What should I work on today?">What should I work on?</button>
         {{end}}
       </div>
-      {{if .Extra.IsFirstRun}}
-      <!-- First run: one secondary path to the structured route. The Ask box
-           above is the primary action; this offers the workspace flow without a
-           second competing hero card. -->
-      <div class="home-assistant-secondary">
-        <span class="home-assistant-secondary-or">or</span>
-        <a id="homeFirstRunStart" href="/workspaces?create=1" class="home-assistant-secondary-link">Create a workspace</a>
-        <span class="home-assistant-secondary-hint">to organize a project's tasks, notes, and files</span>
-      </div>
-      {{end}}
     </div>
-  </div>
+  </section>
 
-  <!-- Onboarding quest log. Populated by progression-widget.js from
-       GET /api/progression; hidden until data loads (and stays hidden when
-       dismissed or all quests are complete). -->
-  <div id="questLog" class="quest-log" hidden aria-live="polite">
-    <div class="quest-log-inner">
-      <header class="quest-log-header">
-        <div class="quest-log-heading">
-          <span class="quest-log-eyebrow">Getting started</span>
-          <h2 class="quest-log-tier" data-role="tier-name">Quest log</h2>
+  <div class="home-command-layout">
+    <section id="homeDashboardSections" class="home-dashboard-sections home-operations-board" data-workspace-count="{{.Extra.WorkspaceCount}}" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}" aria-label="Operations board">
+      <header class="home-operations-header">
+        <div>
+          <span class="home-operations-eyebrow">System overview</span>
+          <p class="home-operations-title">Operations board</p>
         </div>
-        <div class="quest-log-progress">
-          <span class="quest-log-progress-label" data-role="progress-label"></span>
-          <button type="button" class="quest-log-dismiss" data-role="dismiss" aria-label="Hide quest log" title="Hide quest log">✕</button>
+        <div class="home-stat-readout" data-role="stat-readout" role="status" aria-live="polite" aria-label="Workspace statistics">
+          <span class="home-stat"><strong data-role="stat-workspaces">—</strong><span>Workspaces</span></span>
+          <span class="home-stat"><strong data-role="stat-agents">—</strong><span>Agents</span></span>
+          <span class="home-stat"><strong data-role="stat-open-tasks">—</strong><span>Open tasks</span></span>
         </div>
       </header>
-      <ul class="quest-log-list" data-role="quests"></ul>
-      <p class="quest-log-why" data-role="why"></p>
-    </div>
-  </div>
-  <div id="questLogRestore" class="quest-log-restore" hidden>
-    <button type="button" class="quest-log-restore-btn" data-role="restore">Show quest log</button>
-  </div>
 
-  <div id="homeDashboardSections" class="home-dashboard-sections" data-workspace-count="{{.Extra.WorkspaceCount}}">
-    <section id="homeRecentWorkspaces" class="home-section home-section-workspaces" aria-labelledby="homeRecentWorkspacesTitle">
-      <header class="home-section-header">
-        <h2 id="homeRecentWorkspacesTitle" class="home-section-title">Recent workspaces</h2>
-        <a href="/workspaces" class="home-section-link" data-role="view-all" hidden>View all →</a>
-      </header>
-      <div class="home-section-body" data-role="content" aria-live="polite">
-        <div class="home-section-placeholder" data-role="placeholder">Loading…</div>
+      <section id="homeRecentWorkspaces" class="home-section home-section-workspaces" aria-labelledby="homeRecentWorkspacesTitle">
+        <header class="home-section-header">
+          <h2 id="homeRecentWorkspacesTitle" class="home-section-title">Workspaces</h2>
+          <a href="/workspaces" class="home-section-link" data-role="view-all" hidden>All workspaces <span aria-hidden="true">▸</span></a>
+        </header>
+        <div class="home-section-body" data-role="content" aria-live="polite">
+          <div class="home-section-placeholder" data-role="placeholder">Loading workspaces…</div>
+        </div>
+      </section>
+
+      <div class="home-dashboard-row">
+        <section id="homeUpcomingTasks" class="home-section home-section-upcoming" aria-labelledby="homeUpcomingTasksTitle">
+          <header class="home-section-header">
+            <h2 id="homeUpcomingTasksTitle" class="home-section-title">Upcoming</h2>
+          </header>
+          <div class="home-section-body" data-role="content" aria-live="polite">
+            <div class="home-section-placeholder" data-role="placeholder">Loading schedule…</div>
+          </div>
+        </section>
+        <section id="homeRecentActivity" class="home-section home-section-activity" aria-labelledby="homeRecentActivityTitle">
+          <header class="home-section-header">
+            <h2 id="homeRecentActivityTitle" class="home-section-title">Activity</h2>
+          </header>
+          <div class="home-section-body" data-role="content" aria-live="polite">
+            <div class="home-section-placeholder" data-role="placeholder">Loading activity…</div>
+          </div>
+        </section>
       </div>
     </section>
-    <div class="home-dashboard-row">
-      <section id="homeUpcomingTasks" class="home-section home-section-upcoming" aria-labelledby="homeUpcomingTasksTitle">
-        <header class="home-section-header">
-          <h2 id="homeUpcomingTasksTitle" class="home-section-title">Upcoming</h2>
-        </header>
-        <div class="home-section-body" data-role="content" aria-live="polite">
-          <div class="home-section-placeholder" data-role="placeholder">Loading…</div>
+
+    <aside class="home-progression-zone" aria-label="Onboarding progression">
+      <!-- Populated by progression-widget.js from GET /api/progression. -->
+      <div id="questLog" class="quest-log" hidden aria-live="polite">
+        <div class="quest-log-inner">
+          <header class="quest-log-header">
+            <span class="quest-log-insignia" data-role="tier-insignia" aria-hidden="true">01</span>
+            <div class="quest-log-heading">
+              <span class="quest-log-eyebrow">Progression</span>
+              <h2 class="quest-log-tier" data-role="tier-name">Quest log</h2>
+            </div>
+            <div class="quest-log-progress">
+              <span class="quest-log-progress-label" data-role="progress-label"></span>
+              <span class="quest-log-progress-count" data-role="progress-count"></span>
+              <button type="button" class="quest-log-dismiss" data-role="dismiss" aria-label="Collapse quest log" title="Collapse quest log">Collapse</button>
+            </div>
+          </header>
+          <div class="quest-log-meter" role="progressbar" aria-label="Current tier progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+            <span class="quest-log-meter-fill" data-role="progress-bar"></span>
+          </div>
+          <ul class="quest-log-list" data-role="quests"></ul>
+          <p class="quest-log-why" data-role="why"></p>
         </div>
-      </section>
-      <section id="homeRecentActivity" class="home-section home-section-activity" aria-labelledby="homeRecentActivityTitle">
-        <header class="home-section-header">
-          <h2 id="homeRecentActivityTitle" class="home-section-title">Recent activity</h2>
-        </header>
-        <div class="home-section-body" data-role="content" aria-live="polite">
-          <div class="home-section-placeholder" data-role="placeholder">Loading…</div>
-        </div>
-      </section>
-    </div>
+      </div>
+      <div id="questLogRestore" class="quest-log-restore" hidden>
+        <button type="button" class="quest-log-restore-btn" data-role="restore" aria-label="Expand quest log">
+          <span class="quest-log-restore-insignia" data-role="restore-insignia" aria-hidden="true">01</span>
+          <span class="quest-log-restore-copy"><span data-role="restore-tier">Tier 1</span><span data-role="restore-progress">0/0</span></span>
+          <span class="quest-log-restore-meter" aria-hidden="true"><span data-role="restore-meter"></span></span>
+        </button>
+      </div>
+    </aside>
   </div>
 </div>
 

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -2,7 +2,7 @@
 <html data-bs-theme="light">
 {{template "head.tmpl" .}}
 
-<body class="bg-light">
+<body class="bg-light{{if index .Extra "HomeCommandBridge"}} home-command-page{{end}}">
   <!-- Skip link for keyboard users (styled in common.css) -->
   <a class="skip-link" href="#main-content">Skip to main content</a>
 
@@ -13,10 +13,10 @@
   {{template "navbar.tmpl" .}}
 
   <div class="main-content-wrapper">
-    {{template "sidebar.tmpl" .}}
+    {{if not (index .Extra "HideSidebar")}}{{template "sidebar.tmpl" .}}{{end}}
 
     <!-- Main Content -->
-    <main id="main-content" class="main-content" role="main" aria-label="Dashboard">
+    <main id="main-content" class="main-content{{if index .Extra "HomeCommandBridge"}} home-command-main{{end}}" role="main" aria-label="Dashboard">
       {{template "dashboard.tmpl" .}}
     </main>
   </div>

--- a/internal/web/templates/layout/head.tmpl
+++ b/internal/web/templates/layout/head.tmpl
@@ -59,6 +59,7 @@
   <link href="/css/workspace-map.css" rel="stylesheet">
   <link href="/css/workspace-command.css" rel="stylesheet">
   <link href="/css/workspace-construct.css" rel="stylesheet">
+  {{if index .Extra "HomeCommandBridge"}}<link href="/css/home-command.css" rel="stylesheet">{{end}}
   <link href="/css/settings.css" rel="stylesheet">
   <link href="/css/ui-refresh.css" rel="stylesheet">
   <link href="/css/tag-input.css" rel="stylesheet">

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -50,12 +50,12 @@ test.describe('Smoke Tests', () => {
     }
   });
 
-  test('sidebar navigation is accessible', async ({ page }) => {
+  test('home uses navbar navigation without a sidebar', async ({ page }) => {
     await page.goto('/');
 
-    // Check sidebar exists
-    const sidebar = page.locator('.sidebar, [class*="sidebar"]').first();
-    await expect(sidebar).toBeVisible();
+    await expect(page.locator('.navbar').first()).toBeVisible();
+    await expect(page.locator('#sidebar')).toHaveCount(0);
+    await expect(page.locator('#sidebarToggle')).toHaveCount(0);
   });
 });
 
@@ -180,15 +180,314 @@ test.describe('Home First Run', () => {
     test.skip((data.workspaces || []).length !== 0, 'requires an empty workspace store');
 
     await page.goto('/');
-    await expect(page.locator('#homeFirstRunHero')).toBeVisible();
-    await expect(page.locator('#homeFirstRunStart')).toHaveText('Create Workspace');
+    await expect(page.locator('body.home-command-page')).toBeVisible();
+    await expect(page.locator('#homeAssistantCard')).toHaveAttribute('data-first-run', 'true');
+    await expect(page.locator('#homeDashboardSections')).toHaveAttribute('data-first-run', 'true');
+    await expect(page.locator('#homeFirstRunStart')).toContainText('Establish first workspace');
     await expect(page.locator('#homeAssistantInput')).toHaveAttribute(
       'placeholder',
       'Plan a product launch…'
     );
-    await expect(
-      page.getByText('Create a workspace for a software project', { exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create a workspace' })).toBeVisible();
+    await expect(page.locator('#sidebar')).toHaveCount(0);
+  });
+
+  test('keeps the command-strip interaction contract on home', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('#homeAssistantCard')).toBeVisible();
+    await expect(page.locator('#homeAssistantCard h1')).toHaveCount(0);
+    await expect(page.locator('#homeAssistantInput')).toBeVisible();
+    await expect(page.locator('#homeAssistantSendBtn')).toBeVisible();
+    await expect(page.locator('.home-prompt-chip')).toHaveCount(3);
+    await expect(page.locator('#homeDashboardSections')).toBeVisible();
+  });
+
+  test('preserves quick-order chips, the command shortcut, and submit flow', async ({ page }) => {
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+
+    await page.goto('/');
+    const input = page.locator('#homeAssistantInput');
+    const chip = page.locator('.home-prompt-chip').first();
+    const prompt = await chip.getAttribute('data-prompt');
+
+    await chip.focus();
+    await expect(chip).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(input).toHaveValue(prompt || '');
+
+    await page.keyboard.press('Control+j');
+    await expect(input).toBeFocused();
+
+    await input.fill('Summarize current operations');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#homeAssistantThinkingModal')).toHaveClass(/show/);
+  });
+
+  test('renders the bridge without browser console errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', message => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+    await page.route(/\/api\/agents\?name=Ori$/, async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ allow_web_search: false })
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('.home-command-bridge')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('keeps maximum bridge readouts inside a desktop viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+
+    const workspaces = Array.from({ length: 6 }, (_, index) => ({
+      id: `bridge-${index + 1}`,
+      name: `Bridge workspace ${index + 1}`,
+      updated_at: `2026-07-${String(11 - index).padStart(2, '0')}T12:00:00Z`,
+      agent_count: index + 1,
+      open_task_count: index === 1 ? 2 : 0,
+      needs_attention_count: index === 0 ? 1 : 0
+    }));
+    await page.route('**/api/workspaces', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ workspaces })
+      });
+    });
+    await page.route('**/api/orchestration/scheduled-tasks/upcoming**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          upcoming: Array.from({ length: 5 }, (_, index) => ({
+            task_name: `Scheduled operation ${index + 1}`,
+            workspace_id: `bridge-${index + 1}`,
+            workspace_name: `Bridge workspace ${index + 1}`,
+            agent_name: `Agent ${index + 1}`,
+            next_run: `2026-07-12T${String(13 + index).padStart(2, '0')}:00:00Z`
+          }))
+        })
+      });
+    });
+    await page.route('**/api/activity/recent**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          events: Array.from({ length: 5 }, (_, index) => ({
+            kind: index === 0 ? 'task_completed' : 'note_edited',
+            description: `Operation event ${index + 1}`,
+            workspace_id: `bridge-${index + 1}`,
+            workspace_name: `Bridge workspace ${index + 1}`,
+            timestamp: `2026-07-12T${String(11 + index).padStart(2, '0')}:00:00Z`
+          }))
+        })
+      });
+    });
+    await page.route('**/api/progression', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          current_tier: 1,
+          total_tiers: 3,
+          total_count: 3,
+          completed_count: 1,
+          dismissed: false,
+          all_complete: false,
+          tiers: [
+            {
+              tier: 1,
+              name: 'First contact',
+              quests: [
+                { id: 'bridge-q1', title: 'Establish a workspace', status: 'completed' },
+                {
+                  id: 'bridge-q2',
+                  title: 'Plan an operation',
+                  status: 'pending',
+                  action_url: '/workspaces'
+                },
+                { id: 'bridge-q3', title: 'Run a review', status: 'pending', action_url: '/review' }
+              ]
+            }
+          ]
+        })
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('[data-role="workspace-card"]')).toHaveCount(6);
+    await expect(page.locator('.home-row')).toHaveCount(10);
+    await expect(page.locator('.home-status-led.is-attention')).toHaveCount(1);
+    await expect(page.locator('.home-status-led.is-working')).toHaveCount(1);
+    await expect(page.locator('#questLog')).toBeVisible();
+
+    for (const [width, height] of [
+      [1280, 800],
+      [1512, 805]
+    ]) {
+      await page.setViewportSize({ width, height });
+      const dimensions = await page.evaluate(() => ({
+        viewport: window.innerHeight,
+        documentHeight: document.documentElement.scrollHeight,
+        bodyHeight: document.body.scrollHeight
+      }));
+      expect(dimensions.documentHeight).toBeLessThanOrEqual(dimensions.viewport + 1);
+      expect(dimensions.bodyHeight).toBeLessThanOrEqual(dimensions.viewport + 1);
+    }
+  });
+
+  test('collapses the quest log to a progress badge and restores it', async ({ page }) => {
+    const status = {
+      current_tier: 1,
+      total_tiers: 3,
+      total_count: 2,
+      completed_count: 1,
+      all_complete: false,
+      tiers: [
+        {
+          tier: 1,
+          name: 'First contact',
+          quests: [
+            { id: 'collapse-q1', title: 'Say hello to Ori', status: 'completed' },
+            {
+              id: 'collapse-q2',
+              title: 'Personalize Ori',
+              status: 'pending',
+              action_url: '/profile'
+            }
+          ]
+        }
+      ]
+    };
+    const dismisses: boolean[] = [];
+    let dismissed = false;
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+    await page.route('**/api/progression/dismiss', async route => {
+      const request = route.request().postDataJSON();
+      dismissed = Boolean(request.dismissed);
+      dismisses.push(dismissed);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...status, dismissed })
+      });
+    });
+    await page.route('**/api/progression', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...status, dismissed })
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('#questLog')).toBeVisible();
+    await expect(page.locator('[data-role="progress-count"]')).toHaveText('1/2');
+
+    const collapse = page.locator('[data-role="dismiss"]');
+    await collapse.focus();
+    await expect(collapse).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#questLog')).toBeHidden();
+    await expect(page.locator('#questLogRestore')).toBeVisible();
+    await expect(page.locator('[data-role="restore-progress"]')).toHaveText('1/2');
+
+    await page.reload();
+    await expect(page.locator('#questLog')).toBeHidden();
+    await expect(page.locator('#questLogRestore')).toBeVisible();
+
+    const restore = page.locator('[data-role="restore"]');
+    await restore.focus();
+    await expect(restore).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#questLog')).toBeVisible();
+    await expect(page.locator('#questLogRestore')).toBeHidden();
+    expect(dismisses).toEqual([true, false]);
+  });
+
+  test('stacks bridge zones below desktop width without horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 960, height: 720 });
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+    await page.route('**/api/progression', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          current_tier: 1,
+          total_tiers: 3,
+          total_count: 2,
+          completed_count: 0,
+          dismissed: false,
+          all_complete: false,
+          tiers: [
+            {
+              tier: 1,
+              name: 'First contact',
+              quests: [
+                { id: 'responsive-q1', title: 'Say hello to Ori', status: 'pending' },
+                { id: 'responsive-q2', title: 'Create a workspace', status: 'pending' }
+              ]
+            }
+          ]
+        })
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('#homeDashboardSections')).toBeVisible();
+    await expect(page.locator('#questLog')).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const board = document.getElementById('homeDashboardSections')?.getBoundingClientRect();
+      const progression = document.querySelector('.home-progression-zone')?.getBoundingClientRect();
+      return {
+        pageWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth,
+        boardBottom: board?.bottom || 0,
+        progressionTop: progression?.top || 0
+      };
+    });
+    expect(layout.pageWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
+    expect(layout.progressionTop).toBeGreaterThanOrEqual(layout.boardBottom);
   });
 });
 


### PR DESCRIPTION
## Summary

Reshapes the home page into a single-screen tactical **command bridge** that leads with system status instead of a hero prompt. All work lives on the shared home surface, so it lands as one PR.

### Three zones
- **Command strip** — compact Ask Ori console: `COMMAND`/`FIRST COMMAND` eyebrow, `>` prompt glyph, quick-order chips. Drops the H1/subtitle hero; keeps `homeAssistantForm`/`homeAssistantInput`/`homeAssistantSendBtn` IDs and every `[home.ttfa]` source.
- **Operations board** — client-computed stat readout (`N Workspaces · N Agents · N Open tasks`), workspace status chips with attention/active/idle LEDs (6-cap + view-all + new-workspace tile), and terse upcoming + activity readouts with tactical empty states.
- **Progression** — quest log restyle: tier insignia, progress bar, and collapse-to-badge that persists via the existing `POST /api/progression/dismiss`.

### Shell
- Sidebar removed from home (`HideSidebar`/`ShowSidebarToggle=false`); `sidebar.js`/`resizer.js` no-op when the element is absent; other pages unaffected.
- Grid backdrop replaces the body gradient/particles on home only (scoped in `layout.css`).
- One-screen budget enforced via `main-content-wrapper` sizing.
- Reconciled the send button to "Ask" (`dashboard.js` forces it at runtime) to avoid a pre-JS "Execute" flash.
- `smoke.spec.ts` updated for sidebar-free navbar nav + the command-strip contract.

## Verification
Smoke-tested on an isolated server (`HOME`/`ORI_DATA_DIR` override), first-run **and** steady state (6 workspaces), light **and** dark:
- One-screen fit at 1512×805 with max workspaces — no vertical/horizontal page scroll
- Sidebar absent from home DOM; collapse→badge→expand persists across reload
- No console errors
- `go build` / `go vet` / `npm run lint` / `go test ./...` green (the only test failure is a live-API integration test hitting an OpenAI 429 quota — environmental, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)