### PR TITLE
feat: restage create-workspace modal as a blueprint-picker wizard with briefing panel

### DIFF
--- a/internal/projecttemplates/starter/content-production/template.json
+++ b/internal/projecttemplates/starter/content-production/template.json
@@ -1,11 +1,13 @@
 {
   "name": "Content Production",
-  "description": "Brand voice, drafts, scheduled posts. Recommended add-ons: a style-guide note, a publishing-tool MCP, and a Brand Voice skill.",
-  "icon": "✏",
+  "description": "Brand voice, drafts, scheduled posts.",
+  "icon": "\u270f",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 1,
-  "tags": ["content"],
+  "builtin_version": 2,
+  "tags": [
+    "content"
+  ],
   "starter_tasks": [
     {
       "description": "Draft a style guide",
@@ -37,5 +39,11 @@
       "role": "specialist",
       "system_prompt": "You adapt approved content for each channel and schedule it against the content calendar. Tailor length and format per platform without changing the core message."
     }
+  ],
+  "tagline": "Brand voice, drafts, scheduled posts.",
+  "addons": [
+    "style-guide note",
+    "publishing-tool MCP",
+    "Brand Voice skill"
   ]
 }

--- a/internal/projecttemplates/starter/daily-briefings/template.json
+++ b/internal/projecttemplates/starter/daily-briefings/template.json
@@ -1,11 +1,13 @@
 {
   "name": "Daily Briefings",
-  "description": "Morning roundup, market summary, news digest. Recommended add-ons: a web search / news MCP, and any data sources you want summarized.",
-  "icon": "📊",
+  "description": "Morning roundup, market summary, news digest.",
+  "icon": "\ud83d\udcca",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 1,
-  "tags": ["briefing"],
+  "builtin_version": 2,
+  "tags": [
+    "briefing"
+  ],
   "starter_tasks": [
     {
       "description": "Morning briefing",
@@ -16,7 +18,12 @@
     {
       "name": "Briefing Editor",
       "role": "orchestrator",
-      "system_prompt": "You produce the daily briefing for this workspace. Pull from the configured sources, summarize what changed and why it matters, and keep it skimmable — lead with the headline, then the detail. Call out anything that needs a decision or follow-up."
+      "system_prompt": "You produce the daily briefing for this workspace. Pull from the configured sources, summarize what changed and why it matters, and keep it skimmable \u2014 lead with the headline, then the detail. Call out anything that needs a decision or follow-up."
     }
+  ],
+  "tagline": "Morning roundup, market summary, news digest.",
+  "addons": [
+    "web search / news MCP",
+    "data sources to summarize"
   ]
 }

--- a/internal/projecttemplates/starter/personal-ops/template.json
+++ b/internal/projecttemplates/starter/personal-ops/template.json
@@ -1,11 +1,13 @@
 {
   "name": "Personal Ops",
-  "description": "Daily journal, briefings, follow-ups. A personal command center. Recommended add-ons: a calendar MCP, an email MCP, and a daily-summary skill.",
-  "icon": "🗓",
+  "description": "Daily journal, briefings, follow-ups. A personal command center.",
+  "icon": "\ud83d\uddd3",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 1,
-  "tags": ["personal"],
+  "builtin_version": 2,
+  "tags": [
+    "personal"
+  ],
   "starter_tasks": [
     {
       "description": "Morning briefing",
@@ -22,5 +24,11 @@
       "role": "orchestrator",
       "system_prompt": "You are the chief of staff for this personal command center. Run the morning briefing and the end-of-day journal, track open follow-ups across calendar and email, and surface what needs attention before it slips. Keep it concise and action-oriented."
     }
+  ],
+  "tagline": "Daily journal, briefings, follow-ups.",
+  "addons": [
+    "calendar MCP",
+    "email MCP",
+    "daily-summary skill"
   ]
 }

--- a/internal/projecttemplates/starter/reaper-song/template.json
+++ b/internal/projecttemplates/starter/reaper-song/template.json
@@ -1,10 +1,10 @@
 {
   "name": "Reaper Song",
   "description": "A minimal REAPER project seeded with a single .rpp file named after your project, created at 120 BPM and ready to adjust in chat.",
-  "icon": "🎵",
+  "icon": "\ud83c\udfb5",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 5,
+  "builtin_version": 6,
   "tools": {
     "plugins": [
       "reaper-plugin"
@@ -24,7 +24,7 @@
   "starter_tasks": [
     {
       "description": "Adjust the new REAPER session to the user's preferences",
-      "details": "## Created defaults\nThe project scaffold already created the workspace's one authoritative REAPER session file, `<project name>.rpp`, in the workspace project folder. It is set to 120 BPM in 4/4, with no tracks yet. Treat that existing scaffolded file as the song project and never create or initialize a second .rpp file.\n\n## Questions to ask\nTell the user what was created, then ask whether they want to change:\n- Tempo (BPM)\n- Musical key\nIf they are happy with the defaults, confirm and finish without changing anything.\n\n## Validation\n- Tempo must be between 40 and 240 BPM. If the user asks for something outside that range, say why and ask again.\n- Accept any conventional key spelling (e.g. \"A minor\", \"F# major\").\n\n## How to apply changes\nPrefer the reaper-session-setup skill only after live REAPER state and the required control interface are verified. An operating-system open request only asks the default application to open the project file; it does not prove that REAPER has finished opening it or that Web Remote is ready. If live control cannot be verified, say what is unavailable and ask the user to open or wait for REAPER, or enable the required Web Remote interface. Do not claim that live changes were applied.\n\nBefore falling back to direct file edits, explain that live REAPER state could not be verified and ask for the user's explicit confirmation. If they confirm, edit only the existing authoritative .rpp file (the tempo lives on its `TEMPO <bpm> 4 4` line), never create another project, and clearly describe the result as a file change rather than a verified live-session change. Record the chosen key in your summary (and in the session notes if asked) — the .rpp format has no key field.",
+      "details": "## Created defaults\nThe project scaffold already created the workspace's one authoritative REAPER session file, `<project name>.rpp`, in the workspace project folder. It is set to 120 BPM in 4/4, with no tracks yet. Treat that existing scaffolded file as the song project and never create or initialize a second .rpp file.\n\n## Questions to ask\nTell the user what was created, then ask whether they want to change:\n- Tempo (BPM)\n- Musical key\nIf they are happy with the defaults, confirm and finish without changing anything.\n\n## Validation\n- Tempo must be between 40 and 240 BPM. If the user asks for something outside that range, say why and ask again.\n- Accept any conventional key spelling (e.g. \"A minor\", \"F# major\").\n\n## How to apply changes\nPrefer the reaper-session-setup skill only after live REAPER state and the required control interface are verified. An operating-system open request only asks the default application to open the project file; it does not prove that REAPER has finished opening it or that Web Remote is ready. If live control cannot be verified, say what is unavailable and ask the user to open or wait for REAPER, or enable the required Web Remote interface. Do not claim that live changes were applied.\n\nBefore falling back to direct file edits, explain that live REAPER state could not be verified and ask for the user's explicit confirmation. If they confirm, edit only the existing authoritative .rpp file (the tempo lives on its `TEMPO <bpm> 4 4` line), never create another project, and clearly describe the result as a file change rather than a verified live-session change. Record the chosen key in your summary (and in the session notes if asked) \u2014 the .rpp format has no key field.",
       "setup": true
     },
     {
@@ -43,5 +43,6 @@
         ]
       }
     }
-  ]
+  ],
+  "tagline": "A minimal REAPER project at 120 BPM."
 }

--- a/internal/projecttemplates/starter/research-project/template.json
+++ b/internal/projecttemplates/starter/research-project/template.json
@@ -1,11 +1,13 @@
 {
   "name": "Research Project",
-  "description": "Synthesis docs, sources, weekly reading. Maintains a synthesis doc, a sources index, and recurring summaries. Recommended add-ons: a web search MCP and a Citations skill.",
-  "icon": "📚",
+  "description": "Synthesis docs, sources, weekly reading. Maintains a synthesis doc, a sources index, and recurring summaries.",
+  "icon": "\ud83d\udcda",
   "behavior_profile": "research",
   "builtin": true,
-  "builtin_version": 1,
-  "tags": ["research"],
+  "builtin_version": 2,
+  "tags": [
+    "research"
+  ],
   "starter_tasks": [
     {
       "description": "Build the synthesis doc",
@@ -32,5 +34,10 @@
       "role": "synthesizer",
       "system_prompt": "You maintain the synthesis document. Fold new findings into the current best understanding, keep the open-gaps list honest, and write clear, well-attributed summaries."
     }
+  ],
+  "tagline": "Synthesis docs, sources, weekly reading.",
+  "addons": [
+    "web search MCP",
+    "Citations skill"
   ]
 }

--- a/internal/projecttemplates/starter/travels/template.json
+++ b/internal/projecttemplates/starter/travels/template.json
@@ -1,11 +1,13 @@
 {
   "name": "Travels",
-  "description": "Flights, hotels, trip planning. Recommended add-ons: a flight/hotel MCP, a calendar MCP, and a Travel skill.",
-  "icon": "✈",
+  "description": "Flights, hotels, trip planning.",
+  "icon": "\u2708",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 1,
-  "tags": ["travel"],
+  "builtin_version": 2,
+  "tags": [
+    "travel"
+  ],
   "starter_tasks": [
     {
       "description": "Plan an upcoming trip",
@@ -23,5 +25,11 @@
       "role": "researcher",
       "system_prompt": "You research flight, lodging, and local-transit options for the trip. Present a few ranked choices with clear trade-offs (price, timing, location) rather than a single pick."
     }
+  ],
+  "tagline": "Flights, hotels, trip planning.",
+  "addons": [
+    "flight/hotel MCP",
+    "calendar MCP",
+    "Travel skill"
   ]
 }

--- a/internal/projecttemplates/starter/writing-project/template.json
+++ b/internal/projecttemplates/starter/writing-project/template.json
@@ -1,10 +1,10 @@
 {
   "name": "Writing Project",
   "description": "An outline plus a chapters folder for long-form writing.",
-  "icon": "📝",
+  "icon": "\ud83d\udcdd",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 1,
+  "builtin_version": 2,
   "tags": [
     "writing"
   ],
@@ -24,5 +24,6 @@
       "role": "validator",
       "system_prompt": "You edit prose for clarity, rhythm, and consistency while preserving the author's voice. Suggest tightening and fixes; never rewrite wholesale or flatten the style."
     }
-  ]
+  ],
+  "tagline": "An outline plus a chapters folder."
 }

--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -100,6 +100,12 @@ type Template struct {
 	Tags        []string `json:"tags,omitempty"`
 	// Icon is an optional emoji glyph shown on the create-modal picker card.
 	Icon string `json:"icon,omitempty"`
+	// Tagline is a one-line summary shown on the compact create-modal picker
+	// card. Falls back to Description (truncated) when absent.
+	Tagline string `json:"tagline,omitempty"`
+	// Addons are short recommended-addon labels (e.g. "Citations skill") shown
+	// as chips in the create-modal briefing panel's "deploys" readout.
+	Addons []string `json:"addons,omitempty"`
 	// BehaviorProfile is the workspace behavior profile (workspace_preset) a
 	// workspace created from this template defaults to. Always normalized to one
 	// of ValidBehaviorProfiles.
@@ -166,6 +172,8 @@ type manifest struct {
 	Description     string          `json:"description"`
 	Tags            []string        `json:"tags,omitempty"`
 	Icon            string          `json:"icon,omitempty"`
+	Tagline         string          `json:"tagline,omitempty"`
+	Addons          []string        `json:"addons,omitempty"`
 	BehaviorProfile string          `json:"behavior_profile,omitempty"`
 	StarterTasks    []StarterTask   `json:"starter_tasks,omitempty"`
 	ProjectEntry    json.RawMessage `json:"project_entry,omitempty"`
@@ -208,6 +216,8 @@ func newTemplate(path string) Template {
 	t.Description = strings.TrimSpace(m.Description)
 	t.Tags = workspace.NormalizeWorkspaceTags(m.Tags)
 	t.Icon = strings.TrimSpace(m.Icon)
+	t.Tagline = strings.TrimSpace(m.Tagline)
+	t.Addons = normalizeAddons(m.Addons)
 	t.BehaviorProfile = NormalizeBehaviorProfile(m.BehaviorProfile)
 	t.StarterTasks = normalizeStarterTasks(m.StarterTasks)
 	t.Builtin = m.Builtin || IsBuiltinStarterID(t.ID)
@@ -261,6 +271,25 @@ func normalizeStarterTasks(tasks []StarterTask) []StarterTask {
 		setup := task.Setup && !haveSetup
 		haveSetup = haveSetup || setup
 		out = append(out, StarterTask{Description: desc, Details: strings.TrimSpace(task.Details), Setup: setup})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// normalizeAddons trims each recommended-addon label and drops empties.
+func normalizeAddons(addons []string) []string {
+	if len(addons) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(addons))
+	for _, addon := range addons {
+		addon = strings.TrimSpace(addon)
+		if addon == "" {
+			continue
+		}
+		out = append(out, addon)
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/projecttemplates/templates_unified_test.go
+++ b/internal/projecttemplates/templates_unified_test.go
@@ -49,6 +49,55 @@ func TestNewTemplateParsesUnifiedFields(t *testing.T) {
 	}
 }
 
+// TestNewTemplateParsesTaglineAndAddons covers the create-modal briefing-panel
+// metadata: tagline (trimmed) and addons (trimmed, empties dropped, absent when
+// none remain).
+func TestNewTemplateParsesTaglineAndAddons(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "research", ManifestFileName), `{
+		"name": "Research Project",
+		"tagline": "  Synthesis docs, sources, weekly reading.  ",
+		"addons": ["  web search MCP  ", "", "   ", "Citations skill"]
+	}`)
+	writeFile(t, filepath.Join(dir, "writing", ManifestFileName), `{
+		"name": "Writing Project"
+	}`)
+
+	tpl, err := FindLibraryTemplate(dir, "research")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if tpl.Tagline != "Synthesis docs, sources, weekly reading." {
+		t.Errorf("Tagline = %q, want trimmed tagline", tpl.Tagline)
+	}
+	if want := []string{"web search MCP", "Citations skill"}; !equalStrings(tpl.Addons, want) {
+		t.Errorf("Addons = %#v, want %#v (trimmed, empties dropped)", tpl.Addons, want)
+	}
+
+	blank, err := FindLibraryTemplate(dir, "writing")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate: %v", err)
+	}
+	if blank.Tagline != "" {
+		t.Errorf("Tagline = %q, want empty when absent from manifest", blank.Tagline)
+	}
+	if blank.Addons != nil {
+		t.Errorf("Addons = %#v, want nil when absent from manifest", blank.Addons)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestNormalizeBehaviorProfile(t *testing.T) {
 	cases := map[string]string{
 		"general":          BehaviorProfileGeneral,

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -187,7 +187,14 @@
   clip-path: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
   transition:
     transform 0.15s ease,
-    border-color 0.15s ease;
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+/* Uniform, compact blueprint cards: icon + name + a single-line tagline that
+   clamps to two lines so every card in the grid is the same height. */
+.workspace-create-modal .workspace-template-card {
+  min-height: 96px;
+  box-shadow: none;
 }
 .workspace-create-modal .workspace-template-card:hover,
 .workspace-create-modal .workspace-template-row:hover {
@@ -196,8 +203,11 @@
 }
 .workspace-create-modal .workspace-template-card.is-selected,
 .workspace-create-modal .workspace-template-row.is-selected {
-  border-color: var(--wc-faction-deep);
+  border-color: var(--wc-faction);
   background: rgba(70, 211, 154, 0.08);
+  box-shadow:
+    0 0 0 1px var(--wc-faction),
+    0 0 18px -6px var(--wc-faction);
 }
 .workspace-create-modal .workspace-template-card:focus-visible,
 .workspace-create-modal .workspace-template-row:focus-visible {
@@ -215,6 +225,85 @@
 }
 .workspace-create-modal .workspace-template-card-desc {
   color: var(--wc-ink-faint);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ---------- section headers (Select Blueprint / Briefing) ---------- */
+.workspace-create-modal .workspace-create-section-title {
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--wc-faction);
+}
+
+/* ---------- briefing panel ---------- */
+.workspace-create-modal .workspace-template-briefing {
+  border: 1px solid var(--wc-line);
+  background: var(--wc-panel-2);
+  padding: 10px 12px;
+  clip-path: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 9px 100%, 0 calc(100% - 9px));
+}
+.workspace-create-modal .workspace-template-briefing-default,
+.workspace-create-modal .workspace-template-briefing-desc {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-briefing-deploys {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--wc-line);
+}
+.workspace-create-modal .workspace-template-briefing-deploys-kicker {
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--wc-ink-faint);
+  margin-bottom: 6px;
+}
+.workspace-create-modal .workspace-template-briefing-row {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  margin-bottom: 5px;
+  font-size: 12px;
+}
+.workspace-create-modal .workspace-template-briefing-row:last-child {
+  margin-bottom: 0;
+}
+.workspace-create-modal .workspace-template-briefing-row-label {
+  flex: 0 0 88px;
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-template-briefing-row-value {
+  color: var(--wc-ink);
+  line-height: 1.4;
+}
+.workspace-create-modal .workspace-template-briefing-row-addons {
+  align-items: flex-start;
+}
+.workspace-create-modal .workspace-template-briefing-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.workspace-create-modal .workspace-template-briefing-chip {
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.4px;
+  padding: 2px 8px;
+  border: 1px solid var(--wc-line-bright);
+  background: color-mix(in srgb, var(--wc-faction) 9%, transparent);
+  color: var(--wc-ink-dim);
 }
 
 .workspace-create-modal .workspace-template-agent-review {

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -240,6 +240,71 @@
   color: var(--wc-faction);
 }
 
+/* ---------- wizard stepper (Select Blueprint → Construct) ---------- */
+.workspace-create-modal .workspace-create-stepper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-create-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-create-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--wc-line-bright);
+  color: var(--wc-ink-faint);
+  font-size: 9px;
+}
+.workspace-create-modal .workspace-create-step.is-active {
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-create-step.is-active .workspace-create-step-num {
+  border-color: var(--wc-faction);
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-create-step-sep {
+  color: var(--wc-ink-faint);
+}
+
+/* ---------- step-2 recap of the chosen blueprint ---------- */
+.workspace-create-modal .workspace-create-recap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--wc-line);
+  border-left: 2px solid var(--wc-faction);
+  background: var(--wc-panel-2);
+}
+.workspace-create-modal .workspace-create-recap-icon {
+  font-size: 15px;
+  line-height: 1;
+}
+.workspace-create-modal .workspace-create-recap-label {
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-create-recap-name {
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  color: #f3f5f8;
+}
+
 /* ---------- briefing panel ---------- */
 .workspace-create-modal .workspace-template-briefing {
   border: 1px solid var(--wc-line);
@@ -421,6 +486,7 @@
 [data-bs-theme="light"] .workspace-create-modal .workspace-setup-title,
 [data-bs-theme="light"] .workspace-create-modal .workspace-advanced-summary-title,
 [data-bs-theme="light"] .workspace-create-modal .workspace-template-card-label,
+[data-bs-theme="light"] .workspace-create-modal .workspace-create-recap-name,
 [data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-review-title,
 [data-bs-theme="light"] .workspace-create-modal .workspace-template-agent-model strong {
   color: var(--wc-ink-heading);

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -46,6 +46,15 @@
   font-family: var(--wc-font-display);
 }
 
+/* The `hidden` attribute must win over Bootstrap display utilities (.d-flex
+   etc. use `display: … !important`), so JS toggling `.hidden` on a header/row
+   actually hides it — e.g. hiding the Select Blueprint header (a .d-flex row)
+   in import mode. Only applies while [hidden] is set; removing it restores the
+   element's normal display. */
+.workspace-create-modal [hidden] {
+  display: none !important;
+}
+
 /* ---------- chrome ---------- */
 .workspace-create-modal .modal-content {
   background: var(--wc-panel) !important;

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -399,6 +399,13 @@ function ptcEmitSelection() {
   }));
 }
 
+// Double-click on a blueprint: select it, then ask the wizard to advance to the
+// Construct step (the host listens for this on #addFolderModal).
+function ptcEmitAdvance() {
+  document.getElementById('addFolderModal')
+    ?.dispatchEvent(new CustomEvent('workspace-template-advance'));
+}
+
 function ptcMarkSelectedAcross(selectedEl) {
   const els = ptcElements();
   [els.grid, els.userList].forEach((container) => {
@@ -444,6 +451,7 @@ function ptcCard(template) {
     card.append(tagline);
   }
   card.addEventListener('click', () => ptcSelect(template, card));
+  card.addEventListener('dblclick', () => { ptcSelect(template, card); ptcEmitAdvance(); });
   return card;
 }
 
@@ -463,6 +471,7 @@ function ptcRow(template) {
   label.textContent = template.name || template.id;
   row.append(icon, label);
   row.addEventListener('click', () => ptcSelect(template, row));
+  row.addEventListener('dblclick', () => { ptcSelect(template, row); ptcEmitAdvance(); });
   return row;
 }
 

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -314,6 +314,7 @@ const PTC_BLANK = {
   id: '',
   name: '',
   description: '',
+  tagline: 'Start from an empty workspace.',
   icon: '✍',
   label: 'Blank',
   behavior_profile: 'general',
@@ -337,8 +338,37 @@ function ptcElements() {
     manageLink: document.getElementById('projectTemplateManageLink'),
     importToggle: document.getElementById('folderImportToggle'),
     openAfterCreate: document.getElementById('projectTemplateOpenAfterCreate'),
-    openAfterCreateToggle: document.getElementById('projectTemplateOpenAfterCreateToggle')
+    openAfterCreateToggle: document.getElementById('projectTemplateOpenAfterCreateToggle'),
+    // Briefing panel: the selected template's description + a "deploys" readout.
+    blueprintHeader: document.getElementById('workspaceCreateBlueprintHeader'),
+    briefingHeader: document.getElementById('workspaceCreateBriefingHeader'),
+    briefing: document.getElementById('templateBriefing'),
+    briefingDefault: document.getElementById('templateBriefingDefault'),
+    briefingDeploys: document.getElementById('templateBriefingDeploys'),
+    briefingAgentsRow: document.getElementById('templateBriefingAgentsRow'),
+    briefingAgentsValue: document.getElementById('templateBriefingAgentsValue'),
+    briefingScaffoldRow: document.getElementById('templateBriefingScaffoldRow'),
+    briefingScaffoldValue: document.getElementById('templateBriefingScaffoldValue'),
+    briefingAddonsRow: document.getElementById('templateBriefingAddonsRow'),
+    briefingAddonsList: document.getElementById('templateBriefingAddonsList')
   };
+}
+
+// ptcTagline returns the one-line summary for a template's picker card:
+// the explicit tagline, else the first sentence of the description
+// (truncated), else empty.
+function ptcTagline(template) {
+  if (!template) return '';
+  const tagline = String(template.tagline || '').trim();
+  if (tagline) return tagline;
+  const desc = String(template.description || '').trim();
+  if (!desc) return '';
+  // First sentence (up to a period+space), capped so cards stay uniform.
+  const match = desc.match(/^.*?[.!?](?:\s|$)/);
+  let out = (match ? match[0] : desc).trim();
+  const MAX = 80;
+  if (out.length > MAX) out = out.slice(0, MAX - 1).trimEnd() + '…';
+  return out;
 }
 
 function ptcGetPayloadFields() {
@@ -406,12 +436,12 @@ function ptcCard(template) {
   label.className = 'workspace-template-card-label';
   label.textContent = template.label || template.name || template.id;
   card.append(icon, label);
-  const descText = template.description || '';
-  if (descText) {
-    const desc = document.createElement('span');
-    desc.className = 'workspace-template-card-desc';
-    desc.textContent = descText;
-    card.append(desc);
+  const taglineText = ptcTagline(template);
+  if (taglineText) {
+    const tagline = document.createElement('span');
+    tagline.className = 'workspace-template-card-desc';
+    tagline.textContent = taglineText;
+    card.append(tagline);
   }
   card.addEventListener('click', () => ptcSelect(template, card));
   return card;
@@ -438,16 +468,11 @@ function ptcRow(template) {
 
 function ptcUpdateUI() {
   const els = ptcElements();
-  if (els.description) {
-    // Built-in cards show their own description; only surface the hint for a
-    // selected user template (compact rows show name only).
-    const showDesc = Boolean(ptcSelected && !ptcSelected.blank && !ptcSelected.builtin && ptcSelected.description);
-    els.description.textContent = showDesc ? ptcSelected.description : '';
-    els.description.hidden = !showDesc;
-  }
-
   const templatePath = els.pathInput?.value?.trim() || '';
   const importMode = Boolean(els.importToggle?.checked);
+
+  ptcRenderBriefing(els, importMode, templatePath);
+
   const entry = ptcSelected?.project_entry;
   const hasEntry = Boolean(
     !importMode &&
@@ -464,6 +489,70 @@ function ptcUpdateUI() {
     els.openAfterCreateToggle.checked = hasEntry
       ? Boolean(entry.open_after_create_default)
       : false;
+  }
+}
+
+// ptcRenderBriefing fills the Briefing panel from the current selection: the
+// full description plus a "deploys" readout (agents, project folder, add-on
+// chips). When nothing meaningful is selected — Blank, an ad-hoc folder path,
+// or import mode — it falls back to the default helper text. Each deploys row
+// is hidden individually when the template declares nothing for it.
+function ptcRenderBriefing(els, importMode, templatePath) {
+  if (!els.briefing) return;
+
+  const template = ptcSelected;
+  // A meaningful briefing needs a real, non-Blank template with no ad-hoc
+  // folder override and outside import mode (which hides the picker entirely).
+  const showBriefing = Boolean(
+    !importMode &&
+    !templatePath &&
+    template &&
+    !template.blank &&
+    template.id
+  );
+
+  const description = showBriefing ? String(template.description || '').trim() : '';
+  if (els.description) {
+    els.description.textContent = description;
+    els.description.hidden = !description;
+  }
+  if (els.briefingDefault) els.briefingDefault.hidden = showBriefing;
+
+  const agents = showBriefing && Array.isArray(template.agents) ? template.agents : [];
+  const agentNames = agents
+    .map((a) => String(a?.name || '').trim())
+    .filter(Boolean);
+  const showAgents = agentNames.length > 0;
+  if (els.briefingAgentsRow) els.briefingAgentsRow.hidden = !showAgents;
+  if (els.briefingAgentsValue && showAgents) {
+    els.briefingAgentsValue.textContent = `${agentNames.length} — ${agentNames.join(', ')}`;
+  }
+
+  const showScaffold = Boolean(showBriefing && template.has_skeleton);
+  if (els.briefingScaffoldRow) els.briefingScaffoldRow.hidden = !showScaffold;
+  if (els.briefingScaffoldValue && showScaffold) {
+    els.briefingScaffoldValue.textContent = 'Scaffolds a starter project folder';
+  }
+
+  const addons = showBriefing && Array.isArray(template.addons)
+    ? template.addons.map((a) => String(a || '').trim()).filter(Boolean)
+    : [];
+  const showAddons = addons.length > 0;
+  if (els.briefingAddonsRow) els.briefingAddonsRow.hidden = !showAddons;
+  if (els.briefingAddonsList) {
+    els.briefingAddonsList.innerHTML = '';
+    if (showAddons) {
+      for (const addon of addons) {
+        const chip = document.createElement('span');
+        chip.className = 'workspace-template-briefing-chip';
+        chip.textContent = addon;
+        els.briefingAddonsList.appendChild(chip);
+      }
+    }
+  }
+
+  if (els.briefingDeploys) {
+    els.briefingDeploys.hidden = !(showAgents || showScaffold || showAddons);
   }
 }
 
@@ -490,11 +579,12 @@ function ptcSyncImportVisibility() {
   const els = ptcElements();
   const importMode = Boolean(els.importToggle?.checked);
   // Templates scaffold/seed a new workspace; they don't apply when importing an
-  // existing folder as the workspace itself.
+  // existing folder as the workspace itself — hide the whole blueprint/briefing
+  // block, headers included, so nothing dangles above the import form.
   if (els.picker) els.picker.hidden = importMode;
-  if (importMode) {
-    if (els.description) els.description.hidden = true;
-  }
+  if (els.blueprintHeader) els.blueprintHeader.hidden = importMode;
+  if (els.briefingHeader) els.briefingHeader.hidden = importMode;
+  if (els.briefing) els.briefing.hidden = importMode;
   ptcUpdateUI();
 }
 
@@ -609,7 +699,10 @@ function ptcInit() {
 window.ProjectTemplateCard = {
   populate: ptcPopulate,
   reset: ptcReset,
-  syncState: ptcUpdateUI,
+  // syncState re-syncs import-mode visibility (which hides the blueprint grid,
+  // briefing, and their headers) as well as the per-selection UI, so callers
+  // like setImportModeEnabled don't depend on show-handler ordering.
+  syncState: ptcSyncImportVisibility,
   getPayloadFields: ptcGetPayloadFields,
   getSelectedTemplate: ptcGetSelectedTemplate,
   shouldOpenAfterCreate: ptcShouldOpenAfterCreate

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -44,6 +44,10 @@ const sessionManager = {
   // Starting point no longer overwrites their choice. Reset on modal open.
   behaviorOverridden: false,
 
+  // Create-workspace wizard step (1 = Select Blueprint, 2 = Construct). Import
+  // mode is single-step and always renders the step-2 layout. Reset on open.
+  wizardStep: 1,
+
   // Auto mode state
   chatAutoMode: false,
   chatLlmAvailable: false,
@@ -220,6 +224,14 @@ const sessionManager = {
     // Create folder button
     document.getElementById('createFolderBtn')?.addEventListener('click', () => this.createFolder());
 
+    // Wizard navigation (Select Blueprint → Construct).
+    document.getElementById('wizardNextBtn')?.addEventListener('click', () => this.goToWizardStep(2));
+    document.getElementById('wizardBackBtn')?.addEventListener('click', () => this.goToWizardStep(1));
+    // Double-clicking a blueprint selects it and jumps straight to Construct.
+    document.getElementById('addFolderModal')?.addEventListener('workspace-template-advance', () => {
+      if (!this.importModeEnabled) this.goToWizardStep(2);
+    });
+
     // Agent behavior (formerly "Workspace preset"): a manual change marks the
     // value as overridden so picking a Template won't clobber it.
     document.getElementById('folderPresetSelect')?.addEventListener('change', () => {
@@ -236,6 +248,7 @@ const sessionManager = {
       this.prefillTemplateValue(document.getElementById('folderNameInput'), template?.name || '', 'autofillName');
       this.prefillTemplateValue(document.getElementById('folderDescriptionInput'), template?.description || '', 'autofillDescription');
       this.applyTemplateBehavior(template);
+      this.updateWizardRecap(template);
       void this.refreshTemplateAgentPlan();
       // Show the REAPER Setup card only for the Reaper Song template.
       window.ReaperSetupCard?.showForTemplate?.(template);
@@ -3056,6 +3069,7 @@ const sessionManager = {
       this.resetTemplateAgentReview();
     }
     window.ProjectTemplateCard?.syncState?.();
+    this.refreshWizardChrome();
   },
 
   clearImportDuplicateWarning() {
@@ -3194,6 +3208,9 @@ const sessionManager = {
 
   resetAddWorkspaceModalForm(options = {}) {
     const { preserveAskOri = false } = options;
+    // Every open starts on step 1; setImportModeEnabled(false) below re-renders
+    // the wizard chrome, and an import open flips it to the single-step layout.
+    this.wizardStep = 1;
     const modalElement = document.getElementById('addFolderModal');
     const nameInput = document.getElementById('folderNameInput');
     const descriptionInput = document.getElementById('folderDescriptionInput');
@@ -3735,6 +3752,64 @@ const sessionManager = {
     if (tagCount > 0) parts.push(`${tagCount} tag${tagCount === 1 ? '' : 's'}`);
 
     hint.textContent = parts.join(' · ');
+  },
+
+  // ----- Create-workspace wizard (Select Blueprint → Construct) -----
+
+  // Renders the wizard chrome for the current mode + step: which step panel is
+  // visible, the stepper, and which footer buttons show. Import mode is a
+  // single step that always shows the step-2 layout with no stepper/Back/Next.
+  refreshWizardChrome() {
+    const importMode = Boolean(this.importModeEnabled);
+    const step = importMode ? 2 : this.wizardStep;
+
+    const step1 = document.getElementById('wizardStep1');
+    const step2 = document.getElementById('wizardStep2');
+    const stepper = document.getElementById('wizardStepper');
+    const backBtn = document.getElementById('wizardBackBtn');
+    const nextBtn = document.getElementById('wizardNextBtn');
+    const createBtn = document.getElementById('createFolderBtn');
+
+    if (step1) step1.hidden = importMode || step !== 1;
+    if (step2) step2.hidden = step !== 2;
+    if (stepper) stepper.hidden = importMode;
+    stepper?.querySelectorAll('.workspace-create-step').forEach((el) => {
+      el.classList.toggle('is-active', String(el.dataset.step || '') === String(step));
+    });
+
+    const onStep1 = !importMode && step === 1;
+    if (nextBtn) nextBtn.hidden = !onStep1;
+    if (backBtn) backBtn.hidden = importMode || step !== 2;
+    // createFolderBtn stays hidden on step 1; its disabled state is owned by the
+    // REAPER setup card, so only toggle visibility here.
+    if (createBtn) createBtn.hidden = onStep1;
+    // The step-2 recap names the chosen blueprint; import mode has no blueprint.
+    const recap = document.getElementById('wizardStep2Recap');
+    if (recap) recap.hidden = importMode;
+  },
+
+  // Sets the step-2 recap line ("Constructing: <icon> <name>") from the selected
+  // blueprint, falling back to a Blank-workspace label.
+  updateWizardRecap(template) {
+    const nameEl = document.getElementById('wizardStep2RecapName');
+    const iconEl = document.getElementById('wizardStep2RecapIcon');
+    const isBlank = !template || template.blank || !template.id;
+    if (nameEl) nameEl.textContent = isBlank ? 'Blank workspace' : (template.name || template.id);
+    if (iconEl) iconEl.textContent = (template && template.icon) ? template.icon : '✍';
+  },
+
+  // Moves the wizard to a step and re-renders chrome. Scrolls the modal body to
+  // the top and moves focus to the step's primary control.
+  goToWizardStep(step) {
+    this.wizardStep = step === 2 ? 2 : 1;
+    this.refreshWizardChrome();
+    const body = document.querySelector('#addFolderModal .modal-body');
+    if (body) body.scrollTop = 0;
+    if (this.wizardStep === 2) {
+      document.getElementById('folderNameInput')?.focus();
+    } else {
+      document.querySelector('#templateBuiltinGrid .workspace-template-card.is-selected')?.focus();
+    }
   },
 
   // Applies a Template's default Agent behavior to the select, unless the user

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -294,7 +294,17 @@ const sessionManager = {
       btn.addEventListener('click', (e) => {
         document.querySelectorAll('.folder-color-btn').forEach(b => b.classList.remove('active'));
         e.target.classList.add('active');
+        this.updateBehaviorHint();
       });
+    });
+
+    // Group/Color/Tags live inside the Advanced disclosure now; refresh the
+    // collapsed summary hint when they change or when Advanced is toggled shut.
+    document.getElementById('folderParentSelect')?.addEventListener('change', () => {
+      this.updateBehaviorHint();
+    });
+    document.getElementById('folderAdvancedDisclosure')?.addEventListener('toggle', () => {
+      this.updateBehaviorHint();
     });
 
     const addFolderModal = document.getElementById('addFolderModal');
@@ -3701,12 +3711,30 @@ const sessionManager = {
     }
   },
 
-  // Refreshes the collapsed "Agent behavior: X" hint from the select value.
+  // Refreshes the collapsed "Agent behavior: X" hint from the select value,
+  // appending any non-default Group/Color/Tags picks so the collapsed Advanced
+  // section reflects what's set inside it.
   updateBehaviorHint() {
     const hint = document.getElementById('folderBehaviorHint');
     if (!hint) return;
     const profile = document.getElementById('folderPresetSelect')?.value || 'general';
-    hint.textContent = `Agent behavior: ${this.behaviorProfileLabel(profile)}`;
+    const parts = [`Agent behavior: ${this.behaviorProfileLabel(profile)}`];
+
+    const parentSelect = document.getElementById('folderParentSelect');
+    if (parentSelect && parentSelect.value) {
+      const label = parentSelect.options[parentSelect.selectedIndex]?.textContent?.trim();
+      if (label) parts.push(`Group: ${label}`);
+    }
+
+    const activeColor = document.querySelector('#addFolderModal .folder-color-btn.active');
+    if (activeColor && String(activeColor.dataset.color || '').trim()) {
+      parts.push('Color set');
+    }
+
+    const tagCount = window.WorkspaceTagsCard?.getPayloadFields?.().tags?.length || 0;
+    if (tagCount > 0) parts.push(`${tagCount} tag${tagCount === 1 ? '' : 's'}`);
+
+    hint.textContent = parts.join(' · ');
   },
 
   // Applies a Template's default Agent behavior to the select, unless the user

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -12,7 +12,7 @@
           <div class="workspace-create-main-fields">
 
             <!-- ===== SELECT BLUEPRINT: template grid + user templates ===== -->
-            <div class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
+            <div id="workspaceCreateBlueprintHeader" class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
               <span class="workspace-create-section-title">Select Blueprint</span>
               <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
             </div>
@@ -26,7 +26,7 @@
             <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
 
             <!-- ===== BRIEFING: selected template's description + what it deploys ===== -->
-            <div class="workspace-create-section-header" style="margin-bottom: 6px;">
+            <div id="workspaceCreateBriefingHeader" class="workspace-create-section-header" style="margin-bottom: 6px;">
               <span class="workspace-create-section-title">Briefing</span>
             </div>
             <div id="templateBriefing" class="workspace-template-briefing mb-2">

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -10,8 +10,10 @@
       <div class="modal-body workspace-create-modal-body">
         <div class="workspace-create-layout">
           <div class="workspace-create-main-fields">
-            <div class="d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
-              <label style="font-size: 12px; color: var(--text-secondary);">Template</label>
+
+            <!-- ===== SELECT BLUEPRINT: template grid + user templates ===== -->
+            <div class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
+              <span class="workspace-create-section-title">Select Blueprint</span>
               <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
             </div>
             <div id="templatePicker" role="radiogroup" aria-label="Workspace template">
@@ -21,10 +23,32 @@
                 <div id="templateUserList" class="workspace-template-list mb-2"></div>
               </div>
             </div>
-            <div id="projectTemplateDescription" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
             <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
-            <div style="margin-bottom: 12px; font-size: 12px; color: var(--text-secondary);">
-              Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
+
+            <!-- ===== BRIEFING: selected template's description + what it deploys ===== -->
+            <div class="workspace-create-section-header" style="margin-bottom: 6px;">
+              <span class="workspace-create-section-title">Briefing</span>
+            </div>
+            <div id="templateBriefing" class="workspace-template-briefing mb-2">
+              <div id="templateBriefingDefault" class="workspace-template-briefing-default">
+                Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
+              </div>
+              <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
+              <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
+                <div class="workspace-template-briefing-deploys-kicker">Deploys</div>
+                <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row" hidden>
+                  <span class="workspace-template-briefing-row-label">Agents</span>
+                  <span id="templateBriefingAgentsValue" class="workspace-template-briefing-row-value"></span>
+                </div>
+                <div id="templateBriefingScaffoldRow" class="workspace-template-briefing-row" hidden>
+                  <span class="workspace-template-briefing-row-label">Project folder</span>
+                  <span id="templateBriefingScaffoldValue" class="workspace-template-briefing-row-value"></span>
+                </div>
+                <div id="templateBriefingAddonsRow" class="workspace-template-briefing-row workspace-template-briefing-row-addons" hidden>
+                  <span class="workspace-template-briefing-row-label">Add-ons</span>
+                  <div id="templateBriefingAddonsList" class="workspace-template-briefing-chips"></div>
+                </div>
+              </div>
             </div>
 
             <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
@@ -67,6 +91,7 @@
               <div id="reaperSetupActions" class="reaper-setup-actions d-flex flex-wrap gap-2" style="margin-top: 8px;"></div>
             </div>
 
+            <!-- ===== Designation: name + description feed Ori's setup review ===== -->
             <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
             <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
             <div class="workspace-setup-card mb-2">
@@ -86,6 +111,7 @@
               <textarea id="folderContextInput" class="modern-input w-100" placeholder="Folder paths, source docs, launch notes, brand references" rows="2" style="resize: vertical;"></textarea>
             </div>
 
+            <!-- ===== Advanced: agent behavior, folder-as-template, group, tags, color ===== -->
             <details id="folderAdvancedDisclosure" class="workspace-advanced-details mb-2">
               <summary class="workspace-advanced-summary">
                 <span class="workspace-advanced-summary-title">Advanced</span>
@@ -109,8 +135,33 @@
                     Choose folder…
                   </button>
                 </div>
-                <div style="margin-top: -2px; font-size: 12px; color: var(--text-secondary);">
+                <div style="margin-top: -2px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
                   Scaffolds the chosen folder's files into the workspace as its project. Overrides the template selection above.
+                </div>
+
+                <label for="folderParentSelect" style="font-size: 12px; color: var(--text-secondary);">Group (optional)</label>
+                <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select workspace group" aria-describedby="folderParentHelp">
+                  <option value="">No group</option>
+                </select>
+                <div id="folderParentHelp" style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
+                  Optional. Choose a group for this workspace.
+                </div>
+
+                <label style="font-size: 12px; color: var(--text-secondary);">Tags <span style="opacity: 0.8;">(optional)</span></label>
+                <div id="folderTagsMount" class="mb-1"></div>
+                <div id="folderTemplateTagsHint" style="margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
+
+                <div class="folder-color-picker">
+                  <label style="font-size: 12px; color: var(--text-secondary);">Color:</label>
+                  <div id="folderColorOptions" class="folder-color-options mt-1">
+                    <button type="button" class="folder-color-btn active" data-color="" title="Default" aria-label="Default color"></button>
+                    <button type="button" class="folder-color-btn" data-color="#ef4444" title="Red" aria-label="Red color" style="background: #ef4444;"></button>
+                    <button type="button" class="folder-color-btn" data-color="#f59e0b" title="Orange" aria-label="Orange color" style="background: #f59e0b;"></button>
+                    <button type="button" class="folder-color-btn" data-color="#22c55e" title="Green" aria-label="Green color" style="background: #22c55e;"></button>
+                    <button type="button" class="folder-color-btn" data-color="#3b82f6" title="Blue" aria-label="Blue color" style="background: #3b82f6;"></button>
+                    <button type="button" class="folder-color-btn" data-color="#8b5cf6" title="Purple" aria-label="Purple color" style="background: #8b5cf6;"></button>
+                    <button type="button" class="folder-color-btn" data-color="#ec4899" title="Pink" aria-label="Pink color" style="background: #ec4899;"></button>
+                  </div>
                 </div>
               </div>
             </details>
@@ -143,31 +194,6 @@
                     <button type="button" id="folderImportProceedDuplicateBtn" class="modern-btn modern-btn-primary" style="flex: 1;">Import Anyway</button>
                   </div>
                 </div>
-              </div>
-            </div>
-
-            <label for="folderParentSelect" style="font-size: 12px; color: var(--text-secondary);">Group (optional)</label>
-            <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select workspace group" aria-describedby="folderParentHelp">
-              <option value="">No group</option>
-            </select>
-            <div id="folderParentHelp" style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
-              Optional. Choose a group for this workspace.
-            </div>
-
-            <label style="font-size: 12px; color: var(--text-secondary);">Tags <span style="opacity: 0.8;">(optional)</span></label>
-            <div id="folderTagsMount" class="mb-1"></div>
-            <div id="folderTemplateTagsHint" style="margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
-
-            <div class="folder-color-picker">
-              <label style="font-size: 12px; color: var(--text-secondary);">Color:</label>
-              <div id="folderColorOptions" class="folder-color-options mt-1">
-                <button type="button" class="folder-color-btn active" data-color="" title="Default" aria-label="Default color"></button>
-                <button type="button" class="folder-color-btn" data-color="#ef4444" title="Red" aria-label="Red color" style="background: #ef4444;"></button>
-                <button type="button" class="folder-color-btn" data-color="#f59e0b" title="Orange" aria-label="Orange color" style="background: #f59e0b;"></button>
-                <button type="button" class="folder-color-btn" data-color="#22c55e" title="Green" aria-label="Green color" style="background: #22c55e;"></button>
-                <button type="button" class="folder-color-btn" data-color="#3b82f6" title="Blue" aria-label="Blue color" style="background: #3b82f6;"></button>
-                <button type="button" class="folder-color-btn" data-color="#8b5cf6" title="Purple" aria-label="Purple color" style="background: #8b5cf6;"></button>
-                <button type="button" class="folder-color-btn" data-color="#ec4899" title="Pink" aria-label="Pink color" style="background: #ec4899;"></button>
               </div>
             </div>
 

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -11,198 +11,228 @@
         <div class="workspace-create-layout">
           <div class="workspace-create-main-fields">
 
-            <!-- ===== SELECT BLUEPRINT: template grid + user templates ===== -->
-            <div id="workspaceCreateBlueprintHeader" class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
-              <span class="workspace-create-section-title">Select Blueprint</span>
-              <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
-            </div>
-            <div id="templatePicker" role="radiogroup" aria-label="Workspace template">
-              <div id="templateBuiltinGrid" class="workspace-template-grid mb-2"></div>
-              <div id="templateUserSection" hidden>
-                <div class="workspace-template-list-heading">Your templates</div>
-                <div id="templateUserList" class="workspace-template-list mb-2"></div>
-              </div>
-            </div>
-            <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
-
-            <!-- ===== BRIEFING: selected template's description + what it deploys ===== -->
-            <div id="workspaceCreateBriefingHeader" class="workspace-create-section-header" style="margin-bottom: 6px;">
-              <span class="workspace-create-section-title">Briefing</span>
-            </div>
-            <div id="templateBriefing" class="workspace-template-briefing mb-2">
-              <div id="templateBriefingDefault" class="workspace-template-briefing-default">
-                Pick a template to set up the workspace. Some templates also scaffold a starter project folder; everything is optional and editable after creation.
-              </div>
-              <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
-              <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
-                <div class="workspace-template-briefing-deploys-kicker">Deploys</div>
-                <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row" hidden>
-                  <span class="workspace-template-briefing-row-label">Agents</span>
-                  <span id="templateBriefingAgentsValue" class="workspace-template-briefing-row-value"></span>
-                </div>
-                <div id="templateBriefingScaffoldRow" class="workspace-template-briefing-row" hidden>
-                  <span class="workspace-template-briefing-row-label">Project folder</span>
-                  <span id="templateBriefingScaffoldValue" class="workspace-template-briefing-row-value"></span>
-                </div>
-                <div id="templateBriefingAddonsRow" class="workspace-template-briefing-row workspace-template-briefing-row-addons" hidden>
-                  <span class="workspace-template-briefing-row-label">Add-ons</span>
-                  <div id="templateBriefingAddonsList" class="workspace-template-briefing-chips"></div>
-                </div>
-              </div>
+            <!-- Wizard stepper: hidden in import mode (single-step). -->
+            <div id="wizardStepper" class="workspace-create-stepper" aria-hidden="true">
+              <span class="workspace-create-step is-active" data-step="1">
+                <span class="workspace-create-step-num">1</span>Select Blueprint
+              </span>
+              <span class="workspace-create-step-sep">→</span>
+              <span class="workspace-create-step" data-step="2">
+                <span class="workspace-create-step-num">2</span>Construct
+              </span>
             </div>
 
-            <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
-              <label class="d-flex align-items-start gap-2 mb-0" for="projectTemplateOpenAfterCreateToggle" style="cursor: pointer;">
-                <input type="checkbox" id="projectTemplateOpenAfterCreateToggle" class="form-check-input mt-1">
-                <span>
-                  <span class="workspace-setup-title d-block">Open project after creation</span>
-                  <span class="workspace-setup-help d-block">Uses your system's default app for this file type.</span>
-                </span>
-              </label>
+            <!-- ===== STEP 1 · SELECT BLUEPRINT: template grid + user templates ===== -->
+            <div id="wizardStep1">
+              <div id="workspaceCreateBlueprintHeader" class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
+                <span class="workspace-create-section-title">Select Blueprint</span>
+                <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
+              </div>
+              <div id="templatePicker" role="radiogroup" aria-label="Workspace template">
+                <div id="templateBuiltinGrid" class="workspace-template-grid mb-2"></div>
+                <div id="templateUserSection" hidden>
+                  <div class="workspace-template-list-heading">Your templates</div>
+                  <div id="templateUserList" class="workspace-template-list mb-2"></div>
+                </div>
+              </div>
+              <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
+              <div class="workspace-create-step-hint" style="margin-top: 4px; font-size: 12px; color: var(--text-secondary);">
+                Pick a blueprint (or Blank), then continue to name and configure it. Double-click a blueprint to skip ahead.
+              </div>
+
+              <!-- Briefing: the selected blueprint's description + what it deploys.
+                   Lives on step 1 as decision-support while choosing. -->
+              <div id="workspaceCreateBriefingHeader" class="workspace-create-section-header" style="margin-top: 14px; margin-bottom: 6px;">
+                <span class="workspace-create-section-title">Briefing</span>
+              </div>
+              <div id="templateBriefing" class="workspace-template-briefing mb-2">
+                <div id="templateBriefingDefault" class="workspace-template-briefing-default">
+                  Starting from a blank workspace. You can add tools, agents, and structure after it's created.
+                </div>
+                <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
+                <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
+                  <div class="workspace-template-briefing-deploys-kicker">Deploys</div>
+                  <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row" hidden>
+                    <span class="workspace-template-briefing-row-label">Agents</span>
+                    <span id="templateBriefingAgentsValue" class="workspace-template-briefing-row-value"></span>
+                  </div>
+                  <div id="templateBriefingScaffoldRow" class="workspace-template-briefing-row" hidden>
+                    <span class="workspace-template-briefing-row-label">Project folder</span>
+                    <span id="templateBriefingScaffoldValue" class="workspace-template-briefing-row-value"></span>
+                  </div>
+                  <div id="templateBriefingAddonsRow" class="workspace-template-briefing-row workspace-template-briefing-row-addons" hidden>
+                    <span class="workspace-template-briefing-row-label">Add-ons</span>
+                    <div id="templateBriefingAddonsList" class="workspace-template-briefing-chips"></div>
+                  </div>
+                </div>
+              </div>
             </div>
 
-            <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
-              <div class="workspace-template-agent-review-head">
-                <div>
-                  <div class="workspace-template-agent-review-title">Template Agents</div>
-                  <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
-                </div>
-                <label class="workspace-template-agent-toggle">
-                  <input type="checkbox" id="templateAgentReviewToggle" checked>
-                  <span>Create</span>
+            <!-- ===== STEP 2 · CONSTRUCT: name, description, agents, advanced ===== -->
+            <div id="wizardStep2" hidden>
+
+              <!-- Recap of the blueprint chosen on step 1. -->
+              <div id="wizardStep2Recap" class="workspace-create-recap mb-2">
+                <span id="wizardStep2RecapIcon" class="workspace-create-recap-icon" aria-hidden="true">✍</span>
+                <span class="workspace-create-recap-label">Constructing</span>
+                <span id="wizardStep2RecapName" class="workspace-create-recap-name">Blank workspace</span>
+              </div>
+
+              <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
+                <label class="d-flex align-items-start gap-2 mb-0" for="projectTemplateOpenAfterCreateToggle" style="cursor: pointer;">
+                  <input type="checkbox" id="projectTemplateOpenAfterCreateToggle" class="form-check-input mt-1">
+                  <span>
+                    <span class="workspace-setup-title d-block">Open project after creation</span>
+                    <span class="workspace-setup-help d-block">Uses your system's default app for this file type.</span>
+                  </span>
                 </label>
               </div>
-              <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>
-              <div id="templateAgentReviewList" class="workspace-template-agent-list"></div>
-              <div id="templateAgentReviewWarnings" class="workspace-template-agent-warnings" hidden></div>
-            </div>
 
-            <!-- REAPER Setup card: shown only when the Reaper Song template is
-                 selected. Populated by sessions.js from /api/reaper-setup/preview. -->
-            <div id="reaperSetupCard" class="workspace-setup-card reaper-setup-card mb-2" role="group" aria-label="REAPER Setup" hidden>
-              <div class="workspace-setup-header" style="align-items: flex-start;">
-                <div>
-                  <div class="workspace-setup-title">REAPER Setup</div>
-                  <p id="reaperSetupStatusText" class="workspace-setup-help mb-0" aria-live="polite">Checking reaper-plugin…</p>
+              <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
+                <div class="workspace-template-agent-review-head">
+                  <div>
+                    <div class="workspace-template-agent-review-title">Template Agents</div>
+                    <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
+                  </div>
+                  <label class="workspace-template-agent-toggle">
+                    <input type="checkbox" id="templateAgentReviewToggle" checked>
+                    <span>Create</span>
+                  </label>
                 </div>
-                <span id="reaperSetupBadge" class="reaper-setup-badge" aria-hidden="true"></span>
-              </div>
-              <div id="reaperSetupDetail" class="reaper-setup-detail" style="font-size: 12px; color: var(--text-secondary); margin-top: 6px;"></div>
-              <div id="reaperSetupActions" class="reaper-setup-actions d-flex flex-wrap gap-2" style="margin-top: 8px;"></div>
-            </div>
-
-            <!-- ===== Designation: name + description feed Ori's setup review ===== -->
-            <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
-            <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
-            <div class="workspace-setup-card mb-2">
-              <div class="workspace-setup-header" style="align-items: flex-start;">
-                <div>
-                  <label for="folderDescriptionInput" class="workspace-setup-title">Workspace Description</label>
-                  <p class="workspace-setup-help mb-0">Describe what this workspace is for so Ori can review the setup and recommend the right agents, MCPs, and skills.</p>
-                </div>
+                <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>
+                <div id="templateAgentReviewList" class="workspace-template-agent-list"></div>
+                <div id="templateAgentReviewWarnings" class="workspace-template-agent-warnings" hidden></div>
               </div>
 
-              <textarea id="folderDescriptionInput" class="modern-input w-100 mb-2" placeholder="What this workspace is for and what Ori should help with" rows="3" style="resize: vertical;"></textarea>
+              <!-- REAPER Setup card: shown only when the Reaper Song template is
+                   selected. Populated by sessions.js from /api/reaper-setup/preview. -->
+              <div id="reaperSetupCard" class="workspace-setup-card reaper-setup-card mb-2" role="group" aria-label="REAPER Setup" hidden>
+                <div class="workspace-setup-header" style="align-items: flex-start;">
+                  <div>
+                    <div class="workspace-setup-title">REAPER Setup</div>
+                    <p id="reaperSetupStatusText" class="workspace-setup-help mb-0" aria-live="polite">Checking reaper-plugin…</p>
+                  </div>
+                  <span id="reaperSetupBadge" class="reaper-setup-badge" aria-hidden="true"></span>
+                </div>
+                <div id="reaperSetupDetail" class="reaper-setup-detail" style="font-size: 12px; color: var(--text-secondary); margin-top: 6px;"></div>
+                <div id="reaperSetupActions" class="reaper-setup-actions d-flex flex-wrap gap-2" style="margin-top: 8px;"></div>
+              </div>
 
-              <label for="folderSystemsInput" style="font-size: 12px; color: var(--text-secondary);">Apps and systems <span style="opacity: 0.8;">(optional)</span></label>
-              <input type="text" id="folderSystemsInput" class="modern-input w-100 mb-2" placeholder="Keynote, Finder, Google Drive">
-
-              <label for="folderContextInput" style="font-size: 12px; color: var(--text-secondary);">Key files or context <span style="opacity: 0.8;">(optional)</span></label>
-              <textarea id="folderContextInput" class="modern-input w-100" placeholder="Folder paths, source docs, launch notes, brand references" rows="2" style="resize: vertical;"></textarea>
-            </div>
-
-            <!-- ===== Advanced: agent behavior, folder-as-template, group, tags, color ===== -->
-            <details id="folderAdvancedDisclosure" class="workspace-advanced-details mb-2">
-              <summary class="workspace-advanced-summary">
-                <span class="workspace-advanced-summary-title">Advanced</span>
-                <span id="folderBehaviorHint" class="workspace-advanced-summary-hint" aria-live="polite">Agent behavior: General</span>
-              </summary>
-              <div class="workspace-advanced-body">
-                <label for="folderPresetSelect" style="font-size: 12px; color: var(--text-secondary);">Agent behavior</label>
-                <select id="folderPresetSelect" class="modern-input w-100 mb-2" aria-label="Agent behavior">
-                  <option value="general" selected>General</option>
-                  <option value="research">Research</option>
-                  <option value="software_project">Software Project</option>
-                </select>
-                <div style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
-                  Controls how agents in this workspace plan and act — planning depth, whether they write a PRD / task list, and when they ask before destructive actions. Set automatically from your Template; change it anytime.
+              <!-- Designation: name + description feed Ori's setup review. -->
+              <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
+              <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
+              <div class="workspace-setup-card mb-2">
+                <div class="workspace-setup-header" style="align-items: flex-start;">
+                  <div>
+                    <label for="folderDescriptionInput" class="workspace-setup-title">Workspace Description</label>
+                    <p class="workspace-setup-help mb-0">Describe what this workspace is for so Ori can review the setup and recommend the right agents, MCPs, and skills.</p>
+                  </div>
                 </div>
 
-                <label for="projectTemplatePathInput" style="font-size: 12px; color: var(--text-secondary);">Use any folder as a template</label>
-                <div class="d-flex flex-column flex-sm-row gap-2 mb-1">
-                  <input type="text" id="projectTemplatePathInput" class="modern-input w-100" placeholder="/absolute/path/to/template-folder" autocomplete="off">
-                  <button type="button" id="projectTemplateBrowseBtn" class="modern-btn modern-btn-secondary" style="white-space: nowrap; min-width: 130px;" aria-label="Browse for a template folder">
-                    Choose folder…
-                  </button>
+                <textarea id="folderDescriptionInput" class="modern-input w-100 mb-2" placeholder="What this workspace is for and what Ori should help with" rows="3" style="resize: vertical;"></textarea>
+
+                <label for="folderSystemsInput" style="font-size: 12px; color: var(--text-secondary);">Apps and systems <span style="opacity: 0.8;">(optional)</span></label>
+                <input type="text" id="folderSystemsInput" class="modern-input w-100 mb-2" placeholder="Keynote, Finder, Google Drive">
+
+                <label for="folderContextInput" style="font-size: 12px; color: var(--text-secondary);">Key files or context <span style="opacity: 0.8;">(optional)</span></label>
+                <textarea id="folderContextInput" class="modern-input w-100" placeholder="Folder paths, source docs, launch notes, brand references" rows="2" style="resize: vertical;"></textarea>
+              </div>
+
+              <!-- Advanced: agent behavior, folder-as-template, group, tags, color. -->
+              <details id="folderAdvancedDisclosure" class="workspace-advanced-details mb-2">
+                <summary class="workspace-advanced-summary">
+                  <span class="workspace-advanced-summary-title">Advanced</span>
+                  <span id="folderBehaviorHint" class="workspace-advanced-summary-hint" aria-live="polite">Agent behavior: General</span>
+                </summary>
+                <div class="workspace-advanced-body">
+                  <label for="folderPresetSelect" style="font-size: 12px; color: var(--text-secondary);">Agent behavior</label>
+                  <select id="folderPresetSelect" class="modern-input w-100 mb-2" aria-label="Agent behavior">
+                    <option value="general" selected>General</option>
+                    <option value="research">Research</option>
+                    <option value="software_project">Software Project</option>
+                  </select>
+                  <div style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
+                    Controls how agents in this workspace plan and act — planning depth, whether they write a PRD / task list, and when they ask before destructive actions. Set automatically from your Template; change it anytime.
+                  </div>
+
+                  <label for="projectTemplatePathInput" style="font-size: 12px; color: var(--text-secondary);">Use any folder as a template</label>
+                  <div class="d-flex flex-column flex-sm-row gap-2 mb-1">
+                    <input type="text" id="projectTemplatePathInput" class="modern-input w-100" placeholder="/absolute/path/to/template-folder" autocomplete="off">
+                    <button type="button" id="projectTemplateBrowseBtn" class="modern-btn modern-btn-secondary" style="white-space: nowrap; min-width: 130px;" aria-label="Browse for a template folder">
+                      Choose folder…
+                    </button>
+                  </div>
+                  <div style="margin-top: -2px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
+                    Scaffolds the chosen folder's files into the workspace as its project. Overrides the template selection above.
+                  </div>
+
+                  <label for="folderParentSelect" style="font-size: 12px; color: var(--text-secondary);">Group (optional)</label>
+                  <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select workspace group" aria-describedby="folderParentHelp">
+                    <option value="">No group</option>
+                  </select>
+                  <div id="folderParentHelp" style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
+                    Optional. Choose a group for this workspace.
+                  </div>
+
+                  <label style="font-size: 12px; color: var(--text-secondary);">Tags <span style="opacity: 0.8;">(optional)</span></label>
+                  <div id="folderTagsMount" class="mb-1"></div>
+                  <div id="folderTemplateTagsHint" style="margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
+
+                  <div class="folder-color-picker">
+                    <label style="font-size: 12px; color: var(--text-secondary);">Color:</label>
+                    <div id="folderColorOptions" class="folder-color-options mt-1">
+                      <button type="button" class="folder-color-btn active" data-color="" title="Default" aria-label="Default color"></button>
+                      <button type="button" class="folder-color-btn" data-color="#ef4444" title="Red" aria-label="Red color" style="background: #ef4444;"></button>
+                      <button type="button" class="folder-color-btn" data-color="#f59e0b" title="Orange" aria-label="Orange color" style="background: #f59e0b;"></button>
+                      <button type="button" class="folder-color-btn" data-color="#22c55e" title="Green" aria-label="Green color" style="background: #22c55e;"></button>
+                      <button type="button" class="folder-color-btn" data-color="#3b82f6" title="Blue" aria-label="Blue color" style="background: #3b82f6;"></button>
+                      <button type="button" class="folder-color-btn" data-color="#8b5cf6" title="Purple" aria-label="Purple color" style="background: #8b5cf6;"></button>
+                      <button type="button" class="folder-color-btn" data-color="#ec4899" title="Pink" aria-label="Pink color" style="background: #ec4899;"></button>
+                    </div>
+                  </div>
                 </div>
-                <div style="margin-top: -2px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
-                  Scaffolds the chosen folder's files into the workspace as its project. Overrides the template selection above.
+              </details>
+
+              <input type="checkbox" id="folderImportToggle" hidden aria-hidden="true" tabindex="-1">
+              <div id="folderImportCard" class="workspace-setup-card mb-2" hidden>
+                <div class="workspace-setup-header" style="align-items: flex-start;">
+                  <div>
+                    <div class="workspace-setup-title">Import Folder</div>
+                    <p class="workspace-setup-help mb-0">Link a local folder so this workspace starts with real project context.</p>
+                  </div>
                 </div>
 
-                <label for="folderParentSelect" style="font-size: 12px; color: var(--text-secondary);">Group (optional)</label>
-                <select id="folderParentSelect" class="modern-input w-100 mb-2" aria-label="Select workspace group" aria-describedby="folderParentHelp">
-                  <option value="">No group</option>
-                </select>
-                <div id="folderParentHelp" style="margin-top: -6px; margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);">
-                  Optional. Choose a group for this workspace.
-                </div>
+                <div id="folderImportSection" hidden>
+                  <label for="folderImportPathInput" style="font-size: 12px; color: var(--text-secondary);">Folder path</label>
+                  <div class="d-flex flex-column flex-sm-row gap-2 mb-2">
+                    <input type="text" id="folderImportPathInput" class="modern-input w-100" placeholder="/absolute/path/to/project" autocomplete="off">
+                    <button type="button" id="folderImportBrowseBtn" class="modern-btn modern-btn-secondary" style="white-space: nowrap; min-width: 96px;" aria-label="Browse for folder path">
+                      Browse
+                    </button>
+                  </div>
+                  <div style="margin-top: -6px; margin-bottom: 8px; font-size: 12px; color: var(--text-secondary);">
+                    Enter an absolute path to import. Workspace name defaults to the folder name, and you can edit it.
+                  </div>
 
-                <label style="font-size: 12px; color: var(--text-secondary);">Tags <span style="opacity: 0.8;">(optional)</span></label>
-                <div id="folderTagsMount" class="mb-1"></div>
-                <div id="folderTemplateTagsHint" style="margin-bottom: 10px; font-size: 12px; color: var(--text-secondary);" aria-live="polite" hidden></div>
-
-                <div class="folder-color-picker">
-                  <label style="font-size: 12px; color: var(--text-secondary);">Color:</label>
-                  <div id="folderColorOptions" class="folder-color-options mt-1">
-                    <button type="button" class="folder-color-btn active" data-color="" title="Default" aria-label="Default color"></button>
-                    <button type="button" class="folder-color-btn" data-color="#ef4444" title="Red" aria-label="Red color" style="background: #ef4444;"></button>
-                    <button type="button" class="folder-color-btn" data-color="#f59e0b" title="Orange" aria-label="Orange color" style="background: #f59e0b;"></button>
-                    <button type="button" class="folder-color-btn" data-color="#22c55e" title="Green" aria-label="Green color" style="background: #22c55e;"></button>
-                    <button type="button" class="folder-color-btn" data-color="#3b82f6" title="Blue" aria-label="Blue color" style="background: #3b82f6;"></button>
-                    <button type="button" class="folder-color-btn" data-color="#8b5cf6" title="Purple" aria-label="Purple color" style="background: #8b5cf6;"></button>
-                    <button type="button" class="folder-color-btn" data-color="#ec4899" title="Pink" aria-label="Pink color" style="background: #ec4899;"></button>
+                  <div id="folderImportDuplicateWarning" class="modern-card p-2 mb-2" style="display: none; border: 1px solid #f59e0b; background: rgba(245, 158, 11, 0.08);">
+                    <div id="folderImportDuplicateText" style="font-size: 12px; color: var(--text-primary); margin-bottom: 8px;" aria-live="polite"></div>
+                    <div class="d-flex flex-column flex-sm-row gap-2">
+                      <button type="button" id="folderImportOpenExistingBtn" class="modern-btn modern-btn-secondary" style="flex: 1;">Open Existing</button>
+                      <button type="button" id="folderImportProceedDuplicateBtn" class="modern-btn modern-btn-primary" style="flex: 1;">Import Anyway</button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </details>
 
-            <input type="checkbox" id="folderImportToggle" hidden aria-hidden="true" tabindex="-1">
-            <div id="folderImportCard" class="workspace-setup-card mb-2" hidden>
-              <div class="workspace-setup-header" style="align-items: flex-start;">
-                <div>
-                  <div class="workspace-setup-title">Import Folder</div>
-                  <p class="workspace-setup-help mb-0">Link a local folder so this workspace starts with real project context.</p>
-                </div>
-              </div>
-
-              <div id="folderImportSection" hidden>
-                <label for="folderImportPathInput" style="font-size: 12px; color: var(--text-secondary);">Folder path</label>
-                <div class="d-flex flex-column flex-sm-row gap-2 mb-2">
-                  <input type="text" id="folderImportPathInput" class="modern-input w-100" placeholder="/absolute/path/to/project" autocomplete="off">
-                  <button type="button" id="folderImportBrowseBtn" class="modern-btn modern-btn-secondary" style="white-space: nowrap; min-width: 96px;" aria-label="Browse for folder path">
-                    Browse
-                  </button>
-                </div>
-                <div style="margin-top: -6px; margin-bottom: 8px; font-size: 12px; color: var(--text-secondary);">
-                  Enter an absolute path to import. Workspace name defaults to the folder name, and you can edit it.
-                </div>
-
-                <div id="folderImportDuplicateWarning" class="modern-card p-2 mb-2" style="display: none; border: 1px solid #f59e0b; background: rgba(245, 158, 11, 0.08);">
-                  <div id="folderImportDuplicateText" style="font-size: 12px; color: var(--text-primary); margin-bottom: 8px;" aria-live="polite"></div>
-                  <div class="d-flex flex-column flex-sm-row gap-2">
-                    <button type="button" id="folderImportOpenExistingBtn" class="modern-btn modern-btn-secondary" style="flex: 1;">Open Existing</button>
-                    <button type="button" id="folderImportProceedDuplicateBtn" class="modern-btn modern-btn-primary" style="flex: 1;">Import Anyway</button>
-                  </div>
-                </div>
-              </div>
             </div>
-
           </div>
         </div>
       </div>
       <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
+        <button type="button" id="wizardBackBtn" class="modern-btn modern-btn-secondary me-auto" hidden>← Back</button>
         <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" id="createFolderBtn" class="modern-btn modern-btn-primary">Create Workspace</button>
+        <button type="button" id="wizardNextBtn" class="modern-btn modern-btn-primary">Next →</button>
+        <button type="button" id="createFolderBtn" class="modern-btn modern-btn-primary" hidden>Create Workspace</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Restages the create-workspace ("Construct") modal from a single long scroll into a **two-step blueprint-picker wizard**, so the user is never faced with the whole form at once. This addresses the "too much information at once" feel of the previous single-screen modal while keeping every existing field and capability.

### Step 1 · Select Blueprint
- Compact, uniform blueprint cards (icon + name + one-line **tagline**), replacing the old paragraph-per-card grid.
- A live **Briefing** panel below the grid updates on selection: full description + a `DEPLOYS` readout — agent roster by name, recommended add-ons as chips, and whether it scaffolds a project folder. You choose *with* full deploy info in view.
- Double-clicking a blueprint selects it and skips straight to step 2.

### Step 2 · Construct
- A slim recap of the chosen blueprint ("Constructing: <icon> <name>").
- The editable **Template Agents** review, **name**, **description**, and **Advanced** (which now also holds Group / Tags / Color).

A stepper (`Select Blueprint → Construct`) shows progress; **Next/Back** navigate and **Back preserves the selection**. **Import mode** stays a single step — no stepper, no blueprint, no briefing — with the button labeled "Import Folder".

## Backend
- Adds `Tagline` and `Addons` fields to the project-template manifest/type, populates them across the 7 built-in templates (moving "Recommended add-ons:" prose into structured `addons`), and bumps `builtin_version` so existing installs refresh. Covered by a new unit test.

## Verification
Smoke-tested end to end on isolated servers, light and dark themes:
- Created workspaces from **Research Project** (3 agents, 2 starter tasks, tags, description) and **Writing Project** (project-folder scaffold `outline.md` + `chapters/` + 3 agents) — all seeded correctly.
- **Reaper Song**: REAPER setup card, open-after-create toggle, and scaffold row all appear; create is correctly gated by the pre-existing reaper-plugin readiness check.
- Wizard flow: selection updates briefing, double-click advances, Back preserves selection, import mode collapses to a single step.
- `go vet ./...` clean; `projecttemplates` + `server` tests pass. (The only failing tests are pre-existing `internal/llm` live-API 429s, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)