### PR TITLE
feat(home): restore shared sidebar navigation

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,10 +225,8 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Extra["WorkspaceCount"] = workspaceCount
 	data.Extra["IsFirstRun"] = workspaceCount == 0
-	// Home is a dedicated command bridge rather than a second navigation shell.
-	// Keep sidebar behavior on every other page unchanged.
-	data.ShowSidebarToggle = false
-	data.Extra["HideSidebar"] = true
+	// Keep the command bridge as the home surface while retaining the shared
+	// application navigation, including its sidebar and navbar toggle.
 	data.Extra["HomeCommandBridge"] = true
 
 	s.renderAndWritePage(w, "index", data)

--- a/internal/web/static/css/layout.css
+++ b/internal/web/static/css/layout.css
@@ -215,14 +215,6 @@ body.home-command-page::before {
     max-width: 100vw;
     width: 100vw;
   }
-
-  /* Home omits the sidebar from the DOM, so the sibling selector above cannot
-     reset its desktop offset. Scope this reset strictly to the bridge. */
-  body.home-command-page .main-content {
-    margin-left: 0;
-    max-width: 100vw;
-    width: 100%;
-  }
 }
 
 /* =============================================================================

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -50,12 +50,22 @@ test.describe('Smoke Tests', () => {
     }
   });
 
-  test('home uses navbar navigation without a sidebar', async ({ page }) => {
+  test('home exposes the shared sidebar navigation', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.locator('.navbar').first()).toBeVisible();
-    await expect(page.locator('#sidebar')).toHaveCount(0);
-    await expect(page.locator('#sidebarToggle')).toHaveCount(0);
+    const sidebar = page.locator('#sidebar');
+    const sidebarToggle = page.locator('#sidebarToggle');
+
+    await expect(sidebar).toHaveCount(1);
+    await expect(sidebarToggle).toBeVisible();
+    await expect(sidebarToggle).toHaveAttribute('aria-expanded', 'false');
+
+    await sidebarToggle.click();
+
+    await expect(sidebar).toBeVisible();
+    await expect(sidebarToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(sidebar.getByRole('link', { name: 'Workflows' })).toBeVisible();
   });
 });
 
@@ -189,7 +199,8 @@ test.describe('Home First Run', () => {
       'Plan a product launch…'
     );
     await expect(page.getByRole('button', { name: 'Create a workspace' })).toBeVisible();
-    await expect(page.locator('#sidebar')).toHaveCount(0);
+    await expect(page.locator('#sidebar')).toHaveCount(1);
+    await expect(page.locator('#sidebarToggle')).toBeVisible();
   });
 
   test('keeps the command-strip interaction contract on home', async ({ page }) => {


### PR DESCRIPTION
## Summary

- restore the shared sidebar and navbar toggle on the Home Command Bridge
- restore desktop content offset while the sidebar is open
- cover normal and first-run Home sidebar behavior in smoke tests

## Validation

- go test ./internal/server -run '^$'
- focused Playwright Home sidebar and first-run smoke checks