### PR TITLE
fix: reconnect agents roster stage to the full detail page + model picker

### DIFF
--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -541,6 +541,17 @@
 
 .field__control textarea { resize: vertical; line-height: 1.5; }
 
+/* Read-only derived field (e.g. Provider, set by the selected model). */
+.field__control input.field__readonly {
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-secondary, #6b7280);
+  cursor: default;
+}
+.field__control input.field__readonly:focus-visible {
+  outline: none;
+  border-color: var(--border-color, #d1d5db);
+}
+
 .stage-textarea {
   width: 100%;
   resize: vertical;
@@ -651,6 +662,10 @@
 [data-bs-theme="dark"] .field__control textarea,
 [data-bs-theme="dark"] .stage-textarea {
   background: rgba(255, 255, 255, 0.04);
+}
+[data-bs-theme="dark"] .field__control input.field__readonly {
+  background: rgba(255, 255, 255, 0.015);
+  color: var(--text-secondary, #9ca3af);
 }
 
 @media (max-width: 560px) {

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -320,10 +320,30 @@
   background: linear-gradient(180deg, color-mix(in srgb, var(--primary-color, #4f46e5) 6%, transparent), transparent);
 }
 
-.stage__delete {
+.stage__actions {
   position: absolute;
   top: 16px;
   right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage__fullpage {
+  font-size: 12px;
+  border: 1px solid color-mix(in srgb, var(--primary-color, #4f46e5) 45%, var(--border-color, #e5e7eb));
+  color: var(--primary-color, #4f46e5);
+  background: transparent;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.stage__fullpage:hover { background: color-mix(in srgb, var(--primary-color, #4f46e5) 12%, transparent); }
+.stage__fullpage:focus-visible { outline: 2px solid var(--primary-color, #4f46e5); outline-offset: 2px; }
+
+.stage__delete {
   font-size: 12px;
   border: 1px solid color-mix(in srgb, #dc2626 55%, var(--border-color, #e5e7eb));
   color: #dc2626;
@@ -723,7 +743,7 @@
     padding: 18px 18px 16px;
   }
   .stage__avatar { width: 52px; height: 52px; font-size: 20px; }
-  .stage__delete { top: 12px; right: 14px; }
+  .stage__actions { top: 12px; right: 14px; }
   .stage__panels { padding: 16px; }
   .stage-facts { grid-template-columns: 1fr; gap: 2px 0; }
   .stage-facts dt { margin-top: 8px; }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -61,6 +61,7 @@
       promptBody: document.getElementById('promptBody'),
       workspacesBody: document.getElementById('workspacesBody'),
       stageDelete: document.getElementById('stageDelete'),
+      stageFullPage: document.getElementById('stageFullPage'),
       newAgentBtn: document.getElementById('newAgentBtn'),
       createPanel: document.getElementById('createPanel'),
       createBody: document.getElementById('createBody'),
@@ -263,6 +264,10 @@
     els.avatar = document.getElementById('stageAvatar');
     els.name.textContent = listItem.name;
     els.klass.textContent = titleCase(listItem.role || listItem.type || 'agent');
+    // Deep-link to the full agent detail page (/agents/{name}). The server routes
+    // this to the rich editor for catalog agents and to the dedicated read-only
+    // pages for the built-in Claude Code / Codex CLI agents.
+    els.stageFullPage.href = '/agents/' + encodeURIComponent(name);
 
     els.workspacesBody.innerHTML = '<p class="stage-hint">Loading…</p>';
     els.overviewFacts.innerHTML = '<p class="stage-hint">Loading…</p>';

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -344,14 +344,19 @@
     // fall back to free text so the field always works.
     var hasCatalog = Array.isArray(state.providers) && state.providers.length > 0;
     var modelControl = hasCatalog
-      ? modelSelectInput('ov-model', detail.model || '')
+      ? modelSelectInput('ov-model', detail.model || '', detail.provider || '')
       : textInput('ov-model', detail.model || '');
+    // With the picker, provider is derived from the chosen model, so it is shown
+    // read-only. Without a catalog (text fallback) it stays editable.
+    var providerControl = hasCatalog
+      ? readonlyInput('ov-provider', detail.provider || '', 'Set by the selected model')
+      : textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…');
 
     els.overviewFacts.innerHTML =
       '<form class="stage-form" id="overviewForm" novalidate>' +
       field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
       field('Model', modelControl, 'ov-model') +
-      field('Provider', textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…'), 'ov-provider') +
+      field('Provider', providerControl, 'ov-provider') +
       field('Temperature', numInput('ov-temperature', detail.temperature, '0', '2', '0.1'), 'ov-temperature') +
       field('Reasoning effort', selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) { return v ? titleCase(v) : 'Default'; }), 'ov-reasoning') +
       field('Max output tokens', numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1'), 'ov-maxtokens') +
@@ -943,6 +948,12 @@
     return '<input id="' + id + '" type="text" value="' + esc(value) + '"' +
       (placeholder ? ' placeholder="' + esc(placeholder) + '"' : '') + '>';
   }
+  // A read-only text input for derived values (e.g. Provider, set by the model).
+  // Kept as an <input> so the form still submits its value, but not user-editable.
+  function readonlyInput(id, value, title) {
+    return '<input id="' + id + '" class="field__readonly" type="text" readonly tabindex="-1" value="' + esc(value) + '"' +
+      (title ? ' title="' + esc(title) + '"' : '') + '>';
+  }
   function numInput(id, value, min, max, step) {
     return '<input id="' + id + '" type="number" value="' + esc(value === '' ? '' : value) + '"' +
       (min !== '' ? ' min="' + min + '"' : '') + (max ? ' max="' + max + '"' : '') + (step ? ' step="' + step + '"' : '') + '>';
@@ -964,7 +975,7 @@
   // carries data-provider so the Provider field can follow the chosen model. A
   // model that isn't in the catalog (custom, or a provider without a key) is
   // preserved under a "Current" group so switching to a picker never drops it.
-  function modelSelectInput(id, currentValue) {
+  function modelSelectInput(id, currentValue, currentProvider) {
     var providers = state.providers || [];
     var groups = '';
     var matched = false;
@@ -984,7 +995,8 @@
     });
     if (currentValue && !matched) {
       groups = '<optgroup label="Current">' +
-        '<option value="' + esc(currentValue) + '" selected>' + esc(currentValue) + '</option>' +
+        '<option value="' + esc(currentValue) + '" data-provider="' + esc(currentProvider || '') + '" selected>' +
+        esc(currentValue) + '</option>' +
         '</optgroup>' + groups;
     }
     return '<select id="' + id + '">' + groups + '</select>';

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -36,6 +36,7 @@
     dirty: { overview: false, prompt: false, workspaces: false },
     allWorkspaces: null,
     creating: false,
+    providers: null,
   };
 
   var els = {};
@@ -96,10 +97,29 @@
       if (anyDirty()) { e.preventDefault(); e.returnValue = ''; }
     });
 
+    loadProviders();
     loadAgents();
   }
 
   /* ---- data ---------------------------------------------------------------- */
+
+  // Load the available LLM providers + their models so the overview Model field
+  // can offer a picker instead of free text. Fire-and-forget: if it fails or is
+  // slow, renderOverview falls back to a text input.
+  function loadProviders() {
+    fetch('/api/providers')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        state.providers = (data && Array.isArray(data.providers)) ? data.providers : [];
+        // If an agent was already selected and its overview rendered before the
+        // model list arrived (as a text input), re-render so the picker appears.
+        // Guarded by !dirty so we never clobber unsaved edits.
+        if (state.selected && !state.dirty.overview && state.detailCache[state.selected]) {
+          renderOverview(state.selected, state.detailCache[state.selected]);
+        }
+      })
+      .catch(function () { state.providers = []; });
+  }
 
   function loadAgents() {
     fetch('/api/agents/dashboard/list?sort_by=name&order=asc')
@@ -320,10 +340,17 @@
       return;
     }
 
+    // Offer a model picker when the provider/model catalog is loaded; otherwise
+    // fall back to free text so the field always works.
+    var hasCatalog = Array.isArray(state.providers) && state.providers.length > 0;
+    var modelControl = hasCatalog
+      ? modelSelectInput('ov-model', detail.model || '')
+      : textInput('ov-model', detail.model || '');
+
     els.overviewFacts.innerHTML =
       '<form class="stage-form" id="overviewForm" novalidate>' +
       field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
-      field('Model', textInput('ov-model', detail.model || ''), 'ov-model') +
+      field('Model', modelControl, 'ov-model') +
       field('Provider', textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…'), 'ov-provider') +
       field('Temperature', numInput('ov-temperature', detail.temperature, '0', '2', '0.1'), 'ov-temperature') +
       field('Reasoning effort', selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) { return v ? titleCase(v) : 'Default'; }), 'ov-reasoning') +
@@ -336,6 +363,18 @@
     els.overviewDesc.innerHTML = '';
     wireDirty('overview', document.getElementById('overviewForm'));
     wireSaveBar('overview', function () { saveOverview(name); });
+
+    // When picking a model from the catalog, keep the Provider field in sync with
+    // the model's owning provider so the two never drift out of agreement.
+    var modelSel = document.getElementById('ov-model');
+    if (modelSel && modelSel.tagName === 'SELECT') {
+      modelSel.addEventListener('change', function () {
+        var opt = modelSel.options[modelSel.selectedIndex];
+        var prov = opt && opt.getAttribute('data-provider');
+        var provEl = document.getElementById('ov-provider');
+        if (prov && provEl) provEl.value = prov;
+      });
+    }
   }
 
   function readonlyFacts(detail) {
@@ -920,6 +959,35 @@
   }
   function textareaInput(id, value, rows) {
     return '<textarea id="' + id + '" rows="' + rows + '">' + esc(value) + '</textarea>';
+  }
+  // Grouped <select> of available models (optgroup per provider). Each option
+  // carries data-provider so the Provider field can follow the chosen model. A
+  // model that isn't in the catalog (custom, or a provider without a key) is
+  // preserved under a "Current" group so switching to a picker never drops it.
+  function modelSelectInput(id, currentValue) {
+    var providers = state.providers || [];
+    var groups = '';
+    var matched = false;
+    providers.forEach(function (p) {
+      if (!p || !Array.isArray(p.models) || p.models.length === 0) return;
+      var seen = {};
+      var opts = '';
+      p.models.forEach(function (m) {
+        if (!m || !m.value || seen[m.value]) return;
+        seen[m.value] = true;
+        var sel = m.value === currentValue;
+        if (sel) matched = true;
+        opts += '<option value="' + esc(m.value) + '" data-provider="' + esc(m.provider || p.name) + '"' +
+          (sel ? ' selected' : '') + '>' + esc(m.label || m.value) + '</option>';
+      });
+      if (opts) groups += '<optgroup label="' + esc(p.display_name || p.name) + '">' + opts + '</optgroup>';
+    });
+    if (currentValue && !matched) {
+      groups = '<optgroup label="Current">' +
+        '<option value="' + esc(currentValue) + '" selected>' + esc(currentValue) + '</option>' +
+        '</optgroup>' + groups;
+    }
+    return '<select id="' + id + '">' + groups + '</select>';
   }
   function saveBar(tab) {
     return '<div class="save-bar" id="savebar-' + tab + '">' +

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -70,7 +70,10 @@
               <div class="stage__vitals" id="stageVitals" role="group" aria-label="Agent vitals">
                 <!-- vitals chips injected -->
               </div>
-              <button type="button" id="stageDelete" class="stage__delete" hidden title="Delete this agent">Delete</button>
+              <div class="stage__actions">
+                <a id="stageFullPage" class="stage__fullpage" href="#" title="Open the full agent detail page">Open full page ↗</a>
+                <button type="button" id="stageDelete" class="stage__delete" hidden title="Delete this agent">Delete</button>
+              </div>
             </header>
 
             <nav class="stage__tabs" role="tablist" aria-label="Agent detail sections">


### PR DESCRIPTION
## Summary

Polish for the default **Agents roster** page (`/agents`), reconnecting it to the standalone detail page and replacing free-text model entry with a picker.

### 1. Deep-link to the full detail page
The roster's inline stage showed agent details but never linked out to the standalone `/agents/{name}` page — leaving the richer editor (usage stats, full model tuning, profile/avatar/tags) and the dedicated read-only Claude Code / Codex pages reachable only by typing the URL. Added an **"Open full page ↗"** link to the stage hero. The server already routes `/agents/{name}` to the correct per-agent-type detail page.

### 2. Model field → provider-grouped picker
The overview **Model** field was free text, forcing users to remember exact model IDs. It now fetches `/api/providers` and renders a `<select>` grouped by provider (optgroup per provider, duplicate category entries de-duped).
- Off-catalog models (custom, or a provider without a key) are preserved under a **"Current"** group and stay selected — switching to a picker never silently drops an agent's model.
- Falls back to the text input if the catalog hasn't loaded, then re-renders once it arrives (guarded by `!dirty` to protect unsaved edits).

### 3. Provider field read-only, derived from the model
Since a model belongs to a provider, the **Provider** field is now read-only (muted, out of tab order) and auto-fills from the chosen model. It still submits its value; the text-fallback path keeps it editable.

## Testing
Verified live against an isolated smoke server (dummy OpenAI key, 140-model catalog, dark mode):
- "Open full page" navigates to the dedicated Claude Code detail page.
- Model select groups OpenAI/Gemini/Ollama/LM Studio; current model preserved/selected; off-catalog `gpt-5.4-mini` lands in "Current".
- Picking a Gemini model flips Provider `openai → gemini`; Save enables; Provider is `readOnly` with `tabindex=-1`.
- `go build ./cmd/server` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)