### PR TITLE
feat: create-workspace wizard polish (name-first, Blank agent, agent chips, reuse UX, quick wins)

### DIFF
--- a/internal/sessionhttp/project_templates.go
+++ b/internal/sessionhttp/project_templates.go
@@ -56,6 +56,7 @@ func (h *Handler) handleTemplateAgentPlan(w http.ResponseWriter, r *http.Request
 	var req struct {
 		TemplateID   string `json:"template_id,omitempty"`
 		TemplatePath string `json:"template_path,omitempty"`
+		Blank        bool   `json:"blank,omitempty"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
@@ -66,6 +67,12 @@ func (h *Handler) handleTemplateAgentPlan(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if strings.TrimSpace(req.TemplateID) == "" && strings.TrimSpace(req.TemplatePath) == "" {
+		// The Blank blueprint has no library template; serve its synthetic
+		// single-agent roster so the review panel can show/edit the entry agent.
+		if req.Blank {
+			_ = orihttp.RespondSuccess(w, h.buildTemplateAgentPlan(blankWorkspaceTemplate()))
+			return
+		}
 		_ = orihttp.RespondSuccess(w, h.buildTemplateAgentPlan(projecttemplates.Template{}))
 		return
 	}

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -72,6 +72,31 @@ type templateAgentOverride struct {
 	SystemPrompt *string `json:"system_prompt,omitempty"`
 }
 
+// blankWorkspaceEntryAgentName is the reusable entry agent seeded for the Blank
+// blueprint. Like every other template's entry agent (e.g. "Reaper Producer"),
+// it is a normal global agent reused on name-match across blank workspaces.
+const blankWorkspaceEntryAgentName = "Workspace Manager"
+
+const blankWorkspaceEntryPrompt = "You are the workspace manager. Act as the default front door for this workspace: " +
+	"clarify user intent, answer directly when the request only needs shared context, and break work into " +
+	"tasks for specialists when needed."
+
+// blankWorkspaceTemplate is the synthetic single-agent roster for the Blank
+// blueprint. It flows through the normal template-agent plan/seed machinery so a
+// blank workspace ships with a reviewable, editable entry agent — but it carries
+// no skeleton, starter tasks, or project, so only its Agents roster is ever used.
+func blankWorkspaceTemplate() projecttemplates.Template {
+	return projecttemplates.Template{
+		Name: "Blank workspace",
+		Agents: []projecttemplates.AgentSpec{{
+			Name:         blankWorkspaceEntryAgentName,
+			Role:         string(types.RoleOrchestrator),
+			Type:         agent.TypeGeneral,
+			SystemPrompt: blankWorkspaceEntryPrompt,
+		}},
+	}
+}
+
 // validAgentTypes canonicalizes a template-declared agent type to the real
 // vocabulary; an empty/unrecognized value maps to "" so the store applies its
 // own default (PRD FR8).

--- a/internal/sessionhttp/template_agents_test.go
+++ b/internal/sessionhttp/template_agents_test.go
@@ -289,6 +289,40 @@ func TestSeedTemplateAgents_EmptyRosterNoop(t *testing.T) {
 	}
 }
 
+func TestBlankWorkspaceTemplate_SeedsSingleEntryAgent(t *testing.T) {
+	handler, cleanup := createTestHandler(t)
+	defer cleanup()
+
+	tpl := blankWorkspaceTemplate()
+	if !tpl.HasAgents() || len(tpl.Agents) != 1 {
+		t.Fatalf("expected exactly one blank roster agent, got %d", len(tpl.Agents))
+	}
+
+	ws := &session.Workspace{ID: "ws-blank", Name: "Plain"}
+	res := handler.seedTemplateAgents(ws, tpl)
+
+	if !res.EntrySet {
+		t.Fatal("expected the blank Workspace Manager to be set as entry agent")
+	}
+	if got := currentWorkspaceEntryAgentName(ws); got != blankWorkspaceEntryAgentName {
+		t.Fatalf("expected entry agent %q, got %q", blankWorkspaceEntryAgentName, got)
+	}
+	created, ok := handler.agentStore.GetAgent(blankWorkspaceEntryAgentName)
+	if !ok {
+		t.Fatalf("expected agent %q to be created", blankWorkspaceEntryAgentName)
+	}
+	if strings.TrimSpace(created.Settings.SystemPrompt) == "" {
+		t.Fatal("expected the blank entry agent to carry a system prompt")
+	}
+
+	// The plan the review panel renders must advertise the single entry agent.
+	plan := handler.buildTemplateAgentPlan(blankWorkspaceTemplate())
+	if !plan.HasAgents || plan.EntryAgentName != blankWorkspaceEntryAgentName {
+		t.Fatalf("expected plan entry %q, got has_agents=%v entry=%q",
+			blankWorkspaceEntryAgentName, plan.HasAgents, plan.EntryAgentName)
+	}
+}
+
 func TestCanonicalAgentTypeAndRole(t *testing.T) {
 	if got := canonicalAgentType("General"); got != agent.TypeGeneral {
 		t.Fatalf("type General -> %q", got)

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -223,6 +223,7 @@ type createWorkspaceRequest struct {
 	Tags                   []string                   `json:"tags,omitempty"`          // Optional initial tags; merged with template tags
 	CreateTemplateAgents   *bool                      `json:"create_template_agents,omitempty"`
 	TemplateAgentOverrides []templateAgentOverride    `json:"template_agent_overrides,omitempty"`
+	Blank                  bool                       `json:"blank,omitempty"` // The Blank blueprint: seed the synthetic single-agent roster (no template, no project)
 }
 
 // createWorkspace handles POST /api/workspaces. The flow is staged:
@@ -469,6 +470,18 @@ func (h *Handler) selectCreateWorkspaceEntryAgent(w http.ResponseWriter, ws *ses
 				seed.EntrySet = true
 			}
 		}
+	case req.Blank && kind != session.WorkspaceKindGroup && createTemplateAgentsEnabled(req):
+		// Blank blueprint: seed the synthetic single-agent roster (a reusable
+		// "Workspace Manager") so a blank workspace is chat-ready, honoring the
+		// review panel's edits (overrides) and its Create toggle. A seed failure
+		// surfaces a warning and leaves the workspace agent-less — the legacy
+		// no-entry-agent fallback the detail page already handles.
+		blankTpl, err := applyTemplateAgentOverrides(blankWorkspaceTemplate(), req.TemplateAgentOverrides)
+		if err != nil {
+			_ = orihttp.RespondBadRequest(w, err.Error())
+			return seed, false
+		}
+		seed = h.seedTemplateAgents(ws, blankTpl)
 	case kind == session.WorkspaceKindGroup:
 		if agentName := h.autoCreateManagerEntryAgent(ws); agentName != "" {
 			setWorkspaceEntryAgent(ws, agentName)

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -371,6 +371,51 @@
   color: var(--wc-ink-dim);
 }
 
+/* Agent chips: a role-hued dot + name. --wc-agent-dot carries the role hue,
+   defaulting to a neutral for specialists/unknown roles. */
+.workspace-create-modal .workspace-template-briefing-agent-chip {
+  --wc-agent-dot: var(--wc-ink-faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.4px;
+  padding: 2px 8px 2px 7px;
+  border: 1px solid var(--wc-line);
+  background: var(--wc-panel-2);
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-template-briefing-agent-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.5px solid var(--wc-agent-dot);
+  background: transparent;
+}
+/* Role hues. */
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="orchestrator"] { --wc-agent-dot: var(--wc-faction); }
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="researcher"] { --wc-agent-dot: #6cb2ff; }
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="validator"] { --wc-agent-dot: #e5b567; }
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="synthesizer"] { --wc-agent-dot: #b892ff; }
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="analyzer"] { --wc-agent-dot: #5fd0c8; }
+/* Validator reads as a "checkpoint": a mid-filled dot (◉) vs the hollow default. */
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="validator"] .workspace-template-briefing-agent-dot {
+  background: color-mix(in srgb, var(--wc-agent-dot) 55%, transparent);
+}
+/* Entry agent: the lead — solid green dot and a brighter chip. */
+.workspace-create-modal .workspace-template-briefing-agent-chip.is-entry {
+  --wc-agent-dot: var(--wc-faction);
+  border-color: var(--wc-line-bright);
+  background: color-mix(in srgb, var(--wc-faction) 9%, transparent);
+  color: var(--wc-ink);
+}
+.workspace-create-modal .workspace-template-briefing-agent-chip.is-entry .workspace-template-briefing-agent-dot {
+  background: var(--wc-faction);
+  border-color: var(--wc-faction);
+}
+
 .workspace-create-modal .workspace-template-agent-review {
   background: rgba(70, 211, 154, 0.06);
   border-color: var(--wc-faction-deep);

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -484,6 +484,66 @@
   border-color: rgba(78, 197, 230, 0.24);
 }
 
+/* Reused agent: a compact "already exists, will be linked" row. Its editable
+   view is hidden until "Make a workspace copy" forks a fresh agent. */
+.workspace-create-modal .workspace-template-agent-reuse {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.workspace-create-modal .workspace-template-agent-reuse-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+}
+.workspace-create-modal .workspace-template-agent-reuse-head .workspace-template-agent-meta {
+  margin-top: 0;
+}
+.workspace-create-modal .workspace-template-agent-reuse-name {
+  font-weight: 650;
+  color: var(--wc-ink);
+}
+.workspace-create-modal .workspace-template-agent-reuse-sub {
+  font-family: var(--wc-font-mono);
+  font-size: 11px;
+  color: var(--wc-ink-dim);
+}
+/* A locked reuse row hides the right-hand model column (the sub-line already
+   names the saved model); forking reveals the full editable layout. */
+.workspace-create-modal .workspace-template-agent-row.is-reuse:not([data-forked="true"]) .workspace-template-agent-model {
+  display: none;
+}
+.workspace-create-modal .workspace-template-agent-fork-btn {
+  align-self: flex-start;
+  margin-top: 2px;
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  color: var(--wc-faction);
+  background: color-mix(in srgb, var(--wc-faction) 8%, transparent);
+  border: 1px solid var(--wc-faction-deep);
+  cursor: pointer;
+}
+.workspace-create-modal .workspace-template-agent-fork-btn:hover {
+  background: color-mix(in srgb, var(--wc-faction) 16%, transparent);
+}
+.workspace-create-modal .workspace-template-agent-fork-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.workspace-create-modal .workspace-template-agent-fork-note {
+  display: none;
+  margin-top: 0.35rem;
+  font-size: 11px;
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-template-agent-row[data-forked="true"] .workspace-template-agent-fork-note {
+  display: block;
+}
+
 /* color picker: keep the swatch colors, tactical active ring */
 .workspace-create-modal .folder-color-btn.active {
   box-shadow: 0 0 0 2px var(--wc-faction);

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -240,6 +240,21 @@
   color: var(--wc-faction);
 }
 
+/* ---------- workspace name hint / inline error ---------- */
+.workspace-create-modal .workspace-create-name-hint {
+  margin-top: 5px;
+  font-family: var(--wc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.3px;
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-create-name-hint.is-error {
+  color: var(--wc-alert, #e5675b);
+}
+.workspace-create-modal .modern-input.is-invalid {
+  border-color: var(--wc-alert, #e5675b);
+}
+
 /* ---------- wizard stepper (Select Blueprint → Construct) ---------- */
 .workspace-create-modal .workspace-create-stepper {
   display: flex;

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -527,14 +527,36 @@ function ptcRenderBriefing(els, importMode, templatePath) {
   }
   if (els.briefingDefault) els.briefingDefault.hidden = showBriefing;
 
-  const agents = showBriefing && Array.isArray(template.agents) ? template.agents : [];
-  const agentNames = agents
-    .map((a) => String(a?.name || '').trim())
-    .filter(Boolean);
-  const showAgents = agentNames.length > 0;
+  const agentSpecs = showBriefing && Array.isArray(template.agents) ? template.agents : [];
+  const briefingAgents = agentSpecs
+    .map((a) => ({
+      name: String(a?.name || '').trim(),
+      role: String(a?.role || '').trim().toLowerCase()
+    }))
+    .filter((a) => a.name);
+  const showAgents = briefingAgents.length > 0;
   if (els.briefingAgentsRow) els.briefingAgentsRow.hidden = !showAgents;
-  if (els.briefingAgentsValue && showAgents) {
-    els.briefingAgentsValue.textContent = `${agentNames.length} — ${agentNames.join(', ')}`;
+  if (els.briefingAgentsValue) {
+    els.briefingAgentsValue.innerHTML = '';
+    // One chip per agent: a role-hued dot + name. The first roster entry is the
+    // workspace entry agent (solid dot, brighter chip); the rest are specialists.
+    briefingAgents.forEach((agent, index) => {
+      const isEntry = index === 0;
+      const chip = document.createElement('span');
+      chip.className = 'workspace-template-briefing-agent-chip';
+      if (isEntry) chip.classList.add('is-entry');
+      if (agent.role) chip.dataset.role = agent.role;
+      const roleLabel = isEntry
+        ? `entry agent${agent.role ? ` · ${agent.role}` : ''}`
+        : agent.role;
+      if (roleLabel) chip.title = `${agent.name} — ${roleLabel}`;
+      const dot = document.createElement('span');
+      dot.className = 'workspace-template-briefing-agent-dot';
+      dot.setAttribute('aria-hidden', 'true');
+      chip.appendChild(dot);
+      chip.appendChild(document.createTextNode(agent.name));
+      els.briefingAgentsValue.appendChild(chip);
+    });
   }
 
   const showScaffold = Boolean(showBriefing && template.has_skeleton);

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3314,9 +3314,14 @@ const sessionManager = {
     const fields = window.ProjectTemplateCard?.getPayloadFields?.() || {};
     const templateId = String(fields.template_id || '').trim();
     const templatePath = String(fields.template_path || '').trim();
+    // Blank ships a synthetic single-agent roster (Workspace Manager). It has no
+    // template_id/path, so signal it explicitly — but an ad-hoc folder override
+    // (template_path) takes precedence and is no longer "blank".
+    const isBlank = Boolean(window.ProjectTemplateCard?.getSelectedTemplate?.()?.blank)
+      && !templateId && !templatePath;
     const requestId = ++this.templateAgentPlanRequestId;
 
-    if (this.importModeEnabled || (!templateId && !templatePath)) {
+    if (this.importModeEnabled || (!templateId && !templatePath && !isBlank)) {
       this.resetTemplateAgentReview();
       return;
     }
@@ -3328,7 +3333,8 @@ const sessionManager = {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           template_id: templateId || undefined,
-          template_path: templatePath || undefined
+          template_path: templatePath || undefined,
+          blank: isBlank || undefined
         })
       });
       const data = await response.json().catch(() => ({}));
@@ -4013,7 +4019,14 @@ const sessionManager = {
           // Optional project scaffolding from the template picker
           // (template_id/template_path). The scaffolded project folder name
           // defaults to the workspace name server-side.
-          Object.assign(payload, window.ProjectTemplateCard.getPayloadFields());
+          const templateFields = window.ProjectTemplateCard.getPayloadFields();
+          Object.assign(payload, templateFields);
+          // Blank blueprint (no template_id/path, no ad-hoc folder override):
+          // tell the backend to seed the synthetic single-agent roster.
+          if (window.ProjectTemplateCard.getSelectedTemplate?.()?.blank
+            && !templateFields.template_id && !templateFields.template_path) {
+            payload.blank = true;
+          }
         }
         if (this.templateAgentPlan?.has_agents) {
           const createTemplateAgents = Boolean(document.getElementById('templateAgentReviewToggle')?.checked);

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3409,10 +3409,10 @@ const sessionManager = {
     const createCount = agents.filter((agent) => agent.action === 'create').length;
     const reuseCount = agents.filter((agent) => agent.action === 'reuse').length;
     const parts = [];
-    if (createCount) parts.push(`${createCount} new`);
     if (reuseCount) parts.push(`${reuseCount} reused`);
+    if (createCount) parts.push(`${createCount} new`);
     if (summary) {
-      summary.textContent = `${parts.join(' / ')} agent${agents.length === 1 ? '' : 's'} will be attached to this workspace.`;
+      summary.textContent = `${parts.join(' / ')} agent${agents.length === 1 ? '' : 's'} attached to this workspace.`;
     }
     if (status) {
       const provider = String(plan.system_provider || '').trim();
@@ -3455,26 +3455,44 @@ const sessionManager = {
       : 'App default';
     const modelOptions = this.renderTemplateAgentModelOptions(agent, editableModel, editableProvider, modelText);
     const promptState = systemPrompt ? 'Prompt set' : 'No prompt';
-    const chips = [
-      `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>`,
+    const isReuse = action === 'reuse';
+    // The role/type chip pair shared by both the compact reuse view and the
+    // editable view. The action chip lives only in the editable view so its
+    // "Reuse -> Create" flip on fork targets a single element.
+    const roleChips = [
       agent?.entry_point ? '<span class="workspace-template-agent-chip entry">Entry</span>' : '<span class="workspace-template-agent-chip">Specialist</span>',
       role ? `<span class="workspace-template-agent-chip">${this.escapeHtml(role)}</span>` : '',
       type ? `<span class="workspace-template-agent-chip">${this.escapeHtml(type)}</span>` : '',
       tools ? `<span class="workspace-template-agent-chip">${this.escapeHtml(tools)}</span>` : ''
     ].filter(Boolean).join('');
-    const reuseNote = action === 'reuse'
-      ? '<div class="workspace-template-agent-note">This name matches an existing agent. Saved settings are reused unless you rename it.</div>'
-      : '';
+    const chips = `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>${roleChips}`;
+
+    // Reuse view: a name-matched agent already exists, so it is linked, not
+    // created. Shown compact and locked; "Make a workspace copy" reveals the
+    // editable view (below) and forks a fresh, workspace-scoped agent.
+    const reuseView = isReuse ? `
+        <div class="workspace-template-agent-reuse">
+          <div class="workspace-template-agent-reuse-head">
+            <span class="workspace-template-agent-reuse-name">${this.escapeHtml(name)}</span>
+            <div class="workspace-template-agent-meta">
+              <span class="workspace-template-agent-chip reuse">Reuse</span>${roleChips}
+            </div>
+          </div>
+          <div class="workspace-template-agent-reuse-sub">Using your existing agent${model ? ` · ${this.escapeHtml(modelText)}` : ''}</div>
+          <button type="button" class="workspace-template-agent-fork-btn">Make a workspace copy</button>
+        </div>` : '';
 
     return `
-      <div class="workspace-template-agent-row"
+      <div class="workspace-template-agent-row${isReuse ? ' is-reuse' : ''}"
            data-template-agent-index="${index}"
+           data-forked="false"
            data-original-action="${this.escapeHtml(action)}"
            data-original-name="${this.escapeHtml(name)}"
            data-original-model="${this.escapeHtml(editableModel)}"
            data-original-provider="${this.escapeHtml(editableProvider)}"
            data-original-system-prompt="${this.escapeHtml(systemPrompt)}">
-        <div class="workspace-template-agent-main">
+        ${reuseView}
+        <div class="workspace-template-agent-main"${isReuse ? ' hidden' : ''}>
           <div class="workspace-template-agent-fields">
             <label class="workspace-template-agent-field">
               <span>Name</span>
@@ -3491,7 +3509,7 @@ const sessionManager = {
             </label>
           </div>
           <div class="workspace-template-agent-meta">${chips}</div>
-          ${reuseNote}
+          ${isReuse ? '<div class="workspace-template-agent-fork-note">New workspace copy — edit freely. Your existing agent is left untouched.</div>' : ''}
           <details class="workspace-template-agent-prompt" open>
             <summary>
               <span>System prompt</span>
@@ -3556,8 +3574,35 @@ const sessionManager = {
         control.addEventListener('input', () => this.updateTemplateAgentReviewRowState(row));
         control.addEventListener('change', () => this.updateTemplateAgentReviewRowState(row));
       });
+      row.querySelector('.workspace-template-agent-fork-btn')
+        ?.addEventListener('click', () => this.forkTemplateAgentRow(row));
       this.updateTemplateAgentReviewRowState(row);
     });
+  },
+
+  // Fork a reused (name-matched) agent into a fresh workspace-scoped copy:
+  // reveal the editable view, suffix the name so it no longer matches the
+  // existing agent (which flips the row to "Create"), and let the existing
+  // rename-fork override path carry the edits. The existing agent is untouched.
+  forkTemplateAgentRow(row) {
+    if (!row) return;
+    const reuseView = row.querySelector('.workspace-template-agent-reuse');
+    const main = row.querySelector('.workspace-template-agent-main');
+    const nameInput = row.querySelector('.workspace-template-agent-name-input');
+    row.dataset.forked = 'true';
+    if (reuseView) reuseView.hidden = true;
+    if (main) main.hidden = false;
+    if (nameInput) {
+      nameInput.value = this.suggestForkedAgentName(row.dataset.originalName || nameInput.value);
+      nameInput.focus();
+      nameInput.select?.();
+    }
+    this.updateTemplateAgentReviewRowState(row);
+  },
+
+  suggestForkedAgentName(base) {
+    const trimmed = String(base || '').trim();
+    return trimmed ? `${trimmed} copy` : 'Agent copy';
   },
 
   updateTemplateAgentReviewRowState(row) {
@@ -3706,6 +3751,9 @@ const sessionManager = {
     review.classList.toggle('is-disabled', !toggle.checked);
     review.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
       control.disabled = !toggle.checked;
+    });
+    review.querySelectorAll('.workspace-template-agent-fork-btn').forEach((btn) => {
+      btn.disabled = !toggle.checked;
     });
   },
 

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3886,21 +3886,6 @@ const sessionManager = {
     }
   },
 
-  // Mirrors internal/workspace.Slugify so the folder-name preview matches what
-  // the server will create on disk: lowercase, strip accents, non-alphanumeric
-  // to hyphens, collapse/trim hyphens, cap at 64 chars.
-  slugifyWorkspaceName(name) {
-    const s = String(name || '').trim();
-    if (!s) return 'untitled';
-    let slug = s.normalize('NFD').replace(/\p{Mn}/gu, '')
-      .toLowerCase()
-      .replace(/[^a-z0-9-]+/g, '-')
-      .replace(/-{2,}/g, '-')
-      .replace(/^-+|-+$/g, '');
-    if (slug.length > 64) slug = slug.slice(0, 64).replace(/-+$/g, '');
-    return slug || 'untitled';
-  },
-
   // Shows the folder the current name will map to on disk, so the name→folder
   // relationship (and slug conflicts) aren't a surprise at create time. Skipped
   // in import mode, where the folder name comes from the imported path.
@@ -4784,13 +4769,20 @@ const sessionManager = {
     });
   },
 
+  // Mirrors internal/workspace.Slugify so the folder-name preview and the
+  // rename "folder saved as" check match what the server writes to disk:
+  // lowercase, strip accents, non-alphanumeric to hyphens, collapse/trim
+  // hyphens, cap at 64 chars, "untitled" for empty input.
   slugifyWorkspaceName(value) {
-    return String(value || '')
-      .trim()
+    const s = String(value || '').trim();
+    if (!s) return 'untitled';
+    let slug = s.normalize('NFD').replace(/\p{Mn}/gu, '')
       .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .replace(/-{2,}/g, '-');
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (slug.length > 64) slug = slug.slice(0, 64).replace(/-+$/g, '');
+    return slug || 'untitled';
   },
 
   buildWorkspaceSlugConflictMessage(conflict) {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3770,6 +3770,11 @@ const sessionManager = {
     const nextBtn = document.getElementById('wizardNextBtn');
     const createBtn = document.getElementById('createFolderBtn');
 
+    // The workspace name field is a single element relocated to the visible
+    // step's mount, so it's the first input on Select Blueprint yet stays
+    // editable on Construct (and in import mode's single-step layout).
+    this.relocateWizardNameField(step);
+
     if (step1) step1.hidden = importMode || step !== 1;
     if (step2) step2.hidden = step !== 2;
     if (stepper) stepper.hidden = importMode;
@@ -3786,6 +3791,18 @@ const sessionManager = {
     // The step-2 recap names the chosen blueprint; import mode has no blueprint.
     const recap = document.getElementById('wizardStep2Recap');
     if (recap) recap.hidden = importMode;
+  },
+
+  // Moves the single #wizardNameField (which owns #folderNameInput) into the
+  // mount for the given effective step. appendChild preserves the input's value,
+  // focus, and listeners, so no cross-step syncing is needed.
+  relocateWizardNameField(step) {
+    const field = document.getElementById('wizardNameField');
+    if (!field) return;
+    const mount = document.getElementById(step === 2 ? 'wizardStep2NameMount' : 'wizardStep1NameMount');
+    if (mount && field.parentElement !== mount) {
+      mount.appendChild(field);
+    }
   },
 
   // Sets the step-2 recap line ("Constructing: <icon> <name>") from the selected

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -232,6 +232,24 @@ const sessionManager = {
       if (!this.importModeEnabled) this.goToWizardStep(2);
     });
 
+    // Name field: live folder-slug preview, clear the inline error on edit, and
+    // Enter to advance (step 1) or create (step 2). The field is a single
+    // relocated element, so binding once covers both steps.
+    const workspaceNameInput = document.getElementById('folderNameInput');
+    workspaceNameInput?.addEventListener('input', () => {
+      this.clearWorkspaceNameError();
+      this.updateWorkspaceNameHint();
+    });
+    workspaceNameInput?.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      if (this.importModeEnabled || this.wizardStep === 2) {
+        this.createFolder();
+      } else {
+        this.goToWizardStep(2);
+      }
+    });
+
     // Agent behavior (formerly "Workspace preset"): a manual change marks the
     // value as overridden so picking a Template won't clobber it.
     document.getElementById('folderPresetSelect')?.addEventListener('change', () => {
@@ -247,6 +265,7 @@ const sessionManager = {
       this.workspaceTemplate = template;
       this.prefillTemplateValue(document.getElementById('folderNameInput'), template?.name || '', 'autofillName');
       this.prefillTemplateValue(document.getElementById('folderDescriptionInput'), template?.description || '', 'autofillDescription');
+      this.updateWorkspaceNameHint();
       this.applyTemplateBehavior(template);
       this.updateWizardRecap(template);
       void this.refreshTemplateAgentPlan();
@@ -3224,6 +3243,7 @@ const sessionManager = {
       String(modalElement.dataset.askOriPostCreate || '') === 'open_workspace_dashboard'
     );
 
+    this.clearWorkspaceNameError();
     if (!keepSeedValues) {
       if (nameInput) nameInput.value = '';
       if (nameInput) nameInput.dataset.autofillName = '';
@@ -3271,6 +3291,9 @@ const sessionManager = {
     this.resetTemplateAgentReview();
     window.ReaperSetupCard?.hide?.();
     this.updateBehaviorHint();
+    // Refresh the folder-slug preview now that the name value is settled (the
+    // ProjectTemplateCard reset above may have re-prefilled it).
+    this.updateWorkspaceNameHint();
   },
 
   resetTemplateAgentReview() {
@@ -3417,9 +3440,11 @@ const sessionManager = {
     if (status) {
       const provider = String(plan.system_provider || '').trim();
       const model = String(plan.system_model || '').trim();
+      // Applies to any blueprint's roster, not just Blank — the message names
+      // where agents without an explicit model get theirs from.
       status.textContent = provider && model
-        ? `Blank template models resolve to ${provider} / ${model}.`
-        : 'Blank template models use the app default because no system model is configured.';
+        ? `Agents without their own model use ${provider} / ${model}.`
+        : 'Agents without their own model use the app default because no system model is configured.';
     }
     if (list) {
       list.innerHTML = agents.map((agent, index) => this.renderTemplateAgentPlanRow(agent, index)).join('');
@@ -3828,6 +3853,8 @@ const sessionManager = {
     // step's mount, so it's the first input on Select Blueprint yet stays
     // editable on Construct (and in import mode's single-step layout).
     this.relocateWizardNameField(step);
+    // Keep the folder-slug preview in sync with import mode (which hides it).
+    this.updateWorkspaceNameHint();
 
     if (step1) step1.hidden = importMode || step !== 1;
     if (step2) step2.hidden = step !== 2;
@@ -3857,6 +3884,55 @@ const sessionManager = {
     if (mount && field.parentElement !== mount) {
       mount.appendChild(field);
     }
+  },
+
+  // Mirrors internal/workspace.Slugify so the folder-name preview matches what
+  // the server will create on disk: lowercase, strip accents, non-alphanumeric
+  // to hyphens, collapse/trim hyphens, cap at 64 chars.
+  slugifyWorkspaceName(name) {
+    const s = String(name || '').trim();
+    if (!s) return 'untitled';
+    let slug = s.normalize('NFD').replace(/\p{Mn}/gu, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (slug.length > 64) slug = slug.slice(0, 64).replace(/-+$/g, '');
+    return slug || 'untitled';
+  },
+
+  // Shows the folder the current name will map to on disk, so the name→folder
+  // relationship (and slug conflicts) aren't a surprise at create time. Skipped
+  // in import mode, where the folder name comes from the imported path.
+  updateWorkspaceNameHint() {
+    const hint = document.getElementById('workspaceNameHint');
+    if (!hint) return;
+    if (hint.classList.contains('is-error')) return; // an active error owns the slot
+    const name = document.getElementById('folderNameInput')?.value.trim() || '';
+    if (this.importModeEnabled || !name) {
+      hint.textContent = '';
+      hint.hidden = true;
+      return;
+    }
+    hint.textContent = `Folder: ${this.slugifyWorkspaceName(name)}`;
+    hint.hidden = false;
+  },
+
+  setWorkspaceNameError(message) {
+    const hint = document.getElementById('workspaceNameHint');
+    const input = document.getElementById('folderNameInput');
+    input?.classList.add('is-invalid');
+    if (hint) {
+      hint.textContent = message;
+      hint.hidden = false;
+      hint.classList.add('is-error');
+    }
+  },
+
+  clearWorkspaceNameError() {
+    const hint = document.getElementById('workspaceNameHint');
+    document.getElementById('folderNameInput')?.classList.remove('is-invalid');
+    hint?.classList.remove('is-error');
   },
 
   // Sets the step-2 recap line ("Constructing: <icon> <name>") from the selected
@@ -3999,18 +4075,18 @@ const sessionManager = {
     const name = nameInput?.value.trim() || '';
     const description = descriptionInput?.value.trim() || '';
     if (!name && !importEnabled) {
-      this.showToast('Workspace name is required', 'warning');
+      // Inline error on the field (which is now the first thing on step 1) rather
+      // than a toast that fires only after the user reaches the end.
+      this.setWorkspaceNameError('Workspace name is required');
+      nameInput?.focus();
       return;
     }
     if (importEnabled && !importPath) {
       this.showToast('Please enter or browse for a folder path to import', 'warning');
       return;
     }
-    if (!description) {
-      this.showToast('Workspace description is required', 'warning');
-      descriptionInput?.focus();
-      return;
-    }
+    // Description is optional: a workspace can start with just a name, and Ori
+    // can still review the setup later. It only enriches the setup review.
 
     const parentId = parentSelect?.value?.trim() || '';
     const color = colorBtn?.dataset.color || '';

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -64,9 +64,9 @@
                 <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
                 <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
                   <div class="workspace-template-briefing-deploys-kicker">Deploys</div>
-                  <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row" hidden>
+                  <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row workspace-template-briefing-row-addons" hidden>
                     <span class="workspace-template-briefing-row-label">Agents</span>
-                    <span id="templateBriefingAgentsValue" class="workspace-template-briefing-row-value"></span>
+                    <div id="templateBriefingAgentsValue" class="workspace-template-briefing-chips workspace-template-briefing-agents"></div>
                   </div>
                   <div id="templateBriefingScaffoldRow" class="workspace-template-briefing-row" hidden>
                     <span class="workspace-template-briefing-row-label">Project folder</span>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -24,6 +24,18 @@
 
             <!-- ===== STEP 1 · SELECT BLUEPRINT: template grid + user templates ===== -->
             <div id="wizardStep1">
+
+              <!-- Workspace name: the first input users reach. This is the single
+                   canonical #folderNameInput; refreshWizardChrome() relocates the
+                   #wizardNameField wrapper into #wizardStep2NameMount on Construct
+                   so the same field stays editable there (no dueling inputs). -->
+              <div id="wizardStep1NameMount">
+                <div id="wizardNameField" class="workspace-create-name-field mb-3">
+                  <label for="folderNameInput" class="workspace-create-section-title" style="display: block; margin-bottom: 6px;">Workspace name</label>
+                  <input type="text" id="folderNameInput" class="modern-input w-100" placeholder="Name your workspace">
+                </div>
+              </div>
+
               <div id="workspaceCreateBlueprintHeader" class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
                 <span class="workspace-create-section-title">Select Blueprint</span>
                 <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
@@ -78,6 +90,10 @@
                 <span id="wizardStep2RecapName" class="workspace-create-recap-name">Blank workspace</span>
               </div>
 
+              <!-- Editable workspace name on Construct. #wizardNameField is moved
+                   here from step 1 by refreshWizardChrome(); this is just its mount. -->
+              <div id="wizardStep2NameMount" class="mb-2"></div>
+
               <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
                 <label class="d-flex align-items-start gap-2 mb-0" for="projectTemplateOpenAfterCreateToggle" style="cursor: pointer;">
                   <input type="checkbox" id="projectTemplateOpenAfterCreateToggle" class="form-check-input mt-1">
@@ -118,9 +134,8 @@
                 <div id="reaperSetupActions" class="reaper-setup-actions d-flex flex-wrap gap-2" style="margin-top: 8px;"></div>
               </div>
 
-              <!-- Designation: name + description feed Ori's setup review. -->
-              <label for="folderNameInput" style="font-size: 12px; color: var(--text-secondary);">Workspace name</label>
-              <input type="text" id="folderNameInput" class="modern-input w-100 mb-2" placeholder="Workspace name">
+              <!-- Designation: name (relocated above via #wizardStep2NameMount) +
+                   description feed Ori's setup review. -->
               <div class="workspace-setup-card mb-2">
                 <div class="workspace-setup-header" style="align-items: flex-start;">
                   <div>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -112,7 +112,7 @@
                   </div>
                   <label class="workspace-template-agent-toggle">
                     <input type="checkbox" id="templateAgentReviewToggle" checked>
-                    <span>Create</span>
+                    <span>Attach</span>
                   </label>
                 </div>
                 <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -32,7 +32,8 @@
               <div id="wizardStep1NameMount">
                 <div id="wizardNameField" class="workspace-create-name-field mb-3">
                   <label for="folderNameInput" class="workspace-create-section-title" style="display: block; margin-bottom: 6px;">Workspace name</label>
-                  <input type="text" id="folderNameInput" class="modern-input w-100" placeholder="Name your workspace">
+                  <input type="text" id="folderNameInput" class="modern-input w-100" placeholder="Name your workspace" aria-describedby="workspaceNameHint">
+                  <div id="workspaceNameHint" class="workspace-create-name-hint" aria-live="polite"></div>
                 </div>
               </div>
 
@@ -59,7 +60,7 @@
               </div>
               <div id="templateBriefing" class="workspace-template-briefing mb-2">
                 <div id="templateBriefingDefault" class="workspace-template-briefing-default">
-                  Starting from a blank workspace. You can add tools, agents, and structure after it's created.
+                  Starting from a blank workspace with a Workspace Manager agent. You can add tools, more agents, and structure after it's created.
                 </div>
                 <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
                 <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
@@ -139,7 +140,7 @@
               <div class="workspace-setup-card mb-2">
                 <div class="workspace-setup-header" style="align-items: flex-start;">
                   <div>
-                    <label for="folderDescriptionInput" class="workspace-setup-title">Workspace Description</label>
+                    <label for="folderDescriptionInput" class="workspace-setup-title">Workspace Description <span style="opacity: 0.8; font-weight: 400;">(optional)</span></label>
                     <p class="workspace-setup-help mb-0">Describe what this workspace is for so Ori can review the setup and recommend the right agents, MCPs, and skills.</p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

A coherent polish pass on the Create Workspace wizard (`create-workspace-modal.tmpl` + `sessions.js` + `project-templates-manage.js`), landing as one themed PR.

### 1. Workspace name is the first input
The name field now leads step 1 (Select Blueprint) and stays editable on step 2 (Construct) — a single relocated `#folderNameInput`, so all existing prefill/duplicate-slug/create logic is untouched.

### 2. Blank blueprint ships a reviewable entry agent
Blank now seeds a single **Workspace Manager** entry agent, shown in the Template Agents panel (editable, with the same Attach toggle). Implemented as a synthetic code-only template (roster only — no folder/tasks/project) routed through the existing plan/seed machinery. Reused on name-match like other templates' entry agents. *(Intentionally reverses the "concrete workspaces stay agent-less" default from #118; unchecking Attach restores the agent-less path.)*

### 3. Briefing agents render as role-dot chips
The briefing AGENTS row was a plain comma string while ADD-ONS were chips. Now each agent is a chip with a role-hued dot (entry = solid green, validator = amber, specialists = hollow), matching the add-on chips.

### 4. Reuse vs create integrated in the Template Agents panel
An already-existing (name-matched) agent is **linked, not created**: rendered compact and locked ("Using your existing agent · model") with a **Make a workspace copy** fork action (replacing the hidden rename-to-fork trick). Master toggle relabeled **Create → Attach**; summary leads with the reused count.

### 5. Quick-win polish
- **Bug fix:** Template Agents model-status line no longer says "Blank template models…" for every blueprint.
- Workspace Description is now **optional** (backend never required it).
- **Inline name validation** (error + focus) replaces the end-of-flow toast.
- **Live folder-slug preview** under the name (mirrors `internal/workspace.Slugify`).
- **Enter** advances (step 1) or creates (step 2 / import).

## Testing
- New backend test `TestBlankWorkspaceTemplate_SeedsSingleEntryAgent`; `internal/sessionhttp` suite green; `go vet`/`gofmt` clean.
- Verified end-to-end in an isolated smoke server: name relocation + value persistence, Blank seeds/reuses the manager (opt-out → agent-less), briefing chips by role, reuse-lock + fork (existing agent untouched), folder preview, inline error, optional-description create, template-agnostic status copy.

## Follow-ups
Bigger ideas (smart name suggestions, blueprint search, unified post-create next-steps) captured in a local backlog (`tasks/` is gitignored here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)