### PR TITLE
feat(workspace): shared task-presentation resolver + task/run data-deps audit (foundations)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -161,6 +161,7 @@ export default defineConfig([
       'internal/web/static/js/modules/task-result-artifacts.js',
       'internal/web/static/js/modules/tag-input.js',
       'internal/web/static/js/modules/tag-filter-bar.js',
+      'internal/web/static/js/modules/task-presentation.js',
       'internal/web/static/js/modules/template-onboarding.js',
       'internal/web/static/js/modules/workspace-tags-card.js',
       'internal/web/static/js/modules/workspace-command.js',

--- a/internal/web/static/js/modules/task-presentation.js
+++ b/internal/web/static/js/modules/task-presentation.js
@@ -1,0 +1,388 @@
+/**
+ * task-presentation.js
+ *
+ * Single, pure, fixture-testable resolver that maps a raw workspace task
+ * (plus its human-loop / retry context) to one canonical presentation used by
+ * EVERY workspace task surface: the Operations Map rows, the task drawer rows
+ * and preview, the execution tray, the workspace-detail task surfaces, and the
+ * dedicated task page.
+ *
+ * Design (see PRD "Workspace Task Execution UX", section C, FR29–FR45):
+ *  - Same raw task + human-loop data must resolve to the same label, tone,
+ *    count categories, sort priority, and actions on every surface (FR39).
+ *  - Unknown raw states get a safe neutral presentation that exposes the raw
+ *    value and is NEVER silently presented as `Pending` (FR38).
+ *  - `timeout` stays distinct from `failed` — this resolver reads raw `status`
+ *    and does not inherit the legacy `getTaskExecutionState` flattening
+ *    (workspace-detail.js:49-53) that collapsed timeout → failed.
+ *
+ * This module is intentionally free of DOM/window/network access so it can be
+ * exercised directly from fixtures. It attaches to `window.TaskPresentation`
+ * for browser callers when a window exists, and exports named functions for
+ * tests.
+ */
+
+// Canonical presentation state keys. These are surface-agnostic; each surface
+// maps the `primaryAction.id` to its own handler + copy, but the label/tone
+// defaults below keep wording consistent when a surface has no override.
+export const PRESENTATION_STATE = Object.freeze({
+  NEEDS_ASSIGNMENT: 'needs_assignment',
+  READY: 'ready',
+  RUNNING: 'running',
+  NEEDS_INPUT: 'needs_input',
+  BLOCKED: 'blocked',
+  FAILED: 'failed',
+  TIMED_OUT: 'timed_out',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+  SKIPPED: 'skipped',
+  UNKNOWN: 'unknown'
+});
+
+// Drawer filter keys (FR16).
+export const FILTER = Object.freeze({
+  ACTIONABLE: 'actionable',
+  ACTIVE: 'active',
+  NEEDS_ATTENTION: 'needs_attention',
+  COMPLETED: 'completed',
+  ALL: 'all'
+});
+
+// Per-state static metadata: label, tone, which count buckets it belongs to,
+// sort priority (lower sorts earlier — FR24), and default primary/secondary
+// actions. `retry`/`rerun`/`cancel` availability is layered on at resolve time
+// from the task's own data (see resolveTaskPresentation).
+const STATE_META = Object.freeze({
+  [PRESENTATION_STATE.NEEDS_INPUT]: {
+    label: 'Needs Input',
+    tone: 'attention',
+    counts: [FILTER.ACTIONABLE, FILTER.ACTIVE, FILTER.NEEDS_ATTENTION],
+    sortPriority: 0,
+    primaryAction: { id: 'respond', label: 'Respond' }
+  },
+  [PRESENTATION_STATE.BLOCKED]: {
+    label: 'Blocked',
+    tone: 'attention',
+    counts: [FILTER.ACTIONABLE, FILTER.ACTIVE, FILTER.NEEDS_ATTENTION],
+    sortPriority: 1,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  },
+  [PRESENTATION_STATE.NEEDS_ASSIGNMENT]: {
+    label: 'Needs Assignment',
+    tone: 'attention',
+    counts: [FILTER.ACTIONABLE, FILTER.NEEDS_ATTENTION],
+    sortPriority: 2,
+    primaryAction: { id: 'assign_start', label: 'Assign & Start' }
+  },
+  [PRESENTATION_STATE.RUNNING]: {
+    label: 'Running',
+    tone: 'active',
+    counts: [FILTER.ACTIONABLE, FILTER.ACTIVE],
+    sortPriority: 3,
+    primaryAction: { id: 'track', label: 'Track' }
+  },
+  [PRESENTATION_STATE.FAILED]: {
+    label: 'Failed',
+    tone: 'danger',
+    counts: [FILTER.ACTIONABLE, FILTER.NEEDS_ATTENTION],
+    sortPriority: 4,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  },
+  [PRESENTATION_STATE.TIMED_OUT]: {
+    label: 'Timed Out',
+    tone: 'danger',
+    counts: [FILTER.ACTIONABLE, FILTER.NEEDS_ATTENTION],
+    sortPriority: 4,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  },
+  [PRESENTATION_STATE.READY]: {
+    label: 'Ready',
+    tone: 'info',
+    counts: [FILTER.ACTIONABLE, FILTER.ACTIVE],
+    sortPriority: 5,
+    primaryAction: { id: 'start', label: 'Start' }
+  },
+  [PRESENTATION_STATE.COMPLETED]: {
+    label: 'Completed',
+    tone: 'success',
+    counts: [FILTER.COMPLETED],
+    sortPriority: 6,
+    primaryAction: { id: 'view_result', label: 'View Result' }
+  },
+  [PRESENTATION_STATE.CANCELLED]: {
+    label: 'Cancelled',
+    tone: 'neutral',
+    counts: [],
+    sortPriority: 7,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  },
+  [PRESENTATION_STATE.SKIPPED]: {
+    label: 'Skipped',
+    tone: 'neutral',
+    counts: [],
+    sortPriority: 7,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  },
+  [PRESENTATION_STATE.UNKNOWN]: {
+    label: 'Unknown',
+    tone: 'neutral',
+    counts: [],
+    sortPriority: 8,
+    primaryAction: { id: 'inspect', label: 'Inspect' }
+  }
+});
+
+function lc(value) {
+  return String(value == null ? '' : value)
+    .trim()
+    .toLowerCase();
+}
+
+// Raw statuses treated as "ready-ish": not yet running, resolves to Ready or
+// Needs Assignment depending on whether a runnable assignee exists.
+const READYISH_STATUSES = new Set(['pending', 'assigned', 'ready', 'queued', 'todo', 'not_started', '']);
+const COMPLETED_STATUSES = new Set(['completed', 'success', 'done']);
+const FAILED_STATUSES = new Set(['failed', 'error']);
+
+/** Human-loop sub-state, e.g. `blocked` or `waiting_for_choice` (FR33-34). */
+export function taskHumanLoopState(task) {
+  return lc(task && task.context && task.context.human_loop && task.context.human_loop.state);
+}
+
+/** Assignee display string, mirroring the existing `to || agent_name || assigned_to` order. */
+export function taskAssignee(task) {
+  if (!task) return '';
+  return String(task.to || task.agent_name || task.assigned_to || '').trim();
+}
+
+/**
+ * "Latest meaningful activity" timestamp (ms) — the most recent status change
+ * or non-heartbeat run event we can see, approximated by `updated_at` and
+ * falling back to `created_at` (PRD review-gap #6 definition; matches the
+ * existing `taskUpdatedTime` helper). Returns 0 when unknown so it sorts last.
+ */
+export function taskLatestActivityAt(task) {
+  const raw = (task && (task.updated_at || task.created_at)) || '';
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/*
+ * Raw legacy predicates — exact single-status / human-loop checks, extracted
+ * verbatim from the Operations Map so every surface shares one definition
+ * instead of maintaining parallel copies (FR29). Unlike resolveTaskState, these
+ * add NO precedence: e.g. a blocked task that is also awaiting input reports
+ * true from both isBlockedTask and isNeedsInputTask, exactly as the Map did.
+ */
+
+/** status is `blocked`, or human-loop is blocked. */
+export function isBlockedTask(task) {
+  const status = lc(task && task.status);
+  return status === 'blocked' || taskHumanLoopState(task) === 'blocked';
+}
+
+/** status/human-loop is waiting for a choice, or a step is waiting for input (FR33). */
+export function isNeedsInputTask(task) {
+  const status = lc(task && task.status);
+  return (
+    status === 'waiting_for_choice' ||
+    taskHumanLoopState(task) === 'waiting_for_choice' ||
+    Boolean(task && task.context && task.context.execution_step_waiting === true)
+  );
+}
+
+/** status is `in_progress`. */
+export function isWorkingTask(task) {
+  return lc(task && task.status) === 'in_progress';
+}
+
+/** status is `pending`. */
+export function isQueuedTask(task) {
+  return lc(task && task.status) === 'pending';
+}
+
+/** Whether the task is awaiting an answerable input request (FR33). */
+function hasAnswerableInput(task, opts) {
+  if (opts && typeof opts.hasAnswerableInput === 'boolean') return opts.hasAnswerableInput;
+  return isNeedsInputTask(task);
+}
+
+/** Whether retry is supported for a failed/timed-out task (FR35). */
+function retrySupported(task, opts) {
+  if (opts && typeof opts.retrySupported === 'boolean') return opts.retrySupported;
+  const retry = task && task.context && task.context.execution_retry;
+  if (retry && Number(retry.max_attempts) > 0) {
+    return Number(retry.attempts_used || 0) < Number(retry.max_attempts);
+  }
+  // No retry metadata → assume retry is available; the server is authoritative
+  // and will reject an unsupported retry, which the caller surfaces (FR44).
+  return true;
+}
+
+/**
+ * Resolve the canonical presentation state key for a task. Ordering matters:
+ * terminal outcomes win first, then intervention states (needs-input before
+ * blocked, per FR34), then running, then ready-ish, then a safe unknown.
+ */
+export function resolveTaskState(task, opts) {
+  const status = lc(task && task.status);
+  const humanLoop = taskHumanLoopState(task);
+
+  if (COMPLETED_STATUSES.has(status)) return PRESENTATION_STATE.COMPLETED;
+  if (status === 'cancelled') return PRESENTATION_STATE.CANCELLED;
+  if (status === 'skipped') return PRESENTATION_STATE.SKIPPED;
+  if (status === 'timeout') return PRESENTATION_STATE.TIMED_OUT;
+  if (FAILED_STATUSES.has(status)) return PRESENTATION_STATE.FAILED;
+
+  // Needs-input outranks blocked: a blocked task WITH an answerable input
+  // request is Needs Input, not Blocked (FR33-34).
+  if (hasAnswerableInput(task, opts)) return PRESENTATION_STATE.NEEDS_INPUT;
+  if (status === 'blocked' || humanLoop === 'blocked') return PRESENTATION_STATE.BLOCKED;
+
+  if (status === 'in_progress') return PRESENTATION_STATE.RUNNING;
+
+  if (READYISH_STATUSES.has(status)) {
+    const runnable =
+      opts && typeof opts.hasRunnableAssignee === 'boolean'
+        ? opts.hasRunnableAssignee
+        : Boolean(taskAssignee(task));
+    return runnable ? PRESENTATION_STATE.READY : PRESENTATION_STATE.NEEDS_ASSIGNMENT;
+  }
+
+  return PRESENTATION_STATE.UNKNOWN;
+}
+
+/**
+ * Resolve the full canonical presentation for a task.
+ *
+ * @param {object} task - raw task payload
+ * @param {object} [opts] - optional overrides:
+ *   hasRunnableAssignee, hasAnswerableInput, retrySupported (booleans),
+ *   cancelSupported (default true), rerunSupported (default true).
+ * @returns {{
+ *   state: string, label: string, tone: string, rawState: string,
+ *   isUnknown: boolean, countCategories: string[], sortPriority: number,
+ *   primaryAction: {id:string,label:string}|null,
+ *   secondaryActions: Array<{id:string,label:string,confirm?:boolean}>,
+ *   assignee: string, latestActivityAt: number
+ * }}
+ */
+export function resolveTaskPresentation(task, opts) {
+  const options = opts || {};
+  const state = resolveTaskState(task, options);
+  const meta = STATE_META[state] || STATE_META[PRESENTATION_STATE.UNKNOWN];
+  const rawState = lc(task && task.status);
+
+  let primaryAction = meta.primaryAction ? { ...meta.primaryAction } : null;
+  const secondaryActions = [];
+
+  if (state === PRESENTATION_STATE.FAILED || state === PRESENTATION_STATE.TIMED_OUT) {
+    if (retrySupported(task, options)) {
+      primaryAction = { id: 'retry', label: 'Inspect & Retry' };
+    }
+  } else if (state === PRESENTATION_STATE.RUNNING) {
+    const cancelSupported = options.cancelSupported !== false;
+    if (cancelSupported) {
+      secondaryActions.push({ id: 'cancel', label: 'Cancel', confirm: true });
+    }
+  } else if (state === PRESENTATION_STATE.COMPLETED) {
+    const rerunSupported = options.rerunSupported !== false;
+    if (rerunSupported) {
+      secondaryActions.push({ id: 'rerun', label: 'Re-run' });
+    }
+  }
+
+  return {
+    state,
+    label: meta.label,
+    tone: meta.tone,
+    rawState,
+    isUnknown: state === PRESENTATION_STATE.UNKNOWN,
+    countCategories: [FILTER.ALL, ...meta.counts],
+    sortPriority: meta.sortPriority,
+    primaryAction,
+    secondaryActions,
+    assignee: taskAssignee(task),
+    latestActivityAt: taskLatestActivityAt(task)
+  };
+}
+
+/** True when a task belongs in the given drawer filter (FR16-19). */
+export function taskMatchesFilter(task, filter, opts) {
+  if (filter === FILTER.ALL) return true;
+  const pres = resolveTaskPresentation(task, opts);
+  return pres.countCategories.indexOf(filter) !== -1;
+}
+
+/**
+ * Count tasks per filter bucket using the same categories as the rows they
+ * summarize, so a badge can never say "Open Tasks" while excluding visible
+ * attention-required tasks (FR45).
+ */
+export function resolveTaskCounts(tasks, opts) {
+  const counts = {
+    [FILTER.ACTIONABLE]: 0,
+    [FILTER.ACTIVE]: 0,
+    [FILTER.NEEDS_ATTENTION]: 0,
+    [FILTER.COMPLETED]: 0,
+    [FILTER.ALL]: 0
+  };
+  (Array.isArray(tasks) ? tasks : []).forEach(task => {
+    const pres = resolveTaskPresentation(task, opts);
+    pres.countCategories.forEach(cat => {
+      if (counts[cat] != null) counts[cat] += 1;
+    });
+  });
+  return counts;
+}
+
+/**
+ * Deterministic drawer ordering (FR24): intervention states first, then
+ * running, then failed/timed-out, then ready, then terminal history. Ties
+ * break by most-recently-updated, then ascending task ID. Returns a new array
+ * (does not mutate the input).
+ */
+export function sortTasksForDrawer(tasks, opts) {
+  const list = (Array.isArray(tasks) ? tasks : []).slice();
+  return list.sort((a, b) => {
+    const pa = resolveTaskPresentation(a, opts);
+    const pb = resolveTaskPresentation(b, opts);
+    if (pa.sortPriority !== pb.sortPriority) return pa.sortPriority - pb.sortPriority;
+    if (pa.latestActivityAt !== pb.latestActivityAt) return pb.latestActivityAt - pa.latestActivityAt;
+    return String((a && a.id) || '').localeCompare(String((b && b.id) || ''));
+  });
+}
+
+/**
+ * Stable short identifier derived from the task ID (FR15) — never the array
+ * index. Reordering/filtering the list must not renumber a task. Produces a
+ * compact, uppercase suffix of the ID for display next to the title.
+ */
+export function taskShortId(task) {
+  const id = String((task && task.id) || '').trim();
+  if (!id) return '';
+  const tail = id.replace(/[^A-Za-z0-9]/g, '').slice(-4).toUpperCase();
+  return tail ? `#${tail}` : '';
+}
+
+export const TaskPresentation = {
+  PRESENTATION_STATE,
+  FILTER,
+  resolveTaskState,
+  resolveTaskPresentation,
+  taskMatchesFilter,
+  resolveTaskCounts,
+  sortTasksForDrawer,
+  taskShortId,
+  taskAssignee,
+  taskHumanLoopState,
+  taskLatestActivityAt,
+  isBlockedTask,
+  isNeedsInputTask,
+  isWorkingTask,
+  isQueuedTask
+};
+
+if (typeof window !== 'undefined') {
+  window.TaskPresentation = TaskPresentation;
+}

--- a/internal/web/static/js/modules/task-presentation.test.js
+++ b/internal/web/static/js/modules/task-presentation.test.js
@@ -1,0 +1,219 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PRESENTATION_STATE,
+  FILTER,
+  resolveTaskState,
+  resolveTaskPresentation,
+  taskMatchesFilter,
+  resolveTaskCounts,
+  sortTasksForDrawer,
+  taskShortId,
+  taskLatestActivityAt
+} from './task-presentation.js';
+
+// ---- Fixtures for every presentation state (FR143) ----
+const unassigned = { id: 't-unassigned', status: 'pending' };
+const ready = { id: 't-ready', status: 'pending', to: 'agent-a' };
+const readyAssigned = { id: 't-assigned', status: 'assigned', agent_name: 'agent-b' };
+const running = { id: 't-running', status: 'in_progress', to: 'agent-a' };
+const needsInputChoice = { id: 't-choice', status: 'waiting_for_choice', to: 'agent-a' };
+const needsInputHumanLoop = {
+  id: 't-hl',
+  status: 'in_progress',
+  to: 'agent-a',
+  context: { human_loop: { state: 'waiting_for_choice' } }
+};
+const needsInputStep = {
+  id: 't-step',
+  status: 'in_progress',
+  to: 'agent-a',
+  context: { execution_step_waiting: true }
+};
+const blocked = { id: 't-blocked', status: 'blocked', to: 'agent-a' };
+const blockedWithInput = {
+  id: 't-blocked-input',
+  status: 'blocked',
+  to: 'agent-a',
+  context: { human_loop: { state: 'waiting_for_choice' } }
+};
+const failed = { id: 't-failed', status: 'failed', to: 'agent-a' };
+const errored = { id: 't-error', status: 'error', to: 'agent-a' };
+const timedOut = { id: 't-timeout', status: 'timeout', to: 'agent-a' };
+const completed = { id: 't-completed', status: 'completed', to: 'agent-a', result: 'ok' };
+const succeeded = { id: 't-success', status: 'success', to: 'agent-a' };
+const cancelled = { id: 't-cancelled', status: 'cancelled' };
+const skipped = { id: 't-skipped', status: 'skipped' };
+const unknown = { id: 't-unknown', status: 'frobnicating' };
+
+test('resolveTaskState maps every raw status to its canonical state', () => {
+  assert.equal(resolveTaskState(unassigned), PRESENTATION_STATE.NEEDS_ASSIGNMENT);
+  assert.equal(resolveTaskState(ready), PRESENTATION_STATE.READY);
+  assert.equal(resolveTaskState(readyAssigned), PRESENTATION_STATE.READY);
+  assert.equal(resolveTaskState(running), PRESENTATION_STATE.RUNNING);
+  assert.equal(resolveTaskState(needsInputChoice), PRESENTATION_STATE.NEEDS_INPUT);
+  assert.equal(resolveTaskState(needsInputHumanLoop), PRESENTATION_STATE.NEEDS_INPUT);
+  assert.equal(resolveTaskState(needsInputStep), PRESENTATION_STATE.NEEDS_INPUT);
+  assert.equal(resolveTaskState(blocked), PRESENTATION_STATE.BLOCKED);
+  assert.equal(resolveTaskState(failed), PRESENTATION_STATE.FAILED);
+  assert.equal(resolveTaskState(errored), PRESENTATION_STATE.FAILED);
+  assert.equal(resolveTaskState(timedOut), PRESENTATION_STATE.TIMED_OUT);
+  assert.equal(resolveTaskState(completed), PRESENTATION_STATE.COMPLETED);
+  assert.equal(resolveTaskState(succeeded), PRESENTATION_STATE.COMPLETED);
+  assert.equal(resolveTaskState(cancelled), PRESENTATION_STATE.CANCELLED);
+  assert.equal(resolveTaskState(skipped), PRESENTATION_STATE.SKIPPED);
+});
+
+test('timed-out is NOT flattened into failed (FR35)', () => {
+  const pres = resolveTaskPresentation(timedOut);
+  assert.equal(pres.state, PRESENTATION_STATE.TIMED_OUT);
+  assert.equal(pres.label, 'Timed Out');
+  assert.notEqual(pres.state, PRESENTATION_STATE.FAILED);
+});
+
+test('blocked WITH an answerable input resolves to Needs Input, not Blocked (FR34)', () => {
+  assert.equal(resolveTaskState(blockedWithInput), PRESENTATION_STATE.NEEDS_INPUT);
+});
+
+test('unknown raw status is a safe neutral state, never Pending (FR38)', () => {
+  const pres = resolveTaskPresentation(unknown);
+  assert.equal(pres.state, PRESENTATION_STATE.UNKNOWN);
+  assert.equal(pres.isUnknown, true);
+  assert.equal(pres.rawState, 'frobnicating', 'raw value stays exposed for developer detail');
+  assert.notEqual(pres.label, 'Pending');
+});
+
+test('primary actions match the state matrix (FR30-36)', () => {
+  assert.equal(resolveTaskPresentation(unassigned).primaryAction.id, 'assign_start');
+  assert.equal(resolveTaskPresentation(ready).primaryAction.id, 'start');
+  assert.equal(resolveTaskPresentation(running).primaryAction.id, 'track');
+  assert.equal(resolveTaskPresentation(needsInputChoice).primaryAction.id, 'respond');
+  assert.equal(resolveTaskPresentation(blocked).primaryAction.id, 'inspect');
+  assert.equal(resolveTaskPresentation(completed).primaryAction.id, 'view_result');
+});
+
+test('failed/timed-out expose Inspect & Retry only when retry is supported (FR35)', () => {
+  assert.equal(resolveTaskPresentation(failed).primaryAction.id, 'retry');
+  assert.equal(resolveTaskPresentation(timedOut).primaryAction.id, 'retry');
+
+  const exhausted = {
+    id: 't-exhausted',
+    status: 'failed',
+    context: { execution_retry: { attempts_used: 3, max_attempts: 3 } }
+  };
+  assert.equal(resolveTaskPresentation(exhausted).primaryAction.id, 'inspect');
+
+  const hasBudget = {
+    id: 't-budget',
+    status: 'failed',
+    context: { execution_retry: { attempts_used: 1, max_attempts: 3 } }
+  };
+  assert.equal(resolveTaskPresentation(hasBudget).primaryAction.id, 'retry');
+});
+
+test('secondary actions: Running→Cancel(confirm), Completed→Re-run (FR32, FR36)', () => {
+  const runPres = resolveTaskPresentation(running);
+  assert.deepEqual(runPres.secondaryActions, [{ id: 'cancel', label: 'Cancel', confirm: true }]);
+  assert.equal(resolveTaskPresentation(running, { cancelSupported: false }).secondaryActions.length, 0);
+
+  const donePres = resolveTaskPresentation(completed);
+  assert.deepEqual(donePres.secondaryActions, [{ id: 'rerun', label: 'Re-run' }]);
+  assert.equal(resolveTaskPresentation(completed, { rerunSupported: false }).secondaryActions.length, 0);
+});
+
+test('tones carry role-independent runtime meaning (FR40 boundary)', () => {
+  assert.equal(resolveTaskPresentation(running).tone, 'active');
+  assert.equal(resolveTaskPresentation(needsInputChoice).tone, 'attention');
+  assert.equal(resolveTaskPresentation(failed).tone, 'danger');
+  assert.equal(resolveTaskPresentation(timedOut).tone, 'danger');
+  assert.equal(resolveTaskPresentation(completed).tone, 'success');
+});
+
+test('count categories: Actionable/Active/Needs Attention membership (FR16-19)', () => {
+  // Active excludes needs_assignment, failed, timed-out, and terminal states.
+  assert.equal(taskMatchesFilter(unassigned, FILTER.ACTIVE), false);
+  assert.equal(taskMatchesFilter(ready, FILTER.ACTIVE), true);
+  assert.equal(taskMatchesFilter(running, FILTER.ACTIVE), true);
+  assert.equal(taskMatchesFilter(needsInputChoice, FILTER.ACTIVE), true);
+  assert.equal(taskMatchesFilter(blocked, FILTER.ACTIVE), true);
+  assert.equal(taskMatchesFilter(failed, FILTER.ACTIVE), false);
+  assert.equal(taskMatchesFilter(completed, FILTER.ACTIVE), false);
+
+  // Needs Attention: needs assignment, needs input, blocked, failed, timed out.
+  assert.equal(taskMatchesFilter(unassigned, FILTER.NEEDS_ATTENTION), true);
+  assert.equal(taskMatchesFilter(needsInputChoice, FILTER.NEEDS_ATTENTION), true);
+  assert.equal(taskMatchesFilter(blocked, FILTER.NEEDS_ATTENTION), true);
+  assert.equal(taskMatchesFilter(failed, FILTER.NEEDS_ATTENTION), true);
+  assert.equal(taskMatchesFilter(timedOut, FILTER.NEEDS_ATTENTION), true);
+  assert.equal(taskMatchesFilter(running, FILTER.NEEDS_ATTENTION), false);
+
+  // Actionable includes everything that can be acted on; terminal-quiet states excluded.
+  assert.equal(taskMatchesFilter(running, FILTER.ACTIONABLE), true);
+  assert.equal(taskMatchesFilter(failed, FILTER.ACTIONABLE), true);
+  assert.equal(taskMatchesFilter(cancelled, FILTER.ACTIONABLE), false);
+  assert.equal(taskMatchesFilter(completed, FILTER.ACTIONABLE), false);
+});
+
+test('resolveTaskCounts sums the same categories as the rows (FR45)', () => {
+  const tasks = [unassigned, ready, running, needsInputChoice, blocked, failed, timedOut, completed, cancelled];
+  const counts = resolveTaskCounts(tasks);
+  assert.equal(counts[FILTER.ALL], tasks.length);
+  assert.equal(counts[FILTER.COMPLETED], 1);
+  // Needs Attention: unassigned, needsInput, blocked, failed, timedOut = 5
+  assert.equal(counts[FILTER.NEEDS_ATTENTION], 5);
+  // Active: ready, running, needsInput, blocked = 4
+  assert.equal(counts[FILTER.ACTIVE], 4);
+});
+
+test('sortTasksForDrawer: intervention → running → failed/timed → ready → terminal (FR24)', () => {
+  const shuffled = [completed, ready, running, failed, blocked, needsInputChoice, cancelled];
+  const order = sortTasksForDrawer(shuffled).map(t => resolveTaskState(t));
+  assert.deepEqual(order, [
+    PRESENTATION_STATE.NEEDS_INPUT,
+    PRESENTATION_STATE.BLOCKED,
+    PRESENTATION_STATE.RUNNING,
+    PRESENTATION_STATE.FAILED,
+    PRESENTATION_STATE.READY,
+    PRESENTATION_STATE.COMPLETED,
+    PRESENTATION_STATE.CANCELLED
+  ]);
+});
+
+test('sort ties break by most-recent activity then ascending id (FR24)', () => {
+  const older = { id: 'b-older', status: 'in_progress', to: 'x', updated_at: '2026-01-01T00:00:00Z' };
+  const newer = { id: 'a-newer', status: 'in_progress', to: 'x', updated_at: '2026-06-01T00:00:00Z' };
+  const sorted = sortTasksForDrawer([older, newer]);
+  assert.equal(sorted[0].id, 'a-newer', 'more recent activity sorts first');
+
+  const sameTime = [
+    { id: 'z', status: 'in_progress', to: 'x', updated_at: '2026-06-01T00:00:00Z' },
+    { id: 'a', status: 'in_progress', to: 'x', updated_at: '2026-06-01T00:00:00Z' }
+  ];
+  assert.equal(sortTasksForDrawer(sameTime)[0].id, 'a', 'id breaks the tie ascending');
+});
+
+test('sortTasksForDrawer does not mutate its input', () => {
+  const input = [completed, needsInputChoice];
+  const copy = input.slice();
+  sortTasksForDrawer(input);
+  assert.deepEqual(input, copy);
+});
+
+test('taskShortId is stable from the task id, not the array position (FR15)', () => {
+  assert.equal(taskShortId({ id: 'task-abcdef' }), '#CDEF');
+  assert.equal(taskShortId({ id: 'task-abcdef' }), taskShortId({ id: 'task-abcdef' }));
+  assert.equal(taskShortId({ id: '' }), '');
+  assert.equal(taskShortId(null), '');
+});
+
+test('taskLatestActivityAt falls back to created_at then 0', () => {
+  assert.equal(taskLatestActivityAt({ created_at: '2026-06-01T00:00:00Z' }) > 0, true);
+  assert.equal(taskLatestActivityAt({}), 0);
+  assert.equal(taskLatestActivityAt(null), 0);
+});
+
+test('countCategories always include ALL', () => {
+  [unassigned, ready, running, completed, cancelled, unknown].forEach(t => {
+    assert.ok(resolveTaskPresentation(t).countCategories.includes(FILTER.ALL));
+  });
+});

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -6,6 +6,15 @@
  * modals and hidden shared hosts — see #workspace-detail-shared-hosts) and
  * renders into #workspaceCommandView.
  */
+// Shared task-presentation model — single source of truth for task status
+// predicates (and, in later groups, labels/counts/actions). The Map's status
+// predicates delegate here so no surface keeps a parallel copy (FR29).
+import {
+  isBlockedTask as sharedIsBlockedTask,
+  isNeedsInputTask as sharedIsNeedsInputTask,
+  isWorkingTask as sharedIsWorkingTask,
+  isQueuedTask as sharedIsQueuedTask
+} from './task-presentation.js';
 // Legacy view preference from the deleted Detailed/Command toggle; cleared on boot.
 const LEGACY_STORAGE_KEY = 'oriWorkspaceDetailView';
 const VIEW_MODE_STORAGE_KEY = 'oriWorkspaceCommandViewMode';
@@ -2595,40 +2604,23 @@ export class WorkspaceCommandView {
       .toLowerCase();
   }
 
+  // These delegate to the shared task-presentation predicates so the Map no
+  // longer maintains its own copy. Behaviour is byte-identical to the prior
+  // inline logic (FR29, inert landing).
   isBlockedTask(task) {
-    const status = String(task?.status || '')
-      .trim()
-      .toLowerCase();
-    const humanLoop = this.taskHumanLoopState(task);
-    return status === 'blocked' || humanLoop === 'blocked';
+    return sharedIsBlockedTask(task);
   }
 
   isNeedsInputTask(task) {
-    const status = String(task?.status || '')
-      .trim()
-      .toLowerCase();
-    const humanLoop = this.taskHumanLoopState(task);
-    return (
-      status === 'waiting_for_choice' ||
-      humanLoop === 'waiting_for_choice' ||
-      task?.context?.execution_step_waiting === true
-    );
+    return sharedIsNeedsInputTask(task);
   }
 
   isWorkingTask(task) {
-    return (
-      String(task?.status || '')
-        .trim()
-        .toLowerCase() === 'in_progress'
-    );
+    return sharedIsWorkingTask(task);
   }
 
   isQueuedTask(task) {
-    return (
-      String(task?.status || '')
-        .trim()
-        .toLowerCase() === 'pending'
-    );
+    return sharedIsQueuedTask(task);
   }
 
   taskPriority(task) {


### PR DESCRIPTION
**Serialized epic — group 1 of 8: Foundations (lands inert).** First seam-PR of the *Workspace Task Execution UX* redesign (PRD `tasks/prd-workspace-task-execution-ux.md`). No visual change; establishes the shared model + records the backend audit that shapes the rest of the epic.

## What this adds
- **`task-presentation.js`** — a pure, fixture-testable resolver mapping a raw task (+ human-loop / retry context) to one canonical presentation: `state`, `label`, `tone`, `countCategories`, deterministic `sortPriority`, and primary/secondary `actions`. Intended as the single source of truth for the Map rows, the (upcoming) task drawer, execution tray, workspace-detail surfaces, and the dedicated task page (FR29–FR45).
  - `timeout` stays **distinct** from `failed` (the legacy `getTaskExecutionState` map flattened them — FR35).
  - Unknown raw states resolve to a **safe neutral** presentation that exposes the raw value and is never silently shown as `Pending` (FR38).
  - Count buckets (Actionable / Active / Needs Attention / Completed / All) and the drawer sort (intervention → running → failed/timed-out → ready → terminal; ties by recent-activity then ascending id) are pure functions (FR16–FR19, FR24).
- **`task-presentation.test.js`** — 16 unit tests across fixtures for every state (unassigned, ready, running, needs-input, blocked, failed, timed-out, completed, cancelled, unknown…).

## Inert landing
Byte-identical raw predicates (`isBlockedTask`, `isNeedsInputTask`, `isWorkingTask`, `isQueuedTask`) are extracted into the shared module, and the Operations Map's four predicate methods now **delegate** to them (net −8 lines in `workspace-command.js`). Behaviour is unchanged. The resolver's higher-level state *precedence* and new labels/counts/actions are adopted deliberately by later redesign groups (drawer/tray/task-page), not here.

## Backend audit (no backend change required)
Recorded in the PRD's "Audit findings (task 1.1)" section. Task monitoring is **task-ID-keyed** via `/api/orchestration/tasks` + the `window.workspaceRealtime` event bus; the `workspacerun` `/trace?since=` system is a separate, optional deep-history facility. The execute endpoint returns no run ID — fine, since the task ID is known immediately. Every field the resolver needs is already on the task payload.

## Verification
- `npm run test:modules` → **594/594 pass** (16 new, 578 existing untouched).
- `go build ./cmd/server` succeeds; isolated smoke server serves both JS modules (200) with the ESM import graph wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)