### PR TITLE
feat(workspace): execution controller + overlay coordinator + layer tokens (group 2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,6 +165,8 @@ export default defineConfig([
       'internal/web/static/js/modules/template-onboarding.js',
       'internal/web/static/js/modules/workspace-tags-card.js',
       'internal/web/static/js/modules/workspace-command.js',
+      'internal/web/static/js/modules/workspace-execution-controller.js',
+      'internal/web/static/js/modules/workspace-overlay-coordinator.js',
     ],
     languageOptions: {
       sourceType: 'module'

--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -21,6 +21,25 @@
   --ws-line: #262931;
   --ws-line-bright: #363a45;
 
+  /* ---- overlay layer scale ----
+     Single documented z-index scale for the workspace detail surface, mirroring
+     the LAYER constants in workspace-overlay-coordinator.js. New surfaces
+     (drawer/tray/modal/menu/toast) reference these tokens instead of inventing
+     local z-index values. The two `legacy` tokens below preserve the CURRENT
+     stacking (map window 10010 / stat modal 1050) so this change is inert; they
+     get folded into the scale in group 3 when the task drawer replaces the
+     in-map task-manager modal flow and the ordering can be verified end-to-end. */
+  --wsx-layer-map: 100;
+  --wsx-layer-drawer: 200;
+  --wsx-layer-tray: 300;
+  --wsx-layer-popover: 900;
+  --wsx-layer-modal-backdrop: 1000;
+  --wsx-layer-modal: 1010;
+  --wsx-layer-menu: 1100;
+  --wsx-layer-toast: 2000;
+  --wsx-layer-legacy-map-window: 10010;
+  --wsx-layer-legacy-stat-modal: 1050;
+
   /* ink */
   --ws-ink: #d6d9de;
   --ws-ink-dim: #8b909a;
@@ -730,7 +749,7 @@
 .ws-cmd-map-window-backdrop {
   position: fixed;
   inset: clamp(76px, 10vh, 112px) 16px 16px;
-  z-index: 10010;
+  z-index: var(--wsx-layer-legacy-map-window);
   display: grid;
   place-items: start center;
   padding: 28px;
@@ -3637,7 +3656,7 @@
 .ws-cmd-modal {
   position: fixed;
   inset: 0;
-  z-index: 1050;
+  z-index: var(--wsx-layer-legacy-stat-modal);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/internal/web/static/js/modules/workspace-execution-controller.js
+++ b/internal/web/static/js/modules/workspace-execution-controller.js
@@ -1,0 +1,309 @@
+/**
+ * workspace-execution-controller.js
+ *
+ * Workspace-scoped execution controller/store. It owns the lifetime of task
+ * execution monitoring — selected run, active runs, polling + realtime
+ * subscription, activity de-duplication, and reconnect state — DECOUPLED from
+ * any Bootstrap modal (PRD FR47, FR51, FR65, FR266).
+ *
+ * Why this exists: today the execution monitor is started/stopped by the task
+ * execution modal's shown/hidden events (workspace-detail.js:1683-1685), so
+ * closing the modal stops monitoring even while the task is still running. This
+ * controller makes monitoring survive any view change; the tray (group 4) and
+ * the dedicated task page (group 7) render FROM it.
+ *
+ * Monitoring is TASK-ID-KEYED, per the group-1 backend audit: the task object
+ * (`GET /api/orchestration/tasks?id=`) is the authoritative execution state and
+ * the `window.workspaceRealtime` bus pushes `task.*` events. There is no
+ * server-side per-line activity log, so activity is re-derived from task-state
+ * transitions and de-duped by a stable key — reload/attach resumes without
+ * duplicating entries (FR56, FR58, FR127).
+ *
+ * The core is dependency-injected (fetchTask, subscribeRealtime, timers) so it
+ * is exercisable from fixtures without a DOM or network. Group 2 lands it
+ * INERT: it is built and tested but not yet wired into the live surfaces.
+ */
+
+import { resolveTaskPresentation, PRESENTATION_STATE } from './task-presentation.js';
+
+// Phases describe the monitor's lifecycle for one tracked run, independent of
+// how any view chooses to render (collapsed/expanded is a view concern, never
+// a monitor concern — that is the whole point of the decoupling).
+export const RUN_PHASE = Object.freeze({
+  STARTING: 'starting', // action accepted, first authoritative state not seen yet (FR57)
+  LIVE: 'live', // actively polling / receiving events
+  RECONNECTING: 'reconnecting', // a fetch failed; retained activity, will retry (FR58)
+  SETTLED: 'settled' // terminal or needs-input; monitor stopped, run kept available (FR61)
+});
+
+const TERMINAL_STATES = new Set([
+  PRESENTATION_STATE.COMPLETED,
+  PRESENTATION_STATE.FAILED,
+  PRESENTATION_STATE.TIMED_OUT,
+  PRESENTATION_STATE.CANCELLED,
+  PRESENTATION_STATE.SKIPPED
+]);
+
+// A state that stops active polling but keeps the run available for the user
+// to act on (terminal outcomes, plus needs-input which awaits the user).
+function isSettledState(state) {
+  return TERMINAL_STATES.has(state) || state === PRESENTATION_STATE.NEEDS_INPUT;
+}
+
+export class WorkspaceExecutionController {
+  /**
+   * @param {object} deps
+   * @param {string} deps.workspaceId
+   * @param {(taskId:string)=>Promise<object|null>} deps.fetchTask - resolves the authoritative task payload
+   * @param {(workspaceId:string, handler:(event:object)=>void)=>(()=>void)} [deps.subscribeRealtime]
+   *        - subscribes to workspace realtime events; returns an unsubscribe fn
+   * @param {number} [deps.pollIntervalMs=3000]
+   * @param {(fn:Function, ms:number)=>*} [deps.setIntervalFn]
+   * @param {(handle:*)=>void} [deps.clearIntervalFn]
+   * @param {()=>number} [deps.now]
+   */
+  constructor(deps = {}) {
+    this.workspaceId = deps.workspaceId || '';
+    this._fetchTask = typeof deps.fetchTask === 'function' ? deps.fetchTask : async () => null;
+    this._subscribeRealtime = typeof deps.subscribeRealtime === 'function' ? deps.subscribeRealtime : null;
+    this._pollIntervalMs = Number(deps.pollIntervalMs) > 0 ? Number(deps.pollIntervalMs) : 3000;
+    this._setInterval = deps.setIntervalFn || ((fn, ms) => setInterval(fn, ms));
+    this._clearInterval = deps.clearIntervalFn || (handle => clearInterval(handle));
+    this._now = deps.now || (() => Date.now());
+
+    /** @type {Map<string, object>} taskId -> run state */
+    this._runs = new Map();
+    /** @type {Set<Function>} renderer listeners */
+    this._listeners = new Set();
+    this._selectedTaskId = '';
+    this._realtimeUnsub = null;
+    this._disposed = false;
+  }
+
+  // ---- lifecycle ----
+
+  /**
+   * Begin monitoring a task by ID. Idempotent: tracking an already-tracked task
+   * does NOT spawn a second monitor (FR65 — no duplicate monitors). Selects the
+   * run unless `select === false`.
+   */
+  track(taskId, options = {}) {
+    const id = String(taskId || '').trim();
+    if (!id || this._disposed) return null;
+
+    this._ensureRealtime();
+
+    let run = this._runs.get(id);
+    if (!run) {
+      run = this._createRun(id);
+      this._runs.set(id, run);
+      // Kick an immediate authoritative poll, then settle into the interval.
+      this._poll(id);
+      run.timer = this._setInterval(() => this._poll(id), this._pollIntervalMs);
+    }
+    if (options.select !== false) this._selectedTaskId = id;
+    this._emit();
+    return run;
+  }
+
+  /** Stop monitoring one task and forget its run. */
+  untrack(taskId) {
+    const id = String(taskId || '').trim();
+    const run = this._runs.get(id);
+    if (!run) return;
+    this._stopTimer(run);
+    this._runs.delete(id);
+    if (this._selectedTaskId === id) {
+      // Fall back to another active run, else clear the selection.
+      const next = this.getActiveRuns()[0] || this.getRuns()[0] || null;
+      this._selectedTaskId = next ? next.taskId : '';
+    }
+    this._emit();
+  }
+
+  /** Select which run the tray shows, without affecting any other run (FR55). */
+  select(taskId) {
+    const id = String(taskId || '').trim();
+    if (id && this._runs.has(id)) {
+      this._selectedTaskId = id;
+      this._emit();
+    }
+  }
+
+  // ---- reads ----
+
+  getSelectedTaskId() {
+    return this._selectedTaskId;
+  }
+
+  getSelected() {
+    return this._selectedTaskId ? this._runs.get(this._selectedTaskId) || null : null;
+  }
+
+  getRun(taskId) {
+    return this._runs.get(String(taskId || '').trim()) || null;
+  }
+
+  getRuns() {
+    return Array.from(this._runs.values());
+  }
+
+  /** Runs still in flight (not settled) — drives "N other active runs" (FR53). */
+  getActiveRuns() {
+    return this.getRuns().filter(run => run.phase !== RUN_PHASE.SETTLED);
+  }
+
+  /** Runs that need the user (needs-input or a terminal failure) — attention count. */
+  getAttentionRuns() {
+    return this.getRuns().filter(run => {
+      const s = run.presentation && run.presentation.state;
+      return (
+        s === PRESENTATION_STATE.NEEDS_INPUT ||
+        s === PRESENTATION_STATE.FAILED ||
+        s === PRESENTATION_STATE.TIMED_OUT ||
+        s === PRESENTATION_STATE.BLOCKED
+      );
+    });
+  }
+
+  // ---- renderer subscription ----
+
+  /** Subscribe a renderer (tray/task page). Returns an unsubscribe fn. */
+  subscribe(listener) {
+    if (typeof listener !== 'function') return () => {};
+    this._listeners.add(listener);
+    return () => this._listeners.delete(listener);
+  }
+
+  // ---- realtime ----
+
+  /**
+   * Handle a workspace realtime event. If it names a tracked task we re-derive
+   * authoritative state via an immediate poll rather than trusting the event
+   * payload — this keeps one source of truth and lets de-dup absorb repeats
+   * (FR58). Exposed for direct testing.
+   */
+  handleRealtimeEvent(event) {
+    const taskId = this._extractTaskId(event);
+    if (taskId && this._runs.has(taskId)) {
+      this._poll(taskId);
+    }
+  }
+
+  dispose() {
+    this._disposed = true;
+    this.getRuns().forEach(run => this._stopTimer(run));
+    this._runs.clear();
+    if (this._realtimeUnsub) {
+      this._realtimeUnsub();
+      this._realtimeUnsub = null;
+    }
+    this._listeners.clear();
+  }
+
+  // ---- internals ----
+
+  _createRun(taskId) {
+    return {
+      taskId,
+      phase: RUN_PHASE.STARTING,
+      task: null,
+      presentation: null,
+      activity: [],
+      _seenActivityKeys: new Set(),
+      startedAt: this._now(),
+      lastActivityAt: 0,
+      lastStatus: '',
+      timer: null
+    };
+  }
+
+  async _poll(taskId) {
+    const run = this._runs.get(taskId);
+    if (!run || this._disposed) return;
+    let task;
+    try {
+      task = await this._fetchTask(taskId);
+    } catch (_err) {
+      // Transient interruption — retain rendered activity, retry next tick (FR58).
+      if (run.phase !== RUN_PHASE.SETTLED) run.phase = RUN_PHASE.RECONNECTING;
+      this._emit();
+      return;
+    }
+    // The run may have been untracked/disposed while awaiting.
+    if (this._disposed || !this._runs.has(taskId)) return;
+    if (!task || String(task.id || '') !== taskId) return;
+
+    run.task = task;
+    const presentation = resolveTaskPresentation(task);
+    const prevStatus = run.lastStatus;
+    run.presentation = presentation;
+    run.lastStatus = presentation.state;
+
+    // Synthesize an activity entry on a status change, de-duped by a stable key
+    // so reload/attach/realtime bursts never double-log (FR58, FR127).
+    if (presentation.state !== prevStatus) {
+      this._appendActivity(run, {
+        kind: 'status',
+        state: presentation.state,
+        label: presentation.label,
+        at: presentation.latestActivityAt || this._now(),
+        key: `${taskId}:status:${presentation.state}:${task.updated_at || ''}`
+      });
+    }
+    if (presentation.latestActivityAt) run.lastActivityAt = presentation.latestActivityAt;
+
+    if (isSettledState(presentation.state)) {
+      run.phase = RUN_PHASE.SETTLED;
+      this._stopTimer(run); // stop polling, but keep the run available (FR61)
+    } else {
+      run.phase = RUN_PHASE.LIVE;
+    }
+    this._emit();
+  }
+
+  _appendActivity(run, entry) {
+    if (!entry || !entry.key) return;
+    if (run._seenActivityKeys.has(entry.key)) return;
+    run._seenActivityKeys.add(entry.key);
+    run.activity.push(entry);
+  }
+
+  _ensureRealtime() {
+    if (this._realtimeUnsub || !this._subscribeRealtime) return;
+    this._realtimeUnsub = this._subscribeRealtime(this.workspaceId, event => this.handleRealtimeEvent(event));
+  }
+
+  _extractTaskId(event) {
+    const data = event && typeof event === 'object' ? event.data || {} : {};
+    const payload = data && typeof data.data === 'object' ? data.data : data;
+    return String((payload && payload.task_id) || (data && data.task_id) || '').trim();
+  }
+
+  _stopTimer(run) {
+    if (run && run.timer != null) {
+      this._clearInterval(run.timer);
+      run.timer = null;
+    }
+  }
+
+  _emit() {
+    if (this._disposed) return;
+    const snapshot = {
+      selectedTaskId: this._selectedTaskId,
+      runs: this.getRuns(),
+      activeRuns: this.getActiveRuns()
+    };
+    this._listeners.forEach(listener => {
+      try {
+        listener(snapshot);
+      } catch (_err) {
+        /* a renderer error must not break the controller */
+      }
+    });
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.WorkspaceExecutionController = WorkspaceExecutionController;
+}

--- a/internal/web/static/js/modules/workspace-execution-controller.test.js
+++ b/internal/web/static/js/modules/workspace-execution-controller.test.js
@@ -1,0 +1,218 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceExecutionController, RUN_PHASE } from './workspace-execution-controller.js';
+import { PRESENTATION_STATE } from './task-presentation.js';
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+/**
+ * Build a controller with controllable fakes. `scripts` maps taskId -> a
+ * function(callIndex) returning the task payload (or throwing) for each poll.
+ */
+function makeHarness(scripts = {}) {
+  const timers = [];
+  const fetchCalls = [];
+  const callCounts = {};
+  let realtimeHandler = null;
+  let realtimeUnsubbed = false;
+
+  const controller = new WorkspaceExecutionController({
+    workspaceId: 'w1',
+    fetchTask: async id => {
+      fetchCalls.push(id);
+      const n = callCounts[id] || 0;
+      callCounts[id] = n + 1;
+      const script = scripts[id];
+      const value = typeof script === 'function' ? script(n) : script;
+      if (value instanceof Error) throw value;
+      return value;
+    },
+    subscribeRealtime: (_wid, handler) => {
+      realtimeHandler = handler;
+      return () => {
+        realtimeHandler = null;
+        realtimeUnsubbed = true;
+      };
+    },
+    setIntervalFn: fn => {
+      const t = { fn, stopped: false };
+      timers.push(t);
+      return t;
+    },
+    clearIntervalFn: t => {
+      if (t) t.stopped = true;
+    },
+    now: () => 1000
+  });
+
+  return {
+    controller,
+    fetchCalls,
+    liveTimers: () => timers.filter(t => !t.stopped),
+    tick: async () => {
+      timers.filter(t => !t.stopped).forEach(t => t.fn());
+      await flush();
+    },
+    fireRealtime: event => {
+      if (realtimeHandler) realtimeHandler(event);
+    },
+    wasRealtimeUnsubbed: () => realtimeUnsubbed
+  };
+}
+
+const running = { id: 't1', status: 'in_progress', to: 'agent-a', updated_at: '2026-06-01T00:00:00Z' };
+
+test('track() starts a run and resolves presentation from the first poll', async () => {
+  const h = makeHarness({ t1: running });
+  const events = [];
+  h.controller.subscribe(s => events.push(s));
+  h.controller.track('t1');
+  await flush();
+
+  const run = h.controller.getRun('t1');
+  assert.ok(run);
+  assert.equal(run.presentation.state, PRESENTATION_STATE.RUNNING);
+  assert.equal(run.phase, RUN_PHASE.LIVE);
+  assert.equal(h.controller.getSelectedTaskId(), 't1');
+  assert.ok(events.length >= 1, 'renderers are notified');
+});
+
+test('track() is idempotent — no duplicate monitor for the same task (FR65)', async () => {
+  const h = makeHarness({ t1: running });
+  h.controller.track('t1');
+  h.controller.track('t1');
+  await flush();
+  assert.equal(h.liveTimers().length, 1, 'only one interval for the task');
+});
+
+test('multiple concurrent runs; selecting one does not stop the other (FR53, FR55)', async () => {
+  const h = makeHarness({
+    t1: running,
+    t2: { id: 't2', status: 'in_progress', to: 'b', updated_at: '2026-06-01T00:00:00Z' }
+  });
+  h.controller.track('t1');
+  h.controller.track('t2');
+  await flush();
+
+  assert.equal(h.controller.getActiveRuns().length, 2);
+  assert.equal(h.controller.getSelectedTaskId(), 't2', 'latest tracked is selected');
+
+  h.controller.select('t1');
+  assert.equal(h.controller.getSelectedTaskId(), 't1');
+  assert.equal(h.liveTimers().length, 2, 'both runs still monitored after switching selection');
+});
+
+test('terminal state settles: polling stops but the run stays available (FR61)', async () => {
+  const h = makeHarness({ t1: { id: 't1', status: 'completed', to: 'a', result: 'ok' } });
+  h.controller.track('t1');
+  await flush();
+
+  const run = h.controller.getRun('t1');
+  assert.equal(run.phase, RUN_PHASE.SETTLED);
+  assert.equal(h.liveTimers().length, 0, 'no active timer after terminal');
+  assert.equal(h.controller.getActiveRuns().length, 0);
+  assert.ok(h.controller.getRun('t1'), 'run is still retrievable for the user to act on');
+});
+
+test('needs-input settles polling but keeps the run and flags attention', async () => {
+  const h = makeHarness({ t1: { id: 't1', status: 'waiting_for_choice', to: 'a' } });
+  h.controller.track('t1');
+  await flush();
+  assert.equal(h.controller.getRun('t1').phase, RUN_PHASE.SETTLED);
+  assert.equal(h.controller.getAttentionRuns().length, 1);
+});
+
+test('a failed poll enters reconnecting and retains activity, then resumes (FR58)', async () => {
+  const h = makeHarness({
+    t1: n => (n === 1 ? new Error('network') : running) // 1st poll ok, 2nd throws, 3rd ok
+  });
+  h.controller.track('t1');
+  await flush(); // poll 0 -> running (LIVE), 1 activity entry
+  const before = h.controller.getRun('t1').activity.length;
+  assert.equal(h.controller.getRun('t1').phase, RUN_PHASE.LIVE);
+
+  await h.tick(); // poll 1 -> throws -> reconnecting
+  assert.equal(h.controller.getRun('t1').phase, RUN_PHASE.RECONNECTING);
+  assert.equal(h.controller.getRun('t1').activity.length, before, 'activity retained across reconnect');
+
+  await h.tick(); // poll 2 -> running -> live again
+  assert.equal(h.controller.getRun('t1').phase, RUN_PHASE.LIVE);
+});
+
+test('activity is de-duped by stable key across repeated polls (FR58, FR127)', async () => {
+  const h = makeHarness({ t1: running }); // same payload every poll
+  h.controller.track('t1');
+  await flush();
+  await h.tick();
+  await h.tick();
+  const statusEntries = h.controller.getRun('t1').activity.filter(a => a.kind === 'status');
+  assert.equal(statusEntries.length, 1, 'unchanged status logged once, not per poll');
+});
+
+test('a status change appends a new de-duped activity entry', async () => {
+  const h = makeHarness({
+    t1: n =>
+      n === 0
+        ? { id: 't1', status: 'in_progress', to: 'a', updated_at: '2026-06-01T00:00:00Z' }
+        : { id: 't1', status: 'completed', to: 'a', updated_at: '2026-06-02T00:00:00Z', result: 'ok' }
+  });
+  h.controller.track('t1');
+  await flush(); // running
+  await h.tick(); // completed
+  const states = h.controller
+    .getRun('t1')
+    .activity.filter(a => a.kind === 'status')
+    .map(a => a.state);
+  assert.deepEqual(states, [PRESENTATION_STATE.RUNNING, PRESENTATION_STATE.COMPLETED]);
+});
+
+test('realtime event for a tracked task triggers an authoritative poll; untracked is ignored', async () => {
+  const h = makeHarness({ t1: running });
+  h.controller.track('t1');
+  await flush();
+  const before = h.fetchCalls.length;
+
+  h.fireRealtime({ data: { data: { task_id: 't1' } } });
+  await flush();
+  assert.equal(h.fetchCalls.length, before + 1, 'tracked task re-polled on realtime');
+
+  h.fireRealtime({ data: { data: { task_id: 'other' } } });
+  await flush();
+  assert.equal(h.fetchCalls.length, before + 1, 'untracked task ignored');
+});
+
+test('untrack() removes the run and reselects an active one', async () => {
+  const h = makeHarness({
+    t1: running,
+    t2: { id: 't2', status: 'in_progress', to: 'b', updated_at: '2026-06-01T00:00:00Z' }
+  });
+  h.controller.track('t1');
+  h.controller.track('t2'); // selected = t2
+  await flush();
+
+  h.controller.untrack('t2');
+  assert.equal(h.controller.getRun('t2'), null);
+  assert.equal(h.controller.getSelectedTaskId(), 't1', 'reselects a remaining run');
+});
+
+test('dispose() stops all timers and unsubscribes realtime', async () => {
+  const h = makeHarness({ t1: running, t2: running });
+  h.controller.track('t1');
+  h.controller.track('t2');
+  await flush();
+  h.controller.dispose();
+  assert.equal(h.liveTimers().length, 0);
+  assert.equal(h.wasRealtimeUnsubbed(), true);
+  assert.equal(h.controller.getRuns().length, 0);
+});
+
+test('monitoring is independent of any modal/view — no view coupling in the API surface', () => {
+  // The controller exposes no modal/collapse concept; a view collapsing cannot
+  // reach in to stop a monitor. This guards the core decoupling (FR51).
+  const h = makeHarness({ t1: running });
+  const api = Object.getOwnPropertyNames(Object.getPrototypeOf(h.controller));
+  ['track', 'untrack', 'select', 'subscribe', 'dispose'].forEach(m =>
+    assert.ok(api.includes(m), `controller exposes ${m}`)
+  );
+  assert.ok(!api.some(m => /modal|collapse|hide|show/i.test(m)), 'no modal/collapse lifecycle in the controller');
+});

--- a/internal/web/static/js/modules/workspace-overlay-coordinator.js
+++ b/internal/web/static/js/modules/workspace-overlay-coordinator.js
@@ -1,0 +1,216 @@
+/**
+ * workspace-overlay-coordinator.js
+ *
+ * One overlay owner and one documented layer scale for the workspace detail
+ * surface (PRD FR116–FR123, FR267). It exists because the current code escalates
+ * raw z-index locally — the Map window at `10010` sits above the task-manager
+ * modal at `1050`, so opening the task manager from the Map puts it UNDERNEATH
+ * the window that launched it (the reported bug).
+ *
+ * Responsibilities:
+ *  - Provide the single documented layer scale (`LAYER`) mirrored by the CSS
+ *    custom properties in workspace-command.css. No surface should invent a
+ *    local z-index; it registers with a `kind` and gets its layer from here.
+ *  - Enforce that only ONE modal dialog is active at a time. Opening a required
+ *    child modal SUSPENDS/REPLACES the owning modal through the coordinator
+ *    rather than stacking on a higher arbitrary z-index (FR119).
+ *  - Resolve Escape in a predictable topmost-first order: menu/popover, then a
+ *    bounded dialog, then collapse the expanded tray/drawer, then leave the
+ *    underlying Map untouched (FR123).
+ *  - Return focus to an overlay's trigger on close (FR121).
+ *
+ * DOM side effects (inert marking, focus trap/restore) are injected so the core
+ * ordering/single-modal logic is unit-testable without a browser. Group 2 lands
+ * this INERT: the coordinator and layer tokens exist and existing modals are
+ * routed through it with no behavior change; the drawer/tray adopt it later.
+ */
+
+// Documented layer scale. Mirror of the --wsx-layer-* CSS custom properties.
+// Values are ordered and spaced so a surface never needs a local escalation.
+export const LAYER = Object.freeze({
+  BASE: 0,
+  MAP: 100, // Operations Map and its in-map windows
+  DRAWER: 200, // non-modal task drawer
+  TRAY: 300, // sticky execution tray
+  POPOVER: 900, // popovers / inline pickers
+  MODAL_BACKDROP: 1000, // bounded-dialog backdrop
+  MODAL: 1010, // bounded dialog (confirmations/forms)
+  MENU: 1100, // context menus / dropdowns (above a dialog)
+  TOAST: 2000 // transient notifications, always on top
+});
+
+// Overlay kinds and their Escape-dismissal priority (lower = dismissed first).
+// menu/popover outrank a dialog; a dialog outranks collapsing a tray/drawer.
+const KIND_ESCAPE_PRIORITY = Object.freeze({
+  menu: 0,
+  popover: 0,
+  modal: 1,
+  tray: 2,
+  drawer: 2
+});
+
+const MODAL_KINDS = new Set(['modal']);
+
+export class OverlayCoordinator {
+  constructor(effects = {}) {
+    this._effects = {
+      setInert: effects.setInert || (() => {}),
+      releaseInert: effects.releaseInert || (() => {}),
+      trapFocus: effects.trapFocus || (() => {}),
+      restoreFocus: effects.restoreFocus || (() => {})
+    };
+    /** @type {Array<object>} open overlays, most-recently-opened last */
+    this._stack = [];
+  }
+
+  /** z-index for a surface kind (mirrors the CSS tokens). */
+  layerFor(kind) {
+    switch (kind) {
+      case 'map':
+        return LAYER.MAP;
+      case 'drawer':
+        return LAYER.DRAWER;
+      case 'tray':
+        return LAYER.TRAY;
+      case 'popover':
+        return LAYER.POPOVER;
+      case 'menu':
+        return LAYER.MENU;
+      case 'toast':
+        return LAYER.TOAST;
+      case 'modal':
+        return LAYER.MODAL;
+      default:
+        return LAYER.BASE;
+    }
+  }
+
+  /**
+   * Open (register) an overlay.
+   * @param {object} o
+   * @param {string} o.id - unique id
+   * @param {string} o.kind - modal|menu|popover|drawer|tray
+   * @param {Function} [o.onClose] - called when the coordinator closes it
+   * @param {*} [o.trigger] - element/opaque ref focus returns to on close
+   * @param {*} [o.container] - element to trap focus within / mark siblings inert
+   * @returns {object} the registered record
+   */
+  open(o = {}) {
+    const record = {
+      id: String(o.id || ''),
+      kind: String(o.kind || 'modal'),
+      onClose: typeof o.onClose === 'function' ? o.onClose : null,
+      trigger: o.trigger || null,
+      container: o.container || null,
+      suspended: false
+    };
+    if (!record.id) return null;
+
+    // Re-opening an already-open id is a no-op re-focus, not a duplicate.
+    const existing = this._stack.find(r => r.id === record.id);
+    if (existing) return existing;
+
+    // Single-modal rule: opening a modal suspends any currently-active modal so
+    // there is never modal-on-modal stacking (FR117, FR119).
+    if (MODAL_KINDS.has(record.kind)) {
+      const activeModal = this._topModal();
+      if (activeModal) {
+        activeModal.suspended = true;
+        if (activeModal.onClose) activeModal.onClose({ reason: 'suspended', by: record.id });
+        this._effects.releaseInert(activeModal.container);
+      }
+      if (record.container) this._effects.setInert(record.container);
+    }
+
+    this._stack.push(record);
+    if (record.container) this._effects.trapFocus(record.container);
+    return record;
+  }
+
+  /**
+   * Close an overlay by id. Returns focus to its trigger. If closing a modal
+   * that had suspended a prior modal, the prior one resumes (FR119, FR121).
+   */
+  close(id) {
+    const idx = this._stack.findIndex(r => r.id === String(id || ''));
+    if (idx === -1) return false;
+    const [record] = this._stack.splice(idx, 1);
+    if (record.onClose) record.onClose({ reason: 'closed' });
+    if (record.container) this._effects.releaseInert(record.container);
+    if (record.trigger) this._effects.restoreFocus(record.trigger);
+
+    if (MODAL_KINDS.has(record.kind)) {
+      const resume = this._topModalAny();
+      if (resume && resume.suspended) {
+        resume.suspended = false;
+        if (resume.container) {
+          this._effects.setInert(resume.container);
+          this._effects.trapFocus(resume.container);
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Handle Escape: close the single topmost-priority dismissable overlay and
+   * report which one, without touching the underlying Map (FR123). Tray/drawer
+   * are collapsed (closed) only if present; returns the closed id or null.
+   */
+  escapeTopmost() {
+    if (this._stack.length === 0) return null;
+    // Choose by (priority asc, most-recently-opened) so a menu above a dialog
+    // closes before the dialog, and the newest of equal priority wins.
+    let target = null;
+    let best = Infinity;
+    for (let i = this._stack.length - 1; i >= 0; i--) {
+      const r = this._stack[i];
+      if (r.suspended) continue;
+      const p = KIND_ESCAPE_PRIORITY[r.kind];
+      if (p == null) continue;
+      if (p < best) {
+        best = p;
+        target = r;
+      }
+    }
+    if (!target) return null;
+    this.close(target.id);
+    return target.id;
+  }
+
+  /** The active (non-suspended) modal, or null. At most one ever exists. */
+  activeModal() {
+    return this._stack.find(r => MODAL_KINDS.has(r.kind) && !r.suspended) || null;
+  }
+
+  /** Count of currently-registered modals (active + suspended). */
+  modalCount() {
+    return this._stack.filter(r => MODAL_KINDS.has(r.kind)).length;
+  }
+
+  /** All open overlay ids, base-first. */
+  openIds() {
+    return this._stack.map(r => r.id);
+  }
+
+  _topModal() {
+    for (let i = this._stack.length - 1; i >= 0; i--) {
+      if (MODAL_KINDS.has(this._stack[i].kind) && !this._stack[i].suspended) return this._stack[i];
+    }
+    return null;
+  }
+
+  // Topmost modal regardless of suspended state — used to resume the owner when
+  // the child modal that suspended it closes.
+  _topModalAny() {
+    for (let i = this._stack.length - 1; i >= 0; i--) {
+      if (MODAL_KINDS.has(this._stack[i].kind)) return this._stack[i];
+    }
+    return null;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.OverlayCoordinator = OverlayCoordinator;
+  window.OVERLAY_LAYER = LAYER;
+}

--- a/internal/web/static/js/modules/workspace-overlay-coordinator.test.js
+++ b/internal/web/static/js/modules/workspace-overlay-coordinator.test.js
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OverlayCoordinator, LAYER } from './workspace-overlay-coordinator.js';
+
+function makeCoordinator() {
+  const calls = [];
+  const c = new OverlayCoordinator({
+    setInert: el => calls.push(['setInert', el]),
+    releaseInert: el => calls.push(['releaseInert', el]),
+    trapFocus: el => calls.push(['trapFocus', el]),
+    restoreFocus: el => calls.push(['restoreFocus', el])
+  });
+  return { c, calls };
+}
+
+test('layer scale is ordered so modals sit above map windows (retires 10010 vs 1050)', () => {
+  assert.ok(LAYER.MODAL > LAYER.MAP, 'a bounded dialog is above the Map and its windows');
+  assert.ok(LAYER.MENU > LAYER.MODAL, 'menus sit above a dialog');
+  assert.ok(LAYER.TOAST > LAYER.MENU, 'toasts are always on top');
+  assert.ok(LAYER.TRAY > LAYER.DRAWER && LAYER.DRAWER > LAYER.MAP);
+});
+
+test('layerFor maps kinds to the documented tokens', () => {
+  const { c } = makeCoordinator();
+  assert.equal(c.layerFor('map'), LAYER.MAP);
+  assert.equal(c.layerFor('modal'), LAYER.MODAL);
+  assert.equal(c.layerFor('menu'), LAYER.MENU);
+  assert.equal(c.layerFor('drawer'), LAYER.DRAWER);
+  assert.equal(c.layerFor('tray'), LAYER.TRAY);
+});
+
+test('only one modal is active at a time; a child modal suspends the owner (FR119)', () => {
+  const { c } = makeCoordinator();
+  const closes = [];
+  c.open({ id: 'parent', kind: 'modal', onClose: info => closes.push(['parent', info.reason]) });
+  c.open({ id: 'child', kind: 'modal', onClose: info => closes.push(['child', info.reason]) });
+
+  assert.equal(c.activeModal().id, 'child', 'child is the active modal');
+  assert.equal(c.modalCount(), 2, 'parent is retained but suspended, not stacked as active');
+  assert.deepEqual(closes[0], ['parent', 'suspended'], 'owner was suspended via the coordinator');
+});
+
+test('closing the child modal resumes the suspended parent (FR119)', () => {
+  const { c } = makeCoordinator();
+  c.open({ id: 'parent', kind: 'modal' });
+  c.open({ id: 'child', kind: 'modal' });
+  c.close('child');
+  assert.equal(c.activeModal().id, 'parent', 'parent resumes as the active modal');
+  assert.equal(c.modalCount(), 1);
+});
+
+test('a user action never opens a modal under an existing one (FR117) — no two active modals', () => {
+  const { c } = makeCoordinator();
+  c.open({ id: 'a', kind: 'modal' });
+  c.open({ id: 'b', kind: 'modal' });
+  c.open({ id: 'cc', kind: 'modal' });
+  const active = c.openIds().filter(id => id === c.activeModal().id);
+  assert.equal(active.length, 1);
+  assert.equal(c.activeModal().id, 'cc');
+});
+
+test('close returns focus to the overlay trigger (FR121)', () => {
+  const { c, calls } = makeCoordinator();
+  const trigger = { name: 'open-btn' };
+  c.open({ id: 'm', kind: 'modal', trigger });
+  c.close('m');
+  assert.ok(calls.some(([op, arg]) => op === 'restoreFocus' && arg === trigger));
+});
+
+test('Escape closes menu/popover before a dialog (FR123)', () => {
+  const { c } = makeCoordinator();
+  c.open({ id: 'dialog', kind: 'modal' });
+  c.open({ id: 'menu', kind: 'menu' });
+  assert.equal(c.escapeTopmost(), 'menu', 'menu dismissed first');
+  assert.equal(c.escapeTopmost(), 'dialog', 'then the dialog');
+  assert.equal(c.escapeTopmost(), null, 'nothing left dismissable; Map untouched');
+});
+
+test('Escape collapses tray/drawer only after menus and dialogs', () => {
+  const { c } = makeCoordinator();
+  c.open({ id: 'drawer', kind: 'drawer' });
+  c.open({ id: 'tray', kind: 'tray' });
+  c.open({ id: 'dialog', kind: 'modal' });
+  assert.equal(c.escapeTopmost(), 'dialog', 'dialog (priority 1) before tray/drawer (priority 2)');
+  const next = c.escapeTopmost();
+  assert.ok(next === 'tray' || next === 'drawer', 'then a tray/drawer collapses');
+});
+
+test('focus is trapped on open and inert applied for modals', () => {
+  const { c, calls } = makeCoordinator();
+  const container = { id: 'modal-el' };
+  c.open({ id: 'm', kind: 'modal', container });
+  assert.ok(calls.some(([op, arg]) => op === 'setInert' && arg === container));
+  assert.ok(calls.some(([op, arg]) => op === 'trapFocus' && arg === container));
+});
+
+test('re-opening an already-open id is a no-op, not a duplicate', () => {
+  const { c } = makeCoordinator();
+  c.open({ id: 'm', kind: 'modal' });
+  c.open({ id: 'm', kind: 'modal' });
+  assert.equal(c.modalCount(), 1);
+  assert.deepEqual(c.openIds(), ['m']);
+});
+
+test('closing an unknown id is a safe no-op', () => {
+  const { c } = makeCoordinator();
+  assert.equal(c.close('nope'), false);
+});


### PR DESCRIPTION
**Serialized epic — group 2 of 8 (lands inert).** Merges into `epic/workspace-task-execution-ux`, not `dev`. Builds the two infrastructure pieces the visible surfaces (drawer/tray/task-page) render from, plus the overlay layer scale. No backend (Go) change; new modules aren't wired into live surfaces yet and CSS values are unchanged.

## What this adds
- **`workspace-execution-controller.js`** — a workspace-scoped store owning the lifetime of execution monitoring, **decoupled from any Bootstrap modal**. Today the monitor is stopped by the execution modal's `hidden.bs.modal` handler (`workspace-detail.js:1683-1685`), so closing the modal stops monitoring a still-running task; this controller fixes that class of bug. Monitoring is **task-ID-keyed** per the group-1 audit (`GET /api/orchestration/tasks` + `window.workspaceRealtime`), with selected/active runs, a `Starting` phase, activity de-dup by stable key, reconnect handling, and terminal/needs-input persistence (FR47, FR51, FR53, FR55–FR58, FR61, FR65, FR111). Dependency-injected (fetchTask/subscribeRealtime/timers) so the core is unit-testable without a DOM.
- **`workspace-overlay-coordinator.js`** — one overlay owner enforcing a **single active modal** (a child modal suspends and later resumes its owner instead of stacking on a higher z-index), a documented `LAYER` scale, Escape resolution in topmost-first priority (menu/popover → dialog → collapse tray/drawer → leave the Map untouched), and focus-return on close (FR116, FR119–FR123). DOM side effects injected for testability.
- **`workspace-command.css`** — documented `--wsx-layer-*` scale mirroring `LAYER`. The two raw z-indexes (`.ws-cmd-map-window-backdrop` 10010, `.ws-cmd-modal` 1050 — the reported "modal opens under the Objectives window" conflict) are routed through legacy tokens with **identical values**, so this change is inert; the actual re-layering lands in group 3 when the drawer replaces the in-map modal flow and the ordering is verifiable end-to-end.

## Verification
- 23 new tests (12 controller + 11 coordinator); full module suite green **617/617**.
- `eslint` clean; `go build ./cmd/server` succeeds; isolated smoke server serves both modules + CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)