### PR TITLE
feat(workspace): sticky execution tray driven by the execution controller (group 4)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -4726,3 +4726,205 @@
     max-height: 40%;
   }
 }
+
+/* ---------- sticky execution tray (group 4) ----------
+   Collapsible mini-player docked bottom-left. Monitoring lives in the execution
+   controller, so collapsing/closing this never stops a run. */
+.ws-cmd-tray {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  width: min(400px, calc(100vw - 32px));
+  display: flex;
+  flex-direction: column;
+  background: var(--ws-panel);
+  border: 1px solid var(--ws-line-bright);
+  border-radius: var(--ws-clip);
+  box-shadow: var(--ws-glow);
+  overflow: hidden;
+  --tone-active: var(--ws-working);
+  --tone-attention: var(--ws-input);
+  --tone-danger: var(--ws-alert);
+  --tone-success: var(--ws-done);
+  --tone-info: var(--ws-idle);
+  --tone-neutral: var(--ws-ink-dim);
+}
+
+.ws-cmd-tray-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'state title controls' 'meta meta controls';
+  align-items: center;
+  gap: 4px 10px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--tone-neutral);
+}
+.ws-cmd-tray-head.tone-active {
+  border-left-color: var(--tone-active);
+}
+.ws-cmd-tray-head.tone-attention {
+  border-left-color: var(--tone-attention);
+}
+.ws-cmd-tray-head.tone-danger {
+  border-left-color: var(--tone-danger);
+}
+.ws-cmd-tray-head.tone-success {
+  border-left-color: var(--tone-success);
+}
+.ws-cmd-tray-head.tone-info {
+  border-left-color: var(--tone-info);
+}
+.ws-cmd-tray-state {
+  grid-area: state;
+  font-size: 10px;
+  font-family: var(--ws-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--tone-neutral);
+}
+.ws-cmd-tray-head.tone-active .ws-cmd-tray-state {
+  color: var(--tone-active);
+}
+.ws-cmd-tray-head.tone-attention .ws-cmd-tray-state {
+  color: var(--tone-attention);
+}
+.ws-cmd-tray-head.tone-danger .ws-cmd-tray-state {
+  color: var(--tone-danger);
+}
+.ws-cmd-tray-head.tone-success .ws-cmd-tray-state {
+  color: var(--tone-success);
+}
+.ws-cmd-tray-title {
+  grid-area: title;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ws-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ws-cmd-tray-meta {
+  grid-area: meta;
+  font-size: 10px;
+  font-family: var(--ws-font-mono);
+  color: var(--ws-ink-faint);
+}
+.ws-cmd-tray-controls {
+  grid-area: controls;
+  display: flex;
+  gap: 4px;
+}
+.ws-cmd-tray-btn {
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid var(--ws-line);
+  border-radius: var(--ws-clip-sm);
+  color: var(--ws-ink-dim);
+  cursor: pointer;
+  line-height: 1;
+}
+.ws-cmd-tray-btn:hover {
+  color: var(--ws-ink);
+}
+
+.ws-cmd-tray-collapsed-activity,
+.ws-cmd-tray-attention {
+  padding: 0 12px 10px;
+  font-size: 11px;
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-tray-attention {
+  color: var(--ws-input);
+}
+
+.ws-cmd-tray-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--ws-line);
+}
+.ws-cmd-tray-run {
+  padding: 3px 9px;
+  font-size: 10px;
+  font-family: var(--ws-font-mono);
+  color: var(--ws-ink-dim);
+  background: var(--ws-bg-2);
+  border: 1px solid var(--ws-line);
+  border-left: 2px solid var(--tone-neutral);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.ws-cmd-tray-run.tone-active {
+  border-left-color: var(--tone-active);
+}
+.ws-cmd-tray-run.tone-attention {
+  border-left-color: var(--tone-attention);
+}
+.ws-cmd-tray-run.tone-danger {
+  border-left-color: var(--tone-danger);
+}
+.ws-cmd-tray-run.is-selected {
+  color: var(--ws-ink);
+  border-color: var(--ws-idle);
+}
+
+.ws-cmd-tray-log {
+  max-height: 140px;
+  overflow-y: auto;
+  padding: 8px 12px;
+  border-top: 1px solid var(--ws-line);
+  font-family: var(--ws-font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--ws-ink-dim);
+}
+.ws-cmd-tray-log-line.is-muted {
+  color: var(--ws-ink-faint);
+}
+
+.ws-cmd-tray-actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--ws-line);
+}
+.ws-cmd-tray-action {
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ws-bg);
+  background: var(--ws-working);
+  border: none;
+  border-radius: var(--ws-clip-sm);
+  cursor: pointer;
+}
+.ws-cmd-tray-cancel {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--ws-alert);
+  background: transparent;
+  border: 1px solid var(--ws-alert);
+  border-radius: var(--ws-clip-sm);
+  cursor: pointer;
+}
+.ws-cmd-tray-cancel.is-armed {
+  color: var(--ws-bg);
+  background: var(--ws-alert);
+}
+.ws-cmd-tray-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--ws-ink-faint);
+  font-size: 12px;
+}
+
+@media (max-width: 768px) {
+  .ws-cmd-tray {
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    width: auto;
+  }
+}

--- a/internal/web/static/js/modules/workspace-command-drawer.test.js
+++ b/internal/web/static/js/modules/workspace-command-drawer.test.js
@@ -16,6 +16,8 @@ function makeView(tasks, extraPage = {}) {
   view.render = () => {};
   view.ensureTaskDrawer = () => null;
   view.renderTaskDrawerBody = () => {};
+  // Stub the tray hand-off so drawer tests never spin a real polling controller.
+  view.trackAndShowTray = () => {};
   return view;
 }
 
@@ -118,7 +120,7 @@ test('runDrawerAction routes start/retry to the page executeTask handler', () =>
   const calls = [];
   const view = makeView(tasks, { executeTask: (id, opts) => calls.push([id, opts]) });
   view.runDrawerAction('start', 'd-ready');
-  assert.deepEqual(calls, [['d-ready', { skipConfirm: true }]]);
+  assert.deepEqual(calls, [['d-ready', { skipConfirm: true, skipModal: true }]]);
 });
 
 test('runDrawerAction routes view_result to showTaskResult', () => {

--- a/internal/web/static/js/modules/workspace-command-tray.test.js
+++ b/internal/web/static/js/modules/workspace-command-tray.test.js
@@ -1,0 +1,171 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceCommandView } from './workspace-command.js';
+import { RUN_PHASE } from './workspace-execution-controller.js';
+
+globalThis.document = { getElementById: () => null };
+globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+
+// A timer-free stand-in for the execution controller, so tray rendering is
+// tested without spinning real polling intervals.
+function fakeController(runs, selectedId) {
+  let selected = selectedId;
+  return {
+    getSelected: () => runs.find(r => r.taskId === selected) || null,
+    getRun: id => runs.find(r => r.taskId === id) || null,
+    getRuns: () => runs,
+    getActiveRuns: () => runs.filter(r => r.phase !== RUN_PHASE.SETTLED),
+    getAttentionRuns: () =>
+      runs.filter(r => ['needs_input', 'failed', 'timed_out', 'blocked'].includes(r.presentation.state)),
+    select: id => {
+      selected = id;
+    }
+  };
+}
+
+function runFixture(over = {}) {
+  return {
+    taskId: 't1',
+    presentation: {
+      state: 'running',
+      label: 'Running',
+      tone: 'active',
+      assignee: 'editor',
+      primaryAction: { id: 'track', label: 'Track' }
+    },
+    task: { description: 'Export the master' },
+    activity: [{ label: 'Running' }],
+    phase: RUN_PHASE.LIVE,
+    startedAt: Date.now() - 5000,
+    lastActivityAt: 0,
+    ...over
+  };
+}
+
+function makeView() {
+  const view = new WorkspaceCommandView(null);
+  view.page = { workspaceId: 'w1' };
+  view.renderTrayBody = () => {}; // state methods shouldn't touch the DOM here
+  view.trayOpen = true;
+  return view;
+}
+
+test('expanded tray renders title, state, controls, activity log and primary action', () => {
+  const view = makeView();
+  view.execController = fakeController([runFixture()], 't1');
+  const html = view.trayHTML();
+  assert.ok(html.includes('Export the master'));
+  assert.ok(html.includes('Running'));
+  assert.ok(html.includes('data-cmd-tray-collapse'));
+  assert.ok(html.includes('data-cmd-tray-close'));
+  assert.ok(html.includes('ws-cmd-tray-log'));
+  assert.ok(html.includes('data-cmd-tray-action="track"'));
+});
+
+test('collapsed tray drops the log/actions but keeps the header (FR48)', () => {
+  const view = makeView();
+  view.execController = fakeController([runFixture()], 't1');
+  view.trayCollapsed = true;
+  const html = view.trayHTML();
+  assert.ok(html.includes('Export the master'), 'header still present');
+  assert.ok(!html.includes('ws-cmd-tray-log'), 'no full log when collapsed');
+  assert.ok(!html.includes('data-cmd-tray-action'), 'no action buttons when collapsed');
+});
+
+test('toggleTrayCollapsed flips the collapsed flag (monitoring untouched)', () => {
+  const view = makeView();
+  view.execController = fakeController([runFixture()], 't1');
+  assert.equal(view.trayCollapsed, false);
+  view.toggleTrayCollapsed();
+  assert.equal(view.trayCollapsed, true);
+});
+
+test('closeTray hides the launcher but never clears the controller (FR52)', () => {
+  const view = makeView();
+  const controller = fakeController([runFixture()], 't1');
+  view.execController = controller;
+  view.trayEl = { hidden: false };
+  view.closeTray();
+  assert.equal(view.trayOpen, false);
+  assert.equal(view.trayEl.hidden, true);
+  assert.equal(view.execController, controller, 'controller (and its runs) survive closing the tray');
+  assert.ok(controller.getSelected(), 'the run is still tracked');
+});
+
+test('a running task offers Cancel that requires an explicit armed confirmation (FR63)', () => {
+  const cancels = [];
+  const view = makeView();
+  view.page = { workspaceId: 'w1', cancelTask: id => cancels.push(id) };
+  view.execController = fakeController([runFixture()], 't1');
+
+  // First activation arms; it does NOT cancel.
+  view.trayCancel('t1');
+  assert.equal(view._trayCancelArmed, 't1');
+  assert.deepEqual(cancels, []);
+  assert.match(view.trayHTML(), /Confirm cancel/);
+
+  // Second activation cancels.
+  view.trayCancel('t1');
+  assert.deepEqual(cancels, ['t1']);
+  assert.equal(view._trayCancelArmed, '');
+});
+
+test('run switcher lists every run and marks the selected one (FR53)', () => {
+  const view = makeView();
+  const runs = [
+    runFixture(),
+    runFixture({
+      taskId: 't2',
+      task: { description: 'Render intro' },
+      presentation: { state: 'needs_input', label: 'Needs Input', tone: 'attention', assignee: 'ed' }
+    })
+  ];
+  view.execController = fakeController(runs, 't1');
+  const html = view.trayHTML();
+  assert.ok(html.includes('data-cmd-tray-run="t1"'));
+  assert.ok(html.includes('data-cmd-tray-run="t2"'));
+  assert.match(html, /data-cmd-tray-run="t1"[^>]*aria-current="true"/);
+});
+
+test('selectTrayRun switches the controller selection', () => {
+  const view = makeView();
+  const controller = fakeController([runFixture(), runFixture({ taskId: 't2' })], 't1');
+  view.execController = controller;
+  view.selectTrayRun('t2');
+  assert.equal(controller.getSelected().taskId, 't2');
+});
+
+test('terminal run keeps its primary next action available (FR62)', () => {
+  const view = makeView();
+  view.execController = fakeController(
+    [
+      runFixture({
+        phase: RUN_PHASE.SETTLED,
+        presentation: {
+          state: 'completed',
+          label: 'Completed',
+          tone: 'success',
+          primaryAction: { id: 'view_result', label: 'View Result' }
+        }
+      })
+    ],
+    't1'
+  );
+  const html = view.trayHTML();
+  assert.ok(html.includes('data-cmd-tray-action="view_result"'));
+  assert.ok(!html.includes('data-cmd-tray-cancel'), 'no Cancel on a settled run');
+});
+
+test('trayElapsedLabel formats seconds and minutes', () => {
+  const view = makeView();
+  const now = Date.now();
+  assert.equal(view.trayElapsedLabel({ startedAt: now - 5000 }).endsWith('s'), true);
+  const mins = view.trayElapsedLabel({ startedAt: now - 125000 });
+  assert.match(mins, /2m \d+s/);
+});
+
+test('empty controller shows a no-run placeholder', () => {
+  const view = makeView();
+  view.execController = fakeController([], '');
+  assert.match(view.trayHTML(), /No active run/);
+});

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -21,6 +21,7 @@ import {
   taskShortId,
   FILTER
 } from './task-presentation.js';
+import { WorkspaceExecutionController, RUN_PHASE } from './workspace-execution-controller.js';
 // Legacy view preference from the deleted Detailed/Command toggle; cleared on boot.
 const LEGACY_STORAGE_KEY = 'oriWorkspaceDetailView';
 const VIEW_MODE_STORAGE_KEY = 'oriWorkspaceCommandViewMode';
@@ -59,6 +60,13 @@ export class WorkspaceCommandView {
     this.taskDrawerFilter = FILTER.ACTIONABLE;
     this.taskDrawerSelectedId = '';
     this._drawerAnnounce = '';
+    // Sticky execution tray (group 4) — a collapsible mini-player that renders
+    // from the workspace-scoped execution controller. Monitoring survives
+    // collapse and any view change (it lives in the controller, not a modal).
+    this.execController = null;
+    this.trayEl = null;
+    this.trayOpen = false;
+    this.trayCollapsed = false;
     // Quick "New Quest" composer on the operations map (create task → entry-agent default).
     this.taskComposerOpen = false;
     this.taskComposerDraft = '';
@@ -728,6 +736,16 @@ export class WorkspaceCommandView {
       if (this.taskDrawerOpen) {
         this.taskDrawerEl.hidden = false;
         this.renderTaskDrawerBody();
+      }
+    }
+
+    // The sticky execution tray survives full re-renders too — monitoring never
+    // depends on the DOM being present (FR50-FR51).
+    if (this.trayEl && this.container && this.container.appendChild) {
+      this.container.appendChild(this.trayEl);
+      if (this.trayOpen) {
+        this.trayEl.hidden = false;
+        this.renderTrayBody();
       }
     }
   }
@@ -3212,7 +3230,12 @@ export class WorkspaceCommandView {
       case 'start':
       case 'assign_start':
       case 'retry':
-        if (typeof page.executeTask === 'function') page.executeTask(id, { skipConfirm: true });
+        // skipModal: the sticky tray owns monitoring, so suppress the legacy
+        // execution modal (FR46). Monitoring is task-ID-keyed and continues
+        // regardless of drawer/tray view state.
+        if (typeof page.executeTask === 'function')
+          page.executeTask(id, { skipConfirm: true, skipModal: true });
+        this.trackAndShowTray(id);
         break;
       case 'view_result':
         if (typeof page.showTaskResult === 'function') page.showTaskResult(id);
@@ -3225,6 +3248,282 @@ export class WorkspaceCommandView {
         if (typeof page.openTask === 'function') page.openTask(id);
         break;
     }
+  }
+
+  // ---------- Sticky execution tray (group 4) ----------
+  //
+  // A collapsible mini-player rendered from the workspace-scoped execution
+  // controller. Starting/retrying a task tracks it in the controller and opens
+  // the tray; collapsing or navigating never stops monitoring, because the
+  // monitor lives in the controller, not in any modal (FR46-FR52).
+
+  ensureExecController() {
+    if (this.execController) return this.execController;
+    const wsId = typeof this.workspaceId === 'function' ? this.workspaceId() : '';
+    const realtime =
+      typeof window !== 'undefined' &&
+      window.workspaceRealtime &&
+      typeof window.workspaceRealtime.subscribeToWorkspace === 'function'
+        ? (workspaceId, handler) => window.workspaceRealtime.subscribeToWorkspace(workspaceId, handler)
+        : null;
+    this.execController = new WorkspaceExecutionController({
+      workspaceId: wsId,
+      fetchTask: async id => {
+        const r = await fetch('/api/orchestration/tasks?id=' + encodeURIComponent(id));
+        return r.ok ? await r.json() : null;
+      },
+      subscribeRealtime: realtime
+    });
+    // Repaint the tray on any controller state change (poll/realtime/terminal).
+    this.execController.subscribe(() => this.renderTrayBody());
+    return this.execController;
+  }
+
+  // Begin monitoring a task and surface it in the tray (FR46). Requires a real
+  // DOM: without one (headless tests) there is nothing to render and no reason
+  // to spin a polling monitor, so this is inert.
+  trackAndShowTray(taskId) {
+    const id = String(taskId || '').trim();
+    if (!id) return;
+    const el = this.ensureTray();
+    if (!el) return;
+    this.ensureExecController().track(id);
+    this.trayOpen = true;
+    this.trayCollapsed = false;
+    this._trayCancelArmed = '';
+    el.hidden = false;
+    this.renderTrayBody();
+  }
+
+  closeTray() {
+    // Closing the tray only hides the launcher — it never stops monitoring
+    // (FR52). Runs keep running in the controller; reopening restores them.
+    this.trayOpen = false;
+    if (this.trayEl) this.trayEl.hidden = true;
+  }
+
+  toggleTrayCollapsed() {
+    this.trayCollapsed = !this.trayCollapsed;
+    this.renderTrayBody();
+  }
+
+  selectTrayRun(taskId) {
+    if (this.execController) this.execController.select(taskId);
+    this._trayCancelArmed = '';
+    this.renderTrayBody();
+  }
+
+  ensureTray() {
+    if (this.trayEl) return this.trayEl;
+    if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+    const el = document.createElement('section');
+    el.className = 'ws-cmd-tray';
+    el.setAttribute('role', 'region');
+    el.setAttribute('aria-label', 'Active execution');
+    el.hidden = true;
+    el.style.zIndex = 'var(--wsx-layer-tray)';
+    el.addEventListener('click', event => {
+      if (event.target.closest('[data-cmd-tray-collapse]')) {
+        this.toggleTrayCollapsed();
+        return;
+      }
+      if (event.target.closest('[data-cmd-tray-close]')) {
+        this.closeTray();
+        return;
+      }
+      const runChip = event.target.closest('[data-cmd-tray-run]');
+      if (runChip) {
+        this.selectTrayRun(runChip.getAttribute('data-cmd-tray-run'));
+        return;
+      }
+      const cancelBtn = event.target.closest('[data-cmd-tray-cancel]');
+      if (cancelBtn) {
+        this.trayCancel(cancelBtn.getAttribute('data-cmd-tray-cancel'));
+        return;
+      }
+      const actionBtn = event.target.closest('[data-cmd-tray-action]');
+      if (actionBtn) {
+        this.runDrawerAction(
+          actionBtn.getAttribute('data-cmd-tray-action'),
+          actionBtn.getAttribute('data-cmd-tray-task')
+        );
+        return;
+      }
+    });
+    this.trayEl = el;
+    if (this.container && this.container.appendChild) this.container.appendChild(el);
+    return el;
+  }
+
+  renderTrayBody() {
+    const el = this.trayEl;
+    if (!el || !this.trayOpen) return;
+    el.hidden = false;
+    el.classList.toggle('is-collapsed', this.trayCollapsed);
+    el.innerHTML = this.trayHTML();
+  }
+
+  trayElapsedLabel(run) {
+    if (!run || !run.startedAt) return '';
+    const end = run.phase === RUN_PHASE.SETTLED && run.lastActivityAt ? run.lastActivityAt : Date.now();
+    const secs = Math.max(0, Math.round((end - run.startedAt) / 1000));
+    if (secs < 60) return secs + 's';
+    const mins = Math.floor(secs / 60);
+    return mins + 'm ' + (secs % 60) + 's';
+  }
+
+  // Cancel from the tray requires an explicit, task-named confirmation and is
+  // never triggered by dismissing the tray (FR63).
+  trayCancel(taskId) {
+    const id = String(taskId || '').trim();
+    if (this._trayCancelArmed !== id) {
+      this._trayCancelArmed = id;
+      this.renderTrayBody();
+      return;
+    }
+    this._trayCancelArmed = '';
+    this.cancelRun(id);
+    this.renderTrayBody();
+  }
+
+  // Cancel a running task: prefer a page-provided handler, else POST the
+  // authoritative orchestration cancel endpoint. The controller's next poll
+  // reconciles the resulting state.
+  cancelRun(taskId) {
+    const id = String(taskId || '').trim();
+    if (!id) return;
+    const page = this.page || (typeof window !== 'undefined' ? window.workspaceDetail : null);
+    if (page && typeof page.cancelTask === 'function') {
+      page.cancelTask(id);
+      return;
+    }
+    if (typeof fetch === 'function') {
+      fetch('/api/orchestration/tasks/' + encodeURIComponent(id) + '/cancel', { method: 'POST' }).catch(
+        () => {}
+      );
+    }
+  }
+
+  trayHTML() {
+    const c = this.execController;
+    const run = c ? c.getSelected() : null;
+    if (!run) {
+      return '<div class="ws-cmd-tray-empty">No active run.</div>';
+    }
+    const pres = run.presentation || {};
+    const task = run.task || {};
+    const title = String(task.description || task.name || task.title || run.taskId);
+    const assignee = pres.assignee || 'Unassigned';
+    const elapsed = this.trayElapsedLabel(run);
+    const lastActivity = run.activity && run.activity.length ? run.activity[run.activity.length - 1] : null;
+    const activityText = lastActivity ? String(lastActivity.label || lastActivity.state || '') : '';
+    const others = c.getRuns().filter(r => r.taskId !== run.taskId);
+    const attention = c.getAttentionRuns().length;
+
+    const header =
+      '<div class="ws-cmd-tray-head tone-' +
+      escapeHtml(pres.tone || 'neutral') +
+      '">' +
+      '<span class="ws-cmd-tray-state">' +
+      escapeHtml(pres.label || 'Starting') +
+      '</span>' +
+      '<span class="ws-cmd-tray-title">' +
+      escapeHtml(title) +
+      '</span>' +
+      '<span class="ws-cmd-tray-meta">' +
+      escapeHtml(assignee) +
+      (elapsed ? ' · ' + escapeHtml(elapsed) : '') +
+      '</span>' +
+      '<div class="ws-cmd-tray-controls">' +
+      '<button type="button" class="ws-cmd-tray-btn" data-cmd-tray-collapse aria-expanded="' +
+      (this.trayCollapsed ? 'false' : 'true') +
+      '" aria-label="' +
+      (this.trayCollapsed ? 'Expand execution tray' : 'Collapse execution tray') +
+      '">' +
+      (this.trayCollapsed ? '▴' : '▾') +
+      '</button>' +
+      '<button type="button" class="ws-cmd-tray-btn" data-cmd-tray-close aria-label="Hide execution tray">×</button>' +
+      '</div></div>';
+
+    if (this.trayCollapsed) {
+      return (
+        header +
+        (activityText
+          ? '<div class="ws-cmd-tray-collapsed-activity">' + escapeHtml(activityText) + '</div>'
+          : '') +
+        (attention
+          ? '<div class="ws-cmd-tray-attention">' + escapeHtml(String(attention)) + ' need attention</div>'
+          : '')
+      );
+    }
+
+    // Run switcher across concurrent runs (FR53).
+    const switcher = others.length
+      ? '<div class="ws-cmd-tray-switcher" role="group" aria-label="Active runs">' +
+        c
+          .getRuns()
+          .map(r => {
+            const rp = r.presentation || {};
+            const rt = String((r.task && (r.task.description || r.task.name)) || r.taskId);
+            const selected = r.taskId === run.taskId;
+            return (
+              '<button type="button" class="ws-cmd-tray-run tone-' +
+              escapeHtml(rp.tone || 'neutral') +
+              (selected ? ' is-selected' : '') +
+              '" data-cmd-tray-run="' +
+              escapeHtml(r.taskId) +
+              '" aria-current="' +
+              (selected ? 'true' : 'false') +
+              '">' +
+              escapeHtml(rt.slice(0, 24)) +
+              '</button>'
+            );
+          })
+          .join('') +
+        '</div>'
+      : '';
+
+    const activityLog =
+      '<div class="ws-cmd-tray-log" role="log" aria-live="polite">' +
+      (run.activity && run.activity.length
+        ? run.activity
+            .slice(-8)
+            .map(a => '<div class="ws-cmd-tray-log-line">' + escapeHtml(String(a.label || a.state || '')) + '</div>')
+            .join('')
+        : '<div class="ws-cmd-tray-log-line is-muted">Starting…</div>') +
+      '</div>';
+
+    // Actions: terminal/needs-input reuse the shared primary action; a running
+    // task additionally offers a confirmed Cancel.
+    const isRunning = pres.state === 'running';
+    const primary = pres.primaryAction
+      ? '<button type="button" class="ws-cmd-tray-action" data-cmd-tray-action="' +
+        escapeHtml(pres.primaryAction.id) +
+        '" data-cmd-tray-task="' +
+        escapeHtml(run.taskId) +
+        '">' +
+        escapeHtml(pres.primaryAction.label) +
+        '</button>'
+      : '';
+    const cancel = isRunning
+      ? '<button type="button" class="ws-cmd-tray-cancel' +
+        (this._trayCancelArmed === run.taskId ? ' is-armed' : '') +
+        '" data-cmd-tray-cancel="' +
+        escapeHtml(run.taskId) +
+        '">' +
+        (this._trayCancelArmed === run.taskId ? 'Confirm cancel “' + escapeHtml(title.slice(0, 20)) + '”' : 'Cancel') +
+        '</button>'
+      : '';
+
+    return (
+      header +
+      switcher +
+      activityLog +
+      '<div class="ws-cmd-tray-actions">' +
+      primary +
+      cancel +
+      '</div>'
+    );
   }
 
   renderMapStationsPanel() {
@@ -3595,7 +3894,8 @@ export class WorkspaceCommandView {
       return;
     }
     try {
-      await page.executeTask(id, { skipConfirm: true });
+      await page.executeTask(id, { skipConfirm: true, skipModal: true });
+      this.trackAndShowTray(id);
     } catch (_error) {
       if (window.Toast) window.Toast.error('Could not start the quest.');
       if (typeof page.loadTasks === 'function') await page.loadTasks();

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2676,7 +2676,7 @@ test('startMapQuest executes a pending task via the page with skipConfirm', asyn
 
   await view.startMapQuest('q1');
 
-  assert.deepEqual(calls, [['q1', { skipConfirm: true }]]);
+  assert.deepEqual(calls, [['q1', { skipConfirm: true, skipModal: true }]]);
 });
 
 test('startMapQuest reports and refreshes when the quest is no longer pending', async () => {

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -12621,7 +12621,10 @@ export class WorkspaceDetailPage {
       task.execution_mode = selectedStepThrough ? 'step_through' : 'auto';
     }
 
-    this.openTaskExecutionModal(task);
+    // skipModal: the caller (e.g. the command-view sticky tray) owns monitoring,
+    // so suppress the legacy execution modal and its client-side monitor.
+    const useLegacyModal = options.skipModal !== true;
+    if (useLegacyModal) this.openTaskExecutionModal(task);
 
     try {
       const response = await fetch('/api/orchestration/tasks/execute', {
@@ -12645,7 +12648,7 @@ export class WorkspaceDetailPage {
         `${taskId}:dispatched`
       );
       await this.loadTasks();
-      this.startExecutionMonitor(taskId);
+      if (useLegacyModal) this.startExecutionMonitor(taskId);
     } catch (error) {
       console.error('Failed to execute task:', error);
       const message = error && error.message ? error.message : 'Failed to execute task';


### PR DESCRIPTION
**Serialized epic — group 4 of 8.** Merges into `epic/workspace-task-execution-ux`. Adds the collapsible **execution tray**, wired to the group-2 execution controller, so a started task keeps a live, monitored presence that survives collapse and any view change.

## What's here
- A persistent, bottom-docked tray rendering from `WorkspaceExecutionController`. **Collapsed**: state, title, agent, elapsed, latest activity, and an "N need attention" count. **Expanded**: run switcher, activity log, the shared primary action, and Cancel (FR46–FR53).
- **Monitoring decoupled from visibility**: `closeTray` only hides the launcher; collapse only changes footprint — the controller and its runs keep going (FR51–FR52). A test asserts the controller survives closing.
- **Cancel** requires an explicit, task-named armed confirmation and is never triggered by dismissing the tray; it POSTs `/api/orchestration/tasks/{id}/cancel` when the page exposes no handler (FR63).
- `executeTask` gains a **`skipModal`** option; the drawer/Map Start paths pass it, so the **legacy execution modal is suppressed** and the tray is the sole monitor (FR46).

## Verification
- **Browser-verified end-to-end**: starting a task from both the drawer and the Objectives window shows only the tray (no legacy modal), with RUNNING state, elapsed time, live activity, and Track/Cancel — no console errors.
- 10 tray tests + full module suite green (**642**); eslint clean; build OK.
- Fixed a `node --test` hang (a real polling timer) by making `trackAndShowTray` inert without a real DOM.

## Deferred (noted in tasks)
- Reload re-track/restoration (needs the `run` URL param — **group 6**).
- Scroll-aware auto-follow + `New activity` control and high-frequency event grouping (FR59–FR60).
- Toast/announce on a background (non-focused) terminal transition (FR9 partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)