### PR TITLE
feat(workspace): promote entry agent to top-centered command node (group 5)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -4928,3 +4928,90 @@
     width: auto;
   }
 }
+
+/* ---------- entry-agent command node (group 5) ----------
+   The entry agent renders first, top-centered, and larger than a specialist
+   card — a role frame independent of runtime status color (FR66-FR70, FR79:
+   hierarchy via size/position/text only, no required animation). */
+.ws-cmd-map-command-row {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 22px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--ws-line);
+}
+
+.ws-cmd-map-agent.is-command-node {
+  /* ~1.3x a specialist card (152px min-height / 142px min column). */
+  min-width: 200px;
+  min-height: 198px;
+  padding: 18px 16px 14px;
+  border-width: 2px;
+  border-color: var(--ws-keeper);
+  background:
+    linear-gradient(180deg, rgba(232, 181, 75, 0.08), transparent 60%),
+    radial-gradient(circle at 50% 22%, rgba(70, 211, 154, 0.13), rgba(0, 0, 0, 0.16) 62%);
+}
+.ws-cmd-map-agent.is-command-node:hover,
+.ws-cmd-map-agent.is-command-node.is-selected {
+  border-color: var(--ws-keeper);
+  box-shadow: 0 0 0 1px rgba(232, 181, 75, 0.35);
+}
+/* Runtime-status tones still layer on top of the role frame so status color
+   never depends on (and never overrides) the command-node role frame (FR40). */
+.ws-cmd-map-agent.is-command-node.alert {
+  border-color: var(--ws-alert);
+}
+.ws-cmd-map-agent.is-command-node.working {
+  border-color: var(--ws-working);
+}
+.ws-cmd-map-agent.is-command-node.needs-input {
+  border-color: var(--ws-input);
+}
+
+.ws-cmd-map-command-role {
+  font-size: 10px;
+  font-family: var(--ws-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--ws-keeper);
+}
+
+.ws-cmd-map-command-copy {
+  font-size: 11px;
+  color: var(--ws-ink-dim);
+  text-align: center;
+  max-width: 22ch;
+}
+
+.ws-cmd-map-command-repair {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px;
+  margin-bottom: 18px;
+  border: 1px dashed var(--ws-line-bright);
+  border-radius: var(--ws-clip);
+  text-align: center;
+}
+.ws-cmd-map-command-repair strong {
+  color: var(--ws-ink);
+  font-size: 14px;
+}
+.ws-cmd-map-command-repair span {
+  color: var(--ws-ink-dim);
+  font-size: 12px;
+  max-width: 42ch;
+}
+
+/* Narrow layouts: the command node stays first and full-width; specialists
+   keep flowing in the existing responsive grid below it (FR76). */
+@media (max-width: 640px) {
+  .ws-cmd-map-agent.is-command-node {
+    width: 100%;
+    max-width: 320px;
+  }
+}

--- a/internal/web/static/js/modules/workspace-command-entry-node.test.js
+++ b/internal/web/static/js/modules/workspace-command-entry-node.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceCommandView } from './workspace-command.js';
+
+globalThis.document = { getElementById: () => null };
+globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+
+function agent(over = {}) {
+  const name = over.name || 'Agent';
+  return {
+    key: name.toLowerCase(),
+    name,
+    encodedName: name,
+    entry: false,
+    tone: 'idle',
+    destination: 'hub',
+    role: { label: 'Agent' },
+    status: { label: 'Idle' },
+    ...over
+  };
+}
+
+function makeView() {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.selectedAgentKey = '';
+  return view;
+}
+
+test('entry agent renders first, top-centered, ahead of the specialist grid (FR66)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const spec1 = agent({ name: 'Writer', key: 'writer' });
+  const html = view.renderMapAgentUnits([spec1, entry]); // input order reversed
+  const rowIdx = html.indexOf('ws-cmd-map-command-row');
+  const fieldIdx = html.indexOf('ws-cmd-map-agent-field');
+  assert.ok(rowIdx !== -1 && rowIdx < fieldIdx, 'command row renders before the specialist field');
+  assert.ok(html.indexOf('Manager') < html.indexOf('Writer'), 'entry agent appears first in markup');
+});
+
+test('command node carries a role frame class distinct from a specialist card (FR70)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const spec = agent({ name: 'Writer', key: 'writer' });
+  const html = view.renderMapAgentUnits([entry, spec]);
+  assert.match(html, /is-command-node/);
+  // The specialist card must NOT carry the role class.
+  const specialistSection = html.slice(html.indexOf('ws-cmd-map-agent-field'));
+  assert.ok(!specialistSection.includes('is-command-node'));
+});
+
+test('role frame (is-command-node) and runtime tone are independent classes (FR40)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true, tone: 'needs-input' });
+  const html = view.renderMapAgentUnits([entry]);
+  assert.match(html, /is-command-node/);
+  assert.match(html, /needs-input/);
+});
+
+test('orchestration copy reports the specialist count, excluding the entry agent (FR68-69)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const specs = [agent({ name: 'Writer', key: 'writer' }), agent({ name: 'Editor', key: 'editor' })];
+  const html = view.renderMapAgentUnits([entry, ...specs]);
+  assert.match(html, /Routes work to 2 specialist agents/);
+});
+
+test('singular specialist copy reads naturally', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const html = view.renderMapAgentUnits([entry, agent({ name: 'Writer', key: 'writer' })]);
+  assert.match(html, /Routes work to 1 specialist agent(?!s)/);
+});
+
+test('zero specialists gets a neutral copy, not "0 specialist agents"', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const html = view.renderMapAgentUnits([entry]);
+  assert.match(html, /No specialist agents yet/);
+});
+
+test('accessible name on the command node includes role + orchestration copy (FR72)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const html = view.renderMapAgentUnits([entry, agent({ name: 'Writer', key: 'writer' })]);
+  assert.match(html, /aria-label="Select Manager, Entry Agent\. Routes work to 1 specialist agent\. Idle"/);
+});
+
+test('missing entry agent shows a repair state, not a promoted specialist (FR77)', () => {
+  const view = makeView();
+  const spec = agent({ name: 'Writer', key: 'writer' });
+  const html = view.renderMapAgentUnits([spec]);
+  assert.match(html, /ws-cmd-map-command-repair/);
+  assert.match(html, /No entry agent/);
+  assert.match(html, /data-cmd-add-agent/);
+  assert.ok(!html.includes('is-command-node'), 'no specialist is visually promoted to the command position');
+  assert.match(html, /Writer/, 'the specialist still renders in the normal grid');
+});
+
+test('entry agent is individually selectable via the same select-agent contract as specialists (FR73)', () => {
+  const view = makeView();
+  view.selectedAgentKey = 'manager';
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const html = view.renderMapAgentUnits([entry]);
+  assert.match(html, /data-cmd-map-select-agent="Manager"/);
+  assert.match(html, /aria-pressed="true"/);
+});
+
+test('specialists remain individually selectable in a stable grid (FR75)', () => {
+  const view = makeView();
+  const entry = agent({ name: 'Manager', key: 'manager', entry: true });
+  const specs = [agent({ name: 'Writer', key: 'writer' }), agent({ name: 'Editor', key: 'editor' })];
+  const html = view.renderMapAgentUnits([entry, ...specs]);
+  assert.match(html, /data-cmd-map-select-agent="Writer"/);
+  assert.match(html, /data-cmd-map-select-agent="Editor"/);
+});
+
+test('empty roster (no agents at all) keeps the existing empty state', () => {
+  const view = makeView();
+  const html = view.renderMapAgentUnits([]);
+  assert.match(html, /No agents in this workspace/);
+  assert.match(html, /data-cmd-add-agent/);
+});

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -3544,6 +3544,83 @@ export class WorkspaceCommandView {
     );
   }
 
+  // A single agent "unit" card. `commandNode` renders the entry agent as the
+  // larger, role-framed command node (FR66-67, FR70); otherwise a standard
+  // specialist card. Runtime tone classes (working/waiting/needs-input/done)
+  // apply identically to both, so status color never depends on role (FR40).
+  renderMapAgentUnit(agent, index, commandNode) {
+    const selected = agent.key === this.selectedAgentKey;
+    const destination = agent.destination || 'hub';
+    const statusLabel = agent.status?.label || 'Idle';
+    const entryBadge =
+      agent.entry && !commandNode
+        ? '<span class="ws-cmd-map-entry-badge" title="Entry Agent"><i class="bi bi-star-fill" aria-hidden="true"></i><span>Entry</span></span>'
+        : '';
+    const roleLine = commandNode
+      ? '<span class="ws-cmd-map-command-role">Entry Agent</span>'
+      : '';
+    const orchestrationCopy =
+      commandNode && this._commandNodeOrchestrationCopy
+        ? '<span class="ws-cmd-map-command-copy">' +
+          escapeHtml(this._commandNodeOrchestrationCopy) +
+          '</span>'
+        : '';
+    const accessibleName =
+      'Select ' +
+      escapeHtml(agent.name) +
+      ', ' +
+      (agent.entry ? 'Entry Agent. ' : '') +
+      (commandNode && this._commandNodeOrchestrationCopy
+        ? escapeHtml(this._commandNodeOrchestrationCopy) + '. '
+        : '') +
+      escapeHtml(statusLabel);
+    return (
+      '<button type="button" class="ws-cmd-map-agent ' +
+      escapeHtml(agent.tone) +
+      (selected ? ' is-selected' : '') +
+      (commandNode ? ' is-command-node' : '') +
+      ' toward-' +
+      escapeHtml(destination) +
+      '" data-cmd-map-select-agent="' +
+      escapeHtml(agent.encodedName) +
+      '" data-agent-key="' +
+      escapeHtml(agent.key) +
+      '" style="--agent-map-index:' +
+      index +
+      '" aria-pressed="' +
+      (selected ? 'true' : 'false') +
+      '" aria-label="' +
+      accessibleName +
+      '">' +
+      '<span class="ws-cmd-map-agent-path" aria-hidden="true"></span>' +
+      '<span class="ws-cmd-map-agent-status" aria-hidden="true" title="' +
+      escapeHtml(statusLabel) +
+      '"><span class="ws-cmd-led ' +
+      escapeHtml(agent.tone) +
+      '"></span></span>' +
+      entryBadge +
+      this.agentCharacterHTML(agent, 'roster') +
+      roleLine +
+      '<span class="ws-cmd-map-agent-copy"><strong>' +
+      escapeHtml(agent.name) +
+      '</strong><span>' +
+      escapeHtml(agent.role?.label || 'Agent') +
+      '</span><em>' +
+      escapeHtml(statusLabel) +
+      '</em></span>' +
+      orchestrationCopy +
+      '</button>'
+    );
+  }
+
+  // Specialist count for the command node's orchestration copy: the current
+  // roster excluding the entry agent, unassigned placeholders, and duplicate
+  // records — agentGroups() already dedupes and drops unassigned (FR69).
+  commandNodeOrchestrationCopy(specialistCount) {
+    if (specialistCount <= 0) return 'No specialist agents yet';
+    return 'Routes work to ' + specialistCount + ' specialist agent' + (specialistCount === 1 ? '' : 's');
+  }
+
   renderMapAgentUnits(agents) {
     if (!agents.length) {
       return (
@@ -3554,61 +3631,43 @@ export class WorkspaceCommandView {
         '</div>'
       );
     }
-    return agents
-      .map((agent, index) => {
-        const selected = agent.key === this.selectedAgentKey;
-        const destination = agent.destination || 'hub';
-        const entryBadge = agent.entry
-          ? '<span class="ws-cmd-map-entry-badge" title="Entry Agent"><i class="bi bi-star-fill" aria-hidden="true"></i><span>Entry</span></span>'
-          : '';
-        const statusLabel = agent.status?.label || 'Idle';
-        return (
-          '<button type="button" class="ws-cmd-map-agent ' +
-          escapeHtml(agent.tone) +
-          (selected ? ' is-selected' : '') +
-          ' toward-' +
-          escapeHtml(destination) +
-          '" data-cmd-map-select-agent="' +
-          escapeHtml(agent.encodedName) +
-          '" data-agent-key="' +
-          escapeHtml(agent.key) +
-          '" style="--agent-map-index:' +
-          index +
-          '" aria-pressed="' +
-          (selected ? 'true' : 'false') +
-          '" aria-label="Select ' +
-          escapeHtml(agent.name) +
-          ', ' +
-          (agent.entry ? 'Entry Agent, ' : '') +
-          escapeHtml(statusLabel) +
-          '">' +
-          '<span class="ws-cmd-map-agent-path" aria-hidden="true"></span>' +
-          '<span class="ws-cmd-map-agent-status" aria-hidden="true" title="' +
-          escapeHtml(statusLabel) +
-          '"><span class="ws-cmd-led ' +
-          escapeHtml(agent.tone) +
-          '"></span></span>' +
-          entryBadge +
-          this.agentCharacterHTML(agent, 'roster') +
-          '<span class="ws-cmd-map-agent-copy"><strong>' +
-          escapeHtml(agent.name) +
-          '</strong><span>' +
-          escapeHtml(agent.role?.label || 'Agent') +
-          '</span><em>' +
-          escapeHtml(statusLabel) +
-          '</em></span></button>'
-        );
-      })
-      .join('');
+
+    const entry = agents.find(a => a.entry);
+    const specialists = agents.filter(a => a !== entry);
+
+    // No valid entry agent: show a repair state at the command position rather
+    // than promoting an arbitrary specialist visually (FR77). Backend routing
+    // and assignment rules are untouched (FR78) — this is presentation only.
+    if (!entry) {
+      return (
+        '<div class="ws-cmd-map-command-repair">' +
+        '<strong>No entry agent</strong>' +
+        '<span>Chats, routing, and task orchestration need an entry agent.</span>' +
+        '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-agent>Create Entry Agent</button>' +
+        '</div>' +
+        '<div class="ws-cmd-map-agent-field">' +
+        specialists.map((agent, index) => this.renderMapAgentUnit(agent, index, false)).join('') +
+        '</div>'
+      );
+    }
+
+    this._commandNodeOrchestrationCopy = this.commandNodeOrchestrationCopy(specialists.length);
+    return (
+      '<div class="ws-cmd-map-command-row">' +
+      this.renderMapAgentUnit(entry, 0, true) +
+      '</div>' +
+      '<div class="ws-cmd-map-agent-field">' +
+      specialists.map((agent, index) => this.renderMapAgentUnit(agent, index, false)).join('') +
+      '</div>'
+    );
   }
 
   renderMapAgentsZone(agents) {
     return (
       '<section class="ws-cmd-map-world" data-map-zone="agents" aria-label="Agent units">' +
       '<div class="ws-cmd-map-floor" aria-hidden="true"></div>' +
-      '<div class="ws-cmd-map-agent-field">' +
       this.renderMapAgentUnits(agents) +
-      '</div></section>'
+      '</section>'
     );
   }
 

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2288,7 +2288,11 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     assert.doesNotMatch(html, /ws-cmd-map-stations/);
     assert.doesNotMatch(html, /ws-cmd-map-station-node/);
     assert.match(html, /Researcher/);
-    assert.match(html, /ws-cmd-map-entry-badge/);
+    // The sole entry agent renders as the command node (group 5), not the small
+    // entry star badge (which is reserved for a specialist card, never shown
+    // here since there is no specialist in this fixture).
+    assert.match(html, /is-command-node/);
+    assert.match(html, /ws-cmd-map-command-role/);
     assert.match(html, /Entry Agent/);
     assert.doesNotMatch(html, /data-map-zone="mission"/);
     assert.doesNotMatch(html, /data-map-zone="tasks"/);


### PR DESCRIPTION
**Serialized epic — group 5 of 8.** Merges into `epic/workspace-task-execution-ux`. Promotes the entry agent to a visually distinct command node communicating orchestration hierarchy (FR66–FR79).

## What's here
- Entry agent renders **first, top-centered**, ~1.3× a specialist card, via a new `.ws-cmd-map-command-row` above the unchanged specialist grid (FR66–FR67).
- **Orchestration copy**: "Routes work to N specialist agents" (singular/zero handled), computed from the roster excluding the entry agent — `agentGroups()` already dedupes and drops unassigned placeholders, so no new filtering was needed (FR68–FR69).
- **Role vs runtime independence** (FR40, FR70): `.is-command-node` is a static role frame (gold border, "Entry Agent" label); runtime tone classes (`working`/`needs-input`/etc.) still layer on top unchanged. A dedicated test asserts both coexist.
- Selecting the node reuses the identical `data-cmd-map-select-agent` contract as specialists — no separate detail surface (FR73, FR75).
- **Missing-entry repair state**: a dashed placeholder + "Create Entry Agent" (reusing the existing add-agent flow) instead of visually promoting an arbitrary specialist (FR77). Presentation-only — no backend routing/assignment change (FR78).
- No animation touches any new class, so reduced-motion (FR79) has nothing to disable — confirmed by `grep`.

## Verification
- **Browser-verified**: a seeded workspace (1 entry + 2 specialists) renders exactly as designed — "Node Manager" / ENTRY AGENT / "Routes work to 2 specialist agents" above Writer Bot / Editor Bot, no console errors.
- 11 new tests (`workspace-command-entry-node.test.js`); one existing Map-render test updated for the new markup. Full suite green (**653**); eslint clean; build OK.

## Known gaps (noted honestly)
- **Delegation indicators (FR71)** — optional per the PRD ("may connect"); skipped since the accessible orchestration copy already satisfies FR72's relationship-text requirement without the fragility of connector lines.
- **Narrow layout (FR76)** — CSS rule is `grep`/`matchMedia`-verified (negative control at 756px correctly evaluates false), but not visually confirmed at 320/768px: this smoke sandbox has a hard ~756px viewport floor that `resize_window` couldn't get below. Worth a real-device check before considering FR76 fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)