### PR TITLE
feat(workspace): URL/history-backed restoration for map, drawer, tray, agent (group 6)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -167,6 +167,7 @@ export default defineConfig([
       'internal/web/static/js/modules/workspace-command.js',
       'internal/web/static/js/modules/workspace-execution-controller.js',
       'internal/web/static/js/modules/workspace-overlay-coordinator.js',
+      'internal/web/static/js/modules/workspace-url-state.js',
     ],
     languageOptions: {
       sourceType: 'module'

--- a/internal/web/static/js/modules/workspace-command-url-state.test.js
+++ b/internal/web/static/js/modules/workspace-command-url-state.test.js
@@ -1,0 +1,294 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceCommandView } from './workspace-command.js';
+
+/**
+ * A minimal, mutable fake of window.history + window.location good enough to
+ * exercise push/replace/popstate semantics without a real DOM (FR86-FR90).
+ */
+function makeHistoryHarness(initialSearch = '') {
+  const calls = [];
+  const location = { pathname: '/workspaces/ws-1', search: initialSearch, href: '' };
+  location.href = location.pathname + location.search;
+  let state = null;
+  const listeners = [];
+  const history = {
+    get state() {
+      return state;
+    },
+    pushState(nextState, _title, url) {
+      calls.push(['push', url]);
+      state = nextState;
+      applyUrl(url);
+    },
+    replaceState(nextState, _title, url) {
+      calls.push(['replace', url]);
+      state = nextState;
+      applyUrl(url);
+    }
+  };
+  function applyUrl(url) {
+    const u = String(url || '');
+    const qIndex = u.indexOf('?');
+    location.pathname = qIndex === -1 ? u : u.slice(0, qIndex);
+    location.search = qIndex === -1 ? '' : u.slice(qIndex);
+    location.href = location.pathname + location.search;
+  }
+  const win = {
+    location,
+    history,
+    addEventListener(type, fn) {
+      if (type === 'popstate') listeners.push(fn);
+    },
+    Toast: { info() {} }
+  };
+  return {
+    win,
+    calls,
+    fireExternalNavigation(search, historyState) {
+      // Simulate the browser moving Back/Forward: it updates location+state
+      // itself (no history.pushState call from us) before firing popstate.
+      location.search = search;
+      location.href = location.pathname + location.search;
+      state = historyState || null;
+      listeners.forEach(fn => fn({ state }));
+    }
+  };
+}
+
+function makeContainer() {
+  const nodes = {};
+  return {
+    hidden: true,
+    innerHTML: '',
+    children: [],
+    appendChild(el) {
+      this.children.push(el);
+    },
+    querySelector(sel) {
+      return nodes[sel] || null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    _register(sel, el) {
+      nodes[sel] = el;
+    }
+  };
+}
+
+function makePage(over = {}) {
+  return {
+    tasks: [
+      { id: 'task-1', status: 'pending', to: 'writer' },
+      { id: 'task-2', status: 'in_progress', to: 'writer' }
+    ],
+    workspaceId: 'ws-1',
+    buildAgentGroups() {
+      return [{ key: 'writer', name: 'Writer', isWorkspaceAgent: true, instanceCount: 1, roles: ['Agent'], tasks: [] }];
+    },
+    isWorkspaceEntryAgent: () => false,
+    getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' }),
+    ...over
+  };
+}
+
+function withHarness(initialSearch, fn) {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalLocalStorage = globalThis.localStorage;
+  const harness = makeHistoryHarness(initialSearch);
+  const container = makeContainer();
+  try {
+    globalThis.document = {
+      getElementById: id => (id === 'workspaceCommandView' ? container : null),
+      addEventListener() {},
+      activeElement: null
+    };
+    globalThis.window = harness.win;
+    globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+    fn({ harness, container });
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.window = originalWindow;
+    globalThis.localStorage = originalLocalStorage;
+  }
+}
+
+test('boot with valid mode+panel+task+agent applies all of them (FR80, FR82-84)', () => {
+  withHarness('?mode=map&panel=tasks&task=task-1&agent=writer', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    assert.equal(view.viewMode, 'map');
+    assert.equal(view.taskDrawerOpen, true);
+    assert.equal(view.taskDrawerSelectedId, 'task-1');
+    assert.equal(view.selectedAgentKey, 'writer');
+    // The incoming URL was already fully valid and canonical, so boot makes
+    // NO history calls — proving it doesn't needlessly rewrite an accurate URL.
+    assert.deepEqual(harness.calls, []);
+  });
+});
+
+test('boot drops a stale task id; a stale agent falls back to the default selection (FR91)', () => {
+  withHarness('?panel=tasks&task=deleted-task&agent=ghost-agent', () => {
+    const view = new WorkspaceCommandView(makePage());
+    assert.equal(view.taskDrawerSelectedId, '', 'stale task id dropped, not applied');
+    assert.equal(view.taskDrawerOpen, true, 'panel=tasks alone is still honored');
+    // The stale agent is dropped rather than applied; normal default-selection
+    // (first/entry agent) takes over exactly as if no agent had been in the URL.
+    assert.equal(view.selectedAgentKey, 'writer');
+  });
+});
+
+test('a details-mode boot with an empty query string never rewrites the clean URL', () => {
+  // No agents at all, so reconcileAgentSelection has nothing to auto-select —
+  // isolates the "nothing meaningfully changed" invariant from agent defaulting.
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage({ buildAgentGroups: () => [] }));
+    assert.ok(view);
+    assert.deepEqual(harness.calls, [], 'no history call for an already-clean URL at the default mode');
+  });
+});
+
+test('selecting a different agent pushes a new history entry with the agent param (FR86, FR88)', () => {
+  const twoAgents = () => [
+    { key: 'writer', name: 'Writer', isWorkspaceAgent: true, instanceCount: 1, roles: ['Agent'], tasks: [] },
+    { key: 'editor', name: 'Editor', isWorkspaceAgent: true, instanceCount: 1, roles: ['Agent'], tasks: [] }
+  ];
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage({ buildAgentGroups: twoAgents }));
+    assert.equal(view.selectedAgentKey, 'writer', 'the first agent auto-selects at boot');
+    harness.calls.length = 0; // clear the boot normalization call
+    view.selectAgent('Editor', { focus: false });
+    const pushed = harness.calls.find(([kind]) => kind === 'push');
+    assert.ok(pushed, 'selecting a different agent pushes a history entry');
+    assert.match(pushed[1], /agent=editor/);
+  });
+});
+
+test('re-selecting the same agent does not push a duplicate entry (FR86 no-op dedup)', () => {
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    assert.equal(view.selectedAgentKey, 'writer', 'auto-selected at boot');
+    harness.calls.length = 0;
+    view.selectAgent('Writer', { focus: false }); // reselecting the same agent
+    assert.deepEqual(harness.calls, []);
+  });
+});
+
+test('collapsing the tray is presentational: no push/replace with a new URL, only history.state updates (FR87-FR88)', () => {
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    view.execController = { getSelectedTaskId: () => '' };
+    const searchBefore = harness.win.location.search;
+    harness.calls.length = 0;
+    view.toggleTrayCollapsed();
+    assert.equal(harness.calls.length, 1, 'exactly one replaceState for the presentation-state capture');
+    assert.equal(harness.calls[0][0], 'replace');
+    assert.equal(harness.win.location.search, searchBefore, 'the URL query itself is unchanged by a presentational toggle');
+    assert.equal(harness.win.history.state.trayCollapsed, true);
+  });
+});
+
+test('Back/Forward (popstate) restores mode, panel, task, and agent (FR88)', () => {
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    harness.fireExternalNavigation('?mode=map&panel=tasks&task=task-2&agent=writer', {
+      drawerScroll: 0,
+      focusSelector: null,
+      trayCollapsed: false
+    });
+    assert.equal(view.viewMode, 'map');
+    assert.equal(view.taskDrawerOpen, true);
+    assert.equal(view.taskDrawerSelectedId, 'task-2');
+    assert.equal(view.selectedAgentKey, 'writer');
+  });
+});
+
+test('popstate restores the captured trayCollapsed presentation flag from history.state (FR88-FR89)', () => {
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    view.trayCollapsed = false;
+    harness.fireExternalNavigation('', { trayCollapsed: true });
+    assert.equal(view.trayCollapsed, true);
+  });
+});
+
+test('taskHrefWithReturn builds a safe, workspace-scoped href with a validated return param (FR92-93)', () => {
+  withHarness('', () => {
+    const view = new WorkspaceCommandView(makePage());
+    view.selectedAgentKey = 'writer';
+    const href = view.taskHrefWithReturn('task-1');
+    assert.match(href, /^\/workspaces\/ws-1\/task\/task-1\?return=/);
+    const returnParam = decodeURIComponent(href.split('return=')[1]);
+    assert.match(returnParam, /^\/workspaces\/ws-1(\?|$)/, 'return target is relative and workspace-scoped');
+    assert.ok(!returnParam.startsWith('//'), 'not protocol-relative');
+    assert.ok(!/^https?:/.test(returnParam), 'not an absolute URL');
+  });
+});
+
+test('boot restoration survives the real async-load race: tasks/agents are empty at construction and arrive via a later refresh() (regression)', () => {
+  // Reproduces a live-browser finding: WorkspaceCommandView is constructed
+  // synchronously right after the page kicks off its async data load, so
+  // page.tasks/agent groups are still [] on the first applyBootURLState() pass.
+  // A naive `Array.isArray(page.tasks)` gate treated that empty array as
+  // "loaded", sanitized the boot URL against zero valid ids, and permanently
+  // dropped the task+agent before the real data ever arrived.
+  withHarness('?mode=map&panel=tasks&task=task-1&agent=writer', ({ harness }) => {
+    let tasks = []; // starts empty, exactly like the real page constructor
+    const page = {
+      tasks,
+      workspaceId: 'ws-1',
+      buildAgentGroups: () => [], // no agents loaded yet either
+      isWorkspaceEntryAgent: () => false,
+      getAgentRosterStatus: () => ({ key: 'idle', label: 'Idle' })
+    };
+    const view = new WorkspaceCommandView(page);
+
+    // First pass (construction/activate()): data isn't here yet, nothing applied.
+    assert.equal(view.taskDrawerSelectedId, '');
+    assert.equal(view.selectedAgentKey, '');
+
+    // Real data arrives; the page mutates `page.tasks` in place and swaps in a
+    // real buildAgentGroups, then calls refresh() exactly as workspace-detail.js
+    // does in loadTasks()'s finally block.
+    tasks.push({ id: 'task-1', status: 'pending', to: 'writer' });
+    page.buildAgentGroups = () => [
+      { key: 'writer', name: 'Writer', isWorkspaceAgent: true, instanceCount: 1, roles: ['Agent'], tasks: [] }
+    ];
+    harness.calls.length = 0;
+    view.refresh();
+
+    assert.equal(view.taskDrawerOpen, true);
+    assert.equal(view.taskDrawerSelectedId, 'task-1', 'the task now resolves once real data has loaded');
+    assert.equal(view.selectedAgentKey, 'writer', 'the agent now resolves once real data has loaded');
+  });
+});
+
+test('a boot reference to a task/agent that never appears is eventually dropped, not retried forever (FR91)', () => {
+  withHarness('?panel=tasks&task=ghost-task&agent=ghost-agent', () => {
+    const page = { tasks: [], workspaceId: 'ws-1', buildAgentGroups: () => [] };
+    const view = new WorkspaceCommandView(page);
+    // Simulate many refreshes of a workspace that genuinely never gets this
+    // task/agent (deleted, or a bad link) — it must give up eventually.
+    for (let i = 0; i < 25; i++) view.refresh();
+    assert.equal(view.taskDrawerSelectedId, '');
+    assert.equal(view.selectedAgentKey, '');
+  });
+});
+
+test('opening the drawer syncs the URL; closing it removes panel/task from the URL', () => {
+  withHarness('', ({ harness }) => {
+    const view = new WorkspaceCommandView(makePage());
+    harness.calls.length = 0;
+    view.openTaskDrawer(null);
+    let pushed = harness.calls.find(([kind]) => kind === 'push');
+    assert.ok(pushed);
+    assert.match(pushed[1], /panel=tasks/);
+
+    harness.calls.length = 0;
+    view.closeTaskDrawer();
+    pushed = harness.calls.find(([kind]) => kind === 'push');
+    assert.ok(pushed);
+    assert.ok(!pushed[1].includes('panel=tasks'), 'panel/task cleared from the URL on close');
+  });
+});

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -22,6 +22,14 @@ import {
   FILTER
 } from './task-presentation.js';
 import { WorkspaceExecutionController, RUN_PHASE } from './workspace-execution-controller.js';
+import {
+  parseWorkspaceURLState,
+  sanitizeWorkspaceURLState,
+  statesEqual as urlStatesEqual,
+  resolveEffectiveMode,
+  buildReturnTarget,
+  buildWorkspaceURL
+} from './workspace-url-state.js';
 // Legacy view preference from the deleted Detailed/Command toggle; cleared on boot.
 const LEGACY_STORAGE_KEY = 'oriWorkspaceDetailView';
 const VIEW_MODE_STORAGE_KEY = 'oriWorkspaceCommandViewMode';
@@ -42,7 +50,17 @@ export class WorkspaceCommandView {
     this.page = page || null;
     this.container = document.getElementById('workspaceCommandView');
     this.active = false;
-    this.viewMode = this.readCommandViewModePreference();
+    // URL/history restoration (group 6): read the URL once at boot. `mode`
+    // wins over the localStorage preference (FR85); panel/task/agent/run are
+    // held pending until page data is available to sanitize against (FR91).
+    this._urlBootState = typeof window !== 'undefined' ? parseWorkspaceURLState(window.location.search) : null;
+    this._urlStateApplied = false;
+    this._urlSyncEnabled = false;
+    this._lastSyncedURLState = null;
+    this.viewMode = resolveEffectiveMode(
+      this._urlBootState && this._urlBootState.mode,
+      this.readCommandViewModePreference()
+    );
     this.activeRailSection = '';
     this.activeMapWindow = '';
     this.mapInventoryOpen = false;
@@ -97,6 +115,7 @@ export class WorkspaceCommandView {
     this.loadoutError = '';
     this.sharedSurfaceAnchors = {};
     this.boundGlobalKeydown = event => this.handleGlobalKeydown(event);
+    this.boundPopState = event => this.handlePopState(event);
     this.setup();
   }
 
@@ -144,6 +163,7 @@ export class WorkspaceCommandView {
     }
     this.restoreSharedSurfaces();
     this.render();
+    this.syncURLState();
     if (!focus || !this.container || typeof this.container.querySelector !== 'function') return;
     const btn = this.container.querySelector('[data-cmd-view-mode="' + nextMode + '"]');
     if (btn && typeof btn.focus === 'function') btn.focus();
@@ -176,6 +196,10 @@ export class WorkspaceCommandView {
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('keydown', this.boundGlobalKeydown);
     }
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+      window.addEventListener('popstate', this.boundPopState);
+    }
+    this.applyBootURLState();
   }
 
   /** Re-render if active — called by the page after its data loads/refreshes. */
@@ -184,6 +208,216 @@ export class WorkspaceCommandView {
     else if (this.statModalSection) this.renderStatModalBody();
     // Live-refresh the drawer body in place (preserves selection + scroll, FR25).
     if (this.taskDrawerOpen) this.renderTaskDrawerBody();
+    // Data may not have been ready the first time activate() ran; retry once
+    // page.tasks/agents are actually populated (FR90: refresh restores from URL).
+    this.applyBootURLState();
+  }
+
+  // ---------- URL / history restoration (group 6) ----------
+  //
+  // Canonical params: mode, panel, task, agent, run (FR80). URL wins over the
+  // localStorage view-mode preference (FR85, applied in the constructor).
+  // Meaningful transitions (mode/drawer/task/agent/run changes) push or
+  // replace history; presentational changes (scroll, tray collapse) never
+  // touch the URL and are instead captured into history.state (FR86-FR87).
+
+  /** Build the validation context sanitizeWorkspaceURLState needs (FR91). */
+  urlStateContext() {
+    const page = this.page || {};
+    const tasks = Array.isArray(page.tasks) ? page.tasks : [];
+    const validTaskIds = tasks.map(t => String(t?.id || '')).filter(Boolean);
+    let validAgentKeys = [];
+    try {
+      validAgentKeys = this.agentGroups().agents.map(g => this.normalizeAgentKey(g.key || g.name));
+    } catch (_error) {
+      validAgentKeys = [];
+    }
+    return { validTaskIds, validAgentKeys, validRunTaskIds: validTaskIds };
+  }
+
+  /**
+   * Apply the URL state captured at construction, once page data exists to
+   * sanitize against. Idempotent — safe to call from both activate() and
+   * refresh(); only the first call with usable context takes effect.
+   *
+   * WorkspaceCommandView is constructed synchronously right after the page
+   * kicks off its (async) initial data load, so `page.tasks`/agent groups are
+   * still empty on the very first call — merely checking `Array.isArray` is
+   * not enough to tell "no data yet" apart from "genuinely zero tasks." If the
+   * boot URL names a task/agent/run but the currently-known valid set is
+   * completely empty, treat that as "not loaded yet" and retry on the next
+   * refresh() (which the page calls once real data arrives), bounded so a
+   * truly stale link still eventually gets dropped per FR91.
+   */
+  applyBootURLState() {
+    if (this._urlStateApplied || !this._urlBootState) {
+      this._urlSyncEnabled = true;
+      return;
+    }
+    const page = this.page || {};
+    if (!Array.isArray(page.tasks)) return;
+
+    const context = this.urlStateContext();
+    const boot = this._urlBootState;
+    const dataLooksUnready =
+      (boot.task && context.validTaskIds.length === 0) ||
+      (boot.agent && context.validAgentKeys.length === 0) ||
+      (boot.run && (context.validRunTaskIds || context.validTaskIds).length === 0);
+    this._bootApplyAttempts = (this._bootApplyAttempts || 0) + 1;
+    const MAX_BOOT_ATTEMPTS = 20;
+    if (dataLooksUnready && this._bootApplyAttempts < MAX_BOOT_ATTEMPTS) return;
+
+    const { state, dropped } = sanitizeWorkspaceURLState(boot, context);
+    this._urlStateApplied = true;
+
+    if (dropped.length && typeof window !== 'undefined' && window.Toast) {
+      window.Toast.info('Some link details were out of date and were ignored.');
+    }
+
+    const effectiveMode = resolveEffectiveMode(state.mode, this.viewMode, this.viewMode);
+    if (effectiveMode !== this.viewMode) {
+      this.viewMode = effectiveMode;
+      this.persistCommandViewMode(effectiveMode);
+    }
+    if (state.agent) {
+      this.selectedAgentKey = state.agent;
+      this.agentSelectionInitialized = true;
+      this.persistAgentKey(state.agent);
+    }
+    if (state.panel === 'tasks') {
+      this.taskDrawerOpen = true;
+      if (state.task) this.taskDrawerSelectedId = state.task;
+    }
+    if (state.run) this.trackAndShowTray(state.run);
+
+    this._urlSyncEnabled = true;
+    this.render();
+    if (this.taskDrawerOpen) {
+      const el = this.ensureTaskDrawer();
+      if (el) {
+        el.hidden = false;
+        this.renderTaskDrawerBody();
+      }
+    }
+    // Normalize the URL to the sanitized state without adding a history entry.
+    this.syncURLState({ replace: true });
+  }
+
+  /** Current URL-relevant state derived from live view state. */
+  currentURLState() {
+    return {
+      // 'details' is the historical default; omit it so a details-mode URL
+      // stays clean (no ?mode=details noise) and only an explicit `map` needs
+      // to survive reload/sharing.
+      mode: this.viewMode === 'map' ? 'map' : null,
+      panel: this.taskDrawerOpen ? 'tasks' : '',
+      task: this.taskDrawerOpen ? this.taskDrawerSelectedId : '',
+      agent: this.selectedAgentKey || '',
+      run:
+        this.execController && typeof this.execController.getSelectedTaskId === 'function'
+          ? this.execController.getSelectedTaskId()
+          : ''
+    };
+  }
+
+  /** Best-effort selector for the last meaningfully focused control (FR89). */
+  currentFocusSelector() {
+    if (typeof document === 'undefined') return null;
+    const active = document.activeElement;
+    if (!active || typeof active.getAttribute !== 'function') return null;
+    for (const attr of ['data-cmd-map-select-agent', 'data-cmd-drawer-select', 'data-cmd-open-task-drawer']) {
+      const value = active.getAttribute(attr);
+      if (value) return '[' + attr + '="' + value.replace(/"/g, '\\"') + '"]';
+    }
+    return null;
+  }
+
+  /** Snapshot scroll/focus into the CURRENT history entry before navigating away (FR89). */
+  captureHistoryPresentationState() {
+    if (typeof window === 'undefined' || !window.history) return;
+    const current = window.history.state || {};
+    const drawerList =
+      this.taskDrawerEl && typeof this.taskDrawerEl.querySelector === 'function'
+        ? this.taskDrawerEl.querySelector('.ws-cmd-drawer-list')
+        : null;
+    const drawerScroll = drawerList ? drawerList.scrollTop : current.drawerScroll || 0;
+    window.history.replaceState(
+      {
+        ...current,
+        drawerScroll,
+        focusSelector: this.currentFocusSelector() || current.focusSelector || null,
+        trayCollapsed: this.trayCollapsed
+      },
+      '',
+      window.location.href
+    );
+  }
+
+  /**
+   * Push or replace history for the current view state (FR86-FR88). No-op
+   * transitions never create a duplicate entry; the caller decides push vs
+   * replace (replace for normalization, push for a genuine user navigation).
+   */
+  syncURLState({ replace = false } = {}) {
+    if (!this._urlSyncEnabled || typeof window === 'undefined' || !window.history) return;
+    const nextState = this.currentURLState();
+    if (urlStatesEqual(nextState, this._lastSyncedURLState)) return;
+    const url = buildWorkspaceURL(window.location.pathname, nextState);
+    // Nothing to rewrite if the target URL already matches the address bar —
+    // avoids an unnecessary history.replaceState on an already-clean URL.
+    const currentUrl = window.location.pathname + (window.location.search || '');
+    if (url === currentUrl) {
+      this._lastSyncedURLState = nextState;
+      return;
+    }
+    if (!replace) this.captureHistoryPresentationState();
+    const historyEntryState = replace
+      ? { ...(window.history.state || {}) }
+      : { drawerScroll: 0, focusSelector: null, trayCollapsed: this.trayCollapsed };
+    if (replace) window.history.replaceState(historyEntryState, '', url);
+    else window.history.pushState(historyEntryState, '', url);
+    this._lastSyncedURLState = nextState;
+  }
+
+  /** Restore view state from Back/Forward navigation (FR88-FR89). */
+  handlePopState(event) {
+    if (!this._urlSyncEnabled) return;
+    const context = this.urlStateContext();
+    const { state } = sanitizeWorkspaceURLState(parseWorkspaceURLState(window.location.search), context);
+    this._lastSyncedURLState = state;
+
+    const effectiveMode = resolveEffectiveMode(state.mode, this.viewMode, this.viewMode);
+    this.viewMode = effectiveMode;
+    if (state.agent) {
+      this.selectedAgentKey = state.agent;
+      this.agentSelectionInitialized = true;
+    }
+    this.taskDrawerOpen = state.panel === 'tasks';
+    if (this.taskDrawerOpen && state.task) this.taskDrawerSelectedId = state.task;
+    const historyState = (event && event.state) || {};
+    this.trayCollapsed = Boolean(historyState.trayCollapsed);
+    if (state.run) this.trackAndShowTray(state.run);
+
+    this.render();
+    const el = this.taskDrawerOpen ? this.ensureTaskDrawer() : null;
+    if (el) {
+      el.hidden = false;
+      this.renderTaskDrawerBody();
+      const list = el.querySelector('.ws-cmd-drawer-list');
+      if (list && typeof historyState.drawerScroll === 'number') list.scrollTop = historyState.drawerScroll;
+    }
+    if (historyState.focusSelector && this.container && typeof this.container.querySelector === 'function') {
+      const target = this.container.querySelector(historyState.focusSelector);
+      if (target && typeof target.focus === 'function') target.focus({ preventScroll: true });
+    }
+  }
+
+  /** A safe, same-origin `Open Full Task` href carrying a validated return target (FR92). */
+  taskHrefWithReturn(taskId) {
+    const wsId = typeof this.workspaceId === 'function' ? this.workspaceId() : '';
+    const base = '/workspaces/' + encodeURIComponent(wsId) + '/task/' + encodeURIComponent(taskId);
+    const returnTarget = buildReturnTarget(wsId, this.currentURLState());
+    return returnTarget ? base + '?return=' + encodeURIComponent(returnTarget) : base;
   }
 
   handleGlobalKeydown(event) {
@@ -2960,6 +3194,7 @@ export class WorkspaceCommandView {
         }
       }
     }
+    this.syncURLState();
   }
 
   closeTaskDrawer() {
@@ -2974,6 +3209,7 @@ export class WorkspaceCommandView {
       if (fallback && typeof fallback.focus === 'function') target = fallback;
     }
     if (target) target.focus();
+    this.syncURLState();
   }
 
   setDrawerFilter(filter) {
@@ -2994,6 +3230,7 @@ export class WorkspaceCommandView {
     if (!id) return;
     this.taskDrawerSelectedId = id;
     this.renderTaskDrawerBody();
+    this.syncURLState();
   }
 
   drawerSelectedTask() {
@@ -3173,9 +3410,10 @@ export class WorkspaceCommandView {
     const title = String(task.description || task.name || task.title || 'Untitled task');
     const brief = String(task.details || task.brief || task.prompt || '').trim();
     const assignee = pres.assignee || 'Unassigned';
-    const wsId = typeof this.workspaceId === 'function' ? this.workspaceId() : '';
-    const fullHref =
-      '/workspaces/' + encodeURIComponent(wsId) + '/task/' + encodeURIComponent(id);
+    // A safe, same-origin href carrying a validated `return` target so Back To
+    // Workspace (group 7) can restore this exact Map/drawer/task/agent/run
+    // context (FR92-93).
+    const fullHref = this.taskHrefWithReturn(id);
     // Off-filter notice: the selected task is still shown even if it left the
     // current filter mid-interaction (FR26).
     const offFilter = !taskMatchesFilter(task, this.taskDrawerFilter);
@@ -3293,6 +3531,7 @@ export class WorkspaceCommandView {
     this._trayCancelArmed = '';
     el.hidden = false;
     this.renderTrayBody();
+    this.syncURLState();
   }
 
   closeTray() {
@@ -3300,17 +3539,23 @@ export class WorkspaceCommandView {
     // (FR52). Runs keep running in the controller; reopening restores them.
     this.trayOpen = false;
     if (this.trayEl) this.trayEl.hidden = true;
+    this.syncURLState();
   }
 
+  // Collapsing/expanding is presentational (FR87): it never touches the URL,
+  // but is still captured into the current history entry so Back/Forward can
+  // restore it (FR88).
   toggleTrayCollapsed() {
     this.trayCollapsed = !this.trayCollapsed;
     this.renderTrayBody();
+    this.captureHistoryPresentationState();
   }
 
   selectTrayRun(taskId) {
     if (this.execController) this.execController.select(taskId);
     this._trayCancelArmed = '';
     this.renderTrayBody();
+    this.syncURLState();
   }
 
   ensureTray() {
@@ -4797,6 +5042,7 @@ export class WorkspaceCommandView {
     this.agentOverviewScroll = 0;
     if (focus) this.pendingAgentFocusKey = key;
     this.render();
+    this.syncURLState();
   }
 
   setActiveAgentTab(key, { focus = true } = {}) {

--- a/internal/web/static/js/modules/workspace-url-state.js
+++ b/internal/web/static/js/modules/workspace-url-state.js
@@ -1,0 +1,141 @@
+/**
+ * workspace-url-state.js
+ *
+ * Isolated, unit-testable URL/history helpers for the workspace detail page
+ * (PRD section F, FR80-FR96). Pure functions only — no DOM/window access —
+ * so parsing, sanitizing, and diffing can be exercised from fixtures. The
+ * caller (workspace-command.js) is responsible for reading `location.search`,
+ * calling `history.pushState`/`replaceState`, and re-rendering.
+ *
+ * Canonical query params (FR80-81): `mode` (map|details, replaces the retired
+ * `view` param), `panel` (currently only `tasks`), `task`, `agent`, and an
+ * optional `run`. Per the group-1 backend audit, execution monitoring is
+ * TASK-ID-KEYED (there is no separate run-ID surfaced to the frontend yet), so
+ * `run` is treated as a task ID naming which tracked run the tray should show —
+ * documented here rather than invented silently.
+ */
+
+export const MODE = Object.freeze({ MAP: 'map', DETAILS: 'details' });
+const VALID_MODES = new Set([MODE.MAP, MODE.DETAILS]);
+const VALID_PANELS = new Set(['tasks']);
+
+/** Parse a query string (with or without a leading `?`) into raw URL state. */
+export function parseWorkspaceURLState(search) {
+  const params = new URLSearchParams(String(search || '').replace(/^\?/, ''));
+  const mode = params.get('mode');
+  return {
+    mode: mode && VALID_MODES.has(mode) ? mode : null,
+    panel: params.get('panel') || '',
+    task: params.get('task') || '',
+    agent: params.get('agent') || '',
+    run: params.get('run') || ''
+  };
+}
+
+/** Serialize state back into a query string (no leading `?`). Omits empty/null fields. */
+export function serializeWorkspaceURLState(state) {
+  const params = new URLSearchParams();
+  const s = state || {};
+  if (s.mode && VALID_MODES.has(s.mode)) params.set('mode', s.mode);
+  if (s.panel) params.set('panel', s.panel);
+  if (s.task) params.set('task', s.task);
+  if (s.agent) params.set('agent', s.agent);
+  if (s.run) params.set('run', s.run);
+  return params.toString();
+}
+
+/**
+ * Sanitize state against the currently loaded workspace (FR91): unknown,
+ * stale, deleted, or unauthorized values are dropped rather than applied.
+ * `context` supplies the authoritative sets to validate against.
+ *
+ * @param {object} state
+ * @param {{validTaskIds?: Iterable<string>, validAgentKeys?: Iterable<string>, validRunTaskIds?: Iterable<string>}} context
+ * @returns {{state: object, dropped: string[]}} the sanitized state and which fields were dropped (for a concise notice).
+ */
+export function sanitizeWorkspaceURLState(state, context = {}) {
+  const validTaskIds = new Set(context.validTaskIds || []);
+  const validAgentKeys = new Set(context.validAgentKeys || []);
+  const validRunTaskIds = new Set(context.validRunTaskIds || validTaskIds);
+  const s = state || {};
+  const dropped = [];
+  const out = { mode: s.mode || null, panel: '', task: '', agent: '', run: '' };
+
+  if (s.panel && VALID_PANELS.has(s.panel)) out.panel = s.panel;
+  else if (s.panel) dropped.push('panel');
+
+  if (s.task && validTaskIds.has(s.task)) out.task = s.task;
+  else if (s.task) dropped.push('task');
+
+  if (s.agent && validAgentKeys.has(s.agent)) out.agent = s.agent;
+  else if (s.agent) dropped.push('agent');
+
+  if (s.run && validRunTaskIds.has(s.run)) out.run = s.run;
+  else if (s.run) dropped.push('run');
+
+  // panel=tasks without a valid task is still a meaningful "drawer open" state
+  // (FR82 requires panel+task together only to restore the PREVIEW, not to
+  // gate opening the drawer itself).
+  return { state: out, dropped };
+}
+
+/** Whether two (sanitized) states are equivalent for history-entry purposes (FR86). */
+export function statesEqual(a, b) {
+  const x = a || {};
+  const y = b || {};
+  return (
+    (x.mode || null) === (y.mode || null) &&
+    (x.panel || '') === (y.panel || '') &&
+    (x.task || '') === (y.task || '') &&
+    (x.agent || '') === (y.agent || '') &&
+    (x.run || '') === (y.run || '')
+  );
+}
+
+/**
+ * Resolve the effective mode: URL wins; otherwise the local preference; else
+ * the default (FR85).
+ */
+export function resolveEffectiveMode(urlMode, localPreferenceMode, defaultMode = MODE.DETAILS) {
+  if (urlMode && VALID_MODES.has(urlMode)) return urlMode;
+  if (localPreferenceMode && VALID_MODES.has(localPreferenceMode)) return localPreferenceMode;
+  return defaultMode;
+}
+
+/**
+ * Build the safe, same-origin return target embedded in a task-page link
+ * (FR92). Only ever a relative path scoped to this workspace — never an
+ * absolute URL or another workspace's route, so it can't become an open
+ * redirect vector.
+ */
+export function buildReturnTarget(workspaceId, state) {
+  const id = String(workspaceId || '').trim();
+  if (!id) return '';
+  const query = serializeWorkspaceURLState(state);
+  const path = '/workspaces/' + encodeURIComponent(id);
+  return query ? path + '?' + query : path;
+}
+
+/**
+ * Validate a return-target string before navigating to it (FR93): must be a
+ * relative, same-workspace `/workspaces/{id}` path — reject absolute URLs,
+ * protocol-relative (`//host`) links, and any other workspace's route.
+ */
+export function isSafeReturnTarget(raw, workspaceId) {
+  const value = String(raw || '');
+  const id = String(workspaceId || '').trim();
+  if (!value || !id) return false;
+  if (!value.startsWith('/')) return false; // rejects absolute URLs and bare hosts
+  if (value.startsWith('//')) return false; // rejects protocol-relative URLs
+  const expectedPrefix = '/workspaces/' + encodeURIComponent(id);
+  return value === expectedPrefix || value.startsWith(expectedPrefix + '?') || value.startsWith(expectedPrefix + '/');
+}
+
+/**
+ * Build the full path+query for the workspace detail page from a state object,
+ * given the current pathname (used for pushState/replaceState targets).
+ */
+export function buildWorkspaceURL(pathname, state) {
+  const query = serializeWorkspaceURLState(state);
+  return query ? pathname + '?' + query : pathname;
+}

--- a/internal/web/static/js/modules/workspace-url-state.test.js
+++ b/internal/web/static/js/modules/workspace-url-state.test.js
@@ -1,0 +1,129 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MODE,
+  parseWorkspaceURLState,
+  serializeWorkspaceURLState,
+  sanitizeWorkspaceURLState,
+  statesEqual,
+  resolveEffectiveMode,
+  buildReturnTarget,
+  isSafeReturnTarget,
+  buildWorkspaceURL
+} from './workspace-url-state.js';
+
+test('parseWorkspaceURLState reads all canonical params (FR80)', () => {
+  const s = parseWorkspaceURLState('?mode=map&panel=tasks&task=t1&agent=writer&run=t1');
+  assert.deepEqual(s, { mode: 'map', panel: 'tasks', task: 't1', agent: 'writer', run: 't1' });
+});
+
+test('parseWorkspaceURLState rejects an unknown mode value rather than reusing the retired view param (FR81)', () => {
+  assert.equal(parseWorkspaceURLState('?mode=grid').mode, null);
+  assert.equal(parseWorkspaceURLState('?view=command').mode, null, 'the legacy view param is not read at all');
+});
+
+test('parseWorkspaceURLState handles an empty/missing query string', () => {
+  assert.deepEqual(parseWorkspaceURLState(''), { mode: null, panel: '', task: '', agent: '', run: '' });
+  assert.deepEqual(parseWorkspaceURLState(undefined), { mode: null, panel: '', task: '', agent: '', run: '' });
+});
+
+test('serializeWorkspaceURLState omits empty fields and round-trips', () => {
+  const state = { mode: MODE.MAP, panel: 'tasks', task: 't1', agent: '', run: '' };
+  const q = serializeWorkspaceURLState(state);
+  assert.equal(q, 'mode=map&panel=tasks&task=t1');
+  assert.deepEqual(parseWorkspaceURLState(q), { mode: 'map', panel: 'tasks', task: 't1', agent: '', run: '' });
+});
+
+test('serializeWorkspaceURLState drops an invalid mode rather than emitting it', () => {
+  const q = serializeWorkspaceURLState({ mode: 'bogus', task: 't1' });
+  assert.equal(q, 'task=t1');
+});
+
+test('sanitizeWorkspaceURLState keeps only values present in the loaded context (FR91)', () => {
+  const context = { validTaskIds: ['t1', 't2'], validAgentKeys: ['writer'] };
+  const { state, dropped } = sanitizeWorkspaceURLState(
+    { mode: MODE.MAP, panel: 'tasks', task: 't1', agent: 'writer', run: 't9' },
+    context
+  );
+  assert.deepEqual(state, { mode: MODE.MAP, panel: 'tasks', task: 't1', agent: 'writer', run: '' });
+  assert.deepEqual(dropped, ['run']);
+});
+
+test('sanitizeWorkspaceURLState drops a stale task and a stale agent independently', () => {
+  const context = { validTaskIds: ['t1'], validAgentKeys: ['writer'] };
+  const { state, dropped } = sanitizeWorkspaceURLState(
+    { task: 'deleted-task', agent: 'gone-agent', panel: 'tasks' },
+    context
+  );
+  assert.equal(state.task, '');
+  assert.equal(state.agent, '');
+  assert.equal(state.panel, 'tasks');
+  assert.deepEqual(dropped.sort(), ['agent', 'task']);
+});
+
+test('sanitizeWorkspaceURLState drops an unknown panel value', () => {
+  const { state, dropped } = sanitizeWorkspaceURLState({ panel: 'inventory' }, {});
+  assert.equal(state.panel, '');
+  assert.deepEqual(dropped, ['panel']);
+});
+
+test('sanitizeWorkspaceURLState allows panel=tasks with no task id (drawer opens without a restored preview)', () => {
+  const { state, dropped } = sanitizeWorkspaceURLState({ panel: 'tasks' }, { validTaskIds: [] });
+  assert.equal(state.panel, 'tasks');
+  assert.equal(state.task, '');
+  assert.deepEqual(dropped, []);
+});
+
+test('sanitizeWorkspaceURLState falls back run validation to validTaskIds when validRunTaskIds is omitted', () => {
+  const { state } = sanitizeWorkspaceURLState({ run: 't1' }, { validTaskIds: ['t1'] });
+  assert.equal(state.run, 't1');
+});
+
+test('statesEqual treats equivalent states as equal regardless of key order/omission (FR86)', () => {
+  assert.equal(statesEqual({ mode: 'map', task: 't1' }, { mode: 'map', task: 't1', agent: '' }), true);
+  assert.equal(statesEqual({ mode: 'map' }, { mode: 'details' }), false);
+  assert.equal(statesEqual(null, {}), true);
+});
+
+test('resolveEffectiveMode: URL wins over local preference, which wins over the default (FR85)', () => {
+  assert.equal(resolveEffectiveMode(MODE.MAP, MODE.DETAILS), MODE.MAP);
+  assert.equal(resolveEffectiveMode(null, MODE.MAP), MODE.MAP);
+  assert.equal(resolveEffectiveMode(null, null), MODE.DETAILS);
+  assert.equal(resolveEffectiveMode('bogus', MODE.MAP), MODE.MAP, 'an invalid URL mode falls through to the preference');
+});
+
+test('buildReturnTarget produces a relative, workspace-scoped path (FR92)', () => {
+  const target = buildReturnTarget('ws-1', { mode: MODE.MAP, panel: 'tasks', task: 't1' });
+  assert.equal(target, '/workspaces/ws-1?mode=map&panel=tasks&task=t1');
+});
+
+test('buildReturnTarget with no extra state is just the workspace path', () => {
+  assert.equal(buildReturnTarget('ws-1', {}), '/workspaces/ws-1');
+});
+
+test('buildReturnTarget returns empty for a missing workspace id', () => {
+  assert.equal(buildReturnTarget('', { mode: MODE.MAP }), '');
+});
+
+test('isSafeReturnTarget accepts only this workspace\'s relative path (FR93)', () => {
+  assert.equal(isSafeReturnTarget('/workspaces/ws-1', 'ws-1'), true);
+  assert.equal(isSafeReturnTarget('/workspaces/ws-1?mode=map', 'ws-1'), true);
+  assert.equal(isSafeReturnTarget('/workspaces/ws-1/task/t9', 'ws-1'), true);
+});
+
+test('isSafeReturnTarget rejects absolute URLs, protocol-relative links, and cross-workspace paths (open-redirect guard)', () => {
+  assert.equal(isSafeReturnTarget('https://evil.example.com/workspaces/ws-1', 'ws-1'), false);
+  assert.equal(isSafeReturnTarget('//evil.example.com/workspaces/ws-1', 'ws-1'), false);
+  assert.equal(isSafeReturnTarget('/workspaces/other-ws', 'ws-1'), false);
+  assert.equal(isSafeReturnTarget('/workspaces/ws-123', 'ws-1'), false, 'prefix match must not leak into a similar id');
+  assert.equal(isSafeReturnTarget('', 'ws-1'), false);
+  assert.equal(isSafeReturnTarget('/workspaces/ws-1', ''), false);
+});
+
+test('buildWorkspaceURL composes pathname + serialized state', () => {
+  assert.equal(
+    buildWorkspaceURL('/workspaces/ws-1', { mode: MODE.MAP, task: 't1' }),
+    '/workspaces/ws-1?mode=map&task=t1'
+  );
+  assert.equal(buildWorkspaceURL('/workspaces/ws-1', {}), '/workspaces/ws-1');
+});


### PR DESCRIPTION
**Serialized epic — group 6 of 8.** Merges into `epic/workspace-task-execution-ux`. Workspace detail state becomes URL/history-backed (FR80–96): mode, panel, task, agent, and run survive refresh, Back/Forward, and link-sharing.

## What's here
- **`workspace-url-state.js`** — a pure, DOM-free module: parse/serialize `mode`/`panel`/`task`/`agent`/`run` (`mode` replaces the retired `view` param), sanitize against the loaded workspace's valid ids (dropping stale/deleted/cross-workspace references with a toast notice), de-dupe equivalent states so no-op transitions never create a duplicate history entry, and build/validate a safe same-origin `return=` target for the drawer's `Open Full Task` anchor (rejects absolute URLs, protocol-relative links, cross-workspace paths — open-redirect guard).
- **Wired into `workspace-command.js`**: URL wins over the localStorage view-mode preference; meaningful transitions (mode switch, drawer open/close, task/agent select, tray track/close/run-switch) push/replace history; tray collapse/expand is presentational — it never touches the URL, only `history.state`, so Back/Forward can still restore it without cluttering navigation history.

## Bug found + fixed via live browser verification
`WorkspaceCommandView` is constructed synchronously right after the page kicks off its async initial data load, so `page.tasks`/agent groups are still empty on the very first boot-state pass. The original `Array.isArray(page.tasks)` gate treated that empty array as "loaded," sanitized the boot URL against zero valid ids, and **permanently dropped a perfectly valid task+agent as stale** before the real data ever arrived via the page's own `refresh()` call moments later. Fixed by detecting "data looks unready" (a referenced id but zero known-valid ids) and retrying on subsequent `refresh()` calls, bounded to 20 attempts so a genuinely stale link still drops per FR91.

**Confirmed live**: a full-page reload with `?mode=map&panel=tasks&task=<id>&agent=<key>` now correctly restores the drawer's task preview instead of silently degrading to `?mode=map&panel=tasks`.

## Verification
- 18 pure-module tests + 12 mounted tests (real push/replace/popstate history harness), including two regression tests for the race above.
- Full module suite green (**683**); eslint clean; build OK.
- **Browser-verified end to end**: mode switch, drawer open/close, refresh restoration (post-fix), and Back/Forward navigation all correctly update/restore the URL — no console errors.

## Deferred / noted honestly
- Scroll-position restoration code exists (`drawerScroll`/`focusSelector` captured into `history.state`) but pixel-scroll restoration specifically wasn't visually re-verified beyond the unit test.
- Two-tab independence (FR96) holds by construction (no shared mutable state beyond the backend) but has no dedicated multi-tab browser test.
- FR95 (keyed updates vs. full remount) is unchanged from existing behavior — out of scope for this group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)