### PR TITLE
feat(workspace): redesign dedicated task page around current-state action (group 7)

### DIFF
--- a/internal/web/static/js/modules/workspace-task-status-labels.test.js
+++ b/internal/web/static/js/modules/workspace-task-status-labels.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.window = globalThis.window || {};
+
+const { getStatusClass, getDisplayStatus } = await import('./workspace-task.js');
+
+test('getStatusClass keeps its existing six CSS buckets unchanged (no selector breakage)', () => {
+  assert.equal(getStatusClass('completed'), 'completed');
+  assert.equal(getStatusClass('success'), 'completed');
+  assert.equal(getStatusClass('in_progress'), 'in_progress');
+  assert.equal(getStatusClass('blocked'), 'blocked');
+  assert.equal(getStatusClass('waiting_for_choice'), 'blocked');
+  assert.equal(getStatusClass('cancelled'), 'cancelled');
+  assert.equal(getStatusClass('skipped'), 'cancelled');
+  assert.equal(getStatusClass('failed'), 'failed');
+  assert.equal(getStatusClass('error'), 'failed');
+  assert.equal(getStatusClass('timeout'), 'failed');
+  assert.equal(getStatusClass('pending'), 'pending');
+  assert.equal(getStatusClass(''), 'pending');
+});
+
+test('getDisplayStatus preserves every existing known label byte-for-byte', () => {
+  assert.equal(getDisplayStatus('pending'), 'Pending');
+  assert.equal(getDisplayStatus('assigned'), 'Assigned');
+  assert.equal(getDisplayStatus('in_progress'), 'In Progress');
+  assert.equal(getDisplayStatus('waiting_for_choice'), 'Waiting for Choice');
+  assert.equal(getDisplayStatus('completed'), 'Completed');
+  assert.equal(getDisplayStatus('success'), 'Completed');
+  assert.equal(getDisplayStatus('failed'), 'Failed');
+  assert.equal(getDisplayStatus('error'), 'Failed');
+  assert.equal(getDisplayStatus('blocked'), 'Blocked');
+  assert.equal(getDisplayStatus('cancelled'), 'Cancelled');
+  assert.equal(getDisplayStatus('skipped'), 'Skipped');
+  assert.equal(getDisplayStatus('timeout'), 'Timed Out');
+});
+
+test('getDisplayStatus labels a genuinely unrecognized status "Unknown", not silently "Pending" (FR38, FR110)', () => {
+  assert.equal(getDisplayStatus('frobnicating'), 'Unknown');
+  assert.notEqual(getDisplayStatus('frobnicating'), 'Pending');
+});
+
+test('getDisplayStatus still treats an empty/missing status as Pending (unchanged default)', () => {
+  assert.equal(getDisplayStatus(''), 'Pending');
+  assert.equal(getDisplayStatus(undefined), 'Pending');
+});

--- a/internal/web/static/js/modules/workspace-task.js
+++ b/internal/web/static/js/modules/workspace-task.js
@@ -13,6 +13,7 @@ import {
 import { taskSkillDraftMethods } from './workspace-task-skill-draft.js';
 import { taskResultActionsMethods } from './workspace-task-result-actions.js';
 import { showCanvasAgentPicker } from './agent-canvas-dialogs.js';
+import { resolveTaskState, PRESENTATION_STATE } from './task-presentation.js';
 
 const escapeTaskHtml = window.escapeHtml || function fallbackEscapeHtml(value) {
   return String(value ?? '')
@@ -63,23 +64,29 @@ export function getStatusClass(status) {
   return 'pending';
 }
 
+const KNOWN_STATUS_LABELS = {
+  pending: 'Pending',
+  assigned: 'Assigned',
+  in_progress: 'In Progress',
+  waiting_for_choice: 'Waiting for Choice',
+  completed: 'Completed',
+  success: 'Completed',
+  failed: 'Failed',
+  error: 'Failed',
+  blocked: 'Blocked',
+  cancelled: 'Cancelled',
+  skipped: 'Skipped',
+  timeout: 'Timed Out'
+};
+
 export function getDisplayStatus(status) {
   const normalized = String(status || '').trim().toLowerCase();
-  const labels = {
-    pending: 'Pending',
-    assigned: 'Assigned',
-    in_progress: 'In Progress',
-    waiting_for_choice: 'Waiting for Choice',
-    completed: 'Completed',
-    success: 'Completed',
-    failed: 'Failed',
-    error: 'Failed',
-    blocked: 'Blocked',
-    cancelled: 'Cancelled',
-    skipped: 'Skipped',
-    timeout: 'Timed Out'
-  };
-  return labels[normalized] || 'Pending';
+  if (KNOWN_STATUS_LABELS[normalized]) return KNOWN_STATUS_LABELS[normalized];
+  // Shared resolver (FR110) decides only the fallback: a genuinely
+  // unrecognized status is labeled "Unknown", never silently "Pending" (FR38)
+  // — every status this file already knows about is covered above, so this
+  // only changes behavior for a status no caller has ever seen before.
+  return resolveTaskState({ status }) === PRESENTATION_STATE.UNKNOWN ? 'Unknown' : 'Pending';
 }
 
 export function summarizeText(value, maxLength = 220) {

--- a/internal/web/templates/pages/workspace-task.tmpl
+++ b/internal/web/templates/pages/workspace-task.tmpl
@@ -18,7 +18,7 @@
 
         <section class="workspace-task-page-hero">
           <div class="workspace-task-page-hero-copy">
-            <a href="/workspaces/{{.Extra.WorkspaceID}}" class="workspace-task-page-backlink">
+            <a id="workspace-task-backlink" href="/workspaces/{{.Extra.WorkspaceID}}" class="workspace-task-page-backlink">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"/>
               </svg>
@@ -329,6 +329,32 @@
                 </div>
               </section>
 
+              <section id="workspace-task-workflow-card" class="workspace-task-page-card" hidden>
+                <div class="workspace-task-page-card-header">
+                  <div>
+                    <div class="workspace-task-page-card-kicker">Workflow</div>
+                    <h2>Steps</h2>
+                  </div>
+                  <div id="workspace-task-workflow-actions" class="workspace-task-workflow-actions" hidden>
+                    <button type="button" id="workspace-task-workflow-add-step" class="modern-btn modern-btn-secondary workspace-task-workflow-header-btn" title="Add a new step">+ Add step</button>
+                    <button type="button" id="workspace-task-workflow-run-all" class="modern-btn modern-btn-primary workspace-task-workflow-header-btn" title="Run all steps in sequence">▶ Run all</button>
+                  </div>
+                </div>
+                <div id="workspace-task-workflow-empty" class="workspace-task-workflow-empty" hidden>
+                  <div class="workspace-task-workflow-empty-copy">No steps yet. Break this task's result into a runnable list of steps.</div>
+                  <button type="button" id="workspace-task-workflow-generate" class="modern-btn modern-btn-primary workspace-task-workflow-empty-btn">Break this into steps</button>
+                </div>
+                <div id="workspace-task-workflow-steps" class="workspace-task-workflow-list"></div>
+              </section>
+
+          </main>
+
+          <!-- Context column (FR101): schedule/automation+output, recent-run
+               summary, relationships, and the collapsed developer group
+               (raw IDs, run trace, technical context). Every inner element id
+               is unchanged from its previous position inside <main>, so no
+               JS binding or renderX() visibility toggle needed to change. -->
+          <aside class="workspace-task-page-sidebar">
               <!-- Single "Automation & output" card: how/when the task runs,
                    where results are saved, and (for structured tasks) the shape
                    of those results. The schedule card id is kept so renderSchedule
@@ -394,24 +420,6 @@
                 <div id="workspace-task-relationships" class="workspace-task-relationship-groups"></div>
               </section>
 
-              <section id="workspace-task-workflow-card" class="workspace-task-page-card" hidden>
-                <div class="workspace-task-page-card-header">
-                  <div>
-                    <div class="workspace-task-page-card-kicker">Workflow</div>
-                    <h2>Steps</h2>
-                  </div>
-                  <div id="workspace-task-workflow-actions" class="workspace-task-workflow-actions" hidden>
-                    <button type="button" id="workspace-task-workflow-add-step" class="modern-btn modern-btn-secondary workspace-task-workflow-header-btn" title="Add a new step">+ Add step</button>
-                    <button type="button" id="workspace-task-workflow-run-all" class="modern-btn modern-btn-primary workspace-task-workflow-header-btn" title="Run all steps in sequence">▶ Run all</button>
-                  </div>
-                </div>
-                <div id="workspace-task-workflow-empty" class="workspace-task-workflow-empty" hidden>
-                  <div class="workspace-task-workflow-empty-copy">No steps yet. Break this task's result into a runnable list of steps.</div>
-                  <button type="button" id="workspace-task-workflow-generate" class="modern-btn modern-btn-primary workspace-task-workflow-empty-btn">Break this into steps</button>
-                </div>
-                <div id="workspace-task-workflow-steps" class="workspace-task-workflow-list"></div>
-              </section>
-
               <!-- Developer-facing cards (raw IDs, run trace, technical context)
                    grouped and collapsed by default so they stay out of the way
                    of the everyday task view. -->
@@ -472,7 +480,7 @@
                 <div id="workspace-task-context"></div>
               </section>
               </details>
-          </main>
+          </aside>
         </div>
 
         <!-- The slide-out assist panel was retired; its card now renders
@@ -496,7 +504,12 @@
        gradient, no decorative ::after blob, no heavy drop shadow. A single
        surface color and a hairline border. */
     .workspace-task-page-hero {
-      position: relative;
+      /* Sticky command header (FR99): title, canonical state, agent, and the
+         current primary action stay visible while the primary column scrolls.
+         top matches the Map's established navbar-clearance convention. */
+      position: sticky;
+      top: 76px;
+      z-index: 20;
       display: grid;
       grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
       gap: 1.5rem;
@@ -1085,14 +1098,30 @@
       font-weight: 600;
     }
 
+    /* Desktop two-column layout (FR101): a primary work column (current-state
+       action, brief, execution/result, workflow) and a narrower context column
+       (assignment lives in the hero; schedule/automation+output, relationships,
+       and run history/summary live here). Narrow layouts collapse this to one
+       column via the existing max-width:1100px override below (FR102). */
     .workspace-task-page-layout {
-      display: block;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+      gap: 1.5rem;
+      align-items: start;
     }
 
     .workspace-task-page-main {
       display: flex;
       flex-direction: column;
       gap: 1.25rem;
+      min-width: 0;
+    }
+
+    .workspace-task-page-sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      min-width: 0;
     }
 
     .workspace-task-page-agent-picker {
@@ -6696,6 +6725,7 @@
 
   <script type="module">
     import { WorkspaceTaskPage } from '/js/modules/workspace-task.js';
+    import { isSafeReturnTarget } from '/js/modules/workspace-url-state.js';
 
     document.addEventListener('DOMContentLoaded', () => {
       const root = document.getElementById('workspaceTaskPageRoot');
@@ -6706,6 +6736,18 @@
         console.error('Missing workspace or task identifier for task page');
         window.location.href = workspaceId ? `/workspaces/${encodeURIComponent(workspaceId)}` : '/workspaces';
         return;
+      }
+
+      // Back To Workspace uses the Map's preserved return context when the
+      // link carries a valid, same-origin, same-workspace `return` param
+      // (FR92-98); otherwise it falls back to the plain workspace route
+      // already set as the anchor's href.
+      const backlink = document.getElementById('workspace-task-backlink');
+      if (backlink) {
+        const rawReturn = new URLSearchParams(window.location.search).get('return');
+        if (rawReturn && isSafeReturnTarget(rawReturn, workspaceId)) {
+          backlink.href = rawReturn;
+        }
       }
 
       window.currentWorkspaceId = workspaceId;


### PR DESCRIPTION
**Serialized epic — group 7 of 8.** Merges into `epic/workspace-task-execution-ux`. Given the enormous existing surface (~17.5k lines across `workspace-task.tmpl` + `workspace-task.js` + its execution/result-action modules) and the PRD's explicit mandate to preserve every existing capability (Non-Goal 9), this is a **container-level reorganization**, not a rewrite: every card's internal markup, ids, and JS bindings are untouched — only their position/grouping changed.

## What's here
- **Back To Workspace** now consumes the group-6 preserved `return` context (validated same-origin + same-workspace via `isSafeReturnTarget`), falling back to the plain `/workspaces/{id}` route otherwise (FR98).
- The hero (title, canonical state, agent picker, primary actions — all pre-existing) is now `position: sticky` so it stays visible while the primary column scrolls (FR99).
- **Desktop two-column layout** (FR101): the primary column keeps the current-state action, brief+result, blocked-context diagnosis, and workflow steps; a new context column (`<aside class="workspace-task-page-sidebar">`) holds schedule/automation+output, workspace runs, relationships, and the collapsed developer-details group (task id, run history/trace, technical details) — moved as whole, unmodified blocks via a precise line-range script (manual text edits kept mismatching on this file's pre-existing indentation irregularities). Verified tag-balanced (11/11 `<section>`, 2/2 `<details>`, 1/1 `<main>`, 2/2 `<aside>`).
- **Narrow-layout collapse** reuses a dormant `@media (max-width:1100px)` rule that already existed in the file (apparently scaffolded for an earlier, abandoned attempt at this exact redesign) and now does real work now that the desktop grid is real. No sticky side column, so FR102 is moot.
- **FR110**: `workspace-task.js`'s own `getStatusClass`/`getDisplayStatus` — a third independent copy of the same status-mapping logic already found and fixed once in group 1 (Map) — now delegate their fallback to the shared `task-presentation.js` resolver, fixing the same "unknown silently shown as Pending" bug here too. Every existing known-status label and CSS bucket is preserved byte-for-byte (verified by test).

## Verification
- 4 new tests (`workspace-task-status-labels.test.js`). Full module suite green (**687**); eslint clean; build OK.
- Programmatic tag-balance check on the restructured template.
- **User-verified locally** (`go run ./cmd/server`, loaded a task page): sticky header, two-column layout, and card behavior confirmed working.

## Known gaps (noted honestly)
- Chrome extension tooling failed to navigate/screenshot during this session's automated verification (confirmed via `curl` that the server itself serves the page fine — the failure was in the extension connection). Automated screenshot verification wasn't captured; manual verification was performed instead.
- State-driven first-region DOM ordering (FR100) was not re-verified against every individual state (Ready/Running/Needs Input/Blocked/Failed/Completed) — the existing order already approximates the PRD's intent but wasn't exhaustively checked state-by-state.
- A comprehensive regression suite covering every FR103–108 preserved capability (FR142) was not added — the container-only nature of this change makes that lower-risk than a rewrite would, but no automated proof beyond the tag-balance check and the FR110 label tests exists yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)