### PR TITLE
feat(workspace): terminology, a11y, and Escape-priority polish (group 8, final)

### DIFF
--- a/internal/web/static/css/workspace-command.css
+++ b/internal/web/static/css/workspace-command.css
@@ -5015,3 +5015,23 @@
     max-width: 320px;
   }
 }
+
+/* ---------- group 8: accessibility sweep — missing :focus-visible states ----------
+   The drawer/tray controls added in groups 3-4 didn't all get a visible focus
+   ring (FR125). Added here rather than inline per-control so the pattern is
+   easy to audit in one place; light/dark both use the same idle-accent ring
+   already used throughout this file, so no separate light/dark branch is
+   needed (--ws-idle is theme-aware via the token layer). */
+.ws-cmd-drawer-close:focus-visible,
+.ws-cmd-drawer-add:focus-visible,
+.ws-cmd-drawer-filter:focus-visible,
+.ws-cmd-drawer-action:focus-visible,
+.ws-cmd-drawer-reveal:focus-visible,
+.ws-cmd-drawer-openfull:focus-visible,
+.ws-cmd-tray-btn:focus-visible,
+.ws-cmd-tray-run:focus-visible,
+.ws-cmd-tray-action:focus-visible,
+.ws-cmd-tray-cancel:focus-visible {
+  outline: 2px solid var(--ws-idle);
+  outline-offset: 2px;
+}

--- a/internal/web/static/js/modules/workspace-command-a11y-terminology.test.js
+++ b/internal/web/static/js/modules/workspace-command-a11y-terminology.test.js
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WorkspaceCommandView } from './workspace-command.js';
+
+globalThis.document = { getElementById: () => null };
+globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+
+function makeView(over = {}) {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  Object.assign(
+    view,
+    {
+      active: true,
+      statModalSection: '',
+      identityEditMode: false,
+      taskDrawerOpen: false,
+      trayOpen: false,
+      trayCollapsed: false,
+      taskComposerOpen: false,
+      viewMode: 'map',
+      activeMapWindow: '',
+      mapInventoryOpen: false,
+      activeRailSection: '',
+      render() {},
+      renderTrayBody() {},
+      closeTaskDrawer() {
+        this.taskDrawerOpen = false;
+      },
+      captureHistoryPresentationState() {}
+    },
+    over
+  );
+  return view;
+}
+
+function esc(view) {
+  view.handleGlobalKeydown({ key: 'Escape' });
+}
+
+test('terminology: Map window labels are presentation-only Mission/Tasks, keys unchanged (FR3-5, FR5a)', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  const options = view.mapWindowOptions();
+  const objective = options.find(o => o.key === 'objective');
+  const objectives = options.find(o => o.key === 'objectives');
+  assert.equal(objective.label, 'Workspace Mission');
+  assert.equal(objectives.label, 'Tasks');
+  // Panel keys are untouched — activeMapWindow state and every reference to
+  // them elsewhere keeps working without a rename.
+  assert.equal(objective.key, 'objective');
+  assert.equal(objectives.key, 'objectives');
+});
+
+test('Escape collapses an expanded tray rather than closing it (FR123)', () => {
+  const view = makeView({ trayOpen: true, trayCollapsed: false });
+  esc(view);
+  assert.equal(view.trayCollapsed, true, 'tray collapses');
+  assert.equal(view.trayOpen, true, 'tray is not closed/hidden by Escape');
+});
+
+test('Escape on an already-collapsed tray falls through to the next priority tier', () => {
+  const view = makeView({ trayOpen: true, trayCollapsed: true, activeMapWindow: 'objectives' });
+  esc(view);
+  assert.equal(view.activeMapWindow, '', 'falls through to close the map window');
+});
+
+test('Escape prioritizes the task drawer over the tray (drawer closes first)', () => {
+  const view = makeView({ taskDrawerOpen: true, trayOpen: true, trayCollapsed: false });
+  esc(view);
+  assert.equal(view.taskDrawerOpen, false);
+  assert.equal(view.trayCollapsed, false, 'tray is untouched once the drawer handled Escape');
+});
+
+test('Escape no-ops while a stat modal or identity edit is active (dialog tier takes precedence)', () => {
+  const view = makeView({ trayOpen: true, trayCollapsed: false, statModalSection: 'tasks' });
+  esc(view);
+  assert.equal(view.trayCollapsed, false, 'the tray is not touched while a modal is open');
+});
+
+test('trayAnnounceText only changes on a real state transition, not on every render (FR127)', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  const run = (taskId, state) => ({
+    taskId,
+    task: { description: 'Export the master' },
+    presentation: { state, label: state === 'running' ? 'Running' : 'Completed' }
+  });
+
+  const first = view.trayAnnounceText(run('t1', 'running'));
+  assert.match(first, /Export the master: Running/);
+
+  // Same state again (e.g. a poll tick with no change) — same text, not a
+  // fresh announcement each render.
+  const second = view.trayAnnounceText(run('t1', 'running'));
+  assert.equal(second, first);
+
+  // A genuine transition updates the text.
+  const third = view.trayAnnounceText(run('t1', 'completed'));
+  assert.match(third, /Export the master: Completed/);
+  assert.notEqual(third, first);
+});
+
+test('trayHTML never marks the raw activity log as a live region (FR127)', () => {
+  const view = Object.create(WorkspaceCommandView.prototype);
+  view.execController = {
+    getSelected: () => ({
+      taskId: 't1',
+      task: { description: 'Export the master' },
+      presentation: { state: 'running', label: 'Running', tone: 'active', primaryAction: null },
+      activity: [{ label: 'Running' }],
+      startedAt: Date.now()
+    }),
+    getRuns: () => [],
+    getAttentionRuns: () => []
+  };
+  view.trayCollapsed = false;
+  view.trayElapsedLabel = () => '5s';
+  const html = view.trayHTML();
+  assert.ok(!html.includes('class="ws-cmd-tray-log" role="log" aria-live'), 'the raw log is not a live region');
+  assert.match(html, /ws-cmd-tray-live sr-only.*aria-live="polite"/s, 'a small dedicated live region exists instead');
+});

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -427,6 +427,12 @@ export class WorkspaceCommandView {
       this.closeTaskDrawer();
       return;
     }
+    // Collapse (not close) an expanded tray on Escape — collapsing is
+    // reversible and never stops monitoring, unlike closing (FR52, FR123).
+    if (this.trayOpen && !this.trayCollapsed) {
+      this.toggleTrayCollapsed();
+      return;
+    }
     if (this.viewMode === 'map' && this.taskComposerOpen) {
       this.closeTaskComposer();
       return;
@@ -3054,9 +3060,12 @@ export class WorkspaceCommandView {
   }
 
   mapWindowOptions() {
+    // Labels are presentation-only (FR3-5): the underlying panel keys
+    // ('objective'/'objectives') are unchanged so activeMapWindow state and
+    // every reference to them elsewhere keeps working.
     return [
-      { key: 'objective', label: 'Workspace Objective', icon: 'bi-bullseye' },
-      { key: 'objectives', label: 'Objectives', icon: 'bi-list-check' },
+      { key: 'objective', label: 'Workspace Mission', icon: 'bi-bullseye' },
+      { key: 'objectives', label: 'Tasks', icon: 'bi-list-check' },
       { key: 'inventory', label: 'Inventory', icon: 'bi-box-seam' },
       { key: 'stations', label: 'Stations', icon: 'bi-cpu' }
     ];
@@ -3095,7 +3104,7 @@ export class WorkspaceCommandView {
     return (
       '<div class="ws-cmd-map-window-section is-objective">' +
       '<div class="ws-cmd-map-quest-frame">' +
-      '<div class="ws-cmd-map-quest-frame-head"><span>Main Quest</span><strong>Workspace Objective</strong></div>' +
+      '<div class="ws-cmd-map-quest-frame-head"><span>Main Quest</span><strong>Workspace Mission</strong></div>' +
       this.renderMissionPanel() +
       '</div></div>'
     );
@@ -3142,7 +3151,7 @@ export class WorkspaceCommandView {
       : '<div class="ws-cmd-map-empty is-quest-empty"><strong>Quest log clear</strong><span>No active objectives assigned.</span></div>';
     return (
       '<div class="ws-cmd-map-window-section is-objectives">' +
-      this.mapZoneHeaderHTML('Objectives', 'Active Tasks', tasks.length) +
+      this.mapZoneHeaderHTML('Tasks', 'Active Tasks', tasks.length) +
       '<div class="ws-cmd-map-task-list">' +
       rows +
       '</div>' +
@@ -3649,6 +3658,20 @@ export class WorkspaceCommandView {
     }
   }
 
+  // Announce only when the selected run's state actually changes (not on
+  // every poll tick / activity-log line) — a concise polite live region,
+  // distinct from the raw (non-live) activity log below (FR127).
+  trayAnnounceText(run) {
+    if (!run || !run.presentation) return this._trayAnnounceText || '';
+    if (!this._trayAnnouncedStateByTask) this._trayAnnouncedStateByTask = {};
+    const state = run.presentation.state;
+    if (this._trayAnnouncedStateByTask[run.taskId] === state) return this._trayAnnounceText || '';
+    this._trayAnnouncedStateByTask[run.taskId] = state;
+    const title = String((run.task && (run.task.description || run.task.name)) || run.taskId);
+    this._trayAnnounceText = title + ': ' + (run.presentation.label || state);
+    return this._trayAnnounceText;
+  }
+
   trayHTML() {
     const c = this.execController;
     const run = c ? c.getSelected() : null;
@@ -3688,7 +3711,10 @@ export class WorkspaceCommandView {
       (this.trayCollapsed ? '▴' : '▾') +
       '</button>' +
       '<button type="button" class="ws-cmd-tray-btn" data-cmd-tray-close aria-label="Hide execution tray">×</button>' +
-      '</div></div>';
+      '</div></div>' +
+      '<div class="ws-cmd-tray-live sr-only" role="status" aria-live="polite" aria-atomic="true">' +
+      escapeHtml(this.trayAnnounceText(run)) +
+      '</div>';
 
     if (this.trayCollapsed) {
       return (
@@ -3728,8 +3754,11 @@ export class WorkspaceCommandView {
         '</div>'
       : '';
 
+    // Not a live region (FR127): raw streaming activity must not be announced
+    // line by line. State-transition announcements are handled separately by
+    // the small polite region below, which updates only on a state change.
     const activityLog =
-      '<div class="ws-cmd-tray-log" role="log" aria-live="polite">' +
+      '<div class="ws-cmd-tray-log" role="log">' +
       (run.activity && run.activity.length
         ? run.activity
             .slice(-8)

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -2301,7 +2301,9 @@ test('Operations Map renders units first and keeps support panels hidden by defa
 
     commandView.activeMapWindow = 'objectives';
     const windowHTML = commandView.renderOperationsMap();
-    assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Objectives"/);
+    // 'objectives' is the panel KEY (unchanged, FR5a); its user-visible label
+    // is now "Tasks" (group 8 terminology sweep, FR4).
+    assert.match(windowHTML, /role="dialog" aria-modal="true" aria-label="Tasks"/);
     assert.match(windowHTML, /Collect sources/);
 
     commandView.activeMapWindow = 'inspector';


### PR DESCRIPTION
**Serialized epic — group 8 of 8 (final).** Merges into `epic/workspace-task-execution-ux`. A targeted sweep prioritizing real gaps found by direct inspection over a speculative pass across every FR in section H.

## Terminology (FR3–5, FR5a)
`mapWindowOptions()` labels are now presentation-only `Workspace Mission` / `Tasks` in place of `Workspace Objective` / `Objectives` (belt button, quest-frame title, drawer zone kicker). The underlying panel keys (`objective`/`objectives`) and every `activeMapWindow` reference are unchanged — only the copy changed.

## Accessibility fixes (real gaps found by audit)
- Every group 3/4 drawer/tray control that lacked a `:focus-visible` state now has one (FR125).
- **Fixed a genuine FR127 violation**: the tray's raw activity log was `aria-live="polite"`, risking re-announcing the whole scrolling log on every re-render/poll tick. It's now a plain (non-live) log; a new small `sr-only` polite region announces state transitions only, gated so repeated polls with no change never re-announce.
- **Escape had no handling at all for the sticky tray.** It now collapses an expanded tray (reversible, never stops monitoring) with correct priority: after the drawer, before the map-window/composer/inventory tier, and correctly deferring to an open stat modal/identity-edit (FR123).

## Verification
- 7 new tests (`workspace-command-a11y-terminology.test.js`); one existing test updated for the new "Tasks" aria-label. Full module suite green (**694**); eslint clean; `go vet`/`gofmt` clean; build OK.

## Known gaps (noted honestly, not silently skipped)
- **The group-2 `OverlayCoordinator`/`escapeTopmost()` is still not wired into `workspace-command.js`** — it exists only as a tested, standalone module. A full menu/popover → dialog → collapse re-ordering via the coordinator, and confirming only truly-blocking surfaces set `aria-modal`, were not completed. **This is the epic's largest remaining a11y gap.**
- 44×44 touch-target sizing for the smaller drawer/tray icon buttons (32px/28px today) was not changed — no reliable browser tool to verify a resize wouldn't break the compact layouts this session.
- Safe-area insets, virtual-keyboard accounting, 200% zoom, and the 320/768/1280/1512px checklist were not verified.
- Broader cross-layer interaction tests (drawer→Start→tray, tray→confirmation, drawer→create/edit, return-from-task-page) and a dedicated keyboard/SR suite were not added.
- A live smoke-test run via the isolated CLAUDE.md recipe was not performed — browser tooling was unreliable this session (same issue as group 7).

## This is the last seam-PR
Once this merges into the epic branch, all 8 groups are together. The next and final step is **one `epic → dev` PR** — the single point where the whole feature gets reviewed and accepted (or rejected) as a unit, per the epic-branch model set up at the start of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)