### PR TITLE
feat(personal-hq): add Mission 01 onboarding and Daily Brief

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,6 +132,7 @@ export default defineConfig([
       'internal/web/static/js/modules/note-toc.js',
       'internal/web/static/js/modules/note-wikilinks.js',
       'internal/web/static/js/modules/onboarding.js',
+      'internal/web/static/js/modules/personal-hq-onboarding.js',
       'internal/web/static/js/modules/plugin-init-banner.js',
       'internal/web/static/js/modules/progression-widget.js',
       'internal/web/static/js/modules/renderer-connections.js',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,7 @@ export default defineConfig([
       'internal/web/static/js/modules/note-wikilinks.js',
       'internal/web/static/js/modules/onboarding.js',
       'internal/web/static/js/modules/plugin-init-banner.js',
+      'internal/web/static/js/modules/progression-widget.js',
       'internal/web/static/js/modules/renderer-connections.js',
       'internal/web/static/js/modules/renderer-nodes.js',
       'internal/web/static/js/modules/renderer-panels.js',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,7 @@ export default defineConfig([
       'internal/web/static/js/modules/note-wikilinks.js',
       'internal/web/static/js/modules/onboarding.js',
       'internal/web/static/js/modules/personal-hq-onboarding.js',
+      'internal/web/static/js/modules/home-daily-brief.js',
       'internal/web/static/js/modules/plugin-init-banner.js',
       'internal/web/static/js/modules/progression-widget.js',
       'internal/web/static/js/modules/renderer-connections.js',

--- a/internal/agenthttp/home_assistant_workspace_resolver.go
+++ b/internal/agenthttp/home_assistant_workspace_resolver.go
@@ -54,11 +54,20 @@ type homeAssistantWorkspaceFeedbackReader interface {
 	RecentWorkspaceCorrections(ctx context.Context, limit int) ([]HomeAssistantWorkspaceCorrection, error)
 }
 
+// homeAssistantHQProvider resolves the caller's current designated Personal
+// HQ workspace, if any (PRD FR102/FR103). Kept as a narrow interface (rather
+// than depending on internal/personalhq directly) so this package's tests
+// can fake it without constructing a real personalhq.Service.
+type homeAssistantHQProvider interface {
+	CurrentHQWorkspaceID(ctx context.Context) (workspaceID string, ok bool)
+}
+
 type HomeAssistantWorkspaceResolver struct {
 	WorkspaceStore  workspace.Store
 	AgentStore      store.Store
 	RuntimeResolver homeAssistantWorkspaceRuntimeResolver
 	FeedbackReader  homeAssistantWorkspaceFeedbackReader
+	HQProvider      homeAssistantHQProvider
 }
 
 func NewHomeAssistantWorkspaceResolver(workspaceStore workspace.Store, agentStore store.Store) *HomeAssistantWorkspaceResolver {
@@ -80,6 +89,13 @@ func (r *HomeAssistantWorkspaceResolver) SetFeedbackReader(reader homeAssistantW
 		return
 	}
 	r.FeedbackReader = reader
+}
+
+func (r *HomeAssistantWorkspaceResolver) SetHQProvider(provider homeAssistantHQProvider) {
+	if r == nil {
+		return
+	}
+	r.HQProvider = provider
 }
 
 func (r *HomeAssistantWorkspaceResolver) Resolve(prompt string, routeContext normalizedHomeAssistantRouteContext) *HomeAssistantWorkspaceResolution {
@@ -104,6 +120,9 @@ func (r *HomeAssistantWorkspaceResolver) Resolve(prompt string, routeContext nor
 
 	active, err := r.WorkspaceStore.ListActive()
 	if err != nil || len(active) == 0 {
+		if resolution, ok := r.hqFallback(prompt, routeContext, nil); ok {
+			return resolution
+		}
 		return &HomeAssistantWorkspaceResolution{State: homeAssistantWorkspaceStateNoFit}
 	}
 
@@ -115,6 +134,9 @@ func (r *HomeAssistantWorkspaceResolver) Resolve(prompt string, routeContext nor
 		candidates = append(candidates, scoreHomeAssistantWorkspace(prompt, ws))
 	}
 	if len(candidates) == 0 {
+		if resolution, ok := r.hqFallback(prompt, routeContext, nil); ok {
+			return resolution
+		}
 		return &HomeAssistantWorkspaceResolution{State: homeAssistantWorkspaceStateNoFit}
 	}
 
@@ -122,7 +144,19 @@ func (r *HomeAssistantWorkspaceResolver) Resolve(prompt string, routeContext nor
 
 	visible := buildHomeAssistantWorkspaceCandidates(candidates)
 	top := candidates[0]
+	// A zero score means the prompt didn't reference any workspace's
+	// identity at all — a genuinely untargeted, app-wide prompt (PRD
+	// FR103). A nonzero-but-below-threshold score means the prompt weakly
+	// referenced a specific project that just didn't clear the confidence
+	// bar; defaulting that to the HQ would risk masking a real (if messy)
+	// project reference (FR104/FR105), so only the zero-score case falls
+	// back to the HQ.
 	if top.Score < homeAssistantWorkspaceMinScore {
+		if top.Score == 0 {
+			if resolution, ok := r.hqFallback(prompt, routeContext, visible); ok {
+				return resolution
+			}
+		}
 		return &HomeAssistantWorkspaceResolution{
 			State:      homeAssistantWorkspaceStateNoFit,
 			Candidates: visible,
@@ -142,6 +176,38 @@ func (r *HomeAssistantWorkspaceResolver) Resolve(prompt string, routeContext nor
 	resolution.Confidence = workspaceScoreConfidence(top.Score)
 	resolution.Candidates = visible
 	return resolution
+}
+
+// hqFallback resolves to the caller's designated Personal HQ when nothing
+// else fit, but only for a genuinely untargeted, app-wide prompt (PRD
+// FR102/FR103): the request carried no originating workspace context and
+// did not explicitly ask to switch elsewhere (FR104 — a request that names
+// or originates in a project stays out of this path entirely, since it
+// either resolves earlier or fails to match a real candidate rather than
+// reaching here with an empty routeContext.WorkspaceID). Returns ok=false
+// whenever the HQ itself isn't available/ready, so the caller's ordinary
+// no_fit handling still applies (FR105 — the HQ is never a forced catch-all).
+func (r *HomeAssistantWorkspaceResolver) hqFallback(prompt string, routeContext normalizedHomeAssistantRouteContext, visible []HomeAssistantWorkspaceCandidate) (*HomeAssistantWorkspaceResolution, bool) {
+	if r == nil || r.HQProvider == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(routeContext.WorkspaceID) != "" || promptRequestsWorkspaceSwitch(prompt) {
+		return nil, false
+	}
+	workspaceID, ok := r.HQProvider.CurrentHQWorkspaceID(context.Background())
+	if !ok || strings.TrimSpace(workspaceID) == "" {
+		return nil, false
+	}
+	ws, err := r.WorkspaceStore.Get(workspaceID)
+	if err != nil || !isHomeAssistantRoutableWorkspace(ws) {
+		return nil, false
+	}
+	resolution := r.resolveSelectedWorkspace(ws, []string{"defaulting to your Personal HQ for an app-wide prompt"})
+	if resolution.State != homeAssistantWorkspaceStateConfident {
+		return nil, false
+	}
+	resolution.Candidates = visible
+	return resolution, true
 }
 
 type homeAssistantWorkspaceScore struct {

--- a/internal/agenthttp/home_assistant_workspace_resolver_test.go
+++ b/internal/agenthttp/home_assistant_workspace_resolver_test.go
@@ -403,3 +403,138 @@ func containsReason(reasons []string, want string) bool {
 	}
 	return false
 }
+
+type homeWorkspaceResolverHQProviderStub struct {
+	workspaceID string
+	ok          bool
+}
+
+func (s *homeWorkspaceResolverHQProviderStub) CurrentHQWorkspaceID(context.Context) (string, bool) {
+	return s.workspaceID, s.ok
+}
+
+// TestHomeAssistantWorkspaceResolver_NoFitDefaultsToHQForUntargetedPrompt
+// covers PRD FR102/FR103 (task 7.10): a prompt that references no
+// workspace's identity at all, with no originating workspace context, may
+// default to the designated Personal HQ rather than reporting no_fit.
+func TestHomeAssistantWorkspaceResolver_NoFitDefaultsToHQForUntargetedPrompt(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	addHomeRouteTestAgent(t, st, "Chief of Staff", &store.CreateAgentConfig{Type: "general"}, "", nil, nil)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-trip", "Trip Planning", "Plan Portugal travel", "Chief of Staff"),
+		newHomeWorkspaceResolverTestWorkspace("ws-hq", "Command Post", "Personal command center", "Chief of Staff"),
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{workspaceID: "ws-hq", ok: true})
+
+	got := resolver.Resolve("what should I focus on today", normalizedHomeAssistantRouteContext{})
+	if got.State != homeAssistantWorkspaceStateConfident {
+		t.Fatalf("expected state %q, got %#v", homeAssistantWorkspaceStateConfident, got)
+	}
+	if got.SelectedWorkspaceID != "ws-hq" {
+		t.Fatalf("expected the untargeted prompt to default to the HQ, got %q", got.SelectedWorkspaceID)
+	}
+}
+
+// TestHomeAssistantWorkspaceResolver_NamedProjectStillWinsOverHQ covers
+// FR104/FR105: a prompt that names/scores against a real project must stay
+// scoped to it, never hijacked to the HQ merely because one is designated.
+func TestHomeAssistantWorkspaceResolver_NamedProjectStillWinsOverHQ(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	addHomeRouteTestAgent(t, st, "Launch Manager", &store.CreateAgentConfig{Type: "general"}, "", nil, nil)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-launch", "Launch Ops", "Ship the launch deck", "Launch Manager"),
+		newHomeWorkspaceResolverTestWorkspace("ws-hq", "Command Post", "Personal command center", "Launch Manager"),
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{workspaceID: "ws-hq", ok: true})
+
+	got := resolver.Resolve("finish the launch deck today", normalizedHomeAssistantRouteContext{})
+	if got.SelectedWorkspaceID != "ws-launch" {
+		t.Fatalf("expected the named project to win over the HQ default, got %q", got.SelectedWorkspaceID)
+	}
+}
+
+// TestHomeAssistantWorkspaceResolver_NoFitIgnoresHQWhenPromptRequestsExplicitSwitch
+// covers FR105: an explicit "switch workspace" request that fails to match
+// anything real must not silently land on the HQ instead.
+func TestHomeAssistantWorkspaceResolver_NoFitIgnoresHQWhenPromptRequestsExplicitSwitch(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	addHomeRouteTestAgent(t, st, "Chief of Staff", &store.CreateAgentConfig{Type: "general"}, "", nil, nil)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-hq", "Command Post", "Personal command center", "Chief of Staff"),
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{workspaceID: "ws-hq", ok: true})
+
+	got := resolver.Resolve("switch workspace to the nonexistent zeppelin project", normalizedHomeAssistantRouteContext{})
+	if got.State != homeAssistantWorkspaceStateNoFit {
+		t.Fatalf("expected an explicit failed switch to stay no_fit rather than default to HQ, got %#v", got)
+	}
+}
+
+// TestHomeAssistantWorkspaceResolver_NoFitIgnoresHQWhenExplicitContextGiven
+// covers FR104: an active-workspace context that fails to resolve must not
+// fall through to the HQ default — the request originated in a specific
+// (if currently broken) workspace, not an untargeted app-wide prompt.
+func TestHomeAssistantWorkspaceResolver_NoFitIgnoresHQWhenExplicitContextGiven(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	addHomeRouteTestAgent(t, st, "Chief of Staff", &store.CreateAgentConfig{Type: "general"}, "", nil, nil)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-hq", "Command Post", "Personal command center", "Chief of Staff"),
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{workspaceID: "ws-hq", ok: true})
+
+	got := resolver.Resolve("review payroll numbers", normalizedHomeAssistantRouteContext{WorkspaceID: "ws-missing"})
+	if got.State != homeAssistantWorkspaceStateNoFit {
+		t.Fatalf("expected a broken explicit workspace context to stay no_fit rather than default to HQ, got %#v", got)
+	}
+}
+
+// TestHomeAssistantWorkspaceResolver_NoFitWhenHQNotReady covers the case
+// where the HQ itself has no usable entry agent: the fallback must not fire
+// with a broken selection, leaving the ordinary no_fit state instead.
+func TestHomeAssistantWorkspaceResolver_NoFitWhenHQNotReady(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-hq", "Command Post", "Personal command center"), // no entry agent
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{workspaceID: "ws-hq", ok: true})
+
+	got := resolver.Resolve("what should I focus on today", normalizedHomeAssistantRouteContext{})
+	if got.State != homeAssistantWorkspaceStateNoFit {
+		t.Fatalf("expected a not-ready HQ to leave state no_fit, got %#v", got)
+	}
+}
+
+// TestHomeAssistantWorkspaceResolver_NoFitWhenNoHQDesignated covers the
+// baseline (no HQProvider, or one reporting none designated): behavior is
+// unchanged from before task 7.10.
+func TestHomeAssistantWorkspaceResolver_NoFitWhenNoHQDesignated(t *testing.T) {
+	st := newHomeRouteTestStore(t)
+	addHomeRouteTestAgent(t, st, "Travel Manager", &store.CreateAgentConfig{Type: "general"}, "", nil, nil)
+
+	resolver := newHomeWorkspaceResolverForTest(
+		t,
+		st,
+		newHomeWorkspaceResolverTestWorkspace("ws-trip", "Trip Planning", "Plan Portugal travel", "Travel Manager"),
+	)
+	resolver.SetHQProvider(&homeWorkspaceResolverHQProviderStub{ok: false})
+
+	got := resolver.Resolve("review payroll numbers", normalizedHomeAssistantRouteContext{})
+	if got.State != homeAssistantWorkspaceStateNoFit {
+		t.Fatalf("expected state %q with no designated HQ, got %#v", homeAssistantWorkspaceStateNoFit, got)
+	}
+}

--- a/internal/dailybrief/analysis.go
+++ b/internal/dailybrief/analysis.go
@@ -1,0 +1,200 @@
+package dailybrief
+
+import (
+	"sort"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// maxAttentionItems caps Needs Attention at 5 primary items (PRD FR72).
+const maxAttentionItems = 5
+
+// maxTodaysPlanItems caps Today's Plan recommendations at 3 (PRD FR76).
+const maxTodaysPlanItems = 3
+
+// defaultResumeLimit is the default cap on Resume candidates.
+const defaultResumeLimit = 5
+
+// firstBriefWindow is the bounded lookback used when there is no prior
+// successful brief to checkpoint against (PRD FR75).
+const firstBriefWindow = 24 * time.Hour
+
+// AttentionItem is one deterministically-computed "needs attention"
+// candidate: waiting approvals/choices, blocked/failed/timed-out work,
+// high-priority opportunities, or a failing schedule (PRD FR73).
+type AttentionItem struct {
+	Ref           SourceRef
+	Title         string
+	WorkspaceName string
+	// Reason is a machine-readable tag: waiting_for_choice | failed |
+	// timeout | high_priority_opportunity | schedule_failing.
+	Reason string
+}
+
+func attentionRank(reason string) int {
+	switch reason {
+	case "failed":
+		return 5
+	case "timeout":
+		return 4
+	case "waiting_for_choice":
+		return 3
+	case "high_priority_opportunity":
+		return 2
+	case "schedule_failing":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// ComputeNeedsAttention derives deterministic attention candidates from the
+// snapshot, ordered by a fixed severity ranking (never LLM-decided, so
+// results are reproducible) and capped at maxAttentionItems.
+func ComputeNeedsAttention(snap Snapshot) []AttentionItem {
+	var items []AttentionItem
+	for _, ws := range snap.Workspaces {
+		for _, t := range ws.OpenTasks {
+			var reason string
+			switch workspace.TaskStatus(t.Status) {
+			case workspace.TaskStatusWaitingForChoice:
+				reason = "waiting_for_choice"
+			case workspace.TaskStatusFailed:
+				reason = "failed"
+			case workspace.TaskStatusTimeout:
+				reason = "timeout"
+			default:
+				continue
+			}
+			items = append(items, AttentionItem{Ref: t.Ref, Title: t.Description, WorkspaceName: ws.Name, Reason: reason})
+		}
+		for _, o := range ws.Opportunities {
+			if opportunityPriorityRank(o.Priority) >= opportunityPriorityRank("high") {
+				items = append(items, AttentionItem{Ref: o.Ref, Title: o.Title, WorkspaceName: ws.Name, Reason: "high_priority_opportunity"})
+			}
+		}
+		for _, st := range ws.ScheduledTasks {
+			if st.Enabled && (st.FailureCount > 0 || st.LastError != "") {
+				items = append(items, AttentionItem{Ref: st.Ref, Title: st.Name, WorkspaceName: ws.Name, Reason: "schedule_failing"})
+			}
+		}
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		ri, rj := attentionRank(items[i].Reason), attentionRank(items[j].Reason)
+		if ri != rj {
+			return ri > rj
+		}
+		return items[i].Ref.Timestamp.After(items[j].Ref.Timestamp)
+	})
+	if len(items) > maxAttentionItems {
+		items = items[:maxAttentionItems]
+	}
+	return items
+}
+
+// PlanItem is one Today's Plan recommendation: scheduled/in-progress work or
+// a due commitment, with a machine-readable reason (PRD FR76/FR77).
+type PlanItem struct {
+	Ref           SourceRef
+	Title         string
+	WorkspaceName string
+	// Reason: in_progress | due_soon.
+	Reason string
+}
+
+// ComputeTodaysPlan derives deterministic plan candidates: work already in
+// progress and schedules due within the next 24h, capped at
+// maxTodaysPlanItems (in-progress work ranked first — it represents an
+// explicit user commitment already underway).
+func ComputeTodaysPlan(snap Snapshot, now time.Time) []PlanItem {
+	var inProgress, dueSoon []PlanItem
+	for _, ws := range snap.Workspaces {
+		for _, t := range ws.OpenTasks {
+			if workspace.TaskStatus(t.Status) == workspace.TaskStatusInProgress {
+				inProgress = append(inProgress, PlanItem{Ref: t.Ref, Title: t.Description, WorkspaceName: ws.Name, Reason: "in_progress"})
+			}
+		}
+		for _, st := range ws.ScheduledTasks {
+			if st.Enabled && st.NextRun != nil && !st.NextRun.After(now.Add(24*time.Hour)) {
+				dueSoon = append(dueSoon, PlanItem{Ref: st.Ref, Title: st.Name, WorkspaceName: ws.Name, Reason: "due_soon"})
+			}
+		}
+	}
+	items := append(inProgress, dueSoon...)
+	if len(items) > maxTodaysPlanItems {
+		items = items[:maxTodaysPlanItems]
+	}
+	return items
+}
+
+// ChangeItem is one "Since Last Brief" change: a task or session that
+// updated after the checkpoint.
+type ChangeItem struct {
+	Ref           SourceRef
+	Title         string
+	WorkspaceName string
+}
+
+// ResolveCheckpoint returns the "since" boundary for Since Last Brief: the
+// previous successful revision's GeneratedAt, or — when none exists — a
+// clearly bounded default window so synthesis never implies a previous
+// brief existed (PRD FR75).
+func ResolveCheckpoint(previous *Revision, now time.Time) (since time.Time, isFirstBrief bool) {
+	if previous == nil || previous.GeneratedAt.IsZero() {
+		return now.Add(-firstBriefWindow), true
+	}
+	return previous.GeneratedAt, false
+}
+
+// ComputeSinceLastBrief finds tasks/sessions that changed after since.
+func ComputeSinceLastBrief(snap Snapshot, since time.Time) []ChangeItem {
+	var items []ChangeItem
+	for _, ws := range snap.Workspaces {
+		for _, t := range ws.OpenTasks {
+			if t.Ref.Timestamp.After(since) {
+				items = append(items, ChangeItem{Ref: t.Ref, Title: t.Description, WorkspaceName: ws.Name})
+			}
+		}
+		for _, s := range ws.RecentSessions {
+			if s.UpdatedAt.After(since) {
+				items = append(items, ChangeItem{Ref: s.Ref, Title: s.Title, WorkspaceName: ws.Name})
+			}
+		}
+	}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Ref.Timestamp.After(items[j].Ref.Timestamp) })
+	return items
+}
+
+// ResumeItem is a bounded resume-summary candidate for a recent, possibly
+// unfinished session. Known metadata only — a missing preview is left
+// empty rather than inventing an objective or decision (PRD FR79).
+type ResumeItem struct {
+	Ref           SourceRef
+	Title         string
+	Preview       string
+	WorkspaceName string
+	HasPreview    bool
+}
+
+// ComputeResumeCandidates returns up to limit recent sessions across all
+// snapshot workspaces, most recently updated first. limit<=0 defaults to
+// defaultResumeLimit.
+func ComputeResumeCandidates(snap Snapshot, limit int) []ResumeItem {
+	if limit <= 0 {
+		limit = defaultResumeLimit
+	}
+	var all []ResumeItem
+	for _, ws := range snap.Workspaces {
+		for _, s := range ws.RecentSessions {
+			all = append(all, ResumeItem{
+				Ref: s.Ref, Title: s.Title, Preview: s.Preview, WorkspaceName: ws.Name, HasPreview: s.Preview != "",
+			})
+		}
+	}
+	sort.SliceStable(all, func(i, j int) bool { return all[i].Ref.Timestamp.After(all[j].Ref.Timestamp) })
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all
+}

--- a/internal/dailybrief/analysis_test.go
+++ b/internal/dailybrief/analysis_test.go
@@ -1,0 +1,175 @@
+package dailybrief
+
+import (
+	"testing"
+	"time"
+)
+
+func refAt(entityType, id string, ts time.Time) SourceRef {
+	return SourceRef{WorkspaceID: "ws-1", EntityType: entityType, EntityID: id, Timestamp: ts}
+}
+
+func TestComputeNeedsAttention_OrdersBySeverityAndCaps(t *testing.T) {
+	now := time.Now()
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{
+		WorkspaceID: "ws-1", Name: "One",
+		OpenTasks: []TaskSnapshot{
+			{Ref: refAt("task", "t-choice", now), Status: "waiting_for_choice", Description: "waiting"},
+			{Ref: refAt("task", "t-failed", now), Status: "failed", Description: "failed"},
+			{Ref: refAt("task", "t-timeout", now), Status: "timeout", Description: "timeout"},
+			{Ref: refAt("task", "t-pending", now), Status: "pending", Description: "pending, not attention-worthy"},
+		},
+		Opportunities: []OpportunitySnapshot{
+			{Ref: refAt("opportunity", "o-high", now), Priority: "high", Title: "high opp"},
+			{Ref: refAt("opportunity", "o-low", now), Priority: "low", Title: "low opp, not attention-worthy"},
+		},
+		ScheduledTasks: []ScheduledTaskSnapshot{
+			{Ref: refAt("scheduled_task", "st-failing", now), Enabled: true, FailureCount: 2, Name: "failing schedule"},
+			{Ref: refAt("scheduled_task", "st-ok", now), Enabled: true, FailureCount: 0, Name: "healthy schedule"},
+		},
+	}}}
+
+	items := ComputeNeedsAttention(snap)
+	if len(items) != 5 {
+		t.Fatalf("expected exactly the 5 attention-worthy items (cap not needed here), got %d: %+v", len(items), items)
+	}
+	// Failed must rank above timeout, which ranks above waiting_for_choice,
+	// which ranks above high-priority opportunity, which ranks above a
+	// failing schedule.
+	wantOrder := []string{"failed", "timeout", "waiting_for_choice", "high_priority_opportunity", "schedule_failing"}
+	for i, want := range wantOrder {
+		if items[i].Reason != want {
+			t.Fatalf("position %d: expected reason %q, got %q (full: %+v)", i, want, items[i].Reason, items)
+		}
+	}
+}
+
+func TestComputeNeedsAttention_CapsAtFive(t *testing.T) {
+	now := time.Now()
+	var tasks []TaskSnapshot
+	for i := 0; i < 8; i++ {
+		tasks = append(tasks, TaskSnapshot{Ref: refAt("task", string(rune('a'+i)), now), Status: "failed", Description: "failed"})
+	}
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{WorkspaceID: "ws-1", OpenTasks: tasks}}}
+	items := ComputeNeedsAttention(snap)
+	if len(items) != maxAttentionItems {
+		t.Fatalf("expected cap of %d, got %d", maxAttentionItems, len(items))
+	}
+}
+
+func TestComputeNeedsAttention_EmptyWhenNothingNeedsAttention(t *testing.T) {
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{
+		WorkspaceID: "ws-1",
+		OpenTasks:   []TaskSnapshot{{Status: "pending"}, {Status: "in_progress"}},
+	}}}
+	if items := ComputeNeedsAttention(snap); len(items) != 0 {
+		t.Fatalf("expected no attention items on a quiet day, got %+v", items)
+	}
+}
+
+func TestComputeTodaysPlan_InProgressFirstThenDueSoon(t *testing.T) {
+	now := time.Now()
+	soon := now.Add(1 * time.Hour)
+	later := now.Add(48 * time.Hour) // outside the 24h due-soon window
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{
+		WorkspaceID: "ws-1",
+		OpenTasks: []TaskSnapshot{
+			{Ref: refAt("task", "t1", now), Status: "in_progress", Description: "in progress"},
+		},
+		ScheduledTasks: []ScheduledTaskSnapshot{
+			{Ref: refAt("scheduled_task", "st-soon", now), Enabled: true, NextRun: &soon, Name: "due soon"},
+			{Ref: refAt("scheduled_task", "st-later", now), Enabled: true, NextRun: &later, Name: "not due soon"},
+		},
+	}}}
+	items := ComputeTodaysPlan(snap, now)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 plan items (in_progress + due_soon, excluding the far-future one), got %+v", items)
+	}
+	if items[0].Reason != "in_progress" {
+		t.Fatalf("expected in_progress ranked first, got %+v", items[0])
+	}
+}
+
+func TestComputeTodaysPlan_CapsAtThree(t *testing.T) {
+	now := time.Now()
+	var tasks []TaskSnapshot
+	for i := 0; i < 5; i++ {
+		tasks = append(tasks, TaskSnapshot{Ref: refAt("task", string(rune('a'+i)), now), Status: "in_progress"})
+	}
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{WorkspaceID: "ws-1", OpenTasks: tasks}}}
+	if items := ComputeTodaysPlan(snap, now); len(items) != maxTodaysPlanItems {
+		t.Fatalf("expected cap of %d, got %d", maxTodaysPlanItems, len(items))
+	}
+}
+
+func TestResolveCheckpoint_FirstBriefUsesBoundedWindow(t *testing.T) {
+	now := time.Now()
+	since, isFirst := ResolveCheckpoint(nil, now)
+	if !isFirst {
+		t.Fatal("expected isFirstBrief=true when there is no prior revision")
+	}
+	if !since.Equal(now.Add(-firstBriefWindow)) {
+		t.Fatalf("expected the bounded first-brief window, got %v", since)
+	}
+}
+
+func TestResolveCheckpoint_SubsequentBriefUsesPreviousGeneratedAt(t *testing.T) {
+	now := time.Now()
+	prevGenAt := now.Add(-3 * time.Hour)
+	since, isFirst := ResolveCheckpoint(&Revision{GeneratedAt: prevGenAt}, now)
+	if isFirst {
+		t.Fatal("expected isFirstBrief=false when a prior revision exists")
+	}
+	if !since.Equal(prevGenAt) {
+		t.Fatalf("expected checkpoint at the previous revision's GeneratedAt, got %v", since)
+	}
+}
+
+func TestComputeSinceLastBrief_OnlyIncludesChangesAfterCheckpoint(t *testing.T) {
+	now := time.Now()
+	since := now.Add(-1 * time.Hour)
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{
+		WorkspaceID: "ws-1",
+		OpenTasks: []TaskSnapshot{
+			{Ref: refAt("task", "old", now.Add(-2*time.Hour)), Description: "old, before checkpoint"},
+			{Ref: refAt("task", "new", now.Add(-30*time.Minute)), Description: "new, after checkpoint"},
+		},
+	}}}
+	items := ComputeSinceLastBrief(snap, since)
+	if len(items) != 1 || items[0].Ref.EntityID != "new" {
+		t.Fatalf("expected only the post-checkpoint change, got %+v", items)
+	}
+}
+
+func TestComputeResumeCandidates_OrdersByRecencyAndCaps(t *testing.T) {
+	now := time.Now()
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{
+		WorkspaceID: "ws-1",
+		RecentSessions: []SessionSnapshot{
+			{Ref: refAt("session", "old", now.Add(-2*time.Hour)), Title: "old"},
+			{Ref: refAt("session", "new", now.Add(-10*time.Minute)), Title: "new", Preview: "left off here"},
+		},
+	}}}
+	items := ComputeResumeCandidates(snap, 5)
+	if len(items) != 2 || items[0].Ref.EntityID != "new" {
+		t.Fatalf("expected most recent session first, got %+v", items)
+	}
+	if !items[0].HasPreview || items[0].Preview != "left off here" {
+		t.Fatalf("expected the preview to be carried through as grounded metadata, got %+v", items[0])
+	}
+	if items[1].HasPreview {
+		t.Fatalf("expected no invented preview for a session with none, got %+v", items[1])
+	}
+}
+
+func TestComputeResumeCandidates_DefaultsLimitWhenNonPositive(t *testing.T) {
+	now := time.Now()
+	var sessions []SessionSnapshot
+	for i := 0; i < defaultResumeLimit+3; i++ {
+		sessions = append(sessions, SessionSnapshot{Ref: refAt("session", string(rune('a'+i)), now.Add(-time.Duration(i)*time.Minute))})
+	}
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{{WorkspaceID: "ws-1", RecentSessions: sessions}}}
+	if items := ComputeResumeCandidates(snap, 0); len(items) != defaultResumeLimit {
+		t.Fatalf("expected default cap of %d, got %d", defaultResumeLimit, len(items))
+	}
+}

--- a/internal/dailybrief/config.go
+++ b/internal/dailybrief/config.go
@@ -1,0 +1,94 @@
+package dailybrief
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrInvalidTimezone is returned when a non-empty timezone fails
+// time.LoadLocation. An empty timezone defaults to UTC rather than erroring.
+var ErrInvalidTimezone = errors.New("dailybrief: invalid IANA timezone")
+
+// ErrInvalidScheduleTime is returned when ScheduleTime is not "HH:MM".
+var ErrInvalidScheduleTime = errors.New("dailybrief: schedule_time must be HH:MM 24-hour local time")
+
+// ErrWorkspaceIDRequired is returned when a config has no owning workspace.
+var ErrWorkspaceIDRequired = errors.New("dailybrief: workspace id is required")
+
+// NormalizeConfig validates and defaults a caller-supplied Config so the
+// setup/settings flow can be completed with only the fields the user
+// actually chose to change. Returns a new Config; the input is not mutated.
+func NormalizeConfig(in Config) (Config, error) {
+	out := in
+	out.WorkspaceID = strings.TrimSpace(out.WorkspaceID)
+	if out.WorkspaceID == "" {
+		return Config{}, ErrWorkspaceIDRequired
+	}
+
+	tz := strings.TrimSpace(out.Timezone)
+	if tz == "" {
+		tz = "UTC"
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return Config{}, fmt.Errorf("%w: %q", ErrInvalidTimezone, tz)
+	}
+	out.Timezone = tz
+
+	out.ScheduleDays = normalizeScheduleDays(out.ScheduleDays)
+
+	scheduleTime := strings.TrimSpace(out.ScheduleTime)
+	if scheduleTime == "" {
+		scheduleTime = "08:00"
+	}
+	if _, err := time.Parse("15:04", scheduleTime); err != nil {
+		return Config{}, fmt.Errorf("%w: %q", ErrInvalidScheduleTime, scheduleTime)
+	}
+	out.ScheduleTime = scheduleTime
+
+	if out.Scope != ScopeSelected {
+		out.Scope = ScopeAll
+	}
+	if out.Scope == ScopeAll {
+		out.SelectedWorkspaceIDs = nil
+	} else {
+		out.SelectedWorkspaceIDs = normalizeIDs(out.SelectedWorkspaceIDs)
+	}
+
+	return out, nil
+}
+
+func normalizeScheduleDays(days []string) []string {
+	if len(days) == 0 {
+		return append([]string(nil), defaultScheduleDays...)
+	}
+	seen := make(map[string]bool, len(days))
+	out := make([]string, 0, len(days))
+	for _, d := range days {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if !validDays[d] || seen[d] {
+			continue
+		}
+		seen[d] = true
+		out = append(out, d)
+	}
+	if len(out) == 0 {
+		return append([]string(nil), defaultScheduleDays...)
+	}
+	return out
+}
+
+func normalizeIDs(ids []string) []string {
+	seen := make(map[string]bool, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}

--- a/internal/dailybrief/config_test.go
+++ b/internal/dailybrief/config_test.go
@@ -1,0 +1,113 @@
+package dailybrief
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizeConfig_RequiresWorkspaceID(t *testing.T) {
+	_, err := NormalizeConfig(Config{})
+	if !errors.Is(err, ErrWorkspaceIDRequired) {
+		t.Fatalf("expected ErrWorkspaceIDRequired, got %v", err)
+	}
+}
+
+func TestNormalizeConfig_DefaultsEmptyFields(t *testing.T) {
+	got, err := NormalizeConfig(Config{WorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if got.Timezone != "UTC" {
+		t.Errorf("timezone = %q, want UTC", got.Timezone)
+	}
+	if got.ScheduleTime != "08:00" {
+		t.Errorf("schedule time = %q, want 08:00", got.ScheduleTime)
+	}
+	if len(got.ScheduleDays) != 5 {
+		t.Errorf("schedule days = %v, want 5 weekday defaults", got.ScheduleDays)
+	}
+	if got.Scope != ScopeAll {
+		t.Errorf("scope = %q, want all", got.Scope)
+	}
+}
+
+func TestNormalizeConfig_RejectsInvalidTimezone(t *testing.T) {
+	_, err := NormalizeConfig(Config{WorkspaceID: "ws-1", Timezone: "Not/AZone"})
+	if !errors.Is(err, ErrInvalidTimezone) {
+		t.Fatalf("expected ErrInvalidTimezone, got %v", err)
+	}
+}
+
+func TestNormalizeConfig_RejectsInvalidScheduleTime(t *testing.T) {
+	for _, bad := range []string{"25:00", "8:00am", "not-a-time", "08:00:00"} {
+		if _, err := NormalizeConfig(Config{WorkspaceID: "ws-1", ScheduleTime: bad}); !errors.Is(err, ErrInvalidScheduleTime) {
+			t.Errorf("ScheduleTime %q: expected ErrInvalidScheduleTime, got %v", bad, err)
+		}
+	}
+}
+
+func TestNormalizeConfig_AcceptsValidScheduleTime(t *testing.T) {
+	got, err := NormalizeConfig(Config{WorkspaceID: "ws-1", ScheduleTime: "23:59"})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if got.ScheduleTime != "23:59" {
+		t.Errorf("schedule time = %q, want 23:59", got.ScheduleTime)
+	}
+}
+
+func TestNormalizeConfig_DeduplicatesAndLowercasesScheduleDays(t *testing.T) {
+	got, err := NormalizeConfig(Config{WorkspaceID: "ws-1", ScheduleDays: []string{"Mon", " MON ", "tue", "bogus"}})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if want := []string{"mon", "tue"}; !equalStringSlices(got.ScheduleDays, want) {
+		t.Errorf("schedule days = %v, want %v", got.ScheduleDays, want)
+	}
+}
+
+func TestNormalizeConfig_AllScopeDropsSelectedWorkspaceIDs(t *testing.T) {
+	got, err := NormalizeConfig(Config{WorkspaceID: "ws-1", Scope: ScopeAll, SelectedWorkspaceIDs: []string{"ws-2"}})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if got.SelectedWorkspaceIDs != nil {
+		t.Errorf("expected selected workspace ids cleared for scope=all, got %v", got.SelectedWorkspaceIDs)
+	}
+}
+
+func TestNormalizeConfig_SelectedScopeNormalizesIDs(t *testing.T) {
+	got, err := NormalizeConfig(Config{
+		WorkspaceID:          "ws-1",
+		Scope:                ScopeSelected,
+		SelectedWorkspaceIDs: []string{" ws-2 ", "ws-2", "", "ws-3"},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if want := []string{"ws-2", "ws-3"}; !equalStringSlices(got.SelectedWorkspaceIDs, want) {
+		t.Errorf("selected workspace ids = %v, want %v", got.SelectedWorkspaceIDs, want)
+	}
+}
+
+func TestNormalizeConfig_UnknownScopeDefaultsToAll(t *testing.T) {
+	got, err := NormalizeConfig(Config{WorkspaceID: "ws-1", Scope: Scope("bogus")})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if got.Scope != ScopeAll {
+		t.Errorf("scope = %q, want all", got.Scope)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dailybrief/schedule.go
+++ b/internal/dailybrief/schedule.go
@@ -1,0 +1,121 @@
+package dailybrief
+
+import (
+	"fmt"
+	"time"
+)
+
+// dayIndex maps a ScheduleDays code to time.Weekday.
+var dayIndex = map[string]time.Weekday{
+	"sun": time.Sunday,
+	"mon": time.Monday,
+	"tue": time.Tuesday,
+	"wed": time.Wednesday,
+	"thu": time.Thursday,
+	"fri": time.Friday,
+	"sat": time.Saturday,
+}
+
+// ResolveTimezone loads an IANA location, explicitly rejecting a fallback to
+// the server's local zone. This is the only timezone resolver Daily Brief
+// scheduling may use — never time.Now().Location() and never
+// internal/workspace.CalculateNextRun's lastRun.Location(), both of which
+// are server-local rather than the user's persisted zone.
+func ResolveTimezone(name string) (*time.Location, error) {
+	if name == "" {
+		name = "UTC"
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidTimezone, name)
+	}
+	return loc, nil
+}
+
+// LocalDateKey formats t (already in the target location) as the "YYYY-MM-DD"
+// key briefs and claims are keyed by.
+func LocalDateKey(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// NextOccurrence returns the next instant, strictly after `after`, at which
+// cfg's schedule should fire, expressed as an absolute time.Time (safe to
+// compare across zones/DST). ok is false when the schedule has no enabled
+// days (nothing to compute).
+//
+// DST policy (documented, not just implemented — task 5.6/5.7; verified
+// empirically against Go's actual time.Date behavior, not assumed):
+//   - Nonexistent wall-clock time (spring-forward gap, e.g. 2:30 AM when
+//     clocks jump 2:00->3:00): Go's time.Date resolves the wall-clock
+//     reading using the pre-transition (standard-time) offset and does not
+//     re-normalize it into the gap, so the resulting absolute instant, when
+//     displayed back in local time, reads as an EARLIER standard-time
+//     moment than configured (e.g. a configured 02:30 renders as 01:30 EST
+//     on the transition day) rather than rolling forward into daylight
+//     time. This is still exactly one well-defined instant — never an
+//     error, never two firings — just not the nominal clock reading on
+//     that one transition day. Every other day of the year fires at the
+//     literal configured time.
+//   - Repeated wall-clock time (fall-back fold): time.Date resolves to a
+//     single, deterministic offset (Go picks one side of the transition
+//     consistently). Because NextOccurrence only ever constructs one
+//     candidate time.Time per calendar date, the ambiguity can never produce
+//     two firings for the same date — "at most one per local date" holds by
+//     construction, not by special-casing the fold.
+//   - Timezone changes: this function is a pure computation over the
+//     current cfg and `after`; it holds no cached "next run" state, so a
+//     config change (or the app being off across a zone change) is picked
+//     up on the very next call with no migration step required.
+//   - App downtime: if `after` is far in the past, the loop below still
+//     only returns the single next occurrence after it — callers seeking
+//     "catch up on the current local date only" should pass `after` as a
+//     recent reference point (e.g. the last known-good local midnight), not
+//     rely on this function to enumerate every missed day.
+func NextOccurrence(cfg Config, after time.Time) (result time.Time, ok bool, err error) {
+	if !cfg.ScheduleEnabled || len(cfg.ScheduleDays) == 0 {
+		return time.Time{}, false, nil
+	}
+	loc, err := ResolveTimezone(cfg.Timezone)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	hour, minute, err := parseScheduleTime(cfg.ScheduleTime)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	enabledDays := make(map[time.Weekday]bool, len(cfg.ScheduleDays))
+	for _, d := range cfg.ScheduleDays {
+		if wd, ok := dayIndex[d]; ok {
+			enabledDays[wd] = true
+		}
+	}
+	if len(enabledDays) == 0 {
+		return time.Time{}, false, nil
+	}
+
+	afterLocal := after.In(loc)
+	// Search forward day by day (bounded to a week plus one, since the
+	// schedule repeats weekly) for the first enabled weekday whose
+	// configured local time is strictly after `after`.
+	for offset := 0; offset <= 7; offset++ {
+		day := afterLocal.AddDate(0, 0, offset)
+		if !enabledDays[day.Weekday()] {
+			continue
+		}
+		candidate := time.Date(day.Year(), day.Month(), day.Day(), hour, minute, 0, 0, loc)
+		if candidate.After(afterLocal) {
+			return candidate, true, nil
+		}
+	}
+	// Unreachable when at least one day is enabled: within 7 days every
+	// weekday occurs at least once strictly after `after`.
+	return time.Time{}, false, nil
+}
+
+func parseScheduleTime(s string) (hour, minute int, err error) {
+	t, err := time.Parse("15:04", s)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%w: %q", ErrInvalidScheduleTime, s)
+	}
+	return t.Hour(), t.Minute(), nil
+}

--- a/internal/dailybrief/schedule_test.go
+++ b/internal/dailybrief/schedule_test.go
@@ -1,0 +1,229 @@
+package dailybrief
+
+import (
+	"testing"
+	"time"
+)
+
+func mustLoc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Skipf("tzdata for %s unavailable in this environment: %v", name, err)
+	}
+	return loc
+}
+
+// findDSTGap scans forward from start (a date in loc) for the first day
+// whose UTC offset increases from the previous day (a spring-forward
+// transition), returning that day's weekday and date. Scanning empirically
+// (rather than hardcoding a calendar date) keeps the test correct regardless
+// of which year it runs against.
+func findDSTGap(t *testing.T, loc *time.Location, start time.Time) time.Time {
+	t.Helper()
+	prevOffset := offsetAt(start, loc)
+	for i := 1; i < 400; i++ {
+		day := start.AddDate(0, 0, i)
+		offset := offsetAt(day, loc)
+		if offset > prevOffset {
+			return day
+		}
+		prevOffset = offset
+	}
+	t.Fatal("no DST spring-forward transition found within a year")
+	return time.Time{}
+}
+
+// findDSTFold is findDSTGap's mirror: the first day whose UTC offset
+// decreases from the previous day (a fall-back transition).
+func findDSTFold(t *testing.T, loc *time.Location, start time.Time) time.Time {
+	t.Helper()
+	prevOffset := offsetAt(start, loc)
+	for i := 1; i < 400; i++ {
+		day := start.AddDate(0, 0, i)
+		offset := offsetAt(day, loc)
+		if offset < prevOffset {
+			return day
+		}
+		prevOffset = offset
+	}
+	t.Fatal("no DST fall-back transition found within a year")
+	return time.Time{}
+}
+
+func offsetAt(day time.Time, loc *time.Location) int {
+	_, offset := time.Date(day.Year(), day.Month(), day.Day(), 12, 0, 0, 0, loc).Zone()
+	return offset
+}
+
+func TestNextOccurrence_DisabledScheduleReturnsNotOK(t *testing.T) {
+	cfg := Config{Timezone: "UTC", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: false}
+	_, ok, err := NextOccurrence(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for a disabled schedule")
+	}
+}
+
+func TestNextOccurrence_NoDaysReturnsNotOK(t *testing.T) {
+	cfg := Config{Timezone: "UTC", ScheduleDays: nil, ScheduleTime: "08:00", ScheduleEnabled: true}
+	_, ok, err := NextOccurrence(cfg, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false with no configured days")
+	}
+}
+
+func TestNextOccurrence_RejectsInvalidTimezone(t *testing.T) {
+	cfg := Config{Timezone: "Not/AZone", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	if _, _, err := NextOccurrence(cfg, time.Now()); err == nil {
+		t.Fatal("expected an error for an invalid timezone")
+	}
+}
+
+func TestNextOccurrence_SameDayLaterTime(t *testing.T) {
+	loc := mustLoc(t, "UTC")
+	cfg := Config{Timezone: "UTC", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	// A Monday at 06:00 — the 08:00 occurrence is later the same day.
+	after := time.Date(2026, 1, 5, 6, 0, 0, 0, loc) // 2026-01-05 is a Monday.
+	got, ok, err := NextOccurrence(cfg, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence: ok=%v err=%v", ok, err)
+	}
+	if got.Day() != 5 || got.Hour() != 8 {
+		t.Fatalf("expected same-day 08:00, got %v", got)
+	}
+}
+
+func TestNextOccurrence_PastConfiguredTimeRollsToNextEnabledDay(t *testing.T) {
+	loc := mustLoc(t, "UTC")
+	cfg := Config{Timezone: "UTC", ScheduleDays: []string{"mon", "wed"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	// Monday at 09:00 — today's occurrence already passed; next is Wednesday.
+	after := time.Date(2026, 1, 5, 9, 0, 0, 0, loc)
+	got, ok, err := NextOccurrence(cfg, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence: ok=%v err=%v", ok, err)
+	}
+	if got.Weekday() != time.Wednesday || got.Day() != 7 {
+		t.Fatalf("expected Wednesday Jan 7, got %v (%v)", got, got.Weekday())
+	}
+}
+
+func TestNextOccurrence_EveryDayOfWeekWraps(t *testing.T) {
+	loc := mustLoc(t, "UTC")
+	cfg := Config{Timezone: "UTC", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	// A Tuesday: the only enabled day (Monday) is nearly a week away.
+	after := time.Date(2026, 1, 6, 0, 0, 0, 0, loc)
+	got, ok, err := NextOccurrence(cfg, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence: ok=%v err=%v", ok, err)
+	}
+	if got.Weekday() != time.Monday || got.Day() != 12 {
+		t.Fatalf("expected the following Monday Jan 12, got %v", got)
+	}
+}
+
+// TestNextOccurrence_DSTGapProducesExactlyOneWellDefinedInstant covers task
+// 5.6/5.7: a nonexistent wall-clock time (spring-forward) must never error
+// and must produce exactly one occurrence on the transition day — even
+// though (per Go's verified time.Date behavior) it resolves to an earlier
+// standard-time instant than the nominal configured clock reading, not a
+// forward roll into daylight time. The load-bearing guarantees are: no
+// error, no duplicate, and a subsequent call rolls to a later date.
+func TestNextOccurrence_DSTGapProducesExactlyOneWellDefinedInstant(t *testing.T) {
+	loc := mustLoc(t, "America/New_York")
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, loc)
+	gapDay := findDSTGap(t, loc, start)
+
+	cfg := Config{
+		Timezone:        "America/New_York",
+		ScheduleDays:    allDays(),
+		ScheduleTime:    "02:30", // Nominally inside the spring-forward gap (2:00-3:00 AM skipped).
+		ScheduleEnabled: true,
+	}
+	after := gapDay // midnight of the transition day itself, before the configured time
+	got, ok, err := NextOccurrence(cfg, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence: ok=%v err=%v", ok, err)
+	}
+	if got.In(loc).Day() != gapDay.Day() || got.In(loc).Month() != gapDay.Month() {
+		t.Fatalf("expected the occurrence to land on the transition day %v, got %v", gapDay, got.In(loc))
+	}
+
+	// A subsequent call strictly after this occurrence must roll to the
+	// NEXT calendar date, proving the gap did not produce a second firing
+	// later the same day.
+	next, ok, err := NextOccurrence(cfg, got)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence (second): ok=%v err=%v", ok, err)
+	}
+	if next.In(loc).Day() == got.In(loc).Day() && next.In(loc).Month() == got.In(loc).Month() {
+		t.Fatalf("expected the next occurrence on a different calendar date than %v, got %v", got.In(loc), next.In(loc))
+	}
+}
+
+// TestNextOccurrence_DSTFoldProducesExactlyOneOccurrence covers task
+// 5.6/5.7: a repeated wall-clock time (fall-back) must still yield exactly
+// one occurrence for that calendar date, not two.
+func TestNextOccurrence_DSTFoldProducesExactlyOneOccurrence(t *testing.T) {
+	loc := mustLoc(t, "America/New_York")
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, loc)
+	foldDay := findDSTFold(t, loc, start)
+
+	cfg := Config{
+		Timezone:        "America/New_York",
+		ScheduleDays:    allDays(),
+		ScheduleTime:    "01:30", // Occurs twice on the fall-back day (1:00-2:00 AM repeats).
+		ScheduleEnabled: true,
+	}
+	after := foldDay // midnight of the transition day itself, before 01:30
+	first, ok, err := NextOccurrence(cfg, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence: ok=%v err=%v", ok, err)
+	}
+	if first.In(loc).Day() != foldDay.Day() {
+		t.Fatalf("expected the first occurrence on the fold day %v, got %v", foldDay, first.In(loc))
+	}
+	// Asking again strictly after that first occurrence must roll to the
+	// NEXT calendar day's occurrence, not a second one on the fold day —
+	// proving at most one per local date holds even across the fold.
+	second, ok, err := NextOccurrence(cfg, first)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence (second): ok=%v err=%v", ok, err)
+	}
+	if second.In(loc).Day() == first.In(loc).Day() && second.In(loc).Month() == first.In(loc).Month() {
+		t.Fatalf("expected the second occurrence on a different calendar date than %v, got %v", first.In(loc), second.In(loc))
+	}
+}
+
+// TestNextOccurrence_TimezoneChangeTakesEffectImmediately covers task 5.7:
+// NextOccurrence is a pure function of the current config, so a timezone
+// change is picked up on the very next call with no migration step.
+func TestNextOccurrence_TimezoneChangeTakesEffectImmediately(t *testing.T) {
+	utc := mustLoc(t, "UTC")
+	after := time.Date(2026, 1, 5, 0, 0, 0, 0, utc) // Monday 00:00 UTC
+
+	cfgUTC := Config{Timezone: "UTC", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	gotUTC, ok, err := NextOccurrence(cfgUTC, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence (UTC): ok=%v err=%v", ok, err)
+	}
+
+	cfgTokyo := Config{Timezone: "Asia/Tokyo", ScheduleDays: []string{"mon"}, ScheduleTime: "08:00", ScheduleEnabled: true}
+	gotTokyo, ok, err := NextOccurrence(cfgTokyo, after)
+	if err != nil || !ok {
+		t.Fatalf("NextOccurrence (Tokyo): ok=%v err=%v", ok, err)
+	}
+
+	if gotUTC.Equal(gotTokyo) {
+		t.Fatalf("expected different absolute instants for different timezones, got the same: %v", gotUTC)
+	}
+}
+
+func allDays() []string {
+	return []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
+}

--- a/internal/dailybrief/scheduler.go
+++ b/internal/dailybrief/scheduler.go
@@ -1,0 +1,149 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+)
+
+// ScheduledWorkspace is one HQ workspace/user pair the scheduler should
+// check each tick.
+type ScheduledWorkspace struct {
+	WorkspaceID string
+	UserID      string
+}
+
+// WorkspaceLister supplies the set of workspaces to check each tick — in
+// v1, the single designated Personal HQ (if any), expressed as a list for
+// forward compatibility. Implemented by the server wiring layer (which
+// knows about internal/personalhq), not this package.
+type WorkspaceLister interface {
+	ListScheduledWorkspaces(ctx context.Context) ([]ScheduledWorkspace, error)
+}
+
+// Scheduler polls at a fixed interval and requests a scheduled generation
+// for each workspace whose configured schedule is due. It has no claim
+// table of its own — Service.RequestGeneration's existing store-level dedup
+// already guarantees at most one scheduled/first-open generation per
+// workspace/local-date, including across app restarts and multiple ticks
+// landing on the same due occurrence (PRD 5.6-5.8).
+type Scheduler struct {
+	svc          *Service
+	workspaces   WorkspaceLister
+	pollInterval time.Duration
+	now          func() time.Time // overridable in tests; defaults to time.Now
+
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+}
+
+// NewScheduler constructs a Daily Brief scheduler. pollInterval defaults to
+// one minute when zero/negative.
+func NewScheduler(svc *Service, workspaces WorkspaceLister, pollInterval time.Duration) *Scheduler {
+	if pollInterval <= 0 {
+		pollInterval = time.Minute
+	}
+	return &Scheduler{
+		svc:          svc,
+		workspaces:   workspaces,
+		pollInterval: pollInterval,
+		now:          time.Now,
+		stopChan:     make(chan struct{}),
+	}
+}
+
+// Start begins the poll loop in a background goroutine.
+func (s *Scheduler) Start() {
+	s.wg.Add(1)
+	go s.pollLoop()
+}
+
+// Stop signals the poll loop to exit and waits for it to finish. Safe to
+// call multiple times.
+func (s *Scheduler) Stop() {
+	s.stopOnce.Do(func() { close(s.stopChan) })
+	s.wg.Wait()
+}
+
+func (s *Scheduler) pollLoop() {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+	s.Tick() // run immediately on start, so app downtime catches up promptly
+	for {
+		select {
+		case <-s.stopChan:
+			return
+		case <-ticker.C:
+			s.Tick()
+		}
+	}
+}
+
+// Tick runs one scheduling pass. Exported so tests (and a manual/debug
+// trigger) can drive it directly without waiting on the poll interval.
+func (s *Scheduler) Tick() {
+	ctx := context.Background()
+	if s.workspaces == nil {
+		return
+	}
+	workspaces, err := s.workspaces.ListScheduledWorkspaces(ctx)
+	if err != nil {
+		logger.Warn("dailybrief scheduler: failed to list scheduled workspaces", logger.Fields{"error": err})
+		return
+	}
+	for _, w := range workspaces {
+		s.checkOne(ctx, w)
+	}
+}
+
+func (s *Scheduler) checkOne(ctx context.Context, w ScheduledWorkspace) {
+	cfg, err := s.svc.GetConfig(ctx, w.WorkspaceID)
+	if err != nil {
+		return // no Daily Brief config yet; nothing to schedule
+	}
+	if !cfg.ScheduleEnabled {
+		return
+	}
+	loc, err := ResolveTimezone(cfg.Timezone)
+	if err != nil {
+		logger.Warn("dailybrief scheduler: invalid timezone", logger.Fields{"workspace_id": w.WorkspaceID, "error": err})
+		return
+	}
+	now := s.now().In(loc)
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+
+	// The occurrence for TODAY, if the schedule has one: ask for the first
+	// candidate strictly after a moment just before today started. If app
+	// downtime spans the configured time, this still resolves to today's
+	// occurrence (already in the past relative to `now`), producing exactly
+	// one catch-up generation via the store's dedup rather than one per
+	// missed tick.
+	occurrence, ok, err := NextOccurrence(*cfg, todayStart.Add(-time.Nanosecond))
+	if err != nil || !ok {
+		return
+	}
+	if !sameLocalDate(occurrence.In(loc), now) {
+		return // today isn't a scheduled day (or the schedule was just disabled)
+	}
+	if now.Before(occurrence) {
+		return // not due yet
+	}
+
+	localDate := LocalDateKey(now)
+	if _, err := s.svc.RequestGeneration(ctx, *cfg, w.UserID, TriggerScheduled, localDate); err != nil {
+		if !errors.Is(err, ErrGenerationInProgress) {
+			logger.Warn("dailybrief scheduler: scheduled generation failed", logger.Fields{"workspace_id": w.WorkspaceID, "error": err})
+		}
+	}
+}
+
+func sameLocalDate(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}

--- a/internal/dailybrief/scheduler_test.go
+++ b/internal/dailybrief/scheduler_test.go
@@ -1,0 +1,151 @@
+package dailybrief
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type fixedWorkspaceLister struct {
+	workspaces []ScheduledWorkspace
+}
+
+func (f *fixedWorkspaceLister) ListScheduledWorkspaces(ctx context.Context) ([]ScheduledWorkspace, error) {
+	return f.workspaces, nil
+}
+
+func newSchedulerTestService(t *testing.T) (*Service, *fakeGenerator) {
+	t.Helper()
+	store := newTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded}}
+	return NewService(store, gen), gen
+}
+
+func setSchedulerConfig(t *testing.T, svc *Service, cfg Config) {
+	t.Helper()
+	if _, err := svc.UpdateConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+}
+
+func newTestScheduler(svc *Service, at time.Time) (*Scheduler, *fixedWorkspaceLister) {
+	lister := &fixedWorkspaceLister{workspaces: []ScheduledWorkspace{{WorkspaceID: "ws-1", UserID: "local"}}}
+	sched := NewScheduler(svc, lister, time.Minute)
+	sched.now = func() time.Time { return at }
+	return sched, lister
+}
+
+func TestScheduler_DoesNotGenerateBeforeScheduledTime(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: allDays(), ScheduleEnabled: true})
+
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 7, 59, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 0 {
+		t.Fatalf("expected no generation before scheduled time, got %d calls", gen.callCount())
+	}
+}
+
+func TestScheduler_GeneratesOnceScheduledTimeArrives(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: allDays(), ScheduleEnabled: true})
+
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 8, 0, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 1 {
+		t.Fatalf("expected exactly one generation once due, got %d calls", gen.callCount())
+	}
+	current, err := svc.GetCurrent(context.Background(), "ws-1")
+	if err != nil || current.Trigger != TriggerScheduled {
+		t.Fatalf("expected a current scheduled revision, got %#v err=%v", current, err)
+	}
+}
+
+// TestScheduler_MultipleTicksSameDayGenerateOnlyOnce covers task 5.6: the
+// per-workspace/local-date dedup must survive repeated ticks landing on the
+// same due occurrence (the normal poll-interval steady state).
+func TestScheduler_MultipleTicksSameDayGenerateOnlyOnce(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: allDays(), ScheduleEnabled: true})
+
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 8, 5, 0, 0, time.UTC))
+	for i := 0; i < 5; i++ {
+		sched.Tick()
+	}
+	if gen.callCount() != 1 {
+		t.Fatalf("expected exactly one generation across 5 ticks the same day, got %d calls", gen.callCount())
+	}
+}
+
+// TestScheduler_AppDowntimeCatchesUpOnce covers task 5.7/5.8: if the app was
+// off across the scheduled time and comes back up later the same local
+// date, the scheduler must still generate exactly once (a catch-up), not
+// skip the day and not generate repeatedly.
+func TestScheduler_AppDowntimeCatchesUpOnce(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: allDays(), ScheduleEnabled: true})
+
+	// App comes back at 14:00, well after the 08:00 scheduled time.
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 14, 0, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 1 {
+		t.Fatalf("expected exactly one catch-up generation, got %d calls", gen.callCount())
+	}
+}
+
+func TestScheduler_SkipsDaysNotInSchedule(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	// 2026-07-14 is a Tuesday; schedule only Mondays.
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: []string{"mon"}, ScheduleEnabled: true})
+
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 0 {
+		t.Fatalf("expected no generation on a non-scheduled day, got %d calls", gen.callCount())
+	}
+}
+
+func TestScheduler_SkipsWhenScheduleDisabled(t *testing.T) {
+	svc, gen := newSchedulerTestService(t)
+	setSchedulerConfig(t, svc, Config{WorkspaceID: "ws-1", Timezone: "UTC", ScheduleTime: "08:00", ScheduleDays: allDays(), ScheduleEnabled: false})
+
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 0 {
+		t.Fatalf("expected no generation when the schedule is disabled, got %d calls", gen.callCount())
+	}
+}
+
+func TestScheduler_SkipsWorkspaceWithNoConfig(t *testing.T) {
+	store := newTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded}}
+	svc := NewService(store, gen)
+	// No config ever set for ws-1.
+	sched, _ := newTestScheduler(svc, time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC))
+	sched.Tick()
+	if gen.callCount() != 0 {
+		t.Fatalf("expected no generation for an unconfigured workspace, got %d calls", gen.callCount())
+	}
+}
+
+// TestScheduler_StartStopLifecycle proves the poll loop starts and stops
+// cleanly without leaking a goroutine or hanging.
+func TestScheduler_StartStopLifecycle(t *testing.T) {
+	svc, _ := newSchedulerTestService(t)
+	sched, _ := newTestScheduler(svc, time.Now())
+	sched.pollInterval = time.Millisecond
+	sched.Start()
+	time.Sleep(20 * time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		sched.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return in time")
+	}
+	// Calling Stop again must not panic or hang (sync.Once guard).
+	sched.Stop()
+}

--- a/internal/dailybrief/service.go
+++ b/internal/dailybrief/service.go
@@ -157,6 +157,11 @@ func (s *Service) RequestGeneration(ctx context.Context, cfg Config, userID stri
 }
 
 func (s *Service) runGeneration(ctx context.Context, cfg Config, claim *GenerationRequest) (*Revision, error) {
+	// Bounded, field-only observable event (PRD FR138) — trigger/workspace
+	// id/local date only, never prompt content or brief prose.
+	logger.Info("dailybrief: generation requested", logger.Fields{
+		"workspace_id": cfg.WorkspaceID, "trigger": string(claim.Trigger), "local_date": claim.LocalDate,
+	})
 	if err := s.store.UpdateGenerationStatus(ctx, claim.ID, GenerationRunning, "", ""); err != nil {
 		logger.Warn("dailybrief: failed to mark generation running", logger.Fields{"claim_id": claim.ID, "error": err})
 	}
@@ -215,6 +220,10 @@ func (s *Service) runGeneration(ctx context.Context, cfg Config, claim *Generati
 	if err := s.store.UpdateGenerationStatus(ctx, claim.ID, rev.Status, rev.ID, rev.FailureReason); err != nil {
 		logger.Warn("dailybrief: failed to finalize generation status", logger.Fields{"claim_id": claim.ID, "error": err})
 	}
+
+	logger.Info("dailybrief: generation finished", logger.Fields{
+		"workspace_id": cfg.WorkspaceID, "trigger": string(claim.Trigger), "status": string(rev.Status), "revision_id": rev.ID,
+	})
 
 	if genErr != nil {
 		return rev, genErr

--- a/internal/dailybrief/service.go
+++ b/internal/dailybrief/service.go
@@ -51,11 +51,27 @@ type Service struct {
 	// at once for the same workspace (PRD 5.10).
 	mu       sync.Mutex
 	inFlight map[string]bool
+
+	// onRevisionReady fires (outside any lock) after a revision successfully
+	// or partially succeeds and becomes current, for any trigger. Set
+	// post-construction (mirrors internal/personalhq.Service.SetOnDesignated)
+	// so the server wiring layer can hook Action Center notifications
+	// without this package depending on internal/workspace's opportunity
+	// store.
+	onRevisionReady func(cfg Config, rev *Revision)
 }
 
 // NewService constructs a Daily Brief service.
 func NewService(store Store, generator Generator) *Service {
 	return &Service{store: store, generator: generator, inFlight: map[string]bool{}}
+}
+
+// SetOnRevisionReady registers a callback fired whenever a generation
+// succeeds or partially succeeds and becomes the current revision,
+// regardless of trigger. The callback decides whether/how to notify (e.g.
+// only for TriggerScheduled, per PRD FR63).
+func (s *Service) SetOnRevisionReady(fn func(cfg Config, rev *Revision)) {
+	s.onRevisionReady = fn
 }
 
 // GetConfig returns the current config for workspaceID, or ErrConfigNotFound
@@ -190,6 +206,9 @@ func (s *Service) runGeneration(ctx context.Context, cfg Config, claim *Generati
 			logger.Warn("dailybrief: failed to set current revision", logger.Fields{"revision_id": rev.ID, "error": err})
 		} else {
 			rev.IsCurrent = true
+			if s.onRevisionReady != nil {
+				s.onRevisionReady(cfg, rev)
+			}
 		}
 	}
 
@@ -218,6 +237,23 @@ func (s *Service) GetHistory(ctx context.Context, workspaceID string, limit int)
 // never touching another workspace or the current revision.
 func (s *Service) PruneHistory(ctx context.Context, workspaceID string) error {
 	return s.store.PruneHistory(ctx, workspaceID, MinRetentionDays)
+}
+
+// GetActiveGeneration returns today's most recently claimed generation
+// attempt for workspaceID (first-open, scheduled, or manual), or nil if none
+// has been claimed yet — used by the HTTP layer to let a client poll
+// generation status, including a manual refresh, without blocking on it
+// synchronously (PRD FR56/FR57/task 7.4).
+func (s *Service) GetActiveGeneration(ctx context.Context, workspaceID string) (*GenerationRequest, error) {
+	cfg, err := s.store.GetConfig(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	localDate, err := TodayLocalDate(*cfg)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.GetLatestClaim(ctx, workspaceID, localDate)
 }
 
 // RecordNotificationIfEnabled creates an Action Center notification record

--- a/internal/dailybrief/service.go
+++ b/internal/dailybrief/service.go
@@ -1,0 +1,253 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+)
+
+// ErrGenerationInProgress is returned by RequestGeneration when another
+// generation is already running for the same workspace (any trigger). The
+// caller should poll rather than retry immediately.
+var ErrGenerationInProgress = errors.New("dailybrief: a generation is already in progress for this workspace")
+
+// MinRetentionDays is the minimum number of distinct local dates of brief
+// history retained per workspace (PRD FR67: at least 30 days).
+const MinRetentionDays = 30
+
+// GenerationResult is what a Generator produces for one attempt. Content
+// synthesis itself (the grounded snapshot + prompt/response contract) is a
+// separate concern layered on top of this package; GenerationResult is the
+// narrow contract this package needs to persist a revision.
+type GenerationResult struct {
+	ContentJSON       string
+	Status            GenerationStatus // succeeded | partial | failed
+	FailureReason     string
+	SourceWindowStart time.Time
+	SourceWindowEnd   time.Time
+}
+
+// Generator produces brief content for one generation attempt.
+type Generator interface {
+	Generate(ctx context.Context, req GenerationRequest, cfg Config) (GenerationResult, error)
+}
+
+// Service orchestrates Daily Brief configuration and the generation
+// lifecycle: claiming, invoking the Generator, persisting the revision, and
+// atomically flipping the current pointer.
+type Service struct {
+	store     Store
+	generator Generator
+
+	// mu/inFlight serializes ANY concurrent generation for the same
+	// workspace regardless of trigger — stronger than the store's DB-level
+	// dedup, which only covers first_open vs scheduled. Prevents two
+	// simultaneous manual refreshes, or a manual refresh racing a first-open
+	// request, from both invoking a (potentially slow, LLM-backed) Generator
+	// at once for the same workspace (PRD 5.10).
+	mu       sync.Mutex
+	inFlight map[string]bool
+}
+
+// NewService constructs a Daily Brief service.
+func NewService(store Store, generator Generator) *Service {
+	return &Service{store: store, generator: generator, inFlight: map[string]bool{}}
+}
+
+// GetConfig returns the current config for workspaceID, or ErrConfigNotFound
+// if the HQ has never been configured.
+func (s *Service) GetConfig(ctx context.Context, workspaceID string) (*Config, error) {
+	return s.store.GetConfig(ctx, workspaceID)
+}
+
+// UpdateConfig validates/defaults cfg and persists it, bumping
+// ConfigRevision. Source/schedule changes affect only future generations —
+// this never rewrites prior revisions.
+func (s *Service) UpdateConfig(ctx context.Context, cfg Config) (*Config, error) {
+	normalized, err := NormalizeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.store.UpsertConfig(ctx, &normalized); err != nil {
+		return nil, err
+	}
+	return s.store.GetConfig(ctx, normalized.WorkspaceID)
+}
+
+// TodayLocalDate returns the current local date key for cfg's timezone.
+func TodayLocalDate(cfg Config) (string, error) {
+	loc, err := ResolveTimezone(cfg.Timezone)
+	if err != nil {
+		return "", err
+	}
+	return LocalDateKey(time.Now().In(loc)), nil
+}
+
+// RequestGenerationNow resolves "today" from cfg's timezone and requests a
+// generation for it. Used by first-open and manual refresh.
+func (s *Service) RequestGenerationNow(ctx context.Context, workspaceID, userID string, trigger Trigger) (*Revision, error) {
+	cfg, err := s.store.GetConfig(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	localDate, err := TodayLocalDate(*cfg)
+	if err != nil {
+		return nil, err
+	}
+	return s.RequestGeneration(ctx, *cfg, userID, trigger, localDate)
+}
+
+// RequestGeneration claims and (if newly claimed) runs a generation for
+// (cfg.WorkspaceID, localDate). When a first-open/scheduled claim already
+// exists for that date, this returns the outcome of that existing claim
+// instead of starting a duplicate (PRD FR55/FR59):
+//   - if it already succeeded/partial, the current revision is returned;
+//   - if it is still pending/running, ErrGenerationInProgress is returned
+//     so the caller polls rather than duplicating work.
+//
+// Manual refresh (Trigger=TriggerManual) always creates a new revision.
+func (s *Service) RequestGeneration(ctx context.Context, cfg Config, userID string, trigger Trigger, localDate string) (*Revision, error) {
+	if !s.tryLockWorkspace(cfg.WorkspaceID) {
+		return nil, ErrGenerationInProgress
+	}
+	defer s.unlockWorkspace(cfg.WorkspaceID)
+
+	claim, isNew, err := s.store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: cfg.WorkspaceID,
+		UserID:      userID,
+		LocalDate:   localDate,
+		Trigger:     trigger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to claim daily brief generation: %w", err)
+	}
+	if !isNew {
+		switch claim.Status {
+		case GenerationSucceeded, GenerationPartial:
+			if claim.RevisionID != "" {
+				return s.store.GetRevision(ctx, claim.RevisionID)
+			}
+			return s.store.GetCurrentRevision(ctx, cfg.WorkspaceID)
+		default:
+			return nil, ErrGenerationInProgress
+		}
+	}
+
+	return s.runGeneration(ctx, cfg, claim)
+}
+
+func (s *Service) runGeneration(ctx context.Context, cfg Config, claim *GenerationRequest) (*Revision, error) {
+	if err := s.store.UpdateGenerationStatus(ctx, claim.ID, GenerationRunning, "", ""); err != nil {
+		logger.Warn("dailybrief: failed to mark generation running", logger.Fields{"claim_id": claim.ID, "error": err})
+	}
+
+	if s.generator == nil {
+		failMsg := "no brief generator configured"
+		_ = s.store.UpdateGenerationStatus(ctx, claim.ID, GenerationFailed, "", failMsg)
+		return nil, errors.New("dailybrief: " + failMsg)
+	}
+
+	result, genErr := s.generator.Generate(ctx, *claim, cfg)
+	if genErr != nil {
+		result = GenerationResult{Status: GenerationFailed, FailureReason: genErr.Error()}
+	}
+	if result.Status == "" {
+		result.Status = GenerationFailed
+	}
+
+	revisionNumber, err := s.store.NextRevisionNumber(ctx, cfg.WorkspaceID, claim.LocalDate)
+	if err != nil {
+		_ = s.store.UpdateGenerationStatus(ctx, claim.ID, GenerationFailed, "", err.Error())
+		return nil, fmt.Errorf("failed to compute next revision number: %w", err)
+	}
+	rev := &Revision{
+		WorkspaceID:       cfg.WorkspaceID,
+		UserID:            claim.UserID,
+		LocalDate:         claim.LocalDate,
+		RevisionNumber:    revisionNumber,
+		Trigger:           claim.Trigger,
+		Status:            result.Status,
+		ConfigRevision:    cfg.ConfigRevision,
+		ContentJSON:       result.ContentJSON,
+		SourceWindowStart: result.SourceWindowStart,
+		SourceWindowEnd:   result.SourceWindowEnd,
+		FailureReason:     result.FailureReason,
+		GeneratedAt:       time.Now().UTC(),
+	}
+	if err := s.store.CreateRevision(ctx, rev); err != nil {
+		_ = s.store.UpdateGenerationStatus(ctx, claim.ID, GenerationFailed, "", err.Error())
+		return nil, fmt.Errorf("failed to persist daily brief revision: %w", err)
+	}
+
+	if rev.Status == GenerationSucceeded || rev.Status == GenerationPartial {
+		// Preserve the last successful brief on failure: current is only
+		// ever flipped forward on a successful/partial result (PRD 5.12).
+		if err := s.store.SetCurrentRevision(ctx, cfg.WorkspaceID, rev.ID); err != nil {
+			logger.Warn("dailybrief: failed to set current revision", logger.Fields{"revision_id": rev.ID, "error": err})
+		} else {
+			rev.IsCurrent = true
+		}
+	}
+
+	if err := s.store.UpdateGenerationStatus(ctx, claim.ID, rev.Status, rev.ID, rev.FailureReason); err != nil {
+		logger.Warn("dailybrief: failed to finalize generation status", logger.Fields{"claim_id": claim.ID, "error": err})
+	}
+
+	if genErr != nil {
+		return rev, genErr
+	}
+	return rev, nil
+}
+
+// GetCurrent returns the current revision for workspaceID, or
+// ErrRevisionNotFound if no brief has ever been generated.
+func (s *Service) GetCurrent(ctx context.Context, workspaceID string) (*Revision, error) {
+	return s.store.GetCurrentRevision(ctx, workspaceID)
+}
+
+// GetHistory returns up to limit collapsed per-date history entries.
+func (s *Service) GetHistory(ctx context.Context, workspaceID string, limit int) ([]HistorySummary, error) {
+	return s.store.ListHistory(ctx, workspaceID, limit)
+}
+
+// PruneHistory prunes workspaceID's history down to MinRetentionDays,
+// never touching another workspace or the current revision.
+func (s *Service) PruneHistory(ctx context.Context, workspaceID string) error {
+	return s.store.PruneHistory(ctx, workspaceID, MinRetentionDays)
+}
+
+// RecordNotificationIfEnabled creates an Action Center notification record
+// for rev, but only when cfg has opted in AND rev came from a scheduled
+// trigger (PRD FR63: manual/first-open generations never notify) AND rev
+// succeeded. Idempotent per revision (PRD FR65). Returns whether a
+// notification should be surfaced to the user (the Action Center item
+// itself is created by the caller — task 7's integration layer).
+func (s *Service) RecordNotificationIfEnabled(ctx context.Context, cfg Config, rev *Revision) (bool, error) {
+	if !cfg.NotifyOnReady || rev == nil || rev.Trigger != TriggerScheduled {
+		return false, nil
+	}
+	if rev.Status != GenerationSucceeded && rev.Status != GenerationPartial {
+		return false, nil
+	}
+	return s.store.RecordNotification(ctx, rev.ID, cfg.WorkspaceID)
+}
+
+func (s *Service) tryLockWorkspace(workspaceID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inFlight[workspaceID] {
+		return false
+	}
+	s.inFlight[workspaceID] = true
+	return true
+}
+
+func (s *Service) unlockWorkspace(workspaceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.inFlight, workspaceID)
+}

--- a/internal/dailybrief/service_test.go
+++ b/internal/dailybrief/service_test.go
@@ -161,6 +161,60 @@ func TestService_RequestGeneration_ManualAlwaysCreatesNewRevision(t *testing.T) 
 	}
 }
 
+// TestService_GetActiveGeneration_ObservesManualRefreshInFlight covers a gap
+// found while wiring the HTTP status-polling endpoint (task 7.4): manual
+// refreshes deliberately never dedupe via GetActiveClaim (which excludes
+// trigger_type=manual), so a naive status endpoint built on that method
+// could never see a manual refresh running. GetActiveGeneration must use
+// GetLatestClaim instead so manual refresh polling actually observes
+// pending/running, then the terminal status once it completes.
+func TestService_GetActiveGeneration_ObservesManualRefreshInFlight(t *testing.T) {
+	store := newServiceTestStore(t)
+	block := make(chan struct{})
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded, ContentJSON: "v1"}, block: block}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual)
+	}()
+
+	// Poll until the in-flight manual claim becomes observable.
+	deadline := time.Now().Add(2 * time.Second)
+	var active *GenerationRequest
+	for time.Now().Before(deadline) {
+		var err error
+		active, err = svc.GetActiveGeneration(ctx, "ws-1")
+		if err != nil {
+			t.Fatalf("GetActiveGeneration: %v", err)
+		}
+		if active != nil && active.Trigger == TriggerManual {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if active == nil || active.Trigger != TriggerManual {
+		t.Fatalf("expected the manual claim to be observable while in flight, got %#v", active)
+	}
+	if active.Status != GenerationPending && active.Status != GenerationRunning {
+		t.Fatalf("expected pending/running while blocked, got %q", active.Status)
+	}
+
+	close(block)
+	<-done
+
+	final, err := svc.GetActiveGeneration(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetActiveGeneration after completion: %v", err)
+	}
+	if final == nil || final.Status != GenerationSucceeded {
+		t.Fatalf("expected the completed manual claim to report succeeded, got %#v", final)
+	}
+}
+
 // TestService_RequestGeneration_FailurePreservesLastSuccessfulCurrent covers
 // PRD 5.12: a failed generation must not erase the last successful brief.
 func TestService_RequestGeneration_FailurePreservesLastSuccessfulCurrent(t *testing.T) {
@@ -225,6 +279,43 @@ func TestService_RequestGeneration_ConcurrentCallsSerializePerWorkspace(t *testi
 	wg.Wait()
 	if firstErr := <-errs; firstErr != nil {
 		t.Fatalf("first call should have succeeded once unblocked: %v", firstErr)
+	}
+}
+
+// TestService_OnRevisionReadyFiresOnlyForSuccessOrPartial covers task 7.11's
+// wiring point: the hook must fire for a succeeded/partial revision (so the
+// caller can notify) and must never fire for a failed one (nothing to
+// notify about, and the failed revision never becomes current).
+func TestService_OnRevisionReadyFiresOnlyForSuccessOrPartial(t *testing.T) {
+	store := newServiceTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded}}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	fired := 0
+	var lastRev *Revision
+	svc.SetOnRevisionReady(func(cfg Config, rev *Revision) {
+		fired++
+		lastRev = rev
+	})
+
+	if _, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerScheduled); err != nil {
+		t.Fatalf("RequestGenerationNow: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("expected the hook to fire once for a succeeded revision, got %d", fired)
+	}
+	if lastRev == nil || !lastRev.IsCurrent {
+		t.Fatalf("expected the hook to receive the now-current revision, got %#v", lastRev)
+	}
+
+	gen.err = errors.New("boom")
+	if _, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual); err == nil {
+		t.Fatal("expected the manual refresh to report the generator's error")
+	}
+	if fired != 1 {
+		t.Fatalf("expected the hook to NOT fire for a failed generation, got %d total fires", fired)
 	}
 }
 

--- a/internal/dailybrief/service_test.go
+++ b/internal/dailybrief/service_test.go
@@ -1,0 +1,297 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeGenerator is a controllable Generator for service tests.
+type fakeGenerator struct {
+	mu         sync.Mutex
+	calls      int
+	result     GenerationResult
+	err        error
+	block      chan struct{} // if non-nil, Generate waits on this before returning
+	onGenerate func()
+}
+
+func (f *fakeGenerator) Generate(ctx context.Context, req GenerationRequest, cfg Config) (GenerationResult, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.onGenerate != nil {
+		f.onGenerate()
+	}
+	if f.block != nil {
+		<-f.block
+	}
+	return f.result, f.err
+}
+
+func (f *fakeGenerator) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newServiceTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	return newTestStore(t)
+}
+
+func seedConfig(t *testing.T, store Store, workspaceID string) Config {
+	t.Helper()
+	cfg, err := NormalizeConfig(Config{WorkspaceID: workspaceID, UserID: "local", Timezone: "UTC"})
+	if err != nil {
+		t.Fatalf("NormalizeConfig: %v", err)
+	}
+	if err := store.UpsertConfig(context.Background(), &cfg); err != nil {
+		t.Fatalf("UpsertConfig: %v", err)
+	}
+	got, err := store.GetConfig(context.Background(), workspaceID)
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	return *got
+}
+
+func TestService_UpdateConfigValidatesAndPersists(t *testing.T) {
+	store := newServiceTestStore(t)
+	svc := NewService(store, nil)
+	ctx := context.Background()
+
+	_, err := svc.UpdateConfig(ctx, Config{WorkspaceID: "ws-1", Timezone: "Not/AZone"})
+	if !errors.Is(err, ErrInvalidTimezone) {
+		t.Fatalf("expected ErrInvalidTimezone, got %v", err)
+	}
+
+	got, err := svc.UpdateConfig(ctx, Config{WorkspaceID: "ws-1", Timezone: "America/New_York"})
+	if err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	if got.Timezone != "America/New_York" {
+		t.Fatalf("timezone = %q", got.Timezone)
+	}
+}
+
+func TestService_RequestGeneration_FirstOpenSucceedsAndBecomesCurrent(t *testing.T) {
+	store := newServiceTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded, ContentJSON: `{"summary":"hi"}`}}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	cfg := seedConfig(t, store, "ws-1")
+
+	rev, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerFirstOpen)
+	if err != nil {
+		t.Fatalf("RequestGenerationNow: %v", err)
+	}
+	if rev.Status != GenerationSucceeded || !rev.IsCurrent {
+		t.Fatalf("expected succeeded+current revision, got %#v", rev)
+	}
+	if gen.callCount() != 1 {
+		t.Fatalf("expected generator called once, got %d", gen.callCount())
+	}
+
+	current, err := svc.GetCurrent(ctx, "ws-1")
+	if err != nil || current.ID != rev.ID {
+		t.Fatalf("GetCurrent: %#v err=%v", current, err)
+	}
+	_ = cfg
+}
+
+// TestService_RequestGeneration_ScheduledThenFirstOpenDedupes covers PRD
+// FR55/FR59: when a scheduled brief already exists for today, first-open
+// must show it rather than generating another one.
+func TestService_RequestGeneration_ScheduledThenFirstOpenDedupes(t *testing.T) {
+	store := newServiceTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded, ContentJSON: "v1"}}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	first, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerScheduled)
+	if err != nil {
+		t.Fatalf("scheduled request: %v", err)
+	}
+	second, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerFirstOpen)
+	if err != nil {
+		t.Fatalf("first-open request: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected first-open to return the same revision as the scheduled one, got %s vs %s", second.ID, first.ID)
+	}
+	if gen.callCount() != 1 {
+		t.Fatalf("expected the generator to run exactly once, got %d", gen.callCount())
+	}
+}
+
+// TestService_RequestGeneration_ManualAlwaysCreatesNewRevision covers PRD
+// FR58: manual refresh creates a new same-day revision and replaces current.
+func TestService_RequestGeneration_ManualAlwaysCreatesNewRevision(t *testing.T) {
+	store := newServiceTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded, ContentJSON: "v1"}}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	first, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerFirstOpen)
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	gen.result = GenerationResult{Status: GenerationSucceeded, ContentJSON: "v2"}
+	second, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual)
+	if err != nil {
+		t.Fatalf("manual request: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Fatal("expected manual refresh to create a distinct revision")
+	}
+	if second.RevisionNumber != first.RevisionNumber+1 {
+		t.Fatalf("expected revision number to increment, got %d then %d", first.RevisionNumber, second.RevisionNumber)
+	}
+	current, err := svc.GetCurrent(ctx, "ws-1")
+	if err != nil || current.ID != second.ID {
+		t.Fatalf("expected the manual revision to become current, got %#v err=%v", current, err)
+	}
+	if gen.callCount() != 2 {
+		t.Fatalf("expected the generator to run twice, got %d", gen.callCount())
+	}
+}
+
+// TestService_RequestGeneration_FailurePreservesLastSuccessfulCurrent covers
+// PRD 5.12: a failed generation must not erase the last successful brief.
+func TestService_RequestGeneration_FailurePreservesLastSuccessfulCurrent(t *testing.T) {
+	store := newServiceTestStore(t)
+	gen := &fakeGenerator{result: GenerationResult{Status: GenerationSucceeded, ContentJSON: "v1"}}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	good, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerFirstOpen)
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+
+	gen.err = errors.New("model unavailable")
+	if _, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual); err == nil {
+		t.Fatal("expected the manual refresh to report the generator's error")
+	}
+
+	current, err := svc.GetCurrent(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetCurrent after failure: %v", err)
+	}
+	if current.ID != good.ID {
+		t.Fatalf("expected the last successful revision to remain current, got %#v", current)
+	}
+}
+
+// TestService_RequestGeneration_ConcurrentCallsSerializePerWorkspace covers
+// task 5.10: two concurrent calls for the same workspace must not both
+// invoke the (potentially slow) generator at once.
+func TestService_RequestGeneration_ConcurrentCallsSerializePerWorkspace(t *testing.T) {
+	store := newServiceTestStore(t)
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	gen := &fakeGenerator{
+		result:     GenerationResult{Status: GenerationSucceeded},
+		block:      block,
+		onGenerate: func() { started <- struct{}{} },
+	}
+	svc := NewService(store, gen)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual)
+		errs <- err
+	}()
+
+	<-started // wait until the first call is inside the generator
+
+	_, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerManual)
+	if !errors.Is(err, ErrGenerationInProgress) {
+		t.Fatalf("expected ErrGenerationInProgress for the concurrent call, got %v", err)
+	}
+
+	close(block)
+	wg.Wait()
+	if firstErr := <-errs; firstErr != nil {
+		t.Fatalf("first call should have succeeded once unblocked: %v", firstErr)
+	}
+}
+
+func TestService_RecordNotificationIfEnabled_OnlyForScheduledAndOptedIn(t *testing.T) {
+	store := newServiceTestStore(t)
+	svc := NewService(store, nil)
+	ctx := context.Background()
+
+	rev := &Revision{ID: "rev-1", WorkspaceID: "ws-1", Trigger: TriggerScheduled, Status: GenerationSucceeded}
+
+	// Not opted in: no notification.
+	created, err := svc.RecordNotificationIfEnabled(ctx, Config{WorkspaceID: "ws-1", NotifyOnReady: false}, rev)
+	if err != nil || created {
+		t.Fatalf("expected no notification when not opted in, got created=%v err=%v", created, err)
+	}
+
+	// Opted in but manual trigger: no notification (FR63).
+	manualRev := &Revision{ID: "rev-2", WorkspaceID: "ws-1", Trigger: TriggerManual, Status: GenerationSucceeded}
+	created, err = svc.RecordNotificationIfEnabled(ctx, Config{WorkspaceID: "ws-1", NotifyOnReady: true}, manualRev)
+	if err != nil || created {
+		t.Fatalf("expected no notification for a manual trigger, got created=%v err=%v", created, err)
+	}
+
+	// Opted in + scheduled + succeeded: notification created, then idempotent.
+	created, err = svc.RecordNotificationIfEnabled(ctx, Config{WorkspaceID: "ws-1", NotifyOnReady: true}, rev)
+	if err != nil || !created {
+		t.Fatalf("expected a notification to be created, got created=%v err=%v", created, err)
+	}
+	created, err = svc.RecordNotificationIfEnabled(ctx, Config{WorkspaceID: "ws-1", NotifyOnReady: true}, rev)
+	if err != nil || created {
+		t.Fatalf("expected the second call for the same revision to be a no-op, got created=%v err=%v", created, err)
+	}
+}
+
+func TestService_PruneHistoryDelegatesWithMinRetention(t *testing.T) {
+	store := newServiceTestStore(t)
+	svc := NewService(store, nil)
+	ctx := context.Background()
+
+	for i := 0; i < 40; i++ {
+		date := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i).Format("2006-01-02")
+		if err := store.CreateRevision(ctx, &Revision{
+			ID: "rev-" + date, WorkspaceID: "ws-1", UserID: "local", LocalDate: date, RevisionNumber: 1,
+			Trigger: TriggerScheduled, Status: GenerationSucceeded,
+		}); err != nil {
+			t.Fatalf("CreateRevision: %v", err)
+		}
+	}
+	if err := svc.PruneHistory(ctx, "ws-1"); err != nil {
+		t.Fatalf("PruneHistory: %v", err)
+	}
+	history, err := svc.GetHistory(ctx, "ws-1", 100)
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if len(history) != MinRetentionDays {
+		t.Fatalf("expected exactly %d retained days, got %d", MinRetentionDays, len(history))
+	}
+}
+
+func TestService_RequestGeneration_NoGeneratorConfiguredFailsClaim(t *testing.T) {
+	store := newServiceTestStore(t)
+	svc := NewService(store, nil)
+	ctx := context.Background()
+	seedConfig(t, store, "ws-1")
+
+	if _, err := svc.RequestGenerationNow(ctx, "ws-1", "local", TriggerFirstOpen); err == nil {
+		t.Fatal("expected an error when no generator is configured")
+	}
+}

--- a/internal/dailybrief/snapshot.go
+++ b/internal/dailybrief/snapshot.go
@@ -1,0 +1,322 @@
+package dailybrief
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// Bounds on per-workspace snapshot collection, keeping the eventual LLM
+// prompt small and excluding unbounded transcripts/full files (PRD FR113).
+const (
+	maxTasksPerWorkspace         = 20
+	maxOpportunitiesPerWorkspace = 10
+	maxSessionsPerWorkspace      = 5
+)
+
+// SourceRef is a stable reference to the entity a brief item came from:
+// owning workspace, entity type/id, and a timestamp. Every factual item and
+// actionable payload in the eventual synthesized brief must trace back to
+// one of these (PRD FR81, task 6.8), and model output is validated against
+// the set of refs actually present in the snapshot (task 6.12).
+type SourceRef struct {
+	WorkspaceID string    `json:"workspace_id"`
+	EntityType  string    `json:"entity_type"` // task | opportunity | scheduled_task | session
+	EntityID    string    `json:"entity_id"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// Key returns a stable string identity used for allowlist membership.
+func (r SourceRef) Key() string {
+	return r.EntityType + ":" + r.WorkspaceID + ":" + r.EntityID
+}
+
+// TaskSnapshot is a bounded, brief-relevant projection of an open task.
+type TaskSnapshot struct {
+	Ref           SourceRef
+	Description   string
+	Status        string
+	AssignedAgent string
+	Priority      int
+}
+
+// OpportunitySnapshot is a bounded projection of an open Action Center item.
+type OpportunitySnapshot struct {
+	Ref      SourceRef
+	Title    string
+	Priority string
+	Status   string
+}
+
+// ScheduledTaskSnapshot is a bounded projection of a scheduled task.
+type ScheduledTaskSnapshot struct {
+	Ref          SourceRef
+	Name         string
+	Enabled      bool
+	FailureCount int
+	LastError    string
+	NextRun      *time.Time
+	LastRun      *time.Time
+}
+
+// SessionSnapshot is a bounded projection of a recent session — known
+// metadata only (title, preview, message count), never a full transcript.
+type SessionSnapshot struct {
+	Ref          SourceRef
+	Title        string
+	Preview      string
+	AgentName    string
+	MessageCount int
+	UpdatedAt    time.Time
+}
+
+// WorkspaceSnapshot is one eligible workspace's bounded projection.
+type WorkspaceSnapshot struct {
+	WorkspaceID    string
+	Name           string
+	AgentCount     int
+	OpenTasks      []TaskSnapshot
+	Opportunities  []OpportunitySnapshot
+	ScheduledTasks []ScheduledTaskSnapshot
+	RecentSessions []SessionSnapshot
+}
+
+// Snapshot is the bounded, read-only, authorized cross-workspace projection
+// Daily Brief synthesis works from.
+type Snapshot struct {
+	GeneratedAt time.Time
+	Workspaces  []WorkspaceSnapshot
+	// Gaps names data sources that could not be read (an inaccessible
+	// workspace, a failed opportunity/session query, ...) so a missing
+	// source is never silently presented as "no activity" (PRD FR86).
+	Gaps []string
+}
+
+// AllRefs returns every SourceRef present in the snapshot, keyed by
+// SourceRef.Key() — the allowlist synthesis output is validated against.
+func (s Snapshot) AllRefs() map[string]SourceRef {
+	out := map[string]SourceRef{}
+	for _, ws := range s.Workspaces {
+		for _, t := range ws.OpenTasks {
+			out[t.Ref.Key()] = t.Ref
+		}
+		for _, o := range ws.Opportunities {
+			out[o.Ref.Key()] = o.Ref
+		}
+		for _, st := range ws.ScheduledTasks {
+			out[st.Ref.Key()] = st.Ref
+		}
+		for _, sess := range ws.RecentSessions {
+			out[sess.Ref.Key()] = sess.Ref
+		}
+	}
+	return out
+}
+
+// WorkspaceSource is the narrow workspace-listing contract the snapshot
+// builder needs. workspace.Store (the folder-backed store already wired in
+// production) satisfies it.
+type WorkspaceSource interface {
+	Get(id string) (*workspace.Workspace, error)
+	ListActive() ([]*workspace.Workspace, error)
+}
+
+// OpportunitySource is the narrow Action Center contract needed here.
+// workspace.OpportunityStore satisfies it.
+type OpportunitySource interface {
+	List(workspaceID string) ([]workspace.Opportunity, error)
+}
+
+// SessionSource is the narrow session-listing contract needed here.
+// session.HybridStore satisfies it.
+type SessionSource interface {
+	ListSessions(ctx context.Context, filter *session.SessionFilter, opts *session.ListOptions) ([]session.SessionListItem, error)
+}
+
+// SnapshotSources bundles the read-only dependencies BuildSnapshot needs.
+// Any field may be nil; a nil source degrades to a named gap rather than a
+// panic or a silently-empty section (PRD FR136).
+type SnapshotSources struct {
+	Workspaces    WorkspaceSource
+	Opportunities OpportunitySource
+	Sessions      SessionSource
+}
+
+func isGroupWorkspace(ws *workspace.Workspace) bool {
+	return strings.EqualFold(strings.TrimSpace(ws.Kind), "group")
+}
+
+func isOpenTaskStatus(status workspace.TaskStatus) bool {
+	switch status {
+	case workspace.TaskStatusPending, workspace.TaskStatusAssigned, workspace.TaskStatusInProgress,
+		workspace.TaskStatusWaitingForChoice, workspace.TaskStatusFailed, workspace.TaskStatusTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// BuildSnapshot assembles the bounded cross-workspace projection for
+// userID/cfg. It applies the same eligibility rules as workspace navigation
+// (current-user access, non-group, active status) plus the config's scope
+// (all vs. selected) and future-workspace-inclusion choice (PRD FR106-111,
+// task 6.2):
+//   - Scope=Selected: only cfg.SelectedWorkspaceIDs, regardless of
+//     IncludeFutureWorkspaces (an explicit list has nothing to "include
+//     automatically").
+//   - Scope=All + IncludeFutureWorkspaces=true (default): every eligible
+//     active workspace, including ones created after the config was last
+//     saved — no special handling needed, since "all" already means all.
+//   - Scope=All + IncludeFutureWorkspaces=false: frozen to the workspaces
+//     that existed when the config was last saved (CreatedAt <=
+//     cfg.UpdatedAt), so a workspace created afterward is excluded until the
+//     user opts back in — proving inclusion is never silent (PRD FR110).
+func BuildSnapshot(ctx context.Context, sources SnapshotSources, cfg Config, userID string, now time.Time) Snapshot {
+	snap := Snapshot{GeneratedAt: now}
+	if sources.Workspaces == nil {
+		snap.Gaps = append(snap.Gaps, "workspace data is unavailable")
+		return snap
+	}
+
+	var candidates []*workspace.Workspace
+	if cfg.Scope == ScopeSelected {
+		for _, id := range cfg.SelectedWorkspaceIDs {
+			ws, err := sources.Workspaces.Get(id)
+			if err != nil || ws == nil {
+				snap.Gaps = append(snap.Gaps, fmt.Sprintf("workspace %s is unavailable", id))
+				continue
+			}
+			candidates = append(candidates, ws)
+		}
+	} else {
+		all, err := sources.Workspaces.ListActive()
+		if err != nil {
+			snap.Gaps = append(snap.Gaps, "workspace list is unavailable")
+			return snap
+		}
+		candidates = all
+	}
+
+	for _, ws := range candidates {
+		if ws == nil || isGroupWorkspace(ws) || ws.Status != workspace.StatusActive {
+			continue
+		}
+		if ws.OwnerUserID != "" && ws.OwnerUserID != userID {
+			continue
+		}
+		if cfg.Scope == ScopeAll && !cfg.IncludeFutureWorkspaces && !cfg.UpdatedAt.IsZero() && ws.CreatedAt.After(cfg.UpdatedAt) {
+			continue
+		}
+		wsSnap, gaps := buildWorkspaceSnapshot(ctx, sources, ws)
+		snap.Workspaces = append(snap.Workspaces, wsSnap)
+		snap.Gaps = append(snap.Gaps, gaps...)
+	}
+	return snap
+}
+
+func buildWorkspaceSnapshot(ctx context.Context, sources SnapshotSources, ws *workspace.Workspace) (WorkspaceSnapshot, []string) {
+	out := WorkspaceSnapshot{WorkspaceID: ws.ID, Name: ws.Name, AgentCount: len(ws.AgentInstances)}
+	var gaps []string
+
+	for _, task := range ws.Tasks {
+		if !isOpenTaskStatus(task.Status) {
+			continue
+		}
+		out.OpenTasks = append(out.OpenTasks, TaskSnapshot{
+			Ref:           SourceRef{WorkspaceID: ws.ID, EntityType: "task", EntityID: task.ID, Timestamp: task.CreatedAt},
+			Description:   task.Description,
+			Status:        string(task.Status),
+			AssignedAgent: task.To,
+			Priority:      task.Priority,
+		})
+	}
+	sort.Slice(out.OpenTasks, func(i, j int) bool { return out.OpenTasks[i].Ref.Timestamp.After(out.OpenTasks[j].Ref.Timestamp) })
+	if len(out.OpenTasks) > maxTasksPerWorkspace {
+		out.OpenTasks = out.OpenTasks[:maxTasksPerWorkspace]
+	}
+
+	for _, st := range ws.ScheduledTasks {
+		nextRun, lastRun := st.NextRun, st.LastRun
+		out.ScheduledTasks = append(out.ScheduledTasks, ScheduledTaskSnapshot{
+			Ref:          SourceRef{WorkspaceID: ws.ID, EntityType: "scheduled_task", EntityID: st.ID, Timestamp: st.UpdatedAt},
+			Name:         st.Name,
+			Enabled:      st.Enabled,
+			FailureCount: st.FailureCount,
+			LastError:    st.LastError,
+			NextRun:      nextRun,
+			LastRun:      lastRun,
+		})
+	}
+
+	if sources.Opportunities != nil {
+		opps, err := sources.Opportunities.List(ws.ID)
+		if err != nil {
+			gaps = append(gaps, fmt.Sprintf("opportunities for workspace %s are unavailable", ws.Name))
+		} else {
+			for _, o := range opps {
+				if !o.IsOpen() {
+					continue
+				}
+				out.Opportunities = append(out.Opportunities, OpportunitySnapshot{
+					Ref:      SourceRef{WorkspaceID: ws.ID, EntityType: "opportunity", EntityID: o.ID, Timestamp: o.UpdatedAt},
+					Title:    o.Title,
+					Priority: o.Priority,
+					Status:   string(o.Status),
+				})
+			}
+			sort.Slice(out.Opportunities, func(i, j int) bool {
+				return opportunityPriorityRank(out.Opportunities[i].Priority) > opportunityPriorityRank(out.Opportunities[j].Priority)
+			})
+			if len(out.Opportunities) > maxOpportunitiesPerWorkspace {
+				out.Opportunities = out.Opportunities[:maxOpportunitiesPerWorkspace]
+			}
+		}
+	} else {
+		gaps = append(gaps, fmt.Sprintf("opportunities for workspace %s are unavailable", ws.Name))
+	}
+
+	if sources.Sessions != nil {
+		folderID := ws.ID
+		items, err := sources.Sessions.ListSessions(ctx, &session.SessionFilter{FolderID: &folderID}, &session.ListOptions{
+			Limit: maxSessionsPerWorkspace, Sort: session.SortByUpdatedDesc,
+		})
+		if err != nil {
+			gaps = append(gaps, fmt.Sprintf("recent sessions for workspace %s are unavailable", ws.Name))
+		} else {
+			for _, item := range items {
+				out.RecentSessions = append(out.RecentSessions, SessionSnapshot{
+					Ref:          SourceRef{WorkspaceID: ws.ID, EntityType: "session", EntityID: item.ID, Timestamp: item.UpdatedAt},
+					Title:        item.Title,
+					Preview:      item.Preview,
+					AgentName:    item.AgentName,
+					MessageCount: item.MessageCount,
+					UpdatedAt:    item.UpdatedAt,
+				})
+			}
+		}
+	} else {
+		gaps = append(gaps, fmt.Sprintf("recent sessions for workspace %s are unavailable", ws.Name))
+	}
+
+	return out, gaps
+}
+
+func opportunityPriorityRank(p string) int {
+	switch strings.ToLower(strings.TrimSpace(p)) {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/dailybrief/snapshot_test.go
+++ b/internal/dailybrief/snapshot_test.go
@@ -1,0 +1,223 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+type fakeOpportunitySource struct {
+	byWorkspace map[string][]workspace.Opportunity
+	err         error
+}
+
+func (f *fakeOpportunitySource) List(workspaceID string) ([]workspace.Opportunity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byWorkspace[workspaceID], nil
+}
+
+type fakeSessionSource struct {
+	byWorkspace map[string][]session.SessionListItem
+	err         error
+}
+
+func (f *fakeSessionSource) ListSessions(ctx context.Context, filter *session.SessionFilter, opts *session.ListOptions) ([]session.SessionListItem, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if filter == nil || filter.FolderID == nil {
+		return nil, nil
+	}
+	items := f.byWorkspace[*filter.FolderID]
+	if opts != nil && opts.Limit > 0 && len(items) > opts.Limit {
+		items = items[:opts.Limit]
+	}
+	return items, nil
+}
+
+func newTestWorkspace(id, name, kind string, status workspace.WorkspaceStatus, owner string) *workspace.Workspace {
+	return &workspace.Workspace{
+		ID: id, Name: name, Kind: kind, Status: status, OwnerUserID: owner,
+		CreatedAt: time.Now(),
+	}
+}
+
+func TestBuildSnapshot_ExcludesGroupsAndInactiveWorkspaces(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	_ = store.Save(newTestWorkspace("ws-active", "Active", "workspace", workspace.StatusActive, "local"))
+	_ = store.Save(newTestWorkspace("ws-group", "Group", "group", workspace.StatusActive, "local"))
+	_ = store.Save(newTestWorkspace("ws-trashed", "Trashed", "workspace", workspace.StatusTrashed, "local"))
+
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Workspaces) != 1 || snap.Workspaces[0].WorkspaceID != "ws-active" {
+		t.Fatalf("expected only the active, non-group workspace, got %+v", snap.Workspaces)
+	}
+}
+
+func TestBuildSnapshot_ExcludesWorkspacesOwnedByAnotherUser(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	_ = store.Save(newTestWorkspace("ws-mine", "Mine", "workspace", workspace.StatusActive, "local"))
+	_ = store.Save(newTestWorkspace("ws-other", "Other", "workspace", workspace.StatusActive, "someone-else"))
+
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Workspaces) != 1 || snap.Workspaces[0].WorkspaceID != "ws-mine" {
+		t.Fatalf("expected only the user's own workspace, got %+v", snap.Workspaces)
+	}
+}
+
+func TestBuildSnapshot_SelectedScopeOnlyIncludesChosenWorkspaces(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	_ = store.Save(newTestWorkspace("ws-1", "One", "workspace", workspace.StatusActive, "local"))
+	_ = store.Save(newTestWorkspace("ws-2", "Two", "workspace", workspace.StatusActive, "local"))
+	_ = store.Save(newTestWorkspace("ws-3", "Three", "workspace", workspace.StatusActive, "local"))
+
+	cfg := Config{Scope: ScopeSelected, SelectedWorkspaceIDs: []string{"ws-1", "ws-3"}}
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, cfg, "local", time.Now())
+	if len(snap.Workspaces) != 2 {
+		t.Fatalf("expected 2 selected workspaces, got %d: %+v", len(snap.Workspaces), snap.Workspaces)
+	}
+	ids := map[string]bool{}
+	for _, ws := range snap.Workspaces {
+		ids[ws.WorkspaceID] = true
+	}
+	if !ids["ws-1"] || !ids["ws-3"] || ids["ws-2"] {
+		t.Fatalf("expected exactly ws-1 and ws-3, got %+v", ids)
+	}
+}
+
+// TestBuildSnapshot_SelectedScopeNamesGapForMissingWorkspace covers PRD
+// FR86: a selected-but-missing workspace must be named as a gap, not
+// silently dropped.
+func TestBuildSnapshot_SelectedScopeNamesGapForMissingWorkspace(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	cfg := Config{Scope: ScopeSelected, SelectedWorkspaceIDs: []string{"does-not-exist"}}
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, cfg, "local", time.Now())
+	if len(snap.Workspaces) != 0 {
+		t.Fatalf("expected no workspaces, got %+v", snap.Workspaces)
+	}
+	if len(snap.Gaps) != 1 {
+		t.Fatalf("expected exactly one named gap, got %v", snap.Gaps)
+	}
+}
+
+// TestBuildSnapshot_FutureWorkspaceInclusion covers PRD FR110/task 6.2:
+// scope=all with IncludeFutureWorkspaces=false must freeze to workspaces
+// that existed at the config's last save, excluding ones created after.
+func TestBuildSnapshot_FutureWorkspaceInclusion(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	configSavedAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	old := newTestWorkspace("ws-old", "Old", "workspace", workspace.StatusActive, "local")
+	old.CreatedAt = configSavedAt.Add(-24 * time.Hour)
+	_ = store.Save(old)
+
+	newer := newTestWorkspace("ws-new", "New", "workspace", workspace.StatusActive, "local")
+	newer.CreatedAt = configSavedAt.Add(24 * time.Hour)
+	_ = store.Save(newer)
+
+	cfgNoFuture := Config{Scope: ScopeAll, IncludeFutureWorkspaces: false, UpdatedAt: configSavedAt}
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, cfgNoFuture, "local", time.Now())
+	if len(snap.Workspaces) != 1 || snap.Workspaces[0].WorkspaceID != "ws-old" {
+		t.Fatalf("expected only the pre-existing workspace when future inclusion is off, got %+v", snap.Workspaces)
+	}
+
+	cfgWithFuture := Config{Scope: ScopeAll, IncludeFutureWorkspaces: true, UpdatedAt: configSavedAt}
+	snap = BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store}, cfgWithFuture, "local", time.Now())
+	if len(snap.Workspaces) != 2 {
+		t.Fatalf("expected both workspaces when future inclusion is on, got %+v", snap.Workspaces)
+	}
+}
+
+func TestBuildSnapshot_DegradesWithGapWhenWorkspaceSourceMissing(t *testing.T) {
+	snap := BuildSnapshot(context.Background(), SnapshotSources{}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Gaps) != 1 {
+		t.Fatalf("expected a named gap when workspace source is unavailable, got %v", snap.Gaps)
+	}
+}
+
+func TestBuildSnapshot_TruncatesTasksOpportunitiesAndSessions(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	ws := newTestWorkspace("ws-1", "One", "workspace", workspace.StatusActive, "local")
+	for i := 0; i < maxTasksPerWorkspace+10; i++ {
+		ws.Tasks = append(ws.Tasks, workspace.Task{
+			ID: "task-" + string(rune('a'+i%26)) + string(rune(i)), WorkspaceID: "ws-1",
+			Description: "task", Status: workspace.TaskStatusPending, CreatedAt: time.Now().Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	_ = store.Save(ws)
+
+	opps := make([]workspace.Opportunity, 0, maxOpportunitiesPerWorkspace+5)
+	for i := 0; i < maxOpportunitiesPerWorkspace+5; i++ {
+		opps = append(opps, workspace.Opportunity{ID: "opp-" + string(rune(i)), WorkspaceID: "ws-1", Title: "opp", Priority: "high", Status: workspace.OpportunityNew})
+	}
+	oppSource := &fakeOpportunitySource{byWorkspace: map[string][]workspace.Opportunity{"ws-1": opps}}
+
+	sessions := make([]session.SessionListItem, 0, maxSessionsPerWorkspace+5)
+	for i := 0; i < maxSessionsPerWorkspace+5; i++ {
+		sessions = append(sessions, session.SessionListItem{ID: "sess-" + string(rune(i)), Title: "s"})
+	}
+	sessSource := &fakeSessionSource{byWorkspace: map[string][]session.SessionListItem{"ws-1": sessions}}
+
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store, Opportunities: oppSource, Sessions: sessSource}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Workspaces) != 1 {
+		t.Fatalf("expected one workspace, got %d", len(snap.Workspaces))
+	}
+	wsSnap := snap.Workspaces[0]
+	if len(wsSnap.OpenTasks) != maxTasksPerWorkspace {
+		t.Errorf("expected tasks capped at %d, got %d", maxTasksPerWorkspace, len(wsSnap.OpenTasks))
+	}
+	if len(wsSnap.Opportunities) != maxOpportunitiesPerWorkspace {
+		t.Errorf("expected opportunities capped at %d, got %d", maxOpportunitiesPerWorkspace, len(wsSnap.Opportunities))
+	}
+}
+
+func TestBuildSnapshot_NamesGapsForFailingOpportunityAndSessionSources(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	_ = store.Save(newTestWorkspace("ws-1", "One", "workspace", workspace.StatusActive, "local"))
+
+	oppSource := &fakeOpportunitySource{err: errors.New("boom")}
+	sessSource := &fakeSessionSource{err: errors.New("boom")}
+
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store, Opportunities: oppSource, Sessions: sessSource}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Gaps) != 2 {
+		t.Fatalf("expected 2 named gaps (opportunities + sessions), got %v", snap.Gaps)
+	}
+}
+
+func TestBuildSnapshot_OnlyIncludesOpenOpportunities(t *testing.T) {
+	store := workspace.NewInMemoryStore()
+	_ = store.Save(newTestWorkspace("ws-1", "One", "workspace", workspace.StatusActive, "local"))
+	oppSource := &fakeOpportunitySource{byWorkspace: map[string][]workspace.Opportunity{
+		"ws-1": {
+			{ID: "open-1", WorkspaceID: "ws-1", Title: "open", Status: workspace.OpportunityNew, Priority: "high"},
+			{ID: "resolved-1", WorkspaceID: "ws-1", Title: "resolved", Status: workspace.OpportunityResolved, Priority: "high"},
+			{ID: "dismissed-1", WorkspaceID: "ws-1", Title: "dismissed", Status: workspace.OpportunityDismissed, Priority: "high"},
+		},
+	}}
+	snap := BuildSnapshot(context.Background(), SnapshotSources{Workspaces: store, Opportunities: oppSource}, Config{Scope: ScopeAll}, "local", time.Now())
+	if len(snap.Workspaces[0].Opportunities) != 1 || snap.Workspaces[0].Opportunities[0].Ref.EntityID != "open-1" {
+		t.Fatalf("expected only the open opportunity, got %+v", snap.Workspaces[0].Opportunities)
+	}
+}
+
+func TestSnapshot_AllRefsCollectsEveryEntity(t *testing.T) {
+	snap := Snapshot{Workspaces: []WorkspaceSnapshot{
+		{
+			WorkspaceID:    "ws-1",
+			OpenTasks:      []TaskSnapshot{{Ref: SourceRef{WorkspaceID: "ws-1", EntityType: "task", EntityID: "t1"}}},
+			Opportunities:  []OpportunitySnapshot{{Ref: SourceRef{WorkspaceID: "ws-1", EntityType: "opportunity", EntityID: "o1"}}},
+			ScheduledTasks: []ScheduledTaskSnapshot{{Ref: SourceRef{WorkspaceID: "ws-1", EntityType: "scheduled_task", EntityID: "st1"}}},
+			RecentSessions: []SessionSnapshot{{Ref: SourceRef{WorkspaceID: "ws-1", EntityType: "session", EntityID: "s1"}}},
+		},
+	}}
+	refs := snap.AllRefs()
+	if len(refs) != 4 {
+		t.Fatalf("expected 4 refs, got %d: %+v", len(refs), refs)
+	}
+}

--- a/internal/dailybrief/sqlite_store.go
+++ b/internal/dailybrief/sqlite_store.go
@@ -23,6 +23,38 @@ func NewSQLiteStore(db *database.DB) *SQLiteStore {
 	return &SQLiteStore{db: db}
 }
 
+// sqliteTimeLayouts are the formats a time column value might come back as
+// when scanned into a plain string rather than through the driver's own
+// time.Time conversion — which only kicks in for a direct column reference,
+// not a SQL aggregate like MAX(generated_at) (task 7 finding: modernc.org/
+// sqlite persists Go's time.Time via its default String() format, e.g.
+// "2026-07-14 22:21:34.444311 +0000 UTC", not RFC3339).
+var sqliteTimeLayouts = []string{
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05.999999999-07:00",
+}
+
+// parseSQLiteTime parses a time column value that came back as a raw string
+// (e.g. from a MAX()/MIN() aggregate), trying every known storage layout.
+// Returns the zero time.Time if none match, rather than erroring — callers
+// treat a HistorySummary with an unparsed timestamp as non-fatal.
+func parseSQLiteTime(value string) time.Time {
+	// A monotonic-clock-carrying time.Time (any value not passed through
+	// .UTC()/.Round(0) before storage) serializes with a trailing
+	// " m=+1.234" reading that no time layout can express — strip it
+	// defensively rather than requiring every caller to remember .UTC().
+	if idx := strings.Index(value, " m="); idx != -1 {
+		value = value[:idx]
+	}
+	for _, layout := range sqliteTimeLayouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
 var _ Store = (*SQLiteStore)(nil)
 
 func isUniqueConstraintError(err error) bool {
@@ -165,6 +197,19 @@ func (s *SQLiteStore) GetActiveClaim(ctx context.Context, workspaceID, localDate
 		SELECT id, workspace_id, local_date, trigger_type, status, revision_id, error, claimed_at, finished_at
 		FROM daily_brief_generation_claim
 		WHERE workspace_id = ? AND local_date = ? AND trigger_type != 'manual'
+		ORDER BY claimed_at DESC LIMIT 1
+	`, workspaceID, localDate)
+	if errors.Is(err, ErrRequestNotFound) {
+		return nil, nil
+	}
+	return claim, err
+}
+
+func (s *SQLiteStore) GetLatestClaim(ctx context.Context, workspaceID, localDate string) (*GenerationRequest, error) {
+	claim, err := s.scanClaim(ctx, `
+		SELECT id, workspace_id, local_date, trigger_type, status, revision_id, error, claimed_at, finished_at
+		FROM daily_brief_generation_claim
+		WHERE workspace_id = ? AND local_date = ?
 		ORDER BY claimed_at DESC LIMIT 1
 	`, workspaceID, localDate)
 	if errors.Is(err, ErrRequestNotFound) {
@@ -347,11 +392,7 @@ func (s *SQLiteStore) ListHistory(ctx context.Context, workspaceID string, limit
 		h.CurrentRevisionID = currentID.String
 		h.Status = GenerationStatus(status)
 		if generatedAt.Valid {
-			if t, err := time.Parse(time.RFC3339Nano, generatedAt.String); err == nil {
-				h.GeneratedAt = t
-			} else if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", generatedAt.String); err == nil {
-				h.GeneratedAt = t
-			}
+			h.GeneratedAt = parseSQLiteTime(generatedAt.String)
 		}
 		out = append(out, h)
 	}

--- a/internal/dailybrief/sqlite_store.go
+++ b/internal/dailybrief/sqlite_store.go
@@ -1,0 +1,418 @@
+package dailybrief
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/johnjallday/ori-agent/internal/database"
+)
+
+// SQLiteStore implements Store over the shared application database.
+type SQLiteStore struct {
+	db *database.DB
+}
+
+// NewSQLiteStore constructs a Daily Brief store.
+func NewSQLiteStore(db *database.DB) *SQLiteStore {
+	return &SQLiteStore{db: db}
+}
+
+var _ Store = (*SQLiteStore)(nil)
+
+func isUniqueConstraintError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint")
+}
+
+// ---- Config ----
+
+func (s *SQLiteStore) GetConfig(ctx context.Context, workspaceID string) (*Config, error) {
+	var cfg Config
+	var daysJSON, selectedJSON string
+	var scheduleEnabled, includeFuture, notify int
+	var createdAt, updatedAt time.Time
+	err := s.db.QueryRowContext(ctx, `
+		SELECT workspace_id, user_id, timezone, schedule_days, schedule_time, schedule_enabled,
+			scope, selected_workspace_ids, include_future_workspaces, notify_on_ready,
+			config_revision, created_at, updated_at
+		FROM daily_brief_config WHERE workspace_id = ?
+	`, workspaceID).Scan(
+		&cfg.WorkspaceID, &cfg.UserID, &cfg.Timezone, &daysJSON, &cfg.ScheduleTime, &scheduleEnabled,
+		&cfg.Scope, &selectedJSON, &includeFuture, &notify,
+		&cfg.ConfigRevision, &createdAt, &updatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrConfigNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get daily brief config: %w", err)
+	}
+	_ = json.Unmarshal([]byte(daysJSON), &cfg.ScheduleDays)
+	_ = json.Unmarshal([]byte(selectedJSON), &cfg.SelectedWorkspaceIDs)
+	cfg.ScheduleEnabled = scheduleEnabled != 0
+	cfg.IncludeFutureWorkspaces = includeFuture != 0
+	cfg.NotifyOnReady = notify != 0
+	cfg.CreatedAt = createdAt
+	cfg.UpdatedAt = updatedAt
+	return &cfg, nil
+}
+
+func (s *SQLiteStore) UpsertConfig(ctx context.Context, cfg *Config) error {
+	daysJSON, err := json.Marshal(emptySlice(cfg.ScheduleDays))
+	if err != nil {
+		return fmt.Errorf("failed to encode schedule days: %w", err)
+	}
+	selectedJSON, err := json.Marshal(emptySlice(cfg.SelectedWorkspaceIDs))
+	if err != nil {
+		return fmt.Errorf("failed to encode selected workspace ids: %w", err)
+	}
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO daily_brief_config
+			(workspace_id, user_id, timezone, schedule_days, schedule_time, schedule_enabled,
+			 scope, selected_workspace_ids, include_future_workspaces, notify_on_ready,
+			 config_revision, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+		ON CONFLICT(workspace_id) DO UPDATE SET
+			user_id = excluded.user_id,
+			timezone = excluded.timezone,
+			schedule_days = excluded.schedule_days,
+			schedule_time = excluded.schedule_time,
+			schedule_enabled = excluded.schedule_enabled,
+			scope = excluded.scope,
+			selected_workspace_ids = excluded.selected_workspace_ids,
+			include_future_workspaces = excluded.include_future_workspaces,
+			notify_on_ready = excluded.notify_on_ready,
+			config_revision = daily_brief_config.config_revision + 1,
+			updated_at = excluded.updated_at
+	`, cfg.WorkspaceID, cfg.UserID, cfg.Timezone, string(daysJSON), cfg.ScheduleTime, boolToInt(cfg.ScheduleEnabled),
+		string(cfg.Scope), string(selectedJSON), boolToInt(cfg.IncludeFutureWorkspaces), boolToInt(cfg.NotifyOnReady),
+		now, now)
+	if err != nil {
+		return fmt.Errorf("failed to upsert daily brief config: %w", err)
+	}
+	return nil
+}
+
+// ---- Generation claims ----
+
+func (s *SQLiteStore) ClaimGeneration(ctx context.Context, req *GenerationRequest) (*GenerationRequest, bool, error) {
+	if req.ID == "" {
+		req.ID = uuid.New().String()
+	}
+	claimedAt := req.ClaimedAt
+	if claimedAt.IsZero() {
+		claimedAt = time.Now().UTC()
+	}
+	status := req.Status
+	if status == "" {
+		status = GenerationPending
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO daily_brief_generation_claim
+			(id, workspace_id, local_date, trigger_type, status, revision_id, error, claimed_at)
+		VALUES (?, ?, ?, ?, ?, '', '', ?)
+	`, req.ID, req.WorkspaceID, req.LocalDate, string(req.Trigger), string(status), claimedAt)
+	if err == nil {
+		req.ClaimedAt = claimedAt
+		req.Status = status
+		return req, true, nil
+	}
+	if !isUniqueConstraintError(err) || req.Trigger == TriggerManual {
+		return nil, false, fmt.Errorf("failed to claim daily brief generation: %w", err)
+	}
+	// A non-manual claim already exists for this workspace/date: return it.
+	existing, getErr := s.GetActiveClaim(ctx, req.WorkspaceID, req.LocalDate)
+	if getErr != nil {
+		return nil, false, fmt.Errorf("failed to load existing daily brief claim: %w", getErr)
+	}
+	if existing == nil {
+		return nil, false, fmt.Errorf("failed to claim daily brief generation: %w", err)
+	}
+	return existing, false, nil
+}
+
+func (s *SQLiteStore) UpdateGenerationStatus(ctx context.Context, id string, status GenerationStatus, revisionID, errMsg string) error {
+	var finishedAt any
+	if status == GenerationSucceeded || status == GenerationPartial || status == GenerationFailed {
+		finishedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE daily_brief_generation_claim
+		SET status = ?, revision_id = ?, error = ?, finished_at = COALESCE(?, finished_at)
+		WHERE id = ?
+	`, string(status), revisionID, errMsg, finishedAt, id)
+	if err != nil {
+		return fmt.Errorf("failed to update daily brief generation status: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetGenerationRequest(ctx context.Context, id string) (*GenerationRequest, error) {
+	return s.scanClaim(ctx, `
+		SELECT id, workspace_id, local_date, trigger_type, status, revision_id, error, claimed_at, finished_at
+		FROM daily_brief_generation_claim WHERE id = ?
+	`, id)
+}
+
+func (s *SQLiteStore) GetActiveClaim(ctx context.Context, workspaceID, localDate string) (*GenerationRequest, error) {
+	claim, err := s.scanClaim(ctx, `
+		SELECT id, workspace_id, local_date, trigger_type, status, revision_id, error, claimed_at, finished_at
+		FROM daily_brief_generation_claim
+		WHERE workspace_id = ? AND local_date = ? AND trigger_type != 'manual'
+		ORDER BY claimed_at DESC LIMIT 1
+	`, workspaceID, localDate)
+	if errors.Is(err, ErrRequestNotFound) {
+		return nil, nil
+	}
+	return claim, err
+}
+
+func (s *SQLiteStore) scanClaim(ctx context.Context, query string, args ...any) (*GenerationRequest, error) {
+	var req GenerationRequest
+	var triggerType, status string
+	var finishedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&req.ID, &req.WorkspaceID, &req.LocalDate, &triggerType, &status, &req.RevisionID, &req.Error, &req.ClaimedAt, &finishedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrRequestNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get daily brief generation request: %w", err)
+	}
+	req.Trigger = Trigger(triggerType)
+	req.Status = GenerationStatus(status)
+	if finishedAt.Valid {
+		req.FinishedAt = finishedAt.Time
+	}
+	return &req, nil
+}
+
+// ---- Revisions ----
+
+func (s *SQLiteStore) NextRevisionNumber(ctx context.Context, workspaceID, localDate string) (int, error) {
+	var maxNum sql.NullInt64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT MAX(revision_number) FROM daily_brief_revision WHERE workspace_id = ? AND local_date = ?
+	`, workspaceID, localDate).Scan(&maxNum)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compute next revision number: %w", err)
+	}
+	if !maxNum.Valid {
+		return 1, nil
+	}
+	return int(maxNum.Int64) + 1, nil
+}
+
+func (s *SQLiteStore) CreateRevision(ctx context.Context, rev *Revision) error {
+	if rev.ID == "" {
+		rev.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	if rev.CreatedAt.IsZero() {
+		rev.CreatedAt = now
+	}
+	var sourceStart, sourceEnd, generatedAt any
+	if !rev.SourceWindowStart.IsZero() {
+		sourceStart = rev.SourceWindowStart
+	}
+	if !rev.SourceWindowEnd.IsZero() {
+		sourceEnd = rev.SourceWindowEnd
+	}
+	if !rev.GeneratedAt.IsZero() {
+		generatedAt = rev.GeneratedAt
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO daily_brief_revision
+			(id, workspace_id, user_id, local_date, revision_number, is_current, trigger_type, status,
+			 config_revision, content_json, source_window_start, source_window_end, failure_reason, generated_at, created_at)
+		VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, rev.ID, rev.WorkspaceID, rev.UserID, rev.LocalDate, rev.RevisionNumber, string(rev.Trigger), string(rev.Status),
+		rev.ConfigRevision, rev.ContentJSON, sourceStart, sourceEnd, rev.FailureReason, generatedAt, rev.CreatedAt)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return fmt.Errorf("revision %d for %s already exists: %w", rev.RevisionNumber, rev.LocalDate, err)
+		}
+		return fmt.Errorf("failed to create daily brief revision: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) SetCurrentRevision(ctx context.Context, workspaceID, revisionID string) error {
+	return s.db.InTransaction(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE daily_brief_revision SET is_current = 0 WHERE workspace_id = ? AND is_current = 1
+		`, workspaceID); err != nil {
+			return fmt.Errorf("failed to clear prior current revision: %w", err)
+		}
+		res, err := tx.ExecContext(ctx, `
+			UPDATE daily_brief_revision SET is_current = 1 WHERE id = ? AND workspace_id = ?
+		`, revisionID, workspaceID)
+		if err != nil {
+			return fmt.Errorf("failed to set current revision: %w", err)
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrRevisionNotFound
+		}
+		return nil
+	})
+}
+
+func (s *SQLiteStore) GetCurrentRevision(ctx context.Context, workspaceID string) (*Revision, error) {
+	return s.scanRevision(ctx, `
+		SELECT id, workspace_id, user_id, local_date, revision_number, is_current, trigger_type, status,
+			config_revision, content_json, source_window_start, source_window_end, failure_reason, generated_at, created_at
+		FROM daily_brief_revision WHERE workspace_id = ? AND is_current = 1
+	`, workspaceID)
+}
+
+func (s *SQLiteStore) GetRevision(ctx context.Context, id string) (*Revision, error) {
+	return s.scanRevision(ctx, `
+		SELECT id, workspace_id, user_id, local_date, revision_number, is_current, trigger_type, status,
+			config_revision, content_json, source_window_start, source_window_end, failure_reason, generated_at, created_at
+		FROM daily_brief_revision WHERE id = ?
+	`, id)
+}
+
+func (s *SQLiteStore) scanRevision(ctx context.Context, query string, args ...any) (*Revision, error) {
+	var rev Revision
+	var triggerType, status string
+	var isCurrent int
+	var sourceStart, sourceEnd, generatedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&rev.ID, &rev.WorkspaceID, &rev.UserID, &rev.LocalDate, &rev.RevisionNumber, &isCurrent, &triggerType, &status,
+		&rev.ConfigRevision, &rev.ContentJSON, &sourceStart, &sourceEnd, &rev.FailureReason, &generatedAt, &rev.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrRevisionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get daily brief revision: %w", err)
+	}
+	rev.Trigger = Trigger(triggerType)
+	rev.Status = GenerationStatus(status)
+	rev.IsCurrent = isCurrent != 0
+	if sourceStart.Valid {
+		rev.SourceWindowStart = sourceStart.Time
+	}
+	if sourceEnd.Valid {
+		rev.SourceWindowEnd = sourceEnd.Time
+	}
+	if generatedAt.Valid {
+		rev.GeneratedAt = generatedAt.Time
+	}
+	return &rev, nil
+}
+
+// ---- History & retention ----
+
+func (s *SQLiteStore) ListHistory(ctx context.Context, workspaceID string, limit int) ([]HistorySummary, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT local_date,
+			(SELECT id FROM daily_brief_revision r2
+				WHERE r2.workspace_id = r.workspace_id AND r2.local_date = r.local_date AND r2.is_current = 1
+				LIMIT 1) as current_id,
+			COUNT(*) as revision_count,
+			MAX(status) as status,
+			MAX(generated_at) as generated_at
+		FROM daily_brief_revision r
+		WHERE workspace_id = ?
+		GROUP BY local_date
+		ORDER BY local_date DESC
+		LIMIT ?
+	`, workspaceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list daily brief history: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HistorySummary
+	for rows.Next() {
+		var h HistorySummary
+		var currentID sql.NullString
+		var status string
+		var generatedAt sql.NullString
+		if err := rows.Scan(&h.LocalDate, &currentID, &h.RevisionCount, &status, &generatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan daily brief history row: %w", err)
+		}
+		h.CurrentRevisionID = currentID.String
+		h.Status = GenerationStatus(status)
+		if generatedAt.Valid {
+			if t, err := time.Parse(time.RFC3339Nano, generatedAt.String); err == nil {
+				h.GeneratedAt = t
+			} else if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", generatedAt.String); err == nil {
+				h.GeneratedAt = t
+			}
+		}
+		out = append(out, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate daily brief history: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteStore) PruneHistory(ctx context.Context, workspaceID string, keepDays int) error {
+	if keepDays <= 0 {
+		return nil
+	}
+	// Never delete the current revision, and never touch another workspace.
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM daily_brief_revision
+		WHERE workspace_id = ?
+		AND is_current = 0
+		AND local_date NOT IN (
+			SELECT local_date FROM (
+				SELECT DISTINCT local_date FROM daily_brief_revision
+				WHERE workspace_id = ?
+				ORDER BY local_date DESC
+				LIMIT ?
+			)
+		)
+	`, workspaceID, workspaceID, keepDays)
+	if err != nil {
+		return fmt.Errorf("failed to prune daily brief history: %w", err)
+	}
+	return nil
+}
+
+// ---- Notifications ----
+
+func (s *SQLiteStore) RecordNotification(ctx context.Context, revisionID, workspaceID string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO daily_brief_notification (revision_id, workspace_id, notified_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(revision_id) DO NOTHING
+	`, revisionID, workspaceID, time.Now().UTC())
+	if err != nil {
+		return false, fmt.Errorf("failed to record daily brief notification: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("failed to check daily brief notification insert: %w", err)
+	}
+	return n > 0, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func emptySlice(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}

--- a/internal/dailybrief/sqlite_store_test.go
+++ b/internal/dailybrief/sqlite_store_test.go
@@ -284,6 +284,17 @@ func TestSQLiteStore_ListHistoryCollapsesSameDayRevisions(t *testing.T) {
 	if history[0].CurrentRevisionID != "rev-2" {
 		t.Fatalf("expected current revision id rev-2, got %q", history[0].CurrentRevisionID)
 	}
+	// GeneratedAt is a MAX() aggregate, not a direct column reference, so the
+	// driver's own time.Time conversion never kicks in — it must round-trip
+	// through parseSQLiteTime instead (found live: previously always the
+	// zero value because neither prior parse layout matched modernc.org/
+	// sqlite's actual stored format).
+	if history[0].GeneratedAt.IsZero() {
+		t.Fatal("expected GeneratedAt to be parsed from the MAX(generated_at) aggregate, got the zero value")
+	}
+	if history[0].GeneratedAt.Year() < 2020 {
+		t.Fatalf("expected a plausible parsed GeneratedAt, got %v", history[0].GeneratedAt)
+	}
 }
 
 // TestSQLiteStore_PruneHistoryNeverTouchesOtherWorkspaceOrCurrent covers

--- a/internal/dailybrief/sqlite_store_test.go
+++ b/internal/dailybrief/sqlite_store_test.go
@@ -1,0 +1,408 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	db, err := database.Open(context.Background(), &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewSQLiteStore(db)
+}
+
+func TestSQLiteStore_ConfigNotFoundInitially(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.GetConfig(context.Background(), "ws-1"); !errors.Is(err, ErrConfigNotFound) {
+		t.Fatalf("expected ErrConfigNotFound, got %v", err)
+	}
+}
+
+func TestSQLiteStore_UpsertConfigRoundTripsAndIncrementsRevision(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	cfg := &Config{
+		WorkspaceID:             "ws-1",
+		UserID:                  "local",
+		Timezone:                "America/New_York",
+		ScheduleDays:            []string{"mon", "wed"},
+		ScheduleTime:            "08:30",
+		ScheduleEnabled:         true,
+		Scope:                   ScopeSelected,
+		SelectedWorkspaceIDs:    []string{"ws-2"},
+		IncludeFutureWorkspaces: false,
+		NotifyOnReady:           true,
+	}
+	if err := store.UpsertConfig(ctx, cfg); err != nil {
+		t.Fatalf("UpsertConfig: %v", err)
+	}
+	got, err := store.GetConfig(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if got.ConfigRevision != 1 {
+		t.Fatalf("expected initial config_revision 1, got %d", got.ConfigRevision)
+	}
+	if got.Timezone != "America/New_York" || got.ScheduleTime != "08:30" || !got.NotifyOnReady {
+		t.Fatalf("config did not round-trip: %#v", got)
+	}
+	if len(got.ScheduleDays) != 2 || len(got.SelectedWorkspaceIDs) != 1 {
+		t.Fatalf("slices did not round-trip: %#v", got)
+	}
+
+	// A second upsert must bump the revision, not reset it.
+	cfg.Timezone = "UTC"
+	if err := store.UpsertConfig(ctx, cfg); err != nil {
+		t.Fatalf("second UpsertConfig: %v", err)
+	}
+	got, err = store.GetConfig(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetConfig after update: %v", err)
+	}
+	if got.ConfigRevision != 2 {
+		t.Fatalf("expected config_revision 2 after update, got %d", got.ConfigRevision)
+	}
+	if got.Timezone != "UTC" {
+		t.Fatalf("expected updated timezone, got %q", got.Timezone)
+	}
+}
+
+func TestSQLiteStore_ClaimGenerationDedupesFirstOpenAndScheduled(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	first, isNew, err := store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerScheduled,
+	})
+	if err != nil || !isNew {
+		t.Fatalf("first claim: isNew=%v err=%v", isNew, err)
+	}
+
+	second, isNew, err := store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerFirstOpen,
+	})
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if isNew {
+		t.Fatal("expected the second first_open/scheduled claim for the same date to reuse the existing one")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected the same claim id returned, got %s vs %s", second.ID, first.ID)
+	}
+}
+
+func TestSQLiteStore_ClaimGenerationNeverDedupesManual(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, isNew, err := store.ClaimGeneration(ctx, &GenerationRequest{
+			WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerManual,
+		})
+		if err != nil {
+			t.Fatalf("manual claim %d: %v", i, err)
+		}
+		if !isNew {
+			t.Fatalf("manual claim %d must always be new, got isNew=false", i)
+		}
+	}
+}
+
+// TestSQLiteStore_FailedClaimAllowsRetry covers PRD 5.12: a failed scheduled
+// attempt must not permanently block a later first-open/scheduled retry for
+// the same date.
+func TestSQLiteStore_FailedClaimAllowsRetry(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	first, _, err := store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerScheduled,
+	})
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if err := store.UpdateGenerationStatus(ctx, first.ID, GenerationFailed, "", "boom"); err != nil {
+		t.Fatalf("UpdateGenerationStatus: %v", err)
+	}
+
+	retry, isNew, err := store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerFirstOpen,
+	})
+	if err != nil {
+		t.Fatalf("retry claim: %v", err)
+	}
+	if !isNew {
+		t.Fatal("expected a retry claim after a failure to be allowed (isNew=true)")
+	}
+	if retry.ID == first.ID {
+		t.Fatal("expected a distinct claim id for the retry")
+	}
+}
+
+func TestSQLiteStore_GetActiveClaimIgnoresManual(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, _, err := store.ClaimGeneration(ctx, &GenerationRequest{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: TriggerManual,
+	}); err != nil {
+		t.Fatalf("manual claim: %v", err)
+	}
+	active, err := store.GetActiveClaim(ctx, "ws-1", "2026-07-14")
+	if err != nil {
+		t.Fatalf("GetActiveClaim: %v", err)
+	}
+	if active != nil {
+		t.Fatalf("expected no active (non-manual) claim, got %#v", active)
+	}
+}
+
+func TestSQLiteStore_RevisionNumberIncrementsPerDate(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	n, err := store.NextRevisionNumber(ctx, "ws-1", "2026-07-14")
+	if err != nil || n != 1 {
+		t.Fatalf("expected first revision number 1, got %d err=%v", n, err)
+	}
+	if err := store.CreateRevision(ctx, &Revision{
+		WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", RevisionNumber: 1,
+		Trigger: TriggerScheduled, Status: GenerationSucceeded,
+	}); err != nil {
+		t.Fatalf("CreateRevision: %v", err)
+	}
+	n, err = store.NextRevisionNumber(ctx, "ws-1", "2026-07-14")
+	if err != nil || n != 2 {
+		t.Fatalf("expected next revision number 2, got %d err=%v", n, err)
+	}
+	// A different date starts back at 1.
+	n, err = store.NextRevisionNumber(ctx, "ws-1", "2026-07-15")
+	if err != nil || n != 1 {
+		t.Fatalf("expected revision number 1 for a new date, got %d err=%v", n, err)
+	}
+}
+
+func TestSQLiteStore_SetCurrentRevisionIsAtomicSingleWinner(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	rev1 := &Revision{ID: "rev-1", WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", RevisionNumber: 1, Trigger: TriggerScheduled, Status: GenerationSucceeded}
+	rev2 := &Revision{ID: "rev-2", WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", RevisionNumber: 2, Trigger: TriggerManual, Status: GenerationSucceeded}
+	if err := store.CreateRevision(ctx, rev1); err != nil {
+		t.Fatalf("CreateRevision rev1: %v", err)
+	}
+	if err := store.CreateRevision(ctx, rev2); err != nil {
+		t.Fatalf("CreateRevision rev2: %v", err)
+	}
+
+	if err := store.SetCurrentRevision(ctx, "ws-1", "rev-1"); err != nil {
+		t.Fatalf("SetCurrentRevision rev-1: %v", err)
+	}
+	current, err := store.GetCurrentRevision(ctx, "ws-1")
+	if err != nil || current.ID != "rev-1" {
+		t.Fatalf("expected rev-1 current, got %#v err=%v", current, err)
+	}
+
+	// Manual refresh: a new revision becomes current, the old one is cleared.
+	if err := store.SetCurrentRevision(ctx, "ws-1", "rev-2"); err != nil {
+		t.Fatalf("SetCurrentRevision rev-2: %v", err)
+	}
+	current, err = store.GetCurrentRevision(ctx, "ws-1")
+	if err != nil || current.ID != "rev-2" {
+		t.Fatalf("expected rev-2 current, got %#v err=%v", current, err)
+	}
+	old, err := store.GetRevision(ctx, "rev-1")
+	if err != nil {
+		t.Fatalf("GetRevision rev-1: %v", err)
+	}
+	if old.IsCurrent {
+		t.Fatal("expected rev-1 to no longer be current")
+	}
+}
+
+func TestSQLiteStore_SetCurrentRevisionUnknownIDErrors(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.SetCurrentRevision(context.Background(), "ws-1", "does-not-exist"); !errors.Is(err, ErrRevisionNotFound) {
+		t.Fatalf("expected ErrRevisionNotFound, got %v", err)
+	}
+}
+
+func TestSQLiteStore_GetCurrentRevisionNotFoundWhenNeverSet(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.GetCurrentRevision(context.Background(), "ws-1"); !errors.Is(err, ErrRevisionNotFound) {
+		t.Fatalf("expected ErrRevisionNotFound, got %v", err)
+	}
+}
+
+// TestSQLiteStore_ListHistoryCollapsesSameDayRevisions covers task 5.11.
+func TestSQLiteStore_ListHistoryCollapsesSameDayRevisions(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for i, id := range []string{"rev-1", "rev-2"} {
+		if err := store.CreateRevision(ctx, &Revision{
+			ID: id, WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", RevisionNumber: i + 1,
+			Trigger: TriggerManual, Status: GenerationSucceeded, GeneratedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("CreateRevision %s: %v", id, err)
+		}
+	}
+	if err := store.SetCurrentRevision(ctx, "ws-1", "rev-2"); err != nil {
+		t.Fatalf("SetCurrentRevision: %v", err)
+	}
+	if err := store.CreateRevision(ctx, &Revision{
+		ID: "rev-3", WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-13", RevisionNumber: 1,
+		Trigger: TriggerScheduled, Status: GenerationSucceeded, GeneratedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("CreateRevision rev-3: %v", err)
+	}
+
+	history, err := store.ListHistory(ctx, "ws-1", 30)
+	if err != nil {
+		t.Fatalf("ListHistory: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("expected 2 collapsed days, got %d: %#v", len(history), history)
+	}
+	if history[0].LocalDate != "2026-07-14" {
+		t.Fatalf("expected most recent date first, got %+v", history[0])
+	}
+	if history[0].RevisionCount != 2 {
+		t.Fatalf("expected 2026-07-14 to collapse 2 revisions, got %d", history[0].RevisionCount)
+	}
+	if history[0].CurrentRevisionID != "rev-2" {
+		t.Fatalf("expected current revision id rev-2, got %q", history[0].CurrentRevisionID)
+	}
+}
+
+// TestSQLiteStore_PruneHistoryNeverTouchesOtherWorkspaceOrCurrent covers
+// task 5.11: pruning is scoped to one workspace and never deletes the
+// current revision even if it falls outside the retention window.
+func TestSQLiteStore_PruneHistoryNeverTouchesOtherWorkspaceOrCurrent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// ws-1: 5 distinct dates, keep only 2 -> 3 pruned, but not the current one.
+	for i := 0; i < 5; i++ {
+		date := time.Date(2026, 7, 10+i, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+		id := "ws1-rev-" + date
+		if err := store.CreateRevision(ctx, &Revision{
+			ID: id, WorkspaceID: "ws-1", UserID: "local", LocalDate: date, RevisionNumber: 1,
+			Trigger: TriggerScheduled, Status: GenerationSucceeded,
+		}); err != nil {
+			t.Fatalf("CreateRevision %s: %v", id, err)
+		}
+	}
+	// Mark the OLDEST as current, to prove it survives pruning anyway.
+	if err := store.SetCurrentRevision(ctx, "ws-1", "ws1-rev-2026-07-10"); err != nil {
+		t.Fatalf("SetCurrentRevision: %v", err)
+	}
+
+	// ws-2: one revision, must be completely unaffected by pruning ws-1.
+	if err := store.CreateRevision(ctx, &Revision{
+		ID: "ws2-rev-1", WorkspaceID: "ws-2", UserID: "local", LocalDate: "2026-01-01", RevisionNumber: 1,
+		Trigger: TriggerScheduled, Status: GenerationSucceeded,
+	}); err != nil {
+		t.Fatalf("CreateRevision ws-2: %v", err)
+	}
+
+	if err := store.PruneHistory(ctx, "ws-1", 2); err != nil {
+		t.Fatalf("PruneHistory: %v", err)
+	}
+
+	history, err := store.ListHistory(ctx, "ws-1", 30)
+	if err != nil {
+		t.Fatalf("ListHistory ws-1: %v", err)
+	}
+	// The current revision's date survives even though it's outside the
+	// 2-day retention window: 3 non-current dates pruned, 2 kept + 1 current.
+	foundCurrentDate := false
+	for _, h := range history {
+		if h.LocalDate == "2026-07-10" {
+			foundCurrentDate = true
+		}
+	}
+	if !foundCurrentDate {
+		t.Fatal("expected the current revision's date to survive pruning")
+	}
+
+	other, err := store.ListHistory(ctx, "ws-2", 30)
+	if err != nil {
+		t.Fatalf("ListHistory ws-2: %v", err)
+	}
+	if len(other) != 1 {
+		t.Fatalf("expected ws-2 history untouched by pruning ws-1, got %d entries", len(other))
+	}
+}
+
+// TestSQLiteStore_ConcurrentClaimsYieldExactlyOneWinner covers task
+// 5.10/5.14: concurrent first-open and scheduled claims for the same
+// workspace/date racing against each other must still produce exactly one
+// authoritative claim at the database boundary — run with -race.
+func TestSQLiteStore_ConcurrentClaimsYieldExactlyOneWinner(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	const attempts = 8
+	results := make(chan bool, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		trigger := TriggerFirstOpen
+		if i%2 == 0 {
+			trigger = TriggerScheduled
+		}
+		wg.Add(1)
+		go func(trig Trigger) {
+			defer wg.Done()
+			_, isNew, err := store.ClaimGeneration(ctx, &GenerationRequest{
+				WorkspaceID: "ws-1", UserID: "local", LocalDate: "2026-07-14", Trigger: trig,
+			})
+			if err != nil {
+				t.Errorf("ClaimGeneration: %v", err)
+				return
+			}
+			results <- isNew
+		}(trigger)
+	}
+	wg.Wait()
+	close(results)
+
+	newCount := 0
+	for isNew := range results {
+		if isNew {
+			newCount++
+		}
+	}
+	if newCount != 1 {
+		t.Fatalf("expected exactly one winning claim out of %d concurrent attempts, got %d", attempts, newCount)
+	}
+}
+
+// TestSQLiteStore_RecordNotificationIsIdempotent covers PRD FR65.
+func TestSQLiteStore_RecordNotificationIsIdempotent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	created, err := store.RecordNotification(ctx, "rev-1", "ws-1")
+	if err != nil || !created {
+		t.Fatalf("first RecordNotification: created=%v err=%v", created, err)
+	}
+	created, err = store.RecordNotification(ctx, "rev-1", "ws-1")
+	if err != nil {
+		t.Fatalf("second RecordNotification: %v", err)
+	}
+	if created {
+		t.Fatal("expected the second RecordNotification for the same revision to be a no-op")
+	}
+}

--- a/internal/dailybrief/store.go
+++ b/internal/dailybrief/store.go
@@ -38,8 +38,15 @@ type Store interface {
 	// GetGenerationRequest returns a claim by id, or ErrRequestNotFound.
 	GetGenerationRequest(ctx context.Context, id string) (*GenerationRequest, error)
 	// GetActiveClaim returns the current non-manual claim for
-	// (workspaceID, localDate) if one exists (any status), or nil.
+	// (workspaceID, localDate) if one exists (any status), or nil. Used
+	// internally for first-open/scheduled dedup — manual refreshes are
+	// deliberately invisible here since they never dedupe.
 	GetActiveClaim(ctx context.Context, workspaceID, localDate string) (*GenerationRequest, error)
+	// GetLatestClaim returns the most recently claimed generation attempt for
+	// (workspaceID, localDate) regardless of trigger type, or nil. Unlike
+	// GetActiveClaim, this includes manual claims, so status-polling
+	// endpoints can observe a manual refresh in flight.
+	GetLatestClaim(ctx context.Context, workspaceID, localDate string) (*GenerationRequest, error)
 
 	// NextRevisionNumber returns the next monotonic revision number for
 	// (workspaceID, localDate) — 1 for the first revision of that date.

--- a/internal/dailybrief/store.go
+++ b/internal/dailybrief/store.go
@@ -1,0 +1,76 @@
+package dailybrief
+
+import (
+	"context"
+	"errors"
+)
+
+// Errors returned by Store implementations.
+var (
+	ErrConfigNotFound   = errors.New("dailybrief: config not found")
+	ErrRevisionNotFound = errors.New("dailybrief: revision not found")
+	ErrRequestNotFound  = errors.New("dailybrief: generation request not found")
+)
+
+// Store is the durable persistence contract for Daily Brief configuration,
+// generation claims, revisions, and notifications. All operations are keyed
+// by WorkspaceID (the designated HQ), never just UserID, per PRD FR68 —
+// replacing or clearing an HQ must never carry configuration or history
+// onto a different workspace.
+type Store interface {
+	// GetConfig returns the config for workspaceID, or ErrConfigNotFound.
+	GetConfig(ctx context.Context, workspaceID string) (*Config, error)
+	// UpsertConfig creates or updates the config, bumping ConfigRevision by
+	// exactly 1 on every call (the store owns the monotonic counter, not the
+	// caller) so a config revision can never be replayed or skipped.
+	UpsertConfig(ctx context.Context, cfg *Config) error
+
+	// ClaimGeneration attempts to record a new generation attempt. For
+	// TriggerFirstOpen/TriggerScheduled, this is idempotent per
+	// (workspaceID, localDate): if a non-manual, non-failed claim already
+	// exists for that date, it is returned with isNew=false instead of
+	// creating a duplicate. TriggerManual never dedupes — every call creates
+	// a new claim.
+	ClaimGeneration(ctx context.Context, req *GenerationRequest) (claim *GenerationRequest, isNew bool, err error)
+	// UpdateGenerationStatus transitions a claim to a terminal or
+	// in-progress status, optionally recording the resulting revision id.
+	UpdateGenerationStatus(ctx context.Context, id string, status GenerationStatus, revisionID, errMsg string) error
+	// GetGenerationRequest returns a claim by id, or ErrRequestNotFound.
+	GetGenerationRequest(ctx context.Context, id string) (*GenerationRequest, error)
+	// GetActiveClaim returns the current non-manual claim for
+	// (workspaceID, localDate) if one exists (any status), or nil.
+	GetActiveClaim(ctx context.Context, workspaceID, localDate string) (*GenerationRequest, error)
+
+	// NextRevisionNumber returns the next monotonic revision number for
+	// (workspaceID, localDate) — 1 for the first revision of that date.
+	NextRevisionNumber(ctx context.Context, workspaceID, localDate string) (int, error)
+	// CreateRevision persists a new revision. It never sets IsCurrent —
+	// callers use SetCurrentRevision to flip that atomically, so a
+	// revision can be persisted (for audit) even when it must not become
+	// current (e.g. a failed attempt).
+	CreateRevision(ctx context.Context, rev *Revision) error
+	// SetCurrentRevision atomically clears any prior current revision for
+	// workspaceID and marks revisionID current. The two are one statement
+	// pair inside a transaction, so no intermediate "no current revision"
+	// state is observable to a concurrent reader.
+	SetCurrentRevision(ctx context.Context, workspaceID, revisionID string) error
+	// GetCurrentRevision returns the current revision for workspaceID, or
+	// ErrRevisionNotFound if none has ever been set current.
+	GetCurrentRevision(ctx context.Context, workspaceID string) (*Revision, error)
+	// GetRevision returns a revision by id, or ErrRevisionNotFound.
+	GetRevision(ctx context.Context, id string) (*Revision, error)
+
+	// ListHistory returns up to limit HistorySummary entries for
+	// workspaceID, most recent local date first, collapsing same-day
+	// revisions to their current (or latest) one.
+	ListHistory(ctx context.Context, workspaceID string, limit int) ([]HistorySummary, error)
+	// PruneHistory deletes revisions for workspaceID older than the most
+	// recent keepDays distinct local dates. It never touches another
+	// workspace's rows and never deletes the current revision.
+	PruneHistory(ctx context.Context, workspaceID string, keepDays int) error
+
+	// RecordNotification records that an Action Center notification was
+	// created for revisionID. Idempotent: created is false if one already
+	// existed (PRD FR65 — at most one notification per revision).
+	RecordNotification(ctx context.Context, revisionID, workspaceID string) (created bool, err error)
+}

--- a/internal/dailybrief/synthesis.go
+++ b/internal/dailybrief/synthesis.go
@@ -1,0 +1,328 @@
+package dailybrief
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+// BriefContent is the structured content of one brief revision — the
+// synthesis prompt/response contract (task 6.9). Persisted verbatim as
+// Revision.ContentJSON. Facts (NeedsAttention, SinceLastBrief, Resume) and
+// suggestions (TodaysPlan's WhySuggested, SuggestedActions) are kept in
+// visibly distinct fields so a rendering layer never has to guess which is
+// which (PRD FR82, task 6.10).
+type BriefContent struct {
+	OpeningSummary   string               `json:"opening_summary"`
+	NeedsAttention   []BriefAttentionItem `json:"needs_attention"`
+	SinceLastBrief   []BriefChangeItem    `json:"since_last_brief"`
+	TodaysPlan       []BriefPlanItem      `json:"todays_plan"`
+	Resume           []BriefResumeItem    `json:"resume"`
+	SuggestedActions []BriefActionItem    `json:"suggested_actions"`
+	IsFirstBrief     bool                 `json:"is_first_brief"`
+	DataGaps         []string             `json:"data_gaps,omitempty"`
+	// Degraded is true when no model output could be used at all (model
+	// unavailable, or its entire response failed to parse/validate) and
+	// this content is the fully deterministic rendering (PRD FR87).
+	Degraded bool `json:"degraded,omitempty"`
+}
+
+// BriefAttentionItem is a Needs Attention entry. A fact: title/reason
+// describe what was observed, never a model judgment.
+type BriefAttentionItem struct {
+	Ref           SourceRef `json:"ref"`
+	Title         string    `json:"title"`
+	WorkspaceName string    `json:"workspace_name"`
+	Reason        string    `json:"reason"`
+}
+
+// BriefChangeItem is a Since Last Brief entry. Summary, when present, is
+// model-authored prose describing the change — still grounded in Ref, never
+// inventing a different entity.
+type BriefChangeItem struct {
+	Ref           SourceRef `json:"ref"`
+	Title         string    `json:"title"`
+	WorkspaceName string    `json:"workspace_name"`
+	Summary       string    `json:"summary,omitempty"`
+}
+
+// BriefPlanItem is a Today's Plan entry. Reason is the deterministic
+// classification (in_progress/due_soon); WhySuggested is the model's
+// rationale for ranking it — a suggestion, kept in its own field.
+type BriefPlanItem struct {
+	Ref           SourceRef `json:"ref"`
+	Title         string    `json:"title"`
+	WorkspaceName string    `json:"workspace_name"`
+	Reason        string    `json:"reason"`
+	WhySuggested  string    `json:"why_suggested,omitempty"`
+}
+
+// BriefResumeItem is a Resume entry. NextStep is a suggestion; LastKnownState
+// is grounded metadata (a preview), never an invented objective/decision
+// when no preview is available (PRD FR79).
+type BriefResumeItem struct {
+	Ref            SourceRef `json:"ref"`
+	Title          string    `json:"title"`
+	WorkspaceName  string    `json:"workspace_name"`
+	LastKnownState string    `json:"last_known_state,omitempty"`
+	NextStep       string    `json:"next_step,omitempty"`
+}
+
+// BriefActionItem is a direct or suggested action/deep link (PRD FR80).
+type BriefActionItem struct {
+	Ref   SourceRef `json:"ref"`
+	Label string    `json:"label"`
+	// ActionType: open_workspace | resume_session | view_schedule | retry | review_result | create_followup.
+	ActionType string `json:"action_type"`
+}
+
+// ChatCompleter is the narrow LLM contract synthesis needs. llm.Provider
+// satisfies it structurally.
+type ChatCompleter interface {
+	Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error)
+}
+
+// SnapshotResolver resolves the Snapshot and prior current revision (for
+// checkpointing) for a generation request. Injected so Synthesizer stays
+// decoupled from exactly how the caller wires workspace/session/opportunity
+// stores and prior-revision lookup.
+type SnapshotResolver func(ctx context.Context, req GenerationRequest, cfg Config) (snap Snapshot, previous *Revision, err error)
+
+// Synthesizer implements Generator: it produces grounded BriefContent from
+// a Snapshot via an LLM, validates every reference against the snapshot's
+// allowlist, and falls back to a fully deterministic rendering when the
+// model is unavailable or its output doesn't validate at all (PRD FR87,
+// task 6.11/6.12). Chat may be nil, in which case every generation is the
+// deterministic fallback — still a complete, grounded brief.
+type Synthesizer struct {
+	Model    string
+	Chat     ChatCompleter
+	Resolver SnapshotResolver
+}
+
+var _ Generator = (*Synthesizer)(nil)
+
+// Generate implements Generator.
+func (s *Synthesizer) Generate(ctx context.Context, req GenerationRequest, cfg Config) (GenerationResult, error) {
+	if s.Resolver == nil {
+		return GenerationResult{}, errors.New("dailybrief: synthesizer has no snapshot resolver configured")
+	}
+	snap, previous, err := s.Resolver(ctx, req, cfg)
+	if err != nil {
+		return GenerationResult{}, fmt.Errorf("failed to build daily brief snapshot: %w", err)
+	}
+	since, isFirstBrief := ResolveCheckpoint(previous, snap.GeneratedAt)
+	deterministic := BuildDeterministicContent(snap, since, isFirstBrief)
+	deterministic.Degraded = true
+
+	if s.Chat == nil {
+		// No model configured: the deterministic fallback IS the brief.
+		return contentToResult(deterministic, GenerationSucceeded, since, snap.GeneratedAt)
+	}
+
+	modelContent, err := s.synthesizeWithModel(ctx, snap, deterministic, isFirstBrief)
+	if err != nil {
+		// Model unavailable or its output was unusable: fall back rather
+		// than fail the whole brief (PRD FR87). Reported as partial so the
+		// caller/UI can distinguish "used the model" from "fell back".
+		return contentToResult(deterministic, GenerationPartial, since, snap.GeneratedAt)
+	}
+
+	validated, dropped := ValidateAgainstAllowlist(modelContent, snap.AllRefs())
+	validated.DataGaps = snap.Gaps
+	validated.IsFirstBrief = isFirstBrief
+	status := GenerationSucceeded
+	if dropped > 0 {
+		status = GenerationPartial
+	}
+	return contentToResult(validated, status, since, snap.GeneratedAt)
+}
+
+func contentToResult(content BriefContent, status GenerationStatus, since, generatedAt time.Time) (GenerationResult, error) {
+	data, err := json.Marshal(content)
+	if err != nil {
+		return GenerationResult{Status: GenerationFailed, FailureReason: err.Error()}, err
+	}
+	return GenerationResult{
+		ContentJSON:       string(data),
+		Status:            status,
+		SourceWindowStart: since,
+		SourceWindowEnd:   generatedAt,
+	}, nil
+}
+
+// BuildDeterministicContent renders BriefContent directly from the
+// snapshot's deterministic computations, with no model involved. Used both
+// as the no-model/failure fallback and as the grounded-facts input handed
+// to the model for polishing.
+func BuildDeterministicContent(snap Snapshot, since time.Time, isFirstBrief bool) BriefContent {
+	attention := ComputeNeedsAttention(snap)
+	plan := ComputeTodaysPlan(snap, snap.GeneratedAt)
+	changes := ComputeSinceLastBrief(snap, since)
+	resume := ComputeResumeCandidates(snap, defaultResumeLimit)
+
+	content := BriefContent{
+		OpeningSummary: deterministicOpeningSummary(attention, changes, isFirstBrief),
+		IsFirstBrief:   isFirstBrief,
+		DataGaps:       snap.Gaps,
+	}
+	for _, a := range attention {
+		content.NeedsAttention = append(content.NeedsAttention, BriefAttentionItem{
+			Ref: a.Ref, Title: a.Title, WorkspaceName: a.WorkspaceName, Reason: a.Reason,
+		})
+	}
+	for _, c := range changes {
+		content.SinceLastBrief = append(content.SinceLastBrief, BriefChangeItem{
+			Ref: c.Ref, Title: c.Title, WorkspaceName: c.WorkspaceName,
+		})
+	}
+	for _, p := range plan {
+		content.TodaysPlan = append(content.TodaysPlan, BriefPlanItem{
+			Ref: p.Ref, Title: p.Title, WorkspaceName: p.WorkspaceName, Reason: p.Reason,
+		})
+	}
+	for _, r := range resume {
+		item := BriefResumeItem{Ref: r.Ref, Title: r.Title, WorkspaceName: r.WorkspaceName}
+		if r.HasPreview {
+			item.LastKnownState = r.Preview
+		}
+		content.Resume = append(content.Resume, item)
+	}
+	return content
+}
+
+func deterministicOpeningSummary(attention []AttentionItem, changes []ChangeItem, isFirstBrief bool) string {
+	if isFirstBrief {
+		return "This is your first Daily Brief — here's what's happening across your workspaces in the last 24 hours."
+	}
+	if len(attention) == 0 && len(changes) == 0 {
+		return "A quiet day — nothing needs your attention right now."
+	}
+	return fmt.Sprintf("%d item(s) need your attention and %d change(s) since your last brief.", len(attention), len(changes))
+}
+
+// ValidateAgainstAllowlist drops any item in content whose Ref is not
+// present in allowed, so a fabricated or unauthorized reference is never
+// persisted (PRD FR86/task 6.12). Returns the filtered content and how many
+// items were dropped.
+func ValidateAgainstAllowlist(content BriefContent, allowed map[string]SourceRef) (BriefContent, int) {
+	dropped := 0
+	valid := func(ref SourceRef) bool {
+		_, ok := allowed[ref.Key()]
+		return ok
+	}
+
+	out := BriefContent{
+		OpeningSummary: content.OpeningSummary,
+		IsFirstBrief:   content.IsFirstBrief,
+		DataGaps:       content.DataGaps,
+		Degraded:       content.Degraded,
+	}
+	for _, item := range content.NeedsAttention {
+		if valid(item.Ref) {
+			out.NeedsAttention = append(out.NeedsAttention, item)
+		} else {
+			dropped++
+		}
+	}
+	for _, item := range content.SinceLastBrief {
+		if valid(item.Ref) {
+			out.SinceLastBrief = append(out.SinceLastBrief, item)
+		} else {
+			dropped++
+		}
+	}
+	for _, item := range content.TodaysPlan {
+		if valid(item.Ref) {
+			out.TodaysPlan = append(out.TodaysPlan, item)
+		} else {
+			dropped++
+		}
+	}
+	for _, item := range content.Resume {
+		if valid(item.Ref) {
+			out.Resume = append(out.Resume, item)
+		} else {
+			dropped++
+		}
+	}
+	for _, item := range content.SuggestedActions {
+		if valid(item.Ref) {
+			out.SuggestedActions = append(out.SuggestedActions, item)
+		} else {
+			dropped++
+		}
+	}
+	return out, dropped
+}
+
+const synthesisSystemPrompt = `You write a concise daily brief for a user from grounded facts about their workspaces.
+
+Respond with JSON only, matching this exact shape (no prose, no markdown fences):
+{
+  "opening_summary": "one or two sentences",
+  "needs_attention": [{"ref": {"workspace_id":"", "entity_type":"", "entity_id":"", "timestamp":""}, "title": "", "workspace_name": "", "reason": ""}],
+  "since_last_brief": [{"ref": {...}, "title": "", "workspace_name": "", "summary": ""}],
+  "todays_plan": [{"ref": {...}, "title": "", "workspace_name": "", "reason": "", "why_suggested": ""}],
+  "resume": [{"ref": {...}, "title": "", "workspace_name": "", "last_known_state": "", "next_step": ""}],
+  "suggested_actions": [{"ref": {...}, "label": "", "action_type": ""}]
+}
+
+Rules:
+- Only reference facts given to you below. Never invent a task, session, opportunity, or schedule that was not provided.
+- Every item's "ref" must be copied EXACTLY from the facts you were given — never fabricate or alter a ref field.
+- needs_attention: at most 5 items. todays_plan: at most 3 items.
+- If a section has nothing to report, return an empty array (or empty string for opening_summary content), not filler text.
+- Keep "reason"/"summary"/"why_suggested"/"next_step" concise (one short sentence).
+- Do not include usage/token statistics unless explicitly anomalous.`
+
+func (s *Synthesizer) synthesizeWithModel(ctx context.Context, snap Snapshot, deterministic BriefContent, isFirstBrief bool) (BriefContent, error) {
+	prompt, err := buildSynthesisUserPrompt(snap, deterministic, isFirstBrief)
+	if err != nil {
+		return BriefContent{}, err
+	}
+	resp, err := s.Chat.Chat(ctx, llm.ChatRequest{
+		Model:        s.Model,
+		SystemPrompt: synthesisSystemPrompt,
+		Messages:     []llm.Message{{Role: "user", Content: prompt}},
+		Temperature:  0.2,
+		MaxTokens:    4000,
+	})
+	if err != nil {
+		return BriefContent{}, fmt.Errorf("daily brief model call failed: %w", err)
+	}
+	text := llm.StripCodeFence(strings.TrimSpace(resp.Content))
+	var content BriefContent
+	if err := json.Unmarshal([]byte(text), &content); err != nil {
+		return BriefContent{}, fmt.Errorf("failed to parse daily brief synthesis response: %w", err)
+	}
+	return content, nil
+}
+
+// buildSynthesisUserPrompt hands the model the deterministic facts (already
+// computed and bounded) as its only source of truth, plus data gaps, so it
+// polishes prose rather than re-deriving facts itself.
+func buildSynthesisUserPrompt(snap Snapshot, deterministic BriefContent, isFirstBrief bool) (string, error) {
+	facts, err := json.Marshal(deterministic)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode daily brief facts: %w", err)
+	}
+	var b strings.Builder
+	if isFirstBrief {
+		b.WriteString("This is the user's first Daily Brief. Do not imply a previous brief existed.\n")
+	}
+	if len(snap.Gaps) > 0 {
+		b.WriteString("Data gaps (name these explicitly if relevant, never present as \"no activity\"):\n")
+		for _, g := range snap.Gaps {
+			b.WriteString("- " + g + "\n")
+		}
+	}
+	b.WriteString("Grounded facts (JSON) — your only source of truth:\n")
+	b.Write(facts)
+	return b.String(), nil
+}

--- a/internal/dailybrief/synthesis_test.go
+++ b/internal/dailybrief/synthesis_test.go
@@ -1,0 +1,248 @@
+package dailybrief
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/llm"
+)
+
+type fakeChatCompleter struct {
+	response *llm.ChatResponse
+	err      error
+	calls    int
+}
+
+func (f *fakeChatCompleter) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.response, nil
+}
+
+func sampleSnapshot(now time.Time) Snapshot {
+	return Snapshot{
+		GeneratedAt: now,
+		Workspaces: []WorkspaceSnapshot{{
+			WorkspaceID: "ws-1", Name: "Personal HQ",
+			OpenTasks: []TaskSnapshot{
+				{Ref: refAt("task", "t-failed", now), Status: "failed", Description: "Deploy failed"},
+			},
+		}},
+	}
+}
+
+func resolverFor(snap Snapshot, previous *Revision, err error) SnapshotResolver {
+	return func(ctx context.Context, req GenerationRequest, cfg Config) (Snapshot, *Revision, error) {
+		return snap, previous, err
+	}
+}
+
+func TestSynthesizer_NoChatConfiguredUsesDeterministicFallback(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	s := &Synthesizer{Resolver: resolverFor(snap, nil, nil)}
+
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if result.Status != GenerationSucceeded {
+		t.Fatalf("expected succeeded status for the deterministic fallback, got %q", result.Status)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("failed to decode content: %v", err)
+	}
+	if !content.Degraded {
+		t.Fatal("expected Degraded=true when no model is configured")
+	}
+	if len(content.NeedsAttention) != 1 || content.NeedsAttention[0].Ref.EntityID != "t-failed" {
+		t.Fatalf("expected the failed task surfaced in needs_attention, got %+v", content.NeedsAttention)
+	}
+}
+
+func TestSynthesizer_ModelUnavailableFallsBackToPartial(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	s := &Synthesizer{
+		Resolver: resolverFor(snap, nil, nil),
+		Chat:     &fakeChatCompleter{err: errors.New("model unavailable")},
+	}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate should not itself error on model failure (fallback instead): %v", err)
+	}
+	if result.Status != GenerationPartial {
+		t.Fatalf("expected partial status when the model fails and a fallback is used, got %q", result.Status)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !content.Degraded {
+		t.Fatal("expected Degraded=true for the fallback content")
+	}
+}
+
+func TestSynthesizer_ModelSuccessValidatesAndSucceeds(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	modelJSON := `{
+		"opening_summary": "One thing needs attention today.",
+		"needs_attention": [{"ref": {"workspace_id":"ws-1","entity_type":"task","entity_id":"t-failed","timestamp":"` + now.Format(time.RFC3339) + `"}, "title": "Deploy failed", "workspace_name": "Personal HQ", "reason": "failed"}],
+		"since_last_brief": [],
+		"todays_plan": [],
+		"resume": [],
+		"suggested_actions": []
+	}`
+	s := &Synthesizer{
+		Resolver: resolverFor(snap, nil, nil),
+		Chat:     &fakeChatCompleter{response: &llm.ChatResponse{Content: modelJSON}},
+	}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if result.Status != GenerationSucceeded {
+		t.Fatalf("expected succeeded status, got %q", result.Status)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if content.Degraded {
+		t.Fatal("expected Degraded=false when model output was used")
+	}
+	if content.OpeningSummary != "One thing needs attention today." {
+		t.Fatalf("expected the model's opening summary to be used, got %q", content.OpeningSummary)
+	}
+}
+
+// TestSynthesizer_StripsHallucinatedReferenceAndMarksPartial covers task
+// 6.12: a model-fabricated reference (not present in the snapshot) must be
+// dropped, not persisted, and the result marked partial rather than fully
+// succeeded or fully failed.
+func TestSynthesizer_StripsHallucinatedReferenceAndMarksPartial(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	modelJSON := `{
+		"opening_summary": "Two things need attention.",
+		"needs_attention": [
+			{"ref": {"workspace_id":"ws-1","entity_type":"task","entity_id":"t-failed","timestamp":"` + now.Format(time.RFC3339) + `"}, "title": "Deploy failed", "workspace_name": "Personal HQ", "reason": "failed"},
+			{"ref": {"workspace_id":"ws-999","entity_type":"task","entity_id":"fabricated","timestamp":"` + now.Format(time.RFC3339) + `"}, "title": "Made up task", "workspace_name": "Nowhere", "reason": "failed"}
+		],
+		"since_last_brief": [], "todays_plan": [], "resume": [], "suggested_actions": []
+	}`
+	s := &Synthesizer{
+		Resolver: resolverFor(snap, nil, nil),
+		Chat:     &fakeChatCompleter{response: &llm.ChatResponse{Content: modelJSON}},
+	}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if result.Status != GenerationPartial {
+		t.Fatalf("expected partial status when a reference is stripped, got %q", result.Status)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(content.NeedsAttention) != 1 {
+		t.Fatalf("expected exactly the one valid item to survive, got %+v", content.NeedsAttention)
+	}
+	if content.NeedsAttention[0].Ref.EntityID != "t-failed" {
+		t.Fatalf("expected the fabricated item dropped and the real one kept, got %+v", content.NeedsAttention)
+	}
+}
+
+func TestSynthesizer_UnparsableModelResponseFallsBack(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	s := &Synthesizer{
+		Resolver: resolverFor(snap, nil, nil),
+		Chat:     &fakeChatCompleter{response: &llm.ChatResponse{Content: "not json at all"}},
+	}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if result.Status != GenerationPartial {
+		t.Fatalf("expected partial (fallback) status for unparsable model output, got %q", result.Status)
+	}
+}
+
+func TestSynthesizer_QuietDayProducesQuietOpeningSummary(t *testing.T) {
+	now := time.Now()
+	snap := Snapshot{GeneratedAt: now} // no workspaces, nothing happening
+	s := &Synthesizer{Resolver: resolverFor(snap, &Revision{GeneratedAt: now.Add(-24 * time.Hour)}, nil)}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if content.OpeningSummary == "" {
+		t.Fatal("expected a concise quiet-day summary, not an empty string")
+	}
+	if len(content.NeedsAttention) != 0 {
+		t.Fatalf("expected no attention items on a quiet day, got %+v", content.NeedsAttention)
+	}
+}
+
+func TestSynthesizer_FirstBriefFramingWhenNoPreviousRevision(t *testing.T) {
+	now := time.Now()
+	snap := sampleSnapshot(now)
+	s := &Synthesizer{Resolver: resolverFor(snap, nil, nil)}
+	result, err := s.Generate(context.Background(), GenerationRequest{}, Config{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var content BriefContent
+	if err := json.Unmarshal([]byte(result.ContentJSON), &content); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !content.IsFirstBrief {
+		t.Fatal("expected IsFirstBrief=true when there is no previous revision")
+	}
+}
+
+func TestSynthesizer_ResolverErrorPropagates(t *testing.T) {
+	s := &Synthesizer{Resolver: resolverFor(Snapshot{}, nil, errors.New("boom"))}
+	if _, err := s.Generate(context.Background(), GenerationRequest{}, Config{}); err == nil {
+		t.Fatal("expected the resolver's error to propagate")
+	}
+}
+
+func TestSynthesizer_NoResolverConfiguredErrors(t *testing.T) {
+	s := &Synthesizer{}
+	if _, err := s.Generate(context.Background(), GenerationRequest{}, Config{}); err == nil {
+		t.Fatal("expected an error when no resolver is configured")
+	}
+}
+
+func TestValidateAgainstAllowlist_DropsOnlyInvalidRefs(t *testing.T) {
+	allowed := map[string]SourceRef{
+		"task:ws-1:t1": {WorkspaceID: "ws-1", EntityType: "task", EntityID: "t1"},
+	}
+	content := BriefContent{
+		NeedsAttention: []BriefAttentionItem{
+			{Ref: SourceRef{WorkspaceID: "ws-1", EntityType: "task", EntityID: "t1"}, Title: "valid"},
+			{Ref: SourceRef{WorkspaceID: "ws-2", EntityType: "task", EntityID: "fake"}, Title: "invalid"},
+		},
+	}
+	got, dropped := ValidateAgainstAllowlist(content, allowed)
+	if dropped != 1 {
+		t.Fatalf("expected 1 dropped item, got %d", dropped)
+	}
+	if len(got.NeedsAttention) != 1 || got.NeedsAttention[0].Title != "valid" {
+		t.Fatalf("expected only the valid item to survive, got %+v", got.NeedsAttention)
+	}
+}

--- a/internal/dailybrief/types.go
+++ b/internal/dailybrief/types.go
@@ -1,0 +1,132 @@
+// Package dailybrief implements Daily Brief configuration, durable
+// revisions/history, and timezone-aware scheduling for the designated
+// Personal HQ workspace. Content synthesis (grounded snapshots, the actual
+// brief prose) is a separate concern layered on top in a later package —
+// this package owns storage, config, generation lifecycle/concurrency, and
+// the recurrence calculation.
+package dailybrief
+
+import "time"
+
+// Trigger identifies what caused a generation attempt.
+type Trigger string
+
+const (
+	TriggerFirstOpen Trigger = "first_open"
+	TriggerScheduled Trigger = "scheduled"
+	TriggerManual    Trigger = "manual"
+)
+
+// GenerationStatus is the lifecycle status of a single generation attempt or
+// the revision it produced.
+type GenerationStatus string
+
+const (
+	GenerationPending   GenerationStatus = "pending"
+	GenerationRunning   GenerationStatus = "running"
+	GenerationSucceeded GenerationStatus = "succeeded"
+	GenerationPartial   GenerationStatus = "partial"
+	GenerationFailed    GenerationStatus = "failed"
+)
+
+// Scope selects which workspaces a brief covers.
+type Scope string
+
+const (
+	ScopeAll      Scope = "all"
+	ScopeSelected Scope = "selected"
+)
+
+// defaultScheduleDays is Monday-Friday, matching the Build My HQ default
+// (internal/personalhq.SetupCoordinator).
+var defaultScheduleDays = []string{"mon", "tue", "wed", "thu", "fri"}
+
+// validDays is the accepted set of ScheduleDays values.
+var validDays = map[string]bool{
+	"mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": true, "sun": true,
+}
+
+// Config is the Daily Brief configuration for one HQ workspace. It is keyed
+// by WorkspaceID (the designated HQ), not just UserID, so replacing or
+// clearing the HQ designation never carries settings onto a different
+// workspace (PRD FR68) — a new HQ starts with fresh defaults.
+type Config struct {
+	WorkspaceID string
+	UserID      string
+	// Timezone is an IANA zone name, resolved via time.LoadLocation. Never
+	// derived from server-local time.Now().Location().
+	Timezone string
+	// ScheduleDays are lowercase 3-letter day codes (mon..sun).
+	ScheduleDays []string
+	// ScheduleTime is 24-hour "HH:MM" local time in Timezone.
+	ScheduleTime            string
+	ScheduleEnabled         bool
+	Scope                   Scope
+	SelectedWorkspaceIDs    []string
+	IncludeFutureWorkspaces bool
+	NotifyOnReady           bool
+	// ConfigRevision increments on every update. A Revision records the
+	// ConfigRevision that produced it, so config changes affect future
+	// generations only and never retroactively relabel prior history.
+	ConfigRevision int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// GenerationRequest is one attempt (successful or not) to produce a brief
+// for a given local calendar date. First-open and scheduled attempts dedupe
+// against each other per (WorkspaceID, LocalDate); manual never dedupes.
+type GenerationRequest struct {
+	ID          string
+	WorkspaceID string
+	UserID      string
+	// LocalDate is "YYYY-MM-DD" in the config's timezone at claim time.
+	LocalDate  string
+	Trigger    Trigger
+	Status     GenerationStatus
+	RevisionID string
+	Error      string
+	ClaimedAt  time.Time
+	FinishedAt time.Time
+}
+
+// Revision is one generated brief document for a local date. Multiple
+// revisions can exist for the same date (each manual refresh adds one);
+// IsCurrent marks the single authoritative revision for the whole
+// workspace, enforced by a partial unique database index.
+type Revision struct {
+	ID                string
+	WorkspaceID       string
+	UserID            string
+	LocalDate         string
+	RevisionNumber    int
+	IsCurrent         bool
+	Trigger           Trigger
+	Status            GenerationStatus
+	ConfigRevision    int
+	ContentJSON       string
+	SourceWindowStart time.Time
+	SourceWindowEnd   time.Time
+	FailureReason     string
+	GeneratedAt       time.Time
+	CreatedAt         time.Time
+}
+
+// HistorySummary is one calendar date's collapsed entry for the history
+// list: same-day revisions collapse to their current (or latest) one, while
+// the full revision rows remain queryable for audit/debug.
+type HistorySummary struct {
+	LocalDate         string
+	CurrentRevisionID string
+	RevisionCount     int
+	Status            GenerationStatus
+	GeneratedAt       time.Time
+}
+
+// NotificationRecord tracks whether an Action Center notification was
+// already created for a revision (at most one per revision, PRD FR65).
+type NotificationRecord struct {
+	RevisionID  string
+	WorkspaceID string
+	NotifiedAt  time.Time
+}

--- a/internal/dailybrief/types.go
+++ b/internal/dailybrief/types.go
@@ -51,43 +51,43 @@ var validDays = map[string]bool{
 // clearing the HQ designation never carries settings onto a different
 // workspace (PRD FR68) — a new HQ starts with fresh defaults.
 type Config struct {
-	WorkspaceID string
-	UserID      string
+	WorkspaceID string `json:"workspace_id"`
+	UserID      string `json:"user_id"`
 	// Timezone is an IANA zone name, resolved via time.LoadLocation. Never
 	// derived from server-local time.Now().Location().
-	Timezone string
+	Timezone string `json:"timezone"`
 	// ScheduleDays are lowercase 3-letter day codes (mon..sun).
-	ScheduleDays []string
+	ScheduleDays []string `json:"schedule_days"`
 	// ScheduleTime is 24-hour "HH:MM" local time in Timezone.
-	ScheduleTime            string
-	ScheduleEnabled         bool
-	Scope                   Scope
-	SelectedWorkspaceIDs    []string
-	IncludeFutureWorkspaces bool
-	NotifyOnReady           bool
+	ScheduleTime            string   `json:"schedule_time"`
+	ScheduleEnabled         bool     `json:"schedule_enabled"`
+	Scope                   Scope    `json:"scope"`
+	SelectedWorkspaceIDs    []string `json:"selected_workspace_ids"`
+	IncludeFutureWorkspaces bool     `json:"include_future_workspaces"`
+	NotifyOnReady           bool     `json:"notify_on_ready"`
 	// ConfigRevision increments on every update. A Revision records the
 	// ConfigRevision that produced it, so config changes affect future
 	// generations only and never retroactively relabel prior history.
-	ConfigRevision int
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ConfigRevision int       `json:"config_revision"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // GenerationRequest is one attempt (successful or not) to produce a brief
 // for a given local calendar date. First-open and scheduled attempts dedupe
 // against each other per (WorkspaceID, LocalDate); manual never dedupes.
 type GenerationRequest struct {
-	ID          string
-	WorkspaceID string
-	UserID      string
+	ID          string `json:"id"`
+	WorkspaceID string `json:"workspace_id"`
+	UserID      string `json:"user_id"`
 	// LocalDate is "YYYY-MM-DD" in the config's timezone at claim time.
-	LocalDate  string
-	Trigger    Trigger
-	Status     GenerationStatus
-	RevisionID string
-	Error      string
-	ClaimedAt  time.Time
-	FinishedAt time.Time
+	LocalDate  string           `json:"local_date"`
+	Trigger    Trigger          `json:"trigger"`
+	Status     GenerationStatus `json:"status"`
+	RevisionID string           `json:"revision_id"`
+	Error      string           `json:"error,omitempty"`
+	ClaimedAt  time.Time        `json:"claimed_at"`
+	FinishedAt time.Time        `json:"finished_at"`
 }
 
 // Revision is one generated brief document for a local date. Multiple
@@ -95,38 +95,38 @@ type GenerationRequest struct {
 // IsCurrent marks the single authoritative revision for the whole
 // workspace, enforced by a partial unique database index.
 type Revision struct {
-	ID                string
-	WorkspaceID       string
-	UserID            string
-	LocalDate         string
-	RevisionNumber    int
-	IsCurrent         bool
-	Trigger           Trigger
-	Status            GenerationStatus
-	ConfigRevision    int
-	ContentJSON       string
-	SourceWindowStart time.Time
-	SourceWindowEnd   time.Time
-	FailureReason     string
-	GeneratedAt       time.Time
-	CreatedAt         time.Time
+	ID                string           `json:"id"`
+	WorkspaceID       string           `json:"workspace_id"`
+	UserID            string           `json:"user_id"`
+	LocalDate         string           `json:"local_date"`
+	RevisionNumber    int              `json:"revision_number"`
+	IsCurrent         bool             `json:"is_current"`
+	Trigger           Trigger          `json:"trigger"`
+	Status            GenerationStatus `json:"status"`
+	ConfigRevision    int              `json:"config_revision"`
+	ContentJSON       string           `json:"content_json"`
+	SourceWindowStart time.Time        `json:"source_window_start"`
+	SourceWindowEnd   time.Time        `json:"source_window_end"`
+	FailureReason     string           `json:"failure_reason,omitempty"`
+	GeneratedAt       time.Time        `json:"generated_at"`
+	CreatedAt         time.Time        `json:"created_at"`
 }
 
 // HistorySummary is one calendar date's collapsed entry for the history
 // list: same-day revisions collapse to their current (or latest) one, while
 // the full revision rows remain queryable for audit/debug.
 type HistorySummary struct {
-	LocalDate         string
-	CurrentRevisionID string
-	RevisionCount     int
-	Status            GenerationStatus
-	GeneratedAt       time.Time
+	LocalDate         string           `json:"local_date"`
+	CurrentRevisionID string           `json:"current_revision_id"`
+	RevisionCount     int              `json:"revision_count"`
+	Status            GenerationStatus `json:"status"`
+	GeneratedAt       time.Time        `json:"generated_at"`
 }
 
 // NotificationRecord tracks whether an Action Center notification was
 // already created for a revision (at most one per revision, PRD FR65).
 type NotificationRecord struct {
-	RevisionID  string
-	WorkspaceID string
-	NotifiedAt  time.Time
+	RevisionID  string    `json:"revision_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	NotifiedAt  time.Time `json:"notified_at"`
 }

--- a/internal/dailybriefhttp/handler.go
+++ b/internal/dailybriefhttp/handler.go
@@ -1,0 +1,302 @@
+// Package dailybriefhttp exposes the Daily Brief domain (internal/dailybrief)
+// as a user-scoped HTTP API: configuration, current brief, history,
+// first-open/manual generation requests, and generation status polling.
+// Every endpoint resolves and authorizes against the caller's designated
+// Personal HQ workspace on every call (PRD task 7.1) — there is no
+// standalone "brief" identity independent of the HQ.
+package dailybriefhttp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// generationTimeout bounds a background (first-open/manual) generation
+// attempt kicked off from an HTTP request whose own context ends when the
+// response is written.
+const generationTimeout = 2 * time.Minute
+
+// ErrNoValidHQ is returned by currentHQWorkspace when the caller has no
+// valid designated Personal HQ.
+var ErrNoValidHQ = errors.New("dailybriefhttp: no valid personal hq designated")
+
+// Handler serves the Daily Brief API.
+type Handler struct {
+	service    *dailybrief.Service
+	personalHQ *personalhq.Service
+	provider   userprofile.UserProvider
+}
+
+// NewHandler constructs a Daily Brief HTTP handler. provider may be nil, in
+// which case requests resolve to the local single-user profile.
+func NewHandler(service *dailybrief.Service, personalHQ *personalhq.Service, provider userprofile.UserProvider) *Handler {
+	if provider == nil {
+		provider = userprofile.LocalUserProvider{}
+	}
+	return &Handler{service: service, personalHQ: personalHQ, provider: provider}
+}
+
+func (h *Handler) userID(ctx context.Context) (string, error) {
+	if h.provider == nil {
+		return userprofile.LocalUserID, nil
+	}
+	userID, err := h.provider.CurrentUserID(ctx)
+	if err != nil {
+		return "", err
+	}
+	if userID == "" {
+		return userprofile.LocalUserID, nil
+	}
+	return userID, nil
+}
+
+// currentHQWorkspace resolves (userID, workspaceID) for the request,
+// enforcing user/HQ authorization on every call: the caller must have a
+// valid, currently-designated Personal HQ. Returns ErrNoValidHQ otherwise
+// (a stale/missing designation is the personalhq repair flow's job, not
+// this handler's).
+func (h *Handler) currentHQWorkspace(ctx context.Context) (userID, workspaceID string, err error) {
+	userID, err = h.userID(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	status, err := h.personalHQ.Status(ctx, userID)
+	if err != nil {
+		return "", "", err
+	}
+	if !status.Valid {
+		return "", "", ErrNoValidHQ
+	}
+	return userID, status.WorkspaceID, nil
+}
+
+func respondHQError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrNoValidHQ) {
+		orihttp.NotFound(w, "no personal hq is designated")
+		return
+	}
+	orihttp.InternalError(w, "Failed to resolve personal hq: "+err.Error())
+}
+
+func (h *Handler) unavailable() bool {
+	return h == nil || h.service == nil || h.personalHQ == nil
+}
+
+// GetConfig handles GET /api/personal-hq/brief/config.
+func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	_, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	cfg, err := h.service.GetConfig(r.Context(), workspaceID)
+	if errors.Is(err, dailybrief.ErrConfigNotFound) {
+		defaults, normErr := dailybrief.NormalizeConfig(dailybrief.Config{WorkspaceID: workspaceID})
+		if normErr != nil {
+			orihttp.InternalError(w, "Failed to build default daily brief config: "+normErr.Error())
+			return
+		}
+		orihttp.Success(w, map[string]any{"config": defaults, "configured": false})
+		return
+	}
+	if err != nil {
+		orihttp.InternalError(w, "Failed to load daily brief config: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"config": cfg, "configured": true})
+}
+
+// updateConfigRequest is the PUT /api/personal-hq/brief/config body.
+type updateConfigRequest struct {
+	Timezone                string   `json:"timezone"`
+	ScheduleDays            []string `json:"schedule_days"`
+	ScheduleTime            string   `json:"schedule_time"`
+	ScheduleEnabled         *bool    `json:"schedule_enabled"`
+	Scope                   string   `json:"scope"`
+	SelectedWorkspaceIDs    []string `json:"selected_workspace_ids"`
+	IncludeFutureWorkspaces bool     `json:"include_future_workspaces"`
+	NotifyOnReady           bool     `json:"notify_on_ready"`
+}
+
+// UpdateConfig handles PUT /api/personal-hq/brief/config. Source/schedule
+// changes affect future generations only — the underlying Service/Store
+// never rewrites prior revisions (PRD 5.4).
+func (h *Handler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPut) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	userID, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	var req updateConfigRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	scheduleEnabled := true
+	if req.ScheduleEnabled != nil {
+		scheduleEnabled = *req.ScheduleEnabled
+	}
+	cfg, err := h.service.UpdateConfig(r.Context(), dailybrief.Config{
+		WorkspaceID:             workspaceID,
+		UserID:                  userID,
+		Timezone:                req.Timezone,
+		ScheduleDays:            req.ScheduleDays,
+		ScheduleTime:            req.ScheduleTime,
+		ScheduleEnabled:         scheduleEnabled,
+		Scope:                   dailybrief.Scope(req.Scope),
+		SelectedWorkspaceIDs:    req.SelectedWorkspaceIDs,
+		IncludeFutureWorkspaces: req.IncludeFutureWorkspaces,
+		NotifyOnReady:           req.NotifyOnReady,
+	})
+	if err != nil {
+		orihttp.BadRequest(w, err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"config": cfg})
+}
+
+// GetCurrent handles GET /api/personal-hq/brief/current.
+func (h *Handler) GetCurrent(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	_, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	rev, err := h.service.GetCurrent(r.Context(), workspaceID)
+	if errors.Is(err, dailybrief.ErrRevisionNotFound) {
+		orihttp.Success(w, map[string]any{"revision": nil})
+		return
+	}
+	if err != nil {
+		orihttp.InternalError(w, "Failed to load current daily brief: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"revision": rev})
+}
+
+// GetHistory handles GET /api/personal-hq/brief/history.
+func (h *Handler) GetHistory(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	_, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	history, err := h.service.GetHistory(r.Context(), workspaceID, dailybrief.MinRetentionDays)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to load daily brief history: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"history": history})
+}
+
+// GetStatus handles GET /api/personal-hq/brief/status: lets a client poll a
+// first-open/scheduled generation without blocking the request that started
+// it (PRD FR56/task 7.4).
+func (h *Handler) GetStatus(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	_, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	active, err := h.service.GetActiveGeneration(r.Context(), workspaceID)
+	if err != nil || active == nil {
+		orihttp.Success(w, map[string]any{"status": "idle"})
+		return
+	}
+	orihttp.Success(w, map[string]any{"status": string(active.Status), "revision_id": active.RevisionID})
+}
+
+// RequestFirstOpen handles POST /api/personal-hq/brief/open: the first
+// user-visible app open of a local day. Runs in the background so it never
+// blocks Home (PRD FR56/task 7.4/7.9); the client polls GetStatus/GetCurrent.
+func (h *Handler) RequestFirstOpen(w http.ResponseWriter, r *http.Request) {
+	h.requestGeneration(w, r, dailybrief.TriggerFirstOpen)
+}
+
+// RequestRefresh handles POST /api/personal-hq/brief/refresh: a manual
+// refresh, which always creates a new same-day revision (PRD FR58).
+func (h *Handler) RequestRefresh(w http.ResponseWriter, r *http.Request) {
+	h.requestGeneration(w, r, dailybrief.TriggerManual)
+}
+
+func (h *Handler) requestGeneration(w http.ResponseWriter, r *http.Request, trigger dailybrief.Trigger) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h.unavailable() {
+		orihttp.ServiceUnavailable(w, "daily brief is unavailable")
+		return
+	}
+	userID, workspaceID, err := h.currentHQWorkspace(r.Context())
+	if err != nil {
+		respondHQError(w, err)
+		return
+	}
+	// A brand-new HQ may not have explicit brief settings yet; default them
+	// rather than requiring a settings visit before the first brief can
+	// generate (PRD FR21: the default path must be completable with no
+	// extra steps).
+	if _, err := h.service.GetConfig(r.Context(), workspaceID); errors.Is(err, dailybrief.ErrConfigNotFound) {
+		if _, err := h.service.UpdateConfig(r.Context(), dailybrief.Config{WorkspaceID: workspaceID, UserID: userID}); err != nil {
+			orihttp.InternalError(w, "Failed to initialize daily brief config: "+err.Error())
+			return
+		}
+	}
+
+	// Detached from the request's context (which ends when this handler
+	// returns) with its own bound, so generation keeps running in the
+	// background rather than blocking this response.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), generationTimeout)
+		defer cancel()
+		if _, err := h.service.RequestGenerationNow(ctx, workspaceID, userID, trigger); err != nil &&
+			!errors.Is(err, dailybrief.ErrGenerationInProgress) {
+			logger.Warn("dailybriefhttp: background generation failed", logger.Fields{
+				"workspace_id": workspaceID, "trigger": string(trigger), "error": err,
+			})
+		}
+	}()
+	_ = orihttp.RespondJSON(w, http.StatusAccepted, map[string]any{"status": "pending"})
+}

--- a/internal/dailybriefhttp/handler_test.go
+++ b/internal/dailybriefhttp/handler_test.go
@@ -1,0 +1,213 @@
+package dailybriefhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// fakeGenerator is a minimal dailybrief.Generator for HTTP-layer tests.
+type fakeGenerator struct{}
+
+func (fakeGenerator) Generate(ctx context.Context, req dailybrief.GenerationRequest, cfg dailybrief.Config) (dailybrief.GenerationResult, error) {
+	return dailybrief.GenerationResult{Status: dailybrief.GenerationSucceeded, ContentJSON: `{"opening_summary":"ok"}`}, nil
+}
+
+func newTestHandler(t *testing.T) (*Handler, *personalhq.Service, *session.SQLiteStore) {
+	t.Helper()
+	db, err := database.Open(context.Background(), &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	profiles := userprofile.NewSQLiteStore(db)
+	workspaces := session.NewSQLiteStore(db)
+	hq := personalhq.NewService(profiles, workspaces)
+
+	briefStore := dailybrief.NewSQLiteStore(db)
+	briefSvc := dailybrief.NewService(briefStore, fakeGenerator{})
+
+	handler := NewHandler(briefSvc, hq, userprofile.LocalUserProvider{})
+	return handler, hq, workspaces
+}
+
+func designateHQ(t *testing.T, hq *personalhq.Service, workspaces *session.SQLiteStore, workspaceID string) {
+	t.Helper()
+	ctx := context.Background()
+	ws := &session.Workspace{
+		ID: workspaceID, Name: workspaceID, Kind: session.WorkspaceKindWorkspace,
+		OwnerUserID: userprofile.LocalUserID, Status: session.WorkspaceStatusActive,
+	}
+	if err := workspaces.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if _, err := hq.Designate(ctx, userprofile.LocalUserID, workspaceID); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+}
+
+func TestGetConfig_NoValidHQReturns404(t *testing.T) {
+	handler, _, _ := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/config", nil)
+	rec := httptest.NewRecorder()
+	handler.GetConfig(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 with no HQ designated, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetConfig_ReturnsDefaultsWhenUnconfigured(t *testing.T) {
+	handler, hq, workspaces := newTestHandler(t)
+	designateHQ(t, hq, workspaces, "ws-hq")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/config", nil)
+	rec := httptest.NewRecorder()
+	handler.GetConfig(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Config     dailybrief.Config `json:"config"`
+		Configured bool              `json:"configured"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Configured {
+		t.Fatal("expected configured=false before any config is saved")
+	}
+	if got.Config.Timezone != "UTC" {
+		t.Fatalf("expected default timezone UTC, got %q", got.Config.Timezone)
+	}
+}
+
+func TestUpdateConfigThenGetConfigRoundTrips(t *testing.T) {
+	handler, hq, workspaces := newTestHandler(t)
+	designateHQ(t, hq, workspaces, "ws-hq")
+
+	putReq := httptest.NewRequest(http.MethodPut, "/api/personal-hq/brief/config", bytes.NewBufferString(`{"timezone":"America/New_York","notify_on_ready":true}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	handler.UpdateConfig(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d body=%s", putRec.Code, putRec.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/config", nil)
+	getRec := httptest.NewRecorder()
+	handler.GetConfig(getRec, getReq)
+	var got struct {
+		Config     dailybrief.Config `json:"config"`
+		Configured bool              `json:"configured"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Configured || got.Config.Timezone != "America/New_York" || !got.Config.NotifyOnReady {
+		t.Fatalf("config did not round-trip: %#v", got)
+	}
+}
+
+func TestGetCurrent_NoRevisionYetReturnsNil(t *testing.T) {
+	handler, hq, workspaces := newTestHandler(t)
+	designateHQ(t, hq, workspaces, "ws-hq")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/current", nil)
+	rec := httptest.NewRecorder()
+	handler.GetCurrent(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Revision *dailybrief.Revision `json:"revision"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Revision != nil {
+		t.Fatalf("expected nil revision before any generation, got %#v", got.Revision)
+	}
+}
+
+// TestRequestFirstOpenGeneratesInBackgroundThenCurrentReflectsIt covers task
+// 7.4: the request returns immediately (never blocking), and the brief
+// becomes available shortly after via polling.
+func TestRequestFirstOpenGeneratesInBackgroundThenCurrentReflectsIt(t *testing.T) {
+	handler, hq, workspaces := newTestHandler(t)
+	designateHQ(t, hq, workspaces, "ws-hq")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/brief/open", nil)
+	rec := httptest.NewRecorder()
+	handler.RequestFirstOpen(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 Accepted immediately, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		getReq := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/current", nil)
+		getRec := httptest.NewRecorder()
+		handler.GetCurrent(getRec, getReq)
+		var got struct {
+			Revision *dailybrief.Revision `json:"revision"`
+		}
+		_ = json.Unmarshal(getRec.Body.Bytes(), &got)
+		if got.Revision != nil {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected the background generation to produce a current revision within the deadline")
+}
+
+func TestRequestRefresh_RejectsWrongVerb(t *testing.T) {
+	handler, _, _ := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/refresh", nil)
+	rec := httptest.NewRecorder()
+	handler.RequestRefresh(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestGetStatus_IdleWhenNothingRunning(t *testing.T) {
+	handler, hq, workspaces := newTestHandler(t)
+	designateHQ(t, hq, workspaces, "ws-hq")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/status", nil)
+	rec := httptest.NewRecorder()
+	handler.GetStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != "idle" {
+		t.Fatalf("expected idle status, got %q", got.Status)
+	}
+}
+
+func TestServiceUnavailableWhenNotConfigured(t *testing.T) {
+	handler := NewHandler(nil, nil, userprofile.LocalUserProvider{})
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/current", nil)
+	rec := httptest.NewRecorder()
+	handler.GetCurrent(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+}

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -371,6 +371,111 @@ func TestMigration028CreatesUsersAndWorkspaceOwners(t *testing.T) {
 	}
 }
 
+func TestMigration030AddsPersonalHQColumns(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := Open(ctx, &Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var workspaceID string
+	var onboardingState string
+	var updatedAt sql.NullString
+	if err := db.QueryRowContext(ctx, `
+		SELECT personal_workspace_id, hq_onboarding_state, hq_onboarding_updated_at
+		FROM users WHERE id = 'local'
+	`).Scan(&workspaceID, &onboardingState, &updatedAt); err != nil {
+		t.Fatalf("Failed to query personal HQ columns: %v", err)
+	}
+	if workspaceID != "" {
+		t.Errorf("expected empty personal_workspace_id default, got %q", workspaceID)
+	}
+	if onboardingState != "unseen" {
+		t.Errorf("expected hq_onboarding_state default 'unseen', got %q", onboardingState)
+	}
+	if updatedAt.Valid {
+		t.Errorf("expected NULL hq_onboarding_updated_at default, got %q", updatedAt.String)
+	}
+
+	if err := db.runMigration(ctx, 30); err != nil {
+		t.Fatalf("migration 30 should be idempotent: %v", err)
+	}
+}
+
+func TestMigration030UpgradesFromPriorSchema(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := os.MkdirTemp("", "ori-db-migration-030-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	legacyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open legacy database: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		t.Fatalf("Failed to create schema_migrations: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `INSERT INTO schema_migrations (version) VALUES (29)`); err != nil {
+		t.Fatalf("Failed to seed schema version 29: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			display_name TEXT NOT NULL DEFAULT '',
+			email TEXT NOT NULL DEFAULT '',
+			timezone TEXT NOT NULL DEFAULT '',
+			locale TEXT NOT NULL DEFAULT '',
+			role_category TEXT NOT NULL DEFAULT '',
+			specializations TEXT NOT NULL DEFAULT '[]',
+			preferences TEXT NOT NULL DEFAULT '{}',
+			about TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("Failed to create legacy users table: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		INSERT INTO users (id, created_at, updated_at)
+		VALUES ('local', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("Failed to seed legacy local user: %v", err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatalf("Failed to close legacy database: %v", err)
+	}
+
+	db, err := Open(ctx, &Config{Path: dbPath, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to reopen migrated database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var workspaceID, onboardingState string
+	if err := db.QueryRowContext(ctx, `
+		SELECT personal_workspace_id, hq_onboarding_state FROM users WHERE id = 'local'
+	`).Scan(&workspaceID, &onboardingState); err != nil {
+		t.Fatalf("Failed to query personal HQ columns after upgrade: %v", err)
+	}
+	if workspaceID != "" {
+		t.Errorf("expected empty personal_workspace_id after upgrade, got %q", workspaceID)
+	}
+	if onboardingState != "unseen" {
+		t.Errorf("expected hq_onboarding_state 'unseen' after upgrade, got %q", onboardingState)
+	}
+}
+
 func TestInTransaction(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -404,6 +404,93 @@ func TestMigration030AddsPersonalHQColumns(t *testing.T) {
 	}
 }
 
+func TestMigration031CreatesDailyBriefSchema(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := Open(ctx, &Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, table := range []string{"daily_brief_config", "daily_brief_revision", "daily_brief_generation_claim", "daily_brief_notification"} {
+		exists, err := db.tableExists(ctx, table)
+		if err != nil {
+			t.Fatalf("tableExists(%s): %v", table, err)
+		}
+		if !exists {
+			t.Fatalf("expected table %s to exist", table)
+		}
+	}
+
+	if err := db.runMigration(ctx, 31); err != nil {
+		t.Fatalf("migration 31 should be idempotent: %v", err)
+	}
+}
+
+// TestMigration031EnforcesAtMostOneCurrentRevisionPerWorkspace proves the
+// partial unique index (not just application logic) rejects a second
+// current revision for the same workspace.
+func TestMigration031EnforcesAtMostOneCurrentRevisionPerWorkspace(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := Open(ctx, &Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	insert := func(id string, isCurrent int) error {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO daily_brief_revision
+				(id, workspace_id, user_id, local_date, revision_number, is_current, trigger_type, status, created_at)
+			VALUES (?, 'ws-1', 'local', '2026-07-14', 1, ?, 'manual', 'succeeded', CURRENT_TIMESTAMP)
+		`, id, isCurrent)
+		return err
+	}
+	if err := insert("rev-1", 1); err != nil {
+		t.Fatalf("first current revision insert: %v", err)
+	}
+	if err := insert("rev-2", 1); err == nil {
+		t.Fatal("expected a second current revision for the same workspace to be rejected")
+	}
+}
+
+// TestMigration031DedupesNonManualClaimsButNotManual proves the partial
+// unique index allows unlimited manual claims for the same date while
+// rejecting a second first_open/scheduled claim.
+func TestMigration031DedupesNonManualClaimsButNotManual(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := Open(ctx, &Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	insertClaim := func(id, triggerType, status string) error {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO daily_brief_generation_claim
+				(id, workspace_id, local_date, trigger_type, status, claimed_at)
+			VALUES (?, 'ws-1', '2026-07-14', ?, ?, CURRENT_TIMESTAMP)
+		`, id, triggerType, status)
+		return err
+	}
+
+	if err := insertClaim("claim-1", "first_open", "succeeded"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if err := insertClaim("claim-2", "scheduled", "pending"); err == nil {
+		t.Fatal("expected a second non-manual claim for the same date to be rejected")
+	}
+	if err := insertClaim("claim-3", "manual", "succeeded"); err != nil {
+		t.Fatalf("manual claims must never be deduped: %v", err)
+	}
+	if err := insertClaim("claim-4", "manual", "succeeded"); err != nil {
+		t.Fatalf("a second manual claim for the same date must also be allowed: %v", err)
+	}
+}
+
 func TestMigration030UpgradesFromPriorSchema(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -563,6 +563,146 @@ func TestMigration030UpgradesFromPriorSchema(t *testing.T) {
 	}
 }
 
+// TestMigration030DoesNotTouchExistingWorkspaces covers PRD task 8.2: the
+// migration that adds Personal HQ support to the users table must not
+// rename, rewrite, or infer HQ status for a workspace that already existed
+// (e.g. one created from the pre-rename "Personal Ops" template) — the
+// designation lives only on the users row, and no migration in this
+// feature touches the workspaces table at all. Proves the seeded
+// workspace row is byte-identical after migrating to the latest schema,
+// and that no workspace was auto-designated as the user's HQ.
+func TestMigration030DoesNotTouchExistingWorkspaces(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := os.MkdirTemp("", "ori-db-migration-030-workspaces-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	legacyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open legacy database: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		t.Fatalf("Failed to create schema_migrations: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `INSERT INTO schema_migrations (version) VALUES (29)`); err != nil {
+		t.Fatalf("Failed to seed schema version 29: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			display_name TEXT NOT NULL DEFAULT '',
+			email TEXT NOT NULL DEFAULT '',
+			timezone TEXT NOT NULL DEFAULT '',
+			locale TEXT NOT NULL DEFAULT '',
+			role_category TEXT NOT NULL DEFAULT '',
+			specializations TEXT NOT NULL DEFAULT '[]',
+			preferences TEXT NOT NULL DEFAULT '{}',
+			about TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("Failed to create legacy users table: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		INSERT INTO users (id, created_at, updated_at)
+		VALUES ('local', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("Failed to seed legacy local user: %v", err)
+	}
+	if _, err := legacyDB.ExecContext(ctx, `
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			kind TEXT DEFAULT 'workspace',
+			description TEXT DEFAULT '',
+			tags TEXT DEFAULT '[]',
+			owner_user_id TEXT NOT NULL DEFAULT 'local',
+			parent_id TEXT,
+			color TEXT,
+			session_count INTEGER DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			agents TEXT DEFAULT '[]',
+			agent_instances TEXT DEFAULT '[]',
+			shared_data TEXT DEFAULT '{}',
+			status TEXT DEFAULT 'active',
+			layout TEXT,
+			messages_json TEXT DEFAULT '[]',
+			tasks_json TEXT DEFAULT '[]',
+			attachments_json TEXT DEFAULT '[]',
+			folders_json TEXT DEFAULT '[]',
+			scheduled_tasks_json TEXT DEFAULT '[]',
+			store_nodes_json TEXT DEFAULT '[]',
+			workflows_json TEXT DEFAULT '{}',
+			directory_references_json TEXT DEFAULT '[]',
+			mcp_bindings_json TEXT DEFAULT '[]',
+			agent_mcp_access_json TEXT DEFAULT '[]',
+			skill_bindings_json TEXT DEFAULT '[]',
+			agent_skill_access_json TEXT DEFAULT '[]',
+			order_index INTEGER DEFAULT 0,
+			FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+			FOREIGN KEY (parent_id) REFERENCES workspaces(id) ON DELETE SET NULL
+		)
+	`); err != nil {
+		t.Fatalf("Failed to create legacy workspaces table: %v", err)
+	}
+	const seededSharedData = `{"entry_agent_name":"Personal Chief of Staff","template_id":"personal-ops"}`
+	if _, err := legacyDB.ExecContext(ctx, `
+		INSERT INTO workspaces (id, name, owner_user_id, shared_data, status, created_at, updated_at)
+		VALUES ('ws-personal-ops', 'Personal Ops', 'local', ?, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, seededSharedData); err != nil {
+		t.Fatalf("Failed to seed legacy Personal Ops workspace: %v", err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatalf("Failed to close legacy database: %v", err)
+	}
+
+	db, err := Open(ctx, &Config{Path: dbPath, WALMode: false})
+	if err != nil {
+		t.Fatalf("Failed to reopen migrated database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var name, ownerUserID, sharedData, status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT name, owner_user_id, shared_data, status FROM workspaces WHERE id = 'ws-personal-ops'
+	`).Scan(&name, &ownerUserID, &sharedData, &status); err != nil {
+		t.Fatalf("Failed to query the seeded workspace after upgrade: %v", err)
+	}
+	if name != "Personal Ops" {
+		t.Errorf("expected the existing workspace's name to be untouched, got %q", name)
+	}
+	if sharedData != seededSharedData {
+		t.Errorf("expected shared_data to be byte-identical after migration, got %q", sharedData)
+	}
+	if status != "active" {
+		t.Errorf("expected status to be untouched, got %q", status)
+	}
+	if ownerUserID != "local" {
+		t.Errorf("expected owner_user_id to be untouched, got %q", ownerUserID)
+	}
+
+	var personalWorkspaceID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT personal_workspace_id FROM users WHERE id = 'local'
+	`).Scan(&personalWorkspaceID); err != nil {
+		t.Fatalf("Failed to query personal_workspace_id after upgrade: %v", err)
+	}
+	if personalWorkspaceID != "" {
+		t.Errorf("expected migration to designate zero existing workspaces as HQ, got personal_workspace_id=%q", personalWorkspaceID)
+	}
+}
+
 func TestInTransaction(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -10,7 +10,7 @@ import (
 
 // schemaVersion is the current database schema version.
 // Increment this when adding new migrations.
-const schemaVersion = 30
+const schemaVersion = 31
 
 // migrate runs all pending migrations to bring the database up to the current schema.
 func (db *DB) migrate(ctx context.Context) error {
@@ -125,6 +125,8 @@ func (db *DB) runMigration(ctx context.Context, version int) error {
 		return db.migration029WorkspaceNativeMCPOptIn(ctx)
 	case 30:
 		return db.migration030PersonalHQ(ctx)
+	case 31:
+		return db.migration031DailyBrief(ctx)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -1225,6 +1227,86 @@ func (db *DB) migration029WorkspaceNativeMCPOptIn(ctx context.Context) error {
 		ALTER TABLE workspaces ADD COLUMN allow_native_mcp_cli INTEGER NOT NULL DEFAULT 0
 	`); err != nil && !isDuplicateColumnError(err) {
 		return fmt.Errorf("failed to add workspace allow_native_mcp_cli column: %w", err)
+	}
+	return nil
+}
+
+// migration031DailyBrief creates the Daily Brief domain tables: HQ-owned
+// configuration, generation claims (in-flight/idempotency tracking),
+// revisions (the generated documents, with at most one current per
+// workspace), and notification records (at most one Action Center
+// notification per revision). Keyed by workspace_id (the designated HQ),
+// not just user_id, so replacing or clearing an HQ never carries
+// configuration or history onto a different workspace.
+func (db *DB) migration031DailyBrief(ctx context.Context) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS daily_brief_config (
+			workspace_id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			timezone TEXT NOT NULL,
+			schedule_days TEXT NOT NULL DEFAULT '[]',
+			schedule_time TEXT NOT NULL DEFAULT '08:00',
+			schedule_enabled INTEGER NOT NULL DEFAULT 1,
+			scope TEXT NOT NULL DEFAULT 'all',
+			selected_workspace_ids TEXT NOT NULL DEFAULT '[]',
+			include_future_workspaces INTEGER NOT NULL DEFAULT 1,
+			notify_on_ready INTEGER NOT NULL DEFAULT 0,
+			config_revision INTEGER NOT NULL DEFAULT 1,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS daily_brief_revision (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			user_id TEXT NOT NULL,
+			local_date TEXT NOT NULL,
+			revision_number INTEGER NOT NULL,
+			is_current INTEGER NOT NULL DEFAULT 0,
+			trigger_type TEXT NOT NULL,
+			status TEXT NOT NULL,
+			config_revision INTEGER NOT NULL DEFAULT 0,
+			content_json TEXT NOT NULL DEFAULT '',
+			source_window_start DATETIME,
+			source_window_end DATETIME,
+			failure_reason TEXT NOT NULL DEFAULT '',
+			generated_at DATETIME,
+			created_at DATETIME NOT NULL,
+			UNIQUE(workspace_id, local_date, revision_number)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_daily_brief_revision_workspace_date ON daily_brief_revision(workspace_id, local_date)`,
+		// At most one current revision per workspace, enforced at the
+		// database boundary (not just in application code).
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_brief_revision_current ON daily_brief_revision(workspace_id) WHERE is_current = 1`,
+		`CREATE TABLE IF NOT EXISTS daily_brief_generation_claim (
+			id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			local_date TEXT NOT NULL,
+			trigger_type TEXT NOT NULL,
+			status TEXT NOT NULL,
+			revision_id TEXT NOT NULL DEFAULT '',
+			error TEXT NOT NULL DEFAULT '',
+			claimed_at DATETIME NOT NULL,
+			finished_at DATETIME
+		)`,
+		// Deduplicates first-open/scheduled triggers (never manual, which may
+		// always create a new same-day revision) against each other for the
+		// same workspace/local-date, so at most one non-manual claim is ever
+		// in flight or has already succeeded for that date. A failed claim
+		// does not block a later retry.
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_brief_claim_dedupe
+			ON daily_brief_generation_claim(workspace_id, local_date)
+			WHERE trigger_type != 'manual' AND status != 'failed'`,
+		`CREATE INDEX IF NOT EXISTS idx_daily_brief_claim_workspace_date ON daily_brief_generation_claim(workspace_id, local_date)`,
+		`CREATE TABLE IF NOT EXISTS daily_brief_notification (
+			revision_id TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			notified_at DATETIME NOT NULL
+		)`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to create daily brief schema: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -10,7 +10,7 @@ import (
 
 // schemaVersion is the current database schema version.
 // Increment this when adding new migrations.
-const schemaVersion = 29
+const schemaVersion = 30
 
 // migrate runs all pending migrations to bring the database up to the current schema.
 func (db *DB) migrate(ctx context.Context) error {
@@ -123,6 +123,8 @@ func (db *DB) runMigration(ctx context.Context, version int) error {
 		return db.migration028Users(ctx)
 	case 29:
 		return db.migration029WorkspaceNativeMCPOptIn(ctx)
+	case 30:
+		return db.migration030PersonalHQ(ctx)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -1223,6 +1225,37 @@ func (db *DB) migration029WorkspaceNativeMCPOptIn(ctx context.Context) error {
 		ALTER TABLE workspaces ADD COLUMN allow_native_mcp_cli INTEGER NOT NULL DEFAULT 0
 	`); err != nil && !isDuplicateColumnError(err) {
 		return fmt.Errorf("failed to add workspace allow_native_mcp_cli column: %w", err)
+	}
+	return nil
+}
+
+// migration030PersonalHQ adds the per-user Personal HQ designation and
+// onboarding-status columns to the users table. The designation
+// (personal_workspace_id) and the onboarding status are separate columns on
+// purpose: clearing or losing the designated workspace must never reset the
+// user's onboarding history (unseen/in_progress/completed/skipped).
+func (db *DB) migration030PersonalHQ(ctx context.Context) error {
+	exists, err := db.tableExists(ctx, "users")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE users ADD COLUMN personal_workspace_id TEXT NOT NULL DEFAULT ''
+	`); err != nil && !isDuplicateColumnError(err) {
+		return fmt.Errorf("failed to add users.personal_workspace_id column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE users ADD COLUMN hq_onboarding_state TEXT NOT NULL DEFAULT 'unseen'
+	`); err != nil && !isDuplicateColumnError(err) {
+		return fmt.Errorf("failed to add users.hq_onboarding_state column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE users ADD COLUMN hq_onboarding_updated_at DATETIME
+	`); err != nil && !isDuplicateColumnError(err) {
+		return fmt.Errorf("failed to add users.hq_onboarding_updated_at column: %w", err)
 	}
 	return nil
 }

--- a/internal/onboarding/manager.go
+++ b/internal/onboarding/manager.go
@@ -291,8 +291,8 @@ func (m *Manager) SetProgression(p types.ProgressionState) error {
 	return m.saveUnlocked()
 }
 
-// cloneProgression deep-copies the completion map so callers can't mutate
-// persisted state through a shared reference.
+// cloneProgression deep-copies the completion and skip maps so callers can't
+// mutate persisted state through a shared reference.
 func cloneProgression(p types.ProgressionState) types.ProgressionState {
 	if p.CompletedQuests != nil {
 		completed := make(map[string]time.Time, len(p.CompletedQuests))
@@ -300,6 +300,13 @@ func cloneProgression(p types.ProgressionState) types.ProgressionState {
 			completed[id] = at
 		}
 		p.CompletedQuests = completed
+	}
+	if p.SkippedQuests != nil {
+		skipped := make(map[string]time.Time, len(p.SkippedQuests))
+		for id, at := range p.SkippedQuests {
+			skipped[id] = at
+		}
+		p.SkippedQuests = skipped
 	}
 	return p
 }

--- a/internal/onboarding/manager_test.go
+++ b/internal/onboarding/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/johnjallday/ori-agent/internal/database"
 	"github.com/johnjallday/ori-agent/internal/types"
@@ -89,6 +90,102 @@ func TestManager_AssistantProgress_BackwardCompatibleLoad(t *testing.T) {
 	}
 	if progress.Rank == "" {
 		t.Error("expected default rank from legacy load")
+	}
+}
+
+// TestManager_Progression_SkippedQuestsPersistenceRoundTrip covers task 3.2:
+// a per-quest skip must survive an app_state.json reload, independent of
+// CompletedQuests and Dismissed.
+func TestManager_Progression_SkippedQuestsPersistenceRoundTrip(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "app_state.json")
+	mgr := NewManager(statePath)
+
+	skippedAt := time.Now().UTC().Truncate(time.Second)
+	err := mgr.SetProgression(types.ProgressionState{
+		CompletedQuests: map[string]time.Time{"t1-first-message": skippedAt},
+		SkippedQuests:   map[string]time.Time{"t2-build-hq": skippedAt},
+		Dismissed:       false,
+	})
+	if err != nil {
+		t.Fatalf("SetProgression: %v", err)
+	}
+
+	reloaded := NewManager(statePath)
+	p := reloaded.GetProgression()
+	if len(p.SkippedQuests) != 1 || p.SkippedQuests["t2-build-hq"].IsZero() {
+		t.Fatalf("expected skipped quest to survive reload, got %#v", p.SkippedQuests)
+	}
+	if len(p.CompletedQuests) != 1 {
+		t.Fatalf("expected completed quest to survive reload independently, got %#v", p.CompletedQuests)
+	}
+}
+
+// TestManager_Progression_LegacyStateWithoutSkippedQuestsLoadsSafely covers
+// task 3.2: an app_state.json written before SkippedQuests existed (nil map)
+// must load without error and default to an unseeded state, not a nil-map
+// panic on later mutation.
+func TestManager_Progression_LegacyStateWithoutSkippedQuestsLoadsSafely(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "app_state.json")
+
+	legacyState := map[string]any{
+		"onboarding": map[string]any{"completed": true},
+		"progression": map[string]any{
+			"completed_quests": map[string]any{"t1-first-message": time.Now().UTC()},
+			// No skipped_quests key at all — pre-dates the field.
+		},
+		"version": "v0.0.1",
+	}
+	data, err := json.Marshal(legacyState)
+	if err != nil {
+		t.Fatalf("marshal legacy state: %v", err)
+	}
+	if err := os.WriteFile(statePath, data, 0o644); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	mgr := NewManager(statePath)
+	p := mgr.GetProgression()
+	if len(p.CompletedQuests) != 1 {
+		t.Fatalf("expected the pre-existing completion to load, got %#v", p.CompletedQuests)
+	}
+	if len(p.SkippedQuests) != 0 {
+		t.Fatalf("expected no skipped quests from a legacy file, got %#v", p.SkippedQuests)
+	}
+
+	// Must not panic writing through a nil-map field loaded from legacy JSON.
+	if err := mgr.SetProgression(types.ProgressionState{SkippedQuests: map[string]time.Time{"t2-build-hq": time.Now()}}); err != nil {
+		t.Fatalf("SetProgression after legacy load: %v", err)
+	}
+}
+
+// TestManager_Progression_ClonesMapsOnGetAndSet covers task 3.2: neither
+// GetProgression nor SetProgression may hand back a map the caller can
+// mutate to corrupt persisted state through a shared reference.
+func TestManager_Progression_ClonesMapsOnGetAndSet(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "app_state.json")
+	mgr := NewManager(statePath)
+
+	original := map[string]time.Time{"t2-build-hq": time.Now()}
+	if err := mgr.SetProgression(types.ProgressionState{SkippedQuests: original}); err != nil {
+		t.Fatal(err)
+	}
+	// Mutating the caller's map after Set must not affect persisted state.
+	original["t2-build-hq"] = time.Time{}
+	original["injected"] = time.Now()
+
+	got := mgr.GetProgression()
+	if _, ok := got.SkippedQuests["injected"]; ok {
+		t.Fatal("SetProgression must deep-copy the map, not alias the caller's")
+	}
+	if got.SkippedQuests["t2-build-hq"].IsZero() {
+		t.Fatal("SetProgression must not be affected by post-call mutation of the caller's map")
+	}
+
+	// Mutating the map returned by Get must not affect the manager's state.
+	got.SkippedQuests["t2-build-hq"] = time.Time{}
+	got2 := mgr.GetProgression()
+	if got2.SkippedQuests["t2-build-hq"].IsZero() {
+		t.Fatal("GetProgression must return a copy, not the internal map")
 	}
 }
 

--- a/internal/personalhq/service.go
+++ b/internal/personalhq/service.go
@@ -111,6 +111,15 @@ func (s *Status) NeedsRepair() bool {
 type Service struct {
 	profiles   ProfileStore
 	workspaces WorkspaceReader
+
+	// onDesignated fires (outside any lock) after a workspace successfully
+	// becomes the user's designated HQ, whether via Designate or Replace —
+	// which covers both "Build My HQ" (a brand new workspace) and
+	// "designate an existing workspace" in one place. Set post-construction
+	// via SetOnDesignated once the progression engine exists (mirrors
+	// smartOnboardingHandler.SetOnPersonalized in internal/server), since
+	// the engine is built after this service during server startup.
+	onDesignated func(ctx context.Context, userID, workspaceID string)
 }
 
 // NewService constructs a Personal HQ service. Both dependencies are
@@ -118,6 +127,14 @@ type Service struct {
 // to initialize (mirrors other optional-dependency handlers in this repo).
 func NewService(profiles ProfileStore, workspaces WorkspaceReader) *Service {
 	return &Service{profiles: profiles, workspaces: workspaces}
+}
+
+// SetOnDesignated registers a callback fired after a workspace becomes the
+// user's designated Personal HQ (Designate or Replace). Used to complete the
+// optional t2-build-hq progression quest without this package importing
+// internal/progression.
+func (s *Service) SetOnDesignated(fn func(ctx context.Context, userID, workspaceID string)) {
+	s.onDesignated = fn
 }
 
 // Status resolves the current Personal HQ designation and onboarding state
@@ -244,6 +261,9 @@ func (s *Service) setDesignation(ctx context.Context, userID, workspaceID string
 	}
 	if err := s.profiles.SetPersonalWorkspaceID(ctx, userID, workspaceID); err != nil {
 		return nil, err
+	}
+	if s.onDesignated != nil {
+		s.onDesignated(ctx, userID, workspaceID)
 	}
 	return s.Status(ctx, userID)
 }

--- a/internal/personalhq/service.go
+++ b/internal/personalhq/service.go
@@ -1,0 +1,276 @@
+// Package personalhq implements the Personal HQ domain service: the
+// user-scoped, zero-or-one designation of an ordinary workspace as the
+// user's personal command center, plus the durable onboarding status that
+// tracks whether the user has seen, started, finished, or skipped the guided
+// HQ setup experience.
+//
+// Personal HQ is deliberately not a new workspace kind. The designation is a
+// single field on the user's profile row (see internal/userprofile), and
+// this service is the only place that mutates or validates it.
+package personalhq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+var (
+	// ErrWorkspaceIDRequired is returned when Designate or Replace is called
+	// with an empty workspace ID. Use Clear to remove a designation.
+	ErrWorkspaceIDRequired = errors.New("personal hq: workspace id is required")
+	// ErrWorkspaceNotFound is returned when the target workspace does not exist.
+	ErrWorkspaceNotFound = errors.New("personal hq: workspace not found")
+	// ErrGroupNotEligible is returned when the target workspace is a group.
+	// Groups can contain member workspaces and are not eligible to be an HQ.
+	ErrGroupNotEligible = errors.New("personal hq: group workspaces cannot be a personal hq")
+	// ErrWorkspaceUnavailable is returned when the target workspace is
+	// trashed or missing.
+	ErrWorkspaceUnavailable = errors.New("personal hq: workspace is trashed or missing")
+	// ErrUnauthorized is returned when the target workspace belongs to a
+	// different user.
+	ErrUnauthorized = errors.New("personal hq: workspace is not accessible to this user")
+	// ErrAlreadyDesignated is returned by Designate (not Replace) when the
+	// user already has a valid HQ. Callers should use Replace with explicit
+	// confirmation instead.
+	ErrAlreadyDesignated = errors.New("personal hq: user already has a designated personal hq; use replace")
+	// ErrInvalidOnboardingState is returned when SetOnboardingState receives
+	// an unrecognized state value.
+	ErrInvalidOnboardingState = errors.New("personal hq: invalid onboarding state")
+)
+
+// Invalid-designation reasons surfaced on Status.InvalidReason. These are
+// stable strings consumed by the HTTP layer and, eventually, repair UI.
+const (
+	InvalidReasonMissing    = "missing"
+	InvalidReasonTrashed    = "trashed"
+	InvalidReasonGroup      = "group"
+	InvalidReasonWrongOwner = "wrong_owner"
+)
+
+// WorkspaceReader is the narrow workspace-lookup contract this service
+// needs. session.HybridStore and session.SQLiteStore both satisfy it.
+type WorkspaceReader interface {
+	GetWorkspace(ctx context.Context, id string) (*session.Workspace, error)
+}
+
+// ProfileStore is the focused Personal HQ persistence contract. It is
+// intentionally narrower than userprofile.UserStore so existing fakes/tests
+// built against UserStore are not forced to grow HQ-specific methods.
+// userprofile.SQLiteStore satisfies this interface.
+type ProfileStore interface {
+	GetPersonalHQState(ctx context.Context, userID string) (*userprofile.PersonalHQState, error)
+	SetPersonalWorkspaceID(ctx context.Context, userID, workspaceID string) error
+	SetHQOnboardingState(ctx context.Context, userID string, state userprofile.HQOnboardingState) error
+}
+
+// Status is the resolved, read-time view of a user's Personal HQ.
+type Status struct {
+	UserID string `json:"user_id"`
+
+	// WorkspaceID is the raw stored designation, which may be stale or
+	// invalid. It is empty when the user has no HQ designated.
+	WorkspaceID string `json:"workspace_id,omitempty"`
+
+	// Workspace is populated only when the designation resolves to an
+	// eligible, accessible workspace (Valid is true).
+	Workspace *session.Workspace `json:"workspace,omitempty"`
+
+	// Valid is true only when WorkspaceID is set and resolves to an
+	// eligible workspace. A user with no designation at all is not "valid"
+	// but is also not "invalid" — see HasDesignation/NeedsRepair.
+	Valid bool `json:"valid"`
+
+	// InvalidReason explains why a non-empty WorkspaceID failed to resolve:
+	// one of InvalidReasonMissing, InvalidReasonTrashed, InvalidReasonGroup,
+	// or InvalidReasonWrongOwner. Empty when Valid is true or there is no
+	// designation at all.
+	InvalidReason string `json:"invalid_reason,omitempty"`
+
+	OnboardingState userprofile.HQOnboardingState `json:"hq_onboarding_state"`
+}
+
+// HasDesignation reports whether the user has ever pointed at a workspace,
+// regardless of whether it currently resolves.
+func (s *Status) HasDesignation() bool {
+	return s != nil && strings.TrimSpace(s.WorkspaceID) != ""
+}
+
+// NeedsRepair reports whether the stored designation is stale (points at a
+// workspace that no longer resolves) and should surface repair actions
+// (Clear, Choose Existing, Build New) rather than a normal no-HQ state.
+func (s *Status) NeedsRepair() bool {
+	return s.HasDesignation() && !s.Valid
+}
+
+// Service is the Personal HQ domain service.
+type Service struct {
+	profiles   ProfileStore
+	workspaces WorkspaceReader
+}
+
+// NewService constructs a Personal HQ service. Both dependencies are
+// required; callers should nil-check before wiring if either store failed
+// to initialize (mirrors other optional-dependency handlers in this repo).
+func NewService(profiles ProfileStore, workspaces WorkspaceReader) *Service {
+	return &Service{profiles: profiles, workspaces: workspaces}
+}
+
+// Status resolves the current Personal HQ designation and onboarding state
+// for a user. It never errors merely because the stored designation is
+// stale (trashed/missing/deleted/group/wrong-owner) — that is reported via
+// InvalidReason so read paths like Home/Map rendering stay resilient.
+func (s *Service) Status(ctx context.Context, userID string) (*Status, error) {
+	if s == nil || s.profiles == nil {
+		return nil, errors.New("personal hq service is not configured")
+	}
+	userID = normalizeUserID(userID)
+	state, err := s.profiles.GetPersonalHQState(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := &Status{
+		UserID:          userID,
+		WorkspaceID:     state.PersonalWorkspaceID,
+		OnboardingState: userprofile.NormalizeHQOnboardingState(string(state.OnboardingState)),
+	}
+	if !out.HasDesignation() {
+		return out, nil
+	}
+	if s.workspaces == nil {
+		// Degrade rather than fail: the caller can still show onboarding
+		// state and a generic "HQ unavailable" message.
+		out.InvalidReason = InvalidReasonMissing
+		return out, nil
+	}
+	ws, wsErr := s.workspaces.GetWorkspace(ctx, out.WorkspaceID)
+	switch {
+	case errors.Is(wsErr, session.ErrWorkspaceNotFound):
+		out.InvalidReason = InvalidReasonMissing
+	case wsErr != nil:
+		return nil, wsErr
+	default:
+		if reason := ineligibleReason(ws, userID); reason != "" {
+			out.InvalidReason = reason
+		} else {
+			out.Valid = true
+			out.Workspace = ws
+		}
+	}
+	return out, nil
+}
+
+// Designate sets the Personal HQ for a user who does not currently have a
+// valid one. Callers with an existing valid HQ must use Replace, which
+// requires explicit confirmation naming both workspaces (FR37/FR38).
+func (s *Service) Designate(ctx context.Context, userID, workspaceID string) (*Status, error) {
+	userID = normalizeUserID(userID)
+	current, err := s.Status(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if current.Valid {
+		return nil, ErrAlreadyDesignated
+	}
+	return s.setDesignation(ctx, userID, workspaceID)
+}
+
+// Replace atomically switches the Personal HQ designation to a different
+// workspace, regardless of whether one is currently designated. The switch
+// is a single-column update, so no intermediate zero-HQ state is observable.
+func (s *Service) Replace(ctx context.Context, userID, workspaceID string) (*Status, error) {
+	return s.setDesignation(ctx, normalizeUserID(userID), workspaceID)
+}
+
+// Clear removes the Personal HQ designation without touching the workspace
+// itself or the user's onboarding history.
+func (s *Service) Clear(ctx context.Context, userID string) (*Status, error) {
+	if s == nil || s.profiles == nil {
+		return nil, errors.New("personal hq service is not configured")
+	}
+	userID = normalizeUserID(userID)
+	if err := s.profiles.SetPersonalWorkspaceID(ctx, userID, ""); err != nil {
+		return nil, err
+	}
+	return s.Status(ctx, userID)
+}
+
+// SetOnboardingState records a durable Personal HQ onboarding status
+// transition (unseen/in_progress/completed/skipped), independent of the
+// current designation.
+func (s *Service) SetOnboardingState(ctx context.Context, userID string, state userprofile.HQOnboardingState) (*Status, error) {
+	if s == nil || s.profiles == nil {
+		return nil, errors.New("personal hq service is not configured")
+	}
+	userID = normalizeUserID(userID)
+	if _, ok := userprofile.ParseHQOnboardingState(string(state)); !ok {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidOnboardingState, state)
+	}
+	if err := s.profiles.SetHQOnboardingState(ctx, userID, state); err != nil {
+		return nil, err
+	}
+	return s.Status(ctx, userID)
+}
+
+func (s *Service) setDesignation(ctx context.Context, userID, workspaceID string) (*Status, error) {
+	if s == nil || s.profiles == nil {
+		return nil, errors.New("personal hq service is not configured")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return nil, ErrWorkspaceIDRequired
+	}
+	if s.workspaces == nil {
+		return nil, errors.New("personal hq service has no workspace reader configured")
+	}
+	ws, err := s.workspaces.GetWorkspace(ctx, workspaceID)
+	if errors.Is(err, session.ErrWorkspaceNotFound) {
+		return nil, ErrWorkspaceNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	switch ineligibleReason(ws, userID) {
+	case InvalidReasonGroup:
+		return nil, ErrGroupNotEligible
+	case InvalidReasonTrashed, InvalidReasonMissing:
+		return nil, ErrWorkspaceUnavailable
+	case InvalidReasonWrongOwner:
+		return nil, ErrUnauthorized
+	}
+	if err := s.profiles.SetPersonalWorkspaceID(ctx, userID, workspaceID); err != nil {
+		return nil, err
+	}
+	return s.Status(ctx, userID)
+}
+
+// ineligibleReason returns the stable InvalidReason* string explaining why a
+// resolved workspace cannot be (or remain) a user's Personal HQ, or "" when
+// it is eligible.
+func ineligibleReason(ws *session.Workspace, userID string) string {
+	if ws.IsGroup() {
+		return InvalidReasonGroup
+	}
+	switch ws.Status {
+	case session.WorkspaceStatusTrashed:
+		return InvalidReasonTrashed
+	case session.WorkspaceStatusMissing:
+		return InvalidReasonMissing
+	}
+	if ws.OwnerUserID != "" && ws.OwnerUserID != userID {
+		return InvalidReasonWrongOwner
+	}
+	return ""
+}
+
+func normalizeUserID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return userprofile.LocalUserID
+	}
+	return id
+}

--- a/internal/personalhq/service.go
+++ b/internal/personalhq/service.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/userprofile"
 )
@@ -193,14 +194,30 @@ func (s *Service) Designate(ctx context.Context, userID, workspaceID string) (*S
 	if current.Valid {
 		return nil, ErrAlreadyDesignated
 	}
-	return s.setDesignation(ctx, userID, workspaceID)
+	status, err := s.setDesignation(ctx, userID, workspaceID)
+	if err == nil {
+		// Bounded, field-only observable event (PRD FR137) — no prompt,
+		// prose, or workspace content, just stable IDs.
+		logger.Info("personal hq: existing workspace designated", logger.Fields{"user_id": userID, "workspace_id": workspaceID})
+	}
+	return status, err
 }
 
 // Replace atomically switches the Personal HQ designation to a different
 // workspace, regardless of whether one is currently designated. The switch
 // is a single-column update, so no intermediate zero-HQ state is observable.
 func (s *Service) Replace(ctx context.Context, userID, workspaceID string) (*Status, error) {
-	return s.setDesignation(ctx, normalizeUserID(userID), workspaceID)
+	userID = normalizeUserID(userID)
+	previous, _ := s.Status(ctx, userID)
+	status, err := s.setDesignation(ctx, userID, workspaceID)
+	if err == nil {
+		fields := logger.Fields{"user_id": userID, "workspace_id": workspaceID}
+		if previous != nil && previous.HasDesignation() {
+			fields["previous_workspace_id"] = previous.WorkspaceID
+		}
+		logger.Info("personal hq: designation replaced", fields)
+	}
+	return status, err
 }
 
 // Clear removes the Personal HQ designation without touching the workspace
@@ -210,8 +227,12 @@ func (s *Service) Clear(ctx context.Context, userID string) (*Status, error) {
 		return nil, errors.New("personal hq service is not configured")
 	}
 	userID = normalizeUserID(userID)
+	previous, _ := s.Status(ctx, userID)
 	if err := s.profiles.SetPersonalWorkspaceID(ctx, userID, ""); err != nil {
 		return nil, err
+	}
+	if previous != nil && previous.HasDesignation() {
+		logger.Info("personal hq: designation cleared", logger.Fields{"user_id": userID, "workspace_id": previous.WorkspaceID})
 	}
 	return s.Status(ctx, userID)
 }
@@ -227,8 +248,14 @@ func (s *Service) SetOnboardingState(ctx context.Context, userID string, state u
 	if _, ok := userprofile.ParseHQOnboardingState(string(state)); !ok {
 		return nil, fmt.Errorf("%w: %q", ErrInvalidOnboardingState, state)
 	}
+	previous, _ := s.Status(ctx, userID)
 	if err := s.profiles.SetHQOnboardingState(ctx, userID, state); err != nil {
 		return nil, err
+	}
+	if previous != nil {
+		logger.Info("personal hq: onboarding state changed", logger.Fields{
+			"user_id": userID, "from": string(previous.OnboardingState), "to": string(state),
+		})
 	}
 	return s.Status(ctx, userID)
 }

--- a/internal/personalhq/service_test.go
+++ b/internal/personalhq/service_test.go
@@ -1,0 +1,348 @@
+package personalhq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// testHarness wires a real userprofile.SQLiteStore and session.SQLiteStore
+// against the same in-memory database, matching how the service is wired in
+// production (internal/server/builder_handlers.go), rather than hand-rolled
+// fakes that could drift from the real persistence contracts.
+func newTestHarness(t *testing.T) (*Service, *userprofile.SQLiteStore, *session.SQLiteStore) {
+	t.Helper()
+	db, err := database.Open(context.Background(), &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	profiles := userprofile.NewSQLiteStore(db)
+	workspaces := session.NewSQLiteStore(db)
+	return NewService(profiles, workspaces), profiles, workspaces
+}
+
+func createWorkspace(t *testing.T, store *session.SQLiteStore, id, owner string, kind session.WorkspaceKind, status session.WorkspaceStatus) *session.Workspace {
+	t.Helper()
+	ws := &session.Workspace{
+		ID:          id,
+		Name:        id,
+		Kind:        kind,
+		OwnerUserID: owner,
+		Status:      status,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := store.CreateWorkspace(context.Background(), ws); err != nil {
+		t.Fatalf("CreateWorkspace(%s): %v", id, err)
+	}
+	return ws
+}
+
+func TestStatusReportsNoDesignationByDefault(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	ctx := context.Background()
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.HasDesignation() {
+		t.Fatalf("expected no designation, got %#v", status)
+	}
+	if status.Valid {
+		t.Fatalf("expected Valid=false with no designation, got %#v", status)
+	}
+	if status.NeedsRepair() {
+		t.Fatalf("no designation should not need repair, got %#v", status)
+	}
+	if status.OnboardingState != userprofile.HQOnboardingUnseen {
+		t.Fatalf("expected unseen onboarding state, got %q", status.OnboardingState)
+	}
+}
+
+func TestDesignateThenStatusResolvesWorkspace(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	status, err := svc.Designate(ctx, "local", "ws-1")
+	if err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	if !status.Valid || status.Workspace == nil || status.Workspace.ID != "ws-1" {
+		t.Fatalf("expected valid resolved designation, got %#v", status)
+	}
+
+	// Renaming the workspace must not affect the designation: the relation
+	// is keyed by stable ID, never by display name (FR2, FR5).
+	ws, err := workspaces.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	ws.Name = "Renamed HQ"
+	if err := workspaces.UpdateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpdateWorkspace: %v", err)
+	}
+	status, err = svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status after rename: %v", err)
+	}
+	if !status.Valid || status.Workspace.Name != "Renamed HQ" {
+		t.Fatalf("expected designation to survive rename, got %#v", status)
+	}
+}
+
+func TestDesignateRejectsSecondDesignationWithoutReplace(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+	createWorkspace(t, workspaces, "ws-2", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("first Designate: %v", err)
+	}
+	if _, err := svc.Designate(ctx, "local", "ws-2"); !errors.Is(err, ErrAlreadyDesignated) {
+		t.Fatalf("expected ErrAlreadyDesignated, got %v", err)
+	}
+}
+
+func TestReplaceIsAtomicZeroOrOne(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+	createWorkspace(t, workspaces, "ws-2", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	status, err := svc.Replace(ctx, "local", "ws-2")
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if status.WorkspaceID != "ws-2" {
+		t.Fatalf("expected replacement to designate ws-2, got %#v", status)
+	}
+
+	// Replace also works from a zero-HQ state (no prior designation).
+	if _, err := svc.Clear(ctx, "local"); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	status, err = svc.Replace(ctx, "local", "ws-1")
+	if err != nil {
+		t.Fatalf("Replace from zero state: %v", err)
+	}
+	if status.WorkspaceID != "ws-1" {
+		t.Fatalf("expected replace-from-zero to designate ws-1, got %#v", status)
+	}
+}
+
+// TestReplaceLeavesFormerHQContentUntouched covers FR38/FR40 (subtask 1.5):
+// replacing the designation must change only the user->workspace relation.
+// The former HQ workspace itself (its tasks and everything else it owns) is
+// a normal workspace that the service never mutates or deletes.
+func TestReplaceLeavesFormerHQContentUntouched(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	former := createWorkspace(t, workspaces, "ws-former", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+	former.SharedData = map[string]any{"note": "keep me"}
+	if err := workspaces.UpdateWorkspace(ctx, former); err != nil {
+		t.Fatalf("seed former HQ content: %v", err)
+	}
+	createWorkspace(t, workspaces, "ws-new", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-former"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	if _, err := svc.Replace(ctx, "local", "ws-new"); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	reloaded, err := workspaces.GetWorkspace(ctx, "ws-former")
+	if err != nil {
+		t.Fatalf("former HQ workspace must still exist: %v", err)
+	}
+	if reloaded.Status != session.WorkspaceStatusActive {
+		t.Fatalf("former HQ workspace status must be unchanged, got %q", reloaded.Status)
+	}
+	if reloaded.SharedData["note"] != "keep me" {
+		t.Fatalf("former HQ workspace content must be untouched, got %#v", reloaded.SharedData)
+	}
+}
+
+func TestClearPreservesWorkspaceAndOnboardingState(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	if _, err := svc.SetOnboardingState(ctx, "local", userprofile.HQOnboardingCompleted); err != nil {
+		t.Fatalf("SetOnboardingState: %v", err)
+	}
+
+	status, err := svc.Clear(ctx, "local")
+	if err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if status.HasDesignation() {
+		t.Fatalf("expected designation cleared, got %#v", status)
+	}
+	if status.OnboardingState != userprofile.HQOnboardingCompleted {
+		t.Fatalf("expected onboarding state preserved through clear, got %q", status.OnboardingState)
+	}
+
+	// The workspace itself must be untouched.
+	ws, err := workspaces.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("workspace should still exist after clear: %v", err)
+	}
+	if ws.Status != session.WorkspaceStatusActive {
+		t.Fatalf("expected workspace status unchanged, got %q", ws.Status)
+	}
+}
+
+func TestDesignateRejectsGroupWorkspace(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "group-1", "local", session.WorkspaceKindGroup, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "group-1"); !errors.Is(err, ErrGroupNotEligible) {
+		t.Fatalf("expected ErrGroupNotEligible, got %v", err)
+	}
+}
+
+func TestDesignateRejectsTrashedOrMissingWorkspace(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "trashed-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusTrashed)
+	createWorkspace(t, workspaces, "missing-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusMissing)
+
+	if _, err := svc.Designate(ctx, "local", "trashed-1"); !errors.Is(err, ErrWorkspaceUnavailable) {
+		t.Fatalf("expected ErrWorkspaceUnavailable for trashed workspace, got %v", err)
+	}
+	if _, err := svc.Designate(ctx, "local", "missing-1"); !errors.Is(err, ErrWorkspaceUnavailable) {
+		t.Fatalf("expected ErrWorkspaceUnavailable for missing workspace, got %v", err)
+	}
+}
+
+func TestDesignateRejectsWrongOwner(t *testing.T) {
+	svc, profiles, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	// owner_user_id carries a foreign key to users(id), so the owning user
+	// must exist before a workspace can reference it.
+	if err := profiles.Upsert(ctx, &userprofile.UserProfile{ID: "someone-else"}); err != nil {
+		t.Fatalf("seed owner profile: %v", err)
+	}
+	createWorkspace(t, workspaces, "ws-1", "someone-else", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestDesignateRejectsUnknownWorkspace(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	ctx := context.Background()
+
+	if _, err := svc.Designate(ctx, "local", "does-not-exist"); !errors.Is(err, ErrWorkspaceNotFound) {
+		t.Fatalf("expected ErrWorkspaceNotFound, got %v", err)
+	}
+}
+
+func TestDesignateRequiresWorkspaceID(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	ctx := context.Background()
+
+	if _, err := svc.Designate(ctx, "local", "   "); !errors.Is(err, ErrWorkspaceIDRequired) {
+		t.Fatalf("expected ErrWorkspaceIDRequired, got %v", err)
+	}
+}
+
+// TestStatusReportsInvalidReasonAfterWorkspaceDeletion covers requirement
+// 1.7/1.9: deleting the designated workspace out from under a stored
+// reference must be detected lazily on read (no delete-time hook is wired
+// into workspace_handler.go on purpose, so deletion never depends on the
+// personal HQ / user-profile stores being available), and Status must
+// report it as needing repair rather than erroring.
+func TestStatusReportsInvalidReasonAfterWorkspaceDeletion(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	if err := workspaces.DeleteWorkspace(ctx, "ws-1"); err != nil {
+		t.Fatalf("DeleteWorkspace: %v", err)
+	}
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status after deletion should not error: %v", err)
+	}
+	if status.Valid {
+		t.Fatalf("expected invalid status after deletion, got %#v", status)
+	}
+	if !status.NeedsRepair() {
+		t.Fatalf("expected NeedsRepair after deletion, got %#v", status)
+	}
+	if status.InvalidReason != InvalidReasonMissing {
+		t.Fatalf("expected missing reason, got %q", status.InvalidReason)
+	}
+
+	// Clear (one of the offered repair actions) removes the stale reference.
+	status, err = svc.Clear(ctx, "local")
+	if err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if status.HasDesignation() {
+		t.Fatalf("expected designation cleared, got %#v", status)
+	}
+}
+
+func TestSetOnboardingStateRejectsUnknownValue(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	ctx := context.Background()
+
+	if _, err := svc.SetOnboardingState(ctx, "local", userprofile.HQOnboardingState("bogus")); !errors.Is(err, ErrInvalidOnboardingState) {
+		t.Fatalf("expected ErrInvalidOnboardingState, got %v", err)
+	}
+}
+
+func TestOnboardingStateTransitionsSurviveDesignationChanges(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.SetOnboardingState(ctx, "local", userprofile.HQOnboardingSkipped); err != nil {
+		t.Fatalf("SetOnboardingState skipped: %v", err)
+	}
+	status, err := svc.Designate(ctx, "local", "ws-1")
+	if err != nil {
+		t.Fatalf("Designate after skip (resume path): %v", err)
+	}
+	// Designating does not implicitly flip onboarding state; callers (task
+	// 4.x HTTP/UI layer) decide when to mark completed.
+	if status.OnboardingState != userprofile.HQOnboardingSkipped {
+		t.Fatalf("expected onboarding state unchanged by Designate, got %q", status.OnboardingState)
+	}
+
+	if _, err := svc.SetOnboardingState(ctx, "local", userprofile.HQOnboardingCompleted); err != nil {
+		t.Fatalf("SetOnboardingState completed: %v", err)
+	}
+	status, err = svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.OnboardingState != userprofile.HQOnboardingCompleted || !status.Valid {
+		t.Fatalf("expected completed onboarding state with valid HQ, got %#v", status)
+	}
+}

--- a/internal/personalhq/service_test.go
+++ b/internal/personalhq/service_test.go
@@ -308,6 +308,109 @@ func TestStatusReportsInvalidReasonAfterWorkspaceDeletion(t *testing.T) {
 	}
 }
 
+// TestStatusReportsInvalidReasonAfterWorkspaceTrashed covers task 8.3: a
+// designated HQ that is later trashed (not deleted outright) must be
+// reported as needing repair, not silently treated as still valid.
+func TestStatusReportsInvalidReasonAfterWorkspaceTrashed(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	ws, err := workspaces.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	ws.Status = session.WorkspaceStatusTrashed
+	if err := workspaces.UpdateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpdateWorkspace (trash): %v", err)
+	}
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status after trashing should not error: %v", err)
+	}
+	if status.Valid || !status.NeedsRepair() {
+		t.Fatalf("expected NeedsRepair after trashing the designated HQ, got %#v", status)
+	}
+	if status.InvalidReason != InvalidReasonTrashed {
+		t.Fatalf("expected trashed reason, got %q", status.InvalidReason)
+	}
+}
+
+// TestStatusReportsInvalidReasonAfterWorkspaceBecomesGroup covers task 8.3:
+// a designated HQ workspace that is later converted into a group is no
+// longer eligible (groups can contain member workspaces) and must be
+// reported as needing repair.
+func TestStatusReportsInvalidReasonAfterWorkspaceBecomesGroup(t *testing.T) {
+	svc, _, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	ws, err := workspaces.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	ws.Kind = session.WorkspaceKindGroup
+	if err := workspaces.UpdateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpdateWorkspace (convert to group): %v", err)
+	}
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status after conversion to group should not error: %v", err)
+	}
+	if status.Valid || !status.NeedsRepair() {
+		t.Fatalf("expected NeedsRepair after the designated HQ became a group, got %#v", status)
+	}
+	if status.InvalidReason != InvalidReasonGroup {
+		t.Fatalf("expected group reason, got %q", status.InvalidReason)
+	}
+}
+
+// TestStatusReportsInvalidReasonAfterOwnershipChanges covers task 8.3: a
+// designated HQ whose ownership later changes away from the designating
+// user must be reported as inaccessible/needing repair, not silently
+// resolved as if still valid.
+func TestStatusReportsInvalidReasonAfterOwnershipChanges(t *testing.T) {
+	svc, profiles, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	createWorkspace(t, workspaces, "ws-1", "local", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	if _, err := svc.Designate(ctx, "local", "ws-1"); err != nil {
+		t.Fatalf("Designate: %v", err)
+	}
+	// owner_user_id has a FOREIGN KEY on users(id), so the new owner needs a
+	// real profile row first.
+	if err := profiles.Upsert(ctx, &userprofile.UserProfile{ID: "someone-else"}); err != nil {
+		t.Fatalf("seed someone-else profile: %v", err)
+	}
+	ws, err := workspaces.GetWorkspace(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	ws.OwnerUserID = "someone-else"
+	if err := workspaces.UpdateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpdateWorkspace (change owner): %v", err)
+	}
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status after ownership change should not error: %v", err)
+	}
+	if status.Valid || !status.NeedsRepair() {
+		t.Fatalf("expected NeedsRepair after ownership changed away, got %#v", status)
+	}
+	if status.InvalidReason != InvalidReasonWrongOwner {
+		t.Fatalf("expected wrong_owner reason, got %q", status.InvalidReason)
+	}
+}
+
 func TestSetOnboardingStateRejectsUnknownValue(t *testing.T) {
 	svc, _, _ := newTestHarness(t)
 	ctx := context.Background()

--- a/internal/personalhq/setup.go
+++ b/internal/personalhq/setup.go
@@ -1,0 +1,233 @@
+package personalhq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// PersonalHQTemplateID is the built-in template Setup provisions the HQ
+// workspace from. Frozen per PRD FR120 — the internal template ID never
+// changes even though its display name is Personal HQ (task 2.0).
+const PersonalHQTemplateID = "personal-ops"
+
+// briefConfigSharedDataKey is where the provisional Daily Brief
+// configuration captured during setup is stored on the HQ workspace's
+// SharedData, until internal/dailybrief (task 5.0) owns durable
+// configuration storage. Kept as real input capture (not discarded) so task
+// 5.0 has actual user-chosen settings to read rather than re-deriving
+// defaults from scratch.
+const briefConfigSharedDataKey = "personal_hq_brief_config"
+
+// ErrInvalidTimezone is returned when a non-empty timezone fails
+// time.LoadLocation. An empty timezone is not an error — Setup defaults it.
+var ErrInvalidTimezone = errors.New("personal hq: invalid IANA timezone")
+
+// WorkspaceCreator creates a normal workspace from a built-in template and
+// returns its ID, reusing the exact same server-side creation path as the
+// template library (entry-agent selection, tool binding, scaffold
+// provisioning, starter-task seeding, provenance) rather than a second
+// constructor (PRD FR128). Implemented by sessionhttp.Handler.
+type WorkspaceCreator interface {
+	CreateFromTemplate(ctx context.Context, name, templateID string) (workspaceID string, err error)
+}
+
+// WorkspaceWriter is the narrow write contract Setup needs beyond
+// WorkspaceReader, to persist the provisional brief configuration onto the
+// newly created HQ workspace. session.HybridStore satisfies it.
+type WorkspaceWriter interface {
+	WorkspaceReader
+	UpdateWorkspace(ctx context.Context, ws *session.Workspace) error
+}
+
+// SetupRequest is a Build My HQ submission. Every field beyond Name is
+// optional — Setup fills in sensible defaults so the flow can complete with
+// no more than the primary interactions required by PRD success metric 2.
+type SetupRequest struct {
+	Name                    string
+	Timezone                string
+	ScheduleDays            []string
+	ScheduleTime            string
+	Scope                   string // "all" | "selected"
+	SelectedWorkspaceIDs    []string
+	IncludeFutureWorkspaces bool
+	NotifyOnReady           bool
+}
+
+// BriefConfig is the provisional Daily Brief configuration captured by
+// setup. internal/dailybrief (task 5.0) owns durable configuration; this is
+// stored as workspace SharedData in the meantime.
+type BriefConfig struct {
+	Timezone                string   `json:"timezone"`
+	ScheduleDays            []string `json:"schedule_days,omitempty"`
+	ScheduleTime            string   `json:"schedule_time,omitempty"`
+	Scope                   string   `json:"scope"`
+	SelectedWorkspaceIDs    []string `json:"selected_workspace_ids,omitempty"`
+	IncludeFutureWorkspaces bool     `json:"include_future_workspaces"`
+	NotifyOnReady           bool     `json:"notify_on_ready"`
+}
+
+// SetupResult is returned after a successful Build My HQ.
+type SetupResult struct {
+	Status      *Status     `json:"status"`
+	BriefConfig BriefConfig `json:"brief_config"`
+}
+
+// SetupPartialFailureError reports that the HQ workspace was created but a
+// later step failed, naming the workspace so the caller can offer retry or
+// "keep as a normal workspace" (PRD FR30) instead of a bare error with no
+// path forward.
+type SetupPartialFailureError struct {
+	WorkspaceID string
+	Step        string
+	Err         error
+}
+
+func (e *SetupPartialFailureError) Error() string {
+	return fmt.Sprintf("personal hq: workspace %s was created but %s failed: %v", e.WorkspaceID, e.Step, e.Err)
+}
+
+func (e *SetupPartialFailureError) Unwrap() error { return e.Err }
+
+// SetupCoordinator builds a new Personal HQ from the guided first-launch
+// flow: creates the workspace via the canonical template-creation path,
+// designates it for the user (which also completes the t2-build-hq
+// progression quest via Service.onDesignated), and captures the provisional
+// Daily Brief configuration — all as one user-visible operation.
+//
+// Designation only happens after workspace creation succeeds, so a creation
+// failure never leaves a stale designation. If designation itself fails, the
+// workspace already exists; SetupPartialFailureError names it so the caller
+// can retry designation or keep the workspace undesignated rather than
+// silently losing it or deleting user data (PRD FR29/FR30).
+type SetupCoordinator struct {
+	service    *Service
+	creator    WorkspaceCreator
+	workspaces WorkspaceWriter
+}
+
+// NewSetupCoordinator constructs a Build My HQ coordinator. workspaces may
+// be nil — brief-config capture then best-effort no-ops, mirroring how
+// template provenance persistence degrades elsewhere in this codebase.
+func NewSetupCoordinator(service *Service, creator WorkspaceCreator, workspaces WorkspaceWriter) *SetupCoordinator {
+	return &SetupCoordinator{service: service, creator: creator, workspaces: workspaces}
+}
+
+// Setup runs the full Build My HQ flow for userID.
+func (c *SetupCoordinator) Setup(ctx context.Context, userID string, req SetupRequest) (*SetupResult, error) {
+	if c == nil || c.service == nil || c.creator == nil {
+		return nil, errors.New("personal hq setup coordinator is not configured")
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = "My HQ"
+	}
+	tz := strings.TrimSpace(req.Timezone)
+	if tz == "" {
+		tz = "UTC"
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidTimezone, tz)
+	}
+
+	workspaceID, err := c.creator.CreateFromTemplate(ctx, name, PersonalHQTemplateID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the personal hq workspace: %w", err)
+	}
+
+	status, err := c.service.Designate(ctx, userID, workspaceID)
+	if err != nil {
+		return nil, &SetupPartialFailureError{WorkspaceID: workspaceID, Step: "designation", Err: err}
+	}
+
+	brief := BriefConfig{
+		Timezone:                tz,
+		ScheduleDays:            normalizeScheduleDays(req.ScheduleDays),
+		ScheduleTime:            normalizeScheduleTime(req.ScheduleTime),
+		Scope:                   normalizeScope(req.Scope),
+		SelectedWorkspaceIDs:    append([]string(nil), req.SelectedWorkspaceIDs...),
+		IncludeFutureWorkspaces: req.IncludeFutureWorkspaces,
+		NotifyOnReady:           req.NotifyOnReady,
+	}
+	if c.workspaces != nil {
+		if err := c.persistBriefConfig(ctx, workspaceID, brief); err != nil {
+			// Best-effort: the HQ is fully usable without this, and HQ
+			// settings (task 5.0) let the user (re)configure it later.
+			logger.Warn("personal hq: failed to persist brief config", logger.Fields{"workspace_id": workspaceID, "error": err})
+		}
+	}
+
+	if _, err := c.service.SetOnboardingState(ctx, userID, userprofile.HQOnboardingCompleted); err != nil {
+		logger.Warn("personal hq: failed to mark onboarding completed", logger.Fields{"user_id": userID, "error": err})
+	}
+
+	finalStatus, err := c.service.Status(ctx, userID)
+	if err != nil {
+		finalStatus = status
+	}
+	return &SetupResult{Status: finalStatus, BriefConfig: brief}, nil
+}
+
+func (c *SetupCoordinator) persistBriefConfig(ctx context.Context, workspaceID string, brief BriefConfig) error {
+	data, err := json.Marshal(brief)
+	if err != nil {
+		return err
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	ws, err := c.workspaces.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if ws.SharedData == nil {
+		ws.SharedData = map[string]any{}
+	}
+	ws.SharedData[briefConfigSharedDataKey] = raw
+	return c.workspaces.UpdateWorkspace(ctx, ws)
+}
+
+func normalizeScope(scope string) string {
+	if strings.TrimSpace(strings.ToLower(scope)) == "selected" {
+		return "selected"
+	}
+	return "all"
+}
+
+func normalizeScheduleTime(t string) string {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return "08:00"
+	}
+	return t
+}
+
+// defaultScheduleDays is the Monday-Friday default when a setup submission
+// omits schedule days entirely.
+var defaultScheduleDays = []string{"mon", "tue", "wed", "thu", "fri"}
+
+func normalizeScheduleDays(days []string) []string {
+	if len(days) == 0 {
+		return append([]string(nil), defaultScheduleDays...)
+	}
+	out := make([]string, 0, len(days))
+	for _, d := range days {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d != "" {
+			out = append(out, d)
+		}
+	}
+	if len(out) == 0 {
+		return append([]string(nil), defaultScheduleDays...)
+	}
+	return out
+}

--- a/internal/personalhq/setup_test.go
+++ b/internal/personalhq/setup_test.go
@@ -1,0 +1,244 @@
+package personalhq
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// fakeCreator simulates sessionhttp.Handler.CreateFromTemplate without
+// standing up a full workspace/session store: it creates a bare workspace
+// record directly through the same session store the test harness already
+// uses, so Designate (which reads it back) sees a real, eligible workspace.
+type fakeCreator struct {
+	workspaces *session.SQLiteStore
+	nextErr    error
+	created    []string // names of workspaces created, in order
+}
+
+func (f *fakeCreator) CreateFromTemplate(ctx context.Context, name, templateID string) (string, error) {
+	if f.nextErr != nil {
+		err := f.nextErr
+		f.nextErr = nil
+		return "", err
+	}
+	f.created = append(f.created, name)
+	id := "hq-" + name
+	ws := &session.Workspace{
+		ID:          id,
+		Name:        name,
+		Kind:        session.WorkspaceKindWorkspace,
+		OwnerUserID: "local",
+		Status:      session.WorkspaceStatusActive,
+	}
+	if err := f.workspaces.CreateWorkspace(ctx, ws); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func newSetupTestHarness(t *testing.T) (*SetupCoordinator, *Service, *session.SQLiteStore, *fakeCreator) {
+	t.Helper()
+	svc, _, workspaces := newTestHarness(t)
+	creator := &fakeCreator{workspaces: workspaces}
+	coord := NewSetupCoordinator(svc, creator, workspaces)
+	return coord, svc, workspaces, creator
+}
+
+func TestSetup_DefaultsCompleteWithNameOnly(t *testing.T) {
+	coord, svc, _, _ := newSetupTestHarness(t)
+	ctx := context.Background()
+
+	result, err := coord.Setup(ctx, "local", SetupRequest{Name: "My HQ"})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if result.Status == nil || !result.Status.Valid {
+		t.Fatalf("expected a valid designated HQ, got %#v", result.Status)
+	}
+	if result.BriefConfig.Timezone != "UTC" {
+		t.Fatalf("expected default timezone UTC, got %q", result.BriefConfig.Timezone)
+	}
+	if len(result.BriefConfig.ScheduleDays) != 5 {
+		t.Fatalf("expected 5 default schedule days, got %v", result.BriefConfig.ScheduleDays)
+	}
+	if result.BriefConfig.ScheduleTime != "08:00" {
+		t.Fatalf("expected default schedule time 08:00, got %q", result.BriefConfig.ScheduleTime)
+	}
+	if result.BriefConfig.Scope != "all" {
+		t.Fatalf("expected default scope all, got %q", result.BriefConfig.Scope)
+	}
+
+	status, err := svc.Status(ctx, "local")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.OnboardingState != "completed" {
+		t.Fatalf("expected onboarding state completed, got %q", status.OnboardingState)
+	}
+}
+
+func TestSetup_DefaultsNameWhenBlank(t *testing.T) {
+	coord, _, _, creator := newSetupTestHarness(t)
+	if _, err := coord.Setup(context.Background(), "local", SetupRequest{}); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if len(creator.created) != 1 || creator.created[0] != "My HQ" {
+		t.Fatalf("expected default workspace name 'My HQ', got %v", creator.created)
+	}
+}
+
+func TestSetup_RejectsInvalidTimezone(t *testing.T) {
+	coord, _, _, creator := newSetupTestHarness(t)
+	_, err := coord.Setup(context.Background(), "local", SetupRequest{Name: "My HQ", Timezone: "Not/AZone"})
+	if !errors.Is(err, ErrInvalidTimezone) {
+		t.Fatalf("expected ErrInvalidTimezone, got %v", err)
+	}
+	if len(creator.created) != 0 {
+		t.Fatal("workspace must not be created when validation fails before creation")
+	}
+}
+
+func TestSetup_AcceptsValidTimezone(t *testing.T) {
+	coord, _, _, _ := newSetupTestHarness(t)
+	result, err := coord.Setup(context.Background(), "local", SetupRequest{Name: "My HQ", Timezone: "America/New_York"})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if result.BriefConfig.Timezone != "America/New_York" {
+		t.Fatalf("expected timezone to round-trip, got %q", result.BriefConfig.Timezone)
+	}
+}
+
+func TestSetup_PreservesCustomScheduleAndScope(t *testing.T) {
+	coord, _, _, _ := newSetupTestHarness(t)
+	result, err := coord.Setup(context.Background(), "local", SetupRequest{
+		Name:                    "My HQ",
+		ScheduleDays:            []string{"Mon", " Wed ", "FRI"},
+		ScheduleTime:            "07:30",
+		Scope:                   "selected",
+		SelectedWorkspaceIDs:    []string{"ws-a", "ws-b"},
+		IncludeFutureWorkspaces: true,
+		NotifyOnReady:           true,
+	})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	b := result.BriefConfig
+	if want := []string{"mon", "wed", "fri"}; !equalStrings(b.ScheduleDays, want) {
+		t.Fatalf("schedule days = %v, want %v", b.ScheduleDays, want)
+	}
+	if b.ScheduleTime != "07:30" {
+		t.Fatalf("schedule time = %q, want 07:30", b.ScheduleTime)
+	}
+	if b.Scope != "selected" {
+		t.Fatalf("scope = %q, want selected", b.Scope)
+	}
+	if !equalStrings(b.SelectedWorkspaceIDs, []string{"ws-a", "ws-b"}) {
+		t.Fatalf("selected workspace ids = %v", b.SelectedWorkspaceIDs)
+	}
+	if !b.IncludeFutureWorkspaces || !b.NotifyOnReady {
+		t.Fatalf("expected both opt-in flags preserved, got %#v", b)
+	}
+}
+
+// TestSetup_PersistsBriefConfigOntoWorkspace covers task 4.6: the brief
+// configuration collected during setup must actually be stored somewhere
+// durable (workspace SharedData, pending task 5.0's dedicated store), not
+// discarded after the response is returned.
+func TestSetup_PersistsBriefConfigOntoWorkspace(t *testing.T) {
+	coord, _, workspaces, _ := newSetupTestHarness(t)
+	ctx := context.Background()
+
+	result, err := coord.Setup(ctx, "local", SetupRequest{Name: "My HQ", Timezone: "America/Chicago"})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	ws, err := workspaces.GetWorkspace(ctx, result.Status.WorkspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	raw, ok := ws.SharedData[briefConfigSharedDataKey]
+	if !ok {
+		t.Fatal("expected brief config stored in workspace SharedData")
+	}
+	stored, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("expected a map, got %T", raw)
+	}
+	if stored["timezone"] != "America/Chicago" {
+		t.Fatalf("stored timezone = %v, want America/Chicago", stored["timezone"])
+	}
+}
+
+// TestSetup_CreationFailureLeavesNoDesignation covers PRD FR29: a failed
+// creation must never leave a designation pointing at a missing workspace.
+func TestSetup_CreationFailureLeavesNoDesignation(t *testing.T) {
+	coord, svc, _, creator := newSetupTestHarness(t)
+	creator.nextErr = errors.New("disk full")
+
+	if _, err := coord.Setup(context.Background(), "local", SetupRequest{Name: "My HQ"}); err == nil {
+		t.Fatal("expected Setup to fail")
+	}
+	status, err := svc.Status(context.Background(), "local")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.HasDesignation() {
+		t.Fatalf("expected no designation after a failed creation, got %#v", status)
+	}
+}
+
+// TestSetup_DesignationFailureReportsPartialFailure covers PRD FR30: if
+// workspace creation succeeds but designation fails, the caller must learn
+// the workspace ID so it can retry or keep the workspace as a normal one —
+// not just get a bare error.
+func TestSetup_DesignationFailureReportsPartialFailure(t *testing.T) {
+	coord, svc, _, creator := newSetupTestHarness(t)
+	ctx := context.Background()
+
+	// Pre-designate a different, valid workspace so the coordinator's
+	// Designate call is rejected with ErrAlreadyDesignated, simulating a
+	// designation-step failure after workspace creation already succeeded.
+	existing := &fakeCreator{workspaces: creator.workspaces}
+	otherID, err := existing.CreateFromTemplate(ctx, "Other", "personal-ops")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Designate(ctx, "local", otherID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = coord.Setup(ctx, "local", SetupRequest{Name: "My HQ"})
+	var partial *SetupPartialFailureError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected SetupPartialFailureError, got %v", err)
+	}
+	if partial.WorkspaceID == "" {
+		t.Fatal("expected the partial failure to name the created workspace id")
+	}
+
+	// The workspace from the failed setup attempt must still exist (never
+	// silently deleted) even though it isn't designated.
+	ws, err := creator.workspaces.GetWorkspace(ctx, partial.WorkspaceID)
+	if err != nil {
+		t.Fatalf("the created workspace must survive a designation failure: %v", err)
+	}
+	if ws.Name != "My HQ" {
+		t.Fatalf("unexpected workspace: %#v", ws)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/personalhqhttp/handler.go
+++ b/internal/personalhqhttp/handler.go
@@ -16,16 +16,19 @@ import (
 // Handler serves the Personal HQ API.
 type Handler struct {
 	service  *personalhq.Service
+	setup    *personalhq.SetupCoordinator
 	provider userprofile.UserProvider
 }
 
 // NewHandler constructs a Personal HQ HTTP handler. provider may be nil, in
-// which case requests resolve to the local single-user profile.
-func NewHandler(service *personalhq.Service, provider userprofile.UserProvider) *Handler {
+// which case requests resolve to the local single-user profile. setup may be
+// nil (e.g. in tests exercising only status/designate/clear); Setup then
+// reports 503 rather than panicking.
+func NewHandler(service *personalhq.Service, setup *personalhq.SetupCoordinator, provider userprofile.UserProvider) *Handler {
 	if provider == nil {
 		provider = userprofile.LocalUserProvider{}
 	}
-	return &Handler{service: service, provider: provider}
+	return &Handler{service: service, setup: setup, provider: provider}
 }
 
 type designateRequest struct {
@@ -128,6 +131,74 @@ func (h *Handler) handleDesignation(w http.ResponseWriter, r *http.Request, repl
 		return
 	}
 	orihttp.Success(w, map[string]any{"status": status})
+}
+
+// setupRequest is the Build My HQ submission body.
+type setupRequest struct {
+	Name                    string   `json:"name"`
+	Timezone                string   `json:"timezone"`
+	ScheduleDays            []string `json:"schedule_days"`
+	ScheduleTime            string   `json:"schedule_time"`
+	Scope                   string   `json:"scope"`
+	SelectedWorkspaceIDs    []string `json:"selected_workspace_ids"`
+	IncludeFutureWorkspaces bool     `json:"include_future_workspaces"`
+	NotifyOnReady           bool     `json:"notify_on_ready"`
+}
+
+// Setup handles POST /api/personal-hq/setup: the Build My HQ flow. Creates
+// the HQ workspace, designates it, and captures the brief configuration, all
+// as one atomic-from-the-user's-perspective operation.
+func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h == nil || h.setup == nil {
+		orihttp.ServiceUnavailable(w, "personal hq setup is unavailable")
+		return
+	}
+	var req setupRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	userID, err := h.currentUserID(r.Context())
+	if err != nil {
+		orihttp.InternalError(w, "Failed to resolve current user: "+err.Error())
+		return
+	}
+	result, err := h.setup.Setup(r.Context(), userID, personalhq.SetupRequest{
+		Name:                    req.Name,
+		Timezone:                req.Timezone,
+		ScheduleDays:            req.ScheduleDays,
+		ScheduleTime:            req.ScheduleTime,
+		Scope:                   req.Scope,
+		SelectedWorkspaceIDs:    req.SelectedWorkspaceIDs,
+		IncludeFutureWorkspaces: req.IncludeFutureWorkspaces,
+		NotifyOnReady:           req.NotifyOnReady,
+	})
+	if err != nil {
+		respondSetupError(w, err)
+		return
+	}
+	orihttp.Success(w, result)
+}
+
+func respondSetupError(w http.ResponseWriter, err error) {
+	var partial *personalhq.SetupPartialFailureError
+	switch {
+	case errors.Is(err, personalhq.ErrInvalidTimezone):
+		orihttp.BadRequest(w, err.Error())
+	case errors.As(err, &partial):
+		// The workspace exists but a later step failed: give the client
+		// enough to offer retry or "keep as a normal workspace" instead of
+		// a bare error (PRD FR30).
+		_ = orihttp.RespondJSON(w, http.StatusConflict, map[string]any{
+			"error":        err.Error(),
+			"workspace_id": partial.WorkspaceID,
+			"step":         partial.Step,
+		})
+	default:
+		orihttp.InternalError(w, "Failed to set up personal hq: "+err.Error())
+	}
 }
 
 // Clear handles POST /api/personal-hq/clear.

--- a/internal/personalhqhttp/handler.go
+++ b/internal/personalhqhttp/handler.go
@@ -1,0 +1,188 @@
+// Package personalhqhttp exposes the Personal HQ domain service
+// (internal/personalhq) as a user-scoped HTTP API: status, onboarding-state
+// transitions, designate, replace, and clear.
+package personalhqhttp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// Handler serves the Personal HQ API.
+type Handler struct {
+	service  *personalhq.Service
+	provider userprofile.UserProvider
+}
+
+// NewHandler constructs a Personal HQ HTTP handler. provider may be nil, in
+// which case requests resolve to the local single-user profile.
+func NewHandler(service *personalhq.Service, provider userprofile.UserProvider) *Handler {
+	if provider == nil {
+		provider = userprofile.LocalUserProvider{}
+	}
+	return &Handler{service: service, provider: provider}
+}
+
+type designateRequest struct {
+	WorkspaceID string `json:"workspace_id"`
+}
+
+type onboardingStateRequest struct {
+	State string `json:"state"`
+}
+
+// Status handles GET /api/personal-hq/status.
+func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h == nil || h.service == nil {
+		orihttp.ServiceUnavailable(w, "personal hq service is unavailable")
+		return
+	}
+	userID, err := h.currentUserID(r.Context())
+	if err != nil {
+		orihttp.InternalError(w, "Failed to resolve current user: "+err.Error())
+		return
+	}
+	status, err := h.service.Status(r.Context(), userID)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to load personal hq status: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"status": status})
+}
+
+// SetOnboardingState handles POST /api/personal-hq/onboarding-state.
+func (h *Handler) SetOnboardingState(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h == nil || h.service == nil {
+		orihttp.ServiceUnavailable(w, "personal hq service is unavailable")
+		return
+	}
+	var req onboardingStateRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	state, ok := userprofile.ParseHQOnboardingState(req.State)
+	if !ok {
+		orihttp.BadRequest(w, "state must be one of unseen, in_progress, completed, or skipped")
+		return
+	}
+	userID, err := h.currentUserID(r.Context())
+	if err != nil {
+		orihttp.InternalError(w, "Failed to resolve current user: "+err.Error())
+		return
+	}
+	status, err := h.service.SetOnboardingState(r.Context(), userID, state)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to update onboarding state: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"status": status})
+}
+
+// Designate handles POST /api/personal-hq/designate.
+func (h *Handler) Designate(w http.ResponseWriter, r *http.Request) {
+	h.handleDesignation(w, r, false)
+}
+
+// Replace handles POST /api/personal-hq/replace.
+func (h *Handler) Replace(w http.ResponseWriter, r *http.Request) {
+	h.handleDesignation(w, r, true)
+}
+
+func (h *Handler) handleDesignation(w http.ResponseWriter, r *http.Request, replace bool) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h == nil || h.service == nil {
+		orihttp.ServiceUnavailable(w, "personal hq service is unavailable")
+		return
+	}
+	var req designateRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	userID, err := h.currentUserID(r.Context())
+	if err != nil {
+		orihttp.InternalError(w, "Failed to resolve current user: "+err.Error())
+		return
+	}
+
+	var status *personalhq.Status
+	if replace {
+		status, err = h.service.Replace(r.Context(), userID, req.WorkspaceID)
+	} else {
+		status, err = h.service.Designate(r.Context(), userID, req.WorkspaceID)
+	}
+	if err != nil {
+		respondDesignationError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"status": status})
+}
+
+// Clear handles POST /api/personal-hq/clear.
+func (h *Handler) Clear(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h == nil || h.service == nil {
+		orihttp.ServiceUnavailable(w, "personal hq service is unavailable")
+		return
+	}
+	userID, err := h.currentUserID(r.Context())
+	if err != nil {
+		orihttp.InternalError(w, "Failed to resolve current user: "+err.Error())
+		return
+	}
+	status, err := h.service.Clear(r.Context(), userID)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to clear personal hq: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"status": status})
+}
+
+// respondDesignationError maps domain errors from Designate/Replace to
+// actionable HTTP responses instead of a generic 500, per FR42 (missing,
+// inaccessible, trashed/missing, group, wrong-owner workspaces must produce
+// actionable errors).
+func respondDesignationError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, personalhq.ErrWorkspaceIDRequired):
+		orihttp.BadRequest(w, err.Error())
+	case errors.Is(err, personalhq.ErrWorkspaceNotFound):
+		orihttp.NotFound(w, err.Error())
+	case errors.Is(err, personalhq.ErrGroupNotEligible),
+		errors.Is(err, personalhq.ErrWorkspaceUnavailable),
+		errors.Is(err, personalhq.ErrUnauthorized):
+		orihttp.BadRequest(w, err.Error())
+	case errors.Is(err, personalhq.ErrAlreadyDesignated):
+		orihttp.Conflict(w, err.Error())
+	default:
+		orihttp.InternalError(w, "Failed to update personal hq designation: "+err.Error())
+	}
+}
+
+func (h *Handler) currentUserID(ctx context.Context) (string, error) {
+	if h.provider == nil {
+		return userprofile.LocalUserID, nil
+	}
+	userID, err := h.provider.CurrentUserID(ctx)
+	if err != nil {
+		return "", err
+	}
+	if userID == "" {
+		return userprofile.LocalUserID, nil
+	}
+	return userID, nil
+}

--- a/internal/personalhqhttp/handler_test.go
+++ b/internal/personalhqhttp/handler_test.go
@@ -1,0 +1,203 @@
+package personalhqhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+func newTestHandler(t *testing.T) (*Handler, *session.SQLiteStore) {
+	t.Helper()
+	db, err := database.Open(context.Background(), &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	profiles := userprofile.NewSQLiteStore(db)
+	workspaces := session.NewSQLiteStore(db)
+	service := personalhq.NewService(profiles, workspaces)
+	return NewHandler(service, userprofile.LocalUserProvider{}), workspaces
+}
+
+func createWorkspace(t *testing.T, store *session.SQLiteStore, id string, kind session.WorkspaceKind, status session.WorkspaceStatus) {
+	t.Helper()
+	ws := &session.Workspace{
+		ID:          id,
+		Name:        id,
+		Kind:        kind,
+		OwnerUserID: userprofile.LocalUserID,
+		Status:      status,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := store.CreateWorkspace(context.Background(), ws); err != nil {
+		t.Fatalf("CreateWorkspace(%s): %v", id, err)
+	}
+}
+
+func decodeStatus(t *testing.T, rec *httptest.ResponseRecorder) personalhq.Status {
+	t.Helper()
+	var got struct {
+		Status personalhq.Status `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	return got.Status
+}
+
+func TestStatusReturnsNoDesignationInitially(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/status", nil)
+	rec := httptest.NewRecorder()
+	handler.Status(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	status := decodeStatus(t, rec)
+	if status.HasDesignation() {
+		t.Fatalf("expected no designation, got %#v", status)
+	}
+}
+
+func TestDesignateRejectsInvalidWorkspaceWithActionableError(t *testing.T) {
+	handler, workspaces := newTestHandler(t)
+	createWorkspace(t, workspaces, "group-1", session.WorkspaceKindGroup, session.WorkspaceStatusActive)
+
+	body := bytes.NewBufferString(`{"workspace_id":"group-1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/designate", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.Designate(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a group workspace, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDesignateMissingWorkspaceReturnsNotFound(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	body := bytes.NewBufferString(`{"workspace_id":"does-not-exist"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/designate", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.Designate(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing workspace, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDesignateThenReplaceThenClear(t *testing.T) {
+	handler, workspaces := newTestHandler(t)
+	createWorkspace(t, workspaces, "ws-1", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+	createWorkspace(t, workspaces, "ws-2", session.WorkspaceKindWorkspace, session.WorkspaceStatusActive)
+
+	designateReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/designate", bytes.NewBufferString(`{"workspace_id":"ws-1"}`))
+	designateReq.Header.Set("Content-Type", "application/json")
+	designateRec := httptest.NewRecorder()
+	handler.Designate(designateRec, designateReq)
+	if designateRec.Code != http.StatusOK {
+		t.Fatalf("designate status = %d body=%s", designateRec.Code, designateRec.Body.String())
+	}
+	if status := decodeStatus(t, designateRec); status.WorkspaceID != "ws-1" || !status.Valid {
+		t.Fatalf("expected valid designation of ws-1, got %#v", status)
+	}
+
+	// A second Designate call without replace must be rejected (409) — the
+	// UI should route to Replace with explicit confirmation instead.
+	secondDesignateReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/designate", bytes.NewBufferString(`{"workspace_id":"ws-2"}`))
+	secondDesignateReq.Header.Set("Content-Type", "application/json")
+	secondDesignateRec := httptest.NewRecorder()
+	handler.Designate(secondDesignateRec, secondDesignateReq)
+	if secondDesignateRec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for re-designation, got %d body=%s", secondDesignateRec.Code, secondDesignateRec.Body.String())
+	}
+
+	replaceReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/replace", bytes.NewBufferString(`{"workspace_id":"ws-2"}`))
+	replaceReq.Header.Set("Content-Type", "application/json")
+	replaceRec := httptest.NewRecorder()
+	handler.Replace(replaceRec, replaceReq)
+	if replaceRec.Code != http.StatusOK {
+		t.Fatalf("replace status = %d body=%s", replaceRec.Code, replaceRec.Body.String())
+	}
+	if status := decodeStatus(t, replaceRec); status.WorkspaceID != "ws-2" {
+		t.Fatalf("expected replacement to designate ws-2, got %#v", status)
+	}
+
+	clearReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/clear", nil)
+	clearRec := httptest.NewRecorder()
+	handler.Clear(clearRec, clearReq)
+	if clearRec.Code != http.StatusOK {
+		t.Fatalf("clear status = %d body=%s", clearRec.Code, clearRec.Body.String())
+	}
+	if status := decodeStatus(t, clearRec); status.HasDesignation() {
+		t.Fatalf("expected designation cleared, got %#v", status)
+	}
+}
+
+func TestSetOnboardingStateRoundTrips(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/onboarding-state", bytes.NewBufferString(`{"state":"skipped"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.SetOnboardingState(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if status := decodeStatus(t, rec); status.OnboardingState != userprofile.HQOnboardingSkipped {
+		t.Fatalf("expected skipped onboarding state, got %#v", status)
+	}
+}
+
+func TestSetOnboardingStateRejectsUnknownValue(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/onboarding-state", bytes.NewBufferString(`{"state":"bogus"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.SetOnboardingState(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown state, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMethodContractRejectsWrongVerb(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/status", nil)
+	rec := httptest.NewRecorder()
+	handler.Status(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for POST to status, got %d", rec.Code)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/personal-hq/clear", nil)
+	getRec := httptest.NewRecorder()
+	handler.Clear(getRec, getReq)
+	if getRec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET to clear, got %d", getRec.Code)
+	}
+}
+
+func TestStatusDegradesWhenServiceUnavailable(t *testing.T) {
+	handler := NewHandler(nil, userprofile.LocalUserProvider{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/status", nil)
+	rec := httptest.NewRecorder()
+	handler.Status(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when service is nil, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/personalhqhttp/handler_test.go
+++ b/internal/personalhqhttp/handler_test.go
@@ -26,7 +26,28 @@ func newTestHandler(t *testing.T) (*Handler, *session.SQLiteStore) {
 	profiles := userprofile.NewSQLiteStore(db)
 	workspaces := session.NewSQLiteStore(db)
 	service := personalhq.NewService(profiles, workspaces)
-	return NewHandler(service, userprofile.LocalUserProvider{}), workspaces
+	setup := personalhq.NewSetupCoordinator(service, &fakeWorkspaceCreator{workspaces: workspaces}, workspaces)
+	return NewHandler(service, setup, userprofile.LocalUserProvider{}), workspaces
+}
+
+// fakeWorkspaceCreator stands in for sessionhttp.Handler.CreateFromTemplate:
+// it creates a bare, eligible workspace directly through the same store.
+type fakeWorkspaceCreator struct {
+	workspaces *session.SQLiteStore
+}
+
+func (f *fakeWorkspaceCreator) CreateFromTemplate(ctx context.Context, name, templateID string) (string, error) {
+	ws := &session.Workspace{
+		ID:          "hq-" + name,
+		Name:        name,
+		Kind:        session.WorkspaceKindWorkspace,
+		OwnerUserID: userprofile.LocalUserID,
+		Status:      session.WorkspaceStatusActive,
+	}
+	if err := f.workspaces.CreateWorkspace(ctx, ws); err != nil {
+		return "", err
+	}
+	return ws.ID, nil
 }
 
 func createWorkspace(t *testing.T, store *session.SQLiteStore, id string, kind session.WorkspaceKind, status session.WorkspaceStatus) {
@@ -146,6 +167,68 @@ func TestDesignateThenReplaceThenClear(t *testing.T) {
 	}
 }
 
+func TestSetupCreatesDesignatesAndCompletesOnboarding(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"My HQ","timezone":"America/New_York"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.Setup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got struct {
+		Status      personalhq.Status      `json:"status"`
+		BriefConfig personalhq.BriefConfig `json:"brief_config"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	if !got.Status.Valid || got.Status.WorkspaceID == "" {
+		t.Fatalf("expected a valid designated HQ, got %#v", got.Status)
+	}
+	if got.Status.OnboardingState != userprofile.HQOnboardingCompleted {
+		t.Fatalf("expected onboarding state completed, got %q", got.Status.OnboardingState)
+	}
+	if got.BriefConfig.Timezone != "America/New_York" {
+		t.Fatalf("expected timezone to round-trip, got %q", got.BriefConfig.Timezone)
+	}
+}
+
+func TestSetupRejectsInvalidTimezone(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"My HQ","timezone":"Not/AZone"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.Setup(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid timezone, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetupRejectsWrongVerb(t *testing.T) {
+	handler, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/setup", nil)
+	rec := httptest.NewRecorder()
+	handler.Setup(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestSetupServiceUnavailableWhenCoordinatorMissing(t *testing.T) {
+	handler := NewHandler(nil, nil, userprofile.LocalUserProvider{})
+	req := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"My HQ"}`))
+	rec := httptest.NewRecorder()
+	handler.Setup(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+}
+
 func TestSetOnboardingStateRoundTrips(t *testing.T) {
 	handler, _ := newTestHandler(t)
 
@@ -192,7 +275,7 @@ func TestMethodContractRejectsWrongVerb(t *testing.T) {
 }
 
 func TestStatusDegradesWhenServiceUnavailable(t *testing.T) {
-	handler := NewHandler(nil, userprofile.LocalUserProvider{})
+	handler := NewHandler(nil, nil, userprofile.LocalUserProvider{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/status", nil)
 	rec := httptest.NewRecorder()

--- a/internal/progression/engine.go
+++ b/internal/progression/engine.go
@@ -1,12 +1,21 @@
 package progression
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/types"
 	ws "github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+var (
+	// ErrQuestNotFound is returned by Skip for an unknown quest ID.
+	ErrQuestNotFound = errors.New("progression: quest not found")
+	// ErrQuestNotOptional is returned by Skip when the quest is not marked
+	// Optional — only optional quests may be skipped.
+	ErrQuestNotOptional = errors.New("progression: quest is not optional")
 )
 
 // Engine tracks quest completion for a single install. It owns the in-memory
@@ -38,6 +47,9 @@ func New(store StateStore, opts ...Option) *Engine {
 	}
 	if e.state.CompletedQuests == nil {
 		e.state.CompletedQuests = map[string]time.Time{}
+	}
+	if e.state.SkippedQuests == nil {
+		e.state.SkippedQuests = map[string]time.Time{}
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -119,6 +131,35 @@ func (e *Engine) Complete(questID string) bool {
 	return true
 }
 
+// Skip marks an optional quest as explicitly skipped. It is idempotent:
+// skipping an already-skipped quest is a no-op success, and skipping an
+// already-completed quest is a no-op success too (a real completion is never
+// downgraded). Returns ErrQuestNotFound for an unknown ID and
+// ErrQuestNotOptional when the quest does not allow skipping.
+func (e *Engine) Skip(questID string) error {
+	q, ok := e.questByID(questID)
+	if !ok {
+		return ErrQuestNotFound
+	}
+	if !q.Optional {
+		return ErrQuestNotOptional
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if _, done := e.state.CompletedQuests[questID]; done {
+		return nil
+	}
+	if _, skipped := e.state.SkippedQuests[questID]; skipped {
+		return nil
+	}
+	if e.state.SkippedQuests == nil {
+		e.state.SkippedQuests = map[string]time.Time{}
+	}
+	e.state.SkippedQuests[questID] = e.now()
+	return e.persistLocked()
+}
+
 // Backfill runs the one-time startup scan: any quest already satisfied by
 // existing state is marked complete SILENTLY (no onComplete). This grandfathers
 // established installs so they never see beginner quests or toasts. It is a
@@ -176,6 +217,7 @@ func (e *Engine) Reset() error {
 	defer e.mu.Unlock()
 	e.state = types.ProgressionState{
 		CompletedQuests: map[string]time.Time{},
+		SkippedQuests:   map[string]time.Time{},
 		BackfilledAt:    e.now(),
 	}
 	return e.persistLocked()
@@ -191,12 +233,15 @@ func (e *Engine) Status() Status {
 
 // --- lock-held helpers ---
 
-// markLocked records a completion. Caller must hold the lock.
+// markLocked records a completion. If the quest was previously skipped, the
+// skip is replaced by the real completion (FR: a later observed action always
+// wins). Caller must hold the lock.
 func (e *Engine) markLocked(questID string) {
 	if e.state.CompletedQuests == nil {
 		e.state.CompletedQuests = map[string]time.Time{}
 	}
 	e.state.CompletedQuests[questID] = e.now()
+	delete(e.state.SkippedQuests, questID)
 }
 
 // persistLocked writes state through the store. Caller must hold the lock.
@@ -212,15 +257,28 @@ func (e *Engine) persistLocked() error {
 	return nil
 }
 
-// currentTierLocked returns the lowest tier that is not fully complete, or
-// TotalTiers when everything is done. Caller must hold the lock.
+// resolvedLocked reports whether a quest is resolved: either completed (its
+// action was actually observed) or, for an optional quest, explicitly
+// skipped. Caller must hold the lock.
+func (e *Engine) resolvedLocked(questID string) bool {
+	if _, done := e.state.CompletedQuests[questID]; done {
+		return true
+	}
+	_, skipped := e.state.SkippedQuests[questID]
+	return skipped
+}
+
+// currentTierLocked returns the lowest tier that is not fully resolved
+// (completed or, for optional quests, skipped), or TotalTiers when everything
+// is done. A skipped optional quest never keeps a later tier locked. Caller
+// must hold the lock.
 func (e *Engine) currentTierLocked() int {
 	for tier := 1; tier <= TotalTiers; tier++ {
 		for _, q := range e.quests {
 			if q.Tier != tier {
 				continue
 			}
-			if _, done := e.state.CompletedQuests[q.ID]; !done {
+			if !e.resolvedLocked(q.ID) {
 				return tier
 			}
 		}
@@ -235,25 +293,38 @@ func (e *Engine) statusLocked() Status {
 	byTier := map[int]*TierView{}
 	order := []int{}
 	completedCount := 0
+	resolvedCount := 0
 	var next *QuestView
 
 	for _, q := range e.quests {
-		at, done := e.state.CompletedQuests[q.ID]
+		completedAt, done := e.state.CompletedQuests[q.ID]
+		skippedAt, skipped := e.state.SkippedQuests[q.ID]
+		resolved := done || skipped
+
 		status := StatusLocked
-		if done {
+		switch {
+		case done:
 			status = StatusCompleted
 			completedCount++
-		} else if q.Tier <= current {
+			resolvedCount++
+		case skipped:
+			status = StatusSkipped
+			resolvedCount++
+		case q.Tier <= current:
 			status = StatusAvailable
 		}
 
 		qv := QuestView{
 			ID: q.ID, Tier: q.Tier, Title: q.Title, Why: q.Why, Status: status,
-			ActionURL: q.ActionURL, ActionLabel: q.ActionLabel,
+			ActionURL: q.ActionURL, ActionLabel: q.ActionLabel, Optional: q.Optional,
 		}
 		if done {
-			completedAt := at
-			qv.CompletedAt = &completedAt
+			at := completedAt
+			qv.CompletedAt = &at
+		}
+		if skipped {
+			at := skippedAt
+			qv.SkippedAt = &at
 		}
 
 		tv, ok := byTier[q.Tier]
@@ -262,7 +333,7 @@ func (e *Engine) statusLocked() Status {
 			byTier[q.Tier] = tv
 			order = append(order, q.Tier)
 		}
-		if !done {
+		if !resolved {
 			tv.Complete = false
 		}
 		tv.Quests = append(tv.Quests, qv)
@@ -284,8 +355,9 @@ func (e *Engine) statusLocked() Status {
 		CurrentTier:    current,
 		TotalTiers:     TotalTiers,
 		CompletedCount: completedCount,
+		ResolvedCount:  resolvedCount,
 		TotalCount:     total,
-		AllComplete:    completedCount == total,
+		AllComplete:    resolvedCount == total,
 		Dismissed:      e.state.Dismissed,
 		NextQuest:      next,
 	}

--- a/internal/progression/engine_test.go
+++ b/internal/progression/engine_test.go
@@ -479,6 +479,19 @@ func TestAllComplete_TreatsSkipAsResolved(t *testing.T) {
 	}
 }
 
+func TestBuiltinQuests_PersonalHQActionStartsGuidedMission(t *testing.T) {
+	for _, q := range BuiltinQuests() {
+		if q.ID != "t2-build-hq" {
+			continue
+		}
+		if q.ActionURL != "/workspaces?hq_onboarding=1" {
+			t.Fatalf("Personal HQ action URL = %q, want guided Mission 01 route", q.ActionURL)
+		}
+		return
+	}
+	t.Fatal("t2-build-hq quest not found")
+}
+
 // TestSkip_PersistsAcrossRestart covers requirement 3.2/3.9: a skip must
 // survive an engine reload from the same store, distinctly from completion.
 func TestSkip_PersistsAcrossRestart(t *testing.T) {

--- a/internal/progression/engine_test.go
+++ b/internal/progression/engine_test.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/johnjallday/ori-agent/internal/types"
@@ -172,13 +173,15 @@ func TestBackfill_EstablishedInstall_GrandfathersSilently(t *testing.T) {
 		t.Fatalf("backfill must not fire onComplete, got %d", fires)
 	}
 	// Every backfillable quest should be complete; the two live-only quests
-	// (tool-task, unattended-run) have no Satisfied predicate and remain open.
+	// (tool-task, unattended-run) have no Satisfied predicate and remain
+	// open, and the optional Personal HQ quest's Satisfied predicate is
+	// false because this snapshot has no HasPersonalHQ.
 	st := e.Status()
-	if st.CompletedCount != st.TotalCount-2 {
-		t.Fatalf("expected all but the 2 live-only quests complete, got %d/%d", st.CompletedCount, st.TotalCount)
+	if st.CompletedCount != st.TotalCount-3 {
+		t.Fatalf("expected all but the 2 live-only quests and the unmet Personal HQ quest complete, got %d/%d", st.CompletedCount, st.TotalCount)
 	}
-	if completed(e, "t4-tool-task") || completed(e, "t5-unattended-run") {
-		t.Fatal("live-only quests must not be grandfathered")
+	if completed(e, "t4-tool-task") || completed(e, "t5-unattended-run") || completed(e, "t2-build-hq") {
+		t.Fatal("live-only and unmet-Personal-HQ quests must not be grandfathered")
 	}
 }
 
@@ -257,5 +260,237 @@ func TestDismissPersists(t *testing.T) {
 	}
 	if !New(store).Status().Dismissed {
 		t.Fatal("dismissed flag should persist")
+	}
+}
+
+// questView returns the QuestView for id, or nil.
+func questView(e *Engine, id string) *QuestView {
+	for _, tv := range e.Status().Tiers {
+		for i := range tv.Quests {
+			if tv.Quests[i].ID == id {
+				return &tv.Quests[i]
+			}
+		}
+	}
+	return nil
+}
+
+func TestSkip_RejectsUnknownQuest(t *testing.T) {
+	e := New(&fakeStore{})
+	if err := e.Skip("does-not-exist"); !errors.Is(err, ErrQuestNotFound) {
+		t.Fatalf("expected ErrQuestNotFound, got %v", err)
+	}
+}
+
+func TestSkip_RejectsNonOptionalQuest(t *testing.T) {
+	e := New(&fakeStore{})
+	if err := e.Skip("t1-first-message"); !errors.Is(err, ErrQuestNotOptional) {
+		t.Fatalf("expected ErrQuestNotOptional, got %v", err)
+	}
+}
+
+func TestSkip_MarksSkippedAndIsIdempotent(t *testing.T) {
+	e := New(&fakeStore{})
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatalf("Skip: %v", err)
+	}
+	qv := questView(e, "t2-build-hq")
+	if qv == nil || qv.Status != StatusSkipped || qv.SkippedAt == nil {
+		t.Fatalf("expected skipped status with SkippedAt set, got %+v", qv)
+	}
+	firstSkippedAt := *qv.SkippedAt
+
+	// Skipping again must not error and must not disturb the timestamp.
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatalf("second Skip should be a no-op success, got %v", err)
+	}
+	qv = questView(e, "t2-build-hq")
+	if qv.SkippedAt == nil || !qv.SkippedAt.Equal(firstSkippedAt) {
+		t.Fatalf("re-skipping should not change SkippedAt: before=%v after=%v", firstSkippedAt, qv.SkippedAt)
+	}
+}
+
+func TestSkip_NeverFiresOnComplete(t *testing.T) {
+	fires := 0
+	e := New(&fakeStore{}, WithOnComplete(func(Quest) { fires++ }))
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatal(err)
+	}
+	if fires != 0 {
+		t.Fatalf("Skip must never fire onComplete, got %d calls", fires)
+	}
+}
+
+func TestSkip_DoesNotIncreaseCompletedCountButAdvancesResolvedCount(t *testing.T) {
+	e := New(&fakeStore{})
+	before := e.Status()
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatal(err)
+	}
+	after := e.Status()
+
+	if after.CompletedCount != before.CompletedCount {
+		t.Fatalf("skip must not change CompletedCount: before=%d after=%d", before.CompletedCount, after.CompletedCount)
+	}
+	if after.ResolvedCount != before.ResolvedCount+1 {
+		t.Fatalf("skip must advance ResolvedCount by 1: before=%d after=%d", before.ResolvedCount, after.ResolvedCount)
+	}
+}
+
+// TestSkip_AdvancesCurrentTierPastLockedTier covers the core non-gating
+// requirement: skipping the optional Personal HQ quest must not keep tier 3
+// (or the widget's locked-tier display) stuck behind it once every other
+// tier-2 quest resolves.
+func TestSkip_AdvancesCurrentTierPastLockedTier(t *testing.T) {
+	e := New(&fakeStore{})
+	e.Complete("t1-first-message")
+	e.Complete("t1-personalize")
+	e.HandleEvent(ws.Event{Type: ws.EventWorkspaceCreated}) // t2-create-workspace
+	e.HandleEvent(ws.Event{Type: ws.EventNoteCreated})      // t2-create-note
+	e.HandleEvent(ws.Event{Type: ws.EventTaskStarted})      // t2-run-task
+
+	// Before skipping, tier 2 is not yet complete and tier 3 is locked.
+	st := e.Status()
+	if st.CurrentTier != 2 {
+		t.Fatalf("precondition: expected current tier 2 before skip, got %d", st.CurrentTier)
+	}
+	if q := questView(e, "t3-second-agent"); q == nil || q.Status != StatusLocked {
+		t.Fatalf("precondition: tier 3 quest should be locked, got %+v", q)
+	}
+
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatal(err)
+	}
+
+	st = e.Status()
+	if st.CurrentTier != 3 {
+		t.Fatalf("expected current tier to advance to 3 after skip, got %d", st.CurrentTier)
+	}
+	var tier2 *TierView
+	for i := range st.Tiers {
+		if st.Tiers[i].Tier == 2 {
+			tier2 = &st.Tiers[i]
+		}
+	}
+	if tier2 == nil || !tier2.Complete {
+		t.Fatalf("tier 2 should be marked complete once its optional quest is skipped, got %+v", tier2)
+	}
+	if q := questView(e, "t3-second-agent"); q == nil || q.Status != StatusAvailable {
+		t.Fatalf("tier 3 quest should now be available (unlocked), got %+v", q)
+	}
+}
+
+// TestSkip_LaterCompletionReplacesSkip covers requirement 3.5: a later real
+// completion must replace a skip outcome, remove it from SkippedQuests, and
+// fire the completion callback for that newly observed action.
+func TestSkip_LaterCompletionReplacesSkip(t *testing.T) {
+	fires := 0
+	e := New(&fakeStore{}, WithOnComplete(func(Quest) { fires++ }))
+
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatal(err)
+	}
+	if fires != 0 {
+		t.Fatalf("skip must not fire onComplete, got %d", fires)
+	}
+
+	if ok := e.Complete("t2-build-hq"); !ok {
+		t.Fatal("expected Complete to report a newly observed completion")
+	}
+	if fires != 1 {
+		t.Fatalf("the later real completion should fire onComplete exactly once, got %d", fires)
+	}
+
+	qv := questView(e, "t2-build-hq")
+	if qv == nil || qv.Status != StatusCompleted || qv.CompletedAt == nil {
+		t.Fatalf("expected completed status after later completion, got %+v", qv)
+	}
+	if qv.SkippedAt != nil {
+		t.Fatalf("SkippedAt must be cleared once the quest is actually completed, got %v", qv.SkippedAt)
+	}
+}
+
+// TestSkip_NoOpWhenAlreadyCompleted covers the reverse direction: a real
+// completion must never be downgraded back to skipped.
+func TestSkip_NoOpWhenAlreadyCompleted(t *testing.T) {
+	e := New(&fakeStore{})
+	e.Complete("t2-build-hq")
+
+	if err := e.Skip("t2-build-hq"); err != nil {
+		t.Fatalf("Skip on an already-completed quest should be a no-op success, got %v", err)
+	}
+	qv := questView(e, "t2-build-hq")
+	if qv == nil || qv.Status != StatusCompleted {
+		t.Fatalf("quest must remain completed, not regress to skipped: %+v", qv)
+	}
+}
+
+// TestBuildHQQuestDoesNotAffectCreateWorkspaceQuest covers requirement 3.6:
+// the new optional Personal HQ quest must be independent of the existing
+// t2-create-workspace quest in both directions.
+func TestBuildHQQuestDoesNotAffectCreateWorkspaceQuest(t *testing.T) {
+	e := New(&fakeStore{})
+
+	// A normal workspace-created event still only completes
+	// t2-create-workspace, matching FR48 (new-HQ creation goes through this
+	// same event and separately calls Complete("t2-build-hq"), which callers
+	// wire outside the engine).
+	e.HandleEvent(ws.Event{Type: ws.EventWorkspaceCreated})
+	if !completed(e, "t2-create-workspace") {
+		t.Fatal("workspace.created should still complete t2-create-workspace")
+	}
+	if completed(e, "t2-build-hq") {
+		t.Fatal("workspace.created must not implicitly complete t2-build-hq")
+	}
+
+	// Completing the HQ objective directly (as the designate-existing-
+	// workspace path will do, FR49) must not replay t2-create-workspace.
+	e2 := New(&fakeStore{})
+	e2.Complete("t2-build-hq")
+	if completed(e2, "t2-create-workspace") {
+		t.Fatal("completing t2-build-hq directly must not complete t2-create-workspace")
+	}
+}
+
+// TestAllComplete_TreatsSkipAsResolved proves a skipped optional quest can
+// still reach the "all complete" celebratory state without ever being
+// recorded as an actual completion.
+func TestAllComplete_TreatsSkipAsResolved(t *testing.T) {
+	e := New(&fakeStore{})
+	for _, q := range BuiltinQuests() {
+		if q.Optional {
+			if err := e.Skip(q.ID); err != nil {
+				t.Fatalf("Skip(%s): %v", q.ID, err)
+			}
+			continue
+		}
+		e.Complete(q.ID)
+	}
+
+	st := e.Status()
+	if !st.AllComplete {
+		t.Fatalf("expected AllComplete once every quest is completed or skipped, got %+v", st)
+	}
+	if st.ResolvedCount != st.TotalCount {
+		t.Fatalf("ResolvedCount should equal TotalCount, got %d/%d", st.ResolvedCount, st.TotalCount)
+	}
+	if st.CompletedCount >= st.TotalCount {
+		t.Fatalf("CompletedCount must stay below TotalCount when a quest was skipped, got %d/%d", st.CompletedCount, st.TotalCount)
+	}
+}
+
+// TestSkip_PersistsAcrossRestart covers requirement 3.2/3.9: a skip must
+// survive an engine reload from the same store, distinctly from completion.
+func TestSkip_PersistsAcrossRestart(t *testing.T) {
+	store := &fakeStore{}
+	e1 := New(store)
+	if err := e1.Skip("t2-build-hq"); err != nil {
+		t.Fatal(err)
+	}
+
+	e2 := New(store)
+	qv := questView(e2, "t2-build-hq")
+	if qv == nil || qv.Status != StatusSkipped {
+		t.Fatalf("skip should survive reload from the same store, got %+v", qv)
 	}
 }

--- a/internal/progression/quests.go
+++ b/internal/progression/quests.go
@@ -131,11 +131,15 @@ func BuiltinQuests() []Quest {
 		},
 		{
 			ID: "t2-build-hq", Tier: 2,
-			Title:       "Build your Personal HQ",
-			Why:         "Give Ori a home base — a place to prepare your daily brief, track follow-ups, and help you resume work.",
-			Optional:    true,
-			Satisfied:   func(s Snapshot) bool { return s.HasPersonalHQ },
-			ActionURL:   "/workspaces?hq=1",
+			Title:     "Build your Personal HQ",
+			Why:       "Give Ori a home base — a place to prepare your daily brief, track follow-ups, and help you resume work.",
+			Optional:  true,
+			Satisfied: func(s Snapshot) bool { return s.HasPersonalHQ },
+			// Mission 01 is featured from the Home progression panel even before
+			// Tier 2 unlocks. Route straight into the guided HQ briefing instead
+			// of the generic workspace launcher so the action is useful at every
+			// progression tier.
+			ActionURL:   "/workspaces?hq_onboarding=1",
 			ActionLabel: "Build your Personal HQ",
 		},
 		{

--- a/internal/progression/quests.go
+++ b/internal/progression/quests.go
@@ -38,6 +38,13 @@ type Quest struct {
 	// happens inline (e.g. the home chat box) with no separate destination.
 	ActionURL   string
 	ActionLabel string
+	// Optional marks a quest the user may explicitly skip via Engine.Skip
+	// instead of completing. Skipping a non-optional quest is rejected. A
+	// skipped optional quest counts as resolved for current-tier/TierView
+	// completion so it never keeps later tiers locked, but it is never
+	// recorded in CompletedQuests — only a real observed action (live event,
+	// backfill, or direct Complete call) does that.
+	Optional bool
 }
 
 // tierNames maps a tier number to its display name.
@@ -121,6 +128,15 @@ func BuiltinQuests() []Quest {
 			Satisfied:   func(s Snapshot) bool { return s.Workspaces > 0 },
 			ActionURL:   "/workspaces?create=1",
 			ActionLabel: "Create a workspace",
+		},
+		{
+			ID: "t2-build-hq", Tier: 2,
+			Title:       "Build your Personal HQ",
+			Why:         "Give Ori a home base — a place to prepare your daily brief, track follow-ups, and help you resume work.",
+			Optional:    true,
+			Satisfied:   func(s Snapshot) bool { return s.HasPersonalHQ },
+			ActionURL:   "/workspaces?hq=1",
+			ActionLabel: "Build your Personal HQ",
 		},
 		{
 			ID: "t2-create-note", Tier: 2,

--- a/internal/progression/state.go
+++ b/internal/progression/state.go
@@ -34,6 +34,9 @@ type Snapshot struct {
 	// Personalized is true when the user has filled out their profile
 	// (interests / work style) on the Personalize page.
 	Personalized bool
+	// HasPersonalHQ is true when the user already has a valid Personal HQ
+	// designation, grandfathering the optional t2-build-hq quest.
+	HasPersonalHQ bool
 }
 
 // Scanner produces a Snapshot of existing state for the backfill scan. The
@@ -61,6 +64,10 @@ const (
 	// (shown dimmed). Note: detection still runs for locked quests, so a user
 	// who jumps ahead completes them immediately regardless of this status.
 	StatusLocked QuestStatus = "locked-tier"
+	// StatusSkipped means an optional quest was explicitly skipped. It counts
+	// as resolved for current-tier/TierView/AllComplete purposes but never as
+	// completed — a later real action replaces it with StatusCompleted.
+	StatusSkipped QuestStatus = "skipped"
 )
 
 // QuestView is the API representation of a quest.
@@ -71,27 +78,39 @@ type QuestView struct {
 	Why         string      `json:"why"`
 	Status      QuestStatus `json:"status"`
 	CompletedAt *time.Time  `json:"completed_at,omitempty"`
+	SkippedAt   *time.Time  `json:"skipped_at,omitempty"`
 	ActionURL   string      `json:"action_url,omitempty"`
 	ActionLabel string      `json:"action_label,omitempty"`
+	// Optional mirrors Quest.Optional so the UI can offer Skip only where
+	// valid.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // TierView groups a tier's quests for the API.
 type TierView struct {
-	Tier     int         `json:"tier"`
-	Name     string      `json:"name"`
+	Tier int    `json:"tier"`
+	Name string `json:"name"`
+	// Complete is true when every quest in the tier is resolved: completed or
+	// (for optional quests) skipped.
 	Complete bool        `json:"complete"`
 	Quests   []QuestView `json:"quests"`
 }
 
 // Status is the full progression snapshot returned by the API.
 type Status struct {
-	Tiers          []TierView `json:"tiers"`
-	CurrentTier    int        `json:"current_tier"`
-	TotalTiers     int        `json:"total_tiers"`
-	CompletedCount int        `json:"completed_count"`
-	TotalCount     int        `json:"total_count"`
-	AllComplete    bool       `json:"all_complete"`
-	Dismissed      bool       `json:"dismissed"`
+	Tiers       []TierView `json:"tiers"`
+	CurrentTier int        `json:"current_tier"`
+	TotalTiers  int        `json:"total_tiers"`
+	// CompletedCount is the number of quests whose underlying action was
+	// actually observed (live event, backfill, or direct Complete). It never
+	// counts a skipped optional quest.
+	CompletedCount int `json:"completed_count"`
+	// ResolvedCount is CompletedCount plus skipped optional quests — the
+	// total the widget meter and tier/AllComplete advancement are driven by.
+	ResolvedCount int  `json:"resolved_count"`
+	TotalCount    int  `json:"total_count"`
+	AllComplete   bool `json:"all_complete"`
+	Dismissed     bool `json:"dismissed"`
 	// NextQuest is the next actionable quest (lowest tier, first incomplete),
 	// or nil when everything is complete.
 	NextQuest *QuestView `json:"next_quest,omitempty"`

--- a/internal/progressionhttp/handler.go
+++ b/internal/progressionhttp/handler.go
@@ -3,6 +3,7 @@
 package progressionhttp
 
 import (
+	"errors"
 	"net/http"
 
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
@@ -56,6 +57,44 @@ func (h *Handler) Dismiss(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = orihttp.RespondSuccess(w, h.engine.Status())
+}
+
+// SkipRequest identifies which optional quest to skip.
+type SkipRequest struct {
+	QuestID string `json:"quest_id"`
+}
+
+// Skip marks a single optional quest as explicitly skipped and returns
+// updated status. Kept separate from Dismiss, which hides the whole widget
+// rather than resolving one quest.
+// POST /api/progression/skip  body: {"quest_id": "t2-build-hq"}
+func (h *Handler) Skip(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h.engine == nil {
+		_ = orihttp.RespondServiceUnavailable(w, "progression is not available")
+		return
+	}
+	var req SkipRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.QuestID == "" {
+		_ = orihttp.RespondBadRequest(w, "quest_id is required")
+		return
+	}
+	err := h.engine.Skip(req.QuestID)
+	switch {
+	case err == nil:
+		_ = orihttp.RespondSuccess(w, h.engine.Status())
+	case errors.Is(err, progression.ErrQuestNotFound):
+		_ = orihttp.RespondNotFound(w, err.Error())
+	case errors.Is(err, progression.ErrQuestNotOptional):
+		_ = orihttp.RespondBadRequest(w, err.Error())
+	default:
+		_ = orihttp.RespondInternalError(w, "failed to skip quest: "+err.Error())
+	}
 }
 
 // Reset clears all progression state (dev/test parity with onboarding reset).

--- a/internal/progressionhttp/handler_test.go
+++ b/internal/progressionhttp/handler_test.go
@@ -95,10 +95,104 @@ func TestReset(t *testing.T) {
 	}
 }
 
+func TestSkip(t *testing.T) {
+	h, _ := newHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{"quest_id":"t2-build-hq"}`))
+	h.Skip(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	st := decodeStatus(t, rec.Body.Bytes())
+	var found *progression.QuestView
+	for _, tv := range st.Tiers {
+		for i := range tv.Quests {
+			if tv.Quests[i].ID == "t2-build-hq" {
+				found = &tv.Quests[i]
+			}
+		}
+	}
+	if found == nil || found.Status != progression.StatusSkipped {
+		t.Fatalf("expected t2-build-hq to be skipped, got %+v", found)
+	}
+}
+
+func TestSkip_RejectsNonOptionalQuestWith400(t *testing.T) {
+	h, _ := newHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{"quest_id":"t1-first-message"}`))
+	h.Skip(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSkip_UnknownQuestReturns404(t *testing.T) {
+	h, _ := newHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{"quest_id":"does-not-exist"}`))
+	h.Skip(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status code = %d, want 404, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSkip_MissingQuestIDReturns400(t *testing.T) {
+	h, _ := newHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{}`))
+	h.Skip(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSkip_RejectsNonPost(t *testing.T) {
+	h, _ := newHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/progression/skip", nil)
+	h.Skip(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status code = %d, want 405", rec.Code)
+	}
+}
+
+// TestSkipIsDistinctFromDismiss covers the requirement that the per-quest
+// skip endpoint stays separate from the whole-widget dismiss endpoint:
+// skipping one quest must not dismiss the widget, and dismissing the widget
+// must not resolve any quest.
+func TestSkipIsDistinctFromDismiss(t *testing.T) {
+	h, _ := newHandler()
+
+	skipRec := httptest.NewRecorder()
+	h.Skip(skipRec, httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{"quest_id":"t2-build-hq"}`)))
+	if decodeStatus(t, skipRec.Body.Bytes()).Dismissed {
+		t.Fatal("skipping a quest must not dismiss the whole widget")
+	}
+
+	dismissRec := httptest.NewRecorder()
+	h.Dismiss(dismissRec, httptest.NewRequest(http.MethodPost, "/api/progression/dismiss", strings.NewReader(`{"dismissed":true}`)))
+	dismissedStatus := decodeStatus(t, dismissRec.Body.Bytes())
+	if dismissedStatus.ResolvedCount != 1 {
+		t.Fatalf("dismiss must not change resolution state; expected the earlier skip to remain the only resolved quest, got resolved_count=%d", dismissedStatus.ResolvedCount)
+	}
+}
+
 func TestNilEngine_ServiceUnavailable(t *testing.T) {
 	h := NewHandler(nil)
 	rec := httptest.NewRecorder()
 	h.GetStatus(rec, httptest.NewRequest(http.MethodGet, "/api/progression", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want 503", rec.Code)
+	}
+}
+
+func TestNilEngine_SkipServiceUnavailable(t *testing.T) {
+	h := NewHandler(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/progression/skip", strings.NewReader(`{"quest_id":"t2-build-hq"}`))
+	h.Skip(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status code = %d, want 503", rec.Code)
 	}

--- a/internal/projecttemplates/starter/daily-briefings/template.json
+++ b/internal/projecttemplates/starter/daily-briefings/template.json
@@ -1,10 +1,10 @@
 {
-  "name": "Daily Briefings",
-  "description": "Morning roundup, market summary, news digest.",
-  "icon": "\ud83d\udcca",
+  "name": "Custom Digest",
+  "description": "A recurring digest from your own externally sourced feeds — news, markets, research, or anything else you point it at.",
+  "icon": "📊",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 2,
+  "builtin_version": 3,
   "tags": [
     "briefing"
   ],
@@ -18,10 +18,10 @@
     {
       "name": "Briefing Editor",
       "role": "orchestrator",
-      "system_prompt": "You produce the daily briefing for this workspace. Pull from the configured sources, summarize what changed and why it matters, and keep it skimmable \u2014 lead with the headline, then the detail. Call out anything that needs a decision or follow-up."
+      "system_prompt": "You produce a recurring digest for this workspace from externally sourced feeds the user configures here — news, markets, research, or any other feed they define. This is a project-scoped digest, not the app's Personal HQ Daily Brief. Pull from the configured sources, summarize what changed and why it matters, and keep it skimmable — lead with the headline, then the detail. Call out anything that needs a decision or follow-up."
     }
   ],
-  "tagline": "Morning roundup, market summary, news digest.",
+  "tagline": "External news, markets, and research — on your schedule.",
   "addons": [
     "web search / news MCP",
     "data sources to summarize"

--- a/internal/projecttemplates/starter/personal-ops/template.json
+++ b/internal/projecttemplates/starter/personal-ops/template.json
@@ -1,14 +1,19 @@
 {
-  "name": "Personal Ops",
-  "description": "Daily journal, briefings, follow-ups. A personal command center.",
-  "icon": "\ud83d\uddd3",
+  "name": "Personal HQ",
+  "description": "Your personal command center — daily briefs, follow-ups, and journaling, run by a Personal Chief of Staff.",
+  "icon": "🗓",
   "behavior_profile": "general",
   "builtin": true,
-  "builtin_version": 2,
+  "builtin_version": 3,
   "tags": [
     "personal"
   ],
   "starter_tasks": [
+    {
+      "description": "Set up your Personal HQ",
+      "details": "Ask the user what they want tracked here: their top follow-ups, recurring commitments, and (if they have other workspaces already) which ones they'd like surfaced in their daily rhythm. Note whether they prefer a morning briefing, an end-of-day journal, or both, so the scheduled tasks below match how they actually work. Keep it to a few quick questions — this is a one-time setup, not an interview — and confirm you'll adjust the two starter tasks below to match their answers.",
+      "setup": true
+    },
     {
       "description": "Morning briefing",
       "details": "Customize with the channels you care about (calendar, email, urgent threads). Schedule this task to run before your workday starts."
@@ -22,10 +27,10 @@
     {
       "name": "Personal Chief of Staff",
       "role": "orchestrator",
-      "system_prompt": "You are the chief of staff for this personal command center. Run the morning briefing and the end-of-day journal, track open follow-ups across calendar and email, and surface what needs attention before it slips. Keep it concise and action-oriented."
+      "system_prompt": "You are the Personal Chief of Staff for this personal command center. Prioritize what needs attention, prepare the morning briefing and end-of-day journal, and track open follow-ups across calendar and email so nothing slips. When a request is specialist project work, route the user to the right project workspace instead of taking it on yourself — you own prioritization, briefs, follow-ups, and routing, not the specialist work itself. Keep it concise and action-oriented."
     }
   ],
-  "tagline": "Daily journal, briefings, follow-ups.",
+  "tagline": "Your personal command center.",
   "addons": [
     "calendar MCP",
     "email MCP",

--- a/internal/projecttemplates/starter_personal_hq_test.go
+++ b/internal/projecttemplates/starter_personal_hq_test.go
@@ -1,0 +1,164 @@
+package projecttemplates_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+)
+
+// TestPersonalOpsStarterEvolvedToPersonalHQ pins the Personal Ops -> Personal
+// HQ manifest evolution (PRD FR119-FR122, FR128): the internal template ID
+// and folder name are frozen for compatibility, but the display metadata,
+// roster, and starter tasks now describe the Personal HQ blueprint.
+func TestPersonalOpsStarterEvolvedToPersonalHQ(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	// The internal ID/folder name must never change — existing workspaces'
+	// stored template provenance and any hardcoded references key off this.
+	tpl, err := projecttemplates.FindLibraryTemplate(libDir, "personal-ops")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate(personal-ops): %v", err)
+	}
+	if tpl.ID != "personal-ops" {
+		t.Fatalf("template ID must stay personal-ops, got %q", tpl.ID)
+	}
+	if !tpl.Builtin {
+		t.Fatal("personal-ops must remain a built-in template")
+	}
+	if tpl.BuiltinVersion < 3 {
+		t.Fatalf("personal-ops builtin_version = %d, want at least 3", tpl.BuiltinVersion)
+	}
+
+	// Display metadata now presents this as Personal HQ.
+	if tpl.Name != "Personal HQ" {
+		t.Fatalf("display name = %q, want %q", tpl.Name, "Personal HQ")
+	}
+	if !strings.Contains(strings.ToLower(tpl.Description), "personal command center") {
+		t.Fatalf("description must describe a personal command center, got %q", tpl.Description)
+	}
+
+	// Roster: the Personal Chief of Staff must be present and, being the
+	// only declared agent, is first (the entry agent).
+	if len(tpl.Agents) != 1 || tpl.Agents[0].Name != "Personal Chief of Staff" {
+		t.Fatalf("expected Personal Chief of Staff as the sole/entry agent, got %+v", tpl.Agents)
+	}
+	prompt := tpl.Agents[0].SystemPrompt
+	for _, want := range []string{"prioriti", "brief", "follow-up", "route the user"} {
+		if !strings.Contains(strings.ToLower(prompt), want) {
+			t.Errorf("Chief of Staff prompt missing scope keyword %q: %s", want, prompt)
+		}
+	}
+	if !strings.Contains(strings.ToLower(prompt), "not the specialist work itself") &&
+		!strings.Contains(strings.ToLower(prompt), "not take it on yourself") &&
+		!strings.Contains(strings.ToLower(prompt), "route the user to the right project workspace") {
+		t.Errorf("Chief of Staff prompt must not claim ownership of specialist project work: %s", prompt)
+	}
+
+	// Starter tasks: a small set, at most one (here exactly one) marked
+	// setup:true, and it must be first.
+	if len(tpl.StarterTasks) != 3 {
+		t.Fatalf("expected 3 starter tasks (1 setup + 2 recurring), got %d: %+v", len(tpl.StarterTasks), tpl.StarterTasks)
+	}
+	setupCount := 0
+	for i, task := range tpl.StarterTasks {
+		if task.Setup {
+			setupCount++
+			if i != 0 {
+				t.Errorf("setup task must be first in the list, found at index %d", i)
+			}
+		}
+	}
+	if setupCount != 1 {
+		t.Fatalf("expected exactly one setup:true starter task, got %d", setupCount)
+	}
+	if tpl.StarterTasks[1].Description != "Morning briefing" || tpl.StarterTasks[2].Description != "End-of-day journal" {
+		t.Fatalf("expected the pre-existing Morning briefing / End-of-day journal tasks preserved, got %+v", tpl.StarterTasks)
+	}
+
+	if len(tpl.Warnings) != 0 {
+		t.Fatalf("personal-ops should load without warnings, got %v", tpl.Warnings)
+	}
+}
+
+// TestDailyBriefingsStarterEvolvedToCustomDigest pins the Daily Briefings ->
+// Custom Digest manifest evolution (PRD FR123-FR126): frozen internal ID,
+// renamed display metadata, and positioning for externally sourced digests
+// so it does not duplicate the Personal HQ Daily Brief.
+func TestDailyBriefingsStarterEvolvedToCustomDigest(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	tpl, err := projecttemplates.FindLibraryTemplate(libDir, "daily-briefings")
+	if err != nil {
+		t.Fatalf("FindLibraryTemplate(daily-briefings): %v", err)
+	}
+	if tpl.ID != "daily-briefings" {
+		t.Fatalf("template ID must stay daily-briefings, got %q", tpl.ID)
+	}
+	if !tpl.Builtin {
+		t.Fatal("daily-briefings must remain a built-in template")
+	}
+	if tpl.BuiltinVersion < 3 {
+		t.Fatalf("daily-briefings builtin_version = %d, want at least 3", tpl.BuiltinVersion)
+	}
+
+	if tpl.Name != "Custom Digest" {
+		t.Fatalf("display name = %q, want %q", tpl.Name, "Custom Digest")
+	}
+	lowerDesc := strings.ToLower(tpl.Description)
+	for _, want := range []string{"externally sourced", "news", "market", "research"} {
+		if !strings.Contains(lowerDesc, want) {
+			t.Errorf("description missing external-digest positioning keyword %q: %s", want, tpl.Description)
+		}
+	}
+	// Must not read as the app-wide Personal HQ Daily Brief.
+	if strings.Contains(lowerDesc, "personal command center") {
+		t.Errorf("Custom Digest description must not read as the Personal HQ command center: %s", tpl.Description)
+	}
+
+	if len(tpl.Agents) != 1 || tpl.Agents[0].Name != "Briefing Editor" {
+		t.Fatalf("expected Briefing Editor as the sole/entry agent, got %+v", tpl.Agents)
+	}
+	prompt := strings.ToLower(tpl.Agents[0].SystemPrompt)
+	if !strings.Contains(prompt, "externally sourced") {
+		t.Errorf("Briefing Editor prompt should clarify externally sourced feeds: %s", prompt)
+	}
+	if !strings.Contains(prompt, "not the app's personal hq daily brief") {
+		t.Errorf("Briefing Editor prompt should distinguish itself from the Personal HQ Daily Brief: %s", prompt)
+	}
+
+	if len(tpl.Warnings) != 0 {
+		t.Fatalf("daily-briefings should load without warnings, got %v", tpl.Warnings)
+	}
+}
+
+// TestPersonalHQAndCustomDigestIDsFrozen guards against ever renaming the
+// shipped folder/internal IDs as part of a future copy pass (PRD FR120,
+// FR125): user-visible copy must change without touching these.
+func TestPersonalHQAndCustomDigestIDsFrozen(t *testing.T) {
+	libDir := filepath.Join(t.TempDir(), "templates")
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+	templates, err := projecttemplates.ListLibrary(libDir)
+	if err != nil {
+		t.Fatalf("ListLibrary: %v", err)
+	}
+	ids := make(map[string]string, len(templates))
+	for _, tpl := range templates {
+		ids[tpl.ID] = tpl.Name
+	}
+	if name, ok := ids["personal-ops"]; !ok || name != "Personal HQ" {
+		t.Fatalf("expected personal-ops -> Personal HQ, got %q (present=%v)", name, ok)
+	}
+	if name, ok := ids["daily-briefings"]; !ok || name != "Custom Digest" {
+		t.Fatalf("expected daily-briefings -> Custom Digest, got %q (present=%v)", name, ok)
+	}
+}

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -35,6 +35,8 @@ import (
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/orchestrationhttp"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/personalhqhttp"
 	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
 	"github.com/johnjallday/ori-agent/internal/progression"
@@ -218,6 +220,10 @@ type ServerBuilder struct {
 
 	// User profile API
 	userHandler *userhttp.Handler
+
+	// Personal HQ designation and onboarding state
+	personalHQService *personalhq.Service
+	personalHQHandler *personalhqhttp.Handler
 }
 
 // NewServerBuilder creates a new ServerBuilder instance with an empty Server.
@@ -397,6 +403,7 @@ func (b *ServerBuilder) createDomainFacades() {
 		ExternalAgents:   b.externalAgentsHandler,
 		Skills:           b.skillsHandler,
 		User:             b.userHandler,
+		PersonalHQ:       b.personalHQHandler,
 		CLIAgents:        b.cliAgentHandler,
 		CLIAgentRegistry: b.cliAgentRegistry,
 		WorkspaceRuns:    b.workspaceRunHandler,

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -338,6 +338,7 @@ func (b *ServerBuilder) createDomainFacades() {
 		b.userProvider,
 		b.onboardingMgr,
 		b.locationManager,
+		b.personalHQService,
 	)
 
 	// Workflow System Facade

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -14,6 +14,8 @@ import (
 	"github.com/johnjallday/ori-agent/internal/cliagenthttp"
 	"github.com/johnjallday/ori-agent/internal/client"
 	"github.com/johnjallday/ori-agent/internal/config"
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/dailybriefhttp"
 	"github.com/johnjallday/ori-agent/internal/devicehttp"
 	"github.com/johnjallday/ori-agent/internal/evolution"
 	"github.com/johnjallday/ori-agent/internal/evolutionhttp"
@@ -224,6 +226,11 @@ type ServerBuilder struct {
 	// Personal HQ designation and onboarding state
 	personalHQService *personalhq.Service
 	personalHQHandler *personalhqhttp.Handler
+
+	// Daily Brief configuration, generation, and scheduling
+	dailyBriefService   *dailybrief.Service
+	dailyBriefHandler   *dailybriefhttp.Handler
+	dailyBriefScheduler *dailybrief.Scheduler
 }
 
 // NewServerBuilder creates a new ServerBuilder instance with an empty Server.
@@ -301,6 +308,7 @@ func (b *ServerBuilder) Build() (*Server, error) {
 	}
 	b.initializeWorkspaceOrchestrator() // Phase 22
 	b.initializeMissionBridge()         // Phase 22.5 — wire mission cadence → run lifecycle
+	b.initializeDailyBrief()            // Phase 22.6 — wire personal hq daily brief storage/scheduling/synthesis
 	b.initializeTemplateManager()       // Phase 23
 
 	// ═══════════════════════════════════════════════════════════════════════════
@@ -354,6 +362,7 @@ func (b *ServerBuilder) createDomainFacades() {
 	// Trigger service shares the workflow facade's lifecycle (started during
 	// mission-bridge init; stopped on Shutdown).
 	b.server.Workflow.TriggerService = b.triggerService
+	b.server.Workflow.DailyBriefScheduler = b.dailyBriefScheduler
 
 	// Integration System Facade
 	b.server.Integration = NewIntegrationSystemFacade(
@@ -405,6 +414,7 @@ func (b *ServerBuilder) createDomainFacades() {
 		Skills:           b.skillsHandler,
 		User:             b.userHandler,
 		PersonalHQ:       b.personalHQHandler,
+		DailyBrief:       b.dailyBriefHandler,
 		CLIAgents:        b.cliAgentHandler,
 		CLIAgentRegistry: b.cliAgentRegistry,
 		WorkspaceRuns:    b.workspaceRunHandler,

--- a/internal/server/builder_dailybrief.go
+++ b/internal/server/builder_dailybrief.go
@@ -146,7 +146,11 @@ func (b *ServerBuilder) initializeDailyBrief() {
 		}
 		if _, _, err := opportunityStore.Upsert(opp); err != nil {
 			logger.Warn("dailybrief: failed to create action center notification", logger.Fields{"revision_id": rev.ID, "error": err})
+			return
 		}
+		// Bounded, field-only observable event (PRD FR138) — IDs only, no
+		// brief prose/summary content.
+		logger.Info("dailybrief: notified", logger.Fields{"workspace_id": cfg.WorkspaceID, "revision_id": rev.ID})
 	})
 
 	b.dailyBriefService = briefService

--- a/internal/server/builder_dailybrief.go
+++ b/internal/server/builder_dailybrief.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/config"
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/dailybriefhttp"
+	"github.com/johnjallday/ori-agent/internal/llm"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// sessionSourceAdapter adapts session.HybridStore.ListSessions (which
+// returns a paginated *session.ListResult) to dailybrief.SessionSource
+// (which only needs the bounded item list — Daily Brief always requests a
+// small, fixed Limit and never paginates).
+type sessionSourceAdapter struct {
+	store session.HybridStore
+}
+
+func (a *sessionSourceAdapter) ListSessions(ctx context.Context, filter *session.SessionFilter, opts *session.ListOptions) ([]session.SessionListItem, error) {
+	result, err := a.store.ListSessions(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.Sessions, nil
+}
+
+// dailyBriefSchedulerPollInterval balances catch-up promptness (a user who
+// opens the app well after their scheduled time should see a fresh brief
+// soon) against needless churn; the schedule itself is date/time-grained,
+// not sub-minute, so a coarser poll than the 1-minute task scheduler is fine.
+const dailyBriefSchedulerPollInterval = 5 * time.Minute
+
+// systemModelChatCompleter adapts the configured system model to
+// dailybrief.ChatCompleter, resolving the provider/model fresh on every call
+// (not cached at server startup) so a user changing the system model in
+// Settings takes effect on the next generation without a restart.
+type systemModelChatCompleter struct {
+	configManager *config.Manager
+	llmFactory    *llm.Factory
+}
+
+func (c *systemModelChatCompleter) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	if c.configManager == nil || c.llmFactory == nil {
+		return nil, fmt.Errorf("dailybrief: system model is not configured")
+	}
+	providerName, modelName := c.configManager.GetSystemModel()
+	result, err := c.llmFactory.GetSystemModelProvider(providerName, modelName)
+	if err != nil {
+		return nil, err
+	}
+	req.Model = result.Model
+	return result.Provider.Chat(ctx, req)
+}
+
+// personalHQWorkspaceLister adapts internal/personalhq to
+// dailybrief.WorkspaceLister: in v1 there is at most one designated HQ per
+// user, and only when it currently resolves (never a stale/invalid
+// designation — that's the personalhq repair flow's job, not the
+// scheduler's).
+type personalHQWorkspaceLister struct {
+	service *personalhq.Service
+}
+
+func (l *personalHQWorkspaceLister) ListScheduledWorkspaces(ctx context.Context) ([]dailybrief.ScheduledWorkspace, error) {
+	if l.service == nil {
+		return nil, nil
+	}
+	status, err := l.service.Status(ctx, userprofile.LocalUserID)
+	if err != nil {
+		return nil, err
+	}
+	if !status.Valid {
+		return nil, nil
+	}
+	return []dailybrief.ScheduledWorkspace{{WorkspaceID: status.WorkspaceID, UserID: userprofile.LocalUserID}}, nil
+}
+
+// initializeDailyBrief wires the Daily Brief domain (tasks 5/6) into the
+// running server: durable storage, a Synthesizer backed by the configured
+// system model (falling back to deterministic content when none is
+// configured or it fails), a background scheduler driven by the current
+// Personal HQ designation, the HTTP handler, and the Action Center
+// notification hook. Requires the session store, workspace store, and
+// Personal HQ service to already be wired; a no-op otherwise.
+func (b *ServerBuilder) initializeDailyBrief() {
+	if b.sessionStore == nil || b.workspaceStore == nil || b.personalHQService == nil {
+		return
+	}
+	store := dailybrief.NewSQLiteStore(b.sessionStore.DB())
+	opportunityStore := workspace.NewOpportunityStore(b.workspaceStore)
+	sessionSource := &sessionSourceAdapter{store: b.sessionStore}
+	workspaceStore := b.workspaceStore
+
+	resolver := func(ctx context.Context, req dailybrief.GenerationRequest, cfg dailybrief.Config) (dailybrief.Snapshot, *dailybrief.Revision, error) {
+		sources := dailybrief.SnapshotSources{
+			Workspaces:    workspaceStore,
+			Opportunities: opportunityStore,
+			Sessions:      sessionSource,
+		}
+		snap := dailybrief.BuildSnapshot(ctx, sources, cfg, req.UserID, time.Now())
+		previous, err := store.GetCurrentRevision(ctx, cfg.WorkspaceID)
+		if err != nil {
+			previous = nil // ErrRevisionNotFound just means no prior brief yet.
+		}
+		return snap, previous, nil
+	}
+
+	synthesizer := &dailybrief.Synthesizer{
+		Chat:     &systemModelChatCompleter{configManager: b.configManager, llmFactory: b.llmFactory},
+		Resolver: resolver,
+	}
+	briefService := dailybrief.NewService(store, synthesizer)
+
+	// Action Center notification: fires only for a successful/partial
+	// scheduled revision when the user opted in (PRD FR63/FR65). The
+	// title embeds the local date so each day's notification is a distinct
+	// Action Center item rather than merging into yesterday's via the
+	// title-based dedup key (internal/workspace/opportunities.go DedupKey).
+	briefService.SetOnRevisionReady(func(cfg dailybrief.Config, rev *dailybrief.Revision) {
+		created, err := briefService.RecordNotificationIfEnabled(context.Background(), cfg, rev)
+		if err != nil {
+			logger.Warn("dailybrief: failed to record notification", logger.Fields{"revision_id": rev.ID, "error": err})
+			return
+		}
+		if !created {
+			return
+		}
+		opp := workspace.Opportunity{
+			WorkspaceID:       cfg.WorkspaceID,
+			Title:             fmt.Sprintf("Daily Brief ready — %s", rev.LocalDate),
+			Summary:           "Your scheduled Daily Brief has been generated.",
+			Priority:          "medium",
+			Status:            workspace.OpportunityNew,
+			RecommendedAction: "Open Home to view your Daily Brief.",
+		}
+		if _, _, err := opportunityStore.Upsert(opp); err != nil {
+			logger.Warn("dailybrief: failed to create action center notification", logger.Fields{"revision_id": rev.ID, "error": err})
+		}
+	})
+
+	b.dailyBriefService = briefService
+	b.dailyBriefHandler = dailybriefhttp.NewHandler(briefService, b.personalHQService, b.userProvider)
+	b.dailyBriefScheduler = dailybrief.NewScheduler(briefService, &personalHQWorkspaceLister{service: b.personalHQService}, dailyBriefSchedulerPollInterval)
+}

--- a/internal/server/builder_dailybrief_test.go
+++ b/internal/server/builder_dailybrief_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/session"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
@@ -134,5 +136,108 @@ func TestDailyBrief_ScheduledSuccessCreatesExactlyOneActionCenterNotification(t 
 	}
 	if len(opportunities) != 1 {
 		t.Fatalf("expected manual refresh to create no additional opportunity, got %d: %#v", len(opportunities), opportunities)
+	}
+}
+
+// TestReplaceNeverCopiesBriefHistoryToNewHQ covers task 8.4: replacing the
+// designated HQ must never carry the former HQ's brief config/history onto
+// the new one — dailybrief.Store keys everything by WorkspaceID, but this
+// proves it end-to-end through the real HTTP surface (which resolves
+// "current HQ" dynamically via personalhq.Status on every call) rather than
+// only at the storage layer.
+func TestReplaceNeverCopiesBriefHistoryToNewHQ(t *testing.T) {
+	builder, handler := newDailyBriefTestServer(t)
+	ctx := context.Background()
+
+	setupReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"Command Post"}`))
+	setupReq.Header.Set("Content-Type", "application/json")
+	setupRec := httptest.NewRecorder()
+	handler.ServeHTTP(setupRec, setupReq)
+	if setupRec.Code != http.StatusOK {
+		t.Fatalf("setup status = %d body=%s", setupRec.Code, setupRec.Body.String())
+	}
+	var setupResp struct {
+		Status struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(setupRec.Body.Bytes(), &setupResp); err != nil {
+		t.Fatalf("decode setup response: %v", err)
+	}
+	oldHQID := setupResp.Status.WorkspaceID
+
+	openReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/brief/open", nil)
+	openRec := httptest.NewRecorder()
+	handler.ServeHTTP(openRec, openReq)
+	if openRec.Code != http.StatusAccepted {
+		t.Fatalf("open status = %d body=%s", openRec.Code, openRec.Body.String())
+	}
+	var oldRevision *dailybrief.Revision
+	var err error
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		oldRevision, err = builder.dailyBriefService.GetCurrent(ctx, oldHQID)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if oldRevision == nil {
+		t.Fatalf("expected the original HQ to have a current brief before replacing, last err: %v", err)
+	}
+
+	newHQ := &session.Workspace{
+		ID: "ws-new-hq", Name: "New Command Post", Kind: session.WorkspaceKindWorkspace,
+		OwnerUserID: "local", Status: session.WorkspaceStatusActive,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := builder.sessionStore.CreateWorkspace(ctx, newHQ); err != nil {
+		t.Fatalf("CreateWorkspace(new hq): %v", err)
+	}
+	replaceReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/replace", bytes.NewBufferString(`{"workspace_id":"ws-new-hq"}`))
+	replaceReq.Header.Set("Content-Type", "application/json")
+	replaceRec := httptest.NewRecorder()
+	handler.ServeHTTP(replaceRec, replaceReq)
+	if replaceRec.Code != http.StatusOK {
+		t.Fatalf("replace status = %d body=%s", replaceRec.Code, replaceRec.Body.String())
+	}
+
+	// The HTTP surface resolves "current HQ" dynamically, so it now points
+	// at the new workspace — its brief config/history must be untouched
+	// defaults, never a copy of the old HQ's.
+	configReq := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/config", nil)
+	configRec := httptest.NewRecorder()
+	handler.ServeHTTP(configRec, configReq)
+	var configResp struct {
+		Configured bool `json:"configured"`
+	}
+	if err := json.Unmarshal(configRec.Body.Bytes(), &configResp); err != nil {
+		t.Fatalf("decode config response: %v", err)
+	}
+	if configResp.Configured {
+		t.Fatal("expected the new HQ to start with no brief config of its own, not the old HQ's")
+	}
+
+	currentReq := httptest.NewRequest(http.MethodGet, "/api/personal-hq/brief/current", nil)
+	currentRec := httptest.NewRecorder()
+	handler.ServeHTTP(currentRec, currentReq)
+	var currentResp struct {
+		Revision *dailybrief.Revision `json:"revision"`
+	}
+	if err := json.Unmarshal(currentRec.Body.Bytes(), &currentResp); err != nil {
+		t.Fatalf("decode current response: %v", err)
+	}
+	if currentResp.Revision != nil {
+		t.Fatalf("expected the new HQ to have no current brief, got %#v", currentResp.Revision)
+	}
+
+	// The former HQ's own brief history must remain completely intact,
+	// still addressable by its own workspace id.
+	stillThere, err := builder.dailyBriefService.GetCurrent(ctx, oldHQID)
+	if err != nil {
+		t.Fatalf("expected the former HQ's brief to remain intact after replace: %v", err)
+	}
+	if stillThere.ID != oldRevision.ID {
+		t.Fatalf("expected the former HQ's revision to be untouched, got %#v want %#v", stillThere, oldRevision)
 	}
 }

--- a/internal/server/builder_dailybrief_test.go
+++ b/internal/server/builder_dailybrief_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// newDailyBriefTestServer builds a full server (same wiring path as
+// production, via ServerBuilder.Build) rooted at a temp directory, mirroring
+// newRoutesTestHandler in routes_test.go. Returns the builder itself (not
+// just its handler) so tests can reach unexported fields like
+// dailyBriefService/workspaceStore to drive a TriggerScheduled generation,
+// which has no HTTP route (only first-open/manual are exposed to clients).
+func newDailyBriefTestServer(t *testing.T) (*ServerBuilder, http.Handler) {
+	t.Helper()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalWD) })
+	// DefaultWorkspaceRoot() resolves to $HOME/Ori Workspaces regardless of
+	// CWD (it does not respect ORI_DATA_DIR either) — this test actually
+	// creates a workspace, so without this it would write into the real
+	// user's home directory. t.Setenv restores the original HOME after the
+	// test.
+	t.Setenv("HOME", tmpDir)
+
+	builder, err := NewServerBuilder()
+	if err != nil {
+		t.Fatalf("NewServerBuilder failed: %v", err)
+	}
+	srv, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if builder.dailyBriefService == nil {
+		t.Fatal("expected dailyBriefService to be wired")
+	}
+	return builder, srv.Handler()
+}
+
+// TestDailyBrief_ScheduledSuccessCreatesExactlyOneActionCenterNotification
+// covers task 7.11 end-to-end: initializeDailyBrief's onRevisionReady hook
+// (builder_dailybrief.go) must actually create a visible Action Center
+// opportunity for a successful *scheduled* generation when the HQ opted in,
+// wiring RecordNotificationIfEnabled (unit-tested in internal/dailybrief) to
+// a real workspace.OpportunityStore.Upsert call — previously unverified
+// past the unit boundary.
+func TestDailyBrief_ScheduledSuccessCreatesExactlyOneActionCenterNotification(t *testing.T) {
+	builder, handler := newDailyBriefTestServer(t)
+	ctx := context.Background()
+
+	// Build My HQ (creates + designates the workspace in one call).
+	setupReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"Command Post"}`))
+	setupReq.Header.Set("Content-Type", "application/json")
+	setupRec := httptest.NewRecorder()
+	handler.ServeHTTP(setupRec, setupReq)
+	if setupRec.Code != http.StatusOK {
+		t.Fatalf("setup status = %d body=%s", setupRec.Code, setupRec.Body.String())
+	}
+	var setupResp struct {
+		Status struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(setupRec.Body.Bytes(), &setupResp); err != nil {
+		t.Fatalf("decode setup response: %v", err)
+	}
+	workspaceID := setupResp.Status.WorkspaceID
+	if workspaceID == "" {
+		t.Fatal("expected a designated HQ workspace id")
+	}
+
+	// Opt in to notifications.
+	putReq := httptest.NewRequest(http.MethodPut, "/api/personal-hq/brief/config", bytes.NewBufferString(`{"notify_on_ready":true}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	handler.ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("config PUT status = %d body=%s", putRec.Code, putRec.Body.String())
+	}
+
+	// Drive a TriggerScheduled generation directly — the scheduler's own
+	// trigger path has no HTTP route by design (only first-open/manual are
+	// client-initiated).
+	cfg, err := builder.dailyBriefService.GetConfig(ctx, workspaceID)
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	localDate, err := dailybrief.TodayLocalDate(*cfg)
+	if err != nil {
+		t.Fatalf("TodayLocalDate: %v", err)
+	}
+	rev, err := builder.dailyBriefService.RequestGeneration(ctx, *cfg, "local", dailybrief.TriggerScheduled, localDate)
+	if err != nil {
+		t.Fatalf("RequestGeneration: %v", err)
+	}
+	if rev.Status != dailybrief.GenerationSucceeded && rev.Status != dailybrief.GenerationPartial {
+		t.Fatalf("expected the scheduled generation to succeed or partially succeed, got %q", rev.Status)
+	}
+
+	opportunityStore := workspace.NewOpportunityStore(builder.workspaceStore)
+	opportunities, err := opportunityStore.List(workspaceID)
+	if err != nil {
+		t.Fatalf("List opportunities: %v", err)
+	}
+	if len(opportunities) != 1 {
+		t.Fatalf("expected exactly one Action Center opportunity, got %d: %#v", len(opportunities), opportunities)
+	}
+	if opportunities[0].WorkspaceID != workspaceID {
+		t.Fatalf("expected the opportunity to be scoped to the HQ workspace, got %q", opportunities[0].WorkspaceID)
+	}
+
+	// A manual refresh on the same day must not create a second
+	// notification (PRD FR63: manual/first-open never notify).
+	if _, err := builder.dailyBriefService.RequestGeneration(ctx, *cfg, "local", dailybrief.TriggerManual, localDate); err != nil {
+		t.Fatalf("manual RequestGeneration: %v", err)
+	}
+	opportunities, err = opportunityStore.List(workspaceID)
+	if err != nil {
+		t.Fatalf("List opportunities after manual refresh: %v", err)
+	}
+	if len(opportunities) != 1 {
+		t.Fatalf("expected manual refresh to create no additional opportunity, got %d: %#v", len(opportunities), opportunities)
+	}
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -149,11 +149,6 @@ func (b *ServerBuilder) initializeHandlers() {
 			logger.Warn("Failed to seed local user profile", logger.Fields{"error": err})
 		}
 		b.userHandler = userhttp.NewHandler(b.userStore, b.userProvider)
-		// Personal HQ needs the concrete SQLite store (not the narrower
-		// userprofile.UserStore interface) for its focused designation/
-		// onboarding-state methods; see internal/personalhq.ProfileStore.
-		b.personalHQService = personalhq.NewService(userProfileStore, sessionStore)
-		b.personalHQHandler = personalhqhttp.NewHandler(b.personalHQService, b.userProvider)
 		b.chatHandler.SetUserProfileDeps(b.userStore, b.userProvider)
 		b.sessionHandler = sessionhttp.New(sessionStore)
 		b.sessionHandler.SetWorkspaceRootResolver(func() string {
@@ -166,6 +161,15 @@ func (b *ServerBuilder) initializeHandlers() {
 		if b.configManager != nil {
 			b.sessionHandler.SetSystemModelReader(b.configManager)
 		}
+		// Personal HQ needs the concrete SQLite store (not the narrower
+		// userprofile.UserStore interface) for its focused designation/
+		// onboarding-state methods; see internal/personalhq.ProfileStore.
+		// The setup coordinator reuses b.sessionHandler's exact production
+		// workspace-creation path (internal/personalhq.WorkspaceCreator) so
+		// Build My HQ never duplicates that logic.
+		b.personalHQService = personalhq.NewService(userProfileStore, sessionStore)
+		personalHQSetup := personalhq.NewSetupCoordinator(b.personalHQService, b.sessionHandler, sessionStore)
+		b.personalHQHandler = personalhqhttp.NewHandler(b.personalHQService, personalHQSetup, b.userProvider)
 		// Initialize auto-classify handler for session classification
 		b.autoClassifyHandler = sessionhttp.NewAutoClassifyHandler(sessionStore, b.st, b.llmFactory, b.configManager)
 		// Initialize smart input handler for Workspace Hub classification

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -31,6 +31,8 @@ import (
 	"github.com/johnjallday/ori-agent/internal/modelcategoryhttp"
 	"github.com/johnjallday/ori-agent/internal/notehttp"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/personalhqhttp"
 	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/pluginworkspace"
 	"github.com/johnjallday/ori-agent/internal/reapersetup"
@@ -140,12 +142,18 @@ func (b *ServerBuilder) initializeHandlers() {
 	} else {
 		b.sessionStore = sessionStore
 		b.userProvider = userprofile.LocalUserProvider{}
-		b.userStore = userprofile.NewSQLiteStore(sessionStore.DB())
+		userProfileStore := userprofile.NewSQLiteStore(sessionStore.DB())
+		b.userStore = userProfileStore
 		b.onboardingMgr.SetUserStore(b.userStore)
 		if err := b.onboardingMgr.SeedLocalUserProfile(ctx); err != nil {
 			logger.Warn("Failed to seed local user profile", logger.Fields{"error": err})
 		}
 		b.userHandler = userhttp.NewHandler(b.userStore, b.userProvider)
+		// Personal HQ needs the concrete SQLite store (not the narrower
+		// userprofile.UserStore interface) for its focused designation/
+		// onboarding-state methods; see internal/personalhq.ProfileStore.
+		b.personalHQService = personalhq.NewService(userProfileStore, sessionStore)
+		b.personalHQHandler = personalhqhttp.NewHandler(b.personalHQService, b.userProvider)
 		b.chatHandler.SetUserProfileDeps(b.userStore, b.userProvider)
 		b.sessionHandler = sessionhttp.New(sessionStore)
 		b.sessionHandler.SetWorkspaceRootResolver(func() string {

--- a/internal/server/builder_progression.go
+++ b/internal/server/builder_progression.go
@@ -37,6 +37,16 @@ func (b *ServerBuilder) initializeProgression() {
 		})
 	}
 
+	// A workspace becoming the user's Personal HQ is not an event either;
+	// this fires for both Build My HQ (a new workspace) and designating an
+	// existing workspace (PRD FR48/FR49), so t2-build-hq completes either
+	// way without replaying unrelated quests.
+	if b.personalHQService != nil {
+		b.personalHQService.SetOnDesignated(func(ctx context.Context, userID, workspaceID string) {
+			engine.Complete("t2-build-hq")
+		})
+	}
+
 	// One-time backfill so established installs are grandfathered silently.
 	if err := engine.Backfill(progression.ScannerFunc(b.scanProgression)); err != nil {
 		logger.Warn("Onboarding progression backfill failed", logger.Fields{"error": err})

--- a/internal/server/builder_progression.go
+++ b/internal/server/builder_progression.go
@@ -6,6 +6,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/progression"
 	"github.com/johnjallday/ori-agent/internal/progressionhttp"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
 
@@ -65,6 +66,12 @@ func (b *ServerBuilder) scanProgression() progression.Snapshot {
 
 	if profile := b.onboardingMgr.GetUserProfile(); profile != nil && !profile.PersonalizedAt.IsZero() {
 		snap.Personalized = true
+	}
+
+	if b.personalHQService != nil {
+		if status, err := b.personalHQService.Status(context.Background(), userprofile.LocalUserID); err == nil && status.Valid {
+			snap.HasPersonalHQ = true
+		}
 	}
 
 	// Count notes only until we find one — the quest just needs "> 0".

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -25,6 +25,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/orchestrationhttp"
+	"github.com/johnjallday/ori-agent/internal/personalhqhttp"
 	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
 	"github.com/johnjallday/ori-agent/internal/progressionhttp"
@@ -135,6 +136,7 @@ type HandlerFacade struct {
 	Triggers         *triggerhttp.Handler
 	WorkspaceMemory  *memoryhttp.Handler
 	User             *userhttp.Handler
+	PersonalHQ       *personalhqhttp.Handler
 }
 
 // NewCoreSystemFacade creates a new core system facade

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -9,6 +9,8 @@ import (
 	"github.com/johnjallday/ori-agent/internal/cliagenthttp"
 	"github.com/johnjallday/ori-agent/internal/client"
 	"github.com/johnjallday/ori-agent/internal/config"
+	"github.com/johnjallday/ori-agent/internal/dailybrief"
+	"github.com/johnjallday/ori-agent/internal/dailybriefhttp"
 	"github.com/johnjallday/ori-agent/internal/devicehttp"
 	"github.com/johnjallday/ori-agent/internal/evolutionhttp"
 	"github.com/johnjallday/ori-agent/internal/externalagentshttp"
@@ -87,6 +89,9 @@ type WorkflowSystemFacade struct {
 	// TriggerService owns event-trigger file watches; closed on Shutdown.
 	// Assigned post-construction by the builder (not a constructor arg).
 	TriggerService *trigger.Service
+	// DailyBriefScheduler polls for due scheduled Daily Brief generations.
+	// Assigned post-construction by the builder (not a constructor arg).
+	DailyBriefScheduler *dailybrief.Scheduler
 }
 
 // IntegrationSystemFacade manages external integrations (MCP, updates)
@@ -142,6 +147,7 @@ type HandlerFacade struct {
 	WorkspaceMemory  *memoryhttp.Handler
 	User             *userhttp.Handler
 	PersonalHQ       *personalhqhttp.Handler
+	DailyBrief       *dailybriefhttp.Handler
 }
 
 // NewCoreSystemFacade creates a new core system facade
@@ -243,6 +249,9 @@ func (w *WorkflowSystemFacade) Start() {
 	if w.DirectorySync != nil {
 		w.DirectorySync.Start()
 	}
+	if w.DailyBriefScheduler != nil {
+		w.DailyBriefScheduler.Start()
+	}
 }
 
 // Shutdown gracefully shuts down all workflow system background services
@@ -258,6 +267,9 @@ func (w *WorkflowSystemFacade) Shutdown() {
 	}
 	if w.TaskScheduler != nil {
 		w.TaskScheduler.Stop()
+	}
+	if w.DailyBriefScheduler != nil {
+		w.DailyBriefScheduler.Stop()
 	}
 	if w.NotificationService != nil {
 		w.NotificationService.Shutdown()

--- a/internal/server/facades.go
+++ b/internal/server/facades.go
@@ -25,6 +25,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/onboarding"
 	"github.com/johnjallday/ori-agent/internal/onboardinghttp"
 	"github.com/johnjallday/ori-agent/internal/orchestrationhttp"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
 	"github.com/johnjallday/ori-agent/internal/personalhqhttp"
 	"github.com/johnjallday/ori-agent/internal/pluginhttp"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
@@ -68,6 +69,10 @@ type StorageSystemFacade struct {
 	UserProvider    userprofile.UserProvider
 	OnboardingMgr   *onboarding.Manager
 	LocationManager *location.Manager
+	// PersonalHQ is the raw domain service (not the HTTP handler), so
+	// non-HTTP callers like serveIndex's first-run classification can read
+	// onboarding status directly.
+	PersonalHQ *personalhq.Service
 }
 
 // WorkflowSystemFacade manages workspace orchestration dependencies
@@ -166,6 +171,7 @@ func NewStorageSystemFacade(
 	userProvider userprofile.UserProvider,
 	onboardingMgr *onboarding.Manager,
 	locationManager *location.Manager,
+	personalHQ *personalhq.Service,
 ) *StorageSystemFacade {
 	return &StorageSystemFacade{
 		AgentStore:      agentStore,
@@ -176,6 +182,7 @@ func NewStorageSystemFacade(
 		UserProvider:    userProvider,
 		OnboardingMgr:   onboardingMgr,
 		LocationManager: locationManager,
+		PersonalHQ:      personalHQ,
 	}
 }
 

--- a/internal/server/first_run_classification_test.go
+++ b/internal/server/first_run_classification_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// erroringProfileStore satisfies personalhq.ProfileStore and fails every
+// call, so tests can prove degradation when the Personal HQ dependency
+// itself is unavailable (PRD FR136/task 8.7).
+type erroringProfileStore struct{}
+
+func (erroringProfileStore) GetPersonalHQState(context.Context, string) (*userprofile.PersonalHQState, error) {
+	return nil, errors.New("boom: profile store unavailable")
+}
+
+func (erroringProfileStore) SetPersonalWorkspaceID(context.Context, string, string) error {
+	return errors.New("boom: profile store unavailable")
+}
+
+func (erroringProfileStore) SetHQOnboardingState(context.Context, string, userprofile.HQOnboardingState) error {
+	return errors.New("boom: profile store unavailable")
+}
+
+// newFirstRunTestServer builds a full server (same wiring as production)
+// rooted at a temp directory, mirroring newDailyBriefTestServer. HOME is
+// sandboxed since some of these tests actually create a workspace, which
+// would otherwise write into the real user's home directory
+// (DefaultWorkspaceRoot ignores CWD).
+func newFirstRunTestServer(t *testing.T) (*ServerBuilder, http.Handler) {
+	t.Helper()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalWD) })
+	t.Setenv("HOME", tmpDir)
+
+	builder, err := NewServerBuilder()
+	if err != nil {
+		t.Fatalf("NewServerBuilder failed: %v", err)
+	}
+	srv, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	return builder, srv.Handler()
+}
+
+// TestIsBrandNewProfile_GenuinelyFreshInstallIsBrandNew is the baseline: a
+// profile with hq_onboarding_state=unseen (the default for every new row),
+// no completed app-level onboarding, and no workspaces is correctly
+// classified brand-new.
+func TestIsBrandNewProfile_GenuinelyFreshInstallIsBrandNew(t *testing.T) {
+	builder, _ := newFirstRunTestServer(t)
+	if !builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected a genuinely fresh install (unseen, no onboarding, no workspaces) to be classified brand-new")
+	}
+}
+
+// TestIsBrandNewProfile_CompletedAppOnboardingIsNotBrandNew covers task 8.1:
+// migration030PersonalHQ backfills hq_onboarding_state='unseen' onto every
+// pre-existing profile row with a blanket SQL DEFAULT, so an established
+// user upgrading from a pre-HQ version reads exactly the same "unseen"
+// state as a brand-new profile. The separate app-level onboarding
+// completion flag (independent of HQ, tracked since long before this
+// feature existed) must be enough to rule out brand-new.
+func TestIsBrandNewProfile_CompletedAppOnboardingIsNotBrandNew(t *testing.T) {
+	builder, _ := newFirstRunTestServer(t)
+	if builder.server.Storage.OnboardingMgr == nil {
+		t.Fatal("expected OnboardingMgr to be wired")
+	}
+	if err := builder.server.Storage.OnboardingMgr.CompleteOnboarding(); err != nil {
+		t.Fatalf("CompleteOnboarding: %v", err)
+	}
+
+	if builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected an upgraded profile with completed app onboarding to NOT be classified brand-new, even though hq_onboarding_state reads unseen")
+	}
+}
+
+// TestIsBrandNewProfile_ZeroWorkspacesWithCompletedOnboardingIsNotBrandNew
+// covers the PRD's explicit example: "an existing profile with zero
+// workspaces is not automatically treated as brand new" — e.g. a
+// long-time user who deleted every workspace. Workspace count alone is
+// zero, but completed app onboarding still proves prior real usage.
+func TestIsBrandNewProfile_ZeroWorkspacesWithCompletedOnboardingIsNotBrandNew(t *testing.T) {
+	builder, _ := newFirstRunTestServer(t)
+	if err := builder.server.Storage.OnboardingMgr.CompleteOnboarding(); err != nil {
+		t.Fatalf("CompleteOnboarding: %v", err)
+	}
+	ids, err := builder.server.Storage.WorkspaceStore.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected a fresh temp data dir to start with zero workspaces, got %d", len(ids))
+	}
+
+	if builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected zero current workspaces + completed app onboarding to still NOT be classified brand-new")
+	}
+}
+
+// TestIsBrandNewProfile_ExistingWorkspaceHistoryIsNotBrandNew covers the
+// other independent signal named in task 8.1 ("workspace history"): even
+// with app-level onboarding never marked complete, having a real workspace
+// already is strong evidence of prior use.
+func TestIsBrandNewProfile_ExistingWorkspaceHistoryIsNotBrandNew(t *testing.T) {
+	builder, handler := newFirstRunTestServer(t)
+
+	setupReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/setup", bytes.NewBufferString(`{"name":"Command Post"}`))
+	setupReq.Header.Set("Content-Type", "application/json")
+	setupRec := httptest.NewRecorder()
+	handler.ServeHTTP(setupRec, setupReq)
+	if setupRec.Code != http.StatusOK {
+		t.Fatalf("setup status = %d body=%s", setupRec.Code, setupRec.Body.String())
+	}
+
+	if builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected existing workspace history to rule out brand-new classification")
+	}
+}
+
+// TestIsBrandNewProfile_DegradesToFalseWhenPersonalHQErrors covers task 8.7:
+// a failed Personal HQ dependency (e.g. a broken profile store) must never
+// block the app from starting or force the intrusive guided takeover — it
+// degrades to an ordinary Home launch instead.
+func TestIsBrandNewProfile_DegradesToFalseWhenPersonalHQErrors(t *testing.T) {
+	builder, _ := newFirstRunTestServer(t)
+	builder.server.Storage.PersonalHQ = personalhq.NewService(erroringProfileStore{}, nil)
+
+	if builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected a failed Personal HQ dependency to degrade to false (normal Home launch), not brand-new")
+	}
+}
+
+// TestIsBrandNewProfile_DesignatedOrPastHQStateIsNotBrandNew covers the
+// unaffected baseline: once hq_onboarding_state has genuinely moved past
+// "unseen" through the app's own state-transition code (not a migration
+// default), the original check alone already handles it correctly.
+func TestIsBrandNewProfile_DesignatedOrPastHQStateIsNotBrandNew(t *testing.T) {
+	builder, _ := newFirstRunTestServer(t)
+	if _, err := builder.personalHQService.SetOnboardingState(context.Background(), userprofile.LocalUserID, userprofile.HQOnboardingSkipped); err != nil {
+		t.Fatalf("SetOnboardingState: %v", err)
+	}
+
+	if builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected a profile that has already moved past unseen to not be classified brand-new")
+	}
+}

--- a/internal/server/first_run_classification_test.go
+++ b/internal/server/first_run_classification_test.go
@@ -70,14 +70,16 @@ func TestIsBrandNewProfile_GenuinelyFreshInstallIsBrandNew(t *testing.T) {
 	}
 }
 
-// TestIsBrandNewProfile_CompletedAppOnboardingIsNotBrandNew covers task 8.1:
-// migration030PersonalHQ backfills hq_onboarding_state='unseen' onto every
-// pre-existing profile row with a blanket SQL DEFAULT, so an established
-// user upgrading from a pre-HQ version reads exactly the same "unseen"
-// state as a brand-new profile. The separate app-level onboarding
-// completion flag (independent of HQ, tracked since long before this
-// feature existed) must be enough to rule out brand-new.
-func TestIsBrandNewProfile_CompletedAppOnboardingIsNotBrandNew(t *testing.T) {
+// TestIsBrandNewProfile_CompletedAppOnboardingAloneDoesNotSuppressBrandNew
+// covers a regression found while writing this feature's Playwright
+// coverage: the separate app-level onboarding wizard ("what should we call
+// each other?") also completes on a genuinely brand-new profile's very
+// first session, before the user has ever seen HQ setup. An earlier version
+// of this fix treated that completion flag as evidence of "established
+// user," which would have wrongly suppressed the HQ guided takeover the
+// moment a brand-new user dismissed the unrelated wizard and reloaded —
+// deliberately NOT the current behavior.
+func TestIsBrandNewProfile_CompletedAppOnboardingAloneDoesNotSuppressBrandNew(t *testing.T) {
 	builder, _ := newFirstRunTestServer(t)
 	if builder.server.Storage.OnboardingMgr == nil {
 		t.Fatal("expected OnboardingMgr to be wired")
@@ -86,31 +88,8 @@ func TestIsBrandNewProfile_CompletedAppOnboardingIsNotBrandNew(t *testing.T) {
 		t.Fatalf("CompleteOnboarding: %v", err)
 	}
 
-	if builder.server.isBrandNewProfile(context.Background()) {
-		t.Fatal("expected an upgraded profile with completed app onboarding to NOT be classified brand-new, even though hq_onboarding_state reads unseen")
-	}
-}
-
-// TestIsBrandNewProfile_ZeroWorkspacesWithCompletedOnboardingIsNotBrandNew
-// covers the PRD's explicit example: "an existing profile with zero
-// workspaces is not automatically treated as brand new" — e.g. a
-// long-time user who deleted every workspace. Workspace count alone is
-// zero, but completed app onboarding still proves prior real usage.
-func TestIsBrandNewProfile_ZeroWorkspacesWithCompletedOnboardingIsNotBrandNew(t *testing.T) {
-	builder, _ := newFirstRunTestServer(t)
-	if err := builder.server.Storage.OnboardingMgr.CompleteOnboarding(); err != nil {
-		t.Fatalf("CompleteOnboarding: %v", err)
-	}
-	ids, err := builder.server.Storage.WorkspaceStore.List()
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	if len(ids) != 0 {
-		t.Fatalf("expected a fresh temp data dir to start with zero workspaces, got %d", len(ids))
-	}
-
-	if builder.server.isBrandNewProfile(context.Background()) {
-		t.Fatal("expected zero current workspaces + completed app onboarding to still NOT be classified brand-new")
+	if !builder.server.isBrandNewProfile(context.Background()) {
+		t.Fatal("expected completing the unrelated app-level wizard alone (no workspaces yet) to NOT suppress the HQ brand-new classification")
 	}
 }
 

--- a/internal/server/home_assistant_hq_adapter.go
+++ b/internal/server/home_assistant_hq_adapter.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+// homeAssistantHQAdapter satisfies agenthttp's narrow HQ-provider interface
+// over the real personalhq.Service, so an untargeted "Ask Ori" prompt can
+// default to the caller's designated Personal HQ (PRD FR102/FR103, task
+// 7.10) without agenthttp importing internal/personalhq directly.
+type homeAssistantHQAdapter struct {
+	service  *personalhq.Service
+	provider userprofile.UserProvider
+}
+
+func (a *homeAssistantHQAdapter) CurrentHQWorkspaceID(ctx context.Context) (string, bool) {
+	if a == nil || a.service == nil {
+		return "", false
+	}
+	userID := userprofile.LocalUserID
+	if a.provider != nil {
+		if id, err := a.provider.CurrentUserID(ctx); err == nil && id != "" {
+			userID = id
+		}
+	}
+	status, err := a.service.Status(ctx, userID)
+	if err != nil || status == nil || !status.Valid {
+		return "", false
+	}
+	return status.WorkspaceID, true
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -223,6 +223,12 @@ func registerAgentRoutes(mux *http.ServeMux, s *Server) {
 		homeAssistantRouteHandler.SetIntakeTraceStore(traceStore)
 		homeAssistantWorkspaceResolver.SetFeedbackReader(traceStore)
 	}
+	if s.Storage.PersonalHQ != nil {
+		homeAssistantWorkspaceResolver.SetHQProvider(&homeAssistantHQAdapter{
+			service:  s.Storage.PersonalHQ,
+			provider: s.Storage.UserProvider,
+		})
+	}
 	homeAssistantRouteHandler.SetWorkspaceResolver(homeAssistantWorkspaceResolver)
 	if s.Storage != nil && s.Integration != nil {
 		homeAssistantRouteHandler.SetRuntimeResolver(
@@ -349,6 +355,7 @@ func registerOnboardingRoutes(mux *http.ServeMux, s *Server) {
 	}
 
 	registerPersonalHQRoutes(mux, s)
+	registerDailyBriefRoutes(mux, s)
 
 	// Theme endpoints
 	mux.HandleFunc("/api/theme", func(w http.ResponseWriter, r *http.Request) {
@@ -807,6 +814,22 @@ func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("POST /api/personal-hq/designate", s.Handlers.PersonalHQ.Designate)
 		mux.HandleFunc("POST /api/personal-hq/replace", s.Handlers.PersonalHQ.Replace)
 		mux.HandleFunc("POST /api/personal-hq/clear", s.Handlers.PersonalHQ.Clear)
+	}
+}
+
+// registerDailyBriefRoutes registers Personal HQ Daily Brief endpoints.
+func registerDailyBriefRoutes(mux *http.ServeMux, s *Server) {
+	// =============================================================================
+	// Daily Brief Endpoints
+	// =============================================================================
+	if s.Handlers.DailyBrief != nil {
+		mux.HandleFunc("GET /api/personal-hq/brief/config", s.Handlers.DailyBrief.GetConfig)
+		mux.HandleFunc("PUT /api/personal-hq/brief/config", s.Handlers.DailyBrief.UpdateConfig)
+		mux.HandleFunc("GET /api/personal-hq/brief/current", s.Handlers.DailyBrief.GetCurrent)
+		mux.HandleFunc("GET /api/personal-hq/brief/history", s.Handlers.DailyBrief.GetHistory)
+		mux.HandleFunc("GET /api/personal-hq/brief/status", s.Handlers.DailyBrief.GetStatus)
+		mux.HandleFunc("POST /api/personal-hq/brief/open", s.Handlers.DailyBrief.RequestFirstOpen)
+		mux.HandleFunc("POST /api/personal-hq/brief/refresh", s.Handlers.DailyBrief.RequestRefresh)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -347,6 +347,8 @@ func registerOnboardingRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("/api/user/profile", s.Handlers.User.Profile)
 	}
 
+	registerPersonalHQRoutes(mux, s)
+
 	// Theme endpoints
 	mux.HandleFunc("/api/theme", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -789,6 +791,20 @@ func registerTriggerRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("POST /api/workspaces/{workspaceID}/triggers/{triggerID}/regenerate-token", s.Handlers.Triggers.RegenerateToken)
 		mux.HandleFunc("POST /api/workspaces/{workspaceID}/triggers/{triggerID}/test-fire", s.Handlers.Triggers.TestFire)
 		mux.HandleFunc("GET /api/workspaces/{workspaceID}/triggers/{triggerID}/fires", s.Handlers.Triggers.Fires)
+	}
+}
+
+// registerPersonalHQRoutes registers Personal HQ status/designation endpoints.
+func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
+	// =============================================================================
+	// Personal HQ Endpoints
+	// =============================================================================
+	if s.Handlers.PersonalHQ != nil {
+		mux.HandleFunc("GET /api/personal-hq/status", s.Handlers.PersonalHQ.Status)
+		mux.HandleFunc("POST /api/personal-hq/onboarding-state", s.Handlers.PersonalHQ.SetOnboardingState)
+		mux.HandleFunc("POST /api/personal-hq/designate", s.Handlers.PersonalHQ.Designate)
+		mux.HandleFunc("POST /api/personal-hq/replace", s.Handlers.PersonalHQ.Replace)
+		mux.HandleFunc("POST /api/personal-hq/clear", s.Handlers.PersonalHQ.Clear)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -330,6 +330,7 @@ func registerOnboardingRoutes(mux *http.ServeMux, s *Server) {
 	if s.Handlers.Progression != nil {
 		mux.HandleFunc("/api/progression", s.Handlers.Progression.GetStatus)
 		mux.HandleFunc("/api/progression/dismiss", s.Handlers.Progression.Dismiss)
+		mux.HandleFunc("/api/progression/skip", s.Handlers.Progression.Skip)
 		mux.HandleFunc("/api/progression/reset", s.Handlers.Progression.Reset)
 	}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -803,6 +803,7 @@ func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
 	if s.Handlers.PersonalHQ != nil {
 		mux.HandleFunc("GET /api/personal-hq/status", s.Handlers.PersonalHQ.Status)
 		mux.HandleFunc("POST /api/personal-hq/onboarding-state", s.Handlers.PersonalHQ.SetOnboardingState)
+		mux.HandleFunc("POST /api/personal-hq/setup", s.Handlers.PersonalHQ.Setup)
 		mux.HandleFunc("POST /api/personal-hq/designate", s.Handlers.PersonalHQ.Designate)
 		mux.HandleFunc("POST /api/personal-hq/replace", s.Handlers.PersonalHQ.Replace)
 		mux.HandleFunc("POST /api/personal-hq/clear", s.Handlers.PersonalHQ.Clear)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -23,6 +23,12 @@ func newRoutesTestHandler(t *testing.T) http.Handler {
 	t.Cleanup(func() {
 		_ = os.Chdir(originalWD)
 	})
+	// DefaultWorkspaceRoot() resolves to $HOME/Ori Workspaces regardless of
+	// CWD, so any test built on this handler that creates a workspace (or
+	// counts existing ones, e.g. first-run classification) would otherwise
+	// read/write the real developer machine's workspace tree. t.Setenv
+	// restores the original HOME after the test.
+	t.Setenv("HOME", tmpDir)
 
 	builder, err := NewServerBuilder()
 	if err != nil {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -117,6 +117,41 @@ func TestPersonalHQRoutesRegistered(t *testing.T) {
 	}
 }
 
+// TestBrandNewProfileRedirectsHomeToGuidedMap covers task 4.1/4.2: a
+// profile that has never seen the guided Personal HQ first-launch
+// experience must land on the workspace launcher (Map mode) instead of
+// Home, and stop redirecting once onboarding is no longer "unseen".
+func TestBrandNewProfileRedirectsHomeToGuidedMap(t *testing.T) {
+	handler := newRoutesTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect for a brand-new profile, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/workspaces?hq_onboarding=1" {
+		t.Fatalf("expected redirect to the guided Map, got %q", loc)
+	}
+
+	// Once onboarding state moves off "unseen" (e.g. the user skipped),
+	// normal Home launch resumes.
+	skipReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/onboarding-state", strings.NewReader(`{"state":"skipped"}`))
+	skipReq.Header.Set("Content-Type", "application/json")
+	skipRec := httptest.NewRecorder()
+	handler.ServeHTTP(skipRec, skipReq)
+	if skipRec.Code != http.StatusOK {
+		t.Fatalf("expected onboarding-state update to succeed, got %d body=%s", skipRec.Code, skipRec.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected normal Home launch after skipping, got %d", rec2.Code)
+	}
+}
+
 func TestWorkspaceProjectOpenRouteUsesRuntimeHandler(t *testing.T) {
 	handler := newRoutesTestHandler(t)
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -81,6 +81,42 @@ func TestWorkspaceRunRoutesRegistered(t *testing.T) {
 	}
 }
 
+func TestPersonalHQRoutesRegistered(t *testing.T) {
+	handler := newRoutesTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/personal-hq/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected personal hq status to return 200, got %d body %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status"`) {
+		t.Fatalf("expected status response body, got %s", rec.Body.String())
+	}
+
+	// Method contract: the status pattern is GET-only at the mux level, so a
+	// mismatched method doesn't match any registered pattern for this exact
+	// path and is a 404 (net/http.ServeMux only synthesizes 405 when another
+	// method is registered on the same path; see handler_test.go in
+	// personalhqhttp for the handler's own RequireMethod 405 behavior).
+	req = httptest.NewRequest(http.MethodPost, "/api/personal-hq/status", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected POST to status to return 404, got %d", rec.Code)
+	}
+
+	// Designating an unknown workspace must return an actionable error, not
+	// a bare 500.
+	body := bytes.NewReader([]byte(`{"workspace_id":"does-not-exist"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/personal-hq/designate", body)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected designate of unknown workspace to return 404, got %d body %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestWorkspaceProjectOpenRouteUsesRuntimeHandler(t *testing.T) {
 	handler := newRoutesTestHandler(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/platform"
 	"github.com/johnjallday/ori-agent/internal/privateservices"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
 	web "github.com/johnjallday/ori-agent/internal/web"
 	"github.com/johnjallday/ori-agent/internal/workspace"
 )
@@ -202,6 +203,22 @@ func (s *Server) renderAndWritePage(w http.ResponseWriter, templateName string, 
 	orihttp.WriteHTML(w, html)
 }
 
+// isBrandNewProfile reports whether the current user has never seen the
+// guided Personal HQ first-launch experience (HQOnboardingUnseen). Degrades
+// to false (normal Home launch) when the Personal HQ service is unavailable,
+// so a degraded dependency never blocks the app from starting (PRD FR136).
+func (s *Server) isBrandNewProfile(ctx context.Context) bool {
+	if s.Storage == nil || s.Storage.PersonalHQ == nil {
+		return false
+	}
+	status, err := s.Storage.PersonalHQ.Status(ctx, userprofile.LocalUserID)
+	if err != nil {
+		logger.Warn("isBrandNewProfile: failed to load personal hq status", logger.Fields{"error": err})
+		return false
+	}
+	return status.OnboardingState == userprofile.HQOnboardingUnseen
+}
+
 func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 	// Only handle root path, not other paths
 	if r.URL.Path != "/" {
@@ -209,12 +226,26 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A brand-new profile's first visible launch routes to the guided
+	// workspace launcher (Map mode) instead of Home (PRD FR11). "Brand new"
+	// is the authoritative per-user HQ onboarding status, not workspace
+	// count: an established user who deleted every workspace, or upgraded
+	// from a version with no onboarding history, must not be misclassified
+	// as first-run (PRD FR19; task 4.1). Only a GET navigation redirects —
+	// this handler is registered for "/" without a method restriction.
+	if r.Method == http.MethodGet && s.isBrandNewProfile(r.Context()) {
+		http.Redirect(w, r, "/workspaces?hq_onboarding=1", http.StatusSeeOther)
+		return
+	}
+
 	data := s.prepareBasePageData("index")
 
-	// Inject home-dashboard context: the workspace count drives the adaptive
-	// layout (first-run wizard vs returning-user dashboard sections). We
-	// compute it server-side so the template can render the correct shell
-	// without a flash of empty-state from a client-side fetch.
+	// Inject home-dashboard context: the workspace count still drives the
+	// adaptive Home copy (first-visit-feeling placeholder text) for a user
+	// who has moved past the guided launcher (skipped, completed, or an
+	// established user who never saw it). We compute it server-side so the
+	// template can render the correct shell without a flash of empty-state
+	// from a client-side fetch.
 	workspaceCount := 0
 	if s.Storage != nil && s.Storage.WorkspaceStore != nil {
 		if ids, err := s.Storage.WorkspaceStore.List(); err == nil {
@@ -393,6 +424,12 @@ func (s *Server) serveWorkspaces(w http.ResponseWriter, r *http.Request) {
 	data := s.prepareBasePageData("workspaces")
 	data.Title = "Workspaces - Ori Agent"
 	data.BrandText = "Ori Agent"
+	// Authoritative bootstrap hint for the guided Map (PRD FR11/FR20):
+	// avoids a first-paint flash while workspace-hub.js confirms via
+	// GET /api/personal-hq/status. Never a hard requirement — the JS
+	// re-derives this from the API regardless, so a stale/missing hint just
+	// means one extra render pass, not incorrect behavior.
+	data.Extra["HQOnboardingUnseen"] = s.isBrandNewProfile(r.Context())
 	s.renderAndWritePage(w, "workspaces", data)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,18 @@ func (s *Server) renderAndWritePage(w http.ResponseWriter, templateName string, 
 // guided Personal HQ first-launch experience (HQOnboardingUnseen). Degrades
 // to false (normal Home launch) when the Personal HQ service is unavailable,
 // so a degraded dependency never blocks the app from starting (PRD FR136).
+//
+// HQOnboardingUnseen alone is not sufficient: migration030PersonalHQ added
+// the hq_onboarding_state column with a blanket 'unseen' SQL DEFAULT applied
+// retroactively to every pre-existing profile row, so an established user
+// upgrading from a version that predates this feature reads exactly the
+// same "unseen" state as a genuinely brand-new profile. Cross-check two
+// independent, already-durable signals of prior app usage — the separate
+// app-level onboarding flow's completion flag, and workspace history — so
+// an upgraded profile (including one with zero workspaces right now, e.g.
+// after deleting them all) receives only the lightweight resume invitation
+// rather than the full guided construction takeover (PRD FR19/FR116-118,
+// task 8.1).
 func (s *Server) isBrandNewProfile(ctx context.Context) bool {
 	if s.Storage == nil || s.Storage.PersonalHQ == nil {
 		return false
@@ -216,7 +228,18 @@ func (s *Server) isBrandNewProfile(ctx context.Context) bool {
 		logger.Warn("isBrandNewProfile: failed to load personal hq status", logger.Fields{"error": err})
 		return false
 	}
-	return status.OnboardingState == userprofile.HQOnboardingUnseen
+	if status.OnboardingState != userprofile.HQOnboardingUnseen {
+		return false
+	}
+	if s.Storage.OnboardingMgr != nil && s.Storage.OnboardingMgr.IsOnboardingComplete() {
+		return false
+	}
+	if s.Storage.WorkspaceStore != nil {
+		if ids, err := s.Storage.WorkspaceStore.List(); err == nil && len(ids) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -212,13 +212,21 @@ func (s *Server) renderAndWritePage(w http.ResponseWriter, templateName string, 
 // the hq_onboarding_state column with a blanket 'unseen' SQL DEFAULT applied
 // retroactively to every pre-existing profile row, so an established user
 // upgrading from a version that predates this feature reads exactly the
-// same "unseen" state as a genuinely brand-new profile. Cross-check two
-// independent, already-durable signals of prior app usage — the separate
-// app-level onboarding flow's completion flag, and workspace history — so
-// an upgraded profile (including one with zero workspaces right now, e.g.
-// after deleting them all) receives only the lightweight resume invitation
-// rather than the full guided construction takeover (PRD FR19/FR116-118,
-// task 8.1).
+// same "unseen" state as a genuinely brand-new profile. Cross-check
+// workspace history — an established user (including one with zero
+// workspaces right now, e.g. after deleting them all, as long as they ever
+// had one) receives only the lightweight resume invitation rather than the
+// full guided construction takeover (PRD FR19/FR116-118, task 8.1).
+//
+// Deliberately NOT cross-checked against the separate app-level onboarding
+// wizard's completion flag, despite that being a tempting second signal: it
+// completes on a genuinely brand-new profile's very first session too, so
+// using it here would wrongly suppress the HQ takeover the moment a new
+// user dismisses that unrelated wizard and reloads, before ever reaching HQ
+// setup — trading a common regression for a narrower edge case (a
+// long-established user who has deleted every workspace and never engaged
+// with HQ) that would need a dedicated "profile first seen" timestamp,
+// independent of any onboarding flow's completion, to close properly.
 func (s *Server) isBrandNewProfile(ctx context.Context) bool {
 	if s.Storage == nil || s.Storage.PersonalHQ == nil {
 		return false
@@ -229,9 +237,6 @@ func (s *Server) isBrandNewProfile(ctx context.Context) bool {
 		return false
 	}
 	if status.OnboardingState != userprofile.HQOnboardingUnseen {
-		return false
-	}
-	if s.Storage.OnboardingMgr != nil && s.Storage.OnboardingMgr.IsOnboardingComplete() {
 		return false
 	}
 	if s.Storage.WorkspaceStore != nil {

--- a/internal/sessionhttp/workspace_create_personal_hq_test.go
+++ b/internal/sessionhttp/workspace_create_personal_hq_test.go
@@ -1,0 +1,159 @@
+package sessionhttp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/projecttemplates"
+)
+
+// TestCreateWorkspaceFromPersonalHQTemplate proves the renamed Personal HQ
+// built-in (personal-ops folder) still goes through the same server-side
+// workspace-creation path as any other template: entry-agent selection,
+// starter-task seeding, and template provenance persistence all work
+// identically to before the PRD FR119-FR122 rename (task 2.5: no duplicate
+// constructor for HQ creation).
+func TestCreateWorkspaceFromPersonalHQTemplate(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	libDir := handler.templatesRootResolver()
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	w, resp := postCreateWorkspace(t, handler, `{"name":"My HQ","template_id":"personal-ops"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if got, _ := resp["seeded_starter_tasks"].(float64); got != 3 {
+		t.Fatalf("seeded_starter_tasks = %v, want 3", resp["seeded_starter_tasks"])
+	}
+
+	if _, ok := handler.agentStore.GetAgent("Personal Chief of Staff"); !ok {
+		t.Fatal("expected Personal Chief of Staff seeded into the agent store")
+	}
+
+	folder, ok := resp["folder"].(map[string]any)
+	if !ok {
+		t.Fatal("expected folder in response")
+	}
+	wsID, _ := folder["id"].(string)
+	if wsID == "" {
+		t.Fatal("missing workspace id in response")
+	}
+
+	sessWS, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if got := currentWorkspaceEntryAgentName(sessWS); got != "Personal Chief of Staff" {
+		t.Fatalf("entry agent = %q, want Personal Chief of Staff", got)
+	}
+
+	tasks := workspaceTasksFromStore(t, handler, wsID)
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 seeded tasks, got %d: %+v", len(tasks), tasks)
+	}
+
+	diskWS, err := handler.workspaceStore.Get(wsID)
+	if err != nil {
+		t.Fatalf("workspaceStore.Get: %v", err)
+	}
+	prov := diskWS.GetTemplateProvenance()
+	if prov == nil {
+		t.Fatal("expected template provenance to be recorded")
+	}
+	if prov.TemplateID != "personal-ops" {
+		t.Fatalf("provenance TemplateID = %q, want personal-ops", prov.TemplateID)
+	}
+	if prov.TemplateName != "Personal HQ" {
+		t.Fatalf("provenance TemplateName = %q, want Personal HQ", prov.TemplateName)
+	}
+	if prov.Version < 3 {
+		t.Fatalf("provenance Version = %d, want at least 3", prov.Version)
+	}
+
+	// The workspace's own display name is whatever the user chose at
+	// creation ("My HQ" here) — the template's display name never leaks
+	// onto the workspace record.
+	if sessWS.Name != "My HQ" {
+		t.Fatalf("workspace name = %q, want My HQ (user-chosen, independent of template display name)", sessWS.Name)
+	}
+}
+
+// TestLibraryTemplateRefreshNeverRewritesAlreadyCreatedWorkspace covers PRD
+// FR127/FR128 (task 2.4/2.7 migration safety): bumping the shipped Personal
+// HQ manifest's builtin_version (as a later release will) must refresh only
+// the *library's* template.json. A workspace already created from an older
+// manifest keeps its own name and its provenance snapshot exactly as
+// recorded at creation time — nothing about it is migrated, renamed, or
+// rewritten in place.
+func TestLibraryTemplateRefreshNeverRewritesAlreadyCreatedWorkspace(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	libDir := handler.templatesRootResolver()
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	_, resp := postCreateWorkspace(t, handler, `{"name":"My HQ","template_id":"personal-ops"}`)
+	folder, _ := resp["folder"].(map[string]any)
+	wsID, _ := folder["id"].(string)
+	if wsID == "" {
+		t.Fatalf("missing workspace id in response: %v", resp)
+	}
+	before, err := handler.workspaceStore.Get(wsID)
+	if err != nil {
+		t.Fatalf("workspaceStore.Get: %v", err)
+	}
+	beforeProv := before.GetTemplateProvenance()
+	if beforeProv == nil {
+		t.Fatal("expected provenance recorded on create")
+	}
+
+	// Simulate a future shipped release bumping the Personal HQ manifest
+	// (mirrors what refreshBuiltinManifest does to the library copy only).
+	manifestPath := filepath.Join(libDir, "personal-ops", "template.json")
+	raw, err := os.ReadFile(manifestPath) // #nosec G304 -- test-owned temp library path
+	if err != nil {
+		t.Fatalf("read library manifest: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal library manifest: %v", err)
+	}
+	m["name"] = "Personal HQ (future copy)"
+	m["builtin_version"] = 99
+	bumped, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal bumped manifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, bumped, 0o640); err != nil { // #nosec G306 -- test-owned temp library path
+		t.Fatalf("write bumped manifest: %v", err)
+	}
+
+	// The already-created workspace is a separate persisted entity: its
+	// name and its frozen provenance snapshot must be unaffected by the
+	// library manifest changing underneath it.
+	after, err := handler.workspaceStore.Get(wsID)
+	if err != nil {
+		t.Fatalf("workspaceStore.Get after refresh: %v", err)
+	}
+	if after.Name != "My HQ" {
+		t.Fatalf("workspace name changed after library refresh: got %q, want My HQ", after.Name)
+	}
+	afterProv := after.GetTemplateProvenance()
+	if afterProv == nil {
+		t.Fatal("provenance must survive a library manifest refresh")
+	}
+	if afterProv.TemplateName != beforeProv.TemplateName || afterProv.Version != beforeProv.Version {
+		t.Fatalf("provenance snapshot changed after library refresh: before=%+v after=%+v", beforeProv, afterProv)
+	}
+	if afterProv.TemplateName != "Personal HQ" || afterProv.Version < 3 {
+		t.Fatalf("provenance snapshot regressed: %+v", afterProv)
+	}
+}

--- a/internal/sessionhttp/workspace_create_personal_hq_test.go
+++ b/internal/sessionhttp/workspace_create_personal_hq_test.go
@@ -85,6 +85,60 @@ func TestCreateWorkspaceFromPersonalHQTemplate(t *testing.T) {
 	}
 }
 
+// TestCreateFromTemplateReusesTheProductionCreationPath proves the
+// Personal HQ setup coordinator's workspace-creation hook produces an
+// identical result to a normal POST /api/workspaces call — same entry
+// agent, same starter-task seeding, same provenance — rather than a
+// second, divergent constructor (PRD FR128 / task 4.6/2.5).
+func TestCreateFromTemplateReusesTheProductionCreationPath(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	libDir := handler.templatesRootResolver()
+	if err := projecttemplates.EnsureLibrary(libDir); err != nil {
+		t.Fatalf("EnsureLibrary: %v", err)
+	}
+
+	wsID, err := handler.CreateFromTemplate(context.Background(), "My HQ", "personal-ops")
+	if err != nil {
+		t.Fatalf("CreateFromTemplate: %v", err)
+	}
+	if wsID == "" {
+		t.Fatal("expected a non-empty workspace id")
+	}
+
+	sessWS, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if sessWS.Name != "My HQ" {
+		t.Fatalf("name = %q, want My HQ", sessWS.Name)
+	}
+	if got := currentWorkspaceEntryAgentName(sessWS); got != "Personal Chief of Staff" {
+		t.Fatalf("entry agent = %q, want Personal Chief of Staff", got)
+	}
+	if tasks := workspaceTasksFromStore(t, handler, wsID); len(tasks) != 3 {
+		t.Fatalf("expected 3 seeded starter tasks, got %d", len(tasks))
+	}
+}
+
+// TestCreateFromTemplateWithUnknownTemplateStillCreatesAWorkspace matches
+// the existing POST /api/workspaces contract: an unresolvable template_id is
+// non-fatal by design (the workspace is still created, with a
+// generic auto-created manager entry agent, rather than failing outright).
+// CreateFromTemplate must not layer a new hard failure on top of that.
+func TestCreateFromTemplateWithUnknownTemplateStillCreatesAWorkspace(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	wsID, err := handler.CreateFromTemplate(context.Background(), "My HQ", "does-not-exist")
+	if err != nil {
+		t.Fatalf("CreateFromTemplate should not fail on an unresolvable template id, got %v", err)
+	}
+	if wsID == "" {
+		t.Fatal("expected a workspace id even when the template did not resolve")
+	}
+}
+
 // TestLibraryTemplateRefreshNeverRewritesAlreadyCreatedWorkspace covers PRD
 // FR127/FR128 (task 2.4/2.7 migration safety): bumping the shipped Personal
 // HQ manifest's builtin_version (as a later release will) must refresh only

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -1,11 +1,13 @@
 package sessionhttp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -224,6 +226,43 @@ type createWorkspaceRequest struct {
 	CreateTemplateAgents   *bool                      `json:"create_template_agents,omitempty"`
 	TemplateAgentOverrides []templateAgentOverride    `json:"template_agent_overrides,omitempty"`
 	Blank                  bool                       `json:"blank,omitempty"` // The Blank blueprint: seed the synthetic single-agent roster (no template, no project)
+}
+
+// CreateFromTemplate creates a normal (non-group) workspace from a built-in
+// template by ID and returns its new workspace ID. It reuses the exact
+// production POST /api/workspaces path in-process (entry-agent selection,
+// tool binding, scaffold provisioning, starter-task seeding, template
+// provenance) rather than duplicating any of that logic, so callers outside
+// the HTTP layer — such as the Personal HQ setup coordinator — get identical
+// behavior to a user picking the template from the library (PRD FR128).
+func (h *Handler) CreateFromTemplate(ctx context.Context, name, templateID string) (string, error) {
+	body, err := json.Marshal(createWorkspaceRequest{Name: name, TemplateID: templateID})
+	if err != nil {
+		return "", fmt.Errorf("failed to encode workspace creation request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/api/workspaces", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to build workspace creation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleWorkspaces(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		return "", fmt.Errorf("workspace creation failed (%d): %s", rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	var resp struct {
+		Folder struct {
+			ID string `json:"id"`
+		} `json:"folder"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		return "", fmt.Errorf("failed to parse workspace creation response: %w", err)
+	}
+	if resp.Folder.ID == "" {
+		return "", errors.New("workspace creation response missing an id")
+	}
+	return resp.Folder.ID, nil
 }
 
 // createWorkspace handles POST /api/workspaces. The flow is staged:

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -346,6 +346,10 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		seededStarterTasks = h.seedTemplateStarterTasksLogged(ws.ID, resolvedTemplate)
 	}
 
+	// Must run after starter-task seeding above — see
+	// persistCreateWorkspaceTemplateProvenance's doc comment for why.
+	h.persistCreateWorkspaceTemplateProvenance(ws.ID, resolvedTemplate, templateResolved)
+
 	// Completeness/ordering backstop: when the workspace was created with an
 	// entry agent, claim any tasks that already exist on the folder workspace
 	// (e.g. import-style seeds). Template starter tasks are assigned at seed
@@ -659,26 +663,39 @@ func (h *Handler) applyCreateWorkspaceTemplate(ctx context.Context, req createWo
 		}
 	}
 
-	// Persist portable template provenance so features (REAPER readiness, repair)
-	// can identify the originating built-in without scanning filenames or task
-	// prose. Best-effort: a failure here never fails creation.
-	if tc.resolved && tc.template.Builtin && strings.TrimSpace(tc.template.ID) != "" && h.workspaceTaskStore != nil {
-		prov := &agentworkspace.TemplateProvenance{
-			TemplateID:   tc.template.ID,
-			TemplateName: tc.template.Name,
-			Builtin:      true,
-			Version:      tc.template.BuiltinVersion,
-			AppliedAt:    time.Now(),
-		}
-		if err := h.workspaceTaskStore.Update(ws.ID, func(w *agentworkspace.Workspace) error {
-			w.SetTemplateProvenance(prov)
-			return nil
-		}); err != nil {
-			logger.Warn("Failed to persist template provenance", logger.Fields{"id": ws.ID, "template": tc.template.ID, "error": err})
-		}
-	}
-
 	return projectWarning
+}
+
+// persistCreateWorkspaceTemplateProvenance records the built-in template a
+// workspace was created from onto its portable workspace.json (features like
+// REAPER readiness and repair identify origin from this rather than scanning
+// filenames or task prose). Best-effort: a failure never fails creation.
+//
+// Must run after starter-task seeding, not from inside
+// applyCreateWorkspaceTemplate. h.workspaceTaskStore is a SyncStore whose
+// primary is the SQLite-backed session store; session.Workspace has no
+// TemplateProvenance column, so every Update on this store round-trips
+// through a conversion that silently drops it before re-saving to disk. Any
+// later Update on the same workspace id — starter-task seeding runs right
+// after template application — would clobber a provenance write made here
+// earlier. Doing it last avoids that.
+func (h *Handler) persistCreateWorkspaceTemplateProvenance(wsID string, tmpl projecttemplates.Template, resolved bool) {
+	if !resolved || !tmpl.Builtin || strings.TrimSpace(tmpl.ID) == "" || h.workspaceTaskStore == nil {
+		return
+	}
+	prov := &agentworkspace.TemplateProvenance{
+		TemplateID:   tmpl.ID,
+		TemplateName: tmpl.Name,
+		Builtin:      true,
+		Version:      tmpl.BuiltinVersion,
+		AppliedAt:    time.Now(),
+	}
+	if err := h.workspaceTaskStore.Update(wsID, func(w *agentworkspace.Workspace) error {
+		w.SetTemplateProvenance(prov)
+		return nil
+	}); err != nil {
+		logger.Warn("Failed to persist template provenance", logger.Fields{"id": wsID, "template": tmpl.ID, "error": err})
+	}
 }
 
 func workspacePathsEqual(a, b string) bool {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -185,6 +185,12 @@ func (p *AssistantProgress) EnsureDefaults() {
 type ProgressionState struct {
 	// CompletedQuests maps a stable quest ID to the time it was completed.
 	CompletedQuests map[string]time.Time `json:"completed_quests,omitempty"`
+	// SkippedQuests maps a stable *optional* quest ID to the time it was
+	// skipped. Distinct from CompletedQuests (the underlying action was never
+	// observed) and from Dismissed (a skip is per-quest, not whole-widget). A
+	// later real completion removes the quest's entry here and adds it to
+	// CompletedQuests instead — the two maps are never both set for one ID.
+	SkippedQuests map[string]time.Time `json:"skipped_quests,omitempty"`
 	// Dismissed is true when the user has hidden the quest-log widget.
 	Dismissed bool `json:"dismissed,omitempty"`
 	// BackfilledAt is non-zero once the startup backfill scan has run, so it

--- a/internal/userprofile/profile.go
+++ b/internal/userprofile/profile.go
@@ -31,6 +31,64 @@ var allowedPreferenceKeys = map[string]struct{}{
 
 var preferenceRenderOrder = []string{"response_style", "units", "language"}
 
+// HQOnboardingState is the durable Personal HQ onboarding status for a user.
+// It is stored independently from PersonalWorkspaceID (the designation
+// itself) so that clearing or losing the designated workspace never resets
+// the user's onboarding history back to unseen.
+type HQOnboardingState string
+
+const (
+	// HQOnboardingUnseen is the default state for a profile that has never
+	// been shown the guided first-launch Personal HQ experience.
+	HQOnboardingUnseen HQOnboardingState = "unseen"
+	// HQOnboardingInProgress marks a user who started the Build My HQ setup
+	// flow but has not yet completed or skipped it.
+	HQOnboardingInProgress HQOnboardingState = "in_progress"
+	// HQOnboardingCompleted marks a user who finished HQ setup or explicitly
+	// designated an existing workspace as their HQ.
+	HQOnboardingCompleted HQOnboardingState = "completed"
+	// HQOnboardingSkipped marks a user who deferred HQ setup. Product
+	// features and progression tiers remain fully available in this state.
+	HQOnboardingSkipped HQOnboardingState = "skipped"
+)
+
+// ParseHQOnboardingState validates an external (API) onboarding-state value.
+// Unlike NormalizeHQOnboardingState, it rejects unknown input instead of
+// silently defaulting, since callers here are explicit state-transition
+// requests rather than tolerant reads of persisted data.
+func ParseHQOnboardingState(value string) (HQOnboardingState, bool) {
+	switch HQOnboardingState(strings.TrimSpace(value)) {
+	case HQOnboardingUnseen:
+		return HQOnboardingUnseen, true
+	case HQOnboardingInProgress:
+		return HQOnboardingInProgress, true
+	case HQOnboardingCompleted:
+		return HQOnboardingCompleted, true
+	case HQOnboardingSkipped:
+		return HQOnboardingSkipped, true
+	default:
+		return "", false
+	}
+}
+
+// NormalizeHQOnboardingState defaults unknown or empty persisted values to
+// HQOnboardingUnseen rather than failing, so a stray or pre-migration value
+// never breaks a read.
+func NormalizeHQOnboardingState(value string) HQOnboardingState {
+	if state, ok := ParseHQOnboardingState(value); ok {
+		return state
+	}
+	return HQOnboardingUnseen
+}
+
+// PersonalHQState is the read-time view of a user's Personal HQ designation
+// and onboarding status, as persisted on the user profile row.
+type PersonalHQState struct {
+	PersonalWorkspaceID string            `json:"personal_workspace_id,omitempty"`
+	OnboardingState     HQOnboardingState `json:"hq_onboarding_state"`
+	OnboardingUpdatedAt time.Time         `json:"hq_onboarding_updated_at,omitempty"`
+}
+
 type UserProfile struct {
 	ID              string            `json:"id"`
 	DisplayName     string            `json:"display_name,omitempty"`

--- a/internal/userprofile/store.go
+++ b/internal/userprofile/store.go
@@ -104,6 +104,90 @@ func (s *SQLiteStore) Upsert(ctx context.Context, profile *UserProfile) error {
 	return nil
 }
 
+// GetPersonalHQState reads the Personal HQ designation and onboarding status
+// for a user. It intentionally selects only these two columns (not the full
+// profile row) so it stays independent of the generic Get/Upsert round trip
+// and of agent-editable profile fields.
+func (s *SQLiteStore) GetPersonalHQState(ctx context.Context, userID string) (*PersonalHQState, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("user profile store is not configured")
+	}
+	userID = normalizeUserID(userID)
+	var workspaceID, onboardingState string
+	var updatedAtRaw any
+	err := s.db.QueryRowContext(ctx, `
+		SELECT personal_workspace_id, hq_onboarding_state, hq_onboarding_updated_at
+		FROM users
+		WHERE id = ?
+	`, userID).Scan(&workspaceID, &onboardingState, &updatedAtRaw)
+	if err == sql.ErrNoRows {
+		return &PersonalHQState{OnboardingState: HQOnboardingUnseen}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get personal hq state: %w", err)
+	}
+	state := &PersonalHQState{
+		PersonalWorkspaceID: workspaceID,
+		OnboardingState:     NormalizeHQOnboardingState(onboardingState),
+	}
+	if updatedAtRaw != nil {
+		if updatedAt, err := parseTime(updatedAtRaw); err == nil {
+			state.OnboardingUpdatedAt = updatedAt
+		}
+	}
+	return state, nil
+}
+
+// SetPersonalWorkspaceID persists the user's Personal HQ designation as a
+// single-column, atomic update. Passing an empty workspaceID clears the
+// designation. This never touches hq_onboarding_state, so clearing or
+// replacing an HQ never resets onboarding history.
+func (s *SQLiteStore) SetPersonalWorkspaceID(ctx context.Context, userID, workspaceID string) error {
+	if s == nil || s.db == nil {
+		return errors.New("user profile store is not configured")
+	}
+	userID = normalizeUserID(userID)
+	workspaceID = strings.TrimSpace(workspaceID)
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO users (id, personal_workspace_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			personal_workspace_id = excluded.personal_workspace_id,
+			updated_at = excluded.updated_at
+	`, userID, workspaceID, now, now)
+	if err != nil {
+		return fmt.Errorf("failed to set personal workspace id: %w", err)
+	}
+	return nil
+}
+
+// SetHQOnboardingState persists the user's Personal HQ onboarding status as a
+// single-column, atomic update independent of the designation itself.
+func (s *SQLiteStore) SetHQOnboardingState(ctx context.Context, userID string, state HQOnboardingState) error {
+	if s == nil || s.db == nil {
+		return errors.New("user profile store is not configured")
+	}
+	userID = normalizeUserID(userID)
+	normalized, ok := ParseHQOnboardingState(string(state))
+	if !ok {
+		return fmt.Errorf("invalid hq onboarding state: %q", state)
+	}
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO users (id, hq_onboarding_state, hq_onboarding_updated_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			hq_onboarding_state = excluded.hq_onboarding_state,
+			hq_onboarding_updated_at = excluded.hq_onboarding_updated_at,
+			updated_at = excluded.updated_at
+	`, userID, string(normalized), now, now, now)
+	if err != nil {
+		return fmt.Errorf("failed to set hq onboarding state: %w", err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) SetFields(ctx context.Context, id string, fields map[string]any) (*UserProfile, error) {
 	if len(fields) == 0 {
 		return s.Get(ctx, id)

--- a/internal/userprofile/store_test.go
+++ b/internal/userprofile/store_test.go
@@ -122,6 +122,93 @@ func TestRenderUserProfileSection(t *testing.T) {
 	}
 }
 
+func TestSQLiteStorePersonalHQStateDefaultsToUnseen(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	state, err := store.GetPersonalHQState(ctx, "local")
+	if err != nil {
+		t.Fatalf("GetPersonalHQState: %v", err)
+	}
+	if state.PersonalWorkspaceID != "" {
+		t.Fatalf("expected no designation by default, got %#v", state)
+	}
+	if state.OnboardingState != HQOnboardingUnseen {
+		t.Fatalf("expected unseen onboarding state by default, got %q", state.OnboardingState)
+	}
+
+	// A user profile row that has never been created should also default
+	// safely rather than erroring, since not every user has upserted a
+	// profile before Personal HQ status is first read.
+	state, err = store.GetPersonalHQState(ctx, "brand-new-user")
+	if err != nil {
+		t.Fatalf("GetPersonalHQState for unknown user: %v", err)
+	}
+	if state.PersonalWorkspaceID != "" || state.OnboardingState != HQOnboardingUnseen {
+		t.Fatalf("expected zero-value state for unknown user, got %#v", state)
+	}
+}
+
+func TestSQLiteStoreSetPersonalWorkspaceIDIsIndependentOfOnboardingState(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.SetHQOnboardingState(ctx, "local", HQOnboardingCompleted); err != nil {
+		t.Fatalf("SetHQOnboardingState: %v", err)
+	}
+	if err := store.SetPersonalWorkspaceID(ctx, "local", "ws-hq-1"); err != nil {
+		t.Fatalf("SetPersonalWorkspaceID: %v", err)
+	}
+
+	state, err := store.GetPersonalHQState(ctx, "local")
+	if err != nil {
+		t.Fatalf("GetPersonalHQState: %v", err)
+	}
+	if state.PersonalWorkspaceID != "ws-hq-1" {
+		t.Fatalf("expected designation to persist, got %#v", state)
+	}
+	if state.OnboardingState != HQOnboardingCompleted {
+		t.Fatalf("expected onboarding state to persist, got %#v", state)
+	}
+
+	// Clearing the designation (e.g. after workspace deletion) must not
+	// reset onboarding history back to unseen or in_progress.
+	if err := store.SetPersonalWorkspaceID(ctx, "local", ""); err != nil {
+		t.Fatalf("SetPersonalWorkspaceID clear: %v", err)
+	}
+	state, err = store.GetPersonalHQState(ctx, "local")
+	if err != nil {
+		t.Fatalf("GetPersonalHQState after clear: %v", err)
+	}
+	if state.PersonalWorkspaceID != "" {
+		t.Fatalf("expected designation cleared, got %#v", state)
+	}
+	if state.OnboardingState != HQOnboardingCompleted {
+		t.Fatalf("expected onboarding state to survive clearing the designation, got %q", state.OnboardingState)
+	}
+}
+
+func TestSQLiteStoreSetHQOnboardingStateRejectsUnknownValues(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.SetHQOnboardingState(ctx, "local", HQOnboardingState("bogus")); err == nil {
+		t.Fatal("expected an error for an unknown onboarding state")
+	}
+}
+
+func TestSQLiteStorePersonalHQStateNotExposedThroughGenericSetFields(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := store.SetFields(ctx, "local", map[string]any{"personal_workspace_id": "ws-1"}); !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("expected personal_workspace_id to be rejected by generic SetFields, got %v", err)
+	}
+	if _, err := store.SetFields(ctx, "local", map[string]any{"hq_onboarding_state": "completed"}); !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("expected hq_onboarding_state to be rejected by generic SetFields, got %v", err)
+	}
+}
+
 func TestLocalUserProvider(t *testing.T) {
 	got, err := (LocalUserProvider{}).CurrentUserID(context.Background())
 	if err != nil {

--- a/internal/web/static/css/common.css
+++ b/internal/web/static/css/common.css
@@ -2087,6 +2087,36 @@ h3, .h3 {
     text-decoration: line-through;
 }
 
+.quest-item-skipped .quest-mark {
+    color: var(--text-secondary);
+}
+
+.quest-status {
+    margin-left: auto;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+}
+
+.quest-resume,
+.quest-skip {
+    font-size: 0.78rem;
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--border-color, currentColor);
+    border-radius: 0.25rem;
+    background: transparent;
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+
+.quest-resume:hover,
+.quest-resume:focus-visible,
+.quest-skip:hover,
+.quest-skip:focus-visible {
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+    outline: 0;
+}
+
 a.quest-title {
     color: var(--primary-color);
     text-decoration: none;

--- a/internal/web/static/css/home-command.css
+++ b/internal/web/static/css/home-command.css
@@ -1048,3 +1048,209 @@ a.quest-title:focus-visible {
     animation: none;
   }
 }
+
+/*
+ * Daily Brief — the primary Home orientation region once a Personal HQ is
+ * designated (PRD FR97). Shares the Command Bridge panel vocabulary.
+ */
+
+.home-daily-brief {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 10px;
+  padding: 13px 16px;
+  border: 1px solid var(--hc-line);
+  border-radius: 0;
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--hc-panel-raised) 78%, transparent),
+    var(--hc-panel)
+  );
+  box-shadow: var(--hc-shadow);
+}
+
+.home-daily-brief-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.home-daily-brief-eyebrow {
+  display: block;
+  color: var(--hc-signal);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+}
+
+.home-daily-brief-title {
+  margin: 2px 0 0;
+  color: var(--hc-ink);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.home-daily-brief-meta {
+  margin: 2px 0 0;
+  color: var(--hc-ink-faint);
+  font-size: 9px;
+}
+
+.home-daily-brief-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.home-daily-brief-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border: 1px solid var(--hc-line-bright);
+  font-size: 9.5px;
+}
+
+.home-daily-brief-banner.is-failed {
+  border-color: var(--hc-alert);
+  color: var(--hc-alert);
+}
+
+.home-daily-brief-banner.is-partial,
+.home-daily-brief-banner.is-degraded {
+  border-color: var(--hc-amber);
+  color: var(--hc-amber);
+}
+
+.home-daily-brief-banner.is-loading {
+  border-color: var(--hc-idle);
+  color: var(--hc-idle);
+}
+
+.home-daily-brief-placeholder {
+  padding: 8px 0;
+  color: var(--hc-ink-faint);
+  font-size: 9px;
+}
+
+.home-daily-brief-opening {
+  margin: 0 0 10px;
+  color: var(--hc-ink);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.home-daily-brief-gaps {
+  margin: 0 0 10px;
+  color: var(--hc-amber);
+  font-size: 9px;
+}
+
+.home-daily-brief-quiet {
+  color: var(--hc-ink-faint);
+  font-size: 10px;
+}
+
+.home-daily-brief-section {
+  margin-bottom: 12px;
+}
+
+.home-daily-brief-section-title {
+  margin: 0 0 6px;
+  color: var(--hc-ink);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+
+.home-daily-brief-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.home-daily-brief-item {
+  padding: 8px 10px;
+  border: 1px solid var(--hc-line);
+}
+
+.home-daily-brief-item-title {
+  color: var(--hc-ink);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.home-daily-brief-item-title:hover,
+.home-daily-brief-item-title:focus-visible {
+  color: var(--hc-signal);
+  text-decoration: underline;
+}
+
+.home-daily-brief-item-ws {
+  margin-left: 8px;
+  color: var(--hc-ink-faint);
+  font-size: 8.5px;
+}
+
+.home-daily-brief-item-fact {
+  margin: 4px 0 0;
+  color: var(--hc-ink-dim);
+  font-size: 9.5px;
+}
+
+.home-daily-brief-item-why {
+  margin: 4px 0 0;
+  font-size: 9.5px;
+}
+
+/* Suggestions/recommendations are visually distinguished from observed
+   facts without relying on color alone (PRD FR82/FR131). */
+.is-suggestion {
+  font-style: italic;
+}
+
+.is-suggestion::before {
+  margin-right: 4px;
+  font-style: normal;
+  content: "\2192";
+}
+
+.home-daily-brief-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.home-daily-brief-settings-form .home-daily-brief-days {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.home-daily-brief-history-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12px;
+}
+
+.home-daily-brief-history-empty {
+  color: var(--hc-ink-faint);
+}
+
+@media (max-width: 720px) {
+  .home-daily-brief-header {
+    flex-direction: column;
+  }
+}

--- a/internal/web/static/css/home-command.css
+++ b/internal/web/static/css/home-command.css
@@ -828,6 +828,41 @@ body.home-command-page .home-command-bridge * {
   color: var(--hc-signal);
 }
 
+.quest-item-skipped .quest-mark {
+  color: var(--hc-ink-dim);
+}
+
+.quest-status {
+  margin-left: auto;
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.quest-resume,
+.quest-skip {
+  padding: 2px 6px;
+  border: 1px solid var(--hc-line);
+  border-radius: 0;
+  background: transparent;
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 9px;
+  text-decoration: none;
+}
+
+.quest-resume:hover,
+.quest-resume:focus-visible,
+.quest-skip:hover,
+.quest-skip:focus-visible {
+  border-color: var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal) 10%, transparent);
+  color: var(--hc-signal);
+  outline: 0;
+}
+
 .quest-title {
   color: inherit;
 }

--- a/internal/web/static/css/home-command.css
+++ b/internal/web/static/css/home-command.css
@@ -799,6 +799,169 @@ body.home-command-page .home-command-bridge * {
   transition: width 220ms ease;
 }
 
+.quest-log-first-mission {
+  position: relative;
+  display: grid;
+  gap: 8px;
+  margin-top: 11px;
+  padding: 10px 11px 11px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--hc-signal) 62%, var(--hc-line));
+  background:
+    linear-gradient(108deg, color-mix(in srgb, var(--hc-signal) 12%, transparent), transparent 52%),
+    color-mix(in srgb, var(--hc-panel-deep) 68%, var(--hc-panel));
+  clip-path: polygon(0 0, calc(100% - 9px) 0, 100% 9px, 100% 100%, 0 100%);
+}
+
+.quest-log-first-mission[hidden] {
+  display: none;
+}
+
+.quest-log-first-mission::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 2px;
+  background: var(--hc-signal);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--hc-signal) 70%, transparent);
+  content: "";
+}
+
+.quest-log-first-mission::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 23px,
+    color-mix(in srgb, var(--hc-signal) 5%, transparent) 24px
+  );
+}
+
+.quest-log-first-mission-meta,
+.quest-log-first-mission-body {
+  position: relative;
+  z-index: 1;
+}
+
+.quest-log-first-mission-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.quest-log-first-mission-kicker,
+.quest-log-first-mission-status,
+.quest-log-first-mission-action {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.quest-log-first-mission-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--hc-signal);
+}
+
+.quest-log-first-mission-signal {
+  width: 5px;
+  height: 5px;
+  background: var(--hc-signal);
+  box-shadow: 0 0 8px var(--hc-signal);
+  animation: home-command-signal 1.8s steps(2, end) infinite;
+}
+
+.quest-log-first-mission-status {
+  color: var(--hc-ink-dim);
+}
+
+.quest-log-first-mission-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 12px;
+}
+
+.quest-log-first-mission-copy {
+  min-width: 0;
+}
+
+.quest-log-first-mission-title {
+  margin: 0;
+  color: var(--hc-ink);
+  font-family: "Chakra Petch", system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.25px;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.quest-log-first-mission-why {
+  display: -webkit-box;
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--hc-ink-dim);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 7px;
+  letter-spacing: 0.25px;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.quest-log-first-mission-action {
+  display: inline-flex;
+  min-height: 29px;
+  padding: 6px 8px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid var(--hc-signal);
+  background: color-mix(in srgb, var(--hc-signal) 10%, var(--hc-panel));
+  color: var(--hc-signal);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.quest-log-first-mission-action:hover,
+.quest-log-first-mission-action:focus-visible {
+  background: var(--hc-signal);
+  color: var(--hc-panel-deep);
+  outline: 0;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hc-signal) 18%, transparent);
+}
+
+.quest-log-first-mission.is-paused {
+  border-color: color-mix(in srgb, var(--hc-amber) 55%, var(--hc-line));
+}
+
+.quest-log-first-mission.is-paused::before,
+.quest-log-first-mission.is-paused .quest-log-first-mission-signal {
+  background: var(--hc-amber);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--hc-amber) 70%, transparent);
+}
+
+.quest-log-first-mission.is-paused .quest-log-first-mission-kicker {
+  color: var(--hc-amber);
+}
+
+.quest-log-first-mission.is-complete {
+  grid-template-columns: 1fr;
+  border-color: var(--hc-line-bright);
+  background: color-mix(in srgb, var(--hc-signal) 5%, var(--hc-panel-deep));
+}
+
+.quest-log-first-mission.is-complete .quest-log-first-mission-signal {
+  animation: none;
+}
+
 .quest-log-list {
   min-height: 0;
   margin: 12px 0 0;
@@ -1011,6 +1174,14 @@ a.quest-title:focus-visible {
     grid-template-columns: auto minmax(0, 1fr);
   }
 
+  .quest-log-first-mission-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .quest-log-first-mission-action {
+    width: 100%;
+  }
+
   .home-command-execute.modern-btn {
     grid-column: 1 / -1;
     min-height: 34px;
@@ -1044,7 +1215,8 @@ a.quest-title:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   .home-command-input:not(:placeholder-shown) + .home-command-execute::before,
   .home-command-form:focus-within .home-command-prompt::after,
-  .home-status-led.is-working {
+  .home-status-led.is-working,
+  .quest-log-first-mission-signal {
     animation: none;
   }
 }

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -5366,67 +5366,792 @@ body.modal-open .hub-support-chat {
    Personal HQ guided first-launch state (personal-hq-onboarding.js)
    ========================================================================== */
 
+/* The guided state owns the launcher while it is visible. Keeping the normal
+   launcher mounted lets its data load in the background, but removes competing
+   controls and fixes the old empty-state/create-modal race on first launch. */
+#workspaceHub.is-hq-guided .launcher-header,
+#workspaceHub.is-hq-guided .launcher-tabs {
+  display: none;
+}
+
+#workspaceHub.is-hq-guided .launcher-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+#workspaceHub.is-hq-guided #launcherWorkspacesPanel {
+  position: relative;
+}
+
+#workspaceHub.is-hq-guided #launcherWorkspacesPanel > :not(#hqOnboardingGuided) {
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* Ori is already present as the mission guide. The floating assistant would
+   duplicate that role and can overlap the primary action on narrow screens. */
+body:has(#workspaceHub.is-hq-guided) #hubSupportChat {
+  display: none;
+}
+
 .hq-guided {
-  display: flex;
-  flex-direction: column;
+  --hq-canvas: #edf1f3;
+  --hq-canvas-deep: #dfe5e8;
+  --hq-panel: rgba(250, 252, 252, 0.88);
+  --hq-panel-strong: #f9fbfb;
+  --hq-line: rgba(63, 76, 82, 0.24);
+  --hq-line-bright: rgba(31, 107, 78, 0.58);
+  --hq-ink: #151b1e;
+  --hq-ink-soft: #4f5d61;
+  --hq-ink-faint: #738084;
+  --hq-accent: #1f6b4e;
+  --hq-accent-bright: #27835f;
+  --hq-accent-wash: rgba(31, 107, 78, 0.1);
+  --hq-amber: #9a651f;
+  --hq-grid: rgba(47, 67, 73, 0.075);
+  --hq-shadow: 0 30px 75px -48px rgba(10, 10, 10, 0.56);
+
+  position: relative;
+  isolation: isolate;
+  min-height: min(760px, calc(100vh - 8.5rem));
+  overflow: hidden;
+  color: var(--hq-ink);
+  background:
+    radial-gradient(circle at 76% 42%, rgba(31, 107, 78, 0.13), transparent 28%),
+    radial-gradient(circle at 8% 100%, rgba(154, 101, 31, 0.08), transparent 24%),
+    linear-gradient(145deg, var(--hq-canvas), var(--hq-canvas-deep));
+  font-family: "Chakra Petch", var(--font-body, sans-serif);
+  text-align: left;
+}
+
+[data-bs-theme="dark"] .hq-guided,
+.dark-mode .hq-guided {
+  --hq-canvas: #0c0e11;
+  --hq-canvas-deep: #14181b;
+  --hq-panel: rgba(20, 25, 28, 0.88);
+  --hq-panel-strong: #151a1d;
+  --hq-line: rgba(204, 216, 218, 0.17);
+  --hq-line-bright: rgba(70, 211, 154, 0.5);
+  --hq-ink: #edf2f0;
+  --hq-ink-soft: #a8b2b0;
+  --hq-ink-faint: #717c7b;
+  --hq-accent: #46d39a;
+  --hq-accent-bright: #71e6b6;
+  --hq-accent-wash: rgba(70, 211, 154, 0.09);
+  --hq-amber: #e8b54b;
+  --hq-grid: rgba(213, 230, 226, 0.055);
+  --hq-shadow: 0 36px 88px -44px rgba(0, 0, 0, 0.9);
+}
+
+.hq-guided::before,
+.hq-guided::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.hq-guided::before {
+  width: 34rem;
+  height: 34rem;
+  top: -23rem;
+  right: -9rem;
+  border: 1px solid var(--hq-line-bright);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 4.5rem rgba(31, 107, 78, 0.025),
+    0 0 0 9rem rgba(31, 107, 78, 0.018);
+}
+
+.hq-guided::after {
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-right: 1px solid var(--hq-line-bright);
+  border-bottom: 1px solid var(--hq-line-bright);
+}
+
+.hq-guided-grid {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  opacity: 0.8;
+  background-image:
+    linear-gradient(var(--hq-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hq-grid) 1px, transparent 1px);
+  background-size: 32px 32px;
+  -webkit-mask-image: linear-gradient(105deg, rgba(0, 0, 0, 0.78), transparent 72%);
+  mask-image: linear-gradient(105deg, rgba(0, 0, 0, 0.78), transparent 72%);
+}
+
+.hq-guided-shell {
+  width: min(1180px, 100%);
+  min-height: inherit;
+  margin: 0 auto;
+  padding: clamp(1.25rem, 3.2vw, 3.25rem);
+  animation: hq-guided-arrive 0.55s cubic-bezier(0.2, 0.75, 0.25, 1) both;
+}
+
+.hq-guided-commandline {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: 0.5rem;
-  max-width: 32rem;
-  margin: 2.5rem auto;
-  padding: 2rem 1.5rem;
-  text-align: center;
-}
-
-.hq-guided-site {
-  width: 100%;
-  max-width: 14rem;
-  aspect-ratio: 4 / 3;
-  margin-bottom: 0.75rem;
-}
-
-.hq-guided-site-outline {
-  width: 100%;
-  height: 100%;
-  border: 2px dashed var(--border-color);
-  border-radius: var(--radius-lg);
-  background: var(--bg-secondary);
-  opacity: 0.7;
-}
-
-.hq-guided-eyebrow {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.75rem;
+  gap: 1rem;
+  margin-bottom: clamp(1.4rem, 3vw, 2.35rem);
+  color: var(--hq-ink-faint);
+  font-family: "JetBrains Mono", var(--font-mono, monospace);
+  font-size: 0.65rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
-.hq-guided-title {
+.hq-guided-commandline::before,
+.hq-guided-commandline::after {
+  content: "";
+  position: absolute;
+}
+
+.hq-guided-mission-chip,
+.hq-guided-ready-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.hq-guided-mission-chip {
+  justify-self: start;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--hq-amber) 55%, transparent);
+  color: var(--hq-amber);
+  background: color-mix(in srgb, var(--hq-amber) 8%, transparent);
+}
+
+.hq-guided-mission-chip > span,
+.hq-guided-ready-label::before {
+  width: 0.38rem;
+  height: 0.38rem;
+  background: currentColor;
+  transform: rotate(45deg);
+}
+
+.hq-guided-system-label {
+  justify-self: center;
+}
+
+.hq-guided-ready-label {
+  justify-self: end;
+  color: var(--hq-accent);
+}
+
+.hq-guided-dialogue {
+  display: flex;
+  align-items: flex-start;
+  width: min(46rem, 78%);
+  margin: 0 0 clamp(1.8rem, 4vw, 3.4rem);
+  animation: hq-guided-rise 0.48s 0.1s ease-out both;
+}
+
+.hq-guided-avatar {
+  position: relative;
+  display: grid;
+  flex: 0 0 4rem;
+  width: 4rem;
+  height: 4rem;
+  place-items: center;
+  border: 1px solid var(--hq-line-bright);
+  background:
+    radial-gradient(circle at 50% 35%, var(--hq-accent-wash), transparent 68%),
+    var(--hq-panel-strong);
+  color: var(--hq-accent);
+  clip-path: polygon(50% 0, 94% 24%, 94% 76%, 50% 100%, 6% 76%, 6% 24%);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--hq-accent) 15%, transparent);
+}
+
+.hq-guided-avatar svg {
+  width: 2.9rem;
+  height: 2.9rem;
+  fill: currentColor;
+}
+
+.hq-guided-avatar-status {
+  position: absolute;
+  right: 0.25rem;
+  bottom: 0.38rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border: 2px solid var(--hq-panel-strong);
+  border-radius: 50%;
+  background: var(--hq-accent);
+  box-shadow: 0 0 0.65rem var(--hq-accent);
+}
+
+.hq-guided-speech {
+  position: relative;
+  min-width: 0;
+  margin: 0.35rem 0 0 1rem;
+  padding: 0.9rem 1.1rem 0.95rem;
+  border: 1px solid var(--hq-line);
+  background: var(--hq-panel);
+  box-shadow: var(--hq-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.hq-guided-speech::before,
+.hq-guided-speech::after {
+  content: "";
+  position: absolute;
+  top: 1.15rem;
+  width: 0;
+  height: 0;
+  border-top: 0.55rem solid transparent;
+  border-bottom: 0.55rem solid transparent;
+}
+
+.hq-guided-speech::before {
+  left: -0.65rem;
+  border-right: 0.65rem solid var(--hq-line);
+}
+
+.hq-guided-speech::after {
+  left: -0.58rem;
+  border-right: 0.65rem solid var(--hq-panel-strong);
+}
+
+.hq-guided-speaker {
+  display: block;
+  margin-bottom: 0.28rem;
+  color: var(--hq-accent);
+  font-family: "JetBrains Mono", var(--font-mono, monospace);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.hq-guided-speech p {
   margin: 0;
-  color: var(--text-primary);
-  font-size: 1.4rem;
+  color: var(--hq-ink-soft);
+  font-family: var(--font-body, sans-serif);
+  font-size: clamp(0.9rem, 1.25vw, 1rem);
+  line-height: 1.55;
+}
+
+.hq-guided-speech strong {
+  color: var(--hq-ink);
   font-weight: 700;
 }
 
-.hq-guided-copy {
+.hq-guided-stage {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.9fr) minmax(26rem, 1.1fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+}
+
+.hq-guided-brief {
+  position: relative;
+  z-index: 2;
+  padding-left: clamp(0rem, 1.5vw, 1.25rem);
+  animation: hq-guided-rise 0.52s 0.17s ease-out both;
+}
+
+.hq-guided-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0 0 0.7rem;
+  color: var(--hq-amber);
+  font-family: "JetBrains Mono", var(--font-mono, monospace);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.hq-guided-eyebrow::before {
+  content: "";
+  width: 1.8rem;
+  height: 1px;
+  background: currentColor;
+}
+
+.hq-guided-title {
+  max-width: 10ch;
   margin: 0;
-  max-width: 28rem;
-  color: var(--text-secondary);
-  font-size: 0.92rem;
-  line-height: 1.5;
+  color: var(--hq-ink);
+  font-family: "Chakra Petch", var(--font-body, sans-serif);
+  font-size: clamp(2.25rem, 4.2vw, 4.15rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.94;
+  text-wrap: balance;
+}
+
+.hq-guided-copy {
+  max-width: 34rem;
+  margin: 1rem 0 0;
+  color: var(--hq-ink-soft);
+  font-family: var(--font-body, sans-serif);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.hq-guided-outcomes {
+  display: grid;
+  gap: 0.55rem;
+  margin: 1.35rem 0 1.6rem;
+}
+
+.hq-guided-outcome {
+  display: grid;
+  grid-template-columns: 2.2rem 1fr;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.hq-guided-outcome-icon {
+  display: grid;
+  width: 2.2rem;
+  height: 2.2rem;
+  place-items: center;
+  border: 1px solid var(--hq-line);
+  background: var(--hq-accent-wash);
+  color: var(--hq-accent);
+  clip-path: polygon(0 0, calc(100% - 0.45rem) 0, 100% 0.45rem, 100% 100%, 0 100%);
+}
+
+.hq-guided-outcome-icon svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.hq-guided-outcome > span:last-child {
+  display: grid;
+  line-height: 1.25;
+}
+
+.hq-guided-outcome strong {
+  color: var(--hq-ink);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+}
+
+.hq-guided-outcome small {
+  margin-top: 0.12rem;
+  color: var(--hq-ink-faint);
+  font-family: var(--font-body, sans-serif);
+  font-size: 0.74rem;
 }
 
 .hq-guided-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.6rem;
-  margin-top: 0.5rem;
+  display: grid;
+  justify-items: start;
+  gap: 0.55rem;
 }
 
-/* Reduced motion / theme note: this state is intentionally static (a
-   dashed-outline placeholder, no animation), so it needs no additional
-   prefers-reduced-motion override — it already satisfies one. */
+.hq-guided-primary {
+  display: inline-flex;
+  min-height: 3.15rem;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  padding: 0.78rem 1.1rem 0.78rem 1.25rem;
+  border: 1px solid var(--hq-accent);
+  border-radius: 0;
+  background: var(--hq-accent);
+  color: #fff;
+  font: 700 0.78rem/1 "Chakra Petch", var(--font-body, sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  clip-path: polygon(0.55rem 0, 100% 0, 100% calc(100% - 0.55rem), calc(100% - 0.55rem) 100%, 0 100%, 0 0.55rem);
+  box-shadow: 0 12px 28px -16px color-mix(in srgb, var(--hq-accent) 78%, transparent);
+  transition: background 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+[data-bs-theme="dark"] .hq-guided-primary,
+.dark-mode .hq-guided-primary {
+  color: #06110d;
+}
+
+.hq-guided-primary svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 160ms ease;
+}
+
+.hq-guided-primary:hover {
+  background: var(--hq-accent-bright);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px -16px color-mix(in srgb, var(--hq-accent) 86%, transparent);
+}
+
+.hq-guided-primary:hover svg {
+  transform: translateX(0.2rem);
+}
+
+.hq-guided-primary:focus-visible,
+.hq-guided-alternatives button:focus-visible {
+  outline: 2px solid var(--hq-accent);
+  outline-offset: 3px;
+}
+
+.hq-guided-action-note {
+  color: var(--hq-ink-faint);
+  font-family: "JetBrains Mono", var(--font-mono, monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.02em;
+}
+
+.hq-guided-alternatives {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+  margin-top: 1.2rem;
+  color: var(--hq-line-bright);
+  font-family: var(--font-body, sans-serif);
+}
+
+.hq-guided-alternatives button {
+  padding: 0.15rem 0;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  background: transparent;
+  color: var(--hq-ink-soft);
+  font: 600 0.74rem/1.35 var(--font-body, sans-serif);
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.hq-guided-alternatives button:hover {
+  border-bottom-color: var(--hq-accent);
+  color: var(--hq-accent);
+}
+
+.hq-guided-blueprint {
+  position: relative;
+  min-width: 0;
+  border: 1px solid var(--hq-line);
+  background: var(--hq-panel);
+  box-shadow: var(--hq-shadow);
+  clip-path: polygon(0 0, calc(100% - 1.1rem) 0, 100% 1.1rem, 100% 100%, 1.1rem 100%, 0 calc(100% - 1.1rem));
+  backdrop-filter: blur(14px);
+  animation: hq-guided-rise 0.62s 0.24s ease-out both;
+}
+
+.hq-guided-blueprint::before,
+.hq-guided-blueprint::after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  width: 1.35rem;
+  height: 1.35rem;
+  pointer-events: none;
+}
+
+.hq-guided-blueprint::before {
+  top: 0.65rem;
+  left: 0.65rem;
+  border-top: 1px solid var(--hq-accent);
+  border-left: 1px solid var(--hq-accent);
+}
+
+.hq-guided-blueprint::after {
+  right: 0.65rem;
+  bottom: 0.65rem;
+  border-right: 1px solid var(--hq-accent);
+  border-bottom: 1px solid var(--hq-accent);
+}
+
+.hq-guided-blueprint-head,
+.hq-guided-blueprint-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 0.95rem;
+  color: var(--hq-ink-faint);
+  font-family: "JetBrains Mono", var(--font-mono, monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.hq-guided-blueprint-head {
+  border-bottom: 1px solid var(--hq-line);
+}
+
+.hq-guided-unbuilt {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: var(--hq-amber);
+}
+
+.hq-guided-unbuilt i {
+  width: 0.4rem;
+  height: 0.4rem;
+  border: 1px solid currentColor;
+  transform: rotate(45deg);
+}
+
+.hq-guided-blueprint-canvas {
+  position: relative;
+  aspect-ratio: 13 / 9;
+  min-height: 21rem;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 48% 52%, var(--hq-accent-wash), transparent 26%),
+    color-mix(in srgb, var(--hq-canvas) 62%, transparent);
+}
+
+.hq-guided-blueprint-canvas > svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.hq-guided-blueprint-gridline {
+  fill: none;
+  stroke: var(--hq-grid);
+  stroke-width: 1;
+}
+
+.hq-guided-blueprint-orbit,
+.hq-guided-blueprint-structure,
+.hq-guided-blueprint-detail,
+.hq-guided-blueprint-dashed {
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.hq-guided-blueprint-orbit {
+  stroke: var(--hq-line);
+  stroke-width: 1;
+}
+
+.hq-guided-blueprint-structure {
+  fill: var(--hq-accent-wash);
+  stroke: var(--hq-accent);
+  stroke-width: 1.6;
+}
+
+.hq-guided-blueprint-detail {
+  stroke: color-mix(in srgb, var(--hq-accent) 64%, transparent);
+  stroke-width: 1;
+}
+
+.hq-guided-blueprint-dashed {
+  stroke: var(--hq-ink-faint);
+  stroke-width: 1;
+  stroke-dasharray: 4 5;
+}
+
+.hq-guided-blueprint-core {
+  fill: color-mix(in srgb, var(--hq-accent) 18%, transparent);
+  stroke: var(--hq-accent-bright);
+  stroke-width: 1.6;
+  transform-origin: 246px 196px;
+  animation: hq-guided-core 3.4s ease-in-out infinite;
+}
+
+.hq-guided-blueprint-node {
+  fill: var(--hq-panel-strong);
+  stroke: var(--hq-accent);
+  stroke-width: 2;
+}
+
+.hq-guided-blueprint-labels {
+  fill: var(--hq-ink-faint);
+  font: 500 9px "JetBrains Mono", var(--font-mono, monospace);
+  letter-spacing: 2px;
+}
+
+.hq-guided-scanline {
+  position: absolute;
+  inset: -25% 0 auto;
+  height: 22%;
+  opacity: 0.42;
+  background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--hq-accent) 13%, transparent), transparent);
+  animation: hq-guided-scan 5.8s linear infinite;
+}
+
+.hq-guided-blueprint-marker {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.48rem;
+  border: 1px solid var(--hq-line);
+  background: color-mix(in srgb, var(--hq-panel-strong) 88%, transparent);
+  color: var(--hq-ink-soft);
+  font: 500 0.57rem/1.2 "JetBrains Mono", var(--font-mono, monospace);
+  letter-spacing: 0.035em;
+  backdrop-filter: blur(8px);
+}
+
+.hq-guided-blueprint-marker span {
+  color: var(--hq-accent);
+  font-weight: 700;
+}
+
+.hq-guided-blueprint-marker-one {
+  top: 15%;
+  left: 5%;
+}
+
+.hq-guided-blueprint-marker-two {
+  right: 5%;
+  bottom: 12%;
+}
+
+.hq-guided-blueprint-foot {
+  justify-content: flex-start;
+  gap: 1.4rem;
+  border-top: 1px solid var(--hq-line);
+}
+
+.hq-guided-blueprint-foot b {
+  color: var(--hq-ink-soft);
+  font-weight: 600;
+}
+
+@keyframes hq-guided-arrive {
+  from { opacity: 0; transform: scale(0.99); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes hq-guided-rise {
+  from { opacity: 0; transform: translateY(0.85rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes hq-guided-scan {
+  from { transform: translateY(0); }
+  to { transform: translateY(650%); }
+}
+
+@keyframes hq-guided-core {
+  0%, 100% { opacity: 0.68; transform: scale(0.96); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (max-width: 980px) {
+  .hq-guided {
+    min-height: 0;
+  }
+
+  .hq-guided-dialogue {
+    width: min(46rem, 100%);
+  }
+
+  .hq-guided-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .hq-guided-brief {
+    max-width: 38rem;
+    padding-left: 0;
+  }
+
+  .hq-guided-title {
+    max-width: 13ch;
+  }
+
+  .hq-guided-blueprint {
+    width: min(43rem, 100%);
+  }
+}
+
+@media (max-width: 620px) {
+  body:has(#workspaceHub.is-hq-guided) .navbar {
+    display: none;
+  }
+
+  body:has(#workspaceHub.is-hq-guided) .main-content {
+    padding-top: 0.75rem;
+  }
+
+  .hq-guided-shell {
+    padding: 1rem;
+  }
+
+  .hq-guided-commandline {
+    grid-template-columns: 1fr auto;
+    margin-bottom: 1.25rem;
+  }
+
+  .hq-guided-system-label {
+    display: none;
+  }
+
+  .hq-guided-dialogue {
+    align-items: center;
+    margin-bottom: 1.75rem;
+  }
+
+  .hq-guided-avatar {
+    flex-basis: 3.25rem;
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+
+  .hq-guided-avatar svg {
+    width: 2.35rem;
+    height: 2.35rem;
+  }
+
+  .hq-guided-speech {
+    margin-left: 0.75rem;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .hq-guided-speech p {
+    font-size: 0.84rem;
+  }
+
+  .hq-guided-title {
+    font-size: clamp(2.15rem, 13vw, 3.2rem);
+  }
+
+  .hq-guided-primary {
+    width: 100%;
+  }
+
+  .hq-guided-action-note {
+    line-height: 1.5;
+  }
+
+  .hq-guided-blueprint-canvas {
+    min-height: 16rem;
+  }
+
+  .hq-guided-blueprint-marker {
+    display: none;
+  }
+
+  .hq-guided-blueprint-foot {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+}
 
 .hq-resume {
   display: flex;
@@ -5540,9 +6265,19 @@ body.modal-open .hub-support-chat {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hq-guided,
-  .hq-guided-site-outline {
+  .hq-guided-shell,
+  .hq-guided-dialogue,
+  .hq-guided-brief,
+  .hq-guided-blueprint,
+  .hq-guided-blueprint-core,
+  .hq-guided-scanline,
+  .hq-guided-primary,
+  .hq-guided-primary svg {
     transition: none !important;
     animation: none !important;
+  }
+
+  .hq-guided-scanline {
+    display: none;
   }
 }

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -5361,3 +5361,188 @@ body.modal-open .hub-support-chat {
 
 @media (max-width: 860px) {
 }
+
+/* ==========================================================================
+   Personal HQ guided first-launch state (personal-hq-onboarding.js)
+   ========================================================================== */
+
+.hq-guided {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 32rem;
+  margin: 2.5rem auto;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.hq-guided-site {
+  width: 100%;
+  max-width: 14rem;
+  aspect-ratio: 4 / 3;
+  margin-bottom: 0.75rem;
+}
+
+.hq-guided-site-outline {
+  width: 100%;
+  height: 100%;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  opacity: 0.7;
+}
+
+.hq-guided-eyebrow {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hq-guided-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.hq-guided-copy {
+  margin: 0;
+  max-width: 28rem;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.hq-guided-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+/* Reduced motion / theme note: this state is intentionally static (a
+   dashed-outline placeholder, no animation), so it needs no additional
+   prefers-reduced-motion override — it already satisfies one. */
+
+.hq-resume {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.hq-resume-text {
+  flex: 1 1 auto;
+  min-width: 12rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.hq-resume-action {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 0.25rem);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.hq-resume-action:hover,
+.hq-resume-action:focus-visible {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  outline: 0;
+}
+
+.hq-build-intro {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.hq-build-advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--primary-color);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.hq-build-days {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hq-build-days label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.hq-build-error {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--bs-danger, #dc3545);
+  border-radius: var(--radius-sm, 0.25rem);
+  color: var(--bs-danger, #dc3545);
+  font-size: 0.82rem;
+}
+
+.hq-choose-intro {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.hq-choose-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.hq-choose-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.hq-choose-item-name {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.hq-choose-empty {
+  padding: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hq-guided,
+  .hq-guided-site-outline {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -450,6 +450,31 @@
   pointer-events: none;
 }
 
+/* Personal HQ landmark badge (PRD FR43/FR44): a restrained pill, not a
+   color-only cue — the "HQ" text label is the actual signal. Authority
+   comes entirely from the fetched designation (workspace-map.js), never
+   from name/template, so an undesignated workspace never shows this. */
+.ws-map-tile-hq-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 5;
+  padding: 1px 5px;
+  border: 1px solid var(--ws-keeper, #e8b54b);
+  border-radius: 3px;
+  background: rgba(12, 13, 16, 0.85);
+  color: var(--ws-keeper, #e8b54b);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+[data-bs-theme="light"] .ws-map-tile-hq-badge {
+  background: rgba(255, 255, 255, 0.85);
+}
+
 /* Multi-select checkbox — subtle until the tile is hovered/focused or checked,
    so it doesn't compete with the tile's status flag and crest at rest. */
 .ws-map-tile-check {

--- a/internal/web/static/js/modules/home-daily-brief.js
+++ b/internal/web/static/js/modules/home-daily-brief.js
@@ -43,7 +43,9 @@ export function hrefForRef(ref) {
 // server relies on.
 export function localDateInZone(timezone, date) {
   try {
-    return new Intl.DateTimeFormat('en-CA', { timeZone: timezone || 'UTC' }).format(date || new Date());
+    return new Intl.DateTimeFormat('en-CA', { timeZone: timezone || 'UTC' }).format(
+      date || new Date()
+    );
   } catch (_) {
     return new Intl.DateTimeFormat('en-CA', { timeZone: 'UTC' }).format(date || new Date());
   }
@@ -54,7 +56,11 @@ function formatClock(iso, timezone) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
   try {
-    return d.toLocaleString(undefined, { timeZone: timezone || 'UTC', hour: 'numeric', minute: '2-digit' });
+    return d.toLocaleString(undefined, {
+      timeZone: timezone || 'UTC',
+      hour: 'numeric',
+      minute: '2-digit'
+    });
   } catch (_) {
     return d.toLocaleString();
   }
@@ -95,11 +101,19 @@ export function computeBanner(revision, latestClaim) {
   }
   if (!revision) return null;
   if (revision.status === 'partial') {
-    return { kind: 'partial', text: 'Some sources were unavailable — this brief may be incomplete.', showRetry: false };
+    return {
+      kind: 'partial',
+      text: 'Some sources were unavailable — this brief may be incomplete.',
+      showRetry: false
+    };
   }
   const content = parseContent(revision);
   if (content.degraded) {
-    return { kind: 'degraded', text: 'AI synthesis was unavailable — showing a simplified, fact-only brief.', showRetry: false };
+    return {
+      kind: 'degraded',
+      text: 'AI synthesis was unavailable — showing a simplified, fact-only brief.',
+      showRetry: false
+    };
   }
   return null;
 }
@@ -108,17 +122,27 @@ export function computeBanner(revision, latestClaim) {
 // opening summary already says so; the body should not also render five
 // empty section headers (PRD FR83).
 export function isQuietDay(content) {
-  return !(content.needs_attention && content.needs_attention.length) &&
+  return (
+    !(content.needs_attention && content.needs_attention.length) &&
     !(content.since_last_brief && content.since_last_brief.length) &&
     !(content.todays_plan && content.todays_plan.length) &&
     !(content.resume && content.resume.length) &&
-    !(content.suggested_actions && content.suggested_actions.length);
+    !(content.suggested_actions && content.suggested_actions.length)
+  );
 }
 
 function escapeHtml(str) {
-  return String(str == null ? '' : str).replace(/[&<>"']/g, (c) => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-  }[c]));
+  return String(str == null ? '' : str).replace(
+    /[&<>"']/g,
+    c =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      })[c]
+  );
 }
 
 function listSection(title, items, renderItem) {
@@ -140,51 +164,83 @@ export function renderContent(content) {
     parts.push(`<p class="home-daily-brief-opening">${escapeHtml(content.opening_summary)}</p>`);
   }
   if (content.data_gaps && content.data_gaps.length) {
-    parts.push(`<p class="home-daily-brief-gaps">Data gaps: ${escapeHtml(content.data_gaps.join('; '))}</p>`);
+    parts.push(
+      `<p class="home-daily-brief-gaps">Data gaps: ${escapeHtml(content.data_gaps.join('; '))}</p>`
+    );
   }
   if (isQuietDay(content)) {
-    parts.push('<p class="home-daily-brief-quiet">Nothing else needs your attention right now.</p>');
+    parts.push(
+      '<p class="home-daily-brief-quiet">Nothing else needs your attention right now.</p>'
+    );
     return parts.join('');
   }
 
-  parts.push(listSection('Needs Attention', content.needs_attention, (item) => `
+  parts.push(
+    listSection(
+      'Needs Attention',
+      content.needs_attention,
+      item => `
       <li class="home-daily-brief-item">
         <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
         <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
         <p class="home-daily-brief-item-fact">${escapeHtml(item.reason)}</p>
-      </li>`));
+      </li>`
+    )
+  );
 
-  parts.push(listSection('Since Last Brief', content.since_last_brief, (item) => `
+  parts.push(
+    listSection(
+      'Since Last Brief',
+      content.since_last_brief,
+      item => `
       <li class="home-daily-brief-item">
         <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
         <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
         ${item.summary ? `<p class="home-daily-brief-item-fact is-suggestion">${escapeHtml(item.summary)}</p>` : ''}
-      </li>`));
+      </li>`
+    )
+  );
 
-  parts.push(listSection("Today's Plan", content.todays_plan, (item) => `
+  parts.push(
+    listSection(
+      "Today's Plan",
+      content.todays_plan,
+      item => `
       <li class="home-daily-brief-item">
         <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
         <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
         <p class="home-daily-brief-item-fact">${escapeHtml(item.reason)}</p>
         ${item.why_suggested ? `<p class="home-daily-brief-item-why is-suggestion">${escapeHtml(item.why_suggested)}</p>` : ''}
-      </li>`));
+      </li>`
+    )
+  );
 
-  parts.push(listSection('Resume', content.resume, (item) => `
+  parts.push(
+    listSection(
+      'Resume',
+      content.resume,
+      item => `
       <li class="home-daily-brief-item">
         <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
         <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
         ${item.last_known_state ? `<p class="home-daily-brief-item-fact">${escapeHtml(item.last_known_state)}</p>` : ''}
         ${item.next_step ? `<p class="home-daily-brief-item-why is-suggestion">${escapeHtml(item.next_step)}</p>` : ''}
-      </li>`));
+      </li>`
+    )
+  );
 
   if (content.suggested_actions && content.suggested_actions.length) {
     parts.push(`
         <section class="home-daily-brief-section home-daily-brief-actions-section">
           <h3 class="home-daily-brief-section-title">Suggested Next Actions</h3>
           <div class="home-daily-brief-action-row">
-            ${content.suggested_actions.map((a) => `
+            ${content.suggested_actions
+              .map(
+                a => `
               <a href="${hrefForRef(a.ref)}" class="modern-btn modern-btn-secondary modern-btn-sm is-suggestion" data-action-type="${escapeHtml(a.action_type)}">${escapeHtml(a.label)}</a>
-            `).join('')}
+            `
+              )
+              .join('')}
           </div>
         </section>`);
   }
@@ -212,13 +268,16 @@ export function renderContent(content) {
   let polling = false;
 
   async function fetchJSON(url, options) {
-    const res = await fetch(url, Object.assign({ headers: { Accept: 'application/json' } }, options || {}));
+    const res = await fetch(
+      url,
+      Object.assign({ headers: { Accept: 'application/json' } }, options || {})
+    );
     if (!res.ok) throw new Error(`${url} -> ${res.status}`);
     return res.json();
   }
 
   function sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   function renderBanner(banner) {
@@ -230,8 +289,11 @@ export function renderContent(content) {
     }
     bannerEl.hidden = false;
     bannerEl.className = `home-daily-brief-banner is-${banner.kind}`;
-    bannerEl.innerHTML = `<span>${escapeHtml(banner.text)}</span>` +
-      (banner.showRetry ? '<button type="button" class="modern-btn modern-btn-sm" data-role="retry">Retry</button>' : '');
+    bannerEl.innerHTML =
+      `<span>${escapeHtml(banner.text)}</span>` +
+      (banner.showRetry
+        ? '<button type="button" class="modern-btn modern-btn-sm" data-role="retry">Retry</button>'
+        : '');
     if (banner.showRetry) {
       const retryBtn = bannerEl.querySelector('[data-role="retry"]');
       if (retryBtn) retryBtn.addEventListener('click', () => runRefresh());
@@ -244,16 +306,22 @@ export function renderContent(content) {
       if (metaEl) metaEl.textContent = '';
       renderBanner(computeBanner(null, latestClaim));
       if (bodyEl) {
-        bodyEl.innerHTML = (latestClaim && latestClaim.status === 'failed')
-          ? '<div class="home-daily-brief-placeholder">Your Daily Brief could not be generated.</div>'
-          : '<div class="home-daily-brief-placeholder">Generating your Daily Brief…</div>';
+        bodyEl.innerHTML =
+          latestClaim && latestClaim.status === 'failed'
+            ? '<div class="home-daily-brief-placeholder">Your Daily Brief could not be generated.</div>'
+            : '<div class="home-daily-brief-placeholder">Generating your Daily Brief…</div>';
       }
       return;
     }
-    if (titleEl) titleEl.textContent = revision.local_date === localDateInZone((config && config.timezone) || 'UTC') ? 'Today' : revision.local_date;
-    const relativeTimeFn = window.RelativeTime && typeof window.RelativeTime.formatRelativeTime === 'function'
-      ? window.RelativeTime.formatRelativeTime
-      : null;
+    if (titleEl)
+      titleEl.textContent =
+        revision.local_date === localDateInZone((config && config.timezone) || 'UTC')
+          ? 'Today'
+          : revision.local_date;
+    const relativeTimeFn =
+      window.RelativeTime && typeof window.RelativeTime.formatRelativeTime === 'function'
+        ? window.RelativeTime.formatRelativeTime
+        : null;
     if (metaEl) metaEl.textContent = formatMeta(revision, config, relativeTimeFn);
     renderBanner(computeBanner(revision, latestClaim));
     if (bodyEl) bodyEl.innerHTML = renderContent(parseContent(revision));
@@ -324,10 +392,14 @@ export function renderContent(content) {
       if (timeInput) timeInput.value = cfg.schedule_time || '';
       if (scheduleEnabled) scheduleEnabled.checked = !!cfg.schedule_enabled;
       if (notify) notify.checked = !!cfg.notify_on_ready;
-      const days = (cfg.schedule_days || []);
-      document.querySelectorAll('#homeDailyBriefSettingsForm .home-daily-brief-days input[type="checkbox"]').forEach((box) => {
-        box.checked = days.indexOf(box.value) !== -1;
-      });
+      const days = cfg.schedule_days || [];
+      document
+        .querySelectorAll(
+          '#homeDailyBriefSettingsForm .home-daily-brief-days input[type="checkbox"]'
+        )
+        .forEach(box => {
+          box.checked = days.indexOf(box.value) !== -1;
+        });
     } catch (_) {
       // settings form just stays at its defaults
     }
@@ -337,7 +409,9 @@ export function renderContent(content) {
       if (list) {
         const history = historyResp.history || [];
         list.innerHTML = history.length
-          ? history.map((h) => `<li>${escapeHtml(h.local_date)} — ${escapeHtml(h.status)}</li>`).join('')
+          ? history
+              .map(h => `<li>${escapeHtml(h.local_date)} — ${escapeHtml(h.status)}</li>`)
+              .join('')
           : '<li class="home-daily-brief-history-empty">No history yet.</li>';
       }
     } catch (_) {
@@ -348,9 +422,11 @@ export function renderContent(content) {
   function wireSettingsForm() {
     const form = document.getElementById('homeDailyBriefSettingsForm');
     if (!form) return;
-    form.addEventListener('submit', async (evt) => {
+    form.addEventListener('submit', async evt => {
       evt.preventDefault();
-      const days = Array.from(form.querySelectorAll('.home-daily-brief-days input:checked')).map((b) => b.value);
+      const days = Array.from(form.querySelectorAll('.home-daily-brief-days input:checked')).map(
+        b => b.value
+      );
       const body = {
         timezone: document.getElementById('homeDailyBriefTimezone').value.trim(),
         schedule_time: document.getElementById('homeDailyBriefTime').value.trim(),

--- a/internal/web/static/js/modules/home-daily-brief.js
+++ b/internal/web/static/js/modules/home-daily-brief.js
@@ -1,0 +1,435 @@
+// home-daily-brief.js — the Home Daily Brief region (PRD FR53/FR97, task
+// 7.2-7.4/7.9). Primary Home orientation surface once a valid Personal HQ is
+// designated; entirely hidden (no fetch loop, no hidden brief store) when it
+// is not (FR69). Purely additive: no-op on pages without #homeDailyBrief.
+//
+// Pure rendering/decision helpers are exported (loaded as type="module",
+// mirroring personal-hq-onboarding.js) so home-daily-brief.test.js can
+// exercise them under plain Node with no DOM/network — `document`/`window`
+// are genuinely undefined there, so the DOM-wiring IIFE below simply no-ops.
+
+// parseContent safely decodes a Revision's ContentJSON. Returns {} (never
+// throws) on missing/invalid JSON so a corrupt revision degrades to an
+// empty brief rather than breaking the page.
+export function parseContent(revision) {
+  if (!revision || !revision.content_json) return {};
+  try {
+    const parsed = JSON.parse(revision.content_json);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+// hrefForRef builds a real, validated navigation target from a brief item's
+// stable source reference — never from the visible title (PRD FR91). Every
+// action_type routes to the owning workspace's existing page; mutating
+// action types (retry, create_followup) deliberately do not perform the
+// mutation from Home (PRD FR95) — they route to where the user can act
+// through the workspace's own authorized controls.
+export function hrefForRef(ref) {
+  if (!ref || !ref.workspace_id) return '#';
+  const wsId = encodeURIComponent(ref.workspace_id);
+  if (ref.entity_type === 'task' && ref.entity_id) {
+    return `/workspaces/${wsId}/task/${encodeURIComponent(ref.entity_id)}`;
+  }
+  return `/workspaces/${wsId}`;
+}
+
+// localDateInZone returns "YYYY-MM-DD" for `date` (defaults to now) as
+// observed in the IANA zone `timezone`, matching the server's LocalDateKey
+// convention — used purely to detect whether the displayed revision is for
+// today (client-side "is this stale" hint), never to compute anything the
+// server relies on.
+export function localDateInZone(timezone, date) {
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: timezone || 'UTC' }).format(date || new Date());
+  } catch (_) {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: 'UTC' }).format(date || new Date());
+  }
+}
+
+function formatClock(iso, timezone) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  try {
+    return d.toLocaleString(undefined, { timeZone: timezone || 'UTC', hour: 'numeric', minute: '2-digit' });
+  } catch (_) {
+    return d.toLocaleString();
+  }
+}
+
+// formatMeta renders the "generated at / timezone / stale" line required by
+// PRD FR85. Never blank when a revision exists. relativeTimeFn is injected
+// (rather than reading window.RelativeTime directly) so this stays testable
+// under plain Node.
+export function formatMeta(revision, config, relativeTimeFn) {
+  if (!revision) return '';
+  const tz = (config && config.timezone) || 'UTC';
+  const rel = typeof relativeTimeFn === 'function' ? relativeTimeFn(revision.generated_at) : '';
+  const clock = formatClock(revision.generated_at, tz);
+  let text = 'Generated';
+  if (rel) text += ` ${rel}`;
+  if (clock) text += ` (${clock})`;
+  text += ` · ${tz}`;
+  const today = localDateInZone(tz);
+  if (revision.local_date && revision.local_date !== today) {
+    text += ' · showing an earlier day while today’s brief updates';
+  }
+  return text;
+}
+
+// computeBanner decides which (if any) advisory banner sits above the brief
+// content: a failed latest attempt (FR87, preserve-last-successful), a
+// partial/degraded revision, or none. latestClaim may be null.
+export function computeBanner(revision, latestClaim) {
+  if (latestClaim && latestClaim.status === 'failed') {
+    return {
+      kind: 'failed',
+      text: revision
+        ? 'The latest Daily Brief generation failed. Showing your last successful brief.'
+        : 'Your Daily Brief could not be generated.',
+      showRetry: true
+    };
+  }
+  if (!revision) return null;
+  if (revision.status === 'partial') {
+    return { kind: 'partial', text: 'Some sources were unavailable — this brief may be incomplete.', showRetry: false };
+  }
+  const content = parseContent(revision);
+  if (content.degraded) {
+    return { kind: 'degraded', text: 'AI synthesis was unavailable — showing a simplified, fact-only brief.', showRetry: false };
+  }
+  return null;
+}
+
+// isQuietDay is true when every content-bearing section is empty — the
+// opening summary already says so; the body should not also render five
+// empty section headers (PRD FR83).
+export function isQuietDay(content) {
+  return !(content.needs_attention && content.needs_attention.length) &&
+    !(content.since_last_brief && content.since_last_brief.length) &&
+    !(content.todays_plan && content.todays_plan.length) &&
+    !(content.resume && content.resume.length) &&
+    !(content.suggested_actions && content.suggested_actions.length);
+}
+
+function escapeHtml(str) {
+  return String(str == null ? '' : str).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+function listSection(title, items, renderItem) {
+  if (!items || !items.length) return '';
+  return `
+      <section class="home-daily-brief-section">
+        <h3 class="home-daily-brief-section-title">${escapeHtml(title)}</h3>
+        <ul class="home-daily-brief-list">${items.map(renderItem).join('')}</ul>
+      </section>`;
+}
+
+// renderContent renders one brief's full body. Facts (Needs Attention,
+// Since Last Brief, Resume's LastKnownState) and suggestions (WhySuggested,
+// NextStep, Suggested Actions) are visually distinguishable per PRD FR82 —
+// suggestion text is rendered inside a ".is-suggestion" span.
+export function renderContent(content) {
+  const parts = [];
+  if (content.opening_summary) {
+    parts.push(`<p class="home-daily-brief-opening">${escapeHtml(content.opening_summary)}</p>`);
+  }
+  if (content.data_gaps && content.data_gaps.length) {
+    parts.push(`<p class="home-daily-brief-gaps">Data gaps: ${escapeHtml(content.data_gaps.join('; '))}</p>`);
+  }
+  if (isQuietDay(content)) {
+    parts.push('<p class="home-daily-brief-quiet">Nothing else needs your attention right now.</p>');
+    return parts.join('');
+  }
+
+  parts.push(listSection('Needs Attention', content.needs_attention, (item) => `
+      <li class="home-daily-brief-item">
+        <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
+        <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
+        <p class="home-daily-brief-item-fact">${escapeHtml(item.reason)}</p>
+      </li>`));
+
+  parts.push(listSection('Since Last Brief', content.since_last_brief, (item) => `
+      <li class="home-daily-brief-item">
+        <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
+        <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
+        ${item.summary ? `<p class="home-daily-brief-item-fact is-suggestion">${escapeHtml(item.summary)}</p>` : ''}
+      </li>`));
+
+  parts.push(listSection("Today's Plan", content.todays_plan, (item) => `
+      <li class="home-daily-brief-item">
+        <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
+        <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
+        <p class="home-daily-brief-item-fact">${escapeHtml(item.reason)}</p>
+        ${item.why_suggested ? `<p class="home-daily-brief-item-why is-suggestion">${escapeHtml(item.why_suggested)}</p>` : ''}
+      </li>`));
+
+  parts.push(listSection('Resume', content.resume, (item) => `
+      <li class="home-daily-brief-item">
+        <a href="${hrefForRef(item.ref)}" class="home-daily-brief-item-title">${escapeHtml(item.title)}</a>
+        <span class="home-daily-brief-item-ws">${escapeHtml(item.workspace_name)}</span>
+        ${item.last_known_state ? `<p class="home-daily-brief-item-fact">${escapeHtml(item.last_known_state)}</p>` : ''}
+        ${item.next_step ? `<p class="home-daily-brief-item-why is-suggestion">${escapeHtml(item.next_step)}</p>` : ''}
+      </li>`));
+
+  if (content.suggested_actions && content.suggested_actions.length) {
+    parts.push(`
+        <section class="home-daily-brief-section home-daily-brief-actions-section">
+          <h3 class="home-daily-brief-section-title">Suggested Next Actions</h3>
+          <div class="home-daily-brief-action-row">
+            ${content.suggested_actions.map((a) => `
+              <a href="${hrefForRef(a.ref)}" class="modern-btn modern-btn-secondary modern-btn-sm is-suggestion" data-action-type="${escapeHtml(a.action_type)}">${escapeHtml(a.label)}</a>
+            `).join('')}
+          </div>
+        </section>`);
+  }
+
+  return parts.join('');
+}
+
+// ---- DOM wiring (no-op without #homeDailyBrief; genuinely no-op under
+// plain Node, where window/document don't exist at all) ----
+(function () {
+  if (typeof document === 'undefined') return;
+  const section = document.getElementById('homeDailyBrief');
+  if (!section) return;
+
+  const titleEl = document.getElementById('homeDailyBriefTitle');
+  const metaEl = document.getElementById('homeDailyBriefMeta');
+  const bodyEl = document.getElementById('homeDailyBriefBody');
+  const bannerEl = document.getElementById('homeDailyBriefBanner');
+  const openHQLink = document.getElementById('homeDailyBriefOpenHQ');
+  const refreshBtn = document.getElementById('homeDailyBriefRefreshBtn');
+  const settingsBtn = document.getElementById('homeDailyBriefSettingsBtn');
+
+  let currentConfig = null;
+  let hqWorkspaceId = null;
+  let polling = false;
+
+  async function fetchJSON(url, options) {
+    const res = await fetch(url, Object.assign({ headers: { Accept: 'application/json' } }, options || {}));
+    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    return res.json();
+  }
+
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function renderBanner(banner) {
+    if (!bannerEl) return;
+    if (!banner) {
+      bannerEl.hidden = true;
+      bannerEl.innerHTML = '';
+      return;
+    }
+    bannerEl.hidden = false;
+    bannerEl.className = `home-daily-brief-banner is-${banner.kind}`;
+    bannerEl.innerHTML = `<span>${escapeHtml(banner.text)}</span>` +
+      (banner.showRetry ? '<button type="button" class="modern-btn modern-btn-sm" data-role="retry">Retry</button>' : '');
+    if (banner.showRetry) {
+      const retryBtn = bannerEl.querySelector('[data-role="retry"]');
+      if (retryBtn) retryBtn.addEventListener('click', () => runRefresh());
+    }
+  }
+
+  function render(revision, config, latestClaim) {
+    currentConfig = config;
+    if (!revision) {
+      if (metaEl) metaEl.textContent = '';
+      renderBanner(computeBanner(null, latestClaim));
+      if (bodyEl) {
+        bodyEl.innerHTML = (latestClaim && latestClaim.status === 'failed')
+          ? '<div class="home-daily-brief-placeholder">Your Daily Brief could not be generated.</div>'
+          : '<div class="home-daily-brief-placeholder">Generating your Daily Brief…</div>';
+      }
+      return;
+    }
+    if (titleEl) titleEl.textContent = revision.local_date === localDateInZone((config && config.timezone) || 'UTC') ? 'Today' : revision.local_date;
+    const relativeTimeFn = window.RelativeTime && typeof window.RelativeTime.formatRelativeTime === 'function'
+      ? window.RelativeTime.formatRelativeTime
+      : null;
+    if (metaEl) metaEl.textContent = formatMeta(revision, config, relativeTimeFn);
+    renderBanner(computeBanner(revision, latestClaim));
+    if (bodyEl) bodyEl.innerHTML = renderContent(parseContent(revision));
+  }
+
+  async function pollUntilSettled() {
+    if (polling) return;
+    polling = true;
+    try {
+      const deadline = Date.now() + 90000;
+      let statusResp = null;
+      while (Date.now() < deadline) {
+        try {
+          statusResp = await fetchJSON('/api/personal-hq/brief/status');
+        } catch (_) {
+          break;
+        }
+        const st = statusResp && statusResp.status;
+        if (st !== 'pending' && st !== 'running') break;
+        await sleep(1500);
+      }
+      let revision = null;
+      try {
+        const cur = await fetchJSON('/api/personal-hq/brief/current');
+        revision = cur.revision;
+      } catch (_) {
+        // keep whatever was already rendered
+        return;
+      }
+      render(revision, currentConfig, statusResp);
+    } finally {
+      polling = false;
+    }
+  }
+
+  async function runRefresh() {
+    if (refreshBtn) refreshBtn.disabled = true;
+    renderBanner({ kind: 'loading', text: 'Refreshing your Daily Brief…', showRetry: false });
+    try {
+      await fetch('/api/personal-hq/brief/refresh', { method: 'POST' });
+    } catch (_) {
+      // fall through to polling — a transient network failure just means
+      // nothing changes; the button re-enables and the user can retry.
+    }
+    await pollUntilSettled();
+    if (refreshBtn) refreshBtn.disabled = false;
+  }
+
+  function openSettingsModal() {
+    if (!hqWorkspaceId) return;
+    const modalEl = document.getElementById('homeDailyBriefSettingsModal');
+    if (!modalEl) return;
+    loadSettingsAndHistory();
+    if (window.bootstrap && window.bootstrap.Modal) {
+      window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+  }
+
+  async function loadSettingsAndHistory() {
+    try {
+      const cfgResp = await fetchJSON('/api/personal-hq/brief/config');
+      const cfg = cfgResp.config;
+      const tzInput = document.getElementById('homeDailyBriefTimezone');
+      const timeInput = document.getElementById('homeDailyBriefTime');
+      const scheduleEnabled = document.getElementById('homeDailyBriefScheduleEnabled');
+      const notify = document.getElementById('homeDailyBriefNotify');
+      if (tzInput) tzInput.value = cfg.timezone || '';
+      if (timeInput) timeInput.value = cfg.schedule_time || '';
+      if (scheduleEnabled) scheduleEnabled.checked = !!cfg.schedule_enabled;
+      if (notify) notify.checked = !!cfg.notify_on_ready;
+      const days = (cfg.schedule_days || []);
+      document.querySelectorAll('#homeDailyBriefSettingsForm .home-daily-brief-days input[type="checkbox"]').forEach((box) => {
+        box.checked = days.indexOf(box.value) !== -1;
+      });
+    } catch (_) {
+      // settings form just stays at its defaults
+    }
+    try {
+      const historyResp = await fetchJSON('/api/personal-hq/brief/history');
+      const list = document.getElementById('homeDailyBriefHistoryList');
+      if (list) {
+        const history = historyResp.history || [];
+        list.innerHTML = history.length
+          ? history.map((h) => `<li>${escapeHtml(h.local_date)} — ${escapeHtml(h.status)}</li>`).join('')
+          : '<li class="home-daily-brief-history-empty">No history yet.</li>';
+      }
+    } catch (_) {
+      // history list just stays empty
+    }
+  }
+
+  function wireSettingsForm() {
+    const form = document.getElementById('homeDailyBriefSettingsForm');
+    if (!form) return;
+    form.addEventListener('submit', async (evt) => {
+      evt.preventDefault();
+      const days = Array.from(form.querySelectorAll('.home-daily-brief-days input:checked')).map((b) => b.value);
+      const body = {
+        timezone: document.getElementById('homeDailyBriefTimezone').value.trim(),
+        schedule_time: document.getElementById('homeDailyBriefTime').value.trim(),
+        schedule_days: days,
+        schedule_enabled: document.getElementById('homeDailyBriefScheduleEnabled').checked,
+        notify_on_ready: document.getElementById('homeDailyBriefNotify').checked
+      };
+      const submitBtn = form.querySelector('button[type="submit"]');
+      if (submitBtn) submitBtn.disabled = true;
+      try {
+        await fetch('/api/personal-hq/brief/config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        if (window.Toast && typeof window.Toast.success === 'function') {
+          window.Toast.success('Daily Brief settings saved.', 'Saved');
+        }
+      } catch (_) {
+        if (window.Toast && typeof window.Toast.error === 'function') {
+          window.Toast.error('Could not save Daily Brief settings.', 'Save failed');
+        }
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+  }
+
+  async function bootstrap() {
+    let status;
+    try {
+      const statusResp = await fetchJSON('/api/personal-hq/status');
+      status = statusResp.status;
+    } catch (_) {
+      section.hidden = true;
+      return;
+    }
+    if (!status || !status.valid) {
+      section.hidden = true;
+      return;
+    }
+    hqWorkspaceId = status.workspace_id;
+    section.hidden = false;
+    if (openHQLink) openHQLink.href = `/workspaces/${encodeURIComponent(hqWorkspaceId)}`;
+
+    let config = null;
+    try {
+      const cfgResp = await fetchJSON('/api/personal-hq/brief/config');
+      config = cfgResp.config;
+    } catch (_) {
+      // proceed without config metadata; generation can still succeed with
+      // server-side defaults
+    }
+
+    let revision = null;
+    try {
+      const cur = await fetchJSON('/api/personal-hq/brief/current');
+      revision = cur.revision;
+    } catch (_) {
+      // treated the same as "no revision yet" below
+    }
+
+    render(revision, config, null);
+
+    const today = localDateInZone(config ? config.timezone : 'UTC');
+    const needsFreshBrief = !revision || revision.local_date !== today;
+    if (needsFreshBrief) {
+      try {
+        await fetch('/api/personal-hq/brief/open', { method: 'POST' });
+      } catch (_) {
+        // pollUntilSettled will simply observe idle/no-op and keep showing
+        // whatever was already rendered above
+      }
+      await pollUntilSettled();
+    }
+  }
+
+  if (refreshBtn) refreshBtn.addEventListener('click', () => runRefresh());
+  if (settingsBtn) settingsBtn.addEventListener('click', () => openSettingsModal());
+  wireSettingsForm();
+  bootstrap();
+})();

--- a/internal/web/static/js/modules/home-daily-brief.test.js
+++ b/internal/web/static/js/modules/home-daily-brief.test.js
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseContent,
+  hrefForRef,
+  localDateInZone,
+  formatMeta,
+  computeBanner,
+  isQuietDay,
+  renderContent
+} from './home-daily-brief.js';
+
+test('parseContent decodes a revision content_json, degrading to {} on garbage', () => {
+  assert.deepEqual(parseContent({ content_json: '{"opening_summary":"hi"}' }), { opening_summary: 'hi' });
+  assert.deepEqual(parseContent({ content_json: 'not json' }), {});
+  assert.deepEqual(parseContent({ content_json: '' }), {});
+  assert.deepEqual(parseContent(null), {});
+  assert.deepEqual(parseContent({ content_json: '"just a string"' }), {});
+});
+
+test('hrefForRef routes tasks to their deep-link page and everything else to the owning workspace', () => {
+  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' }), '/workspaces/ws-1/task/t-1');
+  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'session', entity_id: 's-1' }), '/workspaces/ws-1');
+  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'scheduled_task', entity_id: 'sc-1' }), '/workspaces/ws-1');
+  assert.equal(hrefForRef({ workspace_id: 'ws 1', entity_type: 'task', entity_id: 't/1' }), '/workspaces/ws%201/task/t%2F1');
+});
+
+test('hrefForRef falls back to # for a ref with no workspace', () => {
+  assert.equal(hrefForRef(null), '#');
+  assert.equal(hrefForRef({}), '#');
+});
+
+test('localDateInZone matches the server LocalDateKey convention (YYYY-MM-DD) for a fixed instant', () => {
+  const instant = new Date('2026-07-14T02:30:00Z');
+  assert.equal(localDateInZone('UTC', instant), '2026-07-14');
+  // America/New_York is UTC-4 in July (EDT): 02:30 UTC is still the 13th locally.
+  assert.equal(localDateInZone('America/New_York', instant), '2026-07-13');
+});
+
+test('formatMeta always includes the timezone and never blanks for a real revision', () => {
+  const revision = { generated_at: '2026-07-14T12:00:00Z', local_date: '2026-07-14' };
+  const text = formatMeta(revision, { timezone: 'UTC' }, () => '2h ago');
+  assert.match(text, /UTC/);
+  assert.match(text, /2h ago/);
+});
+
+test('formatMeta returns empty string with no revision', () => {
+  assert.equal(formatMeta(null, { timezone: 'UTC' }), '');
+});
+
+test('formatMeta flags a revision whose local_date is not today in its own timezone', () => {
+  const yesterday = { generated_at: '2026-07-13T12:00:00Z', local_date: '2026-07-13' };
+  const text = formatMeta(yesterday, { timezone: 'UTC' }, null);
+  assert.match(text, /earlier day/);
+});
+
+test('computeBanner surfaces a failed-latest-attempt banner with retry, preserving the last successful revision', () => {
+  const revision = { status: 'succeeded' };
+  const banner = computeBanner(revision, { status: 'failed' });
+  assert.equal(banner.kind, 'failed');
+  assert.equal(banner.showRetry, true);
+  assert.match(banner.text, /last successful/);
+});
+
+test('computeBanner reports full failure with no prior revision at all', () => {
+  const banner = computeBanner(null, { status: 'failed' });
+  assert.equal(banner.kind, 'failed');
+  assert.doesNotMatch(banner.text, /last successful/);
+});
+
+test('computeBanner flags a partial revision without a retry action', () => {
+  const banner = computeBanner({ status: 'partial' }, null);
+  assert.equal(banner.kind, 'partial');
+  assert.equal(banner.showRetry, false);
+});
+
+test('computeBanner flags a degraded (fallback) revision even when its status is succeeded', () => {
+  const revision = { status: 'succeeded', content_json: JSON.stringify({ degraded: true }) };
+  const banner = computeBanner(revision, null);
+  assert.equal(banner.kind, 'degraded');
+});
+
+test('computeBanner is null for a clean successful revision with no active/failed claim', () => {
+  const revision = { status: 'succeeded', content_json: JSON.stringify({ degraded: false }) };
+  assert.equal(computeBanner(revision, null), null);
+  assert.equal(computeBanner(revision, { status: 'succeeded' }), null);
+});
+
+test('isQuietDay is true only when every content-bearing section is empty', () => {
+  assert.equal(isQuietDay({}), true);
+  assert.equal(isQuietDay({ needs_attention: [] }), true);
+  assert.equal(isQuietDay({ needs_attention: [{ title: 'x' }] }), false);
+  assert.equal(isQuietDay({ suggested_actions: [{ label: 'x' }] }), false);
+});
+
+test('renderContent renders a quiet-day confirmation instead of empty section headers', () => {
+  const html = renderContent({ opening_summary: 'A quiet day.' });
+  assert.match(html, /A quiet day\./);
+  assert.match(html, /Nothing else needs your attention/);
+  assert.doesNotMatch(html, /Needs Attention/);
+});
+
+test('renderContent renders Needs Attention items with a real link built from the stable ref', () => {
+  const html = renderContent({
+    needs_attention: [
+      { ref: { workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' }, title: 'Approve deploy', workspace_name: 'Ops', reason: 'Waiting on your approval.' }
+    ]
+  });
+  assert.match(html, /href="\/workspaces\/ws-1\/task\/t-1"/);
+  assert.match(html, /Approve deploy/);
+  assert.match(html, /Waiting on your approval\./);
+});
+
+test('renderContent visually distinguishes suggestion text (why_suggested\\/next_step) from facts', () => {
+  const html = renderContent({
+    todays_plan: [
+      { ref: { workspace_id: 'ws-1' }, title: 'Ship the release', workspace_name: 'Ops', reason: 'In progress', why_suggested: 'Blocks two dependents' }
+    ]
+  });
+  assert.match(html, /is-suggestion">Blocks two dependents/);
+});
+
+test('renderContent surfaces data gaps distinctly and omits sections with no items', () => {
+  const html = renderContent({ opening_summary: 'Hi', data_gaps: ['workspace-x unavailable'], needs_attention: [{ ref: {}, title: 'A', workspace_name: 'W', reason: 'R' }] });
+  assert.match(html, /Data gaps: workspace-x unavailable/);
+  assert.match(html, /Needs Attention/);
+  assert.doesNotMatch(html, /Since Last Brief/);
+});
+
+test('renderContent renders suggested actions as real links carrying their ref, not the label alone', () => {
+  const html = renderContent({
+    suggested_actions: [{ ref: { workspace_id: 'ws-2', entity_type: 'task', entity_id: 't-9' }, label: 'Retry the failed run', action_type: 'retry' }]
+  });
+  assert.match(html, /href="\/workspaces\/ws-2\/task\/t-9"/);
+  assert.match(html, /Retry the failed run/);
+  assert.match(html, /data-action-type="retry"/);
+});
+
+test('renderContent escapes untrusted title/reason text', () => {
+  const html = renderContent({
+    needs_attention: [{ ref: {}, title: '<script>alert(1)</script>', workspace_name: 'W', reason: 'x' }]
+  });
+  assert.doesNotMatch(html, /<script>/);
+  assert.match(html, /&lt;script&gt;/);
+});

--- a/internal/web/static/js/modules/home-daily-brief.test.js
+++ b/internal/web/static/js/modules/home-daily-brief.test.js
@@ -11,7 +11,9 @@ import {
 } from './home-daily-brief.js';
 
 test('parseContent decodes a revision content_json, degrading to {} on garbage', () => {
-  assert.deepEqual(parseContent({ content_json: '{"opening_summary":"hi"}' }), { opening_summary: 'hi' });
+  assert.deepEqual(parseContent({ content_json: '{"opening_summary":"hi"}' }), {
+    opening_summary: 'hi'
+  });
   assert.deepEqual(parseContent({ content_json: 'not json' }), {});
   assert.deepEqual(parseContent({ content_json: '' }), {});
   assert.deepEqual(parseContent(null), {});
@@ -19,10 +21,22 @@ test('parseContent decodes a revision content_json, degrading to {} on garbage',
 });
 
 test('hrefForRef routes tasks to their deep-link page and everything else to the owning workspace', () => {
-  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' }), '/workspaces/ws-1/task/t-1');
-  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'session', entity_id: 's-1' }), '/workspaces/ws-1');
-  assert.equal(hrefForRef({ workspace_id: 'ws-1', entity_type: 'scheduled_task', entity_id: 'sc-1' }), '/workspaces/ws-1');
-  assert.equal(hrefForRef({ workspace_id: 'ws 1', entity_type: 'task', entity_id: 't/1' }), '/workspaces/ws%201/task/t%2F1');
+  assert.equal(
+    hrefForRef({ workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' }),
+    '/workspaces/ws-1/task/t-1'
+  );
+  assert.equal(
+    hrefForRef({ workspace_id: 'ws-1', entity_type: 'session', entity_id: 's-1' }),
+    '/workspaces/ws-1'
+  );
+  assert.equal(
+    hrefForRef({ workspace_id: 'ws-1', entity_type: 'scheduled_task', entity_id: 'sc-1' }),
+    '/workspaces/ws-1'
+  );
+  assert.equal(
+    hrefForRef({ workspace_id: 'ws 1', entity_type: 'task', entity_id: 't/1' }),
+    '/workspaces/ws%201/task/t%2F1'
+  );
 });
 
 test('hrefForRef falls back to # for a ref with no workspace', () => {
@@ -103,7 +117,12 @@ test('renderContent renders a quiet-day confirmation instead of empty section he
 test('renderContent renders Needs Attention items with a real link built from the stable ref', () => {
   const html = renderContent({
     needs_attention: [
-      { ref: { workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' }, title: 'Approve deploy', workspace_name: 'Ops', reason: 'Waiting on your approval.' }
+      {
+        ref: { workspace_id: 'ws-1', entity_type: 'task', entity_id: 't-1' },
+        title: 'Approve deploy',
+        workspace_name: 'Ops',
+        reason: 'Waiting on your approval.'
+      }
     ]
   });
   assert.match(html, /href="\/workspaces\/ws-1\/task\/t-1"/);
@@ -114,14 +133,24 @@ test('renderContent renders Needs Attention items with a real link built from th
 test('renderContent visually distinguishes suggestion text (why_suggested\\/next_step) from facts', () => {
   const html = renderContent({
     todays_plan: [
-      { ref: { workspace_id: 'ws-1' }, title: 'Ship the release', workspace_name: 'Ops', reason: 'In progress', why_suggested: 'Blocks two dependents' }
+      {
+        ref: { workspace_id: 'ws-1' },
+        title: 'Ship the release',
+        workspace_name: 'Ops',
+        reason: 'In progress',
+        why_suggested: 'Blocks two dependents'
+      }
     ]
   });
   assert.match(html, /is-suggestion">Blocks two dependents/);
 });
 
 test('renderContent surfaces data gaps distinctly and omits sections with no items', () => {
-  const html = renderContent({ opening_summary: 'Hi', data_gaps: ['workspace-x unavailable'], needs_attention: [{ ref: {}, title: 'A', workspace_name: 'W', reason: 'R' }] });
+  const html = renderContent({
+    opening_summary: 'Hi',
+    data_gaps: ['workspace-x unavailable'],
+    needs_attention: [{ ref: {}, title: 'A', workspace_name: 'W', reason: 'R' }]
+  });
   assert.match(html, /Data gaps: workspace-x unavailable/);
   assert.match(html, /Needs Attention/);
   assert.doesNotMatch(html, /Since Last Brief/);
@@ -129,7 +158,13 @@ test('renderContent surfaces data gaps distinctly and omits sections with no ite
 
 test('renderContent renders suggested actions as real links carrying their ref, not the label alone', () => {
   const html = renderContent({
-    suggested_actions: [{ ref: { workspace_id: 'ws-2', entity_type: 'task', entity_id: 't-9' }, label: 'Retry the failed run', action_type: 'retry' }]
+    suggested_actions: [
+      {
+        ref: { workspace_id: 'ws-2', entity_type: 'task', entity_id: 't-9' },
+        label: 'Retry the failed run',
+        action_type: 'retry'
+      }
+    ]
   });
   assert.match(html, /href="\/workspaces\/ws-2\/task\/t-9"/);
   assert.match(html, /Retry the failed run/);
@@ -138,7 +173,9 @@ test('renderContent renders suggested actions as real links carrying their ref, 
 
 test('renderContent escapes untrusted title/reason text', () => {
   const html = renderContent({
-    needs_attention: [{ ref: {}, title: '<script>alert(1)</script>', workspace_name: 'W', reason: 'x' }]
+    needs_attention: [
+      { ref: {}, title: '<script>alert(1)</script>', workspace_name: 'W', reason: 'x' }
+    ]
   });
   assert.doesNotMatch(html, /<script>/);
   assert.match(html, /&lt;script&gt;/);

--- a/internal/web/static/js/modules/onboarding.js
+++ b/internal/web/static/js/modules/onboarding.js
@@ -731,7 +731,7 @@ export class OnboardingManager {
     const name = this.userName || 'friend';
     const doneSpeech = document.getElementById('doneSpeech');
     if (doneSpeech) {
-      doneSpeech.textContent = `All set, ${name}! I’m ready to help. Let’s create your first workspace.`;
+      doneSpeech.textContent = `All set, ${name}! Your first mission is ready: let’s build the Personal HQ we’ll use to run everything else.`;
     }
 
     this.showPhase(2);

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -1,0 +1,458 @@
+// personal-hq-onboarding.js — the guided first-launch Personal HQ experience
+// on the workspace launcher page: the full-screen guided Map state for a
+// brand-new profile (Build My HQ / Start with a Project / Skip for Now), a
+// smaller resume entry for a user who skipped or lost a valid HQ, and the
+// Build My HQ / Choose Existing Workspace modals. Purely additive: no-op on
+// pages without #hqOnboardingGuided (only the workspace launcher has it).
+//
+// Pure decision logic is exported (loaded as type="module") so
+// personal-hq-onboarding.test.js can exercise it without a DOM.
+
+// resolveGuidedMode is the single source of truth for which of the three
+// launcher states to show, given the current Personal HQ status. Kept
+// side-effect-free so it is unit-testable without a DOM/fetch.
+//   - "guided": full-screen first-launch takeover (never seen before).
+//   - "repair": a stored designation exists but does not resolve.
+//   - "resume": no valid HQ and onboarding is not "unseen" (skipped, in
+//     progress, or completed-but-since-cleared) — a small non-blocking entry.
+//   - "none": a valid HQ is designated; nothing to show here.
+export function resolveGuidedMode(status) {
+  if (!status) return 'none';
+  const hasDesignation = !!status.workspace_id;
+  if (hasDesignation && !status.valid) return 'repair';
+  if (status.valid) return 'none';
+  if (status.hq_onboarding_state === 'unseen') return 'guided';
+  return 'resume';
+}
+
+// resumeCopy derives the resume/repair banner's text and which action
+// buttons it offers, so the DOM-wiring code has no branching logic of its
+// own to get wrong.
+export function resumeCopy(mode) {
+  if (mode === 'repair') {
+    return {
+      text: 'Your Personal HQ needs attention — the workspace it pointed to is no longer available.',
+      showBuild: true,
+      showChoose: true,
+      showClear: true
+    };
+  }
+  return {
+    text: 'Set up your Personal HQ for a daily brief and follow-up tracking.',
+    showBuild: true,
+    showChoose: true,
+    showClear: false
+  };
+}
+
+(function () {
+  if (typeof document === 'undefined') return;
+
+  const guided = document.getElementById('hqOnboardingGuided');
+  const homeResume = document.getElementById('homeHQResume');
+  if (!guided && !homeResume) return; // Neither the launcher nor Home has an HQ surface.
+
+  const resume = document.getElementById('hqOnboardingResume');
+  const hub = document.getElementById('workspaceHub');
+
+  async function fetchStatus() {
+    const res = await fetch('/api/personal-hq/status', { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error(`personal hq status ${res.status}`);
+    const body = await res.json();
+    return body.status;
+  }
+
+  async function postJSON(url, body) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const message = data && (data.error || data.message);
+      throw new Error(message || `${url} -> ${res.status}`);
+    }
+    return data;
+  }
+
+  function toast(message, title, variant) {
+    if (window.Toast && typeof window.Toast[variant || 'success'] === 'function') {
+      window.Toast[variant || 'success'](message, { title });
+    } else if (typeof window.notifyToast === 'function') {
+      window.notifyToast(message, variant || 'success');
+    }
+  }
+
+  function setLauncherContentHidden(hidden) {
+    ['launcherGrid', 'launcherEmptyState', 'launcherMap'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.hidden = hidden;
+    });
+  }
+
+  function skipHQObjective() {
+    return Promise.all([
+      postJSON('/api/personal-hq/onboarding-state', { state: 'skipped' }),
+      postJSON('/api/progression/skip', { quest_id: 't2-build-hq' }).catch(() => {
+        /* Quest may already be resolved; skipping onboarding state is what matters. */
+      })
+    ]);
+  }
+
+  function wireGuided() {
+    const buildBtn = document.getElementById('hqGuidedBuildBtn');
+    const projectBtn = document.getElementById('hqGuidedProjectBtn');
+    const skipBtn = document.getElementById('hqGuidedSkipBtn');
+
+    if (buildBtn) buildBtn.addEventListener('click', () => openBuildModal());
+    if (projectBtn) {
+      projectBtn.addEventListener('click', async () => {
+        try {
+          await skipHQObjective();
+        } catch (_) {
+          /* non-fatal: still let the user start a project */
+        }
+        hideGuided();
+        if (window.sessionManager && typeof window.sessionManager.showAddWorkspaceModal === 'function') {
+          window.sessionManager.showAddWorkspaceModal({ entryPoint: 'guided_map_project' });
+        }
+      });
+    }
+    if (skipBtn) {
+      skipBtn.addEventListener('click', async () => {
+        skipBtn.disabled = true;
+        try {
+          await skipHQObjective();
+          hideGuided();
+          await refreshResume();
+        } catch (err) {
+          toast('Could not skip right now. Try again.', 'Skip failed', 'error');
+        } finally {
+          skipBtn.disabled = false;
+        }
+      });
+    }
+  }
+
+  function hideGuided() {
+    if (!guided) return;
+    guided.hidden = true;
+    setLauncherContentHidden(false);
+  }
+
+  function showGuided() {
+    if (!guided) return; // Home has no full-screen takeover, only the resume bar.
+    guided.hidden = false;
+    setLauncherContentHidden(true);
+    if (resume) resume.hidden = true;
+  }
+
+  function updateResumeBar(el, textEl, mode) {
+    if (!el) return;
+    if (mode === 'none') {
+      el.hidden = true;
+      return;
+    }
+    const copy = resumeCopy(mode);
+    if (textEl) textEl.textContent = copy.text;
+    el.hidden = false;
+  }
+
+  async function refreshResume() {
+    let status;
+    try {
+      status = await fetchStatus();
+    } catch (_) {
+      return;
+    }
+    const mode = resolveGuidedMode(status);
+    if (mode === 'guided') {
+      showGuided();
+    } else {
+      hideGuided();
+    }
+
+    if (resume) {
+      if (mode === 'guided' || mode === 'none') {
+        resume.hidden = true;
+      } else {
+        const copy = resumeCopy(mode);
+        const text = document.getElementById('hqResumeText');
+        const chooseBtn = document.getElementById('hqResumeChooseBtn');
+        const clearBtn = document.getElementById('hqResumeClearBtn');
+        if (text) text.textContent = copy.text;
+        if (chooseBtn) chooseBtn.hidden = !copy.showChoose;
+        if (clearBtn) clearBtn.hidden = !copy.showClear;
+        resume.hidden = false;
+      }
+    }
+
+    if (homeResume) {
+      updateResumeBar(homeResume, document.getElementById('homeHQResumeText'), mode === 'guided' ? 'resume' : mode);
+    }
+  }
+
+  function wireResume() {
+    if (resume) {
+      const buildBtn = document.getElementById('hqResumeBuildBtn');
+      const chooseBtn = document.getElementById('hqResumeChooseBtn');
+      const clearBtn = document.getElementById('hqResumeClearBtn');
+      if (buildBtn) buildBtn.addEventListener('click', () => openBuildModal());
+      if (chooseBtn) chooseBtn.addEventListener('click', () => openChooseExistingModal());
+      if (clearBtn) {
+        clearBtn.addEventListener('click', async () => {
+          clearBtn.disabled = true;
+          try {
+            await postJSON('/api/personal-hq/clear');
+            toast('Personal HQ designation cleared.', 'Cleared');
+            await refreshResume();
+          } catch (err) {
+            toast('Could not clear the designation. Try again.', 'Clear failed', 'error');
+          } finally {
+            clearBtn.disabled = false;
+          }
+        });
+      }
+    }
+    if (homeResume) {
+      // Home's resume bar is intentionally simple (no modals live on this
+      // page): Build My HQ routes to the launcher, which owns the full flow.
+      const buildBtn = document.getElementById('homeHQResumeBuildBtn');
+      if (buildBtn) {
+        buildBtn.addEventListener('click', () => {
+          window.location.href = '/workspaces?hq_onboarding=1';
+        });
+      }
+    }
+  }
+
+  // ---- Build My HQ modal ----
+
+  function bootstrapModal(id) {
+    const el = document.getElementById(id);
+    if (!el || !window.bootstrap || !window.bootstrap.Modal) return null;
+    return window.bootstrap.Modal.getOrCreateInstance(el);
+  }
+
+  function browserTimezone() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch (_) {
+      return 'UTC';
+    }
+  }
+
+  // Prefer the user's already-stored profile timezone (PRD FR25: derive
+  // defaults from the current user profile) and fall back to the browser's
+  // detected zone only when the profile has none set yet.
+  async function defaultTimezone() {
+    try {
+      const res = await fetch('/api/user/profile', { headers: { Accept: 'application/json' } });
+      if (res.ok) {
+        const body = await res.json();
+        const tz = body && body.profile && body.profile.timezone;
+        if (tz) return tz;
+      }
+    } catch (_) {
+      /* fall through to browser detection */
+    }
+    return browserTimezone();
+  }
+
+  async function openBuildModal() {
+    const tzInput = document.getElementById('hqBuildTimezone');
+    if (tzInput && !tzInput.value) {
+      tzInput.value = await defaultTimezone();
+    }
+    const errorBox = document.getElementById('hqBuildError');
+    if (errorBox) errorBox.hidden = true;
+    const modal = bootstrapModal('hqBuildModal');
+    if (modal) modal.show();
+  }
+
+  function collectBuildRequest() {
+    const name = (document.getElementById('hqBuildName')?.value || '').trim() || 'My HQ';
+    const timezone = (document.getElementById('hqBuildTimezone')?.value || '').trim();
+    const scheduleDays = Array.from(document.querySelectorAll('#hqBuildAdvanced .hq-build-days input:checked')).map(i => i.value);
+    const scheduleTime = document.getElementById('hqBuildTime')?.value || '';
+    const scope = document.getElementById('hqBuildScope')?.value || 'all';
+    const includeFuture = !!document.getElementById('hqBuildIncludeFuture')?.checked;
+    const notify = !!document.getElementById('hqBuildNotify')?.checked;
+    return {
+      name,
+      timezone,
+      schedule_days: scheduleDays,
+      schedule_time: scheduleTime,
+      scope,
+      include_future_workspaces: includeFuture,
+      notify_on_ready: notify
+    };
+  }
+
+  function wireBuildModal() {
+    const toggle = document.getElementById('hqBuildAdvancedToggle');
+    const advanced = document.getElementById('hqBuildAdvanced');
+    if (toggle && advanced) {
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        advanced.hidden = expanded;
+      });
+    }
+
+    const submitBtn = document.getElementById('hqBuildSubmitBtn');
+    if (!submitBtn) return;
+    submitBtn.addEventListener('click', async () => {
+      const errorBox = document.getElementById('hqBuildError');
+      submitBtn.disabled = true;
+      if (errorBox) errorBox.hidden = true;
+      try {
+        const result = await postJSON('/api/personal-hq/setup', collectBuildRequest());
+        const modal = bootstrapModal('hqBuildModal');
+        if (modal) modal.hide();
+        hideGuided();
+        toast('Your Personal HQ is ready.', 'Personal HQ built');
+        window.setTimeout(() => {
+          window.location.href = '/';
+        }, 700);
+        void result;
+      } catch (err) {
+        if (errorBox) {
+          errorBox.textContent = err && err.message ? err.message : 'Could not build your Personal HQ. Try again.';
+          errorBox.hidden = false;
+        }
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
+  // ---- Choose Existing Workspace modal ----
+
+  async function fetchEligibleWorkspaces() {
+    const res = await fetch('/api/workspaces?tree=true', { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error(`workspaces ${res.status}`);
+    const data = await res.json();
+    const flat = [];
+    const walk = list => {
+      (list || []).forEach(ws => {
+        if (ws.kind !== 'group' && ws.status !== 'trashed' && ws.status !== 'missing') flat.push(ws);
+        if (ws.children) walk(ws.children);
+      });
+    };
+    walk(data.workspaces || data.folders || []);
+    return flat;
+  }
+
+  async function designateWorkspace(ws, btn, errorBox) {
+    btn.disabled = true;
+    try {
+      await postJSON('/api/personal-hq/replace', { workspace_id: ws.id });
+      await postJSON('/api/personal-hq/onboarding-state', { state: 'completed' });
+      const modalInstance = bootstrapModal('hqChooseExistingModal');
+      if (modalInstance) modalInstance.hide();
+      toast(`${ws.name || 'Workspace'} is now your Personal HQ.`, 'Personal HQ designated');
+      hideGuided();
+      await refreshResume();
+    } catch (err) {
+      if (errorBox) {
+        errorBox.textContent = err && err.message ? err.message : 'Could not designate this workspace. Try again.';
+        errorBox.hidden = false;
+      }
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  // Replacing an existing valid HQ requires confirmation naming both
+  // workspaces (PRD FR37) — no content is deleted, only the relationship
+  // changes. A first-time designation (no current valid HQ) skips straight
+  // to the API call since there's nothing to name a replacement against.
+  function confirmReplace(li, ws, currentName, onConfirm) {
+    li.innerHTML = '';
+    const text = document.createElement('span');
+    text.className = 'hq-choose-item-name';
+    text.textContent = `Replace "${currentName}" with "${ws.name || ws.id}"? No content is deleted.`;
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = 'modern-btn modern-btn-primary modern-btn-sm';
+    confirmBtn.textContent = 'Confirm';
+    confirmBtn.addEventListener('click', onConfirm);
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => openChooseExistingModal());
+    li.append(text, confirmBtn, cancelBtn);
+  }
+
+  async function openChooseExistingModal() {
+    const list = document.getElementById('hqChooseExistingList');
+    const empty = document.getElementById('hqChooseExistingEmpty');
+    const errorBox = document.getElementById('hqChooseExistingError');
+    if (!list) return;
+    list.innerHTML = '';
+    if (errorBox) errorBox.hidden = true;
+    if (empty) empty.hidden = true;
+
+    const modal = bootstrapModal('hqChooseExistingModal');
+    if (modal) modal.show();
+
+    let workspaces;
+    let currentStatus;
+    try {
+      [workspaces, currentStatus] = await Promise.all([fetchEligibleWorkspaces(), fetchStatus()]);
+    } catch (_) {
+      if (errorBox) {
+        errorBox.textContent = 'Could not load workspaces. Try again.';
+        errorBox.hidden = false;
+      }
+      return;
+    }
+    if (workspaces.length === 0) {
+      if (empty) empty.hidden = false;
+      return;
+    }
+    const currentName = currentStatus && currentStatus.valid
+      ? (workspaces.find(w => w.id === currentStatus.workspace_id)?.name || 'your current HQ')
+      : null;
+
+    workspaces.forEach(ws => {
+      const li = document.createElement('li');
+      li.className = 'hq-choose-item';
+      const name = document.createElement('span');
+      name.className = 'hq-choose-item-name';
+      name.textContent = ws.name || ws.id;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+      btn.textContent = 'Designate';
+      btn.addEventListener('click', () => {
+        if (currentName && ws.id !== currentStatus.workspace_id) {
+          confirmReplace(li, ws, currentName, () => designateWorkspace(ws, btn, errorBox));
+        } else {
+          designateWorkspace(ws, btn, errorBox);
+        }
+      });
+      li.append(name, btn);
+      list.appendChild(li);
+    });
+  }
+
+  function init() {
+    wireGuided();
+    wireResume();
+    wireBuildModal();
+
+    const hint = hub ? hub.dataset.hqOnboardingHint : null;
+    if (hint === 'unseen') showGuided();
+    refreshResume();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -138,11 +138,13 @@ export function resumeCopy(mode) {
   function hideGuided() {
     if (!guided) return;
     guided.hidden = true;
+    hub?.classList.remove('is-hq-guided');
     setLauncherContentHidden(false);
   }
 
   function showGuided() {
     if (!guided) return; // Home has no full-screen takeover, only the resume bar.
+    hub?.classList.add('is-hq-guided');
     guided.hidden = false;
     setLauncherContentHidden(true);
     if (resume) resume.hidden = true;

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveGuidedMode, resumeCopy } from './personal-hq-onboarding.js';
+
+function status(overrides) {
+  return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
+}
+
+test('resolveGuidedMode: no status at all resolves to none (degrade safely)', () => {
+  assert.equal(resolveGuidedMode(null), 'none');
+  assert.equal(resolveGuidedMode(undefined), 'none');
+});
+
+test('resolveGuidedMode: brand-new profile (unseen, no designation) is guided', () => {
+  assert.equal(resolveGuidedMode(status({ hq_onboarding_state: 'unseen' })), 'guided');
+});
+
+test('resolveGuidedMode: a valid designated HQ is none, regardless of onboarding state', () => {
+  assert.equal(resolveGuidedMode(status({ workspace_id: 'ws-1', valid: true, hq_onboarding_state: 'unseen' })), 'none');
+  assert.equal(resolveGuidedMode(status({ workspace_id: 'ws-1', valid: true, hq_onboarding_state: 'completed' })), 'none');
+});
+
+test('resolveGuidedMode: a stale designation (workspace_id set, not valid) is repair even when unseen', () => {
+  // Defensive precedence: a broken reference must never re-show the
+  // full-screen guided takeover as if nothing had ever happened.
+  assert.equal(resolveGuidedMode(status({ workspace_id: 'ws-1', valid: false, hq_onboarding_state: 'unseen' })), 'repair');
+});
+
+test('resolveGuidedMode: skipped with no designation is resume, not guided', () => {
+  assert.equal(resolveGuidedMode(status({ hq_onboarding_state: 'skipped' })), 'resume');
+});
+
+test('resolveGuidedMode: in_progress with no designation is resume', () => {
+  assert.equal(resolveGuidedMode(status({ hq_onboarding_state: 'in_progress' })), 'resume');
+});
+
+test('resolveGuidedMode: completed onboarding but no current designation (e.g. cleared) is resume', () => {
+  assert.equal(resolveGuidedMode(status({ hq_onboarding_state: 'completed', valid: false, workspace_id: '' })), 'resume');
+});
+
+test('resumeCopy: repair mode offers Build, Choose, and Clear', () => {
+  const copy = resumeCopy('repair');
+  assert.equal(copy.showBuild, true);
+  assert.equal(copy.showChoose, true);
+  assert.equal(copy.showClear, true);
+  assert.match(copy.text, /needs attention/i);
+});
+
+test('resumeCopy: resume mode offers Build and Choose but not Clear (nothing to clear)', () => {
+  const copy = resumeCopy('resume');
+  assert.equal(copy.showBuild, true);
+  assert.equal(copy.showChoose, true);
+  assert.equal(copy.showClear, false);
+});

--- a/internal/web/static/js/modules/progression-widget.js
+++ b/internal/web/static/js/modules/progression-widget.js
@@ -2,8 +2,106 @@
 //
 // Fetches GET /api/progression, renders the current tier's quests + progress,
 // and shows a toast when a quest (or a whole tier) newly completes. Dismissible
-// (POST /api/progression/dismiss) with a restore affordance. Purely additive:
-// no-op on pages without the #questLog element.
+// (POST /api/progression/dismiss) with a restore affordance, and lets an
+// optional quest be Skipped (POST /api/progression/skip) without dismissing
+// the whole widget. Purely additive: no-op on pages without the #questLog
+// element.
+//
+// Pure helpers are exported (loaded as type="module") so progression-widget.test.js
+// can exercise the optional/skipped-quest rendering and toast-suppression
+// decisions without a DOM.
+
+export function currentTier(status) {
+  return (
+    (status.tiers || []).find(tier => tier.tier === status.current_tier) ||
+    (status.tiers || [])[0] ||
+    null
+  );
+}
+
+export function completedCount(tier) {
+  return (tier?.quests || []).filter(quest => quest.status === 'completed').length;
+}
+
+// resolvedCount includes skipped optional quests alongside completed ones, so
+// the meter/progress count advances past a skip without the skipped quest
+// ever being labeled "complete" in its own row (task 3.4/3.8).
+export function resolvedCount(tier) {
+  return (tier?.quests || []).filter(quest => quest.status === 'completed' || quest.status === 'skipped').length;
+}
+
+export function tierInsignia(tier) {
+  const value = Number(tier);
+  return Number.isFinite(value) && value > 0 ? String(value).padStart(2, '0') : '—';
+}
+
+// questRowState derives the pure per-row rendering decision for one quest:
+// which mark/affordances to show. Kept side-effect-free so it can be unit
+// tested without constructing DOM nodes.
+export function questRowState(quest) {
+  const done = quest.status === 'completed';
+  const skipped = quest.status === 'skipped';
+  const resolved = done || skipped;
+  return {
+    done,
+    skipped,
+    resolved,
+    mark: done ? '✓' : skipped ? '⏭' : '○',
+    // A quest renders as a clickable link only while unresolved and it has
+    // a destination; a resolved quest (done or skipped) never does — the
+    // skipped case gets its own separate "Resume" affordance instead.
+    showLink: !resolved && !!quest.action_url,
+    // Skipped quests keep a Resume affordance so they stay reachable
+    // without being a blocking interruption (never shown once truly done).
+    showResume: skipped && !!quest.action_url,
+    // The Skip control appears only for an optional quest that has not yet
+    // resolved either way.
+    showSkip: !resolved && !!quest.optional
+  };
+}
+
+// diffAnnouncements is the pure diff between the previously known state and
+// an incoming status: which quests newly completed and which tiers newly
+// became complete, driving what announceChanges() below actually toasts.
+//
+// A skip must never itself produce a "quest complete" toast (it is not a
+// completion), and a tier is only reported as newly complete here when at
+// least one quest in it actually completed this round — a tier that became
+// complete solely because its last open quest was skipped must not toast,
+// since skipping the optional HQ objective should not read as an
+// achievement.
+export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
+  const completedNow = new Set();
+  (status.tiers || []).forEach(t => {
+    (t.quests || []).forEach(q => {
+      if (q.status === 'completed') completedNow.add(q.id);
+    });
+  });
+
+  const newCompletions = [];
+  const newTierCompletions = [];
+  if (knownCompleted !== null) {
+    (status.tiers || []).forEach(t => {
+      let tierHasNewCompletion = false;
+      (t.quests || []).forEach(q => {
+        if (q.status === 'completed' && !knownCompleted.has(q.id)) {
+          newCompletions.push({ id: q.id, title: q.title });
+          tierHasNewCompletion = true;
+        }
+      });
+      if (t.complete && !knownTierComplete[t.tier] && tierHasNewCompletion) {
+        newTierCompletions.push({ tier: t.tier, name: t.name });
+      }
+    });
+  }
+
+  const nextKnownTierComplete = {};
+  (status.tiers || []).forEach(t => {
+    nextKnownTierComplete[t.tier] = !!t.complete;
+  });
+
+  return { completedNow, nextKnownTierComplete, newCompletions, newTierCompletions };
+}
 
 (function () {
   if (typeof document === 'undefined') return;
@@ -51,61 +149,25 @@
   // Diff the incoming status against what we last knew and toast new wins.
   // Skipped on the very first load so a returning user isn't flooded.
   function announceChanges(status) {
-    const completedNow = new Set();
-    (status.tiers || []).forEach(t => {
-      (t.quests || []).forEach(q => {
-        if (q.status === 'completed') completedNow.add(q.id);
-      });
-    });
+    const diff = diffAnnouncements(status, knownCompleted, knownTierComplete);
+    diff.newCompletions.forEach(q => toast(q.title, 'Quest complete'));
+    diff.newTierCompletions.forEach(t => toast(`Tier complete: ${t.name}`, 'Tier complete'));
 
-    if (knownCompleted !== null) {
-      (status.tiers || []).forEach(t => {
-        (t.quests || []).forEach(q => {
-          if (q.status === 'completed' && !knownCompleted.has(q.id)) {
-            toast(q.title, 'Quest complete');
-          }
-        });
-        if (t.complete && !knownTierComplete[t.tier]) {
-          toast(`Tier complete: ${t.name}`, 'Tier complete');
-        }
-      });
-    }
-
-    knownCompleted = completedNow;
-    knownTierComplete = {};
-    (status.tiers || []).forEach(t => {
-      knownTierComplete[t.tier] = !!t.complete;
-    });
+    knownCompleted = diff.completedNow;
+    knownTierComplete = diff.nextKnownTierComplete;
   }
 
-  function currentTier(status) {
-    return (
-      (status.tiers || []).find(tier => tier.tier === status.current_tier) ||
-      (status.tiers || [])[0] ||
-      null
-    );
-  }
-
-  function completedCount(tier) {
-    return (tier?.quests || []).filter(quest => quest.status === 'completed').length;
-  }
-
-  function setMeter(bar, completed, total) {
+  function setMeter(bar, resolved, total) {
     if (!bar) return;
-    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+    const percent = total > 0 ? Math.round((resolved / total) * 100) : 0;
     bar.style.width = `${Math.max(0, Math.min(100, percent))}%`;
 
     const meter = bar.closest('[role="progressbar"]');
     if (meter) meter.setAttribute('aria-valuenow', String(Math.max(0, Math.min(100, percent))));
   }
 
-  function tierInsignia(tier) {
-    const value = Number(tier);
-    return Number.isFinite(value) && value > 0 ? String(value).padStart(2, '0') : '—';
-  }
-
   function renderRestoreBadge(status, current) {
-    const completed = status.all_complete ? status.total_count : completedCount(current);
+    const resolved = status.all_complete ? status.resolved_count : resolvedCount(current);
     const total = status.all_complete ? status.total_count : (current?.quests || []).length;
     const tierLabel = status.all_complete ? 'All tiers complete' : `Tier ${status.current_tier}`;
 
@@ -116,8 +178,64 @@
     if (insignia)
       insignia.textContent = status.all_complete ? '✓' : tierInsignia(status.current_tier);
     if (tier) tier.textContent = tierLabel;
-    if (progress) progress.textContent = `${completed}/${total}`;
-    if (meter) meter.style.width = `${total > 0 ? Math.round((completed / total) * 100) : 0}%`;
+    if (progress) progress.textContent = `${resolved}/${total}`;
+    if (meter) meter.style.width = `${total > 0 ? Math.round((resolved / total) * 100) : 0}%`;
+  }
+
+  async function skipQuest(questID, button) {
+    button.disabled = true;
+    try {
+      const status = await postJSON('/api/progression/skip', { quest_id: questID });
+      render(status);
+    } catch (_) {
+      button.disabled = false;
+    }
+  }
+
+  function renderQuestRow(q) {
+    const state = questRowState(q);
+    const li = document.createElement('li');
+    li.className = 'quest-item' + (state.done ? ' quest-item-done' : '') + (state.skipped ? ' quest-item-skipped' : '');
+
+    const mark = document.createElement('span');
+    mark.className = 'quest-mark';
+    mark.textContent = state.mark; // Distinct glyph per state, not color alone.
+    mark.setAttribute('aria-hidden', 'true');
+
+    const title = document.createElement(state.showLink ? 'a' : 'span');
+    if (state.showLink) {
+      title.href = q.action_url;
+      title.title = q.action_label || q.title;
+    }
+    title.className = 'quest-title';
+    title.textContent = q.title;
+
+    li.append(mark, title);
+
+    if (state.skipped) {
+      const label = document.createElement('span');
+      label.className = 'quest-status quest-status-skipped';
+      label.textContent = 'Skipped';
+      li.append(label);
+    }
+    if (state.showResume) {
+      const resume = document.createElement('a');
+      resume.className = 'quest-resume';
+      resume.href = q.action_url;
+      resume.textContent = q.action_label || 'Resume';
+      li.append(resume);
+    }
+    if (state.showSkip) {
+      const skipBtn = document.createElement('button');
+      skipBtn.type = 'button';
+      skipBtn.className = 'quest-skip';
+      skipBtn.textContent = 'Skip';
+      skipBtn.setAttribute('aria-label', `Skip: ${q.title}`);
+      skipBtn.addEventListener('click', () => skipQuest(q.id, skipBtn));
+      li.append(skipBtn);
+    }
+
+    return li;
   }
 
   function render(status) {
@@ -155,38 +273,14 @@
     el('tier-name').textContent = current.name;
     el('tier-insignia').textContent = tierInsignia(status.current_tier);
     el('progress-label').textContent = `Tier ${status.current_tier} of ${status.total_tiers}`;
-    const complete = completedCount(current);
+    const resolved = resolvedCount(current);
     const total = current.quests.length;
-    el('progress-count').textContent = `${complete}/${total}`;
-    setMeter(el('progress-bar'), complete, total);
+    el('progress-count').textContent = `${resolved}/${total}`;
+    setMeter(el('progress-bar'), resolved, total);
 
     const list = el('quests');
     list.innerHTML = '';
-    current.quests.forEach(q => {
-      const done = q.status === 'completed';
-      const li = document.createElement('li');
-      li.className = 'quest-item' + (done ? ' quest-item-done' : '');
-      const mark = document.createElement('span');
-      mark.className = 'quest-mark';
-      mark.textContent = done ? '✓' : '○';
-      mark.setAttribute('aria-hidden', 'true');
-
-      // An incomplete quest with an action destination renders as a link so the
-      // user can act on it directly; otherwise it's plain text.
-      let title;
-      if (!done && q.action_url) {
-        title = document.createElement('a');
-        title.href = q.action_url;
-        title.title = q.action_label || q.title;
-      } else {
-        title = document.createElement('span');
-      }
-      title.className = 'quest-title';
-      title.textContent = q.title;
-
-      li.append(mark, title);
-      list.appendChild(li);
-    });
+    current.quests.forEach(q => list.appendChild(renderQuestRow(q)));
 
     const why = el('why');
     why.textContent = status.next_quest ? status.next_quest.why : '';

--- a/internal/web/static/js/modules/progression-widget.js
+++ b/internal/web/static/js/modules/progression-widget.js
@@ -27,12 +27,48 @@ export function completedCount(tier) {
 // the meter/progress count advances past a skip without the skipped quest
 // ever being labeled "complete" in its own row (task 3.4/3.8).
 export function resolvedCount(tier) {
-  return (tier?.quests || []).filter(quest => quest.status === 'completed' || quest.status === 'skipped').length;
+  return (tier?.quests || []).filter(
+    quest => quest.status === 'completed' || quest.status === 'skipped'
+  ).length;
 }
 
 export function tierInsignia(tier) {
   const value = Number(tier);
   return Number.isFinite(value) && value > 0 ? String(value).padStart(2, '0') : '—';
+}
+
+export const FIRST_MISSION_QUEST_ID = 't2-build-hq';
+
+// Mission 01 is intentionally reachable before Tier 2 unlocks. The existing
+// HQ quest remains the source of truth for status and completion; this helper
+// only derives the featured Home presentation from that same quest record.
+export function firstMissionView(status) {
+  const quest = (status?.tiers || [])
+    .flatMap(tier => tier.quests || [])
+    .find(candidate => candidate.id === FIRST_MISSION_QUEST_ID);
+
+  if (!quest || status?.all_complete) return { visible: false };
+
+  const completed = quest.status === 'completed';
+  const skipped = quest.status === 'skipped';
+  return {
+    visible: true,
+    completed,
+    skipped,
+    title: quest.title,
+    why: quest.why || '',
+    statusLabel: completed ? 'Complete' : skipped ? 'Paused' : 'Ready',
+    actionLabel: skipped ? 'Resume mission' : 'Start mission',
+    actionURL: quest.action_url || '/workspaces?hq_onboarding=1',
+    showAction: !completed
+  };
+}
+
+// The HQ quest is rendered as the featured Mission 01 card, so omit it from
+// the ordinary tier list when Tier 2 becomes current rather than showing the
+// same objective twice.
+export function tierQuestRows(tier) {
+  return (tier?.quests || []).filter(quest => quest.id !== FIRST_MISSION_QUEST_ID);
 }
 
 // questRowState derives the pure per-row rendering decision for one quest:
@@ -195,7 +231,10 @@ export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
   function renderQuestRow(q) {
     const state = questRowState(q);
     const li = document.createElement('li');
-    li.className = 'quest-item' + (state.done ? ' quest-item-done' : '') + (state.skipped ? ' quest-item-skipped' : '');
+    li.className =
+      'quest-item' +
+      (state.done ? ' quest-item-done' : '') +
+      (state.skipped ? ' quest-item-skipped' : '');
 
     const mark = document.createElement('span');
     mark.className = 'quest-mark';
@@ -238,6 +277,35 @@ export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
     return li;
   }
 
+  function renderFirstMission(status) {
+    const mission = el('first-mission');
+    if (!mission) return;
+
+    const view = firstMissionView(status);
+    if (!view.visible) {
+      mission.hidden = true;
+      return;
+    }
+
+    mission.classList.toggle('is-complete', view.completed);
+    mission.classList.toggle('is-paused', view.skipped);
+    const title = el('first-mission-title');
+    const why = el('first-mission-why');
+    const state = el('first-mission-status');
+    const action = el('first-mission-action');
+    const actionLabel = el('first-mission-action-label');
+
+    if (title) title.textContent = view.title;
+    if (why) why.textContent = view.why;
+    if (state) state.textContent = view.statusLabel;
+    if (action) {
+      action.hidden = !view.showAction;
+      action.href = view.actionURL;
+    }
+    if (actionLabel) actionLabel.textContent = view.actionLabel;
+    mission.hidden = false;
+  }
+
   function render(status) {
     if (!widget) return;
     latestStatus = status;
@@ -254,6 +322,7 @@ export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
 
     // All quests complete: compact congratulatory state.
     if (status.all_complete) {
+      renderFirstMission(status);
       el('tier-name').textContent = 'All quests complete';
       el('tier-insignia').textContent = '✓';
       el('progress-label').textContent = 'Tier complete';
@@ -266,9 +335,12 @@ export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
     }
 
     if (!current) {
+      renderFirstMission(status);
       widget.hidden = true;
       return;
     }
+
+    renderFirstMission(status);
 
     el('tier-name').textContent = current.name;
     el('tier-insignia').textContent = tierInsignia(status.current_tier);
@@ -280,7 +352,7 @@ export function diffAnnouncements(status, knownCompleted, knownTierComplete) {
 
     const list = el('quests');
     list.innerHTML = '';
-    current.quests.forEach(q => list.appendChild(renderQuestRow(q)));
+    tierQuestRows(current).forEach(q => list.appendChild(renderQuestRow(q)));
 
     const why = el('why');
     why.textContent = status.next_quest ? status.next_quest.why : '';

--- a/internal/web/static/js/modules/progression-widget.test.js
+++ b/internal/web/static/js/modules/progression-widget.test.js
@@ -1,0 +1,181 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  currentTier,
+  completedCount,
+  resolvedCount,
+  tierInsignia,
+  questRowState,
+  diffAnnouncements
+} from './progression-widget.js';
+
+function quest(overrides) {
+  return { id: 'q1', title: 'Quest', status: 'available', optional: false, ...overrides };
+}
+
+function tier(overrides) {
+  return { tier: 2, name: 'Establish a Base', complete: false, quests: [], ...overrides };
+}
+
+test('currentTier finds the tier matching current_tier', () => {
+  const t1 = tier({ tier: 1 });
+  const t2 = tier({ tier: 2 });
+  assert.equal(currentTier({ current_tier: 2, tiers: [t1, t2] }), t2);
+});
+
+test('currentTier falls back to the first tier when current_tier is not found', () => {
+  const t1 = tier({ tier: 1 });
+  assert.equal(currentTier({ current_tier: 99, tiers: [t1] }), t1);
+});
+
+test('completedCount counts only completed quests, not skipped ones', () => {
+  const t = tier({
+    quests: [quest({ status: 'completed' }), quest({ status: 'skipped' }), quest({ status: 'available' })]
+  });
+  assert.equal(completedCount(t), 1);
+});
+
+test('resolvedCount counts completed and skipped quests together (task 3.4)', () => {
+  const t = tier({
+    quests: [quest({ status: 'completed' }), quest({ status: 'skipped' }), quest({ status: 'available' })]
+  });
+  assert.equal(resolvedCount(t), 2);
+});
+
+test('tierInsignia zero-pads a positive tier number', () => {
+  assert.equal(tierInsignia(2), '02');
+  assert.equal(tierInsignia(11), '11');
+});
+
+test('tierInsignia falls back to an em dash for an invalid tier', () => {
+  assert.equal(tierInsignia(0), '—');
+  assert.equal(tierInsignia(undefined), '—');
+});
+
+test('questRowState: an available optional quest shows the Skip control and a link', () => {
+  const state = questRowState(quest({ status: 'available', optional: true, action_url: '/workspaces?hq=1' }));
+  assert.equal(state.done, false);
+  assert.equal(state.skipped, false);
+  assert.equal(state.resolved, false);
+  assert.equal(state.mark, '○');
+  assert.equal(state.showLink, true);
+  assert.equal(state.showSkip, true);
+  assert.equal(state.showResume, false);
+});
+
+test('questRowState: a non-optional available quest never shows Skip', () => {
+  const state = questRowState(quest({ status: 'available', optional: false }));
+  assert.equal(state.showSkip, false);
+});
+
+test('questRowState: a skipped quest is not "done", offers Resume instead of a title link, and never Skip again', () => {
+  const state = questRowState(quest({ status: 'skipped', optional: true, action_url: '/workspaces?hq=1', action_label: 'Build your Personal HQ' }));
+  assert.equal(state.done, false, 'a skip must never be labeled as the action being completed');
+  assert.equal(state.skipped, true);
+  assert.equal(state.resolved, true);
+  assert.equal(state.mark, '⏭');
+  assert.equal(state.showLink, false, 'the quest title itself is no longer the actionable link once skipped');
+  assert.equal(state.showResume, true);
+  assert.equal(state.showSkip, false, 'an already-skipped quest cannot be skipped again');
+});
+
+test('questRowState: a skipped quest with no action_url shows no Resume link', () => {
+  const state = questRowState(quest({ status: 'skipped', optional: true }));
+  assert.equal(state.showResume, false);
+});
+
+test('questRowState: a completed quest shows a checkmark and no link/skip/resume', () => {
+  const state = questRowState(quest({ status: 'completed', optional: true, action_url: '/x' }));
+  assert.equal(state.done, true);
+  assert.equal(state.mark, '✓');
+  assert.equal(state.showLink, false);
+  assert.equal(state.showSkip, false);
+  assert.equal(state.showResume, false);
+});
+
+test('questRowState: a locked-tier quest renders like any other unresolved quest (still linkable once available)', () => {
+  const state = questRowState(quest({ status: 'locked-tier', action_url: '/x' }));
+  assert.equal(state.resolved, false);
+  assert.equal(state.showLink, true);
+});
+
+test('diffAnnouncements is silent on the very first load (knownCompleted === null)', () => {
+  const status = {
+    tiers: [tier({ quests: [quest({ id: 'a', status: 'completed' })] })]
+  };
+  const diff = diffAnnouncements(status, null, {});
+  assert.deepEqual(diff.newCompletions, []);
+  assert.deepEqual(diff.newTierCompletions, []);
+  assert.equal(diff.completedNow.has('a'), true, 'the baseline must still be recorded for next time');
+});
+
+test('diffAnnouncements reports a newly completed quest', () => {
+  const status = {
+    tiers: [tier({ quests: [quest({ id: 'a', status: 'completed', title: 'First quest' })] })]
+  };
+  const diff = diffAnnouncements(status, new Set(), {});
+  assert.deepEqual(diff.newCompletions, [{ id: 'a', title: 'First quest' }]);
+});
+
+test('diffAnnouncements never reports a skip as a completion', () => {
+  const status = {
+    tiers: [tier({ quests: [quest({ id: 'a', status: 'skipped' })] })]
+  };
+  const diff = diffAnnouncements(status, new Set(), {});
+  assert.deepEqual(diff.newCompletions, [], 'skip must never toast as a quest completion');
+});
+
+test('diffAnnouncements reports a tier-complete transition when a real completion drove it', () => {
+  const status = {
+    tiers: [
+      tier({
+        tier: 1,
+        complete: true,
+        quests: [quest({ id: 'a', status: 'completed', title: 'Last quest' })]
+      })
+    ]
+  };
+  const diff = diffAnnouncements(status, new Set(), { 1: false });
+  assert.deepEqual(diff.newTierCompletions, [{ tier: 1, name: 'Establish a Base' }]);
+});
+
+test('diffAnnouncements suppresses a tier-complete transition caused solely by a skip (task 3.8)', () => {
+  const status = {
+    tiers: [
+      tier({
+        tier: 2,
+        complete: true,
+        // Every quest in this tier is already known-completed except the
+        // optional one, which just got skipped this round — nothing in this
+        // diff is a *new* completion.
+        quests: [quest({ id: 'a', status: 'completed' }), quest({ id: 'hq', status: 'skipped', optional: true })]
+      })
+    ]
+  };
+  const diff = diffAnnouncements(status, new Set(['a']), { 2: false });
+  assert.deepEqual(diff.newCompletions, []);
+  assert.deepEqual(diff.newTierCompletions, [], 'a tier resolved solely by a skip must not toast as tier-complete');
+});
+
+test('diffAnnouncements still toasts tier-complete when a skip and a real completion land in the same round', () => {
+  const status = {
+    tiers: [
+      tier({
+        tier: 2,
+        complete: true,
+        quests: [quest({ id: 'a', status: 'completed', title: 'Real one' }), quest({ id: 'hq', status: 'skipped', optional: true })]
+      })
+    ]
+  };
+  const diff = diffAnnouncements(status, new Set(), { 2: false });
+  assert.deepEqual(diff.newCompletions, [{ id: 'a', title: 'Real one' }]);
+  assert.deepEqual(diff.newTierCompletions, [{ tier: 2, name: 'Establish a Base' }], 'a real completion in the same round still earns the tier-complete toast');
+});
+
+test('diffAnnouncements does not re-toast a tier that was already known complete', () => {
+  const status = {
+    tiers: [tier({ tier: 1, complete: true, quests: [quest({ id: 'a', status: 'completed' })] })]
+  };
+  const diff = diffAnnouncements(status, new Set(['a']), { 1: true });
+  assert.deepEqual(diff.newTierCompletions, []);
+});

--- a/internal/web/static/js/modules/progression-widget.test.js
+++ b/internal/web/static/js/modules/progression-widget.test.js
@@ -5,6 +5,8 @@ import {
   completedCount,
   resolvedCount,
   tierInsignia,
+  firstMissionView,
+  tierQuestRows,
   questRowState,
   diffAnnouncements
 } from './progression-widget.js';
@@ -30,14 +32,22 @@ test('currentTier falls back to the first tier when current_tier is not found', 
 
 test('completedCount counts only completed quests, not skipped ones', () => {
   const t = tier({
-    quests: [quest({ status: 'completed' }), quest({ status: 'skipped' }), quest({ status: 'available' })]
+    quests: [
+      quest({ status: 'completed' }),
+      quest({ status: 'skipped' }),
+      quest({ status: 'available' })
+    ]
   });
   assert.equal(completedCount(t), 1);
 });
 
 test('resolvedCount counts completed and skipped quests together (task 3.4)', () => {
   const t = tier({
-    quests: [quest({ status: 'completed' }), quest({ status: 'skipped' }), quest({ status: 'available' })]
+    quests: [
+      quest({ status: 'completed' }),
+      quest({ status: 'skipped' }),
+      quest({ status: 'available' })
+    ]
   });
   assert.equal(resolvedCount(t), 2);
 });
@@ -52,8 +62,95 @@ test('tierInsignia falls back to an em dash for an invalid tier', () => {
   assert.equal(tierInsignia(undefined), '—');
 });
 
+test('firstMissionView exposes the HQ quest before its tier unlocks', () => {
+  const status = {
+    current_tier: 1,
+    tiers: [
+      tier({ tier: 1, quests: [quest({ id: 'hello' })] }),
+      tier({
+        tier: 2,
+        quests: [
+          quest({
+            id: 't2-build-hq',
+            title: 'Build your Personal HQ',
+            why: 'Give Ori a home base.',
+            status: 'locked-tier',
+            action_url: '/workspaces?hq_onboarding=1'
+          })
+        ]
+      })
+    ]
+  };
+
+  assert.deepEqual(firstMissionView(status), {
+    visible: true,
+    completed: false,
+    skipped: false,
+    title: 'Build your Personal HQ',
+    why: 'Give Ori a home base.',
+    statusLabel: 'Ready',
+    actionLabel: 'Start mission',
+    actionURL: '/workspaces?hq_onboarding=1',
+    showAction: true
+  });
+});
+
+test('firstMissionView turns a skipped HQ quest into a resumable mission', () => {
+  const status = {
+    tiers: [
+      tier({
+        quests: [
+          quest({
+            id: 't2-build-hq',
+            status: 'skipped',
+            action_url: '/workspaces?hq_onboarding=1'
+          })
+        ]
+      })
+    ]
+  };
+
+  const view = firstMissionView(status);
+  assert.equal(view.statusLabel, 'Paused');
+  assert.equal(view.actionLabel, 'Resume mission');
+  assert.equal(view.showAction, true);
+});
+
+test('firstMissionView keeps completion visible without a redundant action', () => {
+  const status = {
+    tiers: [tier({ quests: [quest({ id: 't2-build-hq', status: 'completed' })] })]
+  };
+
+  const view = firstMissionView(status);
+  assert.equal(view.visible, true);
+  assert.equal(view.statusLabel, 'Complete');
+  assert.equal(view.showAction, false);
+});
+
+test('firstMissionView hides once all progression is complete', () => {
+  const status = {
+    all_complete: true,
+    tiers: [tier({ quests: [quest({ id: 't2-build-hq', status: 'completed' })] })]
+  };
+  assert.deepEqual(firstMissionView(status), { visible: false });
+});
+
+test('tierQuestRows omits the HQ quest because Mission 01 renders it separately', () => {
+  const rows = tierQuestRows(
+    tier({
+      quests: [quest({ id: 'workspace' }), quest({ id: 't2-build-hq' }), quest({ id: 'note' })]
+    })
+  );
+  assert.deepEqual(
+    rows.map(item => item.id),
+    ['workspace', 'note']
+  );
+});
+
 test('questRowState: an available optional quest shows the Skip control and a link', () => {
-  const state = questRowState(quest({ status: 'available', optional: true, action_url: '/workspaces?hq=1' }));
+  const state = questRowState(
+    quest({ status: 'available', optional: true, action_url: '/workspaces?hq=1' })
+  );
   assert.equal(state.done, false);
   assert.equal(state.skipped, false);
   assert.equal(state.resolved, false);
@@ -69,12 +166,23 @@ test('questRowState: a non-optional available quest never shows Skip', () => {
 });
 
 test('questRowState: a skipped quest is not "done", offers Resume instead of a title link, and never Skip again', () => {
-  const state = questRowState(quest({ status: 'skipped', optional: true, action_url: '/workspaces?hq=1', action_label: 'Build your Personal HQ' }));
+  const state = questRowState(
+    quest({
+      status: 'skipped',
+      optional: true,
+      action_url: '/workspaces?hq=1',
+      action_label: 'Build your Personal HQ'
+    })
+  );
   assert.equal(state.done, false, 'a skip must never be labeled as the action being completed');
   assert.equal(state.skipped, true);
   assert.equal(state.resolved, true);
   assert.equal(state.mark, '⏭');
-  assert.equal(state.showLink, false, 'the quest title itself is no longer the actionable link once skipped');
+  assert.equal(
+    state.showLink,
+    false,
+    'the quest title itself is no longer the actionable link once skipped'
+  );
   assert.equal(state.showResume, true);
   assert.equal(state.showSkip, false, 'an already-skipped quest cannot be skipped again');
 });
@@ -106,7 +214,11 @@ test('diffAnnouncements is silent on the very first load (knownCompleted === nul
   const diff = diffAnnouncements(status, null, {});
   assert.deepEqual(diff.newCompletions, []);
   assert.deepEqual(diff.newTierCompletions, []);
-  assert.equal(diff.completedNow.has('a'), true, 'the baseline must still be recorded for next time');
+  assert.equal(
+    diff.completedNow.has('a'),
+    true,
+    'the baseline must still be recorded for next time'
+  );
 });
 
 test('diffAnnouncements reports a newly completed quest', () => {
@@ -148,13 +260,20 @@ test('diffAnnouncements suppresses a tier-complete transition caused solely by a
         // Every quest in this tier is already known-completed except the
         // optional one, which just got skipped this round — nothing in this
         // diff is a *new* completion.
-        quests: [quest({ id: 'a', status: 'completed' }), quest({ id: 'hq', status: 'skipped', optional: true })]
+        quests: [
+          quest({ id: 'a', status: 'completed' }),
+          quest({ id: 'hq', status: 'skipped', optional: true })
+        ]
       })
     ]
   };
   const diff = diffAnnouncements(status, new Set(['a']), { 2: false });
   assert.deepEqual(diff.newCompletions, []);
-  assert.deepEqual(diff.newTierCompletions, [], 'a tier resolved solely by a skip must not toast as tier-complete');
+  assert.deepEqual(
+    diff.newTierCompletions,
+    [],
+    'a tier resolved solely by a skip must not toast as tier-complete'
+  );
 });
 
 test('diffAnnouncements still toasts tier-complete when a skip and a real completion land in the same round', () => {
@@ -163,13 +282,20 @@ test('diffAnnouncements still toasts tier-complete when a skip and a real comple
       tier({
         tier: 2,
         complete: true,
-        quests: [quest({ id: 'a', status: 'completed', title: 'Real one' }), quest({ id: 'hq', status: 'skipped', optional: true })]
+        quests: [
+          quest({ id: 'a', status: 'completed', title: 'Real one' }),
+          quest({ id: 'hq', status: 'skipped', optional: true })
+        ]
       })
     ]
   };
   const diff = diffAnnouncements(status, new Set(), { 2: false });
   assert.deepEqual(diff.newCompletions, [{ id: 'a', title: 'Real one' }]);
-  assert.deepEqual(diff.newTierCompletions, [{ tier: 2, name: 'Establish a Base' }], 'a real completion in the same round still earns the tier-complete toast');
+  assert.deepEqual(
+    diff.newTierCompletions,
+    [{ tier: 2, name: 'Establish a Base' }],
+    'a real completion in the same round still earns the tier-complete toast'
+  );
 });
 
 test('diffAnnouncements does not re-toast a tier that was already known complete', () => {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -127,7 +127,22 @@ const sessionManager = {
     // Try to restore active session, or prompt to create workspace
     const restored = await this.restoreActiveSession();
     const isWorkspacePage = document.body.classList.contains('home-hub');
-    if (!restored && this.sessions.length === 0 && this.folders.length === 0 && isWorkspacePage) {
+    // Personal HQ owns the true first-run choice on the workspace launcher.
+    // Do not stack the generic create-workspace modal over Ori's mission
+    // briefing; its "Create a project instead" action opens that same modal
+    // deliberately when the user chooses it.
+    const isHQFirstMission =
+      document.getElementById('workspaceHub')?.dataset.hqOnboardingHint === 'unseen';
+    const isHQOnboardingRoute =
+      new URLSearchParams(window.location.search).get('hq_onboarding') === '1';
+    if (
+      !restored &&
+      this.sessions.length === 0 &&
+      this.folders.length === 0 &&
+      isWorkspacePage &&
+      !isHQFirstMission &&
+      !isHQOnboardingRoute
+    ) {
       // Show create workspace modal when no workspaces exist (only on workspaces page)
       this.showAddWorkspaceModal();
     } else if (!restored && this.sessions.length > 0) {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -21,6 +21,30 @@
   // Currently-selected workspace id, remembered across re-mounts (data refreshes).
   var selectedId = '';
 
+  // The authoritative designated Personal HQ workspace id, if any — drives
+  // the HQ landmark badge on its tile (PRD FR43/FR44: based on the actual
+  // designation, never inferred from name/template, and a template-created
+  // but undesignated workspace never gets it). Fetched lazily once per page
+  // load; a re-mount is triggered if the value changes.
+  var hqWorkspaceId = null;
+  var hqFetched = false;
+
+  function ensureHQWorkspaceId() {
+    if (hqFetched || typeof fetch !== 'function') return;
+    hqFetched = true;
+    fetch('/api/personal-hq/status', { headers: { Accept: 'application/json' } })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (body) {
+        var status = body && body.status;
+        var next = (status && status.valid) ? status.workspace_id : null;
+        if (next !== hqWorkspaceId) {
+          hqWorkspaceId = next;
+          if (lastMount) mount(lastMount.container, lastMount.state);
+        }
+      })
+      .catch(function () { /* non-fatal: badge just won't show */ });
+  }
+
   // Ids checked for a bulk operation (multi-select), remembered across re-mounts.
   // Distinct from selectedId: selectedId drives the Overview preview, while this
   // set drives the multi-select action bar. Only plain workspace tiles (not
@@ -236,6 +260,7 @@
     var openTasks = Number(ws.open_task_count || 0);
     var mode = opsModeLabel(ws.ops_mode);
     var hasKeeper = String(ws.entry_agent_name || '').trim() !== '';
+    var isHQ = !!hqWorkspaceId && ws.id === hqWorkspaceId;
     var isSel = selectedId && ws.id === selectedId;
     var selected = isSel ? ' is-selected' : '';
     var isMulti = !!multiSelected[ws.id];
@@ -250,18 +275,20 @@
     var actionHint = isSel ? '. Selected — activate to open' : '. Activate to select, double-click to open';
 
     return (
-      '<button type="button" class="ws-map-tile' + selected + multiCls + '" ' +
+      '<button type="button" class="ws-map-tile' + selected + multiCls + (isHQ ? ' is-hq' : '') + '" ' +
       'data-ws-id="' + escapeHtml(ws.id) + '" ' +
       'aria-pressed="' + (isSel ? 'true' : 'false') + '" ' +
       'style="left:' + left + 'px;top:' + top + 'px;--i:' + (index || 0) + '" ' +
       'aria-label="' + escapeHtml(ws.name || 'Workspace') + ', ' + meta + ', ' + statusText +
-      (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') + actionHint + '">' +
+      (hasKeeper ? ', entry agent ' + escapeHtml(ws.entry_agent_name) : '') +
+      (isHQ ? ', Personal HQ' : '') + actionHint + '">' +
       '<span class="ws-map-tile-check" data-ws-check role="checkbox" tabindex="-1" ' +
       'aria-checked="' + (isMulti ? 'true' : 'false') + '" ' +
       'aria-label="Select for bulk action" title="Select"></span>' +
       '<span class="ws-map-tile-flag"><span class="ws-map-led' + (active ? ' is-working' : '') + '"></span>' +
       escapeHtml(statusText) + '</span>' +
       (hasKeeper ? '<span class="ws-map-tile-crest" title="Entry agent (locked)">★</span>' : '') +
+      (isHQ ? '<span class="ws-map-tile-hq-badge" title="Personal HQ">HQ</span>' : '') +
       structSVG(pal) +
       '<span class="ws-map-tile-name">' + escapeHtml(ws.name || 'Workspace') + '</span>' +
       (mode ? '<span class="ws-map-tile-type">' + escapeHtml(mode) + '</span>' : '') +
@@ -785,6 +812,7 @@
    */
   function mount(container, state) {
     if (!container) return;
+    ensureHQWorkspaceId();
     var workspaces = (state && state.workspaces) || [];
     var incoming = (state && state.selectedId) || '';
     // Keep the current selection if it still exists, else honor an incoming
@@ -830,6 +858,10 @@
     computeMaxCols: computeMaxCols,
     tileHTML: tileHTML,
     overviewBodyHTML: overviewBodyHTML,
-    selBarHTML: selBarHTML
+    selBarHTML: selBarHTML,
+    // Test-only seam: hqWorkspaceId is normally populated by an async fetch
+    // (ensureHQWorkspaceId), which direct tileHTML() calls in unit tests
+    // never trigger. Not used by production code.
+    _setHQWorkspaceIdForTest: function (id) { hqWorkspaceId = id; }
   };
 })();

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -335,6 +335,30 @@ test('overviewBodyHTML labels the delete action "Delete group" for group workspa
   assert.match(html, /data-ws-delete="grp-1"[^>]*>✕ Delete group</);
 });
 
+test('tileHTML marks the designated Personal HQ workspace with a badge, aria-label, and class', () => {
+  const api = loadOriWorkspaceMap();
+  api._setHQWorkspaceIdForTest('ws-hq');
+
+  const hqTile = api.tileHTML({ ws: { id: 'ws-hq', name: 'Command Post' }, col: 0, row: 0 });
+  assert.match(hqTile, /ws-map-tile is-hq/);
+  assert.match(hqTile, /ws-map-tile-hq-badge/);
+  assert.match(hqTile, />HQ</);
+  assert.match(hqTile, /, Personal HQ/);
+
+  const otherTile = api.tileHTML({ ws: { id: 'ws-other', name: 'Side Project' }, col: 0, row: 0 });
+  assert.doesNotMatch(otherTile, /is-hq/);
+  assert.doesNotMatch(otherTile, /ws-map-tile-hq-badge/);
+  assert.doesNotMatch(otherTile, /, Personal HQ/);
+});
+
+test('tileHTML shows no HQ badge for any workspace when no HQ is designated', () => {
+  const api = loadOriWorkspaceMap();
+  api._setHQWorkspaceIdForTest(null);
+  const html = api.tileHTML({ ws: { id: 'ws-anything', name: 'Untouched' }, col: 0, row: 0 });
+  assert.doesNotMatch(html, /is-hq/);
+  assert.doesNotMatch(html, /ws-map-tile-hq-badge/);
+});
+
 test('selBarHTML offers group, delete, and clear actions for the multi-select set', () => {
   const { selBarHTML } = loadOriWorkspaceMap();
   const html = selBarHTML();

--- a/internal/web/templates/components/dashboard.tmpl
+++ b/internal/web/templates/components/dashboard.tmpl
@@ -39,6 +39,79 @@
     <a href="/workspaces?hq_onboarding=1" id="homeHQResumeLink" class="hq-resume-action">Open workspace launcher</a>
   </div>
 
+  <!-- Daily Brief: the primary Home orientation region once a valid Personal
+       HQ is designated (PRD FR97). Hidden entirely with no HQ — no hidden
+       brief store is created and no workspace is silently selected (FR69).
+       Populated/wired by home-daily-brief.js. -->
+  <section id="homeDailyBrief" class="home-daily-brief" data-state="loading" aria-labelledby="homeDailyBriefTitle" hidden>
+    <header class="home-daily-brief-header">
+      <div class="home-daily-brief-heading">
+        <span class="home-daily-brief-eyebrow">Daily Brief</span>
+        <h2 id="homeDailyBriefTitle" class="home-daily-brief-title">Today</h2>
+        <p id="homeDailyBriefMeta" class="home-daily-brief-meta"></p>
+      </div>
+      <div class="home-daily-brief-actions">
+        <a id="homeDailyBriefOpenHQ" href="/workspaces" class="modern-btn modern-btn-secondary modern-btn-sm">Open My HQ</a>
+        <button type="button" id="homeDailyBriefSettingsBtn" class="modern-btn modern-btn-secondary modern-btn-sm">Brief settings</button>
+        <button type="button" id="homeDailyBriefRefreshBtn" class="modern-btn modern-btn-primary modern-btn-sm">Refresh</button>
+      </div>
+    </header>
+    <div id="homeDailyBriefBanner" class="home-daily-brief-banner" role="status" aria-live="polite" hidden></div>
+    <div id="homeDailyBriefBody" class="home-daily-brief-body" aria-live="polite">
+      <div class="home-daily-brief-placeholder">Loading your Daily Brief…</div>
+    </div>
+  </section>
+
+  <!-- Brief settings dialog: HQ-owned config + recent history, opened from
+       Home's "Brief settings" action but scoped to the designated HQ
+       workspace's own data (PRD FR99/task 7.7). -->
+  <div class="modal fade" id="homeDailyBriefSettingsModal" tabindex="-1" aria-labelledby="homeDailyBriefSettingsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 id="homeDailyBriefSettingsModalLabel" class="modal-title">Daily Brief settings</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <form id="homeDailyBriefSettingsForm" class="home-daily-brief-settings-form">
+            <div class="mb-3">
+              <label class="form-label" for="homeDailyBriefTimezone">Timezone</label>
+              <input type="text" class="modern-input" id="homeDailyBriefTimezone" name="timezone" autocomplete="off" placeholder="UTC">
+            </div>
+            <div class="mb-3">
+              <label class="form-label" for="homeDailyBriefTime">Scheduled time</label>
+              <input type="text" class="modern-input" id="homeDailyBriefTime" name="schedule_time" autocomplete="off" placeholder="08:00">
+            </div>
+            <fieldset class="mb-3">
+              <legend class="form-label">Days</legend>
+              <div class="home-daily-brief-days" role="group" aria-label="Scheduled days">
+                <label><input type="checkbox" value="mon"> Mon</label>
+                <label><input type="checkbox" value="tue"> Tue</label>
+                <label><input type="checkbox" value="wed"> Wed</label>
+                <label><input type="checkbox" value="thu"> Thu</label>
+                <label><input type="checkbox" value="fri"> Fri</label>
+                <label><input type="checkbox" value="sat"> Sat</label>
+                <label><input type="checkbox" value="sun"> Sun</label>
+              </div>
+            </fieldset>
+            <div class="mb-3 form-check">
+              <input type="checkbox" class="form-check-input" id="homeDailyBriefScheduleEnabled" name="schedule_enabled">
+              <label class="form-check-label" for="homeDailyBriefScheduleEnabled">Generate automatically on schedule</label>
+            </div>
+            <div class="mb-3 form-check">
+              <input type="checkbox" class="form-check-input" id="homeDailyBriefNotify" name="notify_on_ready">
+              <label class="form-check-label" for="homeDailyBriefNotify">Notify in Action Center when a scheduled brief is ready</label>
+            </div>
+            <button type="submit" class="modern-btn modern-btn-primary">Save settings</button>
+          </form>
+          <hr>
+          <h6>Recent history</h6>
+          <ul id="homeDailyBriefHistoryList" class="home-daily-brief-history-list"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="home-command-layout">
     <section id="homeDashboardSections" class="home-dashboard-sections home-operations-board" data-workspace-count="{{.Extra.WorkspaceCount}}" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}" aria-label="Operations board">
       <header class="home-operations-header">

--- a/internal/web/templates/components/dashboard.tmpl
+++ b/internal/web/templates/components/dashboard.tmpl
@@ -31,6 +31,14 @@
     </div>
   </section>
 
+  <!-- Small non-blocking Personal HQ resume/repair entry; populated/toggled
+       by personal-hq-onboarding.js. Never a full takeover on Home. -->
+  <div id="homeHQResume" class="hq-resume" hidden>
+    <span id="homeHQResumeText" class="hq-resume-text">Set up your Personal HQ</span>
+    <button type="button" id="homeHQResumeBuildBtn" class="hq-resume-action">Build My HQ</button>
+    <a href="/workspaces?hq_onboarding=1" id="homeHQResumeLink" class="hq-resume-action">Open workspace launcher</a>
+  </div>
+
   <div class="home-command-layout">
     <section id="homeDashboardSections" class="home-dashboard-sections home-operations-board" data-workspace-count="{{.Extra.WorkspaceCount}}" data-first-run="{{if .Extra.IsFirstRun}}true{{else}}false{{end}}" aria-label="Operations board">
       <header class="home-operations-header">

--- a/internal/web/templates/components/dashboard.tmpl
+++ b/internal/web/templates/components/dashboard.tmpl
@@ -175,6 +175,22 @@
           <div class="quest-log-meter" role="progressbar" aria-label="Current tier progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
             <span class="quest-log-meter-fill" data-role="progress-bar"></span>
           </div>
+          <section class="quest-log-first-mission" data-role="first-mission" aria-labelledby="questFirstMissionTitle" hidden>
+            <div class="quest-log-first-mission-meta">
+              <span class="quest-log-first-mission-kicker"><span class="quest-log-first-mission-signal" aria-hidden="true"></span>Mission 01</span>
+              <span class="quest-log-first-mission-status" data-role="first-mission-status">Ready</span>
+            </div>
+            <div class="quest-log-first-mission-body">
+              <div class="quest-log-first-mission-copy">
+                <h3 id="questFirstMissionTitle" class="quest-log-first-mission-title" data-role="first-mission-title">Build your Personal HQ</h3>
+                <p class="quest-log-first-mission-why" data-role="first-mission-why"></p>
+              </div>
+              <a class="quest-log-first-mission-action" data-role="first-mission-action" href="/workspaces?hq_onboarding=1">
+                <span data-role="first-mission-action-label">Start mission</span>
+                <span aria-hidden="true">&#8594;</span>
+              </a>
+            </div>
+          </section>
           <ul class="quest-log-list" data-role="quests"></ul>
           <p class="quest-log-why" data-role="why"></p>
         </div>

--- a/internal/web/templates/components/modals.tmpl
+++ b/internal/web/templates/components/modals.tmpl
@@ -1017,14 +1017,14 @@
               </svg>
             </div>
             <div class="ori-speech" id="doneSpeech">
-              All set! Your first quest is waiting on the home page — say hello and tell me what you’re working on, and I’ll set you up.
+              All set! Your first mission is ready: let’s build the Personal HQ we’ll use to run everything else.
             </div>
           </div>
 
           <div class="onboarding-actions">
             <button type="button" class="btn btn-outline-secondary" id="doneBackBtn">Back</button>
             <button type="button" class="btn btn-primary onboarding-next-btn" id="startBtn" style="padding: 8px 28px;">
-              Get Started
+              View First Mission
             </button>
           </div>
         </div>

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -142,23 +142,125 @@
              personal-hq-onboarding.js. Hidden by default; the data-hq-onboarding-hint
              attribute on #workspaceHub above avoids a first-paint flash for a
              brand-new profile while the JS confirms via GET /api/personal-hq/status. -->
-        <div id="hqOnboardingGuided" class="hq-guided" hidden aria-live="polite">
-          <div class="hq-guided-site" aria-hidden="true">
-            <div class="hq-guided-site-outline"></div>
+        <section
+          id="hqOnboardingGuided"
+          class="hq-guided"
+          hidden
+          role="region"
+          aria-labelledby="hqGuidedTitle"
+          aria-describedby="hqGuidedDescription"
+          aria-live="polite">
+          <div class="hq-guided-grid" aria-hidden="true"></div>
+
+          <div class="hq-guided-shell">
+            <div class="hq-guided-commandline" aria-hidden="true">
+              <span class="hq-guided-mission-chip"><span></span> Mission 01</span>
+              <span class="hq-guided-system-label">Ori Agent // First launch</span>
+              <span class="hq-guided-ready-label">Ready</span>
+            </div>
+
+            <div class="hq-guided-dialogue">
+              <div class="hq-guided-avatar" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+                  <path d="M 724 410 L 714 405 L 686 404 L 663 397 L 651 386 L 632 352 L 618 339 L 600 329 L 582 324 L 561 324 L 542 329 L 518 344 L 503 362 L 493 386 L 491 412 L 494 428 L 503 448 L 541 493 L 554 520 L 526 508 L 501 503 L 464 504 L 414 514 L 383 513 L 349 498 L 330 480 L 321 467 L 308 498 L 303 523 L 304 562 L 316 601 L 338 635 L 362 658 L 386 674 L 432 693 L 467 700 L 527 701 L 570 695 L 607 683 L 638 665 L 659 645 L 675 619 L 682 591 L 680 562 L 674 544 L 658 518 L 626 486 L 621 474 L 623 459 L 626 453 L 638 444 L 672 442 L 702 434 L 723 418 Z"/>
+                </svg>
+                <span class="hq-guided-avatar-status"></span>
+              </div>
+              <div class="hq-guided-speech">
+                <span class="hq-guided-speaker">Ori</span>
+                <p><strong>Welcome to Ori Agent.</strong> Let's create your first workspace — a home base for everything we do together.</p>
+              </div>
+            </div>
+
+            <div class="hq-guided-stage">
+              <div class="hq-guided-brief">
+                <p class="hq-guided-eyebrow">Your first mission</p>
+                <h2 class="hq-guided-title" id="hqGuidedTitle">Build your Personal HQ</h2>
+                <p class="hq-guided-copy" id="hqGuidedDescription">
+                  Your HQ is a normal workspace with one special job: keep the big picture in
+                  view while your projects stay focused.
+                </p>
+
+                <div class="hq-guided-outcomes" role="list" aria-label="What Personal HQ adds">
+                  <div class="hq-guided-outcome" role="listitem">
+                    <span class="hq-guided-outcome-icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24"><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm2 5h10M7 12h7M7 16h5"/></svg>
+                    </span>
+                    <span><strong>Daily Brief</strong><small>Start oriented, not overwhelmed.</small></span>
+                  </div>
+                  <div class="hq-guided-outcome" role="listitem">
+                    <span class="hq-guided-outcome-icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24"><path d="m5 12 4 4L19 6M5 20h14"/></svg>
+                    </span>
+                    <span><strong>Follow-through</strong><small>Keep decisions and loose ends visible.</small></span>
+                  </div>
+                  <div class="hq-guided-outcome" role="listitem">
+                    <span class="hq-guided-outcome-icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24"><path d="M12 4v6m0 0-5 4m5-4 5 4M7 14v5m10-5v5M4 19h6m4 0h6"/></svg>
+                    </span>
+                    <span><strong>Clear routing</strong><small>Send each task to the right workspace.</small></span>
+                  </div>
+                </div>
+
+                <div class="hq-guided-actions">
+                  <button type="button" id="hqGuidedBuildBtn" class="hq-guided-primary">
+                    <span>Build Personal HQ</span>
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14m-5-5 5 5-5 5"/></svg>
+                  </button>
+                  <span class="hq-guided-action-note">About a minute · safe defaults · change anything later</span>
+                </div>
+
+                <div class="hq-guided-alternatives" aria-label="Other ways to get started">
+                  <button type="button" id="hqGuidedProjectBtn">Create a project instead</button>
+                  <span aria-hidden="true">/</span>
+                  <button type="button" id="hqGuidedSkipBtn">Not now</button>
+                </div>
+              </div>
+
+              <div class="hq-guided-blueprint" aria-hidden="true">
+                <div class="hq-guided-blueprint-head">
+                  <span>Site plan // Personal HQ</span>
+                  <span class="hq-guided-unbuilt"><i></i> Unbuilt</span>
+                </div>
+                <div class="hq-guided-blueprint-canvas">
+                  <svg viewBox="0 0 520 360" preserveAspectRatio="xMidYMid meet">
+                    <defs>
+                      <pattern id="hqBlueprintGrid" width="24" height="24" patternUnits="userSpaceOnUse">
+                        <path d="M24 0H0V24" class="hq-guided-blueprint-gridline"/>
+                      </pattern>
+                      <filter id="hqBlueprintGlow" x="-80%" y="-80%" width="260%" height="260%">
+                        <feGaussianBlur stdDeviation="6" result="blur"/>
+                        <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+                      </filter>
+                    </defs>
+                    <rect width="520" height="360" fill="url(#hqBlueprintGrid)"/>
+                    <path class="hq-guided-blueprint-orbit" d="M82 260 148 108l194-46 96 128-68 112-198 15Z"/>
+                    <path class="hq-guided-blueprint-structure" d="m153 244 38-105 136-32 49 67-30 84-133 29Z"/>
+                    <path class="hq-guided-blueprint-detail" d="m191 139 55 57 81-89M246 196l100 62M246 196l-33 91M153 244l93-48 130-22"/>
+                    <path class="hq-guided-blueprint-dashed" d="M74 279 174 317M343 62l27 49M438 190l32 12"/>
+                    <g class="hq-guided-blueprint-core" filter="url(#hqBlueprintGlow)">
+                      <path d="m246 163 29 17v33l-29 17-29-17v-33Z"/>
+                      <circle cx="246" cy="196" r="7"/>
+                    </g>
+                    <g class="hq-guided-blueprint-node"><circle cx="191" cy="139" r="5"/><circle cx="327" cy="107" r="5"/><circle cx="346" cy="258" r="5"/><circle cx="213" cy="287" r="5"/></g>
+                    <g class="hq-guided-blueprint-labels">
+                      <text x="54" y="298">ENTRY</text>
+                      <text x="356" y="52">BRIEF</text>
+                      <text x="404" y="221">ROUTE</text>
+                    </g>
+                  </svg>
+                  <div class="hq-guided-scanline"></div>
+                  <div class="hq-guided-blueprint-marker hq-guided-blueprint-marker-one"><span>01</span> Daily orientation</div>
+                  <div class="hq-guided-blueprint-marker hq-guided-blueprint-marker-two"><span>02</span> Cross-workspace view</div>
+                </div>
+                <div class="hq-guided-blueprint-foot">
+                  <span>Workspace type <b>Personal</b></span>
+                  <span>Provisioning <b>On demand</b></span>
+                </div>
+              </div>
+            </div>
           </div>
-          <p class="hq-guided-eyebrow">Ori</p>
-          <h2 class="hq-guided-title">Let's build your Personal HQ</h2>
-          <p class="hq-guided-copy">
-            Your HQ gives me a place to prepare your daily brief, remember follow-ups, and
-            help you resume work. It's a normal workspace — optional, renamable, and yours to
-            change any time.
-          </p>
-          <div class="hq-guided-actions">
-            <button type="button" id="hqGuidedBuildBtn" class="modern-btn modern-btn-primary">Build My HQ</button>
-            <button type="button" id="hqGuidedProjectBtn" class="modern-btn modern-btn-secondary">Start with a Project</button>
-            <button type="button" id="hqGuidedSkipBtn" class="modern-btn modern-btn-ghost">Skip for Now</button>
-          </div>
-        </div>
+        </section>
 
         <!-- Small non-blocking resume/repair entry for a user who has
              skipped, started, or lost a valid HQ. Never a full takeover. -->

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -1,4 +1,4 @@
-<div class="workspace-hub" id="workspaceHub" data-state="loading">
+<div class="workspace-hub" id="workspaceHub" data-state="loading" data-hq-onboarding-hint="{{if .Extra.HQOnboardingUnseen}}unseen{{else}}seen{{end}}">
   <section class="workspace-launcher" id="workspaceLauncher" aria-live="polite">
     <div class="launcher-card modern-card">
       <div class="launcher-header">
@@ -137,6 +137,37 @@
         <div id="launcherEmptyState" class="launcher-empty" style="display: none;">No workspaces yet. Create one to get started.</div>
         <!-- Map view mount point; populated by workspace-map.js. -->
         <div id="launcherMap" class="ws-map" hidden></div>
+
+        <!-- Guided first-launch Personal HQ state; populated/toggled by
+             personal-hq-onboarding.js. Hidden by default; the data-hq-onboarding-hint
+             attribute on #workspaceHub above avoids a first-paint flash for a
+             brand-new profile while the JS confirms via GET /api/personal-hq/status. -->
+        <div id="hqOnboardingGuided" class="hq-guided" hidden aria-live="polite">
+          <div class="hq-guided-site" aria-hidden="true">
+            <div class="hq-guided-site-outline"></div>
+          </div>
+          <p class="hq-guided-eyebrow">Ori</p>
+          <h2 class="hq-guided-title">Let's build your Personal HQ</h2>
+          <p class="hq-guided-copy">
+            Your HQ gives me a place to prepare your daily brief, remember follow-ups, and
+            help you resume work. It's a normal workspace — optional, renamable, and yours to
+            change any time.
+          </p>
+          <div class="hq-guided-actions">
+            <button type="button" id="hqGuidedBuildBtn" class="modern-btn modern-btn-primary">Build My HQ</button>
+            <button type="button" id="hqGuidedProjectBtn" class="modern-btn modern-btn-secondary">Start with a Project</button>
+            <button type="button" id="hqGuidedSkipBtn" class="modern-btn modern-btn-ghost">Skip for Now</button>
+          </div>
+        </div>
+
+        <!-- Small non-blocking resume/repair entry for a user who has
+             skipped, started, or lost a valid HQ. Never a full takeover. -->
+        <div id="hqOnboardingResume" class="hq-resume" hidden>
+          <span id="hqResumeText" class="hq-resume-text">Set up your Personal HQ</span>
+          <button type="button" id="hqResumeBuildBtn" class="hq-resume-action">Build My HQ</button>
+          <button type="button" id="hqResumeChooseBtn" class="hq-resume-action" hidden>Choose Existing</button>
+          <button type="button" id="hqResumeClearBtn" class="hq-resume-action" hidden>Clear</button>
+        </div>
       </section>
 
       <section id="launcherSummaryPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabSummary" hidden>
@@ -976,6 +1007,95 @@
         <div class="modal-footer" style="border-top: 1px solid var(--border-color);">
           <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
           <button type="button" id="hubWorkspaceMoveSaveBtn" class="modern-btn modern-btn-primary">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Build My HQ modal; wired by personal-hq-onboarding.js. Defaults are
+       pre-filled so the default path is: open, confirm, submit. -->
+  <div class="modal fade" id="hqBuildModal" tabindex="-1" aria-labelledby="hqBuildModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="hqBuildModalTitle">Build My HQ</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p class="hq-build-intro">
+            Your HQ uses a curated snapshot of your workspaces for its daily brief — it does
+            not automatically get every project's tools or files.
+          </p>
+          <div class="mb-3">
+            <label for="hqBuildName" class="form-label">Name</label>
+            <input type="text" class="modern-input w-100" id="hqBuildName" value="My HQ" autocomplete="off">
+          </div>
+          <div class="mb-3">
+            <label for="hqBuildTimezone" class="form-label">Timezone</label>
+            <input type="text" class="modern-input w-100" id="hqBuildTimezone" autocomplete="off">
+          </div>
+          <button type="button" id="hqBuildAdvancedToggle" class="hq-build-advanced-toggle" aria-expanded="false" aria-controls="hqBuildAdvanced">
+            Brief schedule &amp; notifications
+          </button>
+          <div id="hqBuildAdvanced" class="hq-build-advanced" hidden>
+            <div class="mb-3">
+              <label class="form-label">Brief days</label>
+              <div class="hq-build-days" role="group" aria-label="Daily brief schedule days">
+                <label><input type="checkbox" value="mon" checked> Mon</label>
+                <label><input type="checkbox" value="tue" checked> Tue</label>
+                <label><input type="checkbox" value="wed" checked> Wed</label>
+                <label><input type="checkbox" value="thu" checked> Thu</label>
+                <label><input type="checkbox" value="fri" checked> Fri</label>
+                <label><input type="checkbox" value="sat"> Sat</label>
+                <label><input type="checkbox" value="sun"> Sun</label>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="hqBuildTime" class="form-label">Brief time</label>
+              <input type="time" class="modern-input" id="hqBuildTime" value="08:00">
+            </div>
+            <div class="mb-3">
+              <label for="hqBuildScope" class="form-label">Workspaces covered</label>
+              <select id="hqBuildScope" class="modern-input w-100">
+                <option value="all" selected>All eligible workspaces</option>
+                <option value="selected">Selected workspaces (choose later in HQ settings)</option>
+              </select>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="hqBuildIncludeFuture" checked>
+              <label class="form-check-label" for="hqBuildIncludeFuture">Include new workspaces automatically</label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="hqBuildNotify">
+              <label class="form-check-label" for="hqBuildNotify">Notify me in Action Center when a brief is ready</label>
+            </div>
+          </div>
+          <div id="hqBuildError" class="hq-build-error" hidden></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="modern-btn modern-btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" id="hqBuildSubmitBtn" class="modern-btn modern-btn-primary">Build My HQ</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Choose Existing Workspace modal (designate/replace); wired by
+       personal-hq-onboarding.js. -->
+  <div class="modal fade" id="hqChooseExistingModal" tabindex="-1" aria-labelledby="hqChooseExistingModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="hqChooseExistingModalTitle">Choose Existing Workspace</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p id="hqChooseExistingIntro" class="hq-choose-intro">
+            Pick a workspace to designate as your Personal HQ. No content is deleted.
+          </p>
+          <ul id="hqChooseExistingList" class="hq-choose-list"></ul>
+          <div id="hqChooseExistingEmpty" class="hq-choose-empty" hidden>No eligible workspaces found.</div>
+          <div id="hqChooseExistingError" class="hq-build-error" hidden></div>
         </div>
       </div>
     </div>

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -356,5 +356,6 @@
   <script type="module" src="/js/modules/relative-time.js"></script>
   <script defer src="/js/modules/home-dashboard.js"></script>
   <script type="module" src="/js/modules/progression-widget.js"></script>
+  <script type="module" src="/js/modules/personal-hq-onboarding.js"></script>
 </body>
 </html>

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -355,6 +355,6 @@
   <script defer src="/js/modules/dashboard.js"></script>
   <script type="module" src="/js/modules/relative-time.js"></script>
   <script defer src="/js/modules/home-dashboard.js"></script>
-  <script defer src="/js/modules/progression-widget.js"></script>
+  <script type="module" src="/js/modules/progression-widget.js"></script>
 </body>
 </html>

--- a/internal/web/templates/layout/base.tmpl
+++ b/internal/web/templates/layout/base.tmpl
@@ -355,6 +355,7 @@
   <script defer src="/js/modules/dashboard.js"></script>
   <script type="module" src="/js/modules/relative-time.js"></script>
   <script defer src="/js/modules/home-dashboard.js"></script>
+  <script type="module" src="/js/modules/home-daily-brief.js"></script>
   <script type="module" src="/js/modules/progression-widget.js"></script>
   <script type="module" src="/js/modules/personal-hq-onboarding.js"></script>
 </body>

--- a/internal/web/templates/pages/workspaces.tmpl
+++ b/internal/web/templates/pages/workspaces.tmpl
@@ -75,6 +75,7 @@
   <script defer src="/js/modules/workspace-hub-panels.js"></script>
   <script defer src="/js/modules/workspace-map.js"></script>
   <script defer src="/js/modules/workspace-hub.js"></script>
+  <script type="module" src="/js/modules/personal-hq-onboarding.js"></script>
   <script defer src="/js/modules/workspace-hub-board.js"></script>
   <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
   <script defer src="/js/modules/workspace-sync.js"></script>

--- a/tests/personal-hq-daily-brief.spec.ts
+++ b/tests/personal-hq-daily-brief.spec.ts
@@ -24,58 +24,45 @@ import { test, expect } from '@playwright/test';
  */
 
 test.describe.serial('Personal HQ onboarding and Daily Brief', () => {
-  // Covers the server-side decision (PRD FR19/FR116-118, task 8.1): a
-  // truly brand-new profile's very first `GET /` redirects to the guided
-  // workspace launcher rather than Home. Deliberately scoped to just the
-  // redirect, proven directly against the real server/API — this is the
-  // one moment in the whole file with a fully virgin profile, before
-  // anything else on the page has had a chance to run.
-  //
-  // Not asserted here: the guided takeover's own visible rendering. On a
-  // truly fresh profile the separate app-level onboarding wizard AND an
-  // independent empty-workspace-list auto-open of the create-workspace
-  // modal both also compete for the same page — closing both was proven
-  // reachable, but a further, pre-existing timing interaction between
-  // workspace-hub.js's empty-state render and personal-hq-onboarding.js's
-  // own reveal logic (neither touched by this feature) meant the guided
-  // panel still didn't reliably show afterward. That rendering path is
-  // exercised more directly by the next test, which loads the guided
-  // launcher URL on a profile that has already cleared the unrelated
-  // wizard — a real, worthwhile finding for a follow-up look at
-  // workspace-hub.js, but out of scope to chase further here.
-  test('a brand-new profile redirects Home to the guided workspace launcher', async ({
+  // Covers the complete first visible moment (PRD FR19/FR116-118, task
+  // 4.14/8.1): Home redirects to the launcher, the generic create-workspace
+  // modal stays out of the way, and Ori's first mission renders even with
+  // motion disabled. The app-level profile/model wizard is intentionally
+  // completed through its real API, then the same page is reloaded to reveal
+  // the mission waiting directly behind it.
+  test('a brand-new profile is welcomed into Ori’s visible first mission', async ({
     page,
     request
   }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
     await page.goto('/');
     await expect(page).toHaveURL(/\/workspaces\?hq_onboarding=1/);
 
-    // Clear the unrelated app-level wizard so later tests in this file
-    // aren't blocked by it.
+    // Clear the separate profile/model wizard so the mission underneath can
+    // be asserted directly without bypassing the real first-launch route.
     const res = await request.post('/api/onboarding/skip');
     expect(res.ok()).toBeTruthy();
+    await page.reload();
+
+    const mission = page.locator('#hqOnboardingGuided');
+    await expect(mission).toBeVisible();
+    await expect(mission).toContainText('Welcome to Ori Agent');
+    await expect(page.locator('#hqGuidedTitle')).toHaveText('Build your Personal HQ');
+    await expect(page.locator('#hqGuidedBuildBtn')).toHaveText(/Build Personal HQ/);
+    await expect(page.locator('#addFolderModal')).toBeHidden();
+    await expect(page.locator('.launcher-header')).toBeHidden();
   });
 
-  // Covers the outcome PRD FR101 cares about: once HQ setup is skipped,
-  // Home shows only the lightweight resume entry, never the full takeover,
-  // and product features stay ungated. Skipped via the real API rather
-  // than clicking #hqGuidedSkipBtn directly — on this exact page, an
-  // independent empty-workspace-list auto-open of the create-workspace
-  // modal races workspace-hub.js's own empty-state render against
-  // personal-hq-onboarding.js's guided-panel reveal (a pre-existing
-  // interaction between two modules this feature doesn't own, found while
-  // writing this file; worth a follow-up look at workspace-hub.js) closely
-  // enough that the guided panel doesn't reliably end up clickable — but
-  // the state transition and its Home-facing result are exactly the same
-  // either way, so this still proves the behavior that matters.
+  // Covers the outcome PRD FR101 cares about through the visible mission UI:
+  // once HQ setup is skipped, Home shows only the lightweight resume entry,
+  // never the full takeover, and product features stay ungated.
   test('Skip for Now stays on the launcher and Home shows only the lightweight resume entry, never the full takeover', async ({
-    page,
-    request
+    page
   }) => {
-    const res = await request.post('/api/personal-hq/onboarding-state', {
-      data: { state: 'skipped' }
-    });
-    expect(res.ok()).toBeTruthy();
+    await page.goto('/workspaces?hq_onboarding=1');
+    await expect(page.locator('#hqOnboardingGuided')).toBeVisible();
+    await page.locator('#hqGuidedSkipBtn').click();
+    await expect(page.locator('#hqOnboardingGuided')).toBeHidden();
 
     await page.goto('/');
     await expect(page).toHaveURL(/\/$/);
@@ -83,22 +70,24 @@ test.describe.serial('Personal HQ onboarding and Daily Brief', () => {
     await expect(page.locator('#homeDailyBrief')).toBeHidden();
   });
 
-  // The resume bar's own "Build My HQ" button opens the identical modal
-  // and calls the identical POST /api/personal-hq/setup as the guided
-  // takeover's button (personal-hq-onboarding.js's openBuildModal/submit
-  // handler is shared by both entry points) — driven directly via the real
-  // API here rather than through the launcher page, which shares the same
-  // pre-existing empty-state-vs-reveal race noted above for the resume bar
-  // itself. What matters for this feature is proven either way: a
-  // completed Build My HQ makes Home show the Daily Brief.
+  // Exercises the default setup path through the actual resume and modal UI.
+  // This also proves the same module is active on /workspaces (where the
+  // mission lives), not only on Home.
   test('Build My HQ with defaults creates the workspace and Home shows the Daily Brief', async ({
-    page,
-    request
+    page
   }) => {
-    const setupRes = await request.post('/api/personal-hq/setup', { data: { name: 'My HQ' } });
-    expect(setupRes.ok()).toBeTruthy();
-
     await page.goto('/');
+    await expect(page.locator('#homeHQResume')).toBeVisible();
+    await page.locator('#homeHQResumeBuildBtn').click();
+    await expect(page).toHaveURL(/\/workspaces\?hq_onboarding=1/);
+    await expect(page.locator('#hqOnboardingResume')).toBeVisible();
+    await page.locator('#hqResumeBuildBtn').click();
+    await expect(page.locator('#hqBuildModal')).toBeVisible();
+    await expect(page.locator('#hqBuildName')).toHaveValue('My HQ');
+    await expect(page.locator('#hqBuildTimezone')).not.toHaveValue('');
+    await page.locator('#hqBuildSubmitBtn').click();
+
+    await expect(page).toHaveURL(/\/$/, { timeout: 15000 });
     await expect(page.locator('#homeDailyBrief')).toBeVisible();
     await expect(page.locator('#homeHQResume')).toBeHidden();
 

--- a/tests/personal-hq-daily-brief.spec.ts
+++ b/tests/personal-hq-daily-brief.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Personal HQ / Daily Brief end-to-end coverage (PRD task 9.4/9.5).
+ *
+ * Run with: PLAYWRIGHT_BASE_URL=http://localhost:PORT npx playwright test tests/personal-hq-daily-brief.spec.ts
+ * against an isolated smoke server (HOME/ORI_DATA_DIR sandboxed to a fresh
+ * temp dir — see CLAUDE.md's smoke-testing recipe). Each test assumes a
+ * genuinely brand-new profile at the start of the run and does not reset
+ * server state between tests, so this file is written to run serially
+ * against one fresh server per full run (matching this repo's CI default
+ * of workers: 1) rather than depending on test isolation the shared local
+ * server does not provide.
+ *
+ * Scope note: concurrent first-open/scheduled generation, DST gap/fold
+ * schedule correctness, and Action Center notification deduplication are
+ * already covered by fast, deterministic Go tests (internal/dailybrief,
+ * internal/server) — re-proving them through a slow real browser adds
+ * little and was left out of this file. Replace/clear/rename/delete-repair
+ * UI flows and partial/fallback-state rendering are also deferred here;
+ * they're covered at the Go/JS-unit level (internal/personalhq,
+ * home-daily-brief.test.js) and are natural candidates for a follow-up
+ * pass if deeper browser coverage is wanted later.
+ */
+
+test.describe.serial('Personal HQ onboarding and Daily Brief', () => {
+  // Covers the server-side decision (PRD FR19/FR116-118, task 8.1): a
+  // truly brand-new profile's very first `GET /` redirects to the guided
+  // workspace launcher rather than Home. Deliberately scoped to just the
+  // redirect, proven directly against the real server/API — this is the
+  // one moment in the whole file with a fully virgin profile, before
+  // anything else on the page has had a chance to run.
+  //
+  // Not asserted here: the guided takeover's own visible rendering. On a
+  // truly fresh profile the separate app-level onboarding wizard AND an
+  // independent empty-workspace-list auto-open of the create-workspace
+  // modal both also compete for the same page — closing both was proven
+  // reachable, but a further, pre-existing timing interaction between
+  // workspace-hub.js's empty-state render and personal-hq-onboarding.js's
+  // own reveal logic (neither touched by this feature) meant the guided
+  // panel still didn't reliably show afterward. That rendering path is
+  // exercised more directly by the next test, which loads the guided
+  // launcher URL on a profile that has already cleared the unrelated
+  // wizard — a real, worthwhile finding for a follow-up look at
+  // workspace-hub.js, but out of scope to chase further here.
+  test('a brand-new profile redirects Home to the guided workspace launcher', async ({
+    page,
+    request
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/workspaces\?hq_onboarding=1/);
+
+    // Clear the unrelated app-level wizard so later tests in this file
+    // aren't blocked by it.
+    const res = await request.post('/api/onboarding/skip');
+    expect(res.ok()).toBeTruthy();
+  });
+
+  // Covers the outcome PRD FR101 cares about: once HQ setup is skipped,
+  // Home shows only the lightweight resume entry, never the full takeover,
+  // and product features stay ungated. Skipped via the real API rather
+  // than clicking #hqGuidedSkipBtn directly — on this exact page, an
+  // independent empty-workspace-list auto-open of the create-workspace
+  // modal races workspace-hub.js's own empty-state render against
+  // personal-hq-onboarding.js's guided-panel reveal (a pre-existing
+  // interaction between two modules this feature doesn't own, found while
+  // writing this file; worth a follow-up look at workspace-hub.js) closely
+  // enough that the guided panel doesn't reliably end up clickable — but
+  // the state transition and its Home-facing result are exactly the same
+  // either way, so this still proves the behavior that matters.
+  test('Skip for Now stays on the launcher and Home shows only the lightweight resume entry, never the full takeover', async ({
+    page,
+    request
+  }) => {
+    const res = await request.post('/api/personal-hq/onboarding-state', {
+      data: { state: 'skipped' }
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('#homeHQResume')).toBeVisible();
+    await expect(page.locator('#homeDailyBrief')).toBeHidden();
+  });
+
+  // The resume bar's own "Build My HQ" button opens the identical modal
+  // and calls the identical POST /api/personal-hq/setup as the guided
+  // takeover's button (personal-hq-onboarding.js's openBuildModal/submit
+  // handler is shared by both entry points) — driven directly via the real
+  // API here rather than through the launcher page, which shares the same
+  // pre-existing empty-state-vs-reveal race noted above for the resume bar
+  // itself. What matters for this feature is proven either way: a
+  // completed Build My HQ makes Home show the Daily Brief.
+  test('Build My HQ with defaults creates the workspace and Home shows the Daily Brief', async ({
+    page,
+    request
+  }) => {
+    const setupRes = await request.post('/api/personal-hq/setup', { data: { name: 'My HQ' } });
+    expect(setupRes.ok()).toBeTruthy();
+
+    await page.goto('/');
+    await expect(page.locator('#homeDailyBrief')).toBeVisible();
+    await expect(page.locator('#homeHQResume')).toBeHidden();
+
+    // First-open generation runs in the background; the placeholder or the
+    // finished brief should appear, never a blank body.
+    await expect(page.locator('#homeDailyBriefBody')).not.toBeEmpty();
+    await expect(page.locator('#homeDailyBriefBody')).toContainText(/./, { timeout: 15000 });
+    await expect(page.locator('#homeDailyBriefOpenHQ')).toHaveAttribute('href', /\/workspaces\//);
+  });
+
+  test('the workspace Map shows the HQ badge on the designated workspace tile only', async ({
+    page
+  }) => {
+    await page.goto('/workspaces');
+    const hqTile = page.locator('.ws-map-tile.is-hq');
+    await expect(hqTile).toHaveCount(1);
+    await expect(hqTile.locator('.ws-map-tile-hq-badge')).toHaveText('HQ');
+    await expect(hqTile).toContainText('My HQ');
+
+    const otherBadges = page.locator('.ws-map-tile:not(.is-hq) .ws-map-tile-hq-badge');
+    await expect(otherBadges).toHaveCount(0);
+  });
+
+  test('manual refresh replaces the current brief without hiding it while generating', async ({
+    page
+  }) => {
+    await page.goto('/');
+    await expect(page.locator('#homeDailyBrief')).toBeVisible();
+    const bodyBefore = await page.locator('#homeDailyBriefBody').innerText();
+
+    await page.locator('#homeDailyBriefRefreshBtn').click();
+
+    // The refresh button disables while in flight — not asserted directly
+    // here since generation against the deterministic fallback (no model
+    // configured in this smoke environment) can complete faster than a
+    // reliable window to observe the disabled state, but re-enabling by the
+    // end and the body never emptying are exactly the behavior that matters
+    // (the last successful brief is never hidden while refreshing).
+    await expect(page.locator('#homeDailyBriefRefreshBtn')).toBeEnabled({ timeout: 15000 });
+    await expect(page.locator('#homeDailyBriefBody')).not.toBeEmpty();
+    expect(bodyBefore.length).toBeGreaterThan(0);
+  });
+
+  test('Brief settings modal opens scoped to the HQ and shows recent history', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#homeDailyBriefSettingsBtn').click();
+    await expect(page.locator('#homeDailyBriefSettingsModal')).toBeVisible();
+    await expect(page.locator('#homeDailyBriefTimezone')).not.toHaveValue('');
+    await expect(page.locator('#homeDailyBriefHistoryList li').first()).toBeVisible();
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -266,6 +266,84 @@ test.describe('Home First Run', () => {
     expect(errors).toEqual([]);
   });
 
+  test('surfaces Mission 01 in progression before the HQ tier unlocks', async ({ page }) => {
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+    await page.route('**/api/progression', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          current_tier: 1,
+          total_tiers: 6,
+          total_count: 3,
+          completed_count: 0,
+          resolved_count: 0,
+          dismissed: false,
+          all_complete: false,
+          next_quest: {
+            id: 't1-first-message',
+            title: 'Say hello to Ori',
+            why: 'Send Ori a message on the home page.',
+            status: 'available'
+          },
+          tiers: [
+            {
+              tier: 1,
+              name: 'First Contact',
+              complete: false,
+              quests: [
+                { id: 't1-first-message', title: 'Say hello to Ori', status: 'available' },
+                { id: 't1-personalize', title: 'Personalize Ori', status: 'available' }
+              ]
+            },
+            {
+              tier: 2,
+              name: 'Establish a Base',
+              complete: false,
+              quests: [
+                {
+                  id: 't2-build-hq',
+                  title: 'Build your Personal HQ',
+                  why: 'Give Ori a home base for your daily brief and follow-ups.',
+                  status: 'locked-tier',
+                  action_url: '/workspaces?hq_onboarding=1',
+                  action_label: 'Build your Personal HQ',
+                  optional: true
+                }
+              ]
+            }
+          ]
+        })
+      });
+    });
+
+    await page.goto('/');
+
+    const mission = page.locator('[data-role="first-mission"]');
+    await expect(mission).toBeVisible();
+    await expect(mission).toContainText('Mission 01');
+    await expect(mission).toContainText('Build your Personal HQ');
+    await expect(mission.locator('[data-role="first-mission-status"]')).toHaveText('Ready');
+    await expect(mission.locator('[data-role="first-mission-action"]')).toHaveAttribute(
+      'href',
+      '/workspaces?hq_onboarding=1'
+    );
+
+    await page.setViewportSize({ width: 720, height: 800 });
+    await expect(mission).toBeVisible();
+    const width = await page.evaluate(() => ({
+      page: document.documentElement.scrollWidth,
+      viewport: window.innerWidth
+    }));
+    expect(width.page).toBeLessThanOrEqual(width.viewport + 1);
+  });
+
   test('keeps maximum bridge readouts inside a desktop viewport', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.route('**/api/onboarding/status', async route => {


### PR DESCRIPTION
## Motivation

Give Ori a user-scoped home base that keeps the big picture visible across
project workspaces. The first-run experience should feel like an assignment
from Ori, not another setup form, while remaining optional and reversible.

## What changed

- add durable Personal HQ designation and onboarding state with safe
  designate, replace, clear, repair, and existing-user migration behavior
- introduce an Ori-authored **Mission 01** first-launch experience for building
  Personal HQ, including project-first and skip paths
- surface Mission 01 in Home Progression before Tier 2 unlocks, synchronized
  with the existing HQ quest's ready, paused, and completed states
- add grounded Daily Brief storage, scheduling, synthesis, history, and
  failure-safe revision handling
- integrate the Daily Brief into Home, the HQ badge into Map, HQ routing into
  Ask Ori, and scheduled-brief notifications into Action Center
- evolve the Personal Ops and Daily Briefings templates into the compatible
  Personal HQ and Custom Digest blueprints
- cover new-profile, skipped, repaired, designated, and responsive UI paths

## UI notes

- mission briefing uses the existing tactical Ori visual language in light and
  dark themes
- generic workspace prompts stay suppressed while Mission 01 owns first launch
- mobile actions stack without horizontal overflow
- reduced-motion users receive the same content and controls without animation

## Validation

- `make build`
- `go test ./internal/progression`
- `node --test internal/web/static/js/modules/progression-widget.test.js`
  (24 passed)
- ESLint and Prettier checks for the affected frontend modules
- focused Playwright Mission 01 progression test (desktop and 720px viewport)
- live visual verification in dark, light, desktop, and narrow layouts

## Delivery

- Base: `dev`
- Head: `feature/personal-hq-onboarding`
