### PR TITLE
feat(workspace-ui): Personal HQ landmark building + home-first Mission 01 onboarding

### DIFF
--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -123,38 +123,27 @@ func TestPersonalHQRoutesRegistered(t *testing.T) {
 	}
 }
 
-// TestBrandNewProfileRedirectsHomeToGuidedMap covers task 4.1/4.2: a
-// profile that has never seen the guided Personal HQ first-launch
-// experience must land on the workspace launcher (Map mode) instead of
-// Home, and stop redirecting once onboarding is no longer "unseen".
-func TestBrandNewProfileRedirectsHomeToGuidedMap(t *testing.T) {
+// TestBrandNewProfileLandsOnHome covers the home-first onboarding direction:
+// a brand-new profile (never-seen HQ onboarding) must land on Home and be
+// free to explore, NOT be force-redirected to the guided workspace launcher.
+// The Mission 01 quest-log card is the pull invitation; the guided takeover is
+// reached only when the user explicitly starts the mission (which navigates to
+// /workspaces?hq_onboarding=1).
+func TestBrandNewProfileLandsOnHome(t *testing.T) {
+	// A freshly built handler runs against an empty temp-HOME profile: it is
+	// brand-new by construction (this is exactly the profile that previously
+	// produced a 303 to /workspaces?hq_onboarding=1). Asserting a 200 Home
+	// render with no redirect proves the forced first-run detour is gone.
 	handler := newRoutesTestHandler(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("expected 303 redirect for a brand-new profile, got %d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected a brand-new profile to land on Home (200), got %d body=%s", rec.Code, rec.Body.String())
 	}
-	if loc := rec.Header().Get("Location"); loc != "/workspaces?hq_onboarding=1" {
-		t.Fatalf("expected redirect to the guided Map, got %q", loc)
-	}
-
-	// Once onboarding state moves off "unseen" (e.g. the user skipped),
-	// normal Home launch resumes.
-	skipReq := httptest.NewRequest(http.MethodPost, "/api/personal-hq/onboarding-state", strings.NewReader(`{"state":"skipped"}`))
-	skipReq.Header.Set("Content-Type", "application/json")
-	skipRec := httptest.NewRecorder()
-	handler.ServeHTTP(skipRec, skipReq)
-	if skipRec.Code != http.StatusOK {
-		t.Fatalf("expected onboarding-state update to succeed, got %d body=%s", skipRec.Code, skipRec.Body.String())
-	}
-
-	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec2 := httptest.NewRecorder()
-	handler.ServeHTTP(rec2, req2)
-	if rec2.Code != http.StatusOK {
-		t.Fatalf("expected normal Home launch after skipping, got %d", rec2.Code)
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("expected no redirect for a brand-new profile, got Location %q", loc)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -254,18 +254,13 @@ func (s *Server) serveIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// A brand-new profile's first visible launch routes to the guided
-	// workspace launcher (Map mode) instead of Home (PRD FR11). "Brand new"
-	// is the authoritative per-user HQ onboarding status, not workspace
-	// count: an established user who deleted every workspace, or upgraded
-	// from a version with no onboarding history, must not be misclassified
-	// as first-run (PRD FR19; task 4.1). Only a GET navigation redirects —
-	// this handler is registered for "/" without a method restriction.
-	if r.Method == http.MethodGet && s.isBrandNewProfile(r.Context()) {
-		http.Redirect(w, r, "/workspaces?hq_onboarding=1", http.StatusSeeOther)
-		return
-	}
-
+	// A brand-new profile lands on Home and is free to explore — first-run
+	// onboarding is a pull invitation (the Mission 01 quest-log card), not a
+	// forced detour. We deliberately do NOT redirect to the guided workspace
+	// launcher here; the guided HQ takeover is reached only when the user
+	// explicitly starts the mission (which navigates to
+	// /workspaces?hq_onboarding=1). isBrandNewProfile still drives adaptive
+	// Home copy below.
 	data := s.prepareBasePageData("index")
 
 	// Inject home-dashboard context: the workspace count still drives the

--- a/internal/web/static/css/workspace-map.css
+++ b/internal/web/static/css/workspace-map.css
@@ -475,6 +475,28 @@
   background: rgba(255, 255, 255, 0.85);
 }
 
+/* The HQ citadel is taller than a standard tile block, so its beacon rises
+   above neighbouring buildings. A warm gold glow (vs. the neutral drop-shadow
+   on ordinary structs) marks it as the map's capital. */
+.ws-map-struct.is-hq-struct {
+  filter:
+    drop-shadow(0 12px 12px rgba(0, 0, 0, 0.55))
+    drop-shadow(0 0 14px rgba(232, 181, 75, 0.45));
+  margin-top: -12px;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .ws-map-struct.is-hq-struct {
+    animation: ws-map-hq-beacon 2.6s ease-in-out infinite;
+  }
+}
+@keyframes ws-map-hq-beacon {
+  50% {
+    filter:
+      drop-shadow(0 12px 12px rgba(0, 0, 0, 0.55))
+      drop-shadow(0 0 20px rgba(232, 181, 75, 0.7));
+  }
+}
+
 /* Multi-select checkbox — subtle until the tile is hovered/focused or checked,
    so it doesn't compete with the tile's status flag and crest at rest. */
 .ws-map-tile-check {

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -25,6 +25,16 @@ export function resolveGuidedMode(status) {
   return 'resume';
 }
 
+// wantsGuidedTakeover decides whether the full-screen guided takeover should
+// appear on the workspace launcher. It requires BOTH a brand-new ("unseen")
+// profile AND explicit Mission 01 intent — the "Start mission" CTA navigates
+// here with ?hq_onboarding=1. Merely browsing to the launcher (even as an
+// unseen profile) must not force the takeover, so the user can explore. Pure
+// for unit testing.
+export function wantsGuidedTakeover(hint, hasIntent) {
+  return hint === 'unseen' && !!hasIntent;
+}
+
 // resumeCopy derives the resume/repair banner's text and which action
 // buttons it offers, so the DOM-wiring code has no branching logic of its
 // own to get wrong.
@@ -54,6 +64,16 @@ export function resumeCopy(mode) {
 
   const resume = document.getElementById('hqOnboardingResume');
   const hub = document.getElementById('workspaceHub');
+
+  // True only when the user arrived via the Mission 01 "Start mission" CTA
+  // (?hq_onboarding=1), which is what gates the full-screen guided takeover.
+  function hasOnboardingIntent() {
+    try {
+      return new URLSearchParams(window.location.search).get('hq_onboarding') === '1';
+    } catch (_) {
+      return false;
+    }
+  }
 
   async function fetchStatus() {
     const res = await fetch('/api/personal-hq/status', { headers: { Accept: 'application/json' } });
@@ -169,7 +189,7 @@ export function resumeCopy(mode) {
       return;
     }
     const mode = resolveGuidedMode(status);
-    if (mode === 'guided') {
+    if (mode === 'guided' && hasOnboardingIntent()) {
       showGuided();
     } else {
       hideGuided();
@@ -191,7 +211,10 @@ export function resumeCopy(mode) {
     }
 
     if (homeResume) {
-      updateResumeBar(homeResume, document.getElementById('homeHQResumeText'), mode === 'guided' ? 'resume' : mode);
+      // On Home, the Mission 01 quest-log card is the single first-run invite
+      // for a brand-new ("guided"/unseen) profile, so suppress the redundant
+      // resume bar there. It still surfaces for skipped/resume/repair states.
+      updateResumeBar(homeResume, document.getElementById('homeHQResumeText'), mode === 'guided' ? 'none' : mode);
     }
   }
 
@@ -448,7 +471,7 @@ export function resumeCopy(mode) {
     wireBuildModal();
 
     const hint = hub ? hub.dataset.hqOnboardingHint : null;
-    if (hint === 'unseen') showGuided();
+    if (wantsGuidedTakeover(hint, hasOnboardingIntent())) showGuided();
     refreshResume();
   }
 

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveGuidedMode, resumeCopy } from './personal-hq-onboarding.js';
+import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover } from './personal-hq-onboarding.js';
 
 function status(overrides) {
   return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
@@ -36,6 +36,17 @@ test('resolveGuidedMode: in_progress with no designation is resume', () => {
 
 test('resolveGuidedMode: completed onboarding but no current designation (e.g. cleared) is resume', () => {
   assert.equal(resolveGuidedMode(status({ hq_onboarding_state: 'completed', valid: false, workspace_id: '' })), 'resume');
+});
+
+test('wantsGuidedTakeover: only an unseen profile WITH explicit intent triggers the takeover', () => {
+  // The home-first flow: a brand-new profile browsing to the launcher must
+  // see the normal launcher; the full-screen takeover appears only after the
+  // user clicks "Start mission" (which arrives with ?hq_onboarding=1).
+  assert.equal(wantsGuidedTakeover('unseen', true), true);
+  assert.equal(wantsGuidedTakeover('unseen', false), false);
+  assert.equal(wantsGuidedTakeover('seen', true), false);
+  assert.equal(wantsGuidedTakeover('seen', false), false);
+  assert.equal(wantsGuidedTakeover(null, true), false);
 });
 
 test('resumeCopy: repair mode offers Build, Choose, and Clear', () => {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -251,6 +251,37 @@
     );
   }
 
+  // Personal HQ landmark: a grander gold citadel — a wide base block topped by a
+  // central tower, beacon spire, and pennant — so the designated HQ reads as a
+  // capital building on the map, not just another tile. Fixed gold palette
+  // (independent of the per-workspace hash) so it's instantly recognizable.
+  function structSVGHQ() {
+    return (
+      '<svg class="ws-map-struct is-hq-struct" width="118" height="104" viewBox="0 0 118 110" aria-hidden="true">' +
+      // ground pad
+      '<polygon points="59,64 109,86 59,108 9,86" fill="#2a2109" stroke="#e8b54b" stroke-opacity=".55"/>' +
+      // base block
+      '<polygon points="19,72 19,88 59,108 59,92" fill="#4c3c17"/>' +
+      '<polygon points="99,72 99,88 59,108 59,92" fill="#372c11"/>' +
+      '<polygon points="59,52 99,72 59,92 19,72" fill="#7a5f22" stroke="#e8b54b" stroke-opacity=".35"/>' +
+      // tower walls
+      '<polygon points="37,40 37,68 59,79 59,51" fill="#9c7a2c"/>' +
+      '<polygon points="81,40 81,68 59,79 59,51" fill="#785e22"/>' +
+      // tower windows (lit)
+      '<circle cx="46" cy="53" r="1.5" fill="#ffe08a"/>' +
+      '<circle cx="46" cy="62" r="1.5" fill="#ffe08a"/>' +
+      '<circle cx="72" cy="53" r="1.5" fill="#ffe08a"/>' +
+      '<circle cx="72" cy="62" r="1.5" fill="#ffe08a"/>' +
+      // gold roof
+      '<polygon points="59,29 81,40 59,51 37,40" fill="#f2c85c" stroke="#ffe08a" stroke-opacity=".5"/>' +
+      // spire + pennant + beacon
+      '<line x1="59" y1="29" x2="59" y2="10" stroke="#ffd469" stroke-width="2.4" stroke-linecap="round"/>' +
+      '<polygon points="59,12 74,17 59,22" fill="#ffd469"/>' +
+      '<circle cx="59" cy="9" r="3.4" fill="#ffe08a" stroke="#ffd469"/>' +
+      '</svg>'
+    );
+  }
+
   function tileHTML(tile, selectedId, index) {
     var ws = tile.ws || {};
     var pal = paletteFor(ws.id);
@@ -289,7 +320,7 @@
       escapeHtml(statusText) + '</span>' +
       (hasKeeper ? '<span class="ws-map-tile-crest" title="Entry agent (locked)">★</span>' : '') +
       (isHQ ? '<span class="ws-map-tile-hq-badge" title="Personal HQ">HQ</span>' : '') +
-      structSVG(pal) +
+      (isHQ ? structSVGHQ() : structSVG(pal)) +
       '<span class="ws-map-tile-name">' + escapeHtml(ws.name || 'Workspace') + '</span>' +
       (mode ? '<span class="ws-map-tile-type">' + escapeHtml(mode) + '</span>' : '') +
       '<span class="ws-map-tile-meta">' + escapeHtml(meta) + '</span>' +


### PR DESCRIPTION
Two related workspace/home UX improvements bundled on `feature/ui-fix`.

## 1. Personal HQ renders as a landmark building on the map
The designated Personal HQ previously used the same building glyph as every other workspace, distinguished only by a small "HQ" pill. It now renders as a grander gold citadel — a wide base block topped by a central tower with lit windows, a gold roof, a beacon spire, and a pennant — so it reads as the map's capital.

- `structSVGHQ()` in `workspace-map.js`, rendered only for the API-designated HQ tile (`isHQ`), never by name.
- Warm gold glow + slow beacon pulse (respects `prefers-reduced-motion`); the taller citadel is lifted so its peak rises above neighbouring blocks.

## 2. Home-first onboarding — Mission 01 becomes a pull invite
Previously a brand-new profile hitting `/` was force-redirected to `/workspaces?hq_onboarding=1`, where a full-screen guided takeover covered the launcher before the user ever saw the app. First-run is now an invitation, not a detour.

- **server (`serveIndex`)**: removed the first-run redirect; a brand-new profile renders Home and can explore. `isBrandNewProfile` retained only for adaptive Home copy.
- **`personal-hq-onboarding.js`**: the guided takeover is gated on explicit intent (`?hq_onboarding=1`) via new pure `wantsGuidedTakeover()` + `hasOnboardingIntent()`, so merely browsing to `/workspaces` shows the normal launcher. The redundant Home resume bar is suppressed for unseen profiles — the existing Mission 01 quest-log card is the single first-run invite, which already links to `/workspaces?hq_onboarding=1`, so clicking **Start mission** opens the same guided takeover (now user-initiated).
- Build flow, Skip path, and Build/Choose modals are untouched.

## Tests
- `TestBrandNewProfileRedirectsHomeToGuidedMap` → `TestBrandNewProfileLandsOnHome` (asserts 200 Home render, no redirect).
- Added `wantsGuidedTakeover` unit test; existing `resolveGuidedMode`/`resumeCopy` and `workspace-map` JS tests still pass.
- Verified: `go build`, `go vet`, full `internal/server` package, and the JS test suites all green; live smoke confirmed `GET /` returns 200 (no redirect) with the Mission 01 card present on Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)