### PR TITLE
feat(personal-hq): Group 5 — confirm-gated reply + send broker

### DIFF
--- a/internal/chathttp/agent_runtime.go
+++ b/internal/chathttp/agent_runtime.go
@@ -131,6 +131,9 @@ func (h *Handler) attachWorkspaceTools(ag *resolvedChatAgent, agentName string, 
 	if h.mailboxAccess != nil {
 		wtp.SetMailboxAccess(h.mailboxAccess)
 	}
+	if h.mailDrafter != nil {
+		wtp.SetMailDrafter(h.mailDrafter)
+	}
 	if h.store != nil || h.mcpRegistry != nil || h.skillsManager != nil {
 		var mcpLister mcpServerLister
 		if reg, ok := h.mcpRegistry.(mcpServerLister); ok {

--- a/internal/chathttp/handlers.go
+++ b/internal/chathttp/handlers.go
@@ -75,7 +75,9 @@ type Handler struct {
 	// mailboxAccess, when set, enables the read-only Personal HQ mail tools for
 	// authorized agents in chat (see SetMailboxAccess).
 	mailboxAccess MailboxAccess
-	evolutionSvc  interface {
+	// mailDrafter, when set, enables the mail_draft_reply tool in chat.
+	mailDrafter  MailDrafter
+	evolutionSvc interface {
 		AwardMessageXP(agentName string, tokenCount int, userMessage string) error
 	}
 	skillsManager interface {
@@ -156,6 +158,11 @@ func (h *Handler) SetFileStore(fs *workspace.FileStore) {
 // agents get the read-only mail tools in chat.
 func (h *Handler) SetMailboxAccess(access MailboxAccess) {
 	h.mailboxAccess = access
+}
+
+// SetMailDrafter wires the reply-drafting capability (mail_draft_reply) in chat.
+func (h *Handler) SetMailDrafter(drafter MailDrafter) {
+	h.mailDrafter = drafter
 }
 
 func (h *Handler) SetUserProfileDeps(store userprofile.UserStore, provider userprofile.UserProvider) {

--- a/internal/chathttp/workspace_mail_tools.go
+++ b/internal/chathttp/workspace_mail_tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/johnjallday/ori-agent/internal/mailbox"
 	"github.com/johnjallday/ori-agent/internal/toolapi"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
 )
 
 // MailboxAccess is the narrow, most-restrictive access boundary between the
@@ -34,6 +35,79 @@ type MailboxAccess interface {
 // authorizing the executing agent), the read-only mail tools are exposed.
 func (p *WorkspaceToolProvider) SetMailboxAccess(access MailboxAccess) {
 	p.mailboxAccess = access
+}
+
+// MailDrafter composes a LOCAL reply proposal for later human-confirmed sending.
+// It never sends — the created proposal is surfaced to the user, who reviews and
+// confirms it through the send broker. Implemented by the server reply service.
+type MailDrafter interface {
+	DraftReply(ctx context.Context, userID, threadID, body string) (*mailbox.ReplyProposal, error)
+}
+
+// SetMailDrafter wires the reply-drafting capability for the mail_draft_reply tool.
+func (p *WorkspaceToolProvider) SetMailDrafter(drafter MailDrafter) {
+	p.mailDrafter = drafter
+}
+
+// --- mail_draft_reply (creates a local proposal; never sends) ---
+
+func (p *WorkspaceToolProvider) mailDraftReplyTool() toolapi.Tool {
+	return &nativeUtilityTool{
+		definition: toolapi.ToolDefinition{
+			Name:        "mail_draft_reply",
+			Description: "Draft a reply to an email thread from the Personal HQ's connected account. This creates a LOCAL draft the user must review and explicitly confirm before anything is sent — you cannot send email yourself. Returns the draft's recipients and subject so you can tell the user what you prepared.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"thread_id": map[string]any{
+						"type":        "string",
+						"description": "The thread ID from mail_search_threads to reply to.",
+					},
+					"body": map[string]any{
+						"type":        "string",
+						"description": "The reply body you drafted for the user to review.",
+					},
+				},
+				"required": []string{"thread_id", "body"},
+			},
+		},
+		call: func(ctx context.Context, args string) (string, error) {
+			var in struct {
+				ThreadID string `json:"thread_id"`
+				Body     string `json:"body"`
+			}
+			if err := json.Unmarshal([]byte(args), &in); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if strings.TrimSpace(in.ThreadID) == "" {
+				return "", fmt.Errorf("thread_id is required")
+			}
+			// Verify the executing agent is authorized to read this HQ's mail
+			// before drafting a reply to it.
+			if _, err := p.resolveMailAccount(ctx); err != nil {
+				return "", err
+			}
+			proposal, err := p.mailDrafter.DraftReply(ctx, mailDraftUserID(), in.ThreadID, in.Body)
+			if err != nil {
+				return "", fmt.Errorf("could not draft the reply: %w", err)
+			}
+			out, _ := json.Marshal(map[string]any{
+				"drafted":     true,
+				"proposal_id": proposal.ID,
+				"to":          proposal.Payload.To,
+				"subject":     proposal.Payload.Subject,
+				"note":        "Draft created. The user must review and confirm it before it is sent.",
+			})
+			return string(out), nil
+		},
+	}
+}
+
+// mailDraftUserID returns the user the draft belongs to. The app is single-user
+// locally; drafts are keyed to the local user so the Home review UI (same user)
+// can list and confirm them.
+func mailDraftUserID() string {
+	return userprofile.LocalUserID
 }
 
 // mailToolsEnabled reports whether the mail tools should be exposed to the

--- a/internal/chathttp/workspace_mail_tools_test.go
+++ b/internal/chathttp/workspace_mail_tools_test.go
@@ -45,6 +45,40 @@ func providerWithMail(access MailboxAccess, agent string) *WorkspaceToolProvider
 	return p
 }
 
+type fakeDrafter struct{ called bool }
+
+func (f *fakeDrafter) DraftReply(ctx context.Context, userID, threadID, body string) (*mailbox.ReplyProposal, error) {
+	f.called = true
+	return &mailbox.ReplyProposal{ID: "p1", Payload: mailbox.ReplyPayload{To: []string{"dana@x.com"}, Subject: "Re: hi", Body: body}}, nil
+}
+
+func TestMailDraftReplyToolCreatesLocalProposal(t *testing.T) {
+	prov := fakeMailProvider{}
+	p := providerWithMail(fakeMailAccess{provider: prov, canAccess: true}, "Inbox")
+	drafter := &fakeDrafter{}
+	p.SetMailDrafter(drafter)
+
+	if !toolNames(p)["mail_draft_reply"] {
+		t.Fatal("authorized agent with a drafter should see mail_draft_reply")
+	}
+	tool := findTool(t, p, "mail_draft_reply")
+	out, err := tool.Call(context.Background(), `{"thread_id":"t1","body":"Sounds good."}`)
+	if err != nil {
+		t.Fatalf("draft: %v", err)
+	}
+	if !drafter.called || !strings.Contains(out, "proposal_id") || !strings.Contains(out, "confirm") {
+		t.Fatalf("draft tool should create a proposal and note confirmation, got %s", out)
+	}
+}
+
+func TestMailDraftReplyHiddenWithoutDrafter(t *testing.T) {
+	prov := fakeMailProvider{}
+	p := providerWithMail(fakeMailAccess{provider: prov, canAccess: true}, "Inbox")
+	if toolNames(p)["mail_draft_reply"] {
+		t.Fatal("mail_draft_reply must not appear without a drafter wired")
+	}
+}
+
 func TestMailToolsExposedOnlyWhenAuthorized(t *testing.T) {
 	prov := fakeMailProvider{}
 	// Authorized: tools present.

--- a/internal/chathttp/workspace_tools.go
+++ b/internal/chathttp/workspace_tools.go
@@ -50,6 +50,10 @@ type WorkspaceToolProvider struct {
 	// mailboxAccess, when set, enables the read-only Personal HQ mail tools for
 	// authorized agents (internal/chathttp/workspace_mail_tools.go).
 	mailboxAccess MailboxAccess
+
+	// mailDrafter, when set, enables the mail_draft_reply tool (creates a LOCAL
+	// reply proposal; never sends).
+	mailDrafter MailDrafter
 }
 
 // mcpServerLister allows listing available MCP servers.
@@ -149,6 +153,9 @@ func (p *WorkspaceToolProvider) Tools() []toolapi.Tool {
 	// access boundary authorizes for this workspace (tasks 3.8/3.9).
 	if p.mailToolsEnabled() {
 		tools = append(tools, p.mailSearchThreadsTool(), p.mailGetThreadTool())
+		if p.mailDrafter != nil {
+			tools = append(tools, p.mailDraftReplyTool())
+		}
 	}
 
 	// Coordinator-only: the entry agent can delegate work to specialists.

--- a/internal/mailbox/broker.go
+++ b/internal/mailbox/broker.go
@@ -1,0 +1,306 @@
+package mailbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Broker errors. They are intentionally coarse and content-free so an HTTP layer
+// can map them to status codes without leaking recipients/subject/body.
+var (
+	ErrProposalNotFound   = errors.New("mailbox: reply proposal not found")
+	ErrProposalNotDraft   = errors.New("mailbox: reply proposal cannot be sent in its current state")
+	ErrProposalExpired    = errors.New("mailbox: reply proposal has expired")
+	ErrPayloadChanged     = errors.New("mailbox: reply content changed since it was reviewed; re-confirm")
+	ErrSendUnauthorized   = errors.New("mailbox: sending is not authorized")
+	ErrBrokerUnconfigured = errors.New("mailbox: send broker is not configured")
+)
+
+// DefaultProposalTTL bounds how long a draft stays sendable before it must be
+// re-created (contract §6 retention: short-lived pending confirmations).
+const DefaultProposalTTL = 15 * time.Minute
+
+// ProposalStatus is a reply proposal's lifecycle state.
+type ProposalStatus string
+
+const (
+	ProposalDraft     ProposalStatus = "draft"
+	ProposalSending   ProposalStatus = "sending" // in-flight; rejects concurrent sends
+	ProposalSent      ProposalStatus = "sent"
+	ProposalFailed    ProposalStatus = "failed" // retryable
+	ProposalCancelled ProposalStatus = "cancelled"
+	ProposalExpired   ProposalStatus = "expired"
+)
+
+// ReplyProposal is a LOCAL draft reply. It never touches Gmail until a send is
+// confirmed (contract §4). It carries no secrets — just the content the user
+// composed and reviewed.
+type ReplyProposal struct {
+	ID            string         `json:"id"`
+	UserID        string         `json:"user_id"`
+	WorkspaceID   string         `json:"workspace_id"`
+	Payload       ReplyPayload   `json:"payload"`
+	Status        ProposalStatus `json:"status"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	ExpiresAt     time.Time      `json:"expires_at"`
+	SentMessageID string         `json:"sent_message_id,omitempty"`
+	LastError     string         `json:"last_error,omitempty"`
+}
+
+// Hash returns the current payload hash — what a send must confirm against.
+func (p *ReplyProposal) Hash() string { return p.Payload.Hash() }
+
+func (p *ReplyProposal) clone() *ReplyProposal {
+	cp := *p
+	cp.Payload.To = append([]string(nil), p.Payload.To...)
+	return &cp
+}
+
+// SendAuthorizer re-evaluates the full most-restrictive send policy (OAuth send
+// scope, account grant, workspace binding, agent access, allowed action, source
+// thread ownership) at both proposal creation and send consumption (task 5.4).
+type SendAuthorizer interface {
+	AuthorizeSend(ctx context.Context, userID, workspaceID string, payload ReplyPayload) error
+}
+
+// SendAuditEvent is a metadata-only record of a send-lifecycle event (task 5.10):
+// never recipients-in-full, subject, or body.
+type SendAuditEvent struct {
+	Event          string    `json:"event"`
+	UserID         string    `json:"user_id"`
+	WorkspaceID    string    `json:"workspace_id"`
+	ProposalID     string    `json:"proposal_id"`
+	AccountID      string    `json:"account_id"`
+	PayloadHash    string    `json:"payload_hash"`
+	RecipientCount int       `json:"recipient_count"`
+	At             time.Time `json:"at"`
+	Detail         string    `json:"detail,omitempty"`
+}
+
+// AuditSink records send-lifecycle events. A nil sink is fine (events dropped).
+type AuditSink interface {
+	RecordSendEvent(event SendAuditEvent)
+}
+
+// Broker is the ONLY path that sends mail (task 5.3/5.11). It owns local reply
+// proposals and turns a confirmed, unmodified proposal into exactly one send.
+type Broker struct {
+	sender MailSender
+	authz  SendAuthorizer
+	audit  AuditSink
+	ttl    time.Duration
+	now    func() time.Time
+
+	mu        sync.Mutex
+	proposals map[string]*ReplyProposal
+}
+
+// NewBroker constructs the broker. sender and authz are required; audit may be nil.
+func NewBroker(sender MailSender, authz SendAuthorizer, audit AuditSink) *Broker {
+	return &Broker{
+		sender:    sender,
+		authz:     authz,
+		audit:     audit,
+		ttl:       DefaultProposalTTL,
+		now:       time.Now,
+		proposals: make(map[string]*ReplyProposal),
+	}
+}
+
+func (b *Broker) record(event string, p *ReplyProposal, detail string) {
+	if b.audit == nil || p == nil {
+		return
+	}
+	b.audit.RecordSendEvent(SendAuditEvent{
+		Event: event, UserID: p.UserID, WorkspaceID: p.WorkspaceID, ProposalID: p.ID,
+		AccountID: p.Payload.AccountID, PayloadHash: p.Hash(), RecipientCount: len(p.Payload.Recipients()),
+		At: b.now().UTC(), Detail: detail,
+	})
+}
+
+// CreateProposal authorizes and stores a local draft reply.
+func (b *Broker) CreateProposal(ctx context.Context, userID, workspaceID string, payload ReplyPayload) (*ReplyProposal, error) {
+	if b == nil || b.sender == nil || b.authz == nil {
+		return nil, ErrBrokerUnconfigured
+	}
+	if err := b.authz.AuthorizeSend(ctx, userID, workspaceID, payload); err != nil {
+		return nil, ErrSendUnauthorized
+	}
+	now := b.now().UTC()
+	p := &ReplyProposal{
+		ID: uuid.NewString(), UserID: userID, WorkspaceID: workspaceID, Payload: payload,
+		Status: ProposalDraft, CreatedAt: now, UpdatedAt: now, ExpiresAt: now.Add(b.ttl),
+	}
+	b.mu.Lock()
+	b.proposals[p.ID] = p
+	b.mu.Unlock()
+	b.record("proposed", p, "")
+	return p.clone(), nil
+}
+
+// GetProposal returns a copy of a proposal owned by userID.
+func (b *Broker) GetProposal(userID, id string) (*ReplyProposal, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	p, ok := b.proposals[id]
+	if !ok || p.UserID != userID {
+		return nil, ErrProposalNotFound
+	}
+	return p.clone(), nil
+}
+
+// EditProposal replaces a draft's payload. Because the payload hash changes, any
+// send the user had reviewed is implicitly invalidated — they must review and
+// confirm the new content (task 5.5).
+func (b *Broker) EditProposal(ctx context.Context, userID, id string, payload ReplyPayload) (*ReplyProposal, error) {
+	b.mu.Lock()
+	p, ok := b.proposals[id]
+	if !ok || p.UserID != userID {
+		b.mu.Unlock()
+		return nil, ErrProposalNotFound
+	}
+	if p.Status != ProposalDraft && p.Status != ProposalFailed {
+		b.mu.Unlock()
+		return nil, ErrProposalNotDraft
+	}
+	p.Payload = payload
+	p.Status = ProposalDraft
+	p.LastError = ""
+	p.UpdatedAt = b.now().UTC()
+	edited := p.clone()
+	b.mu.Unlock()
+	if err := b.authz.AuthorizeSend(ctx, userID, edited.WorkspaceID, payload); err != nil {
+		return nil, ErrSendUnauthorized
+	}
+	b.record("edited", edited, "")
+	return edited, nil
+}
+
+// CancelProposal marks a draft cancelled (idempotent for an already-terminal one).
+func (b *Broker) CancelProposal(userID, id string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	p, ok := b.proposals[id]
+	if !ok || p.UserID != userID {
+		return ErrProposalNotFound
+	}
+	if p.Status == ProposalDraft || p.Status == ProposalFailed {
+		p.Status = ProposalCancelled
+		p.UpdatedAt = b.now().UTC()
+	}
+	return nil
+}
+
+// ConfirmSend is the single, atomic send path. It rejects a non-draft, expired,
+// wrong-owner, or payload-changed proposal, re-authorizes, and sends exactly
+// once. The Draft→Sending transition under the lock makes replay and concurrent
+// double-submit impossible; a send failure lands in Failed (retryable), a
+// success in Sent (terminal).
+func (b *Broker) ConfirmSend(ctx context.Context, userID, id, expectedHash string) (*ReplyProposal, error) {
+	if b == nil || b.sender == nil || b.authz == nil {
+		return nil, ErrBrokerUnconfigured
+	}
+	b.mu.Lock()
+	p, ok := b.proposals[id]
+	if !ok || p.UserID != userID {
+		b.mu.Unlock()
+		return nil, ErrProposalNotFound
+	}
+	// Single-use: only a draft or a previously-failed proposal may be sent.
+	if p.Status != ProposalDraft && p.Status != ProposalFailed {
+		b.mu.Unlock()
+		return nil, ErrProposalNotDraft
+	}
+	if !b.now().Before(p.ExpiresAt) {
+		p.Status = ProposalExpired
+		p.UpdatedAt = b.now().UTC()
+		expired := p.clone()
+		b.mu.Unlock()
+		b.record("expired", expired, "")
+		return nil, ErrProposalExpired
+	}
+	// Bind to the exact reviewed payload: reject if it changed since the user
+	// confirmed (an edit, or a stale confirmation).
+	if strings.TrimSpace(expectedHash) != "" && expectedHash != p.Hash() {
+		b.mu.Unlock()
+		b.record("confirmation_denied", p, "payload hash mismatch")
+		return nil, ErrPayloadChanged
+	}
+	// Claim the send: concurrent callers now see ProposalSending and are rejected.
+	p.Status = ProposalSending
+	p.UpdatedAt = b.now().UTC()
+	toSend := p.clone()
+	b.mu.Unlock()
+
+	// Re-authorize immediately before the side effect (task 5.4).
+	if err := b.authz.AuthorizeSend(ctx, userID, toSend.WorkspaceID, toSend.Payload); err != nil {
+		b.finalize(id, ProposalFailed, "", "authorization revoked")
+		b.record("confirmation_denied", toSend, "authorization revoked")
+		return nil, ErrSendUnauthorized
+	}
+
+	b.record("send_attempted", toSend, "")
+	result, err := b.sender.SendReply(ctx, Account{ID: toSend.Payload.AccountID}, toSend.Payload)
+	if err != nil {
+		final := b.finalize(id, ProposalFailed, "", err.Error())
+		b.record("failed", final, sanitizeSendError(err))
+		return final, err
+	}
+	final := b.finalize(id, ProposalSent, result.ProviderMessageID, "")
+	b.record("sent", final, "")
+	return final, nil
+}
+
+// finalize transitions a proposal to a terminal (or retryable) state and returns
+// a copy.
+func (b *Broker) finalize(id string, status ProposalStatus, sentMessageID, errMsg string) *ReplyProposal {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	p, ok := b.proposals[id]
+	if !ok {
+		return nil
+	}
+	p.Status = status
+	p.SentMessageID = sentMessageID
+	p.LastError = errMsg
+	p.UpdatedAt = b.now().UTC()
+	return p.clone()
+}
+
+// PurgeExpired drops proposals past a retention horizon (contract §6). Returns
+// the number removed. Callers may run this periodically.
+func (b *Broker) PurgeExpired(retainSentFor time.Duration) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	cutoff := b.now().Add(-retainSentFor)
+	removed := 0
+	for id, p := range b.proposals {
+		if p.UpdatedAt.Before(cutoff) {
+			delete(b.proposals, id)
+			removed++
+		}
+	}
+	return removed
+}
+
+// sanitizeSendError maps a provider error to a safe audit detail (no content).
+func sanitizeSendError(err error) string {
+	switch {
+	case errors.Is(err, ErrExpired):
+		return "credentials expired"
+	case errors.Is(err, ErrPermissionDenied):
+		return "permission denied"
+	case errors.Is(err, ErrRateLimited):
+		return "rate limited"
+	case errors.Is(err, ErrTimeout):
+		return "timed out"
+	default:
+		return "provider error"
+	}
+}

--- a/internal/mailbox/broker.go
+++ b/internal/mailbox/broker.go
@@ -3,6 +3,7 @@ package mailbox
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -153,6 +154,21 @@ func (b *Broker) GetProposal(userID, id string) (*ReplyProposal, error) {
 		return nil, ErrProposalNotFound
 	}
 	return p.clone(), nil
+}
+
+// ListProposals returns copies of a user's proposals, most-recently-updated
+// first, excluding cancelled ones.
+func (b *Broker) ListProposals(userID string) []*ReplyProposal {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []*ReplyProposal
+	for _, p := range b.proposals {
+		if p.UserID == userID && p.Status != ProposalCancelled {
+			out = append(out, p.clone())
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].UpdatedAt.After(out[j].UpdatedAt) })
+	return out
 }
 
 // EditProposal replaces a draft's payload. Because the payload hash changes, any

--- a/internal/mailbox/broker_test.go
+++ b/internal/mailbox/broker_test.go
@@ -1,0 +1,220 @@
+package mailbox
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeSender struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+	last  ReplyPayload
+}
+
+func (f *fakeSender) SendReply(ctx context.Context, a Account, p ReplyPayload) (SendResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.last = p
+	if f.err != nil {
+		return SendResult{}, f.err
+	}
+	return SendResult{ProviderMessageID: "m1", ThreadID: p.SourceThreadID, SentAt: time.Now()}, nil
+}
+func (f *fakeSender) count() int { f.mu.Lock(); defer f.mu.Unlock(); return f.calls }
+
+type fakeAuthz struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (f *fakeAuthz) AuthorizeSend(ctx context.Context, userID, workspaceID string, p ReplyPayload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.err
+}
+func (f *fakeAuthz) set(err error) { f.mu.Lock(); defer f.mu.Unlock(); f.err = err }
+
+type fakeAudit struct {
+	mu     sync.Mutex
+	events []SendAuditEvent
+}
+
+func (f *fakeAudit) RecordSendEvent(e SendAuditEvent) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+func (f *fakeAudit) kinds() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, e := range f.events {
+		out = append(out, e.Event)
+	}
+	return out
+}
+
+func samplePayload() ReplyPayload {
+	return ReplyPayload{AccountID: "acct-1", SourceThreadID: "t1", To: []string{"dana@x.com"}, Subject: "Re: hi", Body: "Sounds good."}
+}
+
+func newBrokerFixture() (*Broker, *fakeSender, *fakeAuthz, *fakeAudit) {
+	s, a, au := &fakeSender{}, &fakeAuthz{}, &fakeAudit{}
+	return NewBroker(s, a, au), s, a, au
+}
+
+func TestBrokerHappyPathSendsOnce(t *testing.T) {
+	b, sender, _, audit := newBrokerFixture()
+	p, err := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	if err != nil {
+		t.Fatalf("CreateProposal: %v", err)
+	}
+	final, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash())
+	if err != nil {
+		t.Fatalf("ConfirmSend: %v", err)
+	}
+	if final.Status != ProposalSent || final.SentMessageID != "m1" {
+		t.Fatalf("expected Sent with message id, got %+v", final)
+	}
+	if sender.count() != 1 {
+		t.Fatalf("expected exactly one send, got %d", sender.count())
+	}
+	kinds := audit.kinds()
+	for _, want := range []string{"proposed", "send_attempted", "sent"} {
+		if !slices.Contains(kinds, want) {
+			t.Errorf("audit missing %q event; got %v", want, kinds)
+		}
+	}
+}
+
+func TestBrokerRejectsPayloadTampering(t *testing.T) {
+	b, sender, _, _ := newBrokerFixture()
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, "not-the-real-hash"); !errors.Is(err, ErrPayloadChanged) {
+		t.Fatalf("expected ErrPayloadChanged, got %v", err)
+	}
+	if sender.count() != 0 {
+		t.Fatal("a tampered payload must not send")
+	}
+}
+
+func TestBrokerEditInvalidatesPriorHash(t *testing.T) {
+	b, sender, _, _ := newBrokerFixture()
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	oldHash := p.Hash()
+	edited := samplePayload()
+	edited.Body = "Actually, let's reschedule."
+	if _, err := b.EditProposal(context.Background(), "u1", p.ID, edited); err != nil {
+		t.Fatalf("EditProposal: %v", err)
+	}
+	// Confirming with the pre-edit hash must be rejected.
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, oldHash); !errors.Is(err, ErrPayloadChanged) {
+		t.Fatalf("edit must invalidate the old hash, got %v", err)
+	}
+	if sender.count() != 0 {
+		t.Fatal("stale confirmation must not send")
+	}
+	// Confirming with the new hash works.
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, edited.Hash()); err != nil {
+		t.Fatalf("send with current hash: %v", err)
+	}
+}
+
+func TestBrokerSingleUseRejectsReplay(t *testing.T) {
+	b, sender, _, _ := newBrokerFixture()
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash()); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash()); !errors.Is(err, ErrProposalNotDraft) {
+		t.Fatalf("replay must be rejected, got %v", err)
+	}
+	if sender.count() != 1 {
+		t.Fatalf("replay must not re-send; sends=%d", sender.count())
+	}
+}
+
+func TestBrokerConcurrentSendSendsOnce(t *testing.T) {
+	b, sender, _, _ := newBrokerFixture()
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() { _, _ = b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash()) })
+	}
+	wg.Wait()
+	if sender.count() != 1 {
+		t.Fatalf("concurrent confirmations must send exactly once, got %d", sender.count())
+	}
+}
+
+func TestBrokerExpiry(t *testing.T) {
+	b, sender, _, _ := newBrokerFixture()
+	now := time.Unix(1000, 0)
+	b.now = func() time.Time { return now }
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	now = now.Add(DefaultProposalTTL + time.Second)
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash()); !errors.Is(err, ErrProposalExpired) {
+		t.Fatalf("expected ErrProposalExpired, got %v", err)
+	}
+	if sender.count() != 0 {
+		t.Fatal("an expired proposal must not send")
+	}
+}
+
+func TestBrokerUnauthorizedCreateAndSend(t *testing.T) {
+	b, sender, authz, _ := newBrokerFixture()
+	authz.set(errors.New("denied"))
+	if _, err := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload()); !errors.Is(err, ErrSendUnauthorized) {
+		t.Fatalf("unauthorized create must fail, got %v", err)
+	}
+
+	// Authorize creation, then revoke before send.
+	authz.set(nil)
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	authz.set(errors.New("revoked"))
+	if _, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash()); !errors.Is(err, ErrSendUnauthorized) {
+		t.Fatalf("revoked send must fail, got %v", err)
+	}
+	if sender.count() != 0 {
+		t.Fatal("revoked authorization must not send")
+	}
+}
+
+func TestBrokerWrongOwnerCannotSend(t *testing.T) {
+	b, _, _, _ := newBrokerFixture()
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	if _, err := b.ConfirmSend(context.Background(), "someone-else", p.ID, p.Hash()); !errors.Is(err, ErrProposalNotFound) {
+		t.Fatalf("another user must not see/send the proposal, got %v", err)
+	}
+}
+
+func TestBrokerSendFailureIsRetryable(t *testing.T) {
+	b, sender, _, audit := newBrokerFixture()
+	sender.err = ErrRateLimited
+	p, _ := b.CreateProposal(context.Background(), "u1", "hq-1", samplePayload())
+	final, err := b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash())
+	if err == nil || final.Status != ProposalFailed {
+		t.Fatalf("expected a retryable failure, got status=%v err=%v", final.Status, err)
+	}
+	// Retry after the provider recovers.
+	sender.err = nil
+	final, err = b.ConfirmSend(context.Background(), "u1", p.ID, p.Hash())
+	if err != nil || final.Status != ProposalSent {
+		t.Fatalf("retry should succeed, got status=%v err=%v", final.Status, err)
+	}
+	// Audit records the failed then the sent outcome; never message content.
+	if !slices.Contains(audit.kinds(), "failed") || !slices.Contains(audit.kinds(), "sent") {
+		t.Fatalf("audit should record failed then sent, got %v", audit.kinds())
+	}
+	for _, e := range audit.events {
+		if e.Detail == "Sounds good." || e.PayloadHash == "" {
+			t.Fatalf("audit must be metadata-only (hash present, no body): %+v", e)
+		}
+	}
+}

--- a/internal/mailbox/compose.go
+++ b/internal/mailbox/compose.go
@@ -1,0 +1,59 @@
+package mailbox
+
+import (
+	"context"
+	"strings"
+)
+
+// ComposeReply loads an authorized source thread and builds a bounded reply
+// payload skeleton: recipient (the most recent sender), a "Re:" subject, and the
+// source thread id for Gmail threading. The caller supplies the body (an agent
+// draft or user text). It never mutates the mailbox — it only reads the thread
+// to derive reply metadata (task 5.2).
+//
+// v1 relies on Gmail's ThreadId for threading rather than RFC In-Reply-To
+// headers, because the neutral Message projection intentionally does not expose
+// raw Message-ID headers. Gmail files a reply into the thread by ThreadId, so
+// this threads correctly within Gmail; richer cross-client headers are a future
+// refinement.
+func ComposeReply(ctx context.Context, reader MailboxProvider, account Account, threadID, body string) (ReplyPayload, error) {
+	thread, err := reader.GetThread(ctx, account, threadID)
+	if err != nil {
+		return ReplyPayload{}, err
+	}
+	if len(thread.Messages) == 0 {
+		return ReplyPayload{}, ErrNotFound
+	}
+	last := thread.Messages[len(thread.Messages)-1]
+
+	subject := strings.TrimSpace(thread.Subject)
+	if subject == "" {
+		subject = strings.TrimSpace(last.Subject)
+	}
+	if !strings.HasPrefix(strings.ToLower(subject), "re:") {
+		subject = "Re: " + subject
+	}
+
+	to := strings.TrimSpace(last.From.Address)
+	// If the latest message is the user's own, reply to the first other
+	// participant instead of to themselves.
+	if last.FromUser || to == "" || strings.EqualFold(to, account.EmailAddress) {
+		for _, p := range thread.Participants {
+			if a := strings.TrimSpace(p.Address); a != "" && !strings.EqualFold(a, account.EmailAddress) {
+				to = a
+				break
+			}
+		}
+	}
+
+	payload := ReplyPayload{
+		AccountID:      account.ID,
+		SourceThreadID: thread.ID,
+		Subject:        subject,
+		Body:           body,
+	}
+	if to != "" {
+		payload.To = []string{to}
+	}
+	return payload, nil
+}

--- a/internal/mailbox/gmail.go
+++ b/internal/mailbox/gmail.go
@@ -114,6 +114,68 @@ func (g *GmailProvider) GetThread(ctx context.Context, account Account, threadID
 	return mapThread(account, full, true), nil
 }
 
+var _ MailSender = (*GmailProvider)(nil)
+
+// SendReply sends a reply through Gmail (Users.Messages.Send). It builds a
+// minimal RFC 5322 message with reply threading headers (In-Reply-To /
+// References) and sets ThreadId so Gmail files it in the source thread. Send
+// requires the gmail.send scope; a read-only account surfaces as ErrExpired /
+// ErrPermissionDenied via classifyGmailError.
+func (g *GmailProvider) SendReply(ctx context.Context, account Account, payload ReplyPayload) (SendResult, error) {
+	recipients := payload.Recipients()
+	if len(recipients) == 0 {
+		return SendResult{}, fmt.Errorf("%w: no recipients", ErrProvider)
+	}
+	svc, err := g.service(ctx, account)
+	if err != nil {
+		return SendResult{}, err
+	}
+
+	raw := buildRFC822(account.EmailAddress, recipients, payload)
+	msg := &gmailapi.Message{
+		Raw:      base64.URLEncoding.EncodeToString([]byte(raw)),
+		ThreadId: strings.TrimSpace(payload.SourceThreadID),
+	}
+	sent, err := svc.Users.Messages.Send("me", msg).Context(ctx).Do()
+	if err != nil {
+		return SendResult{}, classifyGmailError(err)
+	}
+	return SendResult{
+		ProviderMessageID: sent.Id,
+		ThreadID:          sent.ThreadId,
+		SentAt:            time.Now().UTC(),
+	}, nil
+}
+
+// buildRFC822 renders a minimal reply message. Header values are sanitized to a
+// single line to prevent header injection from a crafted subject/recipient.
+func buildRFC822(from string, to []string, payload ReplyPayload) string {
+	var b strings.Builder
+	if from = strings.TrimSpace(from); from != "" {
+		b.WriteString("From: " + headerSafe(from) + "\r\n")
+	}
+	b.WriteString("To: " + headerSafe(strings.Join(to, ", ")) + "\r\n")
+	b.WriteString("Subject: " + headerSafe(payload.Subject) + "\r\n")
+	if id := strings.TrimSpace(payload.InReplyToMessageID); id != "" {
+		b.WriteString("In-Reply-To: " + headerSafe(id) + "\r\n")
+	}
+	if refs := strings.TrimSpace(payload.References); refs != "" {
+		b.WriteString("References: " + headerSafe(refs) + "\r\n")
+	}
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(payload.Body)
+	return b.String()
+}
+
+// headerSafe strips CR/LF from a header value to prevent header injection.
+func headerSafe(v string) string {
+	v = strings.ReplaceAll(v, "\r", " ")
+	v = strings.ReplaceAll(v, "\n", " ")
+	return strings.TrimSpace(v)
+}
+
 // threadMetadata fetches a lightweight metadata projection of a thread.
 func (g *GmailProvider) threadMetadata(ctx context.Context, svc *gmailapi.Service, account Account, threadID string) (Thread, error) {
 	t, err := svc.Users.Threads.Get("me", threadID).

--- a/internal/mailbox/gmail_test.go
+++ b/internal/mailbox/gmail_test.go
@@ -159,6 +159,68 @@ func TestGmailDisconnectedResolver(t *testing.T) {
 	}
 }
 
+func TestGmailSendReplyBuildsThreadedMessage(t *testing.T) {
+	var gotRaw string
+	var gotThreadID string
+	g := newTestGmail(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var msg gmailapi.Message
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		gotThreadID = msg.ThreadId
+		if b, err := base64.URLEncoding.DecodeString(msg.Raw); err == nil {
+			gotRaw = string(b)
+		}
+		_ = json.NewEncoder(w).Encode(gmailapi.Message{Id: "sent-1", ThreadId: msg.ThreadId})
+	})
+
+	res, err := g.SendReply(context.Background(), testAccount(), ReplyPayload{
+		AccountID: "acct-1", SourceThreadID: "t1", InReplyToMessageID: "<msg-9@x>", References: "<msg-9@x>",
+		To: []string{"dana@partner.com"}, Subject: "Re: Need your review", Body: "Looks good to me.",
+	})
+	if err != nil {
+		t.Fatalf("SendReply: %v", err)
+	}
+	if res.ProviderMessageID != "sent-1" || res.ThreadID != "t1" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if gotThreadID != "t1" {
+		t.Fatalf("send must set the source ThreadId, got %q", gotThreadID)
+	}
+	for _, want := range []string{"To: dana@partner.com", "Subject: Re: Need your review", "In-Reply-To: <msg-9@x>", "References: <msg-9@x>", "Looks good to me."} {
+		if !strings.Contains(gotRaw, want) {
+			t.Errorf("sent message missing %q:\n%s", want, gotRaw)
+		}
+	}
+}
+
+func TestGmailSendRejectsHeaderInjection(t *testing.T) {
+	var gotRaw string
+	g := newTestGmail(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var msg gmailapi.Message
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		if b, err := base64.URLEncoding.DecodeString(msg.Raw); err == nil {
+			gotRaw = string(b)
+		}
+		_ = json.NewEncoder(w).Encode(gmailapi.Message{Id: "sent-1"})
+	})
+	// A subject containing CRLF must not inject a Bcc header.
+	_, err := g.SendReply(context.Background(), testAccount(), ReplyPayload{
+		AccountID: "acct-1", To: []string{"dana@partner.com"},
+		Subject: "Hi\r\nBcc: victim@x.com", Body: "hello",
+	})
+	if err != nil {
+		t.Fatalf("SendReply: %v", err)
+	}
+	// The injected header must appear only folded into the Subject line, never as
+	// its own Bcc header line.
+	for _, line := range strings.Split(gotRaw, "\r\n") {
+		if strings.HasPrefix(strings.ToLower(line), "bcc:") {
+			t.Fatalf("header injection succeeded: %q", line)
+		}
+	}
+}
+
 func TestGmailEmptyInboxIsHealthy(t *testing.T) {
 	g := newTestGmail(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/mailbox/send.go
+++ b/internal/mailbox/send.go
@@ -1,0 +1,72 @@
+package mailbox
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"strings"
+	"time"
+)
+
+// ReplyPayload is the exact, immutable content of a reply to be sent. Its Hash
+// binds a send confirmation to precisely what the user reviewed, so any edit
+// (which changes the hash) invalidates a prior confirmation (contract §4).
+type ReplyPayload struct {
+	AccountID          string   `json:"account_id"`
+	SourceThreadID     string   `json:"source_thread_id"`
+	InReplyToMessageID string   `json:"in_reply_to_message_id,omitempty"`
+	References         string   `json:"references,omitempty"`
+	To                 []string `json:"to"`
+	Subject            string   `json:"subject"`
+	Body               string   `json:"body"`
+}
+
+// Hash returns a stable content hash over the fields that define "the same
+// send". Callers compare the hash the user confirmed against the proposal's
+// current hash to reject a send whose payload changed underneath them.
+func (p ReplyPayload) Hash() string {
+	h := sha256.New()
+	// A NUL separator between fields avoids ambiguity (e.g. To vs Subject
+	// boundary) that simple concatenation would allow.
+	io.WriteString(h, p.AccountID)
+	h.Write([]byte{0})
+	io.WriteString(h, p.SourceThreadID)
+	h.Write([]byte{0})
+	io.WriteString(h, p.InReplyToMessageID)
+	h.Write([]byte{0})
+	io.WriteString(h, p.References)
+	h.Write([]byte{0})
+	io.WriteString(h, strings.Join(p.To, ","))
+	h.Write([]byte{0})
+	io.WriteString(h, p.Subject)
+	h.Write([]byte{0})
+	io.WriteString(h, p.Body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Recipients returns the trimmed, non-empty recipient addresses.
+func (p ReplyPayload) Recipients() []string {
+	out := make([]string, 0, len(p.To))
+	for _, r := range p.To {
+		if r = strings.TrimSpace(r); r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// SendResult is the typed outcome of a successful send.
+type SendResult struct {
+	ProviderMessageID string    `json:"provider_message_id"`
+	ThreadID          string    `json:"thread_id"`
+	SentAt            time.Time `json:"sent_at"`
+}
+
+// MailSender sends a reply. It is deliberately SEPARATE from MailboxProvider
+// (read), so a read-only wiring can never send, and so the broker can depend on
+// the narrow send capability alone. A read-only Gmail account (no send scope)
+// returns ErrExpired/ErrPermissionDenied when SendReply is attempted.
+type MailSender interface {
+	SendReply(ctx context.Context, account Account, payload ReplyPayload) (SendResult, error)
+}

--- a/internal/personalhqhttp/handler.go
+++ b/internal/personalhqhttp/handler.go
@@ -19,6 +19,7 @@ type Handler struct {
 	setup         *personalhq.SetupCoordinator
 	upgrade       *personalhq.UpgradeCoordinator
 	mailboxLinker MailboxLinker
+	replies       ReplyService
 	provider      userprofile.UserProvider
 }
 

--- a/internal/personalhqhttp/reply.go
+++ b/internal/personalhqhttp/reply.go
@@ -24,6 +24,28 @@ type ReplyService interface {
 // SetReplyService wires the reply/send broker surface.
 func (h *Handler) SetReplyService(svc ReplyService) { h.replies = svc }
 
+// proposalView embeds the proposal and adds its current payload_hash, which the
+// client echoes back on confirm to bind the send to exactly what was reviewed.
+type proposalView struct {
+	*mailbox.ReplyProposal
+	PayloadHash string `json:"payload_hash"`
+}
+
+func viewProposal(p *mailbox.ReplyProposal) proposalView {
+	if p == nil {
+		return proposalView{}
+	}
+	return proposalView{ReplyProposal: p, PayloadHash: p.Hash()}
+}
+
+func viewProposals(ps []*mailbox.ReplyProposal) []proposalView {
+	out := make([]proposalView, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, viewProposal(p))
+	}
+	return out
+}
+
 // DraftReply handles POST /api/personal-hq/mail/draft: compose a LOCAL reply
 // proposal from a source thread. Never sends.
 func (h *Handler) DraftReply(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +72,7 @@ func (h *Handler) DraftReply(w http.ResponseWriter, r *http.Request) {
 		respondReplyError(w, err)
 		return
 	}
-	orihttp.Success(w, map[string]any{"proposal": p})
+	orihttp.Success(w, map[string]any{"proposal": viewProposal(p)})
 }
 
 // ListProposals handles GET /api/personal-hq/mail/proposals.
@@ -62,7 +84,7 @@ func (h *Handler) ListProposals(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	orihttp.Success(w, map[string]any{"proposals": h.replies.ListProposals(userID)})
+	orihttp.Success(w, map[string]any{"proposals": viewProposals(h.replies.ListProposals(userID))})
 }
 
 // EditReply handles POST /api/personal-hq/mail/edit: replace a draft's editable
@@ -93,7 +115,7 @@ func (h *Handler) EditReply(w http.ResponseWriter, r *http.Request) {
 		respondReplyError(w, err)
 		return
 	}
-	orihttp.Success(w, map[string]any{"proposal": p})
+	orihttp.Success(w, map[string]any{"proposal": viewProposal(p)})
 }
 
 // CancelReply handles POST /api/personal-hq/mail/cancel.
@@ -144,7 +166,7 @@ func (h *Handler) ConfirmSend(w http.ResponseWriter, r *http.Request) {
 		respondReplyError(w, err)
 		return
 	}
-	orihttp.Success(w, map[string]any{"proposal": p})
+	orihttp.Success(w, map[string]any{"proposal": viewProposal(p)})
 }
 
 func (h *Handler) replyReady(w http.ResponseWriter, r *http.Request, method string) bool {

--- a/internal/personalhqhttp/reply.go
+++ b/internal/personalhqhttp/reply.go
@@ -1,0 +1,176 @@
+package personalhqhttp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/mailbox"
+)
+
+// ReplyService is the confirm-gated reply/send surface, implemented in the
+// server package over the mailbox broker. Kept as an interface so this handler
+// stays thin and testable, and so all sends funnel through one broker.
+type ReplyService interface {
+	DraftReply(ctx context.Context, userID, threadID, body string) (*mailbox.ReplyProposal, error)
+	GetProposal(userID, id string) (*mailbox.ReplyProposal, error)
+	ListProposals(userID string) []*mailbox.ReplyProposal
+	EditProposal(ctx context.Context, userID, id string, to []string, subject, body string) (*mailbox.ReplyProposal, error)
+	CancelProposal(userID, id string) error
+	ConfirmSend(ctx context.Context, userID, id, expectedHash string) (*mailbox.ReplyProposal, error)
+}
+
+// SetReplyService wires the reply/send broker surface.
+func (h *Handler) SetReplyService(svc ReplyService) { h.replies = svc }
+
+// DraftReply handles POST /api/personal-hq/mail/draft: compose a LOCAL reply
+// proposal from a source thread. Never sends.
+func (h *Handler) DraftReply(w http.ResponseWriter, r *http.Request) {
+	if !h.replyReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ThreadID string `json:"thread_id"`
+		Body     string `json:"body"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.ThreadID == "" {
+		orihttp.BadRequest(w, "thread_id is required")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	p, err := h.replies.DraftReply(r.Context(), userID, req.ThreadID, req.Body)
+	if err != nil {
+		respondReplyError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"proposal": p})
+}
+
+// ListProposals handles GET /api/personal-hq/mail/proposals.
+func (h *Handler) ListProposals(w http.ResponseWriter, r *http.Request) {
+	if !h.replyReady(w, r, http.MethodGet) {
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	orihttp.Success(w, map[string]any{"proposals": h.replies.ListProposals(userID)})
+}
+
+// EditReply handles POST /api/personal-hq/mail/edit: replace a draft's editable
+// fields, invalidating any prior confirmation.
+func (h *Handler) EditReply(w http.ResponseWriter, r *http.Request) {
+	if !h.replyReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID      string   `json:"id"`
+		To      []string `json:"to"`
+		Subject string   `json:"subject"`
+		Body    string   `json:"body"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.ID == "" {
+		orihttp.BadRequest(w, "id is required")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	p, err := h.replies.EditProposal(r.Context(), userID, req.ID, req.To, req.Subject, req.Body)
+	if err != nil {
+		respondReplyError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"proposal": p})
+}
+
+// CancelReply handles POST /api/personal-hq/mail/cancel.
+func (h *Handler) CancelReply(w http.ResponseWriter, r *http.Request) {
+	if !h.replyReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID string `json:"id"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.replies.CancelProposal(userID, req.ID); err != nil {
+		respondReplyError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"ok": true})
+}
+
+// ConfirmSend handles POST /api/personal-hq/mail/confirm: the ONLY send path.
+// expected_hash binds the send to the exact payload the user reviewed.
+func (h *Handler) ConfirmSend(w http.ResponseWriter, r *http.Request) {
+	if !h.replyReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID           string `json:"id"`
+		ExpectedHash string `json:"expected_hash"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if req.ID == "" {
+		orihttp.BadRequest(w, "id is required")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	p, err := h.replies.ConfirmSend(r.Context(), userID, req.ID, req.ExpectedHash)
+	if err != nil {
+		respondReplyError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"proposal": p})
+}
+
+func (h *Handler) replyReady(w http.ResponseWriter, r *http.Request, method string) bool {
+	if !orihttp.RequireMethod(w, r, method) {
+		return false
+	}
+	if h == nil || h.replies == nil {
+		orihttp.ServiceUnavailable(w, "personal hq email replies are unavailable")
+		return false
+	}
+	return true
+}
+
+func respondReplyError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, mailbox.ErrProposalNotFound):
+		orihttp.NotFound(w, "That reply draft was not found")
+	case errors.Is(err, mailbox.ErrSendUnauthorized):
+		orihttp.Forbidden(w, "Sending is not authorized — reconnect your email with send permission")
+	case errors.Is(err, mailbox.ErrProposalExpired):
+		orihttp.Conflict(w, "This draft expired — start a new reply")
+	case errors.Is(err, mailbox.ErrPayloadChanged):
+		orihttp.Conflict(w, "The reply changed since you reviewed it — review and confirm again")
+	case errors.Is(err, mailbox.ErrProposalNotDraft):
+		orihttp.Conflict(w, "This reply can no longer be sent")
+	default:
+		orihttp.BadRequest(w, err.Error())
+	}
+}

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -235,6 +235,10 @@ type ServerBuilder struct {
 	// until the vault system initializes it (internal/server/dailybrief_mailbox.go).
 	dailyBriefMailbox dailybrief.MailboxSource
 
+	// mailDrafter creates local reply proposals for the mail_draft_reply tool;
+	// nil until the vault system initializes it.
+	mailDrafter chathttp.MailDrafter
+
 	// Daily Brief configuration, generation, and scheduling
 	dailyBriefService   *dailybrief.Service
 	dailyBriefHandler   *dailybriefhttp.Handler

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -262,15 +262,21 @@ func (b *ServerBuilder) initializeHandlers() {
 			// Confirm-gated send broker (task 5.3): the ONLY send path. The raw
 			// (uncached) Gmail provider is the sender; sends re-authorize via the
 			// send policy and emit metadata-only audit events.
-			if b.personalHQService != nil && b.personalHQHandler != nil {
+			if b.personalHQService != nil {
 				broker := mailbox.NewBroker(
 					gmailProvider,
 					&sendAuthorizer{hq: b.personalHQService, workspaces: b.workspaceStore},
 					logAuditSink{},
 				)
-				b.personalHQHandler.SetReplyService(
-					newReplyService(b.personalHQService, b.workspaceStore, vaultStore, cachedProvider, broker),
-				)
+				replies := newReplyService(b.personalHQService, b.workspaceStore, vaultStore, cachedProvider, broker)
+				if b.personalHQHandler != nil {
+					b.personalHQHandler.SetReplyService(replies)
+				}
+				// The reply service is also the agent-facing drafter (mail_draft_reply).
+				b.mailDrafter = replies
+				if b.chatHandler != nil {
+					b.chatHandler.SetMailDrafter(replies)
+				}
 			}
 		}
 		logger.Info("Vault system initialized", logger.Fields{})

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -259,6 +259,19 @@ func (b *ServerBuilder) initializeHandlers() {
 			if b.personalHQService != nil {
 				b.dailyBriefMailbox = newDailyBriefMailboxSource(b.personalHQService, b.workspaceStore, vaultStore, cachedProvider)
 			}
+			// Confirm-gated send broker (task 5.3): the ONLY send path. The raw
+			// (uncached) Gmail provider is the sender; sends re-authorize via the
+			// send policy and emit metadata-only audit events.
+			if b.personalHQService != nil && b.personalHQHandler != nil {
+				broker := mailbox.NewBroker(
+					gmailProvider,
+					&sendAuthorizer{hq: b.personalHQService, workspaces: b.workspaceStore},
+					logAuditSink{},
+				)
+				b.personalHQHandler.SetReplyService(
+					newReplyService(b.personalHQService, b.workspaceStore, vaultStore, cachedProvider, broker),
+				)
+			}
 		}
 		logger.Info("Vault system initialized", logger.Fields{})
 	}

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -59,6 +59,9 @@ func (b *ServerBuilder) buildWorkspaceToolFactory() workspace.WorkspaceToolFacto
 		if b.mailboxAccess != nil {
 			provider.SetMailboxAccess(b.mailboxAccess)
 		}
+		if b.mailDrafter != nil {
+			provider.SetMailDrafter(b.mailDrafter)
+		}
 		return provider.Tools()
 	}
 }

--- a/internal/server/mailbox_reply.go
+++ b/internal/server/mailbox_reply.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/mailbox"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/personalhqhttp"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// sendAuthorizer implements mailbox.SendAuthorizer. It re-evaluates the send
+// policy (task 5.4): the target workspace is the user's valid designated HQ, and
+// the HQ's email binding names exactly the account the payload sends from. The
+// OAuth send-scope gate is enforced downstream by Gmail (a read-only token
+// yields ErrPermissionDenied), which is the staged-consent design.
+type sendAuthorizer struct {
+	hq         *personalhq.Service
+	workspaces workspace.Store
+}
+
+func (a *sendAuthorizer) AuthorizeSend(ctx context.Context, userID, workspaceID string, payload mailbox.ReplyPayload) error {
+	if a == nil || a.hq == nil || a.workspaces == nil {
+		return mailbox.ErrSendUnauthorized
+	}
+	status, err := a.hq.Status(ctx, userID)
+	if err != nil || status == nil || !status.Valid || !strings.EqualFold(status.WorkspaceID, strings.TrimSpace(workspaceID)) {
+		return mailbox.ErrSendUnauthorized
+	}
+	ws, err := a.workspaces.Get(workspaceID)
+	if err != nil || ws == nil {
+		return mailbox.ErrSendUnauthorized
+	}
+	binding, ok := emailBindingFor(ws)
+	if !ok || !strings.EqualFold(stringFromConfig(binding.Config, "account_id"), strings.TrimSpace(payload.AccountID)) {
+		return mailbox.ErrSendUnauthorized
+	}
+	return nil
+}
+
+// logAuditSink records send-lifecycle events to the structured log
+// (metadata-only, task 5.10). Durable persistence is a future enhancement.
+type logAuditSink struct{}
+
+func (logAuditSink) RecordSendEvent(e mailbox.SendAuditEvent) {
+	logger.Info("mail send audit", logger.Fields{
+		"event": e.Event, "user_id": e.UserID, "workspace_id": e.WorkspaceID,
+		"proposal_id": e.ProposalID, "account_id": e.AccountID,
+		"recipient_count": e.RecipientCount, "detail": e.Detail,
+	})
+}
+
+// replyService implements personalhqhttp.ReplyService, composing reply proposals
+// from the HQ's connected account and routing every send through the broker.
+type replyService struct {
+	hq         *personalhq.Service
+	workspaces workspace.Store
+	accounts   emailAccountResolver
+	reader     mailbox.MailboxProvider
+	broker     *mailbox.Broker
+}
+
+func newReplyService(hq *personalhq.Service, workspaces workspace.Store, accounts emailAccountResolver, reader mailbox.MailboxProvider, broker *mailbox.Broker) *replyService {
+	return &replyService{hq: hq, workspaces: workspaces, accounts: accounts, reader: reader, broker: broker}
+}
+
+// hqAccount resolves the user's HQ workspace ID and its connected mailbox account.
+func (s *replyService) hqAccount(ctx context.Context, userID string) (string, mailbox.Account, error) {
+	status, err := s.hq.Status(ctx, userID)
+	if err != nil || status == nil || !status.Valid {
+		return "", mailbox.Account{}, fmt.Errorf("no valid Personal HQ is designated")
+	}
+	ws, err := s.workspaces.Get(status.WorkspaceID)
+	if err != nil || ws == nil {
+		return "", mailbox.Account{}, fmt.Errorf("the Personal HQ workspace could not be loaded")
+	}
+	binding, ok := emailBindingFor(ws)
+	if !ok {
+		return "", mailbox.Account{}, fmt.Errorf("no email account is connected to your Personal HQ")
+	}
+	acc, err := s.accounts.GetEmailAccount(ctx, stringFromConfig(binding.Config, "account_id"))
+	if err != nil || acc == nil {
+		return "", mailbox.Account{}, fmt.Errorf("the connected email account could not be loaded")
+	}
+	return ws.ID, mailbox.Account{ID: acc.ID, Provider: string(acc.Provider), EmailAddress: acc.EmailAddress}, nil
+}
+
+func (s *replyService) DraftReply(ctx context.Context, userID, threadID, body string) (*mailbox.ReplyProposal, error) {
+	wsID, acc, err := s.hqAccount(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := mailbox.ComposeReply(ctx, s.reader, acc, threadID, body)
+	if err != nil {
+		return nil, err
+	}
+	return s.broker.CreateProposal(ctx, userID, wsID, payload)
+}
+
+func (s *replyService) GetProposal(userID, id string) (*mailbox.ReplyProposal, error) {
+	return s.broker.GetProposal(userID, id)
+}
+
+func (s *replyService) ListProposals(userID string) []*mailbox.ReplyProposal {
+	return s.broker.ListProposals(userID)
+}
+
+func (s *replyService) EditProposal(ctx context.Context, userID, id string, to []string, subject, body string) (*mailbox.ReplyProposal, error) {
+	current, err := s.broker.GetProposal(userID, id)
+	if err != nil {
+		return nil, err
+	}
+	payload := current.Payload
+	if to != nil {
+		payload.To = to
+	}
+	payload.Subject = subject
+	payload.Body = body
+	return s.broker.EditProposal(ctx, userID, id, payload)
+}
+
+func (s *replyService) CancelProposal(userID, id string) error {
+	return s.broker.CancelProposal(userID, id)
+}
+
+func (s *replyService) ConfirmSend(ctx context.Context, userID, id, expectedHash string) (*mailbox.ReplyProposal, error) {
+	return s.broker.ConfirmSend(ctx, userID, id, expectedHash)
+}
+
+var _ personalhqhttp.ReplyService = (*replyService)(nil)

--- a/internal/server/mailbox_reply_test.go
+++ b/internal/server/mailbox_reply_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+	"github.com/johnjallday/ori-agent/internal/mailbox"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+	"github.com/johnjallday/ori-agent/internal/vault"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// fakeReader returns a canned thread for ComposeReply; SearchThreads is unused.
+type fakeReader struct{}
+
+func (fakeReader) SearchThreads(ctx context.Context, a mailbox.Account, q mailbox.Query) (mailbox.ThreadPage, error) {
+	return mailbox.ThreadPage{}, nil
+}
+func (fakeReader) GetThread(ctx context.Context, a mailbox.Account, id string) (mailbox.Thread, error) {
+	return mailbox.Thread{
+		ID: id, Subject: "Need your review",
+		Participants: []mailbox.Participant{{Address: "dana@partner.com"}},
+		Messages: []mailbox.Message{{
+			ID: "m1", From: mailbox.Participant{Address: "dana@partner.com"}, Subject: "Need your review",
+		}},
+	}, nil
+}
+
+// recordingSender counts sends.
+type recordingSender struct{ calls int }
+
+func (r *recordingSender) SendReply(ctx context.Context, a mailbox.Account, p mailbox.ReplyPayload) (mailbox.SendResult, error) {
+	r.calls++
+	return mailbox.SendResult{ProviderMessageID: "sent-1", ThreadID: p.SourceThreadID}, nil
+}
+
+func newReplyFixture(t *testing.T) (*replyService, *recordingSender, string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := database.Open(ctx, &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	profiles := userprofile.NewSQLiteStore(db)
+	sessionStore := session.NewSQLiteStore(db)
+	hq := personalhq.NewService(profiles, sessionStore)
+	userID := userprofile.LocalUserID
+	_ = profiles.Upsert(ctx, &userprofile.UserProfile{ID: userID})
+	_ = sessionStore.CreateWorkspace(ctx, &session.Workspace{ID: "hq-1", Name: "HQ", Kind: session.WorkspaceKindWorkspace, OwnerUserID: userID, Status: session.WorkspaceStatusActive})
+	if _, err := hq.Designate(ctx, userID, "hq-1"); err != nil {
+		t.Fatalf("designate: %v", err)
+	}
+
+	wstore := workspace.NewInMemoryStore()
+	_ = wstore.Save(&workspace.Workspace{
+		ID: "hq-1",
+		MCPBindings: []workspace.MCPBinding{{
+			ID: "b1", ServerName: "gmail", Enabled: true,
+			Config: map[string]any{"account_id": "acct-1", "allowed_actions": []any{"read", "search"}},
+		}},
+	})
+	accounts := fakeAccounts{acc: &vault.EmailAccount{ID: "acct-1", Provider: vault.EmailProviderGmail, EmailAddress: "me@example.com"}}
+	sender := &recordingSender{}
+	broker := mailbox.NewBroker(sender, &sendAuthorizer{hq: hq, workspaces: wstore}, logAuditSink{})
+	return newReplyService(hq, wstore, accounts, fakeReader{}, broker), sender, userID
+}
+
+func TestReplyServiceDraftThenConfirmSends(t *testing.T) {
+	svc, sender, userID := newReplyFixture(t)
+	ctx := context.Background()
+
+	p, err := svc.DraftReply(ctx, userID, "t1", "Looks good to me.")
+	if err != nil {
+		t.Fatalf("DraftReply: %v", err)
+	}
+	if p.Status != mailbox.ProposalDraft {
+		t.Fatalf("expected a draft, got %v", p.Status)
+	}
+	if p.Payload.Subject != "Re: Need your review" || len(p.Payload.To) != 1 || p.Payload.To[0] != "dana@partner.com" {
+		t.Fatalf("compose produced wrong payload: %+v", p.Payload)
+	}
+	// A draft must NOT have sent anything.
+	if sender.calls != 0 {
+		t.Fatal("drafting must never send")
+	}
+
+	final, err := svc.ConfirmSend(ctx, userID, p.ID, p.Hash())
+	if err != nil {
+		t.Fatalf("ConfirmSend: %v", err)
+	}
+	if final.Status != mailbox.ProposalSent || sender.calls != 1 {
+		t.Fatalf("expected exactly one send, status=%v calls=%d", final.Status, sender.calls)
+	}
+}
+
+func TestReplyServiceEditThenStaleConfirmRejected(t *testing.T) {
+	svc, sender, userID := newReplyFixture(t)
+	ctx := context.Background()
+	p, err := svc.DraftReply(ctx, userID, "t1", "first")
+	if err != nil {
+		t.Fatalf("DraftReply: %v", err)
+	}
+	staleHash := p.Hash()
+	if _, err := svc.EditProposal(ctx, userID, p.ID, nil, p.Payload.Subject, "edited body"); err != nil {
+		t.Fatalf("EditProposal: %v", err)
+	}
+	if _, err := svc.ConfirmSend(ctx, userID, p.ID, staleHash); !errors.Is(err, mailbox.ErrPayloadChanged) {
+		t.Fatalf("stale confirm must be rejected, got %v", err)
+	}
+	if sender.calls != 0 {
+		t.Fatal("a rejected confirm must not send")
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -819,6 +819,11 @@ func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("GET /api/personal-hq/email/status", s.Handlers.PersonalHQ.MailboxStatusHandler)
 		mux.HandleFunc("POST /api/personal-hq/email/link", s.Handlers.PersonalHQ.LinkMailbox)
 		mux.HandleFunc("POST /api/personal-hq/email/unlink", s.Handlers.PersonalHQ.UnlinkMailbox)
+		mux.HandleFunc("POST /api/personal-hq/mail/draft", s.Handlers.PersonalHQ.DraftReply)
+		mux.HandleFunc("GET /api/personal-hq/mail/proposals", s.Handlers.PersonalHQ.ListProposals)
+		mux.HandleFunc("POST /api/personal-hq/mail/edit", s.Handlers.PersonalHQ.EditReply)
+		mux.HandleFunc("POST /api/personal-hq/mail/cancel", s.Handlers.PersonalHQ.CancelReply)
+		mux.HandleFunc("POST /api/personal-hq/mail/confirm", s.Handlers.PersonalHQ.ConfirmSend)
 	}
 }
 

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -6229,6 +6229,65 @@ body:has(#workspaceHub.is-hq-guided) #hubSupportChat {
   color: var(--text-secondary);
 }
 
+/* Personal HQ confirm-gated reply review cards (#hqMailReviewMount). */
+.hq-reply-card {
+  margin: 0.75rem 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--accent-color, var(--border-color));
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.hq-reply-heading {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.hq-reply-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.15rem 0.6rem;
+  margin: 0 0 0.5rem;
+  font-size: 0.82rem;
+}
+
+.hq-reply-meta dt {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.hq-reply-meta dd {
+  margin: 0;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.hq-reply-body {
+  margin: 0 0 0.5rem;
+  padding: 0.5rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: inherit;
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  background: var(--bg-primary, transparent);
+  border-radius: var(--radius-sm, 0.25rem);
+}
+
+.hq-reply-note {
+  margin: 0 0 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.hq-reply-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .hq-resume-text {
   flex: 1 1 auto;
   min-width: 12rem;

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -120,6 +120,32 @@ export function emailStatusView(status) {
   };
 }
 
+// replyProposalView turns a reply proposal (from the mail broker) into the
+// confirm-gated review view-model. Only draft/failed proposals are actionable
+// (sendable); everything else is terminal. The exact reviewed payload_hash is
+// carried so a send binds to precisely what the user saw.
+export function replyProposalView(p) {
+  if (!p) return { show: false };
+  const status = p.status || 'draft';
+  const payload = p.payload || {};
+  const view = {
+    show: true,
+    id: p.id,
+    status,
+    to: Array.isArray(payload.to) ? payload.to.join(', ') : '',
+    subject: payload.subject || '',
+    body: payload.body || '',
+    payloadHash: p.payload_hash || '',
+    canSend: status === 'draft' || status === 'failed',
+    actionLabel: status === 'failed' ? 'Retry send' : 'Send'
+  };
+  if (status === 'failed') view.statusNote = 'The last send attempt failed — you can retry.';
+  else if (status === 'sent') view.statusNote = 'Sent';
+  else if (status === 'expired') view.statusNote = 'This draft expired.';
+  else view.statusNote = '';
+  return view;
+}
+
 (function () {
   if (typeof document === 'undefined') return;
 
@@ -729,6 +755,116 @@ export function emailStatusView(status) {
     renderEmail(mount, emailStatusView(emailStatus));
   }
 
+  async function fetchProposals() {
+    const res = await fetch('/api/personal-hq/mail/proposals', { headers: { Accept: 'application/json' } });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data.proposals) ? data.proposals : [];
+  }
+
+  // renderReplyCard builds one confirm-gated review card using textContent for
+  // all user/email-derived fields (never innerHTML), so untrusted recipients,
+  // subject, and body can never inject markup.
+  function renderReplyCard(view) {
+    const card = document.createElement('div');
+    card.className = 'hq-reply-card';
+
+    const heading = document.createElement('h4');
+    heading.className = 'hq-reply-heading';
+    heading.textContent = 'Review reply before sending';
+    card.appendChild(heading);
+
+    const meta = document.createElement('dl');
+    meta.className = 'hq-reply-meta';
+    [['To', view.to], ['Subject', view.subject]].forEach(([label, value]) => {
+      const dt = document.createElement('dt');
+      dt.textContent = label;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      meta.append(dt, dd);
+    });
+    card.appendChild(meta);
+
+    const body = document.createElement('pre');
+    body.className = 'hq-reply-body';
+    body.textContent = view.body;
+    card.appendChild(body);
+
+    if (view.statusNote) {
+      const note = document.createElement('p');
+      note.className = 'hq-reply-note';
+      note.textContent = view.statusNote;
+      card.appendChild(note);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'hq-reply-actions';
+
+    const sendBtn = document.createElement('button');
+    sendBtn.type = 'button';
+    sendBtn.className = 'modern-btn modern-btn-primary modern-btn-sm';
+    sendBtn.textContent = view.actionLabel;
+    sendBtn.addEventListener('click', async () => {
+      sendBtn.disabled = true;
+      try {
+        await postJSON('/api/personal-hq/mail/confirm', { id: view.id, expected_hash: view.payloadHash });
+        toast('Your reply was sent.', 'Sent', 'success');
+        await wireMailReview();
+      } catch (e) {
+        toast(e && e.message ? e.message : 'The reply could not be sent.', 'Send failed', 'danger');
+        sendBtn.disabled = false;
+      }
+    });
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+    cancelBtn.textContent = 'Discard';
+    cancelBtn.addEventListener('click', async () => {
+      try {
+        await postJSON('/api/personal-hq/mail/cancel', { id: view.id });
+        await wireMailReview();
+      } catch (_) {
+        toast('Could not discard the draft.', 'Error', 'danger');
+      }
+    });
+
+    actions.append(sendBtn, cancelBtn);
+    card.appendChild(actions);
+    return card;
+  }
+
+  // wireMailReview shows confirm-gated review cards for actionable reply drafts.
+  // Additive: a no-op without #hqMailReviewMount or a valid HQ.
+  async function wireMailReview() {
+    const mount = document.getElementById('hqMailReviewMount');
+    if (!mount) return;
+    let status;
+    try {
+      status = await fetchStatus();
+    } catch (_) {
+      return;
+    }
+    if (!status || !status.valid) {
+      mount.hidden = true;
+      return;
+    }
+    let proposals;
+    try {
+      proposals = await fetchProposals();
+    } catch (_) {
+      return;
+    }
+    const actionable = proposals.filter(p => p.status === 'draft' || p.status === 'failed');
+    mount.innerHTML = '';
+    if (!actionable.length) {
+      mount.hidden = true;
+      return;
+    }
+    mount.hidden = false;
+    actionable.forEach(p => mount.appendChild(renderReplyCard(replyProposalView(p))));
+  }
+
   function init() {
     wireGuided();
     wireResume();
@@ -739,6 +875,7 @@ export function emailStatusView(status) {
     refreshResume();
     wireUpgrade();
     wireEmail();
+    wireMailReview();
   }
 
   if (document.readyState === 'loading') {

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView } from './personal-hq-onboarding.js';
+import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView } from './personal-hq-onboarding.js';
 
 function status(overrides) {
   return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
@@ -125,4 +125,30 @@ test('emailStatusView: never-connected offers Connect and promises read-only + c
   assert.equal(view.action, 'connect');
   assert.match(view.detail, /read-only/i);
   assert.match(view.detail, /confirmation/i);
+});
+
+test('replyProposalView: a draft is sendable and carries the exact reviewed payload hash', () => {
+  const view = replyProposalView({
+    id: 'p1', status: 'draft', payload_hash: 'abc',
+    payload: { to: ['dana@x.com', 'sam@x.com'], subject: 'Re: hi', body: 'Sounds good.' }
+  });
+  assert.equal(view.canSend, true);
+  assert.equal(view.actionLabel, 'Send');
+  assert.equal(view.to, 'dana@x.com, sam@x.com');
+  assert.equal(view.subject, 'Re: hi');
+  assert.equal(view.body, 'Sounds good.');
+  assert.equal(view.payloadHash, 'abc');
+});
+
+test('replyProposalView: a failed draft is retryable', () => {
+  const view = replyProposalView({ id: 'p1', status: 'failed', payload: {} });
+  assert.equal(view.canSend, true);
+  assert.equal(view.actionLabel, 'Retry send');
+  assert.match(view.statusNote, /failed/i);
+});
+
+test('replyProposalView: a sent proposal is terminal (not sendable)', () => {
+  const view = replyProposalView({ id: 'p1', status: 'sent', payload: {} });
+  assert.equal(view.canSend, false);
+  assert.equal(view.statusNote, 'Sent');
 });

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -277,6 +277,9 @@
         <!-- Personal HQ email connect/grant/repair card: shown for a valid
              designated HQ. Additive; stays hidden otherwise. -->
         <div id="hqEmailMount" class="hq-email-mount" hidden></div>
+        <!-- Personal HQ confirm-gated reply review: renders draft replies the
+             Inbox agent prepared, for explicit user confirmation. Additive. -->
+        <div id="hqMailReviewMount" class="hq-reply-mount" hidden></div>
       </section>
 
       <section id="launcherSummaryPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabSummary" hidden>


### PR DESCRIPTION
**Group 5 of the Personal HQ Assistant epic** (sub-PR into `epic/personal-hq-assistant`). The confirm-gated outbound path: the Inbox agent drafts replies, the user reviews the exact message, and **every** send funnels through one broker with explicit confirmation. This is the security-critical group.

## What's in this PR (3 commits)

**Broker + send core**
- `send.go` — `ReplyPayload` with a content hash that binds a confirmation to exactly what the user reviewed; `MailSender` kept separate from the read interface so a read-only wiring can never send.
- `gmail.go` — `SendReply` with reply threading (In-Reply-To/References + ThreadId) and CRLF header-injection prevention. Send scope enforced by Gmail (read-only token → permission denied), matching staged consent.
- `broker.go` — the single send entry point. Local proposals never touch Gmail until confirmed; `ConfirmSend` is atomic and single-use (Draft→Sending under the lock rejects replay/concurrent), binds to the exact payload hash (edit/tamper → rejected), expires drafts, re-authorizes right before sending, lands failures in a retryable state, and emits metadata-only audit events.

**Reachable flow**
- `ComposeReply` builds a bounded reply skeleton from an authorized source thread (read-only).
- `sendAuthorizer` re-evaluates HQ designation + binding + account at create and confirm; `logAuditSink` records metadata-only events.
- `personalhqhttp` endpoints: `mail/{draft,proposals,edit,cancel,confirm}` (broker errors → 403/404/409, no content leak; confirm carries `expected_hash`).
- `mail_draft_reply` agent tool (Inbox-gated, never sends) wired into chat + task factories.
- Home review UI: `replyProposalView` + confirm-gated cards rendered with `textContent` only (untrusted recipients/subject/body can't inject markup); Send echoes the reviewed hash, Discard cancels.

## Verification
- `go build ./...` + `go vet` clean
- Go tests (incl. `-race` on the broker): tampering, replay, concurrent-sends-once, expiry, unauthorized/revoked, wrong-owner, retryable failure, audit redaction, Gmail threading + header injection, reply-service draft→confirm, edit-invalidation, tool exposure
- JS: `replyProposalView` states; all **763** module tests + eslint clean

## Deferred
- Playwright (5.13) — folded into the epic-level browser pass.
- Durable audit persistence (currently structured logs) — noted follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)