### PR TITLE
feat(personal-hq): Group 6 — structured follow-ups (domain + API + Home projection)

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -10,7 +10,7 @@ import (
 
 // schemaVersion is the current database schema version.
 // Increment this when adding new migrations.
-const schemaVersion = 31
+const schemaVersion = 32
 
 // migrate runs all pending migrations to bring the database up to the current schema.
 func (db *DB) migrate(ctx context.Context) error {
@@ -127,6 +127,8 @@ func (db *DB) runMigration(ctx context.Context, version int) error {
 		return db.migration030PersonalHQ(ctx)
 	case 31:
 		return db.migration031DailyBrief(ctx)
+	case 32:
+		return db.migration032FollowUps(ctx)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -1238,6 +1240,56 @@ func (db *DB) migration029WorkspaceNativeMCPOptIn(ctx context.Context) error {
 // notification per revision). Keyed by workspace_id (the designated HQ),
 // not just user_id, so replacing or clearing an HQ never carries
 // configuration or history onto a different workspace.
+// migration032FollowUps creates the dedicated structured follow-up domain
+// (contract §2): personal commitments/dependencies with their own lifecycle and
+// source-based deduplication — deliberately NOT reusing Action Center
+// opportunities (which are title-deduped mission findings).
+func (db *DB) migration032FollowUps(ctx context.Context) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS personal_hq_followup (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			workspace_id TEXT NOT NULL,
+			category TEXT NOT NULL,
+			direction TEXT NOT NULL DEFAULT 'none',
+			title TEXT NOT NULL,
+			detail TEXT NOT NULL DEFAULT '',
+			counterparty TEXT NOT NULL DEFAULT '',
+			source_type TEXT NOT NULL DEFAULT 'manual',
+			source_id TEXT NOT NULL DEFAULT '',
+			source_account_id TEXT NOT NULL DEFAULT '',
+			dedup_key TEXT NOT NULL DEFAULT '',
+			provenance TEXT NOT NULL DEFAULT 'manual',
+			confidence TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			due_at DATETIME,
+			snoozed_until DATETIME,
+			last_nudged_at DATETIME,
+			related_workspace_id TEXT NOT NULL DEFAULT '',
+			related_task_id TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			completed_at DATETIME,
+			dismissed_at DATETIME
+		)`,
+		// Source-based dedup: a sourced follow-up is unique per user+dedup_key,
+		// enforced at the DB boundary so reprocessing the same thread can never
+		// create a duplicate. Manual items (empty dedup_key) are exempt.
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_personal_hq_followup_dedup
+			ON personal_hq_followup(user_id, dedup_key)
+			WHERE dedup_key != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_personal_hq_followup_user_status ON personal_hq_followup(user_id, status)`,
+		`CREATE INDEX IF NOT EXISTS idx_personal_hq_followup_due ON personal_hq_followup(user_id, status, due_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_personal_hq_followup_updated ON personal_hq_followup(user_id, status, updated_at)`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to create follow-up schema: %w", err)
+		}
+	}
+	return nil
+}
+
 func (db *DB) migration031DailyBrief(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS daily_brief_config (

--- a/internal/followup/followup_test.go
+++ b/internal/followup/followup_test.go
@@ -1,0 +1,167 @@
+package followup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+)
+
+func newTestService(t *testing.T) (*Service, *SQLiteStore) {
+	t.Helper()
+	db, err := database.Open(context.Background(), &database.Config{InMemory: true, WALMode: false})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := NewSQLiteStore(db)
+	return NewService(store), store
+}
+
+func emailInput(userID, threadID, title string) CaptureInput {
+	return CaptureInput{
+		UserID: userID, WorkspaceID: "hq-1", Category: CategoryWaitingOn, Direction: DirectionInbound,
+		Title: title, Source: SourceRef{Type: "email_thread", ID: threadID, AccountID: "acct-1"},
+		Provenance: ProvenanceExplicit, Confidence: ConfidenceHigh,
+	}
+}
+
+func TestCaptureDeduplicatesBySource(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+
+	f1, err := svc.Capture(ctx, emailInput("u1", "t1", "Waiting on Dana's quote"))
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if f1.Status != StatusActive {
+		t.Fatalf("explicit high-confidence should be active, got %v", f1.Status)
+	}
+
+	// Reprocess the same thread with a refreshed title → updates in place.
+	f2, err := svc.Capture(ctx, emailInput("u1", "t1", "Waiting on Dana's revised quote"))
+	if err != nil {
+		t.Fatalf("recapture: %v", err)
+	}
+	if f2.ID != f1.ID {
+		t.Fatal("reprocessing the same source must not create a second follow-up")
+	}
+	items, _ := store.List(ctx, Filter{UserID: "u1"})
+	if len(items) != 1 || items[0].Title != "Waiting on Dana's revised quote" {
+		t.Fatalf("expected one updated follow-up, got %+v", items)
+	}
+}
+
+func TestInferredBelowThresholdIsCandidate(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	in := emailInput("u1", "t2", "Maybe reply to Sam")
+	in.Provenance = ProvenanceInferred
+	in.Confidence = ConfidenceMedium
+	f, err := svc.Capture(ctx, in)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if f.Status != StatusCandidate {
+		t.Fatalf("inferred medium-confidence must enter as a candidate, got %v", f.Status)
+	}
+	// High-confidence inference activates automatically.
+	in2 := emailInput("u1", "t3", "Send the deck")
+	in2.Provenance = ProvenanceInferred
+	in2.Confidence = ConfidenceHigh
+	f2, _ := svc.Capture(ctx, in2)
+	if f2.Status != StatusActive {
+		t.Fatalf("high-confidence inference should be active, got %v", f2.Status)
+	}
+}
+
+func TestLifecycleTransitions(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	in := emailInput("u1", "t4", "Owe Maya a proposal")
+	in.Provenance = ProvenanceInferred
+	in.Confidence = ConfidenceLow
+	f, _ := svc.Capture(ctx, in) // candidate
+
+	if _, err := svc.ConfirmCandidate(ctx, "u1", f.ID); err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+	if got, _ := svc.Snooze(ctx, "u1", f.ID, time.Now().Add(time.Hour)); got.Status != StatusSnoozed {
+		t.Fatalf("snooze failed: %v", got.Status)
+	}
+	if got, _ := svc.Complete(ctx, "u1", f.ID); got.Status != StatusCompleted || got.CompletedAt == nil {
+		t.Fatalf("complete failed: %+v", got)
+	}
+	if got, _ := svc.Reopen(ctx, "u1", f.ID); got.Status != StatusActive || got.CompletedAt != nil {
+		t.Fatalf("reopen failed: %+v", got)
+	}
+	if got, _ := svc.Dismiss(ctx, "u1", f.ID); got.Status != StatusDismissed {
+		t.Fatalf("dismiss failed: %v", got.Status)
+	}
+}
+
+func TestHomeProjectionStaleFirstAndCapped(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+	svc.now = func() time.Time { return base }
+
+	// One stale (old update, no due date) and one fresh active.
+	stale, _ := svc.Capture(ctx, emailInput("u1", "stale", "old loop"))
+	fresh, _ := svc.Capture(ctx, emailInput("u1", "fresh", "new loop"))
+	// Backdate the stale one's updated_at beyond the window.
+	stale.UpdatedAt = base.Add(-StalenessWindow - time.Hour)
+	_ = store.Update(ctx, stale)
+
+	proj, err := svc.HomeProjection(ctx, "u1")
+	if err != nil {
+		t.Fatalf("projection: %v", err)
+	}
+	if len(proj) != 2 || proj[0].ID != stale.ID {
+		t.Fatalf("stale item must project first, got %+v", proj)
+	}
+	_ = fresh
+}
+
+func TestDueForNudgeIsIdempotentPerWindow(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+	svc.now = func() time.Time { return base }
+
+	f, _ := svc.Capture(ctx, emailInput("u1", "t9", "stale loop"))
+	f.UpdatedAt = base.Add(-StalenessWindow - time.Hour)
+	_ = store.Update(ctx, f)
+
+	due, _ := svc.DueForNudge(ctx, "u1")
+	if len(due) != 1 {
+		t.Fatalf("expected one due nudge, got %d", len(due))
+	}
+	if err := svc.MarkNudged(ctx, "u1", f.ID); err != nil {
+		t.Fatalf("mark nudged: %v", err)
+	}
+	// Within the window, no repeat nudge.
+	if due, _ := svc.DueForNudge(ctx, "u1"); len(due) != 0 {
+		t.Fatalf("must not re-nudge within the window, got %d", len(due))
+	}
+}
+
+func TestWakeReactivatesElapsedSnooze(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+	svc.now = func() time.Time { return base }
+	f, _ := svc.Capture(ctx, emailInput("u1", "t10", "snoozed loop"))
+	_, _ = svc.Snooze(ctx, "u1", f.ID, base.Add(time.Hour))
+
+	svc.now = func() time.Time { return base.Add(2 * time.Hour) }
+	woken, err := svc.Wake(ctx)
+	if err != nil || woken != 1 {
+		t.Fatalf("expected 1 woken, got %d err=%v", woken, err)
+	}
+	got, _ := svc.Get(ctx, "u1", f.ID)
+	if got.Status != StatusActive {
+		t.Fatalf("snooze should have elapsed to active, got %v", got.Status)
+	}
+}

--- a/internal/followup/service.go
+++ b/internal/followup/service.go
@@ -1,0 +1,313 @@
+package followup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// HomeProjectionCap bounds how many follow-ups the Home projection shows
+// (contract §2.5); the full list lives in the Personal HQ management panel.
+const HomeProjectionCap = 5
+
+// NudgeWindow is the minimum spacing between reminders for one follow-up, so a
+// stale item is nudged at most once per window (contract §2.4).
+const NudgeWindow = 24 * time.Hour
+
+// Store is the persistence contract the service needs. *SQLiteStore satisfies it.
+type Store interface {
+	Create(ctx context.Context, f *FollowUp) error
+	Get(ctx context.Context, userID, id string) (*FollowUp, error)
+	GetByDedupKey(ctx context.Context, userID, dedupKey string) (*FollowUp, error)
+	List(ctx context.Context, f Filter) ([]*FollowUp, error)
+	Update(ctx context.Context, f *FollowUp) error
+	Delete(ctx context.Context, userID, id string) error
+}
+
+// Service is the follow-up domain service: capture, lifecycle, staleness, and
+// projection.
+type Service struct {
+	store Store
+	now   func() time.Time
+}
+
+// NewService constructs the follow-up service.
+func NewService(store Store) *Service { return &Service{store: store, now: time.Now} }
+
+// CaptureInput describes a follow-up to capture from a source or manual action.
+type CaptureInput struct {
+	UserID       string
+	WorkspaceID  string
+	Category     Category
+	Direction    Direction
+	Title        string
+	Detail       string
+	Counterparty string
+	Source       SourceRef
+	Provenance   Provenance
+	Confidence   Confidence
+	DueAt        *time.Time
+}
+
+// Capture creates a follow-up, or updates the existing one when the same source
+// is reprocessed (source-based dedup, contract §2.1/§6.5). A sourced item that
+// already exists and is still open has its title/detail refreshed; a
+// completed/dismissed one is left as the user left it (reprocessing does not
+// resurrect a closed loop).
+func (s *Service) Capture(ctx context.Context, in CaptureInput) (*FollowUp, error) {
+	if !ValidCategory(in.Category) {
+		return nil, fmt.Errorf("followup: invalid category %q", in.Category)
+	}
+	title := Truncate(in.Title, MaxTitleLen)
+	if title == "" {
+		return nil, errors.New("followup: title is required")
+	}
+	now := s.now().UTC()
+
+	dedupKey := DedupKey(in.UserID, in.Source.Type, in.Source.ID)
+	if dedupKey != "" {
+		existing, err := s.store.GetByDedupKey(ctx, in.UserID, dedupKey)
+		if err == nil && existing != nil {
+			if existing.IsOpen() {
+				existing.Title = title
+				if d := Truncate(in.Detail, MaxDetailLen); d != "" {
+					existing.Detail = d
+				}
+				existing.UpdatedAt = now
+				if err := s.store.Update(ctx, existing); err != nil {
+					return nil, err
+				}
+			}
+			return existing, nil
+		}
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+	}
+
+	f := &FollowUp{
+		ID:           uuid.NewString(),
+		UserID:       in.UserID,
+		WorkspaceID:  in.WorkspaceID,
+		Category:     in.Category,
+		Direction:    in.Direction,
+		Title:        title,
+		Detail:       Truncate(in.Detail, MaxDetailLen),
+		Counterparty: Truncate(in.Counterparty, MaxTitleLen),
+		Source:       in.Source,
+		DedupKey:     dedupKey,
+		Provenance:   in.Provenance,
+		Confidence:   in.Confidence,
+		Status:       initialStatus(in.Provenance, in.Confidence),
+		DueAt:        in.DueAt,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if f.Provenance == "" {
+		f.Provenance = ProvenanceManual
+	}
+	if f.Direction == "" {
+		f.Direction = DirectionNone
+	}
+	if err := s.store.Create(ctx, f); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// initialStatus decides whether a captured follow-up is immediately active or a
+// review candidate: only an inferred item below high confidence enters as a
+// candidate; explicit commitments and manual items are active (contract §2.3).
+func initialStatus(prov Provenance, conf Confidence) Status {
+	if prov == ProvenanceInferred && conf != ConfidenceHigh {
+		return StatusCandidate
+	}
+	return StatusActive
+}
+
+// Get / List pass through to the store.
+func (s *Service) Get(ctx context.Context, userID, id string) (*FollowUp, error) {
+	return s.store.Get(ctx, userID, id)
+}
+func (s *Service) List(ctx context.Context, f Filter) ([]*FollowUp, error) {
+	return s.store.List(ctx, f)
+}
+
+// transition applies fn to a loaded follow-up and persists it.
+func (s *Service) transition(ctx context.Context, userID, id string, fn func(*FollowUp) error) (*FollowUp, error) {
+	f, err := s.store.Get(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := fn(f); err != nil {
+		return nil, err
+	}
+	f.UpdatedAt = s.now().UTC()
+	if err := s.store.Update(ctx, f); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// ConfirmCandidate promotes an inferred candidate to active.
+func (s *Service) ConfirmCandidate(ctx context.Context, userID, id string) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		if f.Status != StatusCandidate {
+			return fmt.Errorf("followup: only a candidate can be confirmed")
+		}
+		f.Status = StatusActive
+		return nil
+	})
+}
+
+// Edit updates the user-editable fields of a follow-up.
+func (s *Service) Edit(ctx context.Context, userID, id, title, detail string, dueAt *time.Time) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		if t := Truncate(title, MaxTitleLen); t != "" {
+			f.Title = t
+		}
+		f.Detail = Truncate(detail, MaxDetailLen)
+		f.DueAt = dueAt
+		return nil
+	})
+}
+
+// Snooze puts an open follow-up to sleep until until.
+func (s *Service) Snooze(ctx context.Context, userID, id string, until time.Time) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		if !f.IsOpen() {
+			return fmt.Errorf("followup: only an open item can be snoozed")
+		}
+		u := until.UTC()
+		f.Status = StatusSnoozed
+		f.SnoozedUntil = &u
+		return nil
+	})
+}
+
+// Complete closes a follow-up as done.
+func (s *Service) Complete(ctx context.Context, userID, id string) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		now := s.now().UTC()
+		f.Status = StatusCompleted
+		f.CompletedAt = &now
+		return nil
+	})
+}
+
+// Dismiss closes a follow-up without completing it.
+func (s *Service) Dismiss(ctx context.Context, userID, id string) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		now := s.now().UTC()
+		f.Status = StatusDismissed
+		f.DismissedAt = &now
+		return nil
+	})
+}
+
+// Reopen returns a completed/dismissed follow-up to the active backlog.
+func (s *Service) Reopen(ctx context.Context, userID, id string) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		if f.Status != StatusCompleted && f.Status != StatusDismissed {
+			return fmt.Errorf("followup: only a closed item can be reopened")
+		}
+		f.Status = StatusActive
+		f.CompletedAt = nil
+		f.DismissedAt = nil
+		return nil
+	})
+}
+
+// LinkTask attaches a project task reference to a follow-up (a link, never a
+// move — the follow-up and the task are independent, contract §1).
+func (s *Service) LinkTask(ctx context.Context, userID, id string, ref TaskRef) (*FollowUp, error) {
+	return s.transition(ctx, userID, id, func(f *FollowUp) error {
+		f.RelatedTask = &ref
+		return nil
+	})
+}
+
+// Wake re-activates snoozed follow-ups whose snooze has elapsed. Returns how
+// many were woken. Intended to run before stale evaluation.
+func (s *Service) Wake(ctx context.Context) (int, error) {
+	items, err := s.store.List(ctx, Filter{Statuses: []Status{StatusSnoozed}})
+	if err != nil {
+		return 0, err
+	}
+	now := s.now().UTC()
+	woken := 0
+	for _, f := range items {
+		if f.SnoozedUntil != nil && !f.SnoozedUntil.After(now) {
+			f.Status = StatusActive
+			f.SnoozedUntil = nil
+			f.UpdatedAt = now
+			if err := s.store.Update(ctx, f); err != nil {
+				return woken, err
+			}
+			woken++
+		}
+	}
+	return woken, nil
+}
+
+// DueForNudge returns stale follow-ups for userID that have not been nudged
+// within NudgeWindow, so a reminder fires at most once per window (contract
+// §2.4). Callers mark each nudged via MarkNudged after delivering.
+func (s *Service) DueForNudge(ctx context.Context, userID string) ([]*FollowUp, error) {
+	items, err := s.store.List(ctx, Filter{UserID: userID, Statuses: []Status{StatusActive, StatusReopened}})
+	if err != nil {
+		return nil, err
+	}
+	now := s.now().UTC()
+	var out []*FollowUp
+	for _, f := range items {
+		if !f.IsStale(now) {
+			continue
+		}
+		if f.LastNudgedAt != nil && now.Sub(*f.LastNudgedAt) < NudgeWindow {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// MarkNudged stamps a follow-up as nudged now (idempotency for reminders).
+func (s *Service) MarkNudged(ctx context.Context, userID, id string) error {
+	_, err := s.transition(ctx, userID, id, func(f *FollowUp) error {
+		now := s.now().UTC()
+		f.LastNudgedAt = &now
+		return nil
+	})
+	return err
+}
+
+// HomeProjection returns the bounded set of follow-ups Home surfaces: due or
+// stale active items first, then other open items, capped at HomeProjectionCap
+// (contract §2.5). Deterministic ordering: stale-first, then oldest update.
+func (s *Service) HomeProjection(ctx context.Context, userID string) ([]*FollowUp, error) {
+	items, err := s.store.List(ctx, Filter{UserID: userID, OpenOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	now := s.now().UTC()
+	var stale, other []*FollowUp
+	for _, f := range items {
+		if f.Status == StatusCandidate {
+			continue // candidates await review; not projected as active items
+		}
+		if f.IsStale(now) {
+			stale = append(stale, f)
+		} else {
+			other = append(other, f)
+		}
+	}
+	projected := append(stale, other...)
+	if len(projected) > HomeProjectionCap {
+		projected = projected[:HomeProjectionCap]
+	}
+	return projected, nil
+}

--- a/internal/followup/sqlite_store.go
+++ b/internal/followup/sqlite_store.go
@@ -1,0 +1,208 @@
+package followup
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/database"
+)
+
+// ErrNotFound is returned when a follow-up does not exist for the requesting user.
+var ErrNotFound = errors.New("followup: not found")
+
+// SQLiteStore persists follow-ups in the shared SQLite database.
+type SQLiteStore struct {
+	db *database.DB
+}
+
+// NewSQLiteStore constructs a follow-up store over db.
+func NewSQLiteStore(db *database.DB) *SQLiteStore { return &SQLiteStore{db: db} }
+
+const followUpColumns = `id, user_id, workspace_id, category, direction, title, detail, counterparty,
+	source_type, source_id, source_account_id, dedup_key, provenance, confidence, status,
+	due_at, snoozed_until, last_nudged_at, related_workspace_id, related_task_id,
+	created_at, updated_at, completed_at, dismissed_at`
+
+// Create inserts a new follow-up.
+func (s *SQLiteStore) Create(ctx context.Context, f *FollowUp) error {
+	_, err := s.db.ExecContext(ctx, `INSERT INTO personal_hq_followup (`+followUpColumns+`)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		f.ID, f.UserID, f.WorkspaceID, string(f.Category), string(f.Direction), f.Title, f.Detail, f.Counterparty,
+		f.Source.Type, f.Source.ID, f.Source.AccountID, f.DedupKey, string(f.Provenance), string(f.Confidence), string(f.Status),
+		nullTime(f.DueAt), nullTime(f.SnoozedUntil), nullTime(f.LastNudgedAt),
+		taskWorkspace(f.RelatedTask), taskID(f.RelatedTask),
+		f.CreatedAt, f.UpdatedAt, nullTime(f.CompletedAt), nullTime(f.DismissedAt))
+	if err != nil {
+		return fmt.Errorf("followup create: %w", err)
+	}
+	return nil
+}
+
+// Get returns a follow-up by id, scoped to userID.
+func (s *SQLiteStore) Get(ctx context.Context, userID, id string) (*FollowUp, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+followUpColumns+` FROM personal_hq_followup WHERE id = ? AND user_id = ?`, id, userID)
+	f, err := scanFollowUp(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return f, err
+}
+
+// GetByDedupKey returns the existing sourced follow-up for a user+dedup key, or
+// ErrNotFound. Used by source-based upsert to avoid duplicates.
+func (s *SQLiteStore) GetByDedupKey(ctx context.Context, userID, dedupKey string) (*FollowUp, error) {
+	if strings.TrimSpace(dedupKey) == "" {
+		return nil, ErrNotFound
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT `+followUpColumns+` FROM personal_hq_followup WHERE user_id = ? AND dedup_key = ?`, userID, dedupKey)
+	f, err := scanFollowUp(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return f, err
+}
+
+// Filter narrows a list query.
+type Filter struct {
+	UserID   string
+	Statuses []Status // empty = any
+	OpenOnly bool     // convenience: active/snoozed/candidate/reopened
+}
+
+// List returns follow-ups matching the filter, most-recently-updated first.
+func (s *SQLiteStore) List(ctx context.Context, f Filter) ([]*FollowUp, error) {
+	var where []string
+	var args []any
+	// A blank UserID lists across all users (used by global maintenance sweeps
+	// like snooze-wake); a set UserID scopes to that user.
+	if strings.TrimSpace(f.UserID) != "" {
+		where = append(where, "user_id = ?")
+		args = append(args, f.UserID)
+	}
+
+	statuses := f.Statuses
+	if f.OpenOnly {
+		statuses = []Status{StatusActive, StatusSnoozed, StatusCandidate, StatusReopened}
+	}
+	if len(statuses) > 0 {
+		ph := make([]string, len(statuses))
+		for i, st := range statuses {
+			ph[i] = "?"
+			args = append(args, string(st))
+		}
+		where = append(where, "status IN ("+strings.Join(ph, ",")+")")
+	}
+
+	query := `SELECT ` + followUpColumns + ` FROM personal_hq_followup`
+	if len(where) > 0 {
+		query += ` WHERE ` + strings.Join(where, " AND ")
+	}
+	query += ` ORDER BY updated_at DESC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("followup list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*FollowUp
+	for rows.Next() {
+		fu, err := scanFollowUp(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fu)
+	}
+	return out, rows.Err()
+}
+
+// Update writes all mutable fields of an existing follow-up.
+func (s *SQLiteStore) Update(ctx context.Context, f *FollowUp) error {
+	res, err := s.db.ExecContext(ctx, `UPDATE personal_hq_followup SET
+		category=?, direction=?, title=?, detail=?, counterparty=?, provenance=?, confidence=?, status=?,
+		due_at=?, snoozed_until=?, last_nudged_at=?, related_workspace_id=?, related_task_id=?,
+		updated_at=?, completed_at=?, dismissed_at=?
+		WHERE id=? AND user_id=?`,
+		string(f.Category), string(f.Direction), f.Title, f.Detail, f.Counterparty, string(f.Provenance), string(f.Confidence), string(f.Status),
+		nullTime(f.DueAt), nullTime(f.SnoozedUntil), nullTime(f.LastNudgedAt), taskWorkspace(f.RelatedTask), taskID(f.RelatedTask),
+		f.UpdatedAt, nullTime(f.CompletedAt), nullTime(f.DismissedAt),
+		f.ID, f.UserID)
+	if err != nil {
+		return fmt.Errorf("followup update: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes a follow-up (used by retention).
+func (s *SQLiteStore) Delete(ctx context.Context, userID, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM personal_hq_followup WHERE id=? AND user_id=?`, id, userID)
+	return err
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFollowUp(row scanner) (*FollowUp, error) {
+	var f FollowUp
+	var category, direction, provenance, confidence, status string
+	var due, snoozed, nudged, completed, dismissed sql.NullTime
+	var relWS, relTask string
+	if err := row.Scan(
+		&f.ID, &f.UserID, &f.WorkspaceID, &category, &direction, &f.Title, &f.Detail, &f.Counterparty,
+		&f.Source.Type, &f.Source.ID, &f.Source.AccountID, &f.DedupKey, &provenance, &confidence, &status,
+		&due, &snoozed, &nudged, &relWS, &relTask,
+		&f.CreatedAt, &f.UpdatedAt, &completed, &dismissed,
+	); err != nil {
+		return nil, err
+	}
+	f.Category = Category(category)
+	f.Direction = Direction(direction)
+	f.Provenance = Provenance(provenance)
+	f.Confidence = Confidence(confidence)
+	f.Status = Status(status)
+	f.DueAt = scanTime(due)
+	f.SnoozedUntil = scanTime(snoozed)
+	f.LastNudgedAt = scanTime(nudged)
+	f.CompletedAt = scanTime(completed)
+	f.DismissedAt = scanTime(dismissed)
+	if relWS != "" || relTask != "" {
+		f.RelatedTask = &TaskRef{WorkspaceID: relWS, TaskID: relTask}
+	}
+	return &f, nil
+}
+
+func nullTime(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return *t
+}
+
+func scanTime(n sql.NullTime) *time.Time {
+	if !n.Valid {
+		return nil
+	}
+	t := n.Time
+	return &t
+}
+
+func taskWorkspace(r *TaskRef) string {
+	if r == nil {
+		return ""
+	}
+	return r.WorkspaceID
+}
+
+func taskID(r *TaskRef) string {
+	if r == nil {
+		return ""
+	}
+	return r.TaskID
+}

--- a/internal/followup/types.go
+++ b/internal/followup/types.go
@@ -1,0 +1,166 @@
+// Package followup implements the Personal HQ structured follow-up domain
+// (contract §2): personal commitments and dependencies with their own lifecycle
+// and source-based deduplication. It is deliberately NOT built on Action Center
+// opportunities — those are title-deduped mission findings with different
+// semantics.
+package followup
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// Category is the kind of open loop a follow-up represents (v1 set only).
+type Category string
+
+const (
+	CategoryIOwe             Category = "i_owe"
+	CategoryWaitingOn        Category = "waiting_on"
+	CategoryNeedsDecision    Category = "needs_decision"
+	CategoryRecurringCheckIn Category = "recurring_check_in"
+)
+
+// Direction records who owes whom.
+type Direction string
+
+const (
+	DirectionOutbound Direction = "outbound" // I owe them
+	DirectionInbound  Direction = "inbound"  // waiting on them
+	DirectionNone     Direction = "none"
+)
+
+// Provenance records how the follow-up was created.
+type Provenance string
+
+const (
+	ProvenanceExplicit Provenance = "explicit" // an unambiguous commitment in a source
+	ProvenanceInferred Provenance = "inferred" // model-inferred; enters as a candidate
+	ProvenanceManual   Provenance = "manual"   // user-created
+)
+
+// Confidence is the inference confidence (empty for manual/explicit).
+type Confidence string
+
+const (
+	ConfidenceLow    Confidence = "low"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceHigh   Confidence = "high"
+)
+
+// Status is the follow-up lifecycle state.
+type Status string
+
+const (
+	StatusCandidate Status = "candidate" // inferred, awaiting user confirmation
+	StatusActive    Status = "active"
+	StatusSnoozed   Status = "snoozed"
+	StatusCompleted Status = "completed"
+	StatusDismissed Status = "dismissed"
+	StatusReopened  Status = "reopened"
+)
+
+// SourceRef points at what a follow-up came from.
+type SourceRef struct {
+	Type      string `json:"type"` // email_thread | manual | journal
+	ID        string `json:"id,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
+}
+
+// TaskRef links a follow-up to a project task (a link, never ownership).
+type TaskRef struct {
+	WorkspaceID string `json:"workspace_id"`
+	TaskID      string `json:"task_id"`
+}
+
+// FollowUp is one tracked personal commitment/dependency.
+type FollowUp struct {
+	ID           string     `json:"id"`
+	UserID       string     `json:"user_id"`
+	WorkspaceID  string     `json:"workspace_id"`
+	Category     Category   `json:"category"`
+	Direction    Direction  `json:"direction"`
+	Title        string     `json:"title"`
+	Detail       string     `json:"detail,omitempty"`
+	Counterparty string     `json:"counterparty,omitempty"`
+	Source       SourceRef  `json:"source"`
+	DedupKey     string     `json:"dedup_key,omitempty"`
+	Provenance   Provenance `json:"provenance"`
+	Confidence   Confidence `json:"confidence,omitempty"`
+	Status       Status     `json:"status"`
+	DueAt        *time.Time `json:"due_at,omitempty"`
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+	LastNudgedAt *time.Time `json:"last_nudged_at,omitempty"`
+	RelatedTask  *TaskRef   `json:"related_task,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	DismissedAt  *time.Time `json:"dismissed_at,omitempty"`
+}
+
+// Bounds on stored text (contract §2.1).
+const (
+	MaxTitleLen  = 200
+	MaxDetailLen = 1000
+)
+
+// StalenessWindow is the default age after which an active follow-up with no due
+// date is considered stale (contract §2.4).
+const StalenessWindow = 7 * 24 * time.Hour
+
+// IsOpen reports whether the follow-up is in the active backlog.
+func (f FollowUp) IsOpen() bool {
+	switch f.Status {
+	case StatusActive, StatusSnoozed, StatusCandidate, StatusReopened:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsStale reports whether an active follow-up needs attention as of now: a due
+// date in the past, or (with no due date) no update within the staleness window.
+// Only active/reopened items go stale; snoozed items wait until their snooze.
+func (f FollowUp) IsStale(now time.Time) bool {
+	if f.Status != StatusActive && f.Status != StatusReopened {
+		return false
+	}
+	if f.DueAt != nil {
+		return !f.DueAt.After(now)
+	}
+	return now.Sub(f.UpdatedAt) >= StalenessWindow
+}
+
+// DedupKey returns the canonical source-dedup key for a sourced follow-up, or ""
+// for a manual/unsourced one (which is never auto-deduped). Reprocessing the same
+// source thread/message yields the same key so it updates rather than duplicates.
+func DedupKey(userID, sourceType, sourceID string) string {
+	sourceType = strings.TrimSpace(sourceType)
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceType == "" || sourceType == "manual" || sourceID == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(userID) + "|" + sourceType + "|" + sourceID))
+	return hex.EncodeToString(sum[:])
+}
+
+// ValidCategory reports whether c is a supported v1 category.
+func ValidCategory(c Category) bool {
+	switch c {
+	case CategoryIOwe, CategoryWaitingOn, CategoryNeedsDecision, CategoryRecurringCheckIn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Truncate bounds a string to n runes without splitting a multi-byte rune.
+func Truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return strings.TrimSpace(string(r[:n]))
+}

--- a/internal/personalhqhttp/followups.go
+++ b/internal/personalhqhttp/followups.go
@@ -1,0 +1,247 @@
+package personalhqhttp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/followup"
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+)
+
+// FollowUpAPI is the follow-up surface this handler needs, implemented by
+// *followup.Service. Kept as an interface for testability.
+type FollowUpAPI interface {
+	List(ctx context.Context, f followup.Filter) ([]*followup.FollowUp, error)
+	HomeProjection(ctx context.Context, userID string) ([]*followup.FollowUp, error)
+	Get(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+	Capture(ctx context.Context, in followup.CaptureInput) (*followup.FollowUp, error)
+	ConfirmCandidate(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+	Edit(ctx context.Context, userID, id, title, detail string, dueAt *time.Time) (*followup.FollowUp, error)
+	Snooze(ctx context.Context, userID, id string, until time.Time) (*followup.FollowUp, error)
+	Complete(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+	Dismiss(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+	Reopen(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+}
+
+// SetFollowUps wires the follow-up service.
+func (h *Handler) SetFollowUps(api FollowUpAPI) { h.followups = api }
+
+func (h *Handler) followUpsReady(w http.ResponseWriter, r *http.Request, method string) bool {
+	if !orihttp.RequireMethod(w, r, method) {
+		return false
+	}
+	if h == nil || h.followups == nil {
+		orihttp.ServiceUnavailable(w, "personal hq follow-ups are unavailable")
+		return false
+	}
+	return true
+}
+
+// ListFollowUps handles GET /api/personal-hq/followups?status=active,candidate.
+func (h *Handler) ListFollowUps(w http.ResponseWriter, r *http.Request) {
+	if !h.followUpsReady(w, r, http.MethodGet) {
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	filter := followup.Filter{UserID: userID}
+	if raw := strings.TrimSpace(r.URL.Query().Get("status")); raw != "" {
+		if strings.EqualFold(raw, "open") {
+			filter.OpenOnly = true
+		} else {
+			for _, s := range strings.Split(raw, ",") {
+				if s = strings.TrimSpace(s); s != "" {
+					filter.Statuses = append(filter.Statuses, followup.Status(s))
+				}
+			}
+		}
+	}
+	items, err := h.followups.List(r.Context(), filter)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to list follow-ups: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"followups": items})
+}
+
+// HomeFollowUps handles GET /api/personal-hq/followups/home: the bounded Home
+// projection (due/stale first, capped).
+func (h *Handler) HomeFollowUps(w http.ResponseWriter, r *http.Request) {
+	if !h.followUpsReady(w, r, http.MethodGet) {
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	items, err := h.followups.HomeProjection(r.Context(), userID)
+	if err != nil {
+		orihttp.InternalError(w, "Failed to load follow-ups: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"followups": items})
+}
+
+// CreateFollowUp handles POST /api/personal-hq/followups: manual create.
+func (h *Handler) CreateFollowUp(w http.ResponseWriter, r *http.Request) {
+	if !h.followUpsReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		Category     string `json:"category"`
+		Direction    string `json:"direction"`
+		Title        string `json:"title"`
+		Detail       string `json:"detail"`
+		Counterparty string `json:"counterparty"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.Title) == "" {
+		orihttp.BadRequest(w, "title is required")
+		return
+	}
+	cat := followup.Category(strings.TrimSpace(req.Category))
+	if !followup.ValidCategory(cat) {
+		orihttp.BadRequest(w, "category must be one of i_owe, waiting_on, needs_decision, recurring_check_in")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	created, err := h.followups.Capture(r.Context(), followup.CaptureInput{
+		UserID: userID, Category: cat, Direction: followup.Direction(strings.TrimSpace(req.Direction)),
+		Title: req.Title, Detail: req.Detail, Counterparty: req.Counterparty,
+		Source: followup.SourceRef{Type: "manual"}, Provenance: followup.ProvenanceManual,
+	})
+	if err != nil {
+		orihttp.BadRequest(w, err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"followup": created})
+}
+
+// followUpAction dispatches a status transition identified by the URL suffix.
+type followUpAction func(ctx context.Context, userID, id string) (*followup.FollowUp, error)
+
+func (h *Handler) handleFollowUpAction(w http.ResponseWriter, r *http.Request, action followUpAction) {
+	if !h.followUpsReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID string `json:"id"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.ID) == "" {
+		orihttp.BadRequest(w, "id is required")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	f, err := action(r.Context(), userID, req.ID)
+	if err != nil {
+		respondFollowUpError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"followup": f})
+}
+
+func (h *Handler) ConfirmFollowUp(w http.ResponseWriter, r *http.Request) {
+	h.handleFollowUpAction(w, r, h.followups.ConfirmCandidate)
+}
+func (h *Handler) CompleteFollowUp(w http.ResponseWriter, r *http.Request) {
+	h.handleFollowUpAction(w, r, h.followups.Complete)
+}
+func (h *Handler) DismissFollowUp(w http.ResponseWriter, r *http.Request) {
+	h.handleFollowUpAction(w, r, h.followups.Dismiss)
+}
+func (h *Handler) ReopenFollowUp(w http.ResponseWriter, r *http.Request) {
+	h.handleFollowUpAction(w, r, h.followups.Reopen)
+}
+
+// SnoozeFollowUp handles POST /api/personal-hq/followups/snooze {id, until}.
+func (h *Handler) SnoozeFollowUp(w http.ResponseWriter, r *http.Request) {
+	if !h.followUpsReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID    string `json:"id"`
+		Until string `json:"until"` // RFC3339
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	until, err := time.Parse(time.RFC3339, strings.TrimSpace(req.Until))
+	if err != nil {
+		orihttp.BadRequest(w, "until must be an RFC3339 timestamp")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	f, err := h.followups.Snooze(r.Context(), userID, req.ID, until)
+	if err != nil {
+		respondFollowUpError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"followup": f})
+}
+
+// EditFollowUp handles POST /api/personal-hq/followups/edit.
+func (h *Handler) EditFollowUp(w http.ResponseWriter, r *http.Request) {
+	if !h.followUpsReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		ID     string `json:"id"`
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+		DueAt  string `json:"due_at"` // RFC3339 or empty to clear
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.ID) == "" {
+		orihttp.BadRequest(w, "id is required")
+		return
+	}
+	var due *time.Time
+	if s := strings.TrimSpace(req.DueAt); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			orihttp.BadRequest(w, "due_at must be an RFC3339 timestamp")
+			return
+		}
+		due = &t
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	f, err := h.followups.Edit(r.Context(), userID, req.ID, req.Title, req.Detail, due)
+	if err != nil {
+		respondFollowUpError(w, err)
+		return
+	}
+	orihttp.Success(w, map[string]any{"followup": f})
+}
+
+func respondFollowUpError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, followup.ErrNotFound):
+		orihttp.NotFound(w, "That follow-up was not found")
+	default:
+		orihttp.BadRequest(w, err.Error())
+	}
+}

--- a/internal/personalhqhttp/handler.go
+++ b/internal/personalhqhttp/handler.go
@@ -20,6 +20,7 @@ type Handler struct {
 	upgrade       *personalhq.UpgradeCoordinator
 	mailboxLinker MailboxLinker
 	replies       ReplyService
+	followups     FollowUpAPI
 	provider      userprofile.UserProvider
 }
 

--- a/internal/server/builder.go
+++ b/internal/server/builder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/externalagentshttp"
 	"github.com/johnjallday/ori-agent/internal/fileshttp"
 	"github.com/johnjallday/ori-agent/internal/filewatcher"
+	"github.com/johnjallday/ori-agent/internal/followup"
 	"github.com/johnjallday/ori-agent/internal/gateway"
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/location"
@@ -238,6 +239,9 @@ type ServerBuilder struct {
 	// mailDrafter creates local reply proposals for the mail_draft_reply tool;
 	// nil until the vault system initializes it.
 	mailDrafter chathttp.MailDrafter
+
+	// followUpService is the structured follow-up domain service.
+	followUpService *followup.Service
 
 	// Daily Brief configuration, generation, and scheduling
 	dailyBriefService   *dailybrief.Service

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/featureflags"
 	"github.com/johnjallday/ori-agent/internal/fileshttp"
 	"github.com/johnjallday/ori-agent/internal/filewatcher"
+	"github.com/johnjallday/ori-agent/internal/followup"
 	"github.com/johnjallday/ori-agent/internal/locationhttp"
 	"github.com/johnjallday/ori-agent/internal/logger"
 	"github.com/johnjallday/ori-agent/internal/macwake"
@@ -176,6 +177,10 @@ func (b *ServerBuilder) initializeHandlers() {
 		// one provisioning path (task 2.9).
 		personalHQUpgrade := personalhq.NewUpgradeCoordinator(b.personalHQService, sessionStore, b.sessionHandler)
 		b.personalHQHandler = personalhqhttp.NewHandler(b.personalHQService, personalHQSetup, personalHQUpgrade, b.userProvider)
+		// Structured follow-ups (Group 6): a dedicated SQLite domain over the
+		// shared database.
+		b.followUpService = followup.NewService(followup.NewSQLiteStore(sessionStore.DB()))
+		b.personalHQHandler.SetFollowUps(b.followUpService)
 		// Initialize auto-classify handler for session classification
 		b.autoClassifyHandler = sessionhttp.NewAutoClassifyHandler(sessionStore, b.st, b.llmFactory, b.configManager)
 		// Initialize smart input handler for Workspace Hub classification

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -824,6 +824,15 @@ func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("POST /api/personal-hq/mail/edit", s.Handlers.PersonalHQ.EditReply)
 		mux.HandleFunc("POST /api/personal-hq/mail/cancel", s.Handlers.PersonalHQ.CancelReply)
 		mux.HandleFunc("POST /api/personal-hq/mail/confirm", s.Handlers.PersonalHQ.ConfirmSend)
+		mux.HandleFunc("GET /api/personal-hq/followups", s.Handlers.PersonalHQ.ListFollowUps)
+		mux.HandleFunc("GET /api/personal-hq/followups/home", s.Handlers.PersonalHQ.HomeFollowUps)
+		mux.HandleFunc("POST /api/personal-hq/followups", s.Handlers.PersonalHQ.CreateFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/confirm", s.Handlers.PersonalHQ.ConfirmFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/edit", s.Handlers.PersonalHQ.EditFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/snooze", s.Handlers.PersonalHQ.SnoozeFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/complete", s.Handlers.PersonalHQ.CompleteFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/dismiss", s.Handlers.PersonalHQ.DismissFollowUp)
+		mux.HandleFunc("POST /api/personal-hq/followups/reopen", s.Handlers.PersonalHQ.ReopenFollowUp)
 	}
 }
 

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -6288,6 +6288,48 @@ body:has(#workspaceHub.is-hq-guided) #hubSupportChat {
   gap: 0.5rem;
 }
 
+/* Personal HQ Home follow-up projection (#hqFollowUpMount). */
+.hq-followup-heading {
+  margin: 0.75rem 0 0.35rem;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.hq-followup-card {
+  margin: 0 0 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.hq-followup-category {
+  display: inline-block;
+  margin-bottom: 0.2rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.hq-followup-title {
+  margin: 0 0 0.2rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.hq-followup-detail {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.hq-followup-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .hq-resume-text {
   flex: 1 1 auto;
   min-width: 12rem;

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -146,6 +146,33 @@ export function replyProposalView(p) {
   return view;
 }
 
+// followUpCategoryLabel maps a follow-up category to a friendly label.
+export function followUpCategoryLabel(category) {
+  switch (category) {
+    case 'i_owe': return 'You owe';
+    case 'waiting_on': return 'Waiting on';
+    case 'needs_decision': return 'Needs decision';
+    case 'recurring_check_in': return 'Check-in';
+    default: return 'Follow-up';
+  }
+}
+
+// followUpView turns a follow-up record into a Home projection card view-model.
+// A candidate (inferred, unconfirmed) offers Confirm/Dismiss; an active item
+// offers Done/Snooze.
+export function followUpView(f) {
+  if (!f) return null;
+  const status = f.status || 'active';
+  return {
+    id: f.id,
+    title: f.title || '',
+    detail: f.detail || '',
+    counterparty: f.counterparty || '',
+    category: followUpCategoryLabel(f.category),
+    isCandidate: status === 'candidate'
+  };
+}
+
 (function () {
   if (typeof document === 'undefined') return;
 
@@ -865,6 +892,115 @@ export function replyProposalView(p) {
     actionable.forEach(p => mount.appendChild(renderReplyCard(replyProposalView(p))));
   }
 
+  async function fetchHomeFollowUps() {
+    const res = await fetch('/api/personal-hq/followups/home', { headers: { Accept: 'application/json' } });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data.followups) ? data.followups : [];
+  }
+
+  function renderFollowUpCard(view) {
+    const card = document.createElement('div');
+    card.className = 'hq-followup-card';
+
+    const cat = document.createElement('span');
+    cat.className = 'hq-followup-category';
+    cat.textContent = view.counterparty ? `${view.category}: ${view.counterparty}` : view.category;
+    card.appendChild(cat);
+
+    const title = document.createElement('p');
+    title.className = 'hq-followup-title';
+    title.textContent = view.title;
+    card.appendChild(title);
+
+    if (view.detail) {
+      const detail = document.createElement('p');
+      detail.className = 'hq-followup-detail';
+      detail.textContent = view.detail;
+      card.appendChild(detail);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'hq-followup-actions';
+
+    const act = async (url, body, label) => {
+      try {
+        await postJSON(url, body);
+        await wireFollowUps();
+      } catch (_) {
+        toast(`Could not ${label} the follow-up.`, 'Error', 'danger');
+      }
+    };
+
+    if (view.isCandidate) {
+      const confirmBtn = document.createElement('button');
+      confirmBtn.type = 'button';
+      confirmBtn.className = 'modern-btn modern-btn-primary modern-btn-sm';
+      confirmBtn.textContent = 'Track this';
+      confirmBtn.addEventListener('click', () => act('/api/personal-hq/followups/confirm', { id: view.id }, 'confirm'));
+      const dismissBtn = document.createElement('button');
+      dismissBtn.type = 'button';
+      dismissBtn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+      dismissBtn.textContent = 'Not a follow-up';
+      dismissBtn.addEventListener('click', () => act('/api/personal-hq/followups/dismiss', { id: view.id }, 'dismiss'));
+      actions.append(confirmBtn, dismissBtn);
+    } else {
+      const doneBtn = document.createElement('button');
+      doneBtn.type = 'button';
+      doneBtn.className = 'modern-btn modern-btn-primary modern-btn-sm';
+      doneBtn.textContent = 'Done';
+      doneBtn.addEventListener('click', () => act('/api/personal-hq/followups/complete', { id: view.id }, 'complete'));
+      const snoozeBtn = document.createElement('button');
+      snoozeBtn.type = 'button';
+      snoozeBtn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+      snoozeBtn.textContent = 'Snooze 1 day';
+      snoozeBtn.addEventListener('click', () => {
+        const until = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+        act('/api/personal-hq/followups/snooze', { id: view.id, until }, 'snooze');
+      });
+      actions.append(doneBtn, snoozeBtn);
+    }
+    card.appendChild(actions);
+    return card;
+  }
+
+  // wireFollowUps renders the bounded Home follow-up projection. Additive:
+  // no-op without #hqFollowUpMount or a valid HQ.
+  async function wireFollowUps() {
+    const mount = document.getElementById('hqFollowUpMount');
+    if (!mount) return;
+    let status;
+    try {
+      status = await fetchStatus();
+    } catch (_) {
+      return;
+    }
+    if (!status || !status.valid) {
+      mount.hidden = true;
+      return;
+    }
+    let items;
+    try {
+      items = await fetchHomeFollowUps();
+    } catch (_) {
+      return;
+    }
+    mount.innerHTML = '';
+    if (!items.length) {
+      mount.hidden = true;
+      return;
+    }
+    mount.hidden = false;
+    const heading = document.createElement('h4');
+    heading.className = 'hq-followup-heading';
+    heading.textContent = 'Follow-ups';
+    mount.appendChild(heading);
+    items.forEach(f => {
+      const view = followUpView(f);
+      if (view) mount.appendChild(renderFollowUpCard(view));
+    });
+  }
+
   function init() {
     wireGuided();
     wireResume();
@@ -876,6 +1012,7 @@ export function replyProposalView(p) {
     wireUpgrade();
     wireEmail();
     wireMailReview();
+    wireFollowUps();
   }
 
   if (document.readyState === 'loading') {

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView } from './personal-hq-onboarding.js';
+import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView, followUpView, followUpCategoryLabel } from './personal-hq-onboarding.js';
 
 function status(overrides) {
   return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
@@ -151,4 +151,25 @@ test('replyProposalView: a sent proposal is terminal (not sendable)', () => {
   const view = replyProposalView({ id: 'p1', status: 'sent', payload: {} });
   assert.equal(view.canSend, false);
   assert.equal(view.statusNote, 'Sent');
+});
+
+test('followUpCategoryLabel maps v1 categories to friendly labels', () => {
+  assert.equal(followUpCategoryLabel('i_owe'), 'You owe');
+  assert.equal(followUpCategoryLabel('waiting_on'), 'Waiting on');
+  assert.equal(followUpCategoryLabel('needs_decision'), 'Needs decision');
+  assert.equal(followUpCategoryLabel('recurring_check_in'), 'Check-in');
+  assert.equal(followUpCategoryLabel('unknown'), 'Follow-up');
+});
+
+test('followUpView: an active item is actionable (Done/Snooze), not a candidate', () => {
+  const view = followUpView({ id: 'f1', status: 'active', category: 'waiting_on', title: "Dana's quote", counterparty: 'Dana' });
+  assert.equal(view.isCandidate, false);
+  assert.equal(view.category, 'Waiting on');
+  assert.equal(view.counterparty, 'Dana');
+  assert.equal(view.title, "Dana's quote");
+});
+
+test('followUpView: a candidate is flagged for confirm/dismiss', () => {
+  const view = followUpView({ id: 'f2', status: 'candidate', category: 'i_owe', title: 'Maybe send deck' });
+  assert.equal(view.isCandidate, true);
 });

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -280,6 +280,9 @@
         <!-- Personal HQ confirm-gated reply review: renders draft replies the
              Inbox agent prepared, for explicit user confirmation. Additive. -->
         <div id="hqMailReviewMount" class="hq-reply-mount" hidden></div>
+        <!-- Personal HQ follow-up projection: bounded due/stale follow-ups with
+             quick actions. Additive; hidden when there are none. -->
+        <div id="hqFollowUpMount" class="hq-followup-mount" hidden></div>
       </section>
 
       <section id="launcherSummaryPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabSummary" hidden>


### PR DESCRIPTION
**Group 6 of the Personal HQ Assistant epic** (sub-PR into `epic/personal-hq-assistant`). A dedicated structured follow-up domain — personal commitments/dependencies with their own lifecycle and source-based dedup, reachable via API and surfaced on Home. Deliberately NOT built on Action Center opportunities.

## What's in this PR (2 commits)

**Domain** (`internal/followup`, migration 032)
- `personal_hq_followup` table with a **DB-enforced** source-dedup unique index `(user_id, dedup_key)`, plus due/status/updated query indexes.
- v1 categories (`i_owe`/`waiting_on`/`needs_decision`/`recurring_check_in`), direction, provenance, confidence; the candidate/active/snoozed/completed/dismissed/reopened lifecycle. `DedupKey = sha256(user|source_type|source_id)` (empty for manual — never deduped).
- Capture with source-based upsert (reprocessing refreshes an open loop, never resurrects a closed one); only inferred-below-high enters as a review candidate. Snooze-wake, `DueForNudge`+`MarkNudged` (one reminder per 24h window), and a stale-first `HomeProjection` capped at 5.

**Reachable feature**
- `personalhqhttp` endpoints: list (status filter) / home / create / confirm / edit / snooze / complete / dismiss / reopen — wired + routed.
- Home projection UI on the launcher: `followUpView` (pure, tested) + a card list rendered with `textContent` only; active items get Done/Snooze, candidates get Track-this/Not-a-follow-up.

## Verification
- `go build`/`vet` clean; Go tests (dedup, candidate threshold, all transitions, stale projection ordering, nudge idempotency, snooze wake); all **766** JS module tests + eslint clean

## Deferred (documented in the task list)
Action Center reminder-delivery **scheduler** (6.6 — the evaluation + idempotency logic is built and unit-tested; only the periodic wiring to Action Center is pending), convert-to-project-task (6.8), read-only follow-up agent tools (6.10), the full Personal HQ management panel (6.11), explicit memory promotion (6.12), disconnect retention (6.13), and Playwright (6.15). These are enhancements on a functional core; I can fold them into a follow-on slice or Group 7's polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)