### PR TITLE
feat(personal-hq): Group 7 — end-of-day journal

### DIFF
--- a/docs/features/personal-hq-assistant.md
+++ b/docs/features/personal-hq-assistant.md
@@ -1,5 +1,19 @@
 # Personal HQ Assistant — Code-Facing Contracts (v1)
 
+> **Implementation status (2026-07-16).** Delivered on the `epic/personal-hq-assistant`
+> integration branch: G1 contracts, G2 provisioning/upgrade, G3 Gmail mailbox runtime +
+> read tools, G4 grounded email in the Daily Brief, G5 confirm-gated reply/send broker,
+> G6 structured follow-ups, G7 end-of-day journal. **Intentionally deferred to a v1.x
+> follow-on** (not silently dropped): the Action-Center reminder-**delivery** scheduler
+> (follow-up staleness evaluation + nudge idempotency are built and unit-tested; only the
+> periodic wiring is pending), convert-follow-up-to-project-task, read-only follow-up agent
+> tools, the full Personal HQ management panel, explicit journal→memory promotion, the
+> timezone-scheduled EOD prompt (the journal is on-demand for now), account-disconnect
+> retention sweeps, durable send-audit persistence (currently structured logs), and the
+> Playwright browser suites. Calendar remains a separate v2 PRD (Non-Goals below).
+
+
+
 **Status:** Frozen for implementation · **Source PRD:** `tasks/prd-personal-hq-assistant.md`
 **Scope:** This document freezes the non-negotiable data, privacy, security, scheduling, and
 interaction contracts that Groups 2–7 implement against. Do **not** begin a dependent

--- a/internal/personalhq/journal.go
+++ b/internal/personalhq/journal.go
@@ -1,0 +1,183 @@
+package personalhq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// JournalSnapshot is the bounded, grounded material an end-of-day journal is
+// prefilled from (contract §7): completed work, notable email threads, and
+// follow-up status changes for the local day. It excludes full transcripts and
+// unrestricted email bodies — only short, already-sanitized summaries.
+type JournalSnapshot struct {
+	CompletedTasks  []string
+	EmailSummaries  []string
+	FollowUpChanges []string
+	// Gaps names sources that could not be read, so the draft never implies a
+	// quiet day when it was really an unavailable source.
+	Gaps []string
+}
+
+// IsEmpty reports whether the snapshot has no grounded content.
+func (s JournalSnapshot) IsEmpty() bool {
+	return len(s.CompletedTasks) == 0 && len(s.EmailSummaries) == 0 && len(s.FollowUpChanges) == 0
+}
+
+// JournalSection is one titled group of grounded lines in the proposal.
+type JournalSection struct {
+	Title string   `json:"title"`
+	Items []string `json:"items"`
+}
+
+// JournalProposal is the editable end-of-day journal offered to the user. It has
+// NO write side effect — nothing is persisted until the user explicitly saves
+// (contract §7).
+type JournalProposal struct {
+	LocalDate string           `json:"local_date"`
+	Sections  []JournalSection `json:"sections"`
+	// Draft is the prefilled, editable journal text (markdown) the user reviews.
+	Draft string `json:"draft"`
+	// Gaps and Degraded surface incomplete grounding without blocking the entry.
+	Gaps     []string `json:"gaps,omitempty"`
+	Degraded bool     `json:"degraded"`
+}
+
+// SnapshotBuilder assembles the grounded journal snapshot for a user's local day.
+type SnapshotBuilder interface {
+	BuildJournalSnapshot(ctx context.Context, userID, localDate string) (JournalSnapshot, error)
+}
+
+// NoteWriter persists a saved journal as a workspace note. session.HybridStore
+// satisfies it.
+type NoteWriter interface {
+	CreateNote(ctx context.Context, note *session.WorkspaceNote) error
+}
+
+// JournalService produces and saves end-of-day journals for the designated HQ.
+type JournalService struct {
+	service *Service
+	builder SnapshotBuilder
+	notes   NoteWriter
+	now     func() time.Time
+}
+
+// NewJournalService constructs the journal service. builder may be nil (the
+// proposal then degrades to an empty, still-editable draft).
+func NewJournalService(service *Service, builder SnapshotBuilder, notes NoteWriter) *JournalService {
+	return &JournalService{service: service, builder: builder, notes: notes, now: time.Now}
+}
+
+// Propose builds the editable end-of-day journal for localDate (a YYYY-MM-DD
+// string in the user's timezone). It never writes anything.
+func (j *JournalService) Propose(ctx context.Context, userID, localDate string) (*JournalProposal, error) {
+	if j == nil {
+		return nil, fmt.Errorf("journal service is not configured")
+	}
+	localDate = strings.TrimSpace(localDate)
+	if localDate == "" {
+		localDate = j.now().UTC().Format("2006-01-02")
+	}
+
+	var snap JournalSnapshot
+	degraded := false
+	if j.builder != nil {
+		s, err := j.builder.BuildJournalSnapshot(ctx, userID, localDate)
+		if err != nil {
+			degraded = true
+			snap.Gaps = append(snap.Gaps, "some activity could not be loaded")
+		} else {
+			snap = s
+		}
+	} else {
+		degraded = true
+	}
+
+	sections := buildJournalSections(snap)
+	return &JournalProposal{
+		LocalDate: localDate,
+		Sections:  sections,
+		Draft:     BuildJournalDraft(localDate, snap),
+		Gaps:      snap.Gaps,
+		Degraded:  degraded,
+	}, nil
+}
+
+// Save persists an explicitly-reviewed journal as a dated Personal HQ note. The
+// default save path NEVER writes to MEMORY.md (contract §7) — memory promotion is
+// a separate, explicit action.
+func (j *JournalService) Save(ctx context.Context, userID, localDate, content string) (*session.WorkspaceNote, error) {
+	if j == nil || j.notes == nil {
+		return nil, fmt.Errorf("journal saving is not configured")
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil, fmt.Errorf("journal content is empty")
+	}
+	status, err := j.service.Status(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if status == nil || !status.Valid {
+		return nil, fmt.Errorf("no valid Personal HQ is designated")
+	}
+	localDate = strings.TrimSpace(localDate)
+	if localDate == "" {
+		localDate = j.now().UTC().Format("2006-01-02")
+	}
+	now := j.now().UTC()
+	note := &session.WorkspaceNote{
+		ID:          uuid.NewString(),
+		WorkspaceID: status.WorkspaceID,
+		Name:        "Journal — " + localDate,
+		Content:     content,
+		Tags:        []string{"journal"},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := j.notes.CreateNote(ctx, note); err != nil {
+		return nil, err
+	}
+	return note, nil
+}
+
+func buildJournalSections(snap JournalSnapshot) []JournalSection {
+	var out []JournalSection
+	if len(snap.CompletedTasks) > 0 {
+		out = append(out, JournalSection{Title: "Completed", Items: snap.CompletedTasks})
+	}
+	if len(snap.FollowUpChanges) > 0 {
+		out = append(out, JournalSection{Title: "Follow-ups", Items: snap.FollowUpChanges})
+	}
+	if len(snap.EmailSummaries) > 0 {
+		out = append(out, JournalSection{Title: "Notable threads", Items: snap.EmailSummaries})
+	}
+	return out
+}
+
+// BuildJournalDraft renders a prefilled, editable markdown draft from the
+// grounded snapshot. Pure and side-effect-free. An empty snapshot yields a
+// gentle reflection prompt rather than fabricated accomplishments (contract §7).
+func BuildJournalDraft(localDate string, snap JournalSnapshot) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# End of day — %s\n\n", localDate)
+	if snap.IsEmpty() {
+		b.WriteString("What went well today, and what carries over to tomorrow?\n")
+		return b.String()
+	}
+	for _, sec := range buildJournalSections(snap) {
+		fmt.Fprintf(&b, "## %s\n", sec.Title)
+		for _, item := range sec.Items {
+			fmt.Fprintf(&b, "- %s\n", item)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("## Reflection\n")
+	b.WriteString("What carries over to tomorrow?\n")
+	return b.String()
+}

--- a/internal/personalhq/journal_test.go
+++ b/internal/personalhq/journal_test.go
@@ -1,0 +1,123 @@
+package personalhq
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/session"
+	"github.com/johnjallday/ori-agent/internal/userprofile"
+)
+
+type fakeSnapshotBuilder struct {
+	snap JournalSnapshot
+	err  error
+}
+
+func (f fakeSnapshotBuilder) BuildJournalSnapshot(ctx context.Context, userID, localDate string) (JournalSnapshot, error) {
+	return f.snap, f.err
+}
+
+type fakeNoteWriter struct{ notes []*session.WorkspaceNote }
+
+func (f *fakeNoteWriter) CreateNote(ctx context.Context, note *session.WorkspaceNote) error {
+	f.notes = append(f.notes, note)
+	return nil
+}
+
+func TestBuildJournalDraftFromGroundedSnapshot(t *testing.T) {
+	snap := JournalSnapshot{
+		CompletedTasks:  []string{"Shipped the report"},
+		FollowUpChanges: []string{"Closed: waiting on Dana"},
+	}
+	draft := BuildJournalDraft("2026-07-15", snap)
+	for _, want := range []string{"End of day — 2026-07-15", "## Completed", "Shipped the report", "## Follow-ups", "Reflection"} {
+		if !strings.Contains(draft, want) {
+			t.Errorf("draft missing %q:\n%s", want, draft)
+		}
+	}
+}
+
+func TestBuildJournalDraftEmptyIsReflectionPrompt(t *testing.T) {
+	draft := BuildJournalDraft("2026-07-15", JournalSnapshot{})
+	if strings.Contains(draft, "## Completed") {
+		t.Fatal("empty snapshot must not fabricate sections")
+	}
+	if !strings.Contains(draft, "What went well today") {
+		t.Fatalf("empty snapshot should offer a reflection prompt:\n%s", draft)
+	}
+}
+
+func TestJournalProposeHasNoWriteSideEffect(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	notes := &fakeNoteWriter{}
+	j := NewJournalService(svc, fakeSnapshotBuilder{snap: JournalSnapshot{CompletedTasks: []string{"x"}}}, notes)
+
+	p, err := j.Propose(context.Background(), "local", "2026-07-15")
+	if err != nil {
+		t.Fatalf("Propose: %v", err)
+	}
+	if len(p.Sections) == 0 || p.Draft == "" {
+		t.Fatalf("expected a grounded proposal, got %+v", p)
+	}
+	if len(notes.notes) != 0 {
+		t.Fatal("Propose must never write a note")
+	}
+}
+
+func TestJournalProposeDegradesWhenBuilderFails(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	j := NewJournalService(svc, fakeSnapshotBuilder{err: context.DeadlineExceeded}, &fakeNoteWriter{})
+	p, err := j.Propose(context.Background(), "local", "2026-07-15")
+	if err != nil {
+		t.Fatalf("Propose should degrade, not error: %v", err)
+	}
+	if !p.Degraded || len(p.Gaps) == 0 {
+		t.Fatalf("expected a degraded proposal with a named gap, got %+v", p)
+	}
+}
+
+func TestJournalSaveCreatesDatedNoteNoMemory(t *testing.T) {
+	svc, profiles, workspaces := newTestHarness(t)
+	ctx := context.Background()
+	if err := profiles.Upsert(ctx, &userprofile.UserProfile{ID: "local"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	ws := &session.Workspace{ID: "hq-1", Name: "HQ", Kind: session.WorkspaceKindWorkspace, OwnerUserID: "local", Status: session.WorkspaceStatusActive}
+	if err := workspaces.CreateWorkspace(ctx, ws); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if _, err := svc.Designate(ctx, "local", "hq-1"); err != nil {
+		t.Fatalf("designate: %v", err)
+	}
+
+	notes := &fakeNoteWriter{}
+	j := NewJournalService(svc, nil, notes)
+	note, err := j.Save(ctx, "local", "2026-07-15", "Today I shipped the thing.")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(notes.notes) != 1 {
+		t.Fatalf("expected exactly one note written, got %d", len(notes.notes))
+	}
+	got := notes.notes[0]
+	if got.WorkspaceID != "hq-1" || !strings.Contains(got.Name, "2026-07-15") {
+		t.Fatalf("unexpected note: %+v", got)
+	}
+	if len(got.Tags) == 0 || got.Tags[0] != "journal" {
+		t.Fatalf("journal note should be tagged 'journal', got %v", got.Tags)
+	}
+	_ = note
+}
+
+func TestJournalSaveRejectsEmptyContentAndNoHQ(t *testing.T) {
+	svc, _, _ := newTestHarness(t)
+	j := NewJournalService(svc, nil, &fakeNoteWriter{})
+	if _, err := j.Save(context.Background(), "local", "2026-07-15", "   "); err == nil {
+		t.Fatal("empty content must be rejected")
+	}
+	// No designated HQ → cannot save.
+	if _, err := j.Save(context.Background(), "local", "2026-07-15", "content"); err == nil {
+		t.Fatal("saving without a valid HQ must fail")
+	}
+}

--- a/internal/personalhqhttp/handler.go
+++ b/internal/personalhqhttp/handler.go
@@ -21,6 +21,7 @@ type Handler struct {
 	mailboxLinker MailboxLinker
 	replies       ReplyService
 	followups     FollowUpAPI
+	journal       JournalAPI
 	provider      userprofile.UserProvider
 }
 

--- a/internal/personalhqhttp/journal.go
+++ b/internal/personalhqhttp/journal.go
@@ -1,0 +1,89 @@
+package personalhqhttp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+	"github.com/johnjallday/ori-agent/internal/session"
+)
+
+// JournalAPI is the end-of-day journal surface, implemented by
+// *personalhq.JournalService.
+type JournalAPI interface {
+	Propose(ctx context.Context, userID, localDate string) (*personalhq.JournalProposal, error)
+	Save(ctx context.Context, userID, localDate, content string) (*session.WorkspaceNote, error)
+}
+
+// SetJournal wires the end-of-day journal service.
+func (h *Handler) SetJournal(api JournalAPI) { h.journal = api }
+
+func (h *Handler) journalReady(w http.ResponseWriter, r *http.Request, method string) bool {
+	if !orihttp.RequireMethod(w, r, method) {
+		return false
+	}
+	if h == nil || h.journal == nil {
+		orihttp.ServiceUnavailable(w, "personal hq journal is unavailable")
+		return false
+	}
+	return true
+}
+
+// ProposeJournal handles GET /api/personal-hq/journal/propose?date=YYYY-MM-DD:
+// the grounded, editable end-of-day draft. Never writes.
+func (h *Handler) ProposeJournal(w http.ResponseWriter, r *http.Request) {
+	if !h.journalReady(w, r, http.MethodGet) {
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	proposal, err := h.journal.Propose(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("date")))
+	if err != nil {
+		orihttp.InternalError(w, "Failed to prepare the journal: "+err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"proposal": proposal})
+}
+
+// SaveJournal handles POST /api/personal-hq/journal/save: persist a reviewed
+// journal as a dated note. The default path never writes to MEMORY.md.
+func (h *Handler) SaveJournal(w http.ResponseWriter, r *http.Request) {
+	if !h.journalReady(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		LocalDate string `json:"local_date"`
+		Content   string `json:"content"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.Content) == "" {
+		orihttp.BadRequest(w, "content is required")
+		return
+	}
+	userID, ok := h.resolveUser(w, r)
+	if !ok {
+		return
+	}
+	note, err := h.journal.Save(r.Context(), userID, req.LocalDate, req.Content)
+	if err != nil {
+		orihttp.Conflict(w, err.Error())
+		return
+	}
+	orihttp.Success(w, map[string]any{"note_id": note.ID, "workspace_id": note.WorkspaceID})
+}
+
+// DismissJournal handles POST /api/personal-hq/journal/dismiss. Dismissing is a
+// pure no-op with NO side effect — an ignored prompt must never create a note or
+// memory entry (contract §7).
+func (h *Handler) DismissJournal(w http.ResponseWriter, r *http.Request) {
+	if !orihttp.RequireMethod(w, r, http.MethodPost) {
+		return
+	}
+	orihttp.Success(w, map[string]any{"ok": true})
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -181,6 +181,13 @@ func (b *ServerBuilder) initializeHandlers() {
 		// shared database.
 		b.followUpService = followup.NewService(followup.NewSQLiteStore(sessionStore.DB()))
 		b.personalHQHandler.SetFollowUps(b.followUpService)
+		// End-of-day journal (Group 7): grounded on the day's closed follow-ups,
+		// saved as a dated Personal HQ note (never MEMORY.md by default).
+		b.personalHQHandler.SetJournal(personalhq.NewJournalService(
+			b.personalHQService,
+			&journalSnapshotBuilder{followups: b.followUpService},
+			sessionStore,
+		))
 		// Initialize auto-classify handler for session classification
 		b.autoClassifyHandler = sessionhttp.NewAutoClassifyHandler(sessionStore, b.st, b.llmFactory, b.configManager)
 		// Initialize smart input handler for Workspace Hub classification

--- a/internal/server/journal.go
+++ b/internal/server/journal.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+
+	"github.com/johnjallday/ori-agent/internal/followup"
+	"github.com/johnjallday/ori-agent/internal/personalhq"
+)
+
+// journalSnapshotBuilder assembles the grounded end-of-day journal snapshot. v1
+// grounds the draft on follow-ups the user closed during the local day; completed
+// tasks and notable email threads are future additions.
+type journalSnapshotBuilder struct {
+	followups *followup.Service
+}
+
+func (b *journalSnapshotBuilder) BuildJournalSnapshot(ctx context.Context, userID, localDate string) (personalhq.JournalSnapshot, error) {
+	var snap personalhq.JournalSnapshot
+	if b == nil || b.followups == nil {
+		return snap, nil
+	}
+	completed, err := b.followups.List(ctx, followup.Filter{UserID: userID, Statuses: []followup.Status{followup.StatusCompleted}})
+	if err != nil {
+		return snap, err
+	}
+	for _, f := range completed {
+		if f.CompletedAt != nil && f.CompletedAt.Format("2006-01-02") == localDate {
+			snap.FollowUpChanges = append(snap.FollowUpChanges, "Closed: "+f.Title)
+		}
+	}
+	return snap, nil
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -833,6 +833,9 @@ func registerPersonalHQRoutes(mux *http.ServeMux, s *Server) {
 		mux.HandleFunc("POST /api/personal-hq/followups/complete", s.Handlers.PersonalHQ.CompleteFollowUp)
 		mux.HandleFunc("POST /api/personal-hq/followups/dismiss", s.Handlers.PersonalHQ.DismissFollowUp)
 		mux.HandleFunc("POST /api/personal-hq/followups/reopen", s.Handlers.PersonalHQ.ReopenFollowUp)
+		mux.HandleFunc("GET /api/personal-hq/journal/propose", s.Handlers.PersonalHQ.ProposeJournal)
+		mux.HandleFunc("POST /api/personal-hq/journal/save", s.Handlers.PersonalHQ.SaveJournal)
+		mux.HandleFunc("POST /api/personal-hq/journal/dismiss", s.Handlers.PersonalHQ.DismissJournal)
 	}
 }
 

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -6330,6 +6330,50 @@ body:has(#workspaceHub.is-hq-guided) #hubSupportChat {
   gap: 0.5rem;
 }
 
+/* Personal HQ end-of-day journal (#hqJournalMount). */
+.hq-journal-launch {
+  margin: 0.75rem 0;
+}
+
+.hq-journal-card {
+  margin: 0.75rem 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.hq-journal-heading {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.hq-journal-note {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.hq-journal-editor {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  background: var(--bg-primary, transparent);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 0.25rem);
+  resize: vertical;
+}
+
+.hq-journal-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .hq-resume-text {
   flex: 1 1 auto;
   min-width: 12rem;

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -157,6 +157,19 @@ export function followUpCategoryLabel(category) {
   }
 }
 
+// journalPromptView turns an end-of-day journal proposal into the editor
+// view-model: the prefilled editable draft plus a degraded flag when grounding
+// was incomplete. Pure and unit-testable.
+export function journalPromptView(proposal) {
+  if (!proposal) return { draft: '', degraded: false, localDate: '' };
+  return {
+    localDate: proposal.local_date || '',
+    draft: proposal.draft || '',
+    degraded: !!proposal.degraded,
+    gaps: Array.isArray(proposal.gaps) ? proposal.gaps : []
+  };
+}
+
 // followUpView turns a follow-up record into a Home projection card view-model.
 // A candidate (inferred, unconfirmed) offers Confirm/Dismiss; an active item
 // offers Done/Snooze.
@@ -1001,6 +1014,106 @@ export function followUpView(f) {
     });
   }
 
+  function renderJournalEditor(mount, view) {
+    mount.innerHTML = '';
+    const card = document.createElement('div');
+    card.className = 'hq-journal-card';
+
+    const heading = document.createElement('h4');
+    heading.className = 'hq-journal-heading';
+    heading.textContent = 'End-of-day journal';
+    card.appendChild(heading);
+
+    if (view.degraded) {
+      const note = document.createElement('p');
+      note.className = 'hq-journal-note';
+      note.textContent = 'Some activity could not be loaded — the draft may be incomplete.';
+      card.appendChild(note);
+    }
+
+    const editor = document.createElement('textarea');
+    editor.className = 'hq-journal-editor';
+    editor.rows = 10;
+    editor.value = view.draft;
+    editor.setAttribute('aria-label', 'End-of-day journal draft');
+    card.appendChild(editor);
+
+    const actions = document.createElement('div');
+    actions.className = 'hq-journal-actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'modern-btn modern-btn-primary modern-btn-sm';
+    saveBtn.textContent = 'Save journal';
+    saveBtn.addEventListener('click', async () => {
+      saveBtn.disabled = true;
+      try {
+        await postJSON('/api/personal-hq/journal/save', { local_date: view.localDate, content: editor.value });
+        toast('Your journal was saved.', 'Saved', 'success');
+        mount.innerHTML = '';
+        mount.appendChild(journalLauncher(mount));
+      } catch (e) {
+        toast(e && e.message ? e.message : 'Could not save the journal.', 'Save failed', 'danger');
+        saveBtn.disabled = false;
+      }
+    });
+
+    const dismissBtn = document.createElement('button');
+    dismissBtn.type = 'button';
+    dismissBtn.className = 'modern-btn modern-btn-secondary modern-btn-sm';
+    dismissBtn.textContent = 'Not now';
+    dismissBtn.addEventListener('click', async () => {
+      // Dismiss is a pure no-op server-side; just collapse the editor.
+      try { await postJSON('/api/personal-hq/journal/dismiss'); } catch (_) { /* no-op */ }
+      mount.innerHTML = '';
+      mount.appendChild(journalLauncher(mount));
+    });
+
+    actions.append(saveBtn, dismissBtn);
+    card.appendChild(actions);
+    mount.appendChild(card);
+    editor.focus();
+  }
+
+  function journalLauncher(mount) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'modern-btn modern-btn-secondary modern-btn-sm hq-journal-launch';
+    btn.textContent = 'Write your end-of-day journal';
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      try {
+        const res = await fetch('/api/personal-hq/journal/propose', { headers: { Accept: 'application/json' } });
+        const data = res.ok ? await res.json() : null;
+        renderJournalEditor(mount, journalPromptView(data && data.proposal));
+      } catch (_) {
+        toast('Could not open the journal.', 'Error', 'danger');
+        btn.disabled = false;
+      }
+    });
+    return btn;
+  }
+
+  // wireJournal shows an on-demand end-of-day journal launcher. Additive: no-op
+  // without #hqJournalMount or a valid HQ. (A scheduled prompt is a future add.)
+  async function wireJournal() {
+    const mount = document.getElementById('hqJournalMount');
+    if (!mount) return;
+    let status;
+    try {
+      status = await fetchStatus();
+    } catch (_) {
+      return;
+    }
+    if (!status || !status.valid) {
+      mount.hidden = true;
+      return;
+    }
+    mount.hidden = false;
+    mount.innerHTML = '';
+    mount.appendChild(journalLauncher(mount));
+  }
+
   function init() {
     wireGuided();
     wireResume();
@@ -1013,6 +1126,7 @@ export function followUpView(f) {
     wireEmail();
     wireMailReview();
     wireFollowUps();
+    wireJournal();
   }
 
   if (document.readyState === 'loading') {

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView, followUpView, followUpCategoryLabel } from './personal-hq-onboarding.js';
+import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView, followUpView, followUpCategoryLabel, journalPromptView } from './personal-hq-onboarding.js';
 
 function status(overrides) {
   return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
@@ -173,3 +173,18 @@ test('followUpView: a candidate is flagged for confirm/dismiss', () => {
   const view = followUpView({ id: 'f2', status: 'candidate', category: 'i_owe', title: 'Maybe send deck' });
   assert.equal(view.isCandidate, true);
 });
+
+test('journalPromptView: carries the editable draft and degraded flag', () => {
+  const view = journalPromptView({ local_date: '2026-07-15', draft: '# End of day', degraded: true, gaps: ['x'] });
+  assert.equal(view.localDate, '2026-07-15');
+  assert.equal(view.draft, '# End of day');
+  assert.equal(view.degraded, true);
+  assert.deepEqual(view.gaps, ['x']);
+});
+
+test('journalPromptView: degrades safely with no proposal', () => {
+  const view = journalPromptView(null);
+  assert.equal(view.draft, '');
+  assert.equal(view.degraded, false);
+});
+

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -283,6 +283,9 @@
         <!-- Personal HQ follow-up projection: bounded due/stale follow-ups with
              quick actions. Additive; hidden when there are none. -->
         <div id="hqFollowUpMount" class="hq-followup-mount" hidden></div>
+        <!-- Personal HQ end-of-day journal: on-demand launcher + editor.
+             Additive; hidden without a valid HQ. -->
+        <div id="hqJournalMount" class="hq-journal-mount" hidden></div>
       </section>
 
       <section id="launcherSummaryPanel" class="launcher-tab-panel" role="tabpanel" aria-labelledby="launcherTabSummary" hidden>


### PR DESCRIPTION
**Group 7 of the Personal HQ Assistant epic** — the end-of-day journal, the last feature group before the final `epic → dev` gate.

## What's in this PR
- `personalhq.JournalService`: `Propose` builds a bounded, grounded, **editable** draft from a `SnapshotBuilder` (v1 grounds on the day's closed follow-ups), with explicit gaps/degraded metadata and **no write side effect**. `Save` persists an explicitly-reviewed journal as a dated, `journal`-tagged Personal HQ note — the default path **never** writes `MEMORY.md`. Pure `BuildJournalDraft` (empty snapshot → a reflection prompt, never fabricated accomplishments).
- `personalhqhttp` journal `propose`/`save`/`dismiss` (dismiss is a pure no-op — an ignored prompt creates no note or memory).
- `server.journalSnapshotBuilder` over the follow-up service; wired with the session note store.
- Home UI: an on-demand journal launcher + accessible editor (`textContent`/`value` only); Save writes the note, Not-now collapses with no side effect.
- Contract doc gains an **implementation-status + explicit-deferrals** note.

## Verification
- `go build`/`vet` clean; Go journal-domain tests (grounded/empty/no-write/degrade/dated-note/no-memory); all **768** JS module tests + eslint

## Deferred (documented in the task list + contract doc)
The timezone-**scheduled** EOD prompt (on-demand for now, no seeded cron), the journal history panel, explicit journal→memory promotion, disconnect retention sweeps, and Playwright.

Once this merges, the epic branch holds Groups 3–7; the final `epic → dev` PR is the single ship gate for the whole feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)