### PR TITLE
feat(personal-hq): in-app Gmail OAuth setup — Settings UI + email loadout chip

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,7 @@ export default defineConfig([
       'internal/web/static/js/modules/note-wikilinks.js',
       'internal/web/static/js/modules/onboarding.js',
       'internal/web/static/js/modules/personal-hq-onboarding.js',
+      'internal/web/static/js/modules/personal-hq-email-setup.js',
       'internal/web/static/js/modules/home-daily-brief.js',
       'internal/web/static/js/modules/plugin-init-banner.js',
       'internal/web/static/js/modules/progression-widget.js',

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,10 +50,16 @@ type MacWakeSettings struct {
 
 // Settings holds application-wide configuration
 type Settings struct {
-	OpenAIAPIKey    string   `json:"openai_api_key"`
-	AnthropicAPIKey string   `json:"anthropic_api_key"`
-	GeminiAPIKey    string   `json:"gemini_api_key"`
-	AllowedOrigins  []string `json:"allowed_origins,omitempty"` // CORS allowed origins (defaults to localhost)
+	OpenAIAPIKey    string `json:"openai_api_key"`
+	AnthropicAPIKey string `json:"anthropic_api_key"`
+	GeminiAPIKey    string `json:"gemini_api_key"`
+
+	// Personal HQ email OAuth client credentials (Google), settable in-app so a
+	// self-hosted user does not need env vars. Empty falls back to the
+	// ORI_EMAIL_GOOGLE_CLIENT_ID / _SECRET environment variables.
+	EmailGoogleClientID     string   `json:"email_google_client_id,omitempty"`
+	EmailGoogleClientSecret string   `json:"email_google_client_secret,omitempty"`
+	AllowedOrigins          []string `json:"allowed_origins,omitempty"` // CORS allowed origins (defaults to localhost)
 
 	// System model settings - used for internal AI tasks (auto-config, suggestions, etc.)
 	SystemProvider        string `json:"system_provider,omitempty"`         // Provider for system tasks (e.g., "openai", "codex", "claude_code", "claude", "gemini", "ollama", "lmstudio", "mlx_lm")
@@ -711,6 +717,40 @@ func (m *Manager) GetAnthropicAPIKey() string {
 	}
 
 	return ""
+}
+
+// GetEmailGoogleOAuth returns the Google email OAuth client credentials,
+// preferring in-app settings over the ORI_EMAIL_GOOGLE_CLIENT_ID / _SECRET
+// environment variables, so a self-hosted user can configure OAuth without env
+// vars.
+func (m *Manager) GetEmailGoogleOAuth() (clientID, clientSecret string) {
+	m.mu.RLock()
+	clientID = strings.TrimSpace(m.settings.EmailGoogleClientID)
+	clientSecret = strings.TrimSpace(m.settings.EmailGoogleClientSecret)
+	m.mu.RUnlock()
+	if clientID == "" {
+		clientID = strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_ID"))
+	}
+	if clientSecret == "" {
+		clientSecret = strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_SECRET"))
+	}
+	return clientID, clientSecret
+}
+
+// GetEmailGoogleOAuthConfigured reports whether both Google OAuth credentials
+// are present (settings or env).
+func (m *Manager) GetEmailGoogleOAuthConfigured() bool {
+	id, secret := m.GetEmailGoogleOAuth()
+	return id != "" && secret != ""
+}
+
+// SetEmailGoogleOAuth persists the Google email OAuth client credentials.
+func (m *Manager) SetEmailGoogleOAuth(clientID, clientSecret string) error {
+	m.mu.Lock()
+	m.settings.EmailGoogleClientID = strings.TrimSpace(clientID)
+	m.settings.EmailGoogleClientSecret = strings.TrimSpace(clientSecret)
+	m.mu.Unlock()
+	return m.Save()
 }
 
 // GetGeminiAPIKey returns the Gemini API key, checking settings first, then environment variable

--- a/internal/config/email_oauth_test.go
+++ b/internal/config/email_oauth_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEmailGoogleOAuthSettingsFirstThenEnv(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), "settings.json"))
+	if err := m.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Env fallback when nothing is configured.
+	t.Setenv("ORI_EMAIL_GOOGLE_CLIENT_ID", "env-id")
+	t.Setenv("ORI_EMAIL_GOOGLE_CLIENT_SECRET", "env-secret")
+	if id, secret := m.GetEmailGoogleOAuth(); id != "env-id" || secret != "env-secret" {
+		t.Fatalf("expected env fallback, got %q/%q", id, secret)
+	}
+	if !m.GetEmailGoogleOAuthConfigured() {
+		t.Fatal("env-configured should report configured")
+	}
+
+	// In-app settings take precedence over env.
+	if err := m.SetEmailGoogleOAuth("cfg-id", "cfg-secret"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if id, secret := m.GetEmailGoogleOAuth(); id != "cfg-id" || secret != "cfg-secret" {
+		t.Fatalf("settings should win over env, got %q/%q", id, secret)
+	}
+
+	// Persisted across a reload.
+	m2 := NewManager(m.filePath)
+	if err := m2.Load(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if id, _ := m2.GetEmailGoogleOAuth(); id != "cfg-id" {
+		t.Fatalf("credentials should persist, got %q", id)
+	}
+}
+
+func TestEmailGoogleOAuthUnconfigured(t *testing.T) {
+	t.Setenv("ORI_EMAIL_GOOGLE_CLIENT_ID", "")
+	t.Setenv("ORI_EMAIL_GOOGLE_CLIENT_SECRET", "")
+	m := NewManager(filepath.Join(t.TempDir(), "settings.json"))
+	_ = m.Load()
+	if m.GetEmailGoogleOAuthConfigured() {
+		t.Fatal("should be unconfigured with no settings or env")
+	}
+}

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -236,6 +236,17 @@ func (b *ServerBuilder) initializeHandlers() {
 			ManagedVaultRoot: resolveVaultRoot(b.configManager),
 		})
 		b.vaultHandler = vaulthttp.NewHandler(vaultStore)
+		// Let in-app Settings supply the Google email OAuth client credentials,
+		// taking precedence over ORI_EMAIL_GOOGLE_* env vars, so a self-hosted
+		// user can enable Personal HQ email without editing the environment.
+		if b.configManager != nil {
+			vaulthttp.EmailOAuthCredentialOverride = func(provider vault.EmailProvider) (string, string) {
+				if provider == vault.EmailProviderGmail {
+					return b.configManager.GetEmailGoogleOAuth()
+				}
+				return "", ""
+			}
+		}
 		b.settingsHandler.SetVaultRootUpdater(vaultStore.SetManagedVaultRoot)
 		if b.workspaceHandler != nil {
 			b.workspaceHandler.SetEmailAccountStore(vaultStore)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -267,6 +267,7 @@ func registerSettingsRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("/api/settings/available-models", s.Handlers.Settings.AvailableModelsHandler)
 	mux.HandleFunc("/api/settings/system-paths", s.Handlers.Settings.SystemPathsHandler)
 	mux.HandleFunc("/api/settings/external-agents", s.Handlers.Settings.ExternalAgentsSettingsHandler)
+	mux.HandleFunc("/api/settings/email-oauth", s.Handlers.Settings.EmailOAuthSettingsHandler)
 	mux.HandleFunc("/api/settings/speech", s.Handlers.Settings.SpeechSettingsHandler)
 	mux.HandleFunc("/api/settings/utility", s.Handlers.Settings.UtilitySettingsHandler)
 	mux.HandleFunc("/api/settings/mac-wake", s.Handlers.Settings.MacWakeSettingsHandler)

--- a/internal/settingshttp/email_oauth.go
+++ b/internal/settingshttp/email_oauth.go
@@ -1,0 +1,52 @@
+package settingshttp
+
+import (
+	"net/http"
+	"strings"
+
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+)
+
+// EmailOAuthSettingsHandler serves GET/POST /api/settings/email-oauth: the
+// in-app configuration of the Google email OAuth client credentials, so a
+// self-hosted user can enable Personal HQ email without environment variables.
+//
+// The client SECRET is never returned by GET (only whether one is set); the
+// client ID is public and returned for display.
+func (h *Handler) EmailOAuthSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.configManager == nil {
+		orihttp.ServiceUnavailable(w, "configuration is unavailable")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		clientID, _ := h.configManager.GetEmailGoogleOAuth()
+		orihttp.Success(w, map[string]any{
+			"provider":          "google",
+			"configured":        h.configManager.GetEmailGoogleOAuthConfigured(),
+			"client_id":         clientID, // public identifier, safe to display
+			"has_client_secret": h.configManager.GetEmailGoogleOAuthConfigured() && strings.TrimSpace(clientID) != "",
+		})
+	case http.MethodPost:
+		var req struct {
+			ClientID     string `json:"client_id"`
+			ClientSecret string `json:"client_secret"`
+		}
+		if !orihttp.ParseJSONBody(w, r, &req) {
+			return
+		}
+		clientID := strings.TrimSpace(req.ClientID)
+		clientSecret := strings.TrimSpace(req.ClientSecret)
+		if clientID == "" || clientSecret == "" {
+			orihttp.BadRequest(w, "both client_id and client_secret are required")
+			return
+		}
+		if err := h.configManager.SetEmailGoogleOAuth(clientID, clientSecret); err != nil {
+			orihttp.InternalError(w, "Failed to save email OAuth credentials: "+err.Error())
+			return
+		}
+		orihttp.Success(w, map[string]any{"configured": h.configManager.GetEmailGoogleOAuthConfigured()})
+	default:
+		orihttp.MethodNotAllowed(w)
+	}
+}

--- a/internal/vaulthttp/email_oauth.go
+++ b/internal/vaulthttp/email_oauth.go
@@ -207,6 +207,24 @@ func gmailScopesForStage(stage string) []string {
 	return []string{gmailScopeReadonly, "openid", "email", "profile"}
 }
 
+// EmailOAuthCredentialOverride, when set, supplies OAuth client credentials
+// (e.g. from in-app Settings) that take precedence over the ORI_EMAIL_*
+// environment variables — so a self-hosted user can configure Google OAuth
+// entirely in-app. The server wires it once at startup from config.Manager. A
+// resolver that returns empty strings falls back to the env vars.
+var EmailOAuthCredentialOverride func(provider vault.EmailProvider) (clientID, clientSecret string)
+
+// resolveEmailOAuthCredentials returns the client id/secret for provider,
+// preferring the configured override over the environment.
+func resolveEmailOAuthCredentials(provider vault.EmailProvider, envID, envSecret string) (string, string) {
+	if EmailOAuthCredentialOverride != nil {
+		if id, secret := EmailOAuthCredentialOverride(provider); strings.TrimSpace(id) != "" && strings.TrimSpace(secret) != "" {
+			return strings.TrimSpace(id), strings.TrimSpace(secret)
+		}
+	}
+	return envID, envSecret
+}
+
 func loadEmailOAuthProviderConfig(provider vault.EmailProvider, r *http.Request, redirectOverride string) emailOAuthProviderConfig {
 	redirectURL := firstNonEmpty(
 		strings.TrimSpace(redirectOverride),
@@ -220,13 +238,16 @@ func loadEmailOAuthProviderConfig(provider vault.EmailProvider, r *http.Request,
 		if r != nil {
 			stage = r.URL.Query().Get("stage")
 		}
+		clientID, clientSecret := resolveEmailOAuthCredentials(provider,
+			strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_ID")),
+			strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_SECRET")))
 		return emailOAuthProviderConfig{
 			provider:      provider,
 			label:         "Google",
 			authURL:       firstNonEmpty(strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_AUTH_URL")), "https://accounts.google.com/o/oauth2/v2/auth"),
 			tokenURL:      firstNonEmpty(strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_TOKEN_URL")), "https://oauth2.googleapis.com/token"),
-			clientID:      strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_ID")),
-			clientSecret:  strings.TrimSpace(os.Getenv("ORI_EMAIL_GOOGLE_CLIENT_SECRET")),
+			clientID:      clientID,
+			clientSecret:  clientSecret,
 			redirectURL:   redirectURL,
 			scopes:        gmailScopesForStage(stage),
 			defaultSource: "google-oauth",

--- a/internal/web/static/css/workspace-hub.css
+++ b/internal/web/static/css/workspace-hub.css
@@ -6229,6 +6229,55 @@ body:has(#workspaceHub.is-hq-guided) #hubSupportChat {
   color: var(--text-secondary);
 }
 
+/* Personal HQ loadout chip — a first-class equipped-capability item (email in
+   v1). Rendered into #hqEmailMount. */
+.hq-loadout-chip {
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.hq-loadout-chip-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+}
+
+.hq-loadout-chip-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.hq-loadout-chip-state {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--bg-tertiary, var(--bg-primary));
+  color: var(--text-secondary);
+}
+
+.hq-loadout-chip-state-equipped {
+  color: var(--success-color, #2e7d32);
+}
+
+.hq-loadout-chip-state-repair {
+  color: var(--warning-color, #b26a00);
+}
+
+.hq-loadout-chip-detail {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
 /* Personal HQ confirm-gated reply review cards (#hqMailReviewMount). */
 .hq-reply-card {
   margin: 0.75rem 0;

--- a/internal/web/static/js/modules/personal-hq-email-setup.js
+++ b/internal/web/static/js/modules/personal-hq-email-setup.js
@@ -94,6 +94,10 @@ import { emailStatusView, chipStateLabel } from './personal-hq-onboarding.js';
       fetchJSON('/api/settings/email-oauth')
     ]);
     const status = statusResp && statusResp.status ? statusResp.status : null;
+    if (window.OriHQEmailSetup) {
+      window.OriHQEmailSetup.connected = !!(status && status.connected);
+      window.OriHQEmailSetup.address = (status && status.email_address) || '';
+    }
     const view = emailStatusView(status, oauth ? !!oauth.configured : true);
 
     body.innerHTML = '';
@@ -150,6 +154,16 @@ import { emailStatusView, chipStateLabel } from './personal-hq-onboarding.js';
     const status = data && data.status;
     if (status && status.valid && String(status.workspace_id) === wsId) {
       btn.hidden = false;
+      // Publish a tiny global so the command view's Map inventory can show an
+      // Email slot and open this modal (workspace-command.js is a non-module
+      // script and cannot import from here).
+      const shared = (window.OriHQEmailSetup = window.OriHQEmailSetup || {});
+      shared.isHQ = true;
+      shared.open = openModal;
+      const emailResp = await fetchJSON('/api/personal-hq/email/status');
+      const emailStatus = emailResp && emailResp.status;
+      shared.connected = !!(emailStatus && emailStatus.connected);
+      shared.address = (emailStatus && emailStatus.email_address) || '';
     }
   }
 

--- a/internal/web/static/js/modules/personal-hq-email-setup.js
+++ b/internal/web/static/js/modules/personal-hq-email-setup.js
@@ -1,0 +1,165 @@
+// personal-hq-email-setup.js — the "Set up email" button + modal on the
+// workspace detail page. It appears ONLY when the current workspace is the
+// user's designated Personal HQ, and opens a modal that reuses the loadout-chip
+// view-model to route setup correctly: no OAuth client → Settings, configured →
+// Connect, connected → Disconnect, stale → Reconnect.
+//
+// Self-contained (no Bootstrap): a lightweight overlay toggled by a class. The
+// pure view-model helpers are imported from personal-hq-onboarding.js so the
+// state logic has one source of truth.
+
+import { emailStatusView, chipStateLabel } from './personal-hq-onboarding.js';
+
+(function () {
+  if (typeof document === 'undefined') return;
+
+  const btn = document.getElementById('hqEmailSetupBtn');
+  const modal = document.getElementById('hqEmailSetupModal');
+  if (!btn || !modal) return;
+
+  const body = modal.querySelector('.hq-email-setup-body');
+
+  function currentWorkspaceId() {
+    if (window.currentWorkspaceId) return String(window.currentWorkspaceId);
+    const parts = window.location.pathname.split('/');
+    return parts[2] || '';
+  }
+
+  async function fetchJSON(url) {
+    try {
+      const res = await fetch(url, { headers: { Accept: 'application/json' } });
+      return res.ok ? await res.json() : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function postJSON(url, payload) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload ? JSON.stringify(payload) : undefined
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error((data && (data.error || data.message)) || 'Request failed');
+    return data;
+  }
+
+  function toast(message, variant) {
+    if (window.Toast && typeof window.Toast[variant || 'success'] === 'function') {
+      window.Toast[variant || 'success'](message);
+    }
+  }
+
+  function openModal() {
+    modal.hidden = false;
+    modal.classList.add('is-open');
+    renderBody();
+  }
+  function closeModal() {
+    modal.hidden = true;
+    modal.classList.remove('is-open');
+  }
+
+  function connectEmail() {
+    const popup = window.open('/api/vault/email/oauth/start?provider=gmail', 'ori-hq-email', 'width=520,height=680');
+    if (!popup) {
+      toast('Allow pop-ups to connect your email.', 'danger');
+      return;
+    }
+    const onMessage = async (event) => {
+      const data = event && event.data;
+      if (!data || data.type !== 'ori:vault-email-oauth') return;
+      window.removeEventListener('message', onMessage);
+      if (!data.success || !data.account || !data.account.id) {
+        toast(data && data.error ? data.error : 'Could not connect your email.', 'danger');
+        return;
+      }
+      try {
+        await postJSON('/api/personal-hq/email/link', { account_id: data.account.id });
+        toast('Email connected to your Personal HQ.', 'success');
+        renderBody();
+      } catch (_) {
+        toast('Connected the account but could not link it to your HQ.', 'danger');
+      }
+    };
+    window.addEventListener('message', onMessage);
+  }
+
+  async function renderBody() {
+    if (!body) return;
+    body.textContent = 'Loading…';
+    const [statusResp, oauth] = await Promise.all([
+      fetchJSON('/api/personal-hq/email/status'),
+      fetchJSON('/api/settings/email-oauth')
+    ]);
+    const status = statusResp && statusResp.status ? statusResp.status : null;
+    const view = emailStatusView(status, oauth ? !!oauth.configured : true);
+
+    body.innerHTML = '';
+
+    const head = document.createElement('div');
+    head.className = 'hq-loadout-chip-head';
+    const name = document.createElement('span');
+    name.className = 'hq-loadout-chip-name';
+    name.textContent = view.chip || 'Email';
+    const chip = document.createElement('span');
+    chip.className = 'hq-loadout-chip-state hq-loadout-chip-state-' + (view.chipState || 'empty');
+    chip.textContent = chipStateLabel(view.chipState);
+    head.append(name, chip);
+    body.appendChild(head);
+
+    if (view.detail) {
+      const detail = document.createElement('p');
+      detail.className = 'hq-loadout-chip-detail';
+      detail.textContent = view.detail;
+      body.appendChild(detail);
+    }
+
+    const action = document.createElement('button');
+    action.type = 'button';
+    action.className = 'modern-btn modern-btn-sm ' + (view.action === 'disconnect' ? 'modern-btn-secondary' : 'modern-btn-primary');
+    action.textContent = view.actionLabel;
+    action.addEventListener('click', async () => {
+      if (view.action === 'settings') {
+        window.location.href = '/settings#personal-hq-email';
+        return;
+      }
+      if (view.action === 'disconnect') {
+        action.disabled = true;
+        try {
+          await postJSON('/api/personal-hq/email/unlink');
+          toast('Email disconnected.', 'success');
+          renderBody();
+        } catch (_) {
+          toast('Could not disconnect the email account.', 'danger');
+          action.disabled = false;
+        }
+        return;
+      }
+      connectEmail();
+    });
+    body.appendChild(action);
+  }
+
+  // Show the button only when this workspace is the user's valid, designated HQ.
+  async function maybeShowButton() {
+    const wsId = currentWorkspaceId();
+    if (!wsId) return;
+    const data = await fetchJSON('/api/personal-hq/status');
+    const status = data && data.status;
+    if (status && status.valid && String(status.workspace_id) === wsId) {
+      btn.hidden = false;
+    }
+  }
+
+  btn.addEventListener('click', openModal);
+  modal.addEventListener('click', (e) => {
+    if (e.target && e.target.hasAttribute && e.target.hasAttribute('data-hq-email-close')) closeModal();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.classList.contains('is-open')) closeModal();
+  });
+
+  maybeShowButton();
+})();

--- a/internal/web/static/js/modules/personal-hq-onboarding.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.js
@@ -86,38 +86,52 @@ export function upgradeView(plan) {
   };
 }
 
-// emailStatusView turns the Personal HQ email status (from GET
-// /api/personal-hq/email/status) into the view-model the connect/grant/repair UI
-// renders, so all branching is unit-testable. Three states:
-//   - connected: show the address + a Disconnect action.
-//   - repair: a binding exists but the account is gone/expired — offer Reconnect.
-//   - disconnected: never connected — offer Connect.
-export function emailStatusView(status) {
+// emailStatusView turns the Personal HQ email status (GET /email/status) plus
+// whether the server has Google OAuth credentials (oauthConfigured) into the
+// loadout-chip view-model. Email is a first-class HQ inventory item — equipped,
+// not required — so the chip owns its own setup routing. States:
+//   - connected: equipped; show the address + Disconnect.
+//   - setup:     the server has no OAuth client yet — route to Settings.
+//   - repair:    a binding exists but the account is gone/expired — Reconnect.
+//   - disconnected: OAuth is configured but no account connected — Connect.
+// oauthConfigured defaults to true (backward compatible) unless explicitly false.
+export function emailStatusView(status, oauthConfigured) {
+  const configured = oauthConfigured !== false;
   if (status && status.connected) {
     return {
-      state: 'connected',
-      heading: 'Email connected',
-      detail: status.email_address || '',
-      action: 'disconnect',
-      actionLabel: 'Disconnect'
+      state: 'connected', chip: 'Email', chipState: 'equipped',
+      heading: 'Email connected', detail: status.email_address || '',
+      action: 'disconnect', actionLabel: 'Disconnect'
+    };
+  }
+  if (!configured) {
+    return {
+      state: 'setup', chip: 'Email', chipState: 'empty',
+      heading: 'Set up email', detail: 'Add your Google OAuth credentials in Settings to enable Personal HQ email.',
+      action: 'settings', actionLabel: 'Set up in Settings'
     };
   }
   if (status && status.account_id) {
     return {
-      state: 'repair',
-      heading: 'Reconnect your email',
-      detail: 'Your connected email needs to be reconnected before the assistant can read it.',
-      action: 'connect',
-      actionLabel: 'Reconnect'
+      state: 'repair', chip: 'Email', chipState: 'repair',
+      heading: 'Reconnect your email', detail: 'Your connected email needs to be reconnected before the assistant can read it.',
+      action: 'connect', actionLabel: 'Reconnect'
     };
   }
   return {
-    state: 'disconnected',
-    heading: 'Connect your email',
-    detail: 'Let your Inbox specialist surface threads that need attention and help draft replies. Read-only — nothing is ever sent without your explicit confirmation.',
-    action: 'connect',
-    actionLabel: 'Connect email'
+    state: 'disconnected', chip: 'Email', chipState: 'empty',
+    heading: 'Connect your email', detail: 'Let your Inbox specialist surface threads that need attention and help draft replies. Read-only — nothing is ever sent without your explicit confirmation.',
+    action: 'connect', actionLabel: 'Connect email'
   };
+}
+
+// chipStateLabel renders the short inventory-chip status word.
+export function chipStateLabel(chipState) {
+  switch (chipState) {
+    case 'equipped': return 'Connected';
+    case 'repair': return 'Needs repair';
+    default: return 'Not set up';
+  }
 }
 
 // replyProposalView turns a reply proposal (from the mail broker) into the
@@ -717,20 +731,42 @@ export function followUpView(f) {
     window.addEventListener('message', onMessage);
   }
 
+  async function fetchOAuthConfigured() {
+    try {
+      const res = await fetch('/api/settings/email-oauth', { headers: { Accept: 'application/json' } });
+      if (!res.ok) return true; // assume configured; the connect flow will surface a real error
+      const data = await res.json();
+      return !!data.configured;
+    } catch (_) {
+      return true;
+    }
+  }
+
+  // renderEmail renders the Email inventory chip — a first-class HQ loadout item
+  // with its own state and setup routing. The chip's action routes correctly:
+  // 'settings' (server has no OAuth client) opens Settings, 'connect' opens the
+  // OAuth popup, 'disconnect' unlinks.
   function renderEmail(mount, view) {
     mount.innerHTML = '';
     mount.hidden = false;
-    const card = document.createElement('div');
-    card.className = 'hq-email-card hq-email-' + view.state;
 
-    const heading = document.createElement('h4');
-    heading.className = 'hq-email-heading';
-    heading.textContent = view.heading;
-    card.appendChild(heading);
+    const card = document.createElement('div');
+    card.className = 'hq-loadout-chip hq-email-' + view.state;
+
+    const head = document.createElement('div');
+    head.className = 'hq-loadout-chip-head';
+    const name = document.createElement('span');
+    name.className = 'hq-loadout-chip-name';
+    name.textContent = view.chip || 'Email';
+    const state = document.createElement('span');
+    state.className = 'hq-loadout-chip-state hq-loadout-chip-state-' + (view.chipState || 'empty');
+    state.textContent = chipStateLabel(view.chipState);
+    head.append(name, state);
+    card.appendChild(head);
 
     if (view.detail) {
       const detail = document.createElement('p');
-      detail.className = 'hq-email-detail';
+      detail.className = 'hq-loadout-chip-detail';
       detail.textContent = view.detail;
       card.appendChild(detail);
     }
@@ -740,6 +776,10 @@ export function followUpView(f) {
     btn.className = 'modern-btn modern-btn-sm ' + (view.action === 'disconnect' ? 'modern-btn-secondary' : 'modern-btn-primary');
     btn.textContent = view.actionLabel;
     btn.addEventListener('click', async () => {
+      if (view.action === 'settings') {
+        window.location.href = '/settings#personal-hq-email';
+        return;
+      }
       if (view.action === 'disconnect') {
         btn.disabled = true;
         try {
@@ -750,16 +790,16 @@ export function followUpView(f) {
           toast('Could not disconnect the email account.', 'Error', 'danger');
           btn.disabled = false;
         }
-      } else {
-        connectEmail();
+        return;
       }
+      connectEmail();
     });
     card.appendChild(btn);
     mount.appendChild(card);
   }
 
-  // wireEmail shows the email connect/grant/repair card for a valid designated
-  // HQ. Additive: a no-op when the page has no #hqEmailMount or no valid HQ.
+  // wireEmail renders the Email loadout chip for a valid designated HQ. Additive:
+  // a no-op when the page has no #hqEmailMount or no valid HQ.
   async function wireEmail() {
     const mount = document.getElementById('hqEmailMount');
     if (!mount) return;
@@ -773,13 +813,11 @@ export function followUpView(f) {
       mount.hidden = true;
       return;
     }
-    let emailStatus;
-    try {
-      emailStatus = await fetchEmailStatus();
-    } catch (_) {
-      return;
-    }
-    renderEmail(mount, emailStatusView(emailStatus));
+    const [emailStatus, oauthConfigured] = await Promise.all([
+      fetchEmailStatus().catch(() => null),
+      fetchOAuthConfigured()
+    ]);
+    renderEmail(mount, emailStatusView(emailStatus, oauthConfigured));
   }
 
   async function fetchProposals() {

--- a/internal/web/static/js/modules/personal-hq-onboarding.test.js
+++ b/internal/web/static/js/modules/personal-hq-onboarding.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, replyProposalView, followUpView, followUpCategoryLabel } from './personal-hq-onboarding.js';
+import { resolveGuidedMode, resumeCopy, wantsGuidedTakeover, upgradeView, emailStatusView, chipStateLabel, replyProposalView, followUpView, followUpCategoryLabel } from './personal-hq-onboarding.js';
 
 function status(overrides) {
   return { workspace_id: '', valid: false, hq_onboarding_state: 'unseen', ...overrides };
@@ -125,6 +125,28 @@ test('emailStatusView: never-connected offers Connect and promises read-only + c
   assert.equal(view.action, 'connect');
   assert.match(view.detail, /read-only/i);
   assert.match(view.detail, /confirmation/i);
+});
+
+test('emailStatusView: no OAuth client on the server routes to Settings (setup state)', () => {
+  const view = emailStatusView(null, false);
+  assert.equal(view.state, 'setup');
+  assert.equal(view.action, 'settings');
+  assert.equal(view.chipState, 'empty');
+  assert.match(view.detail, /Settings/i);
+});
+
+test('emailStatusView: connected is an equipped loadout chip', () => {
+  const view = emailStatusView({ connected: true, email_address: 'me@x.com' }, true);
+  assert.equal(view.chipState, 'equipped');
+  assert.equal(view.chip, 'Email');
+  assert.equal(view.action, 'disconnect');
+});
+
+test('chipStateLabel maps loadout states to short words', () => {
+  assert.equal(chipStateLabel('equipped'), 'Connected');
+  assert.equal(chipStateLabel('repair'), 'Needs repair');
+  assert.equal(chipStateLabel('empty'), 'Not set up');
+  assert.equal(chipStateLabel(undefined), 'Not set up');
 });
 
 test('replyProposalView: a draft is sendable and carries the exact reviewed payload hash', () => {

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -2046,6 +2046,11 @@ export class WorkspaceCommandView {
   }
 
   openRailItem(sectionKey, id, source) {
+    // Personal HQ email slots open the setup modal; no page object required.
+    if (String(sectionKey || '') === 'email') {
+      this.openHQEmailSetup();
+      return;
+    }
     const page = this.page || window.workspaceDetail;
     if (!page || !id) return;
 
@@ -4450,7 +4455,7 @@ export class WorkspaceCommandView {
     const page = this.page || {};
     const folders = this.folderRowData();
     const files = this.fileRowData();
-    return [
+    const groups = [
       {
         key: 'notes',
         label: 'Notes',
@@ -4537,6 +4542,31 @@ export class WorkspaceCommandView {
         }))
       }
     ];
+    // Personal HQ only: email is a first-class inventory item (equipped, not
+    // required). State is published by personal-hq-email-setup.js, whose modal
+    // owns the actual connect/repair/disconnect flow.
+    const hqEmail = typeof window !== 'undefined' ? window.OriHQEmailSetup : null;
+    if (hqEmail && hqEmail.isHQ) {
+      groups.push({
+        key: 'email',
+        label: 'Email',
+        icon: 'bi-envelope',
+        count: hqEmail.connected ? 1 : 0,
+        action: hqEmail.connected ? 'Manage Email' : 'Set up Email',
+        slotLabel: 'Email',
+        items: hqEmail.connected
+          ? [
+              {
+                label: hqEmail.address || 'Connected account',
+                meta: 'Connected',
+                section: 'email',
+                id: 'hq-email'
+              }
+            ]
+          : []
+      });
+    }
+    return groups;
   }
 
   renderMapInventoryItems(group) {
@@ -4826,7 +4856,19 @@ export class WorkspaceCommandView {
       this.openSystemTab(this.activeSystemTab || 'memory');
       return;
     }
+    if (section === 'email') {
+      this.openHQEmailSetup();
+      return;
+    }
     this.runRailPrimaryAction(section, triggerButton);
+  }
+
+  // openHQEmailSetup opens the Personal HQ email modal owned by
+  // personal-hq-email-setup.js (present on the detail page for the designated
+  // HQ). No-op when the module has not published its opener.
+  openHQEmailSetup() {
+    const hqEmail = typeof window !== 'undefined' ? window.OriHQEmailSetup : null;
+    if (hqEmail && typeof hqEmail.open === 'function') hqEmail.open();
   }
 
   bindOperationsMap() {

--- a/internal/web/templates/pages/settings.tmpl
+++ b/internal/web/templates/pages/settings.tmpl
@@ -108,6 +108,14 @@
               </span>
               <span class="settings-nav-item-text">External Agents</span>
             </a>
+            <a href="#personal-hq-email" class="settings-nav-item" data-section="personal-hq-email">
+              <span class="settings-nav-item-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20,4H4A2,2 0 0,0 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6A2,2 0 0,0 20,4M20,8L12,13L4,8V6L12,11L20,6V8Z"/>
+                </svg>
+              </span>
+              <span class="settings-nav-item-text">Personal HQ Email</span>
+            </a>
             <a href="#mcp-servers" class="settings-nav-item" data-section="mcp-servers">
               <span class="settings-nav-item-icon">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -874,6 +882,42 @@
                 </svg>
                 <span style="color: var(--text-secondary); font-size: 0.85rem;">External agents are visible in the <a href="/agents" style="color: var(--primary-color);">Agents dashboard</a></span>
               </div>
+            </div>
+          </section>
+
+          <!-- Personal HQ Email (Google OAuth) Section -->
+          <section id="personal-hq-email" class="settings-section modern-card p-4">
+            <div class="settings-section-header">
+              <span class="settings-section-icon">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20,4H4A2,2 0 0,0 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6A2,2 0 0,0 20,4M20,8L12,13L4,8V6L12,11L20,6V8Z"/>
+                </svg>
+              </span>
+              <h2 class="settings-section-title">Personal HQ Email</h2>
+              <span class="settings-section-subtitle">(Google OAuth)</span>
+            </div>
+
+            <p class="settings-section-description">
+              To let your Personal HQ connect Gmail, register a Google OAuth 2.0 <strong>Web application</strong>
+              client (Google Cloud Console → Credentials; enable the Gmail API), add
+              <code id="hqEmailRedirectHint">this server's <em>/api/vault/email/oauth/callback</em></code> as an
+              authorized redirect URI, then paste the client ID and secret below. Read-only Gmail access is
+              requested; nothing is sent without your explicit confirmation.
+            </p>
+
+            <div class="settings-field">
+              <label class="settings-label" for="hqEmailClientId">Client ID</label>
+              <input type="text" id="hqEmailClientId" class="form-control settings-input"
+                     placeholder="…apps.googleusercontent.com" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="settings-field">
+              <label class="settings-label" for="hqEmailClientSecret">Client Secret</label>
+              <input type="password" id="hqEmailClientSecret" class="form-control settings-input"
+                     placeholder="Enter to set or replace" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="d-flex align-items-center gap-2 mt-2">
+              <button type="button" id="hqEmailSaveBtn" class="modern-btn modern-btn-primary modern-btn-sm">Save credentials</button>
+              <span id="hqEmailStatus" class="settings-field-hint" role="status" aria-live="polite"></span>
             </div>
           </section>
 
@@ -1703,6 +1747,65 @@
   <script defer src="/js/modules/toast.js"></script>
   {{template "theme-init.tmpl" .}}
   <script>
+    // Personal HQ Email (Google OAuth) credentials
+    (function() {
+      const idInput = document.getElementById('hqEmailClientId');
+      const secretInput = document.getElementById('hqEmailClientSecret');
+      const saveBtn = document.getElementById('hqEmailSaveBtn');
+      const statusEl = document.getElementById('hqEmailStatus');
+      const redirectHint = document.getElementById('hqEmailRedirectHint');
+      if (!idInput || !saveBtn) return;
+
+      if (redirectHint) {
+        redirectHint.textContent = window.location.origin + '/api/vault/email/oauth/callback';
+      }
+
+      function setStatus(text, isError) {
+        if (!statusEl) return;
+        statusEl.textContent = text;
+        statusEl.style.color = isError ? 'var(--danger-color, #d33)' : 'var(--text-secondary)';
+      }
+
+      async function load() {
+        try {
+          const res = await fetch('/api/settings/email-oauth', { headers: { Accept: 'application/json' } });
+          if (!res.ok) return;
+          const data = await res.json();
+          if (data.client_id) idInput.value = data.client_id;
+          if (data.has_client_secret) secretInput.placeholder = 'Saved — enter to replace';
+          setStatus(data.configured ? 'Configured — the Connect Email button is enabled.' : 'Not configured yet.', false);
+        } catch (_) { /* ignore */ }
+      }
+
+      saveBtn.addEventListener('click', async () => {
+        const clientId = idInput.value.trim();
+        const clientSecret = secretInput.value.trim();
+        if (!clientId || !clientSecret) {
+          setStatus('Enter both the client ID and client secret.', true);
+          return;
+        }
+        saveBtn.disabled = true;
+        try {
+          const res = await fetch('/api/settings/email-oauth', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ client_id: clientId, client_secret: clientSecret })
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error((data && (data.error || data.message)) || 'Save failed');
+          secretInput.value = '';
+          secretInput.placeholder = 'Saved — enter to replace';
+          setStatus('Saved — the Connect Email button is now enabled.', false);
+        } catch (e) {
+          setStatus(e && e.message ? e.message : 'Could not save.', true);
+        } finally {
+          saveBtn.disabled = false;
+        }
+      });
+
+      load();
+    })();
+
     // External Agents Settings
     (function() {
       const claudeToggle = document.getElementById('claudeAgentsToggle');

--- a/internal/web/templates/pages/workspace-detail.tmpl
+++ b/internal/web/templates/pages/workspace-detail.tmpl
@@ -26,10 +26,44 @@
                 <h2 class="workspace-detail-tools-title" id="workspace-detail-tools-title">Add-ons</h2>
                 <p class="workspace-detail-tools-sub">Optional. Searches the marketplaces for MCPs, skills, and plugins matching your description — add any you want.</p>
               </div>
-              <button type="button" class="modern-btn modern-btn-primary modern-btn-sm" id="workspace-tools-find-btn">Find tools</button>
+              <div class="workspace-detail-tools-actions">
+                <!-- Shown by personal-hq-email-setup.js only when this workspace
+                     is the designated Personal HQ. -->
+                <button type="button" class="modern-btn modern-btn-secondary modern-btn-sm" id="hqEmailSetupBtn" hidden>Set up email</button>
+                <button type="button" class="modern-btn modern-btn-primary modern-btn-sm" id="workspace-tools-find-btn">Find tools</button>
+              </div>
             </div>
             <div id="workspace-tools-panel-host" hidden></div>
           </section>
+
+          <style>
+            .workspace-detail-tools-actions { display: flex; gap: 0.5rem; align-items: center; }
+            .hq-email-setup-modal[hidden] { display: none; }
+            .hq-email-setup-modal { position: fixed; inset: 0; z-index: 1080; display: flex; align-items: center; justify-content: center; }
+            .hq-email-setup-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.45); }
+            .hq-email-setup-dialog { position: relative; width: min(440px, 92vw); background: var(--bg-secondary, #fff); color: var(--text-primary, #111); border: 1px solid var(--border-color, #ddd); border-radius: var(--radius-md, 0.5rem); padding: 1rem 1.1rem; box-shadow: 0 10px 40px rgba(0,0,0,0.25); }
+            .hq-email-setup-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.6rem; }
+            .hq-email-setup-title { margin: 0; font-size: 1.05rem; }
+            .hq-email-setup-close { background: none; border: none; font-size: 1.4rem; line-height: 1; cursor: pointer; color: var(--text-secondary, #666); }
+            .hq-email-setup-body .hq-loadout-chip-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.4rem; }
+            .hq-email-setup-body .hq-loadout-chip-name { font-weight: 600; }
+            .hq-email-setup-body .hq-loadout-chip-state { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; padding: 0.1rem 0.45rem; border-radius: 999px; background: var(--bg-tertiary, #eee); color: var(--text-secondary, #666); }
+            .hq-email-setup-body .hq-loadout-chip-state-equipped { color: var(--success-color, #2e7d32); }
+            .hq-email-setup-body .hq-loadout-chip-state-repair { color: var(--warning-color, #b26a00); }
+            .hq-email-setup-body .hq-loadout-chip-detail { margin: 0 0 0.6rem; font-size: 0.85rem; color: var(--text-secondary, #666); }
+          </style>
+          <!-- Personal HQ email setup modal (opened by #hqEmailSetupBtn). A
+               lightweight overlay — no Bootstrap dependency. -->
+          <div id="hqEmailSetupModal" class="hq-email-setup-modal" hidden role="dialog" aria-modal="true" aria-labelledby="hqEmailSetupTitle">
+            <div class="hq-email-setup-backdrop" data-hq-email-close></div>
+            <div class="hq-email-setup-dialog" role="document">
+              <div class="hq-email-setup-header">
+                <h2 id="hqEmailSetupTitle" class="hq-email-setup-title">Personal HQ Email</h2>
+                <button type="button" class="hq-email-setup-close" data-hq-email-close aria-label="Close">×</button>
+              </div>
+              <div class="hq-email-setup-body">Loading…</div>
+            </div>
+          </div>
 
 
           <div class="modern-card workspace-detail-config-card is-collapsed mb-4" id="workspace-detail-settings-panel">
@@ -8633,6 +8667,7 @@
   <script defer src="/js/modules/workspace-triggers.js"></script>
   <script defer src="/js/modules/project-templates-manage.js"></script>
   <script defer src="/js/modules/workspace-hub-support-chat.js"></script>
+  <script type="module" src="/js/modules/personal-hq-email-setup.js"></script>
 
   <!-- Workspace Detail Page -->
   <script type="module">


### PR DESCRIPTION
Removes the env-var-only barrier to setting up Personal HQ email — the whole Gmail setup is now in-app. Follow-on sub-PR into `epic/personal-hq-assistant` (independent of the Group 7 journal PR).

## Why
Connecting Gmail required setting `ORI_EMAIL_GOOGLE_CLIENT_ID` / `_SECRET` env vars before starting the server — there was no UI for it, so a self-hosted user couldn't discover or do it from the app.

## What
- **config**: `EmailGoogleClientID/Secret` settings + `GetEmailGoogleOAuth` (in-app settings take precedence over the `ORI_EMAIL_GOOGLE_*` env vars) + `SetEmailGoogleOAuth` (persisted). Unit-tested (precedence, reload persistence, unconfigured).
- **vaulthttp**: an `EmailOAuthCredentialOverride` hook so the OAuth config loader prefers configured credentials over the environment.
- **settingshttp**: `GET/POST /api/settings/email-oauth` — GET reports configured state + the *public* client ID (never the secret); POST saves both. Wired in the builder to feed the vaulthttp override from `config.Manager`.
- **Settings page**: a "Personal HQ Email (Google OAuth)" section under Integrations — Client ID / Client Secret inputs, Save, live status, and an **auto-filled redirect-URI hint** (`origin + /api/vault/email/oauth/callback`) so the user has the exact value to register in Google Cloud Console.

## Result
Paste two fields in Settings → click **Connect Email** on the Personal HQ card. No environment variables.

## Verification
`go build`/`vet` clean; Go tests for `config`, `settingshttp`, `vaulthttp`, `server`; eslint clean. The OAuth round-trip itself still needs a real Google client to smoke-test end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)