### PR TITLE
feat(agents): roster bulk management and metadata

### DIFF
--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -281,6 +281,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Description     string                     `json:"description,omitempty"`
 		Tags            []string                   `json:"tags,omitempty"`
 		AvatarColor     string                     `json:"avatar_color,omitempty"`
+		Favorite        bool                       `json:"favorite,omitempty"`
 		LLMProvider     string                     `json:"llm_provider,omitempty"`
 		ReasoningEffort string                     `json:"reasoning_effort,omitempty"`
 		MaxOutputTokens int                        `json:"max_output_tokens,omitempty"`
@@ -334,7 +335,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set metadata if provided
-	if req.Description != "" || len(req.Tags) > 0 || req.AvatarColor != "" || req.RoutingProfile != nil {
+	if req.Description != "" || len(req.Tags) > 0 || req.AvatarColor != "" || req.Favorite || req.RoutingProfile != nil {
 		agent, ok := h.State.GetAgent(req.Name)
 		if ok && agent != nil {
 			if agent.Metadata == nil {
@@ -343,6 +344,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			agent.Metadata.Description = req.Description
 			agent.Metadata.Tags = req.Tags
 			agent.Metadata.AvatarColor = req.AvatarColor
+			agent.Metadata.Favorite = req.Favorite
 			agent.Metadata.RoutingProfile = cloneRoutingProfile(req.RoutingProfile)
 			if err := h.State.SetAgent(req.Name, agent); err != nil {
 				logger.Error("Failed to set metadata", logger.Fields{"err": err})

--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -669,15 +669,29 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.State.DeleteAgent(name); err != nil {
+	// Deletion lifecycle (store delete, session purge, activity log) is shared
+	// with the bulk endpoint so the two paths cannot drift (PRD FR52).
+	if err := h.performAgentDeletion(r.Context(), name); err != nil {
 		orihttp.BadRequest(w, err.Error())
 		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// performAgentDeletion runs the deletion lifecycle for an agent whose deletion
+// guards have already passed: remove it from the store, purge any sessions that
+// still reference it, and write a deletion activity event. Shared by the
+// single-agent DELETE handler and the bulk delete operation (PRD FR43/FR52).
+func (h *Handler) performAgentDeletion(ctx context.Context, name string) error {
+	if err := h.State.DeleteAgent(name); err != nil {
+		return err
 	}
 
 	// Remove any sessions still referencing this agent so the UI cannot
 	// restore stale state that resolves to a 404 on /api/agents.
 	if h.sessionPurger != nil {
-		if n, err := h.sessionPurger.DeleteSessionsByAgent(r.Context(), name); err != nil {
+		if n, err := h.sessionPurger.DeleteSessionsByAgent(ctx, name); err != nil {
 			logger.Error("Failed to purge sessions for deleted agent", logger.Fields{"agent": name, "err": err})
 		} else if n > 0 {
 			logger.Info("Purged sessions for deleted agent", logger.Fields{"agent": name, "count": n})
@@ -692,7 +706,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.WriteHeader(http.StatusOK)
+	return nil
 }
 
 func normalizeAgentReasoningEffort(providerName, modelName, reasoningEffort string) (string, error) {

--- a/internal/agenthttp/agents_bulk.go
+++ b/internal/agenthttp/agents_bulk.go
@@ -1,0 +1,368 @@
+package agenthttp
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/agent"
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/types"
+	"github.com/johnjallday/ori-agent/internal/workspace"
+)
+
+// maxBulkBatchSize bounds one bulk request so a single call cannot start an
+// unbounded set of filesystem mutations (PRD FR48/FR53).
+const maxBulkBatchSize = 100
+
+// bulkOperation is the discriminator for POST /api/agents/bulk (PRD FR47).
+type bulkOperation string
+
+const (
+	bulkOpDelete      bulkOperation = "delete"
+	bulkOpAddTags     bulkOperation = "add_tags"
+	bulkOpRemoveTags  bulkOperation = "remove_tags"
+	bulkOpSetFavorite bulkOperation = "set_favorite"
+)
+
+// bulkStatus is the per-agent outcome (PRD FR49).
+type bulkStatus string
+
+const (
+	bulkStatusSucceeded bulkStatus = "succeeded"
+	bulkStatusSkipped   bulkStatus = "skipped"
+	bulkStatusFailed    bulkStatus = "failed"
+)
+
+// Stable reason codes are part of the UI contract (PRD FR51). Business-rule
+// outcomes (skipped) are distinguishable from unexpected server errors (failed).
+const (
+	reasonProtectedAgent    = "protected_agent" // reserved system assistant
+	reasonReadOnlyAgent     = "read_only_agent" // built-in CLI agent
+	reasonAttachedAgent     = "attached_agent"  // attached to >=1 workspace
+	reasonAgentNotFound     = "agent_not_found" // no such user agent
+	reasonSharedEditNeedsOK = "shared_edit_requires_confirmation"
+	reasonInternalError     = "internal_error" // unexpected server failure
+)
+
+// bulkRequest is the POST /api/agents/bulk body (PRD FR46).
+type bulkRequest struct {
+	AgentNames        []string      `json:"agent_names"`
+	Operation         bulkOperation `json:"operation"`
+	Tags              []string      `json:"tags,omitempty"`
+	Favorite          *bool         `json:"favorite,omitempty"`
+	ConfirmSharedEdit bool          `json:"confirm_shared_edit,omitempty"`
+}
+
+// bulkResult is one per-agent outcome in the response (PRD FR49).
+type bulkResult struct {
+	Name       string     `json:"name"`
+	Status     bulkStatus `json:"status"`
+	ReasonCode string     `json:"reason_code,omitempty"`
+	Message    string     `json:"message,omitempty"`
+}
+
+// bulkSummary carries the aggregate counts (PRD FR50).
+type bulkSummary struct {
+	Requested int `json:"requested"`
+	Succeeded int `json:"succeeded"`
+	Skipped   int `json:"skipped"`
+	Failed    int `json:"failed"`
+}
+
+// bulkResponse is the full response shape (PRD FR49/FR50).
+type bulkResponse struct {
+	Summary bulkSummary  `json:"summary"`
+	Results []bulkResult `json:"results"`
+}
+
+// HandleBulk serves POST /api/agents/bulk: a bounded, partial-success batch of
+// one operation (delete / add_tags / remove_tags / set_favorite) across a set of
+// named agents. It reuses the same guards, persistence, session cleanup, and
+// activity logging as the single-agent handlers so the bulk path cannot become a
+// weaker mutation path (PRD FR52).
+func (h *Handler) HandleBulk(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req bulkRequest
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+
+	// Deterministic result ordering: one result per unique name, in first-seen
+	// request order. Duplicates collapse to a single result (PRD FR48/FR49).
+	names := dedupeAgentNames(req.AgentNames)
+	if len(names) == 0 {
+		orihttp.BadRequest(w, "agent_names must contain at least one agent")
+		return
+	}
+	if len(names) > maxBulkBatchSize {
+		orihttp.BadRequest(w, fmt.Sprintf("too many agents in one request (max %d)", maxBulkBatchSize))
+		return
+	}
+
+	switch req.Operation {
+	case bulkOpDelete, bulkOpAddTags, bulkOpRemoveTags, bulkOpSetFavorite:
+	default:
+		orihttp.BadRequest(w, fmt.Sprintf("unsupported operation %q", req.Operation))
+		return
+	}
+
+	// set_favorite requires an explicit boolean so the intent is unambiguous.
+	if req.Operation == bulkOpSetFavorite && req.Favorite == nil {
+		orihttp.BadRequest(w, "set_favorite requires a boolean \"favorite\" field")
+		return
+	}
+
+	// Normalize tags once for tag operations; an empty resulting set is rejected
+	// so callers get a clear 400 rather than a batch of no-op successes.
+	var tags []string
+	if req.Operation == bulkOpAddTags || req.Operation == bulkOpRemoveTags {
+		tags = normalizeTags(req.Tags)
+		if len(tags) == 0 {
+			orihttp.BadRequest(w, "tags must contain at least one non-empty tag")
+			return
+		}
+	}
+
+	results := make([]bulkResult, 0, len(names))
+	for _, name := range names {
+		switch req.Operation {
+		case bulkOpDelete:
+			results = append(results, h.bulkDeleteOne(r, name))
+		case bulkOpAddTags, bulkOpRemoveTags:
+			results = append(results, h.bulkTagOne(name, req.Operation, tags, req.ConfirmSharedEdit))
+		case bulkOpSetFavorite:
+			results = append(results, h.bulkFavoriteOne(name, *req.Favorite))
+		}
+	}
+
+	orihttp.WriteJSON(w, bulkResponse{Summary: summarize(results), Results: results})
+}
+
+// bulkDeleteOne applies the deletion guards and lifecycle to one name, returning
+// a per-agent result. Eligibility is re-checked here (not trusted from the
+// client preview) immediately before deletion (PRD FR40).
+func (h *Handler) bulkDeleteOne(r *http.Request, name string) bulkResult {
+	if code, msg := h.checkAgentDeletable(name); code != "" {
+		return bulkResult{Name: name, Status: bulkStatusSkipped, ReasonCode: code, Message: msg}
+	}
+	if err := h.performAgentDeletion(r.Context(), name); err != nil {
+		logger.Error("bulk delete failed", logger.Fields{"agent": name, "err": err})
+		return bulkResult{Name: name, Status: bulkStatusFailed, ReasonCode: reasonInternalError, Message: "Failed to delete agent."}
+	}
+	return bulkResult{Name: name, Status: bulkStatusSucceeded}
+}
+
+// bulkTagOne adds or removes tags on one agent's latest stored metadata,
+// preserving unrelated tags (PRD FR24/FR25/FR32).
+func (h *Handler) bulkTagOne(name string, op bulkOperation, tags []string, confirmed bool) bulkResult {
+	ag, code, msg := h.metadataMutationTarget(name, true, confirmed)
+	if code != "" {
+		return bulkResult{Name: name, Status: bulkStatusSkipped, ReasonCode: code, Message: msg}
+	}
+
+	if ag.Metadata == nil {
+		ag.Metadata = &types.AgentMetadata{}
+	}
+	var changed bool
+	if op == bulkOpAddTags {
+		changed = addTags(ag.Metadata, tags)
+	} else {
+		changed = removeTags(ag.Metadata, tags)
+	}
+
+	if !changed {
+		// No-op is a success: the requested end state already holds.
+		return bulkResult{Name: name, Status: bulkStatusSucceeded}
+	}
+	if res, ok := h.persistMetadataMutation(name, ag, []string{"tags"}); !ok {
+		return res
+	}
+	return bulkResult{Name: name, Status: bulkStatusSucceeded}
+}
+
+// bulkFavoriteOne sets an explicit favorite boolean on one agent. Favorite is
+// not a shared-definition field, so it never requires shared-edit confirmation
+// (mirrors the single-agent PATCH path).
+func (h *Handler) bulkFavoriteOne(name string, favorite bool) bulkResult {
+	ag, code, msg := h.metadataMutationTarget(name, false, false)
+	if code != "" {
+		return bulkResult{Name: name, Status: bulkStatusSkipped, ReasonCode: code, Message: msg}
+	}
+	if ag.Metadata == nil {
+		ag.Metadata = &types.AgentMetadata{}
+	}
+	if ag.Metadata.Favorite == favorite {
+		return bulkResult{Name: name, Status: bulkStatusSucceeded}
+	}
+	ag.Metadata.Favorite = favorite
+	if res, ok := h.persistMetadataMutation(name, ag, []string{"favorite"}); !ok {
+		return res
+	}
+	return bulkResult{Name: name, Status: bulkStatusSucceeded}
+}
+
+// persistMetadataMutation saves an in-memory agent mutation and writes an update
+// activity event. Returns (failedResult, false) on persistence error.
+func (h *Handler) persistMetadataMutation(name string, ag *agent.Agent, fields []string) (bulkResult, bool) {
+	if ag.Statistics != nil {
+		ag.Statistics.UpdatedAt = time.Now()
+	}
+	if err := h.State.SetAgent(name, ag); err != nil {
+		logger.Error("bulk metadata save failed", logger.Fields{"agent": name, "err": err})
+		return bulkResult{Name: name, Status: bulkStatusFailed, ReasonCode: reasonInternalError, Message: "Failed to update agent."}, false
+	}
+	if h.ActivityLogger != nil {
+		if err := h.ActivityLogger.LogActivity(name, types.ActivityEventUpdated, map[string]any{"fields": fields}, ""); err != nil {
+			logger.Error("Failed to log activity", logger.Fields{"err": err})
+		}
+	}
+	return bulkResult{}, true
+}
+
+// checkAgentDeletable returns ("", "") when the named agent may be deleted, or a
+// stable reason code + message identifying why it must be skipped. Shared by the
+// single-agent DELETE handler's guard intent and the bulk delete path so the two
+// cannot drift (PRD FR36–FR38).
+func (h *Handler) checkAgentDeletable(name string) (reasonCode, message string) {
+	if isSystemAssistantAgent(name) {
+		return reasonProtectedAgent, "The system assistant cannot be deleted."
+	}
+	if h.isCLIAgent(name) {
+		return reasonReadOnlyAgent, "CLI agents are built-in and cannot be deleted."
+	}
+	if _, ok := h.State.GetAgent(name); !ok {
+		return reasonAgentNotFound, "Agent not found."
+	}
+	if m := workspace.WorkspaceMembershipFor(h.workspaceStore, name); m.Count > 0 {
+		return reasonAttachedAgent, fmt.Sprintf("Attached to %d workspace(s); detach it before deleting.", m.Count)
+	}
+	return "", ""
+}
+
+// metadataMutationTarget resolves the agent to mutate for a bulk metadata
+// operation, or returns a skip reason. CLI agents are read-only; missing agents
+// are reported; tag mutations on a definition shared by >1 workspace require
+// explicit confirmation, matching the single-agent PATCH rules (PRD FR30/FR31).
+func (h *Handler) metadataMutationTarget(name string, touchesSharedDefinition, confirmed bool) (*agent.Agent, string, string) {
+	if h.isCLIAgent(name) {
+		return nil, reasonReadOnlyAgent, "CLI agents cannot be modified."
+	}
+	ag, ok := h.State.GetAgent(name)
+	if !ok || ag == nil {
+		return nil, reasonAgentNotFound, "Agent not found."
+	}
+	if touchesSharedDefinition && !isSystemAssistantAgent(name) {
+		if m := workspace.WorkspaceMembershipFor(h.workspaceStore, name); m.Count > 1 && !confirmed {
+			return nil, reasonSharedEditNeedsOK, fmt.Sprintf("Attached to %d workspaces — confirm the shared edit to proceed.", m.Count)
+		}
+	}
+	return ag, "", ""
+}
+
+// dedupeAgentNames trims each name and returns the unique, non-empty names in
+// first-seen order. Comparison is case-insensitive on the trimmed name so the
+// same agent requested twice (or with stray whitespace) collapses to one result.
+func dedupeAgentNames(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// normalizeTags trims each tag and drops empties/case-insensitive duplicates,
+// preserving first-seen order and original casing (matches the profile editor).
+func normalizeTags(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		tag := strings.TrimSpace(raw)
+		if tag == "" {
+			continue
+		}
+		key := strings.ToLower(tag)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, tag)
+	}
+	return out
+}
+
+// addTags merges tags into the metadata, preserving existing (unrelated) tags
+// and skipping case-insensitive duplicates. Returns whether anything changed.
+func addTags(md *types.AgentMetadata, tags []string) bool {
+	existing := make(map[string]struct{}, len(md.Tags))
+	for _, t := range md.Tags {
+		existing[strings.ToLower(strings.TrimSpace(t))] = struct{}{}
+	}
+	changed := false
+	for _, t := range tags {
+		key := strings.ToLower(strings.TrimSpace(t))
+		if key == "" {
+			continue
+		}
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		existing[key] = struct{}{}
+		md.Tags = append(md.Tags, t)
+		changed = true
+	}
+	return changed
+}
+
+// removeTags deletes the named tags (case-insensitive) from the metadata while
+// preserving all other tags. Returns whether anything changed.
+func removeTags(md *types.AgentMetadata, tags []string) bool {
+	remove := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		remove[strings.ToLower(strings.TrimSpace(t))] = struct{}{}
+	}
+	kept := md.Tags[:0]
+	changed := false
+	for _, t := range md.Tags {
+		if _, drop := remove[strings.ToLower(strings.TrimSpace(t))]; drop {
+			changed = true
+			continue
+		}
+		kept = append(kept, t)
+	}
+	md.Tags = kept
+	return changed
+}
+
+// summarize tallies per-agent results into the response summary counts.
+func summarize(results []bulkResult) bulkSummary {
+	s := bulkSummary{Requested: len(results)}
+	for _, r := range results {
+		switch r.Status {
+		case bulkStatusSucceeded:
+			s.Succeeded++
+		case bulkStatusSkipped:
+			s.Skipped++
+		case bulkStatusFailed:
+			s.Failed++
+		}
+	}
+	return s
+}

--- a/internal/agenthttp/agents_bulk_test.go
+++ b/internal/agenthttp/agents_bulk_test.go
@@ -1,0 +1,339 @@
+package agenthttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// postBulk issues a POST /api/agents/bulk against the handler and decodes the
+// response. It fails the test on a non-200 status (use rawBulk for error cases).
+func postBulk(t *testing.T, h *Handler, body string) bulkResponse {
+	t.Helper()
+	rr := rawBulk(t, h, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+	}
+	return resp
+}
+
+func rawBulk(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/bulk", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.HandleBulk(rr, req)
+	return rr
+}
+
+// resultFor returns the per-agent result for a name (case-insensitive).
+func resultFor(resp bulkResponse, name string) (bulkResult, bool) {
+	for _, r := range resp.Results {
+		if strings.EqualFold(r.Name, name) {
+			return r, true
+		}
+	}
+	return bulkResult{}, false
+}
+
+func agentTags(t *testing.T, h *Handler, name string) []string {
+	t.Helper()
+	ag, ok := h.State.GetAgent(name)
+	if !ok || ag == nil || ag.Metadata == nil {
+		return nil
+	}
+	return ag.Metadata.Tags
+}
+
+func setTags(t *testing.T, h *Handler, name string, tags []string) {
+	t.Helper()
+	ag, ok := h.State.GetAgent(name)
+	if !ok || ag == nil {
+		t.Fatalf("agent %q not found", name)
+	}
+	if ag.Metadata == nil {
+		ag.Metadata = &types.AgentMetadata{}
+	}
+	ag.Metadata.Tags = tags
+	if err := h.State.SetAgent(name, ag); err != nil {
+		t.Fatalf("SetAgent %q: %v", name, err)
+	}
+}
+
+// --- Validation -------------------------------------------------------------
+
+func TestBulkRejectsEmptyList(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":[],"operation":"delete"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty list, got %d", rr.Code)
+	}
+}
+
+func TestBulkRejectsUnknownOperation(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":["A"],"operation":"nuke"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown operation, got %d", rr.Code)
+	}
+}
+
+func TestBulkRejectsOversizedBatch(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	names := make([]string, 0, maxBulkBatchSize+1)
+	for i := 0; i <= maxBulkBatchSize; i++ {
+		names = append(names, fmt.Sprintf("%q", fmt.Sprintf("agent-%d", i)))
+	}
+	body := `{"agent_names":[` + strings.Join(names, ",") + `],"operation":"delete"}`
+	rr := rawBulk(t, h, body)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized batch, got %d", rr.Code)
+	}
+}
+
+func TestBulkSetFavoriteRequiresBoolean(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":["A"],"operation":"set_favorite"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when favorite omitted, got %d", rr.Code)
+	}
+}
+
+func TestBulkTagRejectsEmptyTags(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":["A"],"operation":"add_tags","tags":["  ",""]}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty tags, got %d", rr.Code)
+	}
+}
+
+// --- Delete -----------------------------------------------------------------
+
+func TestBulkDeleteMixedPartialSuccess(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Loose1", "Loose2", "Attached"},
+		map[string][]string{"ws-a": {"Attached"}},
+	)
+	body := `{"agent_names":["Loose1","Attached","Ori","Missing","Loose2"],"operation":"delete"}`
+	resp := postBulk(t, h, body)
+
+	if resp.Summary.Requested != 5 {
+		t.Fatalf("requested=%d, want 5", resp.Summary.Requested)
+	}
+	if resp.Summary.Succeeded != 2 {
+		t.Errorf("succeeded=%d, want 2", resp.Summary.Succeeded)
+	}
+	if resp.Summary.Skipped != 3 {
+		t.Errorf("skipped=%d, want 3 (attached, protected, missing)", resp.Summary.Skipped)
+	}
+
+	if r, _ := resultFor(resp, "Loose1"); r.Status != bulkStatusSucceeded {
+		t.Errorf("Loose1 status=%s, want succeeded", r.Status)
+	}
+	if r, _ := resultFor(resp, "Attached"); r.ReasonCode != reasonAttachedAgent {
+		t.Errorf("Attached reason=%s, want %s", r.ReasonCode, reasonAttachedAgent)
+	}
+	if r, _ := resultFor(resp, "Ori"); r.ReasonCode != reasonProtectedAgent {
+		t.Errorf("Ori reason=%s, want %s", r.ReasonCode, reasonProtectedAgent)
+	}
+	if r, _ := resultFor(resp, "Missing"); r.ReasonCode != reasonAgentNotFound {
+		t.Errorf("Missing reason=%s, want %s", r.ReasonCode, reasonAgentNotFound)
+	}
+
+	// Deleted agents are gone; skipped agents survive.
+	if _, ok := h.State.GetAgent("Loose1"); ok {
+		t.Errorf("Loose1 should be deleted from store")
+	}
+	if _, ok := h.State.GetAgent("Attached"); !ok {
+		t.Errorf("Attached should survive the bulk delete")
+	}
+}
+
+func TestBulkDeletePurgesSessionsAndLogs(t *testing.T) {
+	h := guardTestHandler(t, []string{"Gone"}, nil)
+	purger := &fakeSessionPurger{}
+	h.SetSessionPurger(purger)
+	logger := newTestActivityLogger(t)
+	h.ActivityLogger = logger
+
+	resp := postBulk(t, h, `{"agent_names":["Gone"],"operation":"delete"}`)
+	if resp.Summary.Succeeded != 1 {
+		t.Fatalf("expected 1 success, got %+v", resp.Summary)
+	}
+	if purger.calls != 1 || purger.lastAgent != "Gone" {
+		t.Errorf("expected session purge for Gone, got calls=%d agent=%q", purger.calls, purger.lastAgent)
+	}
+	logs, _, err := logger.GetActivityLog("Gone", 0, 0, types.ActivityEventDeleted, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetActivityLog: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Errorf("expected 1 deletion activity event, got %d", len(logs))
+	}
+}
+
+func TestBulkDeleteDedupesNames(t *testing.T) {
+	h := guardTestHandler(t, []string{"Dup"}, nil)
+	resp := postBulk(t, h, `{"agent_names":["Dup","dup","  Dup  "],"operation":"delete"}`)
+	if resp.Summary.Requested != 1 {
+		t.Fatalf("expected 1 unique requested, got %d", resp.Summary.Requested)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resp.Results))
+	}
+}
+
+// --- Tags -------------------------------------------------------------------
+
+func TestBulkAddTagsPreservesUnrelatedTags(t *testing.T) {
+	h := guardTestHandler(t, []string{"A", "B"}, nil)
+	setTags(t, h, "A", []string{"keep"})
+	setTags(t, h, "B", []string{"content"})
+
+	resp := postBulk(t, h, `{"agent_names":["A","B"],"operation":"add_tags","tags":["content","new"]}`)
+	if resp.Summary.Succeeded != 2 {
+		t.Fatalf("expected 2 successes, got %+v results=%+v", resp.Summary, resp.Results)
+	}
+
+	gotA := agentTags(t, h, "A")
+	if !containsAll(gotA, "keep", "content", "new") || len(gotA) != 3 {
+		t.Errorf("A tags=%v, want keep+content+new", gotA)
+	}
+	// B already had "content" — must not duplicate it.
+	gotB := agentTags(t, h, "B")
+	if countTag(gotB, "content") != 1 {
+		t.Errorf("B should have exactly one 'content' tag, got %v", gotB)
+	}
+}
+
+func TestBulkRemoveTagsPreservesOthers(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	setTags(t, h, "A", []string{"content", "draft", "keep"})
+
+	resp := postBulk(t, h, `{"agent_names":["A"],"operation":"remove_tags","tags":["content","draft"]}`)
+	if resp.Summary.Succeeded != 1 {
+		t.Fatalf("expected 1 success, got %+v", resp.Summary)
+	}
+	got := agentTags(t, h, "A")
+	if len(got) != 1 || got[0] != "keep" {
+		t.Errorf("A tags=%v, want [keep]", got)
+	}
+}
+
+func TestBulkTagSkipsCLIAndMissing(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	resp := postBulk(t, h, `{"agent_names":["A","Nope"],"operation":"add_tags","tags":["x"]}`)
+	if r, _ := resultFor(resp, "Nope"); r.ReasonCode != reasonAgentNotFound {
+		t.Errorf("Nope reason=%s, want %s", r.ReasonCode, reasonAgentNotFound)
+	}
+	if r, _ := resultFor(resp, "A"); r.Status != bulkStatusSucceeded {
+		t.Errorf("A status=%s, want succeeded", r.Status)
+	}
+}
+
+func TestBulkTagSharedRequiresConfirmation(t *testing.T) {
+	h := guardTestHandler(t,
+		[]string{"Shared"},
+		map[string][]string{"ws-a": {"Shared"}, "ws-b": {"Shared"}},
+	)
+	// Without confirmation → skipped.
+	resp := postBulk(t, h, `{"agent_names":["Shared"],"operation":"add_tags","tags":["x"]}`)
+	if r, _ := resultFor(resp, "Shared"); r.ReasonCode != reasonSharedEditNeedsOK {
+		t.Fatalf("expected shared-edit skip, got %+v", r)
+	}
+	if got := agentTags(t, h, "Shared"); containsAll(got, "x") {
+		t.Errorf("tag should not be applied without confirmation, got %v", got)
+	}
+	// With confirmation → applied.
+	resp = postBulk(t, h, `{"agent_names":["Shared"],"operation":"add_tags","tags":["x"],"confirm_shared_edit":true}`)
+	if r, _ := resultFor(resp, "Shared"); r.Status != bulkStatusSucceeded {
+		t.Fatalf("expected success with confirmation, got %+v", r)
+	}
+	if got := agentTags(t, h, "Shared"); !containsAll(got, "x") {
+		t.Errorf("tag should be applied with confirmation, got %v", got)
+	}
+}
+
+// --- Favorite ---------------------------------------------------------------
+
+func TestBulkSetFavorite(t *testing.T) {
+	h := guardTestHandler(t, []string{"A", "B"}, nil)
+	resp := postBulk(t, h, `{"agent_names":["A","B"],"operation":"set_favorite","favorite":true}`)
+	if resp.Summary.Succeeded != 2 {
+		t.Fatalf("expected 2 successes, got %+v", resp.Summary)
+	}
+	for _, name := range []string{"A", "B"} {
+		ag, _ := h.State.GetAgent(name)
+		if ag.Metadata == nil || !ag.Metadata.Favorite {
+			t.Errorf("%s should be favorited", name)
+		}
+	}
+
+	// Unfavorite one back.
+	resp = postBulk(t, h, `{"agent_names":["A"],"operation":"set_favorite","favorite":false}`)
+	if resp.Summary.Succeeded != 1 {
+		t.Fatalf("expected 1 success, got %+v", resp.Summary)
+	}
+	ag, _ := h.State.GetAgent("A")
+	if ag.Metadata.Favorite {
+		t.Errorf("A should be unfavorited")
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+type fakeSessionPurger struct {
+	calls     int
+	lastAgent string
+}
+
+func (f *fakeSessionPurger) DeleteSessionsByAgent(_ context.Context, agentName string) (int, error) {
+	f.calls++
+	f.lastAgent = agentName
+	return 1, nil
+}
+
+func newTestActivityLogger(t *testing.T) *ActivityLogger {
+	t.Helper()
+	al, err := NewActivityLogger(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewActivityLogger: %v", err)
+	}
+	return al
+}
+
+func containsAll(haystack []string, needles ...string) bool {
+	for _, n := range needles {
+		found := false
+		for _, h := range haystack {
+			if strings.EqualFold(h, n) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func countTag(tags []string, tag string) int {
+	c := 0
+	for _, t := range tags {
+		if strings.EqualFold(t, tag) {
+			c++
+		}
+	}
+	return c
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -161,6 +161,12 @@ func registerAgentRoutes(mux *http.ServeMux, s *Server) {
 	mux.HandleFunc("/api/agents/dashboard/list", dashboardHandler.ListAgentsWithStats)
 	mux.HandleFunc("/api/agents/dashboard/stats", dashboardHandler.GetDashboardStats)
 
+	// Bounded bulk-operation endpoint (delete / add_tags / remove_tags /
+	// set_favorite). Registered as an exact path so it resolves before the
+	// generic /api/agents/ subpath handler and is never read as an agent named
+	// "bulk" (PRD FR46).
+	mux.HandleFunc("/api/agents/bulk", agentHandler.HandleBulk)
+
 	mux.HandleFunc("/api/agents/", func(w http.ResponseWriter, r *http.Request) {
 		// Route evolution API requests first
 		if s.Handlers.Evolution != nil && strings.HasSuffix(r.URL.Path, "/evolution/path") && r.Method == http.MethodPost {

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -148,22 +148,68 @@
   outline-offset: 2px;
 }
 
-/* Roster card */
+/* Roster card: a checkbox (bulk selection) + an open button (focus/stage), as
+   sibling controls so the two selection concepts never nest or collide. */
 .roster-card {
   display: grid;
-  grid-template-columns: 40px minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 11px;
-  padding: 10px 12px;
+  gap: 6px;
+  padding: 6px 10px 6px 8px;
   border: 1px solid var(--border-color, #e5e7eb);
   border-radius: 12px;
   background: var(--bg-primary, #fff);
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
 .roster-card:hover {
   border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 45%, var(--border-color, #e5e7eb));
+}
+
+/* Checkbox column */
+.roster-card__checkwrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  margin: 0;
+  cursor: pointer;
+  align-self: stretch;
+}
+
+.roster-card__check {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--primary-color, #4f46e5);
+}
+
+.roster-card__check:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 2px;
+}
+
+/* Open/focus button: a full-width, unstyled button that carries the card's
+   avatar + body + status. Button reset so it reads as a card, not a control. */
+.roster-card__open {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 4px 2px;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
+.roster-card__open:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 2px;
 }
 
 /* Built-in "permanent residency" agents (CLI + Ori): a warm amber tint sets
@@ -183,10 +229,26 @@
   background: color-mix(in srgb, #f59e0b 20%, var(--bg-primary, #1f2430));
 }
 
-.roster-card[aria-selected="true"] {
+/* Focused agent (drives the stage): a left edge-bar + subtle tint. Distinct from
+   the checked cue below so a card can show focused, checked, both, or neither
+   without relying on color alone (PRD FR5). */
+.roster-card.is-focused {
   border-color: var(--primary-color, #4f46e5);
   background: color-mix(in srgb, var(--primary-color, #4f46e5) 8%, var(--bg-primary, #fff));
   box-shadow: inset 3px 0 0 var(--primary-color, #4f46e5);
+}
+
+/* Checked agent (bulk target): a ring around the whole card, driven by the
+   checkbox, independent of focus. */
+.roster-card.is-checked {
+  border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 70%, var(--border-color, #e5e7eb));
+  background: color-mix(in srgb, var(--primary-color, #4f46e5) 5%, var(--bg-primary, #fff));
+}
+
+/* Focused AND checked: combine the edge-bar (focus) with the checked ring. */
+.roster-card.is-focused.is-checked {
+  box-shadow: inset 3px 0 0 var(--primary-color, #4f46e5),
+    0 0 0 1px color-mix(in srgb, var(--primary-color, #4f46e5) 55%, transparent);
 }
 
 .roster-card__avatar {
@@ -204,6 +266,8 @@
 
 .roster-card__body {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .roster-card__namerow {
@@ -278,6 +342,94 @@
   cursor: pointer;
   font-size: 13px;
   text-decoration: underline;
+}
+
+.roster-linkbtn:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ---- Bulk selection controls + action bar --------------------------------- */
+
+.roster-selectbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 2px 4px;
+  min-height: 20px;
+}
+
+/* Contextual bulk action bar, revealed when >=1 agent is checked. Sticks to the
+   bottom of the roster rail so it stays reachable without covering the stage
+   (PRD FR16/FR21). */
+.bulk-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  padding: 10px 12px;
+  margin: 8px 4px 0;
+  border: 1px solid color-mix(in srgb, var(--primary-color, #4f46e5) 40%, var(--border-color, #e5e7eb));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--primary-color, #4f46e5) 6%, var(--bg-primary, #fff));
+  box-shadow: 0 -4px 12px color-mix(in srgb, #000 8%, transparent);
+}
+
+.bulk-bar__count {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bulk-bar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.bulk-bar__btn {
+  border: 1px solid var(--border-color, #d1d5db);
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+  border-radius: 8px;
+  padding: 6px 11px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.bulk-bar__btn:hover {
+  border-color: var(--primary-color, #4f46e5);
+}
+
+.bulk-bar__btn:focus-visible {
+  outline: 2px solid var(--primary-color, #4f46e5);
+  outline-offset: 1px;
+}
+
+.bulk-bar__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulk-bar__btn--danger {
+  border-color: color-mix(in srgb, #ef4444 55%, var(--border-color, #d1d5db));
+  color: #b91c1c;
+}
+
+.bulk-bar__btn--danger:hover {
+  border-color: #ef4444;
+  background: color-mix(in srgb, #ef4444 8%, var(--bg-primary, #fff));
+}
+
+[data-bs-theme="dark"] .bulk-bar__btn--danger {
+  color: #f87171;
 }
 
 /* ---- Stage ---------------------------------------------------------------- */

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -395,6 +395,8 @@
   flex: none;
 }
 
+/* Solid (opaque) pill colors so contrast is predictable on any card background,
+   including the amber built-in cards (WCAG AA, PRD FR55/FR87). */
 .roster-card__statuslabel {
   flex: none;
   font-size: 10px;
@@ -403,19 +405,20 @@
   text-transform: uppercase;
   padding: 1px 6px;
   border-radius: 999px;
-  color: var(--text-secondary, #6b7280);
-  background: color-mix(in srgb, var(--text-secondary, #6b7280) 12%, transparent);
+  color: #374151;
+  background: #e5e7eb;
 }
 .roster-card__statuslabel.is-active {
-  color: #15803d;
-  background: color-mix(in srgb, #22c55e 16%, transparent);
+  color: #14532d;
+  background: #bbf7d0;
 }
 .roster-card__statuslabel.is-error {
-  color: #b91c1c;
-  background: color-mix(in srgb, #ef4444 14%, transparent);
+  color: #7f1d1d;
+  background: #fecaca;
 }
-[data-bs-theme="dark"] .roster-card__statuslabel.is-active { color: #4ade80; }
-[data-bs-theme="dark"] .roster-card__statuslabel.is-error { color: #f87171; }
+[data-bs-theme="dark"] .roster-card__statuslabel { color: #1f2937; background: #cbd5e1; }
+[data-bs-theme="dark"] .roster-card__statuslabel.is-active { color: #14532d; background: #86efac; }
+[data-bs-theme="dark"] .roster-card__statuslabel.is-error { color: #7f1d1d; background: #fca5a5; }
 
 .roster-card__tags {
   display: flex;
@@ -704,8 +707,8 @@
 }
 
 .btn-danger {
-  border: 1px solid #ef4444;
-  background: #ef4444;
+  border: 1px solid #b91c1c;
+  background: #b91c1c; /* white text meets WCAG AA (contrast > 5:1) */
   color: #fff;
   border-radius: 8px;
   padding: 8px 16px;
@@ -715,8 +718,8 @@
   transition: background 0.15s ease;
 }
 
-.btn-danger:hover:not(:disabled) { background: #dc2626; }
-.btn-danger:focus-visible { outline: 2px solid #ef4444; outline-offset: 2px; }
+.btn-danger:hover:not(:disabled) { background: #991b1b; }
+.btn-danger:focus-visible { outline: 2px solid #b91c1c; outline-offset: 2px; }
 .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
 
 [data-bs-theme="dark"] .bulk-dialog { background: var(--bg-primary, #1f2430); }
@@ -1304,6 +1307,16 @@
   .roster-list {
     max-height: 44vh;
   }
+  /* Stack the bulk bar so its count and actions never overflow the narrow rail
+     or force horizontal page scrolling (PRD FR21). */
+  .bulk-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .bulk-bar__actions {
+    justify-content: flex-start;
+  }
+  .roster-filter select { max-width: none; flex: 1 1 auto; }
   .stage__hero {
     grid-template-columns: 52px minmax(0, 1fr);
     padding: 18px 18px 16px;
@@ -1317,8 +1330,13 @@
 
 @media (prefers-reduced-motion: reduce) {
   .roster-card,
+  .roster-card__open,
+  .roster-stat,
+  .bulk-bar__btn,
+  .bulk-bar__btn--danger,
   .btn-primary,
-  .btn-ghost {
+  .btn-ghost,
+  .btn-danger {
     transition: none;
   }
 }

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -328,6 +328,59 @@
 .roster-card__status.is-error { background: #ef4444; }
 .roster-card__status.is-disabled { background: #d1d5db; }
 
+/* Favorite star + textual status label + tag chips on the card. Status is
+   conveyed by text, never by the dot's color alone (PRD FR55). */
+.roster-card__fav {
+  color: #f59e0b;
+  font-size: 13px;
+  flex: none;
+}
+
+.roster-card__statuslabel {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: var(--text-secondary, #6b7280);
+  background: color-mix(in srgb, var(--text-secondary, #6b7280) 12%, transparent);
+}
+.roster-card__statuslabel.is-active {
+  color: #15803d;
+  background: color-mix(in srgb, #22c55e 16%, transparent);
+}
+.roster-card__statuslabel.is-error {
+  color: #b91c1c;
+  background: color-mix(in srgb, #ef4444 14%, transparent);
+}
+[data-bs-theme="dark"] .roster-card__statuslabel.is-active { color: #4ade80; }
+[data-bs-theme="dark"] .roster-card__statuslabel.is-error { color: #f87171; }
+
+.roster-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 3px;
+}
+.roster-card__tag {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: var(--text-secondary, #6b7280);
+  background: color-mix(in srgb, var(--primary-color, #4f46e5) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary-color, #4f46e5) 20%, transparent);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roster-card__tag--more {
+  background: none;
+  border-color: var(--border-color, #e5e7eb);
+}
+
 .roster-empty {
   text-align: center;
   color: var(--text-secondary, #6b7280);
@@ -608,6 +661,88 @@
 .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
 
 [data-bs-theme="dark"] .bulk-dialog { background: var(--bg-primary, #1f2430); }
+
+.bulk-dialog__text {
+  width: 100%;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 14px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+}
+
+.bulk-tags-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.bulk-tags-checklist__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+/* ---- Overview metadata controls ------------------------------------------- */
+
+.color-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.color-input input[type="color"] {
+  width: 38px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+}
+.color-input__hex {
+  width: 92px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+}
+
+.avatar-control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.avatar-control__status {
+  font-size: 12px;
+  color: var(--text-secondary, #6b7280);
+}
+
+.stage-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+  font-size: 12px;
+}
+.stage-meta dt {
+  color: var(--text-secondary, #6b7280);
+  font-weight: 600;
+}
+.stage-meta dd {
+  margin: 0;
+  color: var(--text-primary, #111827);
+}
 
 /* ---- Stage ---------------------------------------------------------------- */
 

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -73,12 +73,71 @@
   border: 1px solid var(--border-color, #e5e7eb);
   border-radius: 10px;
   background: var(--bg-secondary, #f9fafb);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
+.roster-stat:hover { border-color: color-mix(in srgb, var(--primary-color, #4f46e5) 45%, var(--border-color, #e5e7eb)); }
+.roster-stat:focus-visible { outline: 2px solid var(--primary-color, #4f46e5); outline-offset: 2px; }
+/* Selected health filter: ring + check glyph, not color alone. */
+.roster-stat.is-selected {
+  border-color: var(--primary-color, #4f46e5);
+  box-shadow: inset 0 0 0 1px var(--primary-color, #4f46e5);
+}
+.roster-stat.is-selected .roster-stat__label::after { content: " ✓"; }
 .roster-stat__value { font-size: 18px; font-weight: 700; line-height: 1.1; color: var(--text-primary, #111827); }
 .roster-stat__label { font-size: 11px; color: var(--text-secondary, #6b7280); }
 .roster-stat--needs .roster-stat__value { color: #dc2626; }
 .roster-stat--needs.roster-stat--zero .roster-stat__value,
 .roster-stat--disabled.roster-stat--zero .roster-stat__value { color: var(--text-primary, #111827); }
+
+/* ---- Filter controls ------------------------------------------------------ */
+.roster-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.roster-filter select {
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  padding: 5px 8px;
+  font-size: 12px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+  max-width: 140px;
+}
+.roster-filter select:focus-visible { outline: 2px solid var(--primary-color, #4f46e5); outline-offset: 1px; }
+.roster-filter-toggle {
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+}
+.roster-filter-toggle:hover { border-color: var(--primary-color, #4f46e5); }
+.roster-filter-toggle:focus-visible { outline: 2px solid var(--primary-color, #4f46e5); outline-offset: 1px; }
+.roster-filter-toggle.is-active {
+  border-color: #f59e0b;
+  background: color-mix(in srgb, #f59e0b 14%, transparent);
+  color: #b45309;
+}
+[data-bs-theme="dark"] .roster-filter-toggle.is-active { color: #fbbf24; }
+
+.roster-empty__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 6px;
+}
+[data-bs-theme="dark"] .roster-filter select,
+[data-bs-theme="dark"] .roster-filter-toggle { background: var(--bg-primary, #1f2430); }
 
 .roster-rail__actions {
   display: flex;

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -432,6 +432,183 @@
   color: #f87171;
 }
 
+/* ---- Bulk result surface -------------------------------------------------- */
+
+.bulk-result {
+  margin: 8px 4px 0;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 12px;
+  background: var(--bg-primary, #fff);
+  padding: 10px 12px;
+}
+
+.bulk-result__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+}
+
+.bulk-result__list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bulk-result__item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--text-secondary, #6b7280) 8%, transparent);
+}
+
+.bulk-result__item.is-failed {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+}
+
+.bulk-result__name {
+  font-weight: 600;
+  color: var(--text-primary, #111827);
+  flex: none;
+}
+
+.bulk-result__reason {
+  color: var(--text-secondary, #6b7280);
+  min-width: 0;
+}
+
+[data-bs-theme="dark"] .bulk-result { background: var(--bg-primary, #1f2430); }
+
+/* ---- Bulk-delete confirmation dialog -------------------------------------- */
+
+.bulk-dialog {
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 14px;
+  padding: 22px 24px;
+  max-width: 460px;
+  width: calc(100vw - 32px);
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111827);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.25);
+}
+
+.bulk-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.bulk-dialog__title {
+  margin: 0 0 4px;
+  font-size: 19px;
+}
+
+.bulk-dialog__lead {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--text-secondary, #6b7280);
+}
+
+.bulk-dialog__body {
+  max-height: 46vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.bulk-dialog__group {
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.bulk-dialog__group.is-danger {
+  border-color: color-mix(in srgb, #ef4444 40%, var(--border-color, #e5e7eb));
+}
+
+.bulk-dialog__grouptitle {
+  margin: 0 0 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary, #6b7280);
+}
+
+.bulk-dialog__grouplist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.bulk-dialog__grouplist li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.bulk-dialog__agent {
+  font-weight: 600;
+}
+
+.bulk-dialog__reason,
+.bulk-dialog__wslink {
+  font-size: 12px;
+  color: var(--text-secondary, #6b7280);
+}
+
+.bulk-dialog__none {
+  font-size: 13px;
+  color: var(--text-secondary, #6b7280);
+  margin: 0;
+}
+
+.bulk-dialog__error {
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #b91c1c;
+  background: color-mix(in srgb, #ef4444 10%, transparent);
+}
+
+.bulk-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.btn-danger {
+  border: 1px solid #ef4444;
+  background: #ef4444;
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.btn-danger:hover:not(:disabled) { background: #dc2626; }
+.btn-danger:focus-visible { outline: 2px solid #ef4444; outline-offset: 2px; }
+.btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+
+[data-bs-theme="dark"] .bulk-dialog { background: var(--bg-primary, #1f2430); }
+
 /* ---- Stage ---------------------------------------------------------------- */
 
 .roster-stage {

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -40,6 +40,10 @@
     allWorkspaces: null,
     creating: false,
     providers: null,
+    // Metadata-driven filters. Categories combine with AND; `health` is a
+    // multi-value set combining with OR (PRD FR73). None are ever persisted to
+    // the checked set — only to the URL (PRD FR77/FR80).
+    filters: { health: new Set(), role: '', source: '', assignment: '', tag: '', favorite: false },
     // Checked agents: the session-only bulk-selection set, kept entirely separate
     // from `selected` (the focused agent driving the stage). Never persisted to
     // URL or localStorage; a reload starts empty (PRD FR1/FR12/FR13).
@@ -107,6 +111,15 @@
       bulkTagsBody: document.getElementById('bulkTagsBody'),
       bulkTagsCancel: document.getElementById('bulkTagsCancel'),
       bulkTagsConfirm: document.getElementById('bulkTagsConfirm'),
+      filterRole: document.getElementById('filterRole'),
+      filterSource: document.getElementById('filterSource'),
+      filterAssignment: document.getElementById('filterAssignment'),
+      filterTag: document.getElementById('filterTag'),
+      filterFavorite: document.getElementById('filterFavorite'),
+      clearFilters: document.getElementById('clearFilters'),
+      emptyMsg: document.getElementById('rosterEmptyMsg'),
+      emptyClearFilters: document.getElementById('rosterEmptyClearFilters'),
+      emptyCreate: document.getElementById('rosterEmptyCreate'),
     };
 
     els.search.addEventListener('input', onSearch);
@@ -125,6 +138,22 @@
 
     els.selectAll.addEventListener('click', selectAllVisible);
     els.clearSelection.addEventListener('click', function () { clearSelection(true); });
+
+    els.filterRole.addEventListener('change', function () { state.filters.role = els.filterRole.value; onFilterChange(); });
+    els.filterSource.addEventListener('change', function () { state.filters.source = els.filterSource.value; onFilterChange(); });
+    els.filterAssignment.addEventListener('change', function () { state.filters.assignment = els.filterAssignment.value; onFilterChange(); });
+    els.filterTag.addEventListener('change', function () { state.filters.tag = els.filterTag.value; onFilterChange(); });
+    els.filterFavorite.addEventListener('click', function () {
+      state.filters.favorite = !state.filters.favorite;
+      els.filterFavorite.setAttribute('aria-pressed', state.filters.favorite ? 'true' : 'false');
+      els.filterFavorite.classList.toggle('is-active', state.filters.favorite);
+      onFilterChange();
+    });
+    els.clearFilters.addEventListener('click', clearFilters);
+    els.emptyClearFilters.addEventListener('click', clearFilters);
+    els.emptyCreate.addEventListener('click', openCreate);
+    // Status summary tiles double as health filter buttons (PRD FR72).
+    els.stats.addEventListener('click', onStatTileClick);
 
     els.bulkDelete.addEventListener('click', openBulkDelete);
     els.bulkDeleteCancel.addEventListener('click', function () { closeBulkDelete(); });
@@ -148,8 +177,14 @@
     });
 
     window.addEventListener('popstate', function () {
+      // Restore search/sort/filters/tab and the focused agent from the URL, but
+      // never the (session-only) checked set (PRD FR14/FR80).
+      applyUrlToState();
+      populateFilterOptions();
+      applyFilterSort();
       var name = new URLSearchParams(window.location.search).get('agent');
       if (name && state.byName[name]) selectAgent(name, { push: false });
+      restoreTabFromUrl();
     });
 
     window.addEventListener('beforeunload', function (e) {
@@ -194,8 +229,11 @@
         state.byName = {};
         agents.forEach(function (a) { state.byName[a.name] = a; });
         pruneChecked();
+        applyUrlToState();
+        populateFilterOptions();
         applyFilterSort();
         restoreSelection();
+        restoreTabFromUrl();
       })
       .catch(function (err) {
         els.count.textContent = 'Could not load agents.';
@@ -230,9 +268,7 @@
   function applyFilterSort() {
     var q = state.query.trim().toLowerCase();
     var list = state.agents.filter(function (a) {
-      if (!q) return true;
-      var hay = (a.name + ' ' + (a.role || '') + ' ' + ((a.metadata && a.metadata.description) || '')).toLowerCase();
-      return hay.indexOf(q) !== -1;
+      return matchesSearch(a, q) && matchesFilters(a);
     });
 
     list.sort(function (a, b) {
@@ -248,6 +284,107 @@
     renderRoster();
   }
 
+  // Search matches name, role, description, and tags (PRD FR74).
+  function matchesSearch(a, q) {
+    if (!q) return true;
+    var tags = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags.join(' ') : '';
+    var hay = (a.name + ' ' + (a.role || '') + ' ' + ((a.metadata && a.metadata.description) || '') + ' ' + tags).toLowerCase();
+    return hay.indexOf(q) !== -1;
+  }
+
+  // Filter categories combine with AND; multiple health values combine with OR
+  // (PRD FR73).
+  function matchesFilters(a) {
+    var f = state.filters;
+    if (f.health.size > 0 && !f.health.has(agentHealth(a))) return false;
+    if (f.role && String(a.role || '').toLowerCase() !== f.role.toLowerCase()) return false;
+    if (f.source && agentSourceKind(a) !== f.source) return false;
+    if (f.assignment === 'library' && (a.workspace_count || 0) > 0) return false;
+    if (f.assignment === 'assigned' && (a.workspace_count || 0) === 0) return false;
+    if (f.favorite && !(a.metadata && a.metadata.favorite)) return false;
+    if (f.tag) {
+      var tags = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags : [];
+      var has = tags.some(function (t) { return String(t).toLowerCase() === f.tag.toLowerCase(); });
+      if (!has) return false;
+    }
+    return true;
+  }
+
+  // Health bucket mirroring the status-summary tiles.
+  function agentHealth(a) {
+    var status = String((a && a.status) || 'idle').toLowerCase();
+    if (status === 'disabled') return 'disabled';
+    if (status === 'error' || !String((a && a.model) || '').trim()) return 'needs';
+    return 'ready';
+  }
+
+  function agentSourceKind(a) {
+    return String((a && a.source) || 'user').toLowerCase() === 'cli' ? 'cli' : 'user';
+  }
+
+  function filtersActive() {
+    var f = state.filters;
+    return f.health.size > 0 || !!f.role || !!f.source || !!f.assignment || !!f.tag || f.favorite;
+  }
+
+  function onFilterChange() {
+    els.clearFilters.hidden = !filtersActive();
+    applyFilterSort();
+    syncUrl(state.selected, false);
+  }
+
+  function clearFilters() {
+    state.filters = { health: new Set(), role: '', source: '', assignment: '', tag: '', favorite: false };
+    els.filterRole.value = '';
+    els.filterSource.value = '';
+    els.filterAssignment.value = '';
+    els.filterTag.value = '';
+    els.filterFavorite.setAttribute('aria-pressed', 'false');
+    els.filterFavorite.classList.remove('is-active');
+    onFilterChange();
+  }
+
+  function onStatTileClick(e) {
+    var tile = e.target.closest('.roster-stat');
+    if (!tile) return;
+    var health = tile.dataset.health;
+    if (!health || health === 'total') { state.filters.health.clear(); }
+    else if (state.filters.health.has(health)) { state.filters.health.delete(health); }
+    else { state.filters.health.add(health); }
+    onFilterChange();
+  }
+
+  // Populate the Role and Tag filter dropdowns from the values actually present
+  // in the roster, preserving the current selection when still valid.
+  function populateFilterOptions() {
+    var roles = {};
+    var tags = {};
+    state.agents.forEach(function (a) {
+      var role = String(a.role || '').trim();
+      if (role) roles[role.toLowerCase()] = role;
+      var t = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags : [];
+      t.forEach(function (tag) { var k = String(tag).toLowerCase(); if (k) tags[k] = tag; });
+    });
+    fillSelect(els.filterRole, 'All roles', roles, state.filters.role, titleCase);
+    fillSelect(els.filterTag, 'All tags', tags, state.filters.tag, null);
+    // A previously-selected value that no longer exists falls back to "all".
+    if (state.filters.role && !roles[state.filters.role.toLowerCase()]) { state.filters.role = ''; els.filterRole.value = ''; }
+    if (state.filters.tag && !tags[state.filters.tag.toLowerCase()]) { state.filters.tag = ''; els.filterTag.value = ''; }
+  }
+
+  function fillSelect(sel, allLabel, valueMap, current, labeler) {
+    if (!sel) return;
+    var keys = Object.keys(valueMap).sort(function (a, b) { return valueMap[a].localeCompare(valueMap[b]); });
+    var html = '<option value="">' + esc(allLabel) + '</option>';
+    keys.forEach(function (k) {
+      var v = valueMap[k];
+      var label = labeler ? labeler(v) : v;
+      html += '<option value="' + esc(v) + '">' + esc(label) + '</option>';
+    });
+    sel.innerHTML = html;
+    if (current) sel.value = current;
+  }
+
   function renderRoster() {
     els.list.innerHTML = '';
     var total = state.agents.length;
@@ -256,7 +393,7 @@
     renderStatusTiles();
 
     if (shown === 0) {
-      els.empty.hidden = false;
+      renderEmptyState(total);
       els.count.textContent = total === 0 ? 'No agents yet.' : '0 of ' + total + ' agents';
       updateBulkBar();
       return;
@@ -296,12 +433,19 @@
       statTile('total', 'Total', total);
   }
 
+  // Each tile is a toggle filter button (PRD FR72). "Total" clears the health
+  // filter; the others toggle their health bucket. Selection is reflected with
+  // aria-pressed + an is-selected class (not color alone).
   function statTile(kind, label, value) {
     var zero = value === 0 ? ' roster-stat--zero' : '';
-    return '<div class="roster-stat roster-stat--' + kind + zero + '">' +
+    var health = kind === 'total' ? 'total' : kind;
+    var selected = kind !== 'total' && state.filters.health.has(kind);
+    var sel = selected ? ' is-selected' : '';
+    return '<button type="button" class="roster-stat roster-stat--' + kind + zero + sel + '"' +
+      ' data-health="' + health + '" aria-pressed="' + (selected ? 'true' : 'false') + '">' +
       '<span class="roster-stat__value">' + value + '</span>' +
       '<span class="roster-stat__label">' + esc(label) + '</span>' +
-      '</div>';
+      '</button>';
   }
 
   function buildCard(agent, idx) {
@@ -376,6 +520,24 @@
     }).join('');
     var more = tags.length > 2 ? '<span class="roster-card__tag roster-card__tag--more">+' + (tags.length - 2) + '</span>' : '';
     return '<span class="roster-card__tags" aria-hidden="true">' + shown + more + '</span>';
+  }
+
+  // Distinct empty states (PRD FR81): no agents at all vs. an active
+  // search/filter that hid everything.
+  function renderEmptyState(total) {
+    els.empty.hidden = false;
+    var hasSearch = state.query.trim() !== '';
+    var hasFilters = filtersActive();
+    els.emptyClearFilters.hidden = !hasFilters;
+    els.clearSearch.hidden = !hasSearch;
+    els.emptyCreate.hidden = total !== 0;
+    if (total === 0) {
+      els.emptyMsg.textContent = 'No agents yet. Create your first agent to get started.';
+    } else if (hasSearch || hasFilters) {
+      els.emptyMsg.textContent = 'No agents match the current search and filters.';
+    } else {
+      els.emptyMsg.textContent = 'No agents to show.';
+    }
   }
 
   function highlightSelected() {
@@ -1105,6 +1267,7 @@
         agents.forEach(function (a) { state.byName[a.name] = a; });
         state.detailCache = {};
         pruneChecked();
+        populateFilterOptions();
         applyFilterSort();
         if (name && state.byName[name]) selectAgent(name, { push: true });
         else if (state.filtered[0]) selectAgent(state.filtered[0].name, { push: false });
@@ -1164,6 +1327,7 @@
     setActiveTab(tabName);
     if (tabName === 'prompt' && state.selected) renderPrompt(state.selected);
     if (focus) document.getElementById('tab-' + tabName).focus();
+    syncUrl(state.selected, false);
   }
 
   function setActiveTab(tabName) {
@@ -1803,8 +1967,8 @@
     announce(msg + '.');
   }
 
-  function onSearch() { state.query = els.search.value || ''; applyFilterSort(); }
-  function onSort() { state.sort = els.sort.value || 'name-asc'; applyFilterSort(); if (state.selected) highlightSelected(); }
+  function onSearch() { state.query = els.search.value || ''; applyFilterSort(); syncUrl(state.selected, false); }
+  function onSort() { state.sort = els.sort.value || 'name-asc'; applyFilterSort(); if (state.selected) highlightSelected(); syncUrl(state.selected, false); }
 
   /* ---- form field builders ------------------------------------------------- */
 
@@ -2023,13 +2187,71 @@
     return s.replace(/\w\S*/g, function (w) { return w.charAt(0).toUpperCase() + w.slice(1); });
   }
 
+  // Serialize search, sort, filters, focused agent, and active tab to the URL.
+  // Checked-agent state is intentionally excluded (PRD FR77/FR80). `push` adds a
+  // history entry (agent focus changes); everything else replaces in place.
   function syncUrl(name, push) {
-    var params = new URLSearchParams(window.location.search);
-    params.delete('view'); // roster is the default Agents page now
-    params.set('agent', name);
-    var url = window.location.pathname + '?' + params.toString();
-    if (push) window.history.pushState({ agent: name }, '', url);
-    else window.history.replaceState({ agent: name }, '', url);
+    var params = new URLSearchParams();
+    if (name) params.set('agent', name);
+    if (state.query.trim()) params.set('q', state.query.trim());
+    if (state.sort && state.sort !== 'name-asc') params.set('sort', state.sort);
+    var tab = currentTab();
+    if (tab && tab !== 'overview') params.set('tab', tab);
+    var f = state.filters;
+    if (f.role) params.set('role', f.role);
+    if (f.source) params.set('source', f.source);
+    if (f.assignment) params.set('assign', f.assignment);
+    if (f.favorite) params.set('fav', '1');
+    if (f.tag) params.append('tag', f.tag);
+    f.health.forEach(function (h) { params.append('health', h); });
+
+    var qs = params.toString();
+    var url = window.location.pathname + (qs ? '?' + qs : '');
+    var stateObj = { agent: name };
+    if (push) window.history.pushState(stateObj, '', url);
+    else window.history.replaceState(stateObj, '', url);
+  }
+
+  // Read filter/search/sort/tab state from the URL into state (not the focused
+  // agent — that is resolved separately against the loaded roster). Invalid or
+  // unknown values are discarded safely (PRD FR79).
+  function applyUrlToState() {
+    var p = new URLSearchParams(window.location.search);
+    state.query = p.get('q') || '';
+    if (els.search) els.search.value = state.query;
+    var sort = p.get('sort') || 'name-asc';
+    var validSorts = { 'name-asc': 1, 'name-desc': 1, 'workspaces-desc': 1, 'active-desc': 1 };
+    state.sort = validSorts[sort] ? sort : 'name-asc';
+    if (els.sort) els.sort.value = state.sort;
+
+    var f = { health: new Set(), role: '', source: '', assignment: '', tag: '', favorite: false };
+    var role = p.get('role'); if (role) f.role = role;
+    var source = p.get('source'); if (source === 'user' || source === 'cli') f.source = source;
+    var assign = p.get('assign'); if (assign === 'library' || assign === 'assigned') f.assignment = assign;
+    if (p.get('fav') === '1') f.favorite = true;
+    var tag = p.get('tag'); if (tag) f.tag = tag;
+    p.getAll('health').forEach(function (h) { if (h === 'needs' || h === 'ready' || h === 'disabled') f.health.add(h); });
+    state.filters = f;
+    reflectFiltersInControls();
+  }
+
+  // Push current filter state onto the controls (after a URL restore / popstate).
+  function reflectFiltersInControls() {
+    var f = state.filters;
+    if (els.filterRole) els.filterRole.value = f.role;
+    if (els.filterSource) els.filterSource.value = f.source;
+    if (els.filterAssignment) els.filterAssignment.value = f.assignment;
+    if (els.filterTag) els.filterTag.value = f.tag;
+    if (els.filterFavorite) {
+      els.filterFavorite.setAttribute('aria-pressed', f.favorite ? 'true' : 'false');
+      els.filterFavorite.classList.toggle('is-active', f.favorite);
+    }
+    if (els.clearFilters) els.clearFilters.hidden = !filtersActive();
+  }
+
+  function restoreTabFromUrl() {
+    var tab = new URLSearchParams(window.location.search).get('tab');
+    if (tab && TAB_ORDER.indexOf(tab) !== -1 && tab !== 'overview') requestTab(tab, false);
   }
 
   function safeStorageGet() { try { return window.localStorage.getItem(STORAGE_KEY); } catch (e) { return null; } }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -40,6 +40,13 @@
     allWorkspaces: null,
     creating: false,
     providers: null,
+    // Checked agents: the session-only bulk-selection set, kept entirely separate
+    // from `selected` (the focused agent driving the stage). Never persisted to
+    // URL or localStorage; a reload starts empty (PRD FR1/FR12/FR13).
+    checked: new Set(),
+    // Anchor index (into the current sorted+filtered roster) for Shift-click and
+    // Shift+Space contiguous range selection (PRD FR10).
+    rangeAnchor: -1,
   };
 
   var els = {};
@@ -71,6 +78,16 @@
       createPanel: document.getElementById('createPanel'),
       createBody: document.getElementById('createBody'),
       createCancel: document.getElementById('createCancel'),
+      selectAll: document.getElementById('rosterSelectAll'),
+      clearSelection: document.getElementById('rosterClearSelection'),
+      bulkBar: document.getElementById('bulkBar'),
+      bulkCount: document.getElementById('bulkCount'),
+      bulkLive: document.getElementById('bulkLive'),
+      bulkAddTags: document.getElementById('bulkAddTags'),
+      bulkRemoveTags: document.getElementById('bulkRemoveTags'),
+      bulkFavorite: document.getElementById('bulkFavorite'),
+      bulkUnfavorite: document.getElementById('bulkUnfavorite'),
+      bulkDelete: document.getElementById('bulkDelete'),
     };
 
     els.search.addEventListener('input', onSearch);
@@ -82,9 +99,13 @@
     });
     els.list.addEventListener('click', onListClick);
     els.list.addEventListener('keydown', onListKeydown);
+    els.list.addEventListener('change', onListChange);
     els.newAgentBtn.addEventListener('click', openCreate);
     els.createCancel.addEventListener('click', closeCreate);
     els.stageDelete.addEventListener('click', onDeleteClick);
+
+    els.selectAll.addEventListener('click', selectAllVisible);
+    els.clearSelection.addEventListener('click', function () { clearSelection(true); });
 
     var tabs = document.querySelectorAll('.stage__tab');
     tabs.forEach(function (tab) {
@@ -138,6 +159,7 @@
         state.agents = agents;
         state.byName = {};
         agents.forEach(function (a) { state.byName[a.name] = a; });
+        pruneChecked();
         applyFilterSort();
         restoreSelection();
       })
@@ -145,6 +167,15 @@
         els.count.textContent = 'Could not load agents.';
         console.error('[roster] load failed', err);
       });
+  }
+
+  // Drop checked names that no longer exist in the roster (e.g. after a reload or
+  // a bulk delete) so counts and the action bar never reference missing agents.
+  function pruneChecked() {
+    if (state.checked.size === 0) return;
+    var stale = [];
+    state.checked.forEach(function (name) { if (!state.byName[name]) stale.push(name); });
+    stale.forEach(function (name) { state.checked.delete(name); });
   }
 
   function fetchDetail(name, force) {
@@ -193,6 +224,7 @@
     if (shown === 0) {
       els.empty.hidden = false;
       els.count.textContent = total === 0 ? 'No agents yet.' : '0 of ' + total + ' agents';
+      updateBulkBar();
       return;
     }
     els.empty.hidden = true;
@@ -204,6 +236,7 @@
     });
     els.list.appendChild(frag);
     highlightSelected();
+    updateBulkBar();
   }
 
   // At-a-glance status summary over ALL agents (not the filtered view). Mirrors
@@ -240,10 +273,8 @@
   function buildCard(agent, idx) {
     var li = document.createElement('li');
     li.className = 'roster-card' + (isPermanent(agent) ? ' is-permanent' : '');
-    li.setAttribute('role', 'option');
-    li.id = 'roster-opt-' + idx;
     li.dataset.name = agent.name;
-    li.setAttribute('aria-selected', 'false');
+    li.dataset.index = idx;
 
     var status = healthKind(agent);
     var metaBits = [];
@@ -252,32 +283,46 @@
     metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
 
     var permanent = isPermanent(agent);
+    var isChecked = state.checked.has(agent.name);
 
     // Concise spoken label so screen readers don't read the raw dot markup.
     var wcLabel = wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
-    li.setAttribute('aria-label', agent.name + (permanent ? ', built-in' : '') + ', ' + status + ', ' + wcLabel);
+    var openLabel = agent.name + (permanent ? ', built-in' : '') + ', ' + status + ', ' + wcLabel;
 
     var badge = permanent
       ? '<span class="roster-card__badge" title="Built-in agent — always available and cannot be deleted">Built-in</span>'
       : '';
+
+    // A labeled checkbox and a separate open/focus button are siblings — never
+    // nested — so the checkbox is not a child of an interactive element and the
+    // two actions stay independent (PRD FR2/FR3/FR4).
     li.innerHTML =
+      '<label class="roster-card__checkwrap">' +
+      '<span class="visually-hidden">Select ' + esc(agent.name) + '</span>' +
+      '<input type="checkbox" class="roster-card__check" data-check="' + esc(agent.name) + '"' + (isChecked ? ' checked' : '') + '>' +
+      '</label>' +
+      '<button type="button" class="roster-card__open" data-open="' + esc(agent.name) + '" aria-label="' + esc(openLabel) + '">' +
       avatarMarkup(agent, 'roster-card__avatar') +
-      '<div class="roster-card__body">' +
-      '<div class="roster-card__namerow">' +
+      '<span class="roster-card__body">' +
+      '<span class="roster-card__namerow">' +
       '<span class="roster-card__name">' + esc(agent.name) + '</span>' + badge +
-      '</div>' +
-      '<p class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</p>' +
-      '</div>' +
-      '<span class="roster-card__status is-' + status + '" title="' + esc(status) + '"></span>';
+      '</span>' +
+      '<span class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</span>' +
+      '</span>' +
+      '<span class="roster-card__status is-' + status + '" title="' + esc(status) + '"></span>' +
+      '</button>';
+
+    if (isChecked) li.classList.add('is-checked');
     return li;
   }
 
   function highlightSelected() {
-    var options = els.list.querySelectorAll('.roster-card');
-    options.forEach(function (opt) {
-      var isSel = opt.dataset.name === state.selected;
-      opt.setAttribute('aria-selected', isSel ? 'true' : 'false');
-      if (isSel) els.list.setAttribute('aria-activedescendant', opt.id);
+    var cards = els.list.querySelectorAll('.roster-card');
+    cards.forEach(function (card) {
+      var open = card.querySelector('.roster-card__open');
+      var isSel = card.dataset.name === state.selected;
+      card.classList.toggle('is-focused', isSel);
+      if (open) open.setAttribute('aria-current', isSel ? 'true' : 'false');
     });
   }
 
@@ -856,6 +901,7 @@
         state.byName = {};
         agents.forEach(function (a) { state.byName[a.name] = a; });
         state.detailCache = {};
+        pruneChecked();
         applyFilterSort();
         if (name && state.byName[name]) selectAgent(name, { push: true });
         else if (state.filtered[0]) selectAgent(state.filtered[0].name, { push: false });
@@ -1037,27 +1083,171 @@
 
   /* ---- roster interaction -------------------------------------------------- */
 
+  // Clicking a card's open button focuses that agent (drives the stage) without
+  // touching its checkbox. The checkbox is handled by onListChange so a plain
+  // click there only changes bulk-selection state (PRD FR3/FR4).
   function onListClick(e) {
-    var card = e.target.closest('.roster-card');
-    if (card && card.dataset.name) selectAgent(card.dataset.name);
+    var open = e.target.closest('.roster-card__open');
+    if (open && open.dataset.open) { selectAgent(open.dataset.open); return; }
+
+    // Shift-click on (or near) a checkbox extends a contiguous range from the
+    // anchor. The native toggle still fires via onListChange; here we only widen
+    // the range when Shift is held.
+    var check = e.target.closest('.roster-card__check');
+    if (check && e.shiftKey) {
+      e.preventDefault();
+      var card = check.closest('.roster-card');
+      var idx = card ? Number(card.dataset.index) : -1;
+      if (idx >= 0) { rangeSelectTo(idx); }
+    }
+  }
+
+  function onListChange(e) {
+    var check = e.target.closest('.roster-card__check');
+    if (!check) return;
+    var name = check.dataset.check;
+    var card = check.closest('.roster-card');
+    var idx = card ? Number(card.dataset.index) : -1;
+    setChecked(name, check.checked);
+    state.rangeAnchor = idx;
+    if (card) card.classList.toggle('is-checked', check.checked);
+    updateBulkBar();
   }
 
   function onListKeydown(e) {
+    // Roving focus over the open buttons; Space toggles the row's checkbox
+    // without moving focus (PRD FR83). Shift+Space extends a range from the
+    // anchor — the documented keyboard equivalent of Shift-click (PRD FR10).
+    var open = e.target.closest('.roster-card__open');
     var n = state.filtered.length;
     if (n === 0) return;
-    var idx = state.focusIndex < 0 ? 0 : state.focusIndex;
-    if (e.key === 'ArrowDown') { e.preventDefault(); selectByIndex(Math.min(idx + 1, n - 1)); }
-    else if (e.key === 'ArrowUp') { e.preventDefault(); selectByIndex(Math.max(idx - 1, 0)); }
-    else if (e.key === 'Home') { e.preventDefault(); selectByIndex(0); }
-    else if (e.key === 'End') { e.preventDefault(); selectByIndex(n - 1); }
+
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Home' || e.key === 'End') {
+      if (!open) return;
+      e.preventDefault();
+      var card = open.closest('.roster-card');
+      var idx = card ? Number(card.dataset.index) : 0;
+      var next = idx;
+      if (e.key === 'ArrowDown') next = Math.min(idx + 1, n - 1);
+      else if (e.key === 'ArrowUp') next = Math.max(idx - 1, 0);
+      else if (e.key === 'Home') next = 0;
+      else next = n - 1;
+      focusRow(next);
+      return;
+    }
+
+    if (e.key === ' ' || e.key === 'Spacebar') {
+      if (!open) return;
+      e.preventDefault();
+      var c = open.closest('.roster-card');
+      var i = c ? Number(c.dataset.index) : -1;
+      if (i < 0) return;
+      if (e.shiftKey) { rangeSelectTo(i); }
+      else {
+        var name = c.dataset.name;
+        var nowChecked = !state.checked.has(name);
+        setChecked(name, nowChecked);
+        state.rangeAnchor = i;
+        var box = c.querySelector('.roster-card__check');
+        if (box) box.checked = nowChecked;
+        c.classList.toggle('is-checked', nowChecked);
+        updateBulkBar();
+      }
+    }
   }
 
-  function selectByIndex(i) {
+  // Move keyboard focus to the open button of the row at filtered index i.
+  function focusRow(i) {
     var agent = state.filtered[i];
     if (!agent) return;
-    selectAgent(agent.name);
-    var opt = els.list.querySelector('.roster-card[data-name="' + cssEscape(agent.name) + '"]');
-    if (opt && opt.scrollIntoView) opt.scrollIntoView({ block: 'nearest' });
+    var card = els.list.querySelector('.roster-card[data-name="' + cssEscape(agent.name) + '"]');
+    if (!card) return;
+    var open = card.querySelector('.roster-card__open');
+    if (open) open.focus();
+    if (card.scrollIntoView) card.scrollIntoView({ block: 'nearest' });
+  }
+
+  /* ---- bulk selection ------------------------------------------------------ */
+
+  function setChecked(name, on) {
+    if (!name) return;
+    if (on) state.checked.add(name);
+    else state.checked.delete(name);
+  }
+
+  // Check every agent in the current filtered result set — and only those, never
+  // agents hidden by the active filters (PRD FR7).
+  function selectAllVisible() {
+    state.filtered.forEach(function (a) { state.checked.add(a.name); });
+    reflectCheckedInDom();
+    updateBulkBar();
+    announce(state.checked.size + ' agent' + (state.checked.size === 1 ? '' : 's') + ' selected.');
+  }
+
+  function clearSelection(focusControl) {
+    state.checked.clear();
+    state.rangeAnchor = -1;
+    reflectCheckedInDom();
+    updateBulkBar();
+    announce('Selection cleared.');
+    if (focusControl && els.selectAll) els.selectAll.focus();
+  }
+
+  // Select the contiguous range between the anchor and index i in the current
+  // sorted+filtered order, adding every row in between to the checked set.
+  function rangeSelectTo(i) {
+    var anchor = state.rangeAnchor;
+    if (anchor < 0 || anchor >= state.filtered.length) anchor = i;
+    var lo = Math.min(anchor, i);
+    var hi = Math.max(anchor, i);
+    for (var k = lo; k <= hi; k++) {
+      var a = state.filtered[k];
+      if (a) state.checked.add(a.name);
+    }
+    state.rangeAnchor = i;
+    reflectCheckedInDom();
+    updateBulkBar();
+  }
+
+  // Sync checkbox + card classes to the checked set without a full re-render.
+  function reflectCheckedInDom() {
+    els.list.querySelectorAll('.roster-card').forEach(function (card) {
+      var on = state.checked.has(card.dataset.name);
+      var box = card.querySelector('.roster-card__check');
+      if (box) box.checked = on;
+      card.classList.toggle('is-checked', on);
+    });
+  }
+
+  // Count checked agents that are not in the current filtered result set, so the
+  // action bar can disclose "N selected · M hidden by filters" (PRD FR9).
+  function hiddenCheckedCount() {
+    if (state.checked.size === 0) return 0;
+    var visible = {};
+    state.filtered.forEach(function (a) { visible[a.name] = true; });
+    var hidden = 0;
+    state.checked.forEach(function (name) { if (!visible[name]) hidden++; });
+    return hidden;
+  }
+
+  function updateBulkBar() {
+    var total = state.checked.size;
+    if (els.clearSelection) els.clearSelection.hidden = total === 0;
+    if (!els.bulkBar) return;
+    if (total === 0) {
+      els.bulkBar.hidden = true;
+      els.bulkCount.textContent = '';
+      return;
+    }
+    els.bulkBar.hidden = false;
+    var hidden = hiddenCheckedCount();
+    var label = total + ' selected';
+    if (hidden > 0) label += ' · ' + hidden + ' hidden by filters';
+    els.bulkCount.textContent = label;
+  }
+
+  function announce(msg) {
+    if (els.bulkLive) els.bulkLive.textContent = msg;
   }
 
   function onSearch() { state.query = els.search.value || ''; applyFilterSort(); }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -51,6 +51,12 @@
 
   var els = {};
 
+  // Active OriTagInput instance for the focused agent's Overview tab (rebuilt on
+  // each render); read back in overviewEdits.
+  var overviewTagsInput = null;
+  // OriTagInput instance for the Create panel; read back in submitCreate.
+  var createTagsInput = null;
+
   document.addEventListener('DOMContentLoaded', init);
 
   function init() {
@@ -96,6 +102,11 @@
       bulkDeleteBody: document.getElementById('bulkDeleteBody'),
       bulkDeleteCancel: document.getElementById('bulkDeleteCancel'),
       bulkDeleteConfirm: document.getElementById('bulkDeleteConfirm'),
+      bulkTagsDialog: document.getElementById('bulkTagsDialog'),
+      bulkTagsTitle: document.getElementById('bulkTagsTitle'),
+      bulkTagsBody: document.getElementById('bulkTagsBody'),
+      bulkTagsCancel: document.getElementById('bulkTagsCancel'),
+      bulkTagsConfirm: document.getElementById('bulkTagsConfirm'),
     };
 
     els.search.addEventListener('input', onSearch);
@@ -121,6 +132,14 @@
     els.bulkResultDismiss.addEventListener('click', dismissBulkResult);
     // Native <dialog> fires 'cancel' on Escape; keep our teardown consistent.
     els.bulkDeleteDialog.addEventListener('cancel', function (e) { e.preventDefault(); closeBulkDelete(); });
+
+    els.bulkAddTags.addEventListener('click', function () { openBulkTags('add'); });
+    els.bulkRemoveTags.addEventListener('click', function () { openBulkTags('remove'); });
+    els.bulkTagsCancel.addEventListener('click', closeBulkTags);
+    els.bulkTagsConfirm.addEventListener('click', runBulkTags);
+    els.bulkTagsDialog.addEventListener('cancel', function (e) { e.preventDefault(); closeBulkTags(); });
+    els.bulkFavorite.addEventListener('click', function () { runBulkFavorite(true); });
+    els.bulkUnfavorite.addEventListener('click', function () { runBulkFavorite(false); });
 
     var tabs = document.querySelectorAll('.stage__tab');
     tabs.forEach(function (tab) {
@@ -292,21 +311,36 @@
     li.dataset.index = idx;
 
     var status = healthKind(agent);
+    var statusText = titleCase(String(agent.status || 'idle'));
     var metaBits = [];
+    var role = titleCase(agent.role || '');
+    if (role) metaBits.push(role);
     if (agent.model) metaBits.push(agent.model);
     var wc = agent.workspace_count || 0;
     metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
+    var active = lastActiveLabel(agent);
+    if (active) metaBits.push(active);
 
     var permanent = isPermanent(agent);
     var isChecked = state.checked.has(agent.name);
+    var favorite = !!(agent.metadata && agent.metadata.favorite);
+    var tags = (agent.metadata && Array.isArray(agent.metadata.tags)) ? agent.metadata.tags : [];
 
-    // Concise spoken label so screen readers don't read the raw dot markup.
+    // Concise spoken label so screen readers don't read the raw dot markup, and
+    // it carries the FULL tag list even when the visible chips are truncated
+    // (PRD FR59).
     var wcLabel = wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
-    var openLabel = agent.name + (permanent ? ', built-in' : '') + ', ' + status + ', ' + wcLabel;
+    var openLabel = agent.name + (permanent ? ', built-in' : '') +
+      (favorite ? ', favorite' : '') + ', ' + statusText + ', ' + wcLabel +
+      (tags.length ? ', tags: ' + tags.join(', ') : '');
 
     var badge = permanent
       ? '<span class="roster-card__badge" title="Built-in agent — always available and cannot be deleted">Built-in</span>'
       : '';
+    var star = favorite
+      ? '<span class="roster-card__fav" title="Favorite" aria-hidden="true">★</span>'
+      : '';
+    var tagsRow = tagsRowHTML(tags);
 
     // A labeled checkbox and a separate open/focus button are siblings — never
     // nested — so the checkbox is not a child of an interactive element and the
@@ -320,15 +354,28 @@
       avatarMarkup(agent, 'roster-card__avatar') +
       '<span class="roster-card__body">' +
       '<span class="roster-card__namerow">' +
-      '<span class="roster-card__name">' + esc(agent.name) + '</span>' + badge +
+      '<span class="roster-card__name">' + esc(agent.name) + '</span>' + star + badge +
+      '<span class="roster-card__statuslabel is-' + status + '">' + esc(statusText) + '</span>' +
       '</span>' +
       '<span class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</span>' +
+      tagsRow +
       '</span>' +
-      '<span class="roster-card__status is-' + status + '" title="' + esc(status) + '"></span>' +
+      '<span class="roster-card__status is-' + status + '" title="' + esc(statusText) + '" aria-hidden="true"></span>' +
       '</button>';
 
     if (isChecked) li.classList.add('is-checked');
     return li;
+  }
+
+  // Up to two visible tag chips + a "+N" indicator when more exist. The full list
+  // still reaches assistive tech via the open button's aria-label (PRD FR58/FR59).
+  function tagsRowHTML(tags) {
+    if (!tags || tags.length === 0) return '';
+    var shown = tags.slice(0, 2).map(function (t) {
+      return '<span class="roster-card__tag">' + esc(t) + '</span>';
+    }).join('');
+    var more = tags.length > 2 ? '<span class="roster-card__tag roster-card__tag--more">+' + (tags.length - 2) + '</span>' : '';
+    return '<span class="roster-card__tags" aria-hidden="true">' + shown + more + '</span>';
   }
 
   function highlightSelected() {
@@ -471,6 +518,7 @@
       ? readonlyInput('ov-provider', detail.provider || '', 'Set by the selected model')
       : textInput('ov-provider', detail.provider || '', 'openai / anthropic / ollama…');
 
+    var md = detail.metadata || {};
     els.overviewFacts.innerHTML =
       '<form class="stage-form" id="overviewForm" novalidate>' +
       field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
@@ -485,11 +533,19 @@
         '</div></div>' +
       field('Max output tokens', numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1'), 'ov-maxtokens') +
       field('Web search', checkInput('ov-websearch', detail.allow_web_search)) +
-      field('Description', textareaInput('ov-description', (detail.metadata && detail.metadata.description) || '', 3), 'ov-description') +
+      field('Description', textareaInput('ov-description', md.description || '', 3), 'ov-description') +
+      field('Favorite', '<label class="check"><input id="ov-favorite" type="checkbox"' + (md.favorite ? ' checked' : '') + '> Favorited</label>') +
+      field('Tags', '<div id="ov-tags-host"></div>', 'ov-tags-host') +
+      field('Avatar color', colorInput('ov-avatarcolor', md.avatar_color || colorFor(name)), 'ov-avatarcolor') +
+      '<div class="field"><span class="field__label">Avatar image</span><div class="field__control" id="ov-avatar-control"></div></div>' +
       '</form>' +
+      readonlyMetaHTML(detail) +
       saveBar('overview');
 
     els.overviewDesc.innerHTML = '';
+    wireOverviewTags(name, md.tags || []);
+    wireAvatarControl(name, md);
+    wireColorInput('ov-avatarcolor');
     wireDirty('overview', document.getElementById('overviewForm'));
     wireSaveBar('overview', function () { saveOverview(name); });
 
@@ -600,9 +656,125 @@
     if (!isNaN(maxNum) && maxNum !== Number(detail.max_output_tokens || 0)) out.max_output_tokens = maxNum;
     var web = checked('ov-websearch');
     if (web !== !!detail.allow_web_search) out.allow_web_search = web;
+    var md = detail.metadata || {};
     var desc = val('ov-description');
-    if (desc !== ((detail.metadata && detail.metadata.description) || '')) out.description = desc;
+    if (desc !== (md.description || '')) out.description = desc;
+    var fav = checked('ov-favorite');
+    if (fav !== !!md.favorite) out.favorite = fav;
+    var color = val('ov-avatarcolor');
+    if (color && color !== (md.avatar_color || '')) out.avatar_color = color;
+    // Tags: compare case-insensitively so re-saving unchanged tags is a no-op.
+    if (overviewTagsInput) {
+      var nextTags = overviewTagsInput.getTags();
+      if (tagsDiffer(nextTags, md.tags || [])) out.tags = nextTags;
+    }
     return out;
+  }
+
+  function tagsDiffer(a, b) {
+    var na = (a || []).map(function (t) { return String(t).toLowerCase().trim(); }).filter(Boolean).sort();
+    var nb = (b || []).map(function (t) { return String(t).toLowerCase().trim(); }).filter(Boolean).sort();
+    if (na.length !== nb.length) return true;
+    for (var i = 0; i < na.length; i++) { if (na[i] !== nb[i]) return true; }
+    return false;
+  }
+
+  function wireOverviewTags(name, initial) {
+    overviewTagsInput = null;
+    var host = document.getElementById('ov-tags-host');
+    if (!host) return;
+    if (window.OriTagInput) {
+      overviewTagsInput = window.OriTagInput.createTagInput({
+        container: host,
+        initialTags: initial,
+        onChange: function () { markDirty('overview', true); },
+      });
+    } else {
+      host.innerHTML = '<input id="ov-tags-text" type="text" value="' + esc((initial || []).join(', ')) + '" placeholder="tag1, tag2">';
+    }
+  }
+
+  // Avatar upload/remove control, reusing the existing avatar endpoints. Uploads
+  // apply immediately (multipart) and refresh the card + stage avatar.
+  function wireAvatarControl(name, md) {
+    var host = document.getElementById('ov-avatar-control');
+    if (!host) return;
+    var hasImage = !!(md && md.avatar_image);
+    host.innerHTML =
+      '<div class="avatar-control">' +
+      '<input type="file" id="ov-avatar-file" accept="image/png,image/jpeg,image/gif,image/webp" class="avatar-control__file">' +
+      (hasImage ? '<button type="button" class="btn-ghost avatar-control__remove" id="ov-avatar-remove">Remove image</button>' : '') +
+      '<span class="avatar-control__status" id="ov-avatar-status" aria-live="polite"></span>' +
+      '</div>';
+    var file = document.getElementById('ov-avatar-file');
+    if (file) file.addEventListener('change', function () { uploadAvatar(name, file.files && file.files[0]); });
+    var remove = document.getElementById('ov-avatar-remove');
+    if (remove) remove.addEventListener('click', function () { removeAvatar(name); });
+  }
+
+  function uploadAvatar(name, fileObj) {
+    if (!fileObj) return;
+    var status = document.getElementById('ov-avatar-status');
+    if (status) status.textContent = 'Uploading…';
+    var form = new FormData();
+    form.append('avatar', fileObj);
+    fetch('/api/agents/' + encodeURIComponent(name) + '/avatar', { method: 'POST', body: form })
+      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (res) {
+        if (res.status >= 200 && res.status < 300) afterAvatarChange(name, status, 'Uploaded.');
+        else if (status) status.textContent = (res.data && res.data.message) || 'Upload failed.';
+      })
+      .catch(function () { if (status) status.textContent = 'Network error.'; });
+  }
+
+  function removeAvatar(name) {
+    var status = document.getElementById('ov-avatar-status');
+    if (status) status.textContent = 'Removing…';
+    fetch('/api/agents/' + encodeURIComponent(name) + '/avatar', { method: 'DELETE' })
+      .then(function (r) { return r.status; })
+      .then(function (code) {
+        if (code >= 200 && code < 300) afterAvatarChange(name, status, 'Removed.');
+        else if (status) status.textContent = 'Remove failed.';
+      })
+      .catch(function () { if (status) status.textContent = 'Network error.'; });
+  }
+
+  function afterAvatarChange(name, status, msg) {
+    fetchDetail(name, true).then(function (detail) {
+      if (status) status.textContent = msg;
+      if (state.selected !== name) return;
+      // Re-render avatar + card from the fresh metadata.
+      var item = state.byName[name];
+      if (item && detail.metadata) item.metadata = Object.assign({}, item.metadata, detail.metadata);
+      els.avatar.outerHTML = avatarMarkup(item, 'stage__avatar', 'stageAvatar');
+      els.avatar = document.getElementById('stageAvatar');
+      refreshRosterMeta(name, detail);
+      wireAvatarControl(name, detail.metadata || {});
+    });
+  }
+
+  // Read-only created / updated / last-active timestamps below the editable form.
+  function readonlyMetaHTML(detail) {
+    var s = detail.statistics || {};
+    var rows = [
+      ['Created', fmtDate(s.created_at)],
+      ['Updated', fmtDate(s.updated_at)],
+      ['Last active', fmtDate(s.last_active)],
+    ].filter(function (r) { return r[1]; });
+    if (rows.length === 0) return '';
+    return '<dl class="stage-meta">' + rows.map(function (r) {
+      return '<dt>' + esc(r[0]) + '</dt><dd>' + esc(r[1]) + '</dd>';
+    }).join('') + '</dl>';
+  }
+
+  var dateFmt = (typeof Intl !== 'undefined' && Intl.DateTimeFormat)
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+    : null;
+  function fmtDate(v) {
+    if (!v) return '';
+    var t = Date.parse(v);
+    if (isNaN(t) || t <= 0) return '';
+    return dateFmt ? dateFmt.format(new Date(t)) : new Date(t).toLocaleString();
   }
 
   function saveOverview(name) {
@@ -859,12 +1031,23 @@
       field('Role', selectInput('cr-role', ROLES, 'general', titleCase), 'cr-role') +
       field('Model', textInput('cr-model', 'gpt-4o-mini'), 'cr-model') +
       field('Description', textareaInput('cr-description', '', 3), 'cr-description') +
+      field('Favorite', '<label class="check"><input id="cr-favorite" type="checkbox"> Favorited</label>') +
+      field('Tags', '<div id="cr-tags-host"></div>', 'cr-tags-host') +
+      field('Avatar color', colorInput('cr-avatarcolor', '#4f46e5'), 'cr-avatarcolor') +
       '</form>' +
       '<div class="save-bar" id="savebar-create">' +
       '<span class="save-status is-muted"></span>' +
       '<button type="button" class="btn-ghost" id="createCancel2">Cancel</button>' +
       '<button type="button" class="btn-primary" id="createSubmit">Create agent</button>' +
       '</div>';
+    createTagsInput = null;
+    var tagHost = document.getElementById('cr-tags-host');
+    if (window.OriTagInput && tagHost) {
+      createTagsInput = window.OriTagInput.createTagInput({ container: tagHost, placeholder: 'Add tag…' });
+    } else if (tagHost) {
+      tagHost.innerHTML = '<input id="cr-tags-text" type="text" placeholder="tag1, tag2">';
+    }
+    wireColorInput('cr-avatarcolor');
     document.getElementById('createSubmit').addEventListener('click', submitCreate);
     document.getElementById('createCancel2').addEventListener('click', closeCreate);
     var nameInput = document.getElementById('cr-name');
@@ -882,12 +1065,17 @@
     var name = val('cr-name').trim();
     var status = document.querySelector('#savebar-create .save-status');
     if (!name) { status.textContent = 'Name is required.'; status.className = 'save-status is-error'; return; }
+    var crTags = createTagsInput ? createTagsInput.getTags()
+      : (val('cr-tags-text') ? val('cr-tags-text').split(',').map(function (t) { return t.trim(); }).filter(Boolean) : []);
     var body = {
       name: name,
       type: 'tool-calling',
       role: val('cr-role'),
       model: val('cr-model').trim(),
       description: val('cr-description'),
+      tags: crTags,
+      favorite: checked('cr-favorite'),
+      avatar_color: val('cr-avatarcolor'),
     };
     var submit = document.getElementById('createSubmit');
     submit.disabled = true; submit.textContent = 'Creating…';
@@ -953,12 +1141,16 @@
     var item = state.byName[name];
     if (!item) return;
     if (detail.model) item.model = detail.model;
-    if (detail.metadata) item.metadata = Object.assign({}, item.metadata, { description: (detail.metadata.description || '') });
+    // Merge the full metadata snapshot (description, tags, favorite, avatar) so
+    // the rebuilt card reflects every edit, not just the description.
+    if (detail.metadata) item.metadata = Object.assign({}, item.metadata, detail.metadata);
+    if (detail.role) item.role = detail.role;
     var card = els.list.querySelector('.roster-card[data-name="' + cssEscape(name) + '"]');
     if (card) {
-      var meta = card.querySelector('.roster-card__meta');
-      var wc = item.workspace_count || 0;
-      if (meta) meta.textContent = [detail.model, wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's')].filter(Boolean).join(' · ');
+      var idx = Number(card.dataset.index);
+      var rebuilt = buildCard(item, isNaN(idx) ? 0 : idx);
+      if (card.classList.contains('is-focused')) rebuilt.classList.add('is-focused');
+      card.replaceWith(rebuilt);
     }
   }
 
@@ -1443,6 +1635,174 @@
     if (els.selectAll) els.selectAll.focus();
   }
 
+  /* ---- bulk tags + favorite ------------------------------------------------ */
+
+  var bulkTagsInput = null; // active OriTagInput instance for the add flow
+
+  function openBulkTags(mode) {
+    if (state.checked.size === 0) return;
+    if (state.selected && state.checked.has(state.selected) && !guardUnsaved()) return;
+    var dlg = els.bulkTagsDialog;
+    dlg.dataset.mode = mode;
+    els.bulkTagsTitle.textContent = mode === 'add' ? 'Add tags' : 'Remove tags';
+    els.bulkTagsConfirm.disabled = false;
+    els.bulkTagsConfirm.textContent = mode === 'add' ? 'Add tags' : 'Remove tags';
+    bulkTagsInput = null;
+
+    if (mode === 'add') {
+      els.bulkTagsBody.innerHTML =
+        '<p class="bulk-dialog__lead">Tags are added to every eligible selected agent; existing tags are kept.</p>' +
+        '<div id="bulkTagsInputHost"></div>';
+      var host = document.getElementById('bulkTagsInputHost');
+      if (window.OriTagInput && host) {
+        bulkTagsInput = window.OriTagInput.createTagInput({ container: host, placeholder: 'Add tag…' });
+      } else if (host) {
+        host.innerHTML = '<input id="bulkTagsText" type="text" class="bulk-dialog__text" placeholder="tag1, tag2">';
+      }
+    } else {
+      // Remove: offer the union of tags across the checked set as a checklist so
+      // the user picks from values that actually exist (PRD FR27).
+      var union = tagsUnion(Array.from(state.checked));
+      if (union.length === 0) {
+        els.bulkTagsBody.innerHTML = '<p class="bulk-dialog__none">The selected agents have no tags to remove.</p>';
+        els.bulkTagsConfirm.disabled = true;
+      } else {
+        els.bulkTagsBody.innerHTML =
+          '<p class="bulk-dialog__lead">Remove these tags from every selected agent that has them.</p>' +
+          '<div class="bulk-tags-checklist">' + union.map(function (t) {
+            return '<label class="bulk-tags-checklist__item"><input type="checkbox" value="' + esc(t) + '"> ' + esc(t) + '</label>';
+          }).join('') + '</div>';
+      }
+    }
+    if (typeof dlg.showModal === 'function') dlg.showModal(); else dlg.setAttribute('open', '');
+  }
+
+  function closeBulkTags() {
+    var dlg = els.bulkTagsDialog;
+    if (dlg.open && typeof dlg.close === 'function') dlg.close(); else dlg.removeAttribute('open');
+    bulkTagsInput = null;
+    if (els.selectAll) els.selectAll.focus();
+  }
+
+  // Union of tags across the given agents (case-insensitive, original casing).
+  function tagsUnion(names) {
+    var seen = {};
+    var out = [];
+    names.forEach(function (name) {
+      var a = state.byName[name];
+      var tags = (a && a.metadata && a.metadata.tags) || [];
+      tags.forEach(function (t) {
+        var key = String(t).toLowerCase();
+        if (!seen[key]) { seen[key] = true; out.push(t); }
+      });
+    });
+    out.sort(function (a, b) { return String(a).localeCompare(String(b)); });
+    return out;
+  }
+
+  function runBulkTags() {
+    var btn = els.bulkTagsConfirm;
+    if (btn.disabled || btn.dataset.busy === '1') return;
+    var mode = els.bulkTagsDialog.dataset.mode;
+    var tags = [];
+    if (mode === 'add') {
+      if (bulkTagsInput) tags = bulkTagsInput.getTags();
+      else {
+        var txt = document.getElementById('bulkTagsText');
+        tags = txt ? txt.value.split(',') : [];
+      }
+    } else {
+      els.bulkTagsBody.querySelectorAll('input[type="checkbox"]:checked').forEach(function (c) { tags.push(c.value); });
+    }
+    tags = tags.map(function (t) { return String(t).trim(); }).filter(Boolean);
+    if (tags.length === 0) {
+      els.bulkTagsBody.insertAdjacentHTML('afterbegin', '<p class="bulk-dialog__error" role="alert">Enter at least one tag.</p>');
+      return;
+    }
+    var op = mode === 'add' ? 'add_tags' : 'remove_tags';
+    btn.dataset.busy = '1';
+    btn.disabled = true;
+    var restore = btn.textContent;
+    btn.textContent = 'Working…';
+    submitBulkMetadata({ operation: op, agent_names: Array.from(state.checked), tags: tags }, function () {
+      btn.dataset.busy = ''; btn.disabled = false; btn.textContent = restore;
+    }, closeBulkTags);
+  }
+
+  function runBulkFavorite(favorite) {
+    if (state.checked.size === 0) return;
+    if (state.selected && state.checked.has(state.selected) && !guardUnsaved()) return;
+    var btns = [els.bulkFavorite, els.bulkUnfavorite];
+    btns.forEach(function (b) { b.disabled = true; });
+    announce(favorite ? 'Favoriting…' : 'Unfavoriting…');
+    submitBulkMetadata({ operation: 'set_favorite', agent_names: Array.from(state.checked), favorite: favorite }, function () {
+      btns.forEach(function (b) { b.disabled = false; });
+    }, null);
+  }
+
+  // Shared bulk-metadata POST with shared-definition confirmation retry. `always`
+  // runs on completion; `onDone` (optional) runs only on a successful response
+  // (e.g. to close a dialog).
+  function submitBulkMetadata(payload, always, onDone) {
+    fetch('/api/agents/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+      .then(function (r) { return r.json().catch(function () { return null; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (res) {
+        if (always) always();
+        if (res.status < 200 || res.status >= 300 || !res.data || !Array.isArray(res.data.results)) {
+          announce('Bulk update failed.');
+          return;
+        }
+        var results = res.data.results;
+        // Any agent needing shared-definition confirmation → ask once, resend
+        // with confirm_shared_edit for the whole batch (PRD FR31).
+        var needsConfirm = results.some(function (r) { return r.reason_code === 'shared_edit_requires_confirmation'; });
+        if (needsConfirm && !payload.confirm_shared_edit) {
+          var n = results.filter(function (r) { return r.reason_code === 'shared_edit_requires_confirmation'; }).length;
+          if (window.confirm(n + ' selected agent(s) are attached to multiple workspaces. This change affects all of them. Apply it?')) {
+            submitBulkMetadata(Object.assign({}, payload, { confirm_shared_edit: true }), always, onDone);
+            return;
+          }
+        }
+        if (onDone) onDone();
+        renderBulkMetadataResult(res.data);
+        // Refresh roster data so cards/overview/filters reflect the change,
+        // keeping the focused agent and (via pruneChecked) the checked set.
+        reloadThenSelect(state.selected);
+      })
+      .catch(function (err) {
+        if (always) always();
+        announce('Network error — no changes applied.');
+        console.error('[roster] bulk metadata failed', err);
+      });
+  }
+
+  function renderBulkMetadataResult(payload) {
+    var summary = payload.summary || {};
+    var results = payload.results || [];
+    if (!els.bulkResult) return;
+    var parts = [];
+    parts.push((summary.requested || results.length) + ' requested');
+    parts.push((summary.succeeded || 0) + ' updated');
+    if (summary.skipped) parts.push(summary.skipped + ' skipped');
+    if (summary.failed) parts.push(summary.failed + ' failed');
+    els.bulkResultSummary.textContent = parts.join(' · ');
+    var rows = results.filter(function (r) { return r.status !== 'succeeded'; }).map(function (r) {
+      var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
+      return '<li class="bulk-result__item is-' + esc(r.status) + '">' +
+        '<span class="bulk-result__name">' + esc(r.name) + '</span>' +
+        '<span class="bulk-result__reason">' + reason + '</span></li>';
+    }).join('');
+    els.bulkResultList.innerHTML = rows;
+    els.bulkResult.hidden = false;
+    var msg = (summary.succeeded || 0) + ' updated';
+    if (summary.skipped) msg += ', ' + summary.skipped + ' skipped';
+    announce(msg + '.');
+  }
+
   function onSearch() { state.query = els.search.value || ''; applyFilterSort(); }
   function onSort() { state.sort = els.sort.value || 'name-asc'; applyFilterSort(); if (state.selected) highlightSelected(); }
 
@@ -1482,6 +1842,24 @@
   }
   function textareaInput(id, value, rows) {
     return '<textarea id="' + id + '" rows="' + rows + '">' + esc(value) + '</textarea>';
+  }
+  // Color picker + hex text, kept in sync, for the avatar color field.
+  function colorInput(id, value) {
+    var v = /^#[0-9a-fA-F]{6}$/.test(String(value)) ? value : '#4f46e5';
+    return '<span class="color-input">' +
+      '<input id="' + id + '" type="color" value="' + esc(v) + '">' +
+      '<input id="' + id + '-hex" type="text" class="color-input__hex" value="' + esc(v) + '" maxlength="7" spellcheck="false" aria-label="Avatar color hex">' +
+      '</span>';
+  }
+  // Keep the color picker and its hex text field in sync (either drives the other).
+  function wireColorInput(id) {
+    var picker = document.getElementById(id);
+    var hex = document.getElementById(id + '-hex');
+    if (!picker || !hex) return;
+    picker.addEventListener('input', function () { hex.value = picker.value; });
+    hex.addEventListener('input', function () {
+      if (/^#[0-9a-fA-F]{6}$/.test(hex.value)) picker.value = hex.value;
+    });
   }
   // Grouped <select> of available models (optgroup per provider). Each option
   // carries data-provider so the Provider field can follow the chosen model. A
@@ -1610,6 +1988,33 @@
     var v = agent && agent.statistics && agent.statistics.last_active;
     var t = v ? Date.parse(v) : 0;
     return isNaN(t) ? 0 : t;
+  }
+
+  // Locale-aware relative "last active" so the Recently Active sort is legible
+  // (PRD FR60). Returns '' when there's no usable timestamp. A zero/epoch value
+  // (never active) is treated as missing rather than "55 years ago".
+  var relTimeFmt = (typeof Intl !== 'undefined' && Intl.RelativeTimeFormat)
+    ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+    : null;
+  function lastActiveLabel(agent) {
+    var t = lastActive(agent);
+    if (!t) return '';
+    var diffMs = t - Date.now();
+    var absMin = Math.abs(diffMs) / 60000;
+    if (absMin < 1) return 'Active now';
+    if (!relTimeFmt) return '';
+    var units = [
+      ['year', 525600], ['month', 43200], ['week', 10080],
+      ['day', 1440], ['hour', 60], ['minute', 1],
+    ];
+    for (var i = 0; i < units.length; i++) {
+      var perUnit = units[i][1];
+      if (absMin >= perUnit || units[i][0] === 'minute') {
+        var value = Math.round(diffMs / 60000 / perUnit);
+        return relTimeFmt.format(value, units[i][0]);
+      }
+    }
+    return '';
   }
 
   function titleCase(s) {

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -88,6 +88,14 @@
       bulkFavorite: document.getElementById('bulkFavorite'),
       bulkUnfavorite: document.getElementById('bulkUnfavorite'),
       bulkDelete: document.getElementById('bulkDelete'),
+      bulkResult: document.getElementById('bulkResult'),
+      bulkResultSummary: document.getElementById('bulkResultSummary'),
+      bulkResultList: document.getElementById('bulkResultList'),
+      bulkResultDismiss: document.getElementById('bulkResultDismiss'),
+      bulkDeleteDialog: document.getElementById('bulkDeleteDialog'),
+      bulkDeleteBody: document.getElementById('bulkDeleteBody'),
+      bulkDeleteCancel: document.getElementById('bulkDeleteCancel'),
+      bulkDeleteConfirm: document.getElementById('bulkDeleteConfirm'),
     };
 
     els.search.addEventListener('input', onSearch);
@@ -106,6 +114,13 @@
 
     els.selectAll.addEventListener('click', selectAllVisible);
     els.clearSelection.addEventListener('click', function () { clearSelection(true); });
+
+    els.bulkDelete.addEventListener('click', openBulkDelete);
+    els.bulkDeleteCancel.addEventListener('click', function () { closeBulkDelete(); });
+    els.bulkDeleteConfirm.addEventListener('click', runBulkDelete);
+    els.bulkResultDismiss.addEventListener('click', dismissBulkResult);
+    // Native <dialog> fires 'cancel' on Escape; keep our teardown consistent.
+    els.bulkDeleteDialog.addEventListener('cancel', function (e) { e.preventDefault(); closeBulkDelete(); });
 
     var tabs = document.querySelectorAll('.stage__tab');
     tabs.forEach(function (tab) {
@@ -1248,6 +1263,184 @@
 
   function announce(msg) {
     if (els.bulkLive) els.bulkLive.textContent = msg;
+  }
+
+  /* ---- bulk delete --------------------------------------------------------- */
+
+  // Advisory client-side eligibility. The server re-checks and is authoritative
+  // (PRD FR40); this only drives the preview grouping and the eligible count.
+  function deleteEligibility(agent) {
+    if (!agent) return { eligible: false, reason: 'Agent not found.' };
+    if (isPermanent(agent)) {
+      var role = String(agent.role || '').toLowerCase();
+      var source = String(agent.source || '').toLowerCase();
+      if (source === 'cli' || role === 'cli_agent') return { eligible: false, reason: 'Built-in CLI agent.' };
+      return { eligible: false, reason: 'System assistant.' };
+    }
+    if ((agent.workspace_count || 0) > 0) {
+      return { eligible: false, reason: 'Attached to ' + agent.workspace_count + ' workspace' + (agent.workspace_count === 1 ? '' : 's') + '.' };
+    }
+    return { eligible: true, reason: '' };
+  }
+
+  function openBulkDelete() {
+    if (state.checked.size === 0) return;
+    // Deleting the focused agent will replace the stage; guard unsaved edits
+    // before we commit to the flow (PRD FR15).
+    var names = Array.from(state.checked);
+    var eligible = [];
+    var skipped = [];
+    names.forEach(function (name) {
+      var agent = state.byName[name];
+      var e = deleteEligibility(agent);
+      (e.eligible ? eligible : skipped).push({ name: name, reason: e.reason });
+    });
+
+    var body = '';
+    body += deleteGroupHTML('To delete', eligible, true);
+    if (skipped.length) body += deleteGroupHTML('Will be skipped', skipped, false);
+    if (eligible.length === 0) {
+      body += '<p class="bulk-dialog__none">None of the selected agents can be deleted.</p>';
+    }
+    els.bulkDeleteBody.innerHTML = body;
+
+    els.bulkDeleteConfirm.disabled = eligible.length === 0;
+    els.bulkDeleteConfirm.textContent = eligible.length
+      ? 'Delete ' + eligible.length + ' agent' + (eligible.length === 1 ? '' : 's')
+      : 'Delete';
+    // Stash the authoritative-request payload: send ALL checked names so the
+    // server returns a result per agent and eligibility changes are caught.
+    els.bulkDeleteConfirm.dataset.names = JSON.stringify(names);
+    els.bulkDeleteConfirm.dataset.eligible = String(eligible.length);
+
+    if (typeof els.bulkDeleteDialog.showModal === 'function') els.bulkDeleteDialog.showModal();
+    else els.bulkDeleteDialog.setAttribute('open', '');
+  }
+
+  function deleteGroupHTML(title, rows, danger) {
+    if (!rows.length) return '';
+    var items = rows.map(function (r) {
+      var agent = state.byName[r.name];
+      var reason = r.reason ? '<span class="bulk-dialog__reason">' + esc(r.reason) + '</span>' : '';
+      var wsLink = '';
+      if (agent && Array.isArray(agent.workspaces) && agent.workspaces.length) {
+        var ws = agent.workspaces[0];
+        if (ws && ws.id) wsLink = ' <a class="bulk-dialog__wslink" href="/workspaces/' + encodeURIComponent(ws.id) + '">' + esc(ws.name || 'workspace') + '</a>';
+      }
+      return '<li><span class="bulk-dialog__agent">' + esc(r.name) + '</span>' + reason + wsLink + '</li>';
+    }).join('');
+    return '<div class="bulk-dialog__group' + (danger ? ' is-danger' : '') + '">' +
+      '<h3 class="bulk-dialog__grouptitle">' + esc(title) + ' (' + rows.length + ')</h3>' +
+      '<ul class="bulk-dialog__grouplist">' + items + '</ul></div>';
+  }
+
+  function closeBulkDelete() {
+    if (els.bulkDeleteDialog.open && typeof els.bulkDeleteDialog.close === 'function') els.bulkDeleteDialog.close();
+    else els.bulkDeleteDialog.removeAttribute('open');
+    // Return focus to a stable control rather than a possibly-removed card.
+    if (els.selectAll) els.selectAll.focus();
+  }
+
+  function runBulkDelete() {
+    var btn = els.bulkDeleteConfirm;
+    if (btn.disabled || btn.dataset.busy === '1') return; // prevent double submit
+    var names;
+    try { names = JSON.parse(btn.dataset.names || '[]'); } catch (e) { names = []; }
+    if (!names.length) { closeBulkDelete(); return; }
+
+    // If the focused agent is among those being deleted, honor the unsaved guard.
+    if (state.selected && names.indexOf(state.selected) !== -1 && !guardUnsaved()) return;
+
+    btn.dataset.busy = '1';
+    btn.disabled = true;
+    var restoreLabel = btn.textContent;
+    btn.textContent = 'Deleting…';
+    announce('Deleting agents…');
+
+    fetch('/api/agents/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ operation: 'delete', agent_names: names }),
+    })
+      .then(function (r) { return r.json().catch(function () { return null; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (res) {
+        btn.dataset.busy = '';
+        btn.textContent = restoreLabel;
+        if (res.status < 200 || res.status >= 300 || !res.data || !Array.isArray(res.data.results)) {
+          // Do NOT claim any deletion happened on a malformed/error response.
+          announce('Bulk delete failed.');
+          els.bulkDeleteBody.insertAdjacentHTML('afterbegin',
+            '<p class="bulk-dialog__error" role="alert">Delete failed (' + res.status + '). No agents were changed.</p>');
+          btn.disabled = false;
+          return;
+        }
+        applyBulkDeleteResults(res.data);
+      })
+      .catch(function (err) {
+        btn.dataset.busy = '';
+        btn.disabled = false;
+        btn.textContent = restoreLabel;
+        announce('Network error — no agents deleted.');
+        els.bulkDeleteBody.insertAdjacentHTML('afterbegin',
+          '<p class="bulk-dialog__error" role="alert">Network error — no agents were deleted.</p>');
+        console.error('[roster] bulk delete failed', err);
+      });
+  }
+
+  function applyBulkDeleteResults(payload) {
+    var results = payload.results || [];
+    var summary = payload.summary || {};
+
+    // Drop successfully deleted agents from the checked set; skipped/failed stay
+    // checked and inspectable (PRD FR44).
+    var focusedDeleted = false;
+    results.forEach(function (r) {
+      if (r.status === 'succeeded') {
+        state.checked.delete(r.name);
+        if (r.name === state.selected) focusedDeleted = true;
+      }
+    });
+
+    closeBulkDelete();
+    renderBulkResult(summary, results);
+
+    // Reload from the server (authoritative): deleted agents vanish, skipped
+    // survive and remain checked via pruneChecked. Keep the focused agent when
+    // it survived; otherwise fall back predictably.
+    reloadThenSelect(focusedDeleted ? null : state.selected);
+
+    var msg = (summary.succeeded || 0) + ' deleted';
+    if (summary.skipped) msg += ', ' + summary.skipped + ' skipped';
+    if (summary.failed) msg += ', ' + summary.failed + ' failed';
+    announce(msg + '.');
+  }
+
+  function renderBulkResult(summary, results) {
+    if (!els.bulkResult) return;
+    var parts = [];
+    parts.push((summary.requested || results.length) + ' requested');
+    parts.push((summary.succeeded || 0) + ' deleted');
+    if (summary.skipped) parts.push(summary.skipped + ' skipped');
+    if (summary.failed) parts.push(summary.failed + ' failed');
+    els.bulkResultSummary.textContent = parts.join(' · ');
+
+    // List only non-success results — those are the ones worth inspecting.
+    var rows = results.filter(function (r) { return r.status !== 'succeeded'; }).map(function (r) {
+      var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
+      return '<li class="bulk-result__item is-' + esc(r.status) + '">' +
+        '<span class="bulk-result__name">' + esc(r.name) + '</span>' +
+        '<span class="bulk-result__reason">' + reason + '</span></li>';
+    }).join('');
+    els.bulkResultList.innerHTML = rows;
+    els.bulkResult.hidden = false;
+  }
+
+  function dismissBulkResult() {
+    if (!els.bulkResult) return;
+    els.bulkResult.hidden = true;
+    els.bulkResultList.innerHTML = '';
+    els.bulkResultSummary.textContent = '';
+    if (els.selectAll) els.selectAll.focus();
   }
 
   function onSearch() { state.query = els.search.value || ''; applyFilterSort(); }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -21,7 +21,15 @@
 
   var STORAGE_KEY = 'ori.roster.selectedAgent';
   var TAB_ORDER = ['overview', 'prompt', 'workspaces'];
-  var ROLES = ['general', 'orchestrator', 'researcher', 'analyzer', 'synthesizer', 'validator', 'specialist'];
+  var ROLES = [
+    'general',
+    'orchestrator',
+    'researcher',
+    'analyzer',
+    'synthesizer',
+    'validator',
+    'specialist'
+  ];
   var REASONING = ['', 'minimal', 'low', 'medium', 'high'];
   // Agent capability types; these mirror the model catalog's category strings so
   // the Model picker can be filtered to models that fit the selected type.
@@ -50,7 +58,7 @@
     checked: new Set(),
     // Anchor index (into the current sorted+filtered roster) for Shift-click and
     // Shift+Space contiguous range selection (PRD FR10).
-    rangeAnchor: -1,
+    rangeAnchor: -1
   };
 
   var els = {};
@@ -119,7 +127,7 @@
       clearFilters: document.getElementById('clearFilters'),
       emptyMsg: document.getElementById('rosterEmptyMsg'),
       emptyClearFilters: document.getElementById('rosterEmptyClearFilters'),
-      emptyCreate: document.getElementById('rosterEmptyCreate'),
+      emptyCreate: document.getElementById('rosterEmptyCreate')
     };
 
     els.search.addEventListener('input', onSearch);
@@ -137,12 +145,26 @@
     els.stageDelete.addEventListener('click', onDeleteClick);
 
     els.selectAll.addEventListener('click', selectAllVisible);
-    els.clearSelection.addEventListener('click', function () { clearSelection(true); });
+    els.clearSelection.addEventListener('click', function () {
+      clearSelection(true);
+    });
 
-    els.filterRole.addEventListener('change', function () { state.filters.role = els.filterRole.value; onFilterChange(); });
-    els.filterSource.addEventListener('change', function () { state.filters.source = els.filterSource.value; onFilterChange(); });
-    els.filterAssignment.addEventListener('change', function () { state.filters.assignment = els.filterAssignment.value; onFilterChange(); });
-    els.filterTag.addEventListener('change', function () { state.filters.tag = els.filterTag.value; onFilterChange(); });
+    els.filterRole.addEventListener('change', function () {
+      state.filters.role = els.filterRole.value;
+      onFilterChange();
+    });
+    els.filterSource.addEventListener('change', function () {
+      state.filters.source = els.filterSource.value;
+      onFilterChange();
+    });
+    els.filterAssignment.addEventListener('change', function () {
+      state.filters.assignment = els.filterAssignment.value;
+      onFilterChange();
+    });
+    els.filterTag.addEventListener('change', function () {
+      state.filters.tag = els.filterTag.value;
+      onFilterChange();
+    });
     els.filterFavorite.addEventListener('click', function () {
       state.filters.favorite = !state.filters.favorite;
       els.filterFavorite.setAttribute('aria-pressed', state.filters.favorite ? 'true' : 'false');
@@ -156,23 +178,41 @@
     els.stats.addEventListener('click', onStatTileClick);
 
     els.bulkDelete.addEventListener('click', openBulkDelete);
-    els.bulkDeleteCancel.addEventListener('click', function () { closeBulkDelete(); });
+    els.bulkDeleteCancel.addEventListener('click', function () {
+      closeBulkDelete();
+    });
     els.bulkDeleteConfirm.addEventListener('click', runBulkDelete);
     els.bulkResultDismiss.addEventListener('click', dismissBulkResult);
     // Native <dialog> fires 'cancel' on Escape; keep our teardown consistent.
-    els.bulkDeleteDialog.addEventListener('cancel', function (e) { e.preventDefault(); closeBulkDelete(); });
+    els.bulkDeleteDialog.addEventListener('cancel', function (e) {
+      e.preventDefault();
+      closeBulkDelete();
+    });
 
-    els.bulkAddTags.addEventListener('click', function () { openBulkTags('add'); });
-    els.bulkRemoveTags.addEventListener('click', function () { openBulkTags('remove'); });
+    els.bulkAddTags.addEventListener('click', function () {
+      openBulkTags('add');
+    });
+    els.bulkRemoveTags.addEventListener('click', function () {
+      openBulkTags('remove');
+    });
     els.bulkTagsCancel.addEventListener('click', closeBulkTags);
     els.bulkTagsConfirm.addEventListener('click', runBulkTags);
-    els.bulkTagsDialog.addEventListener('cancel', function (e) { e.preventDefault(); closeBulkTags(); });
-    els.bulkFavorite.addEventListener('click', function () { runBulkFavorite(true); });
-    els.bulkUnfavorite.addEventListener('click', function () { runBulkFavorite(false); });
+    els.bulkTagsDialog.addEventListener('cancel', function (e) {
+      e.preventDefault();
+      closeBulkTags();
+    });
+    els.bulkFavorite.addEventListener('click', function () {
+      runBulkFavorite(true);
+    });
+    els.bulkUnfavorite.addEventListener('click', function () {
+      runBulkFavorite(false);
+    });
 
     var tabs = document.querySelectorAll('.stage__tab');
     tabs.forEach(function (tab) {
-      tab.addEventListener('click', function () { requestTab(tab.dataset.tab, true); });
+      tab.addEventListener('click', function () {
+        requestTab(tab.dataset.tab, true);
+      });
       tab.addEventListener('keydown', onTabKeydown);
     });
 
@@ -188,7 +228,10 @@
     });
 
     window.addEventListener('beforeunload', function (e) {
-      if (anyDirty()) { e.preventDefault(); e.returnValue = ''; }
+      if (anyDirty()) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
     });
 
     loadProviders();
@@ -202,9 +245,11 @@
   // slow, renderOverview falls back to a text input.
   function loadProviders() {
     fetch('/api/providers')
-      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
       .then(function (data) {
-        state.providers = (data && Array.isArray(data.providers)) ? data.providers : [];
+        state.providers = data && Array.isArray(data.providers) ? data.providers : [];
         // If an agent was already selected and its stage rendered before the model
         // catalog arrived, refresh the catalog-dependent surfaces: the overview
         // (picker + notes) and the vitals (legacy badge). Guarded by !dirty so we
@@ -214,7 +259,9 @@
           renderOverview(state.selected, state.detailCache[state.selected]);
         }
       })
-      .catch(function () { state.providers = []; });
+      .catch(function () {
+        state.providers = [];
+      });
   }
 
   function loadAgents() {
@@ -227,7 +274,9 @@
         var agents = Array.isArray(data) ? data : (data && data.agents) || [];
         state.agents = agents;
         state.byName = {};
-        agents.forEach(function (a) { state.byName[a.name] = a; });
+        agents.forEach(function (a) {
+          state.byName[a.name] = a;
+        });
         pruneChecked();
         applyUrlToState();
         populateFilterOptions();
@@ -246,8 +295,12 @@
   function pruneChecked() {
     if (state.checked.size === 0) return;
     var stale = [];
-    state.checked.forEach(function (name) { if (!state.byName[name]) stale.push(name); });
-    stale.forEach(function (name) { state.checked.delete(name); });
+    state.checked.forEach(function (name) {
+      if (!state.byName[name]) stale.push(name);
+    });
+    stale.forEach(function (name) {
+      state.checked.delete(name);
+    });
   }
 
   function fetchDetail(name, force) {
@@ -273,10 +326,16 @@
 
     list.sort(function (a, b) {
       switch (state.sort) {
-        case 'name-desc': return b.name.localeCompare(a.name);
-        case 'workspaces-desc': return (b.workspace_count || 0) - (a.workspace_count || 0) || a.name.localeCompare(b.name);
-        case 'active-desc': return lastActive(b) - lastActive(a) || a.name.localeCompare(b.name);
-        default: return a.name.localeCompare(b.name);
+        case 'name-desc':
+          return b.name.localeCompare(a.name);
+        case 'workspaces-desc':
+          return (
+            (b.workspace_count || 0) - (a.workspace_count || 0) || a.name.localeCompare(b.name)
+          );
+        case 'active-desc':
+          return lastActive(b) - lastActive(a) || a.name.localeCompare(b.name);
+        default:
+          return a.name.localeCompare(b.name);
       }
     });
 
@@ -287,8 +346,16 @@
   // Search matches name, role, description, and tags (PRD FR74).
   function matchesSearch(a, q) {
     if (!q) return true;
-    var tags = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags.join(' ') : '';
-    var hay = (a.name + ' ' + (a.role || '') + ' ' + ((a.metadata && a.metadata.description) || '') + ' ' + tags).toLowerCase();
+    var tags = a.metadata && Array.isArray(a.metadata.tags) ? a.metadata.tags.join(' ') : '';
+    var hay = (
+      a.name +
+      ' ' +
+      (a.role || '') +
+      ' ' +
+      ((a.metadata && a.metadata.description) || '') +
+      ' ' +
+      tags
+    ).toLowerCase();
     return hay.indexOf(q) !== -1;
   }
 
@@ -303,8 +370,10 @@
     if (f.assignment === 'assigned' && (a.workspace_count || 0) === 0) return false;
     if (f.favorite && !(a.metadata && a.metadata.favorite)) return false;
     if (f.tag) {
-      var tags = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags : [];
-      var has = tags.some(function (t) { return String(t).toLowerCase() === f.tag.toLowerCase(); });
+      var tags = a.metadata && Array.isArray(a.metadata.tags) ? a.metadata.tags : [];
+      var has = tags.some(function (t) {
+        return String(t).toLowerCase() === f.tag.toLowerCase();
+      });
       if (!has) return false;
     }
     return true;
@@ -334,7 +403,14 @@
   }
 
   function clearFilters() {
-    state.filters = { health: new Set(), role: '', source: '', assignment: '', tag: '', favorite: false };
+    state.filters = {
+      health: new Set(),
+      role: '',
+      source: '',
+      assignment: '',
+      tag: '',
+      favorite: false
+    };
     els.filterRole.value = '';
     els.filterSource.value = '';
     els.filterAssignment.value = '';
@@ -348,9 +424,13 @@
     var tile = e.target.closest('.roster-stat');
     if (!tile) return;
     var health = tile.dataset.health;
-    if (!health || health === 'total') { state.filters.health.clear(); }
-    else if (state.filters.health.has(health)) { state.filters.health.delete(health); }
-    else { state.filters.health.add(health); }
+    if (!health || health === 'total') {
+      state.filters.health.clear();
+    } else if (state.filters.health.has(health)) {
+      state.filters.health.delete(health);
+    } else {
+      state.filters.health.add(health);
+    }
     onFilterChange();
   }
 
@@ -362,19 +442,30 @@
     state.agents.forEach(function (a) {
       var role = String(a.role || '').trim();
       if (role) roles[role.toLowerCase()] = role;
-      var t = (a.metadata && Array.isArray(a.metadata.tags)) ? a.metadata.tags : [];
-      t.forEach(function (tag) { var k = String(tag).toLowerCase(); if (k) tags[k] = tag; });
+      var t = a.metadata && Array.isArray(a.metadata.tags) ? a.metadata.tags : [];
+      t.forEach(function (tag) {
+        var k = String(tag).toLowerCase();
+        if (k) tags[k] = tag;
+      });
     });
     fillSelect(els.filterRole, 'All roles', roles, state.filters.role, titleCase);
     fillSelect(els.filterTag, 'All tags', tags, state.filters.tag, null);
     // A previously-selected value that no longer exists falls back to "all".
-    if (state.filters.role && !roles[state.filters.role.toLowerCase()]) { state.filters.role = ''; els.filterRole.value = ''; }
-    if (state.filters.tag && !tags[state.filters.tag.toLowerCase()]) { state.filters.tag = ''; els.filterTag.value = ''; }
+    if (state.filters.role && !roles[state.filters.role.toLowerCase()]) {
+      state.filters.role = '';
+      els.filterRole.value = '';
+    }
+    if (state.filters.tag && !tags[state.filters.tag.toLowerCase()]) {
+      state.filters.tag = '';
+      els.filterTag.value = '';
+    }
   }
 
   function fillSelect(sel, allLabel, valueMap, current, labeler) {
     if (!sel) return;
-    var keys = Object.keys(valueMap).sort(function (a, b) { return valueMap[a].localeCompare(valueMap[b]); });
+    var keys = Object.keys(valueMap).sort(function (a, b) {
+      return valueMap[a].localeCompare(valueMap[b]);
+    });
     var html = '<option value="">' + esc(allLabel) + '</option>';
     keys.forEach(function (k) {
       var v = valueMap[k];
@@ -399,7 +490,10 @@
       return;
     }
     els.empty.hidden = true;
-    els.count.textContent = shown === total ? total + ' agent' + (total === 1 ? '' : 's') : shown + ' of ' + total + ' agents';
+    els.count.textContent =
+      shown === total
+        ? total + ' agent' + (total === 1 ? '' : 's')
+        : shown + ' of ' + total + ' agents';
 
     var frag = document.createDocumentFragment();
     state.filtered.forEach(function (agent, idx) {
@@ -417,12 +511,22 @@
   function renderStatusTiles() {
     if (!els.stats) return;
     var total = state.agents.length;
-    if (total === 0) { els.stats.hidden = true; els.stats.innerHTML = ''; return; }
-    var needs = 0, disabled = 0;
+    if (total === 0) {
+      els.stats.hidden = true;
+      els.stats.innerHTML = '';
+      return;
+    }
+    var needs = 0,
+      disabled = 0;
     state.agents.forEach(function (a) {
       var status = String((a && a.status) || 'idle').toLowerCase();
-      if (status === 'disabled') { disabled++; return; }
-      if (status === 'error' || !String((a && a.model) || '').trim()) { needs++; }
+      if (status === 'disabled') {
+        disabled++;
+        return;
+      }
+      if (status === 'error' || !String((a && a.model) || '').trim()) {
+        needs++;
+      }
     });
     var ready = total - needs - disabled;
     els.stats.hidden = false;
@@ -441,11 +545,25 @@
     var health = kind === 'total' ? 'total' : kind;
     var selected = kind !== 'total' && state.filters.health.has(kind);
     var sel = selected ? ' is-selected' : '';
-    return '<button type="button" class="roster-stat roster-stat--' + kind + zero + sel + '"' +
-      ' data-health="' + health + '" aria-pressed="' + (selected ? 'true' : 'false') + '">' +
-      '<span class="roster-stat__value">' + value + '</span>' +
-      '<span class="roster-stat__label">' + esc(label) + '</span>' +
-      '</button>';
+    return (
+      '<button type="button" class="roster-stat roster-stat--' +
+      kind +
+      zero +
+      sel +
+      '"' +
+      ' data-health="' +
+      health +
+      '" aria-pressed="' +
+      (selected ? 'true' : 'false') +
+      '">' +
+      '<span class="roster-stat__value">' +
+      value +
+      '</span>' +
+      '<span class="roster-stat__label">' +
+      esc(label) +
+      '</span>' +
+      '</button>'
+    );
   }
 
   function buildCard(agent, idx) {
@@ -468,14 +586,21 @@
     var permanent = isPermanent(agent);
     var isChecked = state.checked.has(agent.name);
     var favorite = !!(agent.metadata && agent.metadata.favorite);
-    var tags = (agent.metadata && Array.isArray(agent.metadata.tags)) ? agent.metadata.tags : [];
+    var tags = agent.metadata && Array.isArray(agent.metadata.tags) ? agent.metadata.tags : [];
 
     // Concise spoken label so screen readers don't read the raw dot markup, and
     // it carries the FULL tag list even when the visible chips are truncated
     // (PRD FR59).
-    var wcLabel = wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
-    var openLabel = agent.name + (permanent ? ', built-in' : '') +
-      (favorite ? ', favorite' : '') + ', ' + statusText + ', ' + wcLabel +
+    var wcLabel =
+      wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
+    var openLabel =
+      agent.name +
+      (permanent ? ', built-in' : '') +
+      (favorite ? ', favorite' : '') +
+      ', ' +
+      statusText +
+      ', ' +
+      wcLabel +
       (tags.length ? ', tags: ' + tags.join(', ') : '');
 
     var badge = permanent
@@ -491,20 +616,44 @@
     // two actions stay independent (PRD FR2/FR3/FR4).
     li.innerHTML =
       '<label class="roster-card__checkwrap">' +
-      '<span class="visually-hidden">Select ' + esc(agent.name) + '</span>' +
-      '<input type="checkbox" class="roster-card__check" data-check="' + esc(agent.name) + '"' + (isChecked ? ' checked' : '') + '>' +
+      '<span class="visually-hidden">Select ' +
+      esc(agent.name) +
+      '</span>' +
+      '<input type="checkbox" class="roster-card__check" data-check="' +
+      esc(agent.name) +
+      '"' +
+      (isChecked ? ' checked' : '') +
+      '>' +
       '</label>' +
-      '<button type="button" class="roster-card__open" data-open="' + esc(agent.name) + '" aria-label="' + esc(openLabel) + '">' +
+      '<button type="button" class="roster-card__open" data-open="' +
+      esc(agent.name) +
+      '" aria-label="' +
+      esc(openLabel) +
+      '">' +
       avatarMarkup(agent, 'roster-card__avatar') +
       '<span class="roster-card__body">' +
       '<span class="roster-card__namerow">' +
-      '<span class="roster-card__name">' + esc(agent.name) + '</span>' + star + badge +
-      '<span class="roster-card__statuslabel is-' + status + '">' + esc(statusText) + '</span>' +
+      '<span class="roster-card__name">' +
+      esc(agent.name) +
       '</span>' +
-      '<span class="roster-card__meta">' + esc(metaBits.join(' · ')) + '</span>' +
+      star +
+      badge +
+      '<span class="roster-card__statuslabel is-' +
+      status +
+      '">' +
+      esc(statusText) +
+      '</span>' +
+      '</span>' +
+      '<span class="roster-card__meta">' +
+      esc(metaBits.join(' · ')) +
+      '</span>' +
       tagsRow +
       '</span>' +
-      '<span class="roster-card__status is-' + status + '" title="' + esc(statusText) + '" aria-hidden="true"></span>' +
+      '<span class="roster-card__status is-' +
+      status +
+      '" title="' +
+      esc(statusText) +
+      '" aria-hidden="true"></span>' +
       '</button>';
 
     if (isChecked) li.classList.add('is-checked');
@@ -515,10 +664,16 @@
   // still reaches assistive tech via the open button's aria-label (PRD FR58/FR59).
   function tagsRowHTML(tags) {
     if (!tags || tags.length === 0) return '';
-    var shown = tags.slice(0, 2).map(function (t) {
-      return '<span class="roster-card__tag">' + esc(t) + '</span>';
-    }).join('');
-    var more = tags.length > 2 ? '<span class="roster-card__tag roster-card__tag--more">+' + (tags.length - 2) + '</span>' : '';
+    var shown = tags
+      .slice(0, 2)
+      .map(function (t) {
+        return '<span class="roster-card__tag">' + esc(t) + '</span>';
+      })
+      .join('');
+    var more =
+      tags.length > 2
+        ? '<span class="roster-card__tag roster-card__tag--more">+' + (tags.length - 2) + '</span>'
+        : '';
     return '<span class="roster-card__tags" aria-hidden="true">' + shown + more + '</span>';
   }
 
@@ -555,9 +710,11 @@
   function restoreSelection() {
     var fromUrl = new URLSearchParams(window.location.search).get('agent');
     var fromStore = safeStorageGet();
-    var pick = (fromUrl && state.byName[fromUrl] && fromUrl) ||
+    var pick =
+      (fromUrl && state.byName[fromUrl] && fromUrl) ||
       (fromStore && state.byName[fromStore] && fromStore) ||
-      (state.filtered[0] && state.filtered[0].name) || null;
+      (state.filtered[0] && state.filtered[0].name) ||
+      null;
     if (pick) selectAgent(pick, { push: false });
   }
 
@@ -566,7 +723,9 @@
     if (!state.byName[name]) return;
     if (name !== state.selected && !guardUnsaved()) return;
     state.selected = name;
-    state.focusIndex = state.filtered.findIndex(function (a) { return a.name === name; });
+    state.focusIndex = state.filtered.findIndex(function (a) {
+      return a.name === name;
+    });
     resetDirty();
     safeStorageSet(name);
     syncUrl(name, opts.push !== false);
@@ -630,7 +789,9 @@
     if (cost) vitals.push(vital('Cost', '$' + Number(cost).toFixed(2)));
     var meta = detail && detail.model ? modelMeta(detail.model) : null;
     if (meta && meta.is_legacy) {
-      vitals.push('<span class="vital vital--warn" title="This model is past its deprecation date"><span>Model</span><b>⚠ Legacy</b></span>');
+      vitals.push(
+        '<span class="vital vital--warn" title="This model is past its deprecation date"><span>Model</span><b>⚠ Legacy</b></span>'
+      );
     }
     els.vitals.innerHTML = vitals.join('');
   }
@@ -663,7 +824,8 @@
 
     if (!editable) {
       els.overviewFacts.innerHTML = '<dl class="stage-facts">' + readonlyFacts(detail) + '</dl>';
-      els.overviewDesc.innerHTML = '<p class="stage-hint">This is a built-in agent and cannot be edited here.</p>';
+      els.overviewDesc.innerHTML =
+        '<p class="stage-hint">This is a built-in agent and cannot be edited here.</p>';
       return;
     }
 
@@ -685,20 +847,47 @@
       '<form class="stage-form" id="overviewForm" novalidate>' +
       field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
       field('Type', selectInput('ov-type', TYPES, agentType, typeLabel), 'ov-type') +
-      field('Model', modelControl + '<p class="model-note" id="ov-model-note" aria-live="polite"></p>', 'ov-model') +
+      field(
+        'Model',
+        modelControl + '<p class="model-note" id="ov-model-note" aria-live="polite"></p>',
+        'ov-model'
+      ) +
       field('Provider', providerControl, 'ov-provider') +
-      field('Temperature', numInput('ov-temperature', detail.temperature, '0', '2', '0.1'), 'ov-temperature') +
+      field(
+        'Temperature',
+        numInput('ov-temperature', detail.temperature, '0', '2', '0.1'),
+        'ov-temperature'
+      ) +
       '<div class="field" id="ov-reasoning-field">' +
-        '<label class="field__label" for="ov-reasoning">Reasoning effort</label>' +
-        '<div class="field__control">' +
-        selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) { return v ? titleCase(v) : 'Default'; }) +
-        '</div></div>' +
-      field('Max output tokens', numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1'), 'ov-maxtokens') +
+      '<label class="field__label" for="ov-reasoning">Reasoning effort</label>' +
+      '<div class="field__control">' +
+      selectInput('ov-reasoning', REASONING, detail.reasoning_effort || '', function (v) {
+        return v ? titleCase(v) : 'Default';
+      }) +
+      '</div></div>' +
+      field(
+        'Max output tokens',
+        numInput('ov-maxtokens', detail.max_output_tokens || '', '0', '', '1'),
+        'ov-maxtokens'
+      ) +
       field('Web search', checkInput('ov-websearch', detail.allow_web_search)) +
-      field('Description', textareaInput('ov-description', md.description || '', 3), 'ov-description') +
-      field('Favorite', '<label class="check"><input id="ov-favorite" type="checkbox"' + (md.favorite ? ' checked' : '') + '> Favorited</label>') +
+      field(
+        'Description',
+        textareaInput('ov-description', md.description || '', 3),
+        'ov-description'
+      ) +
+      field(
+        'Favorite',
+        '<label class="check"><input id="ov-favorite" type="checkbox"' +
+          (md.favorite ? ' checked' : '') +
+          '> Favorited</label>'
+      ) +
       field('Tags', '<div id="ov-tags-host"></div>', 'ov-tags-host') +
-      field('Avatar color', colorInput('ov-avatarcolor', md.avatar_color || colorFor(name)), 'ov-avatarcolor') +
+      field(
+        'Avatar color',
+        colorInput('ov-avatarcolor', md.avatar_color || colorFor(name)),
+        'ov-avatarcolor'
+      ) +
       '<div class="field"><span class="field__label">Avatar image</span><div class="field__control" id="ov-avatar-control"></div></div>' +
       '</form>' +
       readonlyMetaHTML(detail) +
@@ -709,7 +898,9 @@
     wireAvatarControl(name, md);
     wireColorInput('ov-avatarcolor');
     wireDirty('overview', document.getElementById('overviewForm'));
-    wireSaveBar('overview', function () { saveOverview(name); });
+    wireSaveBar('overview', function () {
+      saveOverview(name);
+    });
 
     var modelSel = document.getElementById('ov-model');
     if (modelSel && modelSel.tagName === 'SELECT') {
@@ -748,7 +939,11 @@
   function updateModelNote(opt) {
     var note = document.getElementById('ov-model-note');
     if (!note) return;
-    if (!opt) { note.textContent = ''; note.className = 'model-note'; return; }
+    if (!opt) {
+      note.textContent = '';
+      note.className = 'model-note';
+      return;
+    }
     var bits = [];
     var goodFor = opt.getAttribute('data-goodfor');
     if (goodFor) bits.push(goodFor);
@@ -757,7 +952,7 @@
     var legacy = opt.getAttribute('data-legacy') === '1';
     var dep = opt.getAttribute('data-deprecation');
     note.className = 'model-note' + (legacy ? ' is-legacy' : '');
-    var warn = legacy ? ('⚠ Legacy model' + (dep ? ' — deprecated ' + dep : '') + '. ') : '';
+    var warn = legacy ? '⚠ Legacy model' + (dep ? ' — deprecated ' + dep : '') + '. ' : '';
     note.textContent = warn + bits.join(' · ');
   }
 
@@ -772,18 +967,25 @@
   }
 
   function supportsReasoning(model) {
-    var m = String(model || '').toLowerCase().trim();
+    var m = String(model || '')
+      .toLowerCase()
+      .trim();
     if (!m) return false;
     return /^o[1345](-|$)/.test(m) || m.indexOf('gpt-5') !== -1 || m.indexOf('codex') !== -1;
   }
 
   function typeLabel(v) {
     switch (v) {
-      case 'tool-calling': return 'Tool Calling';
-      case 'general': return 'General Purpose';
-      case 'research': return 'Research';
-      case 'orchestration': return 'Orchestration';
-      default: return titleCase(v || '');
+      case 'tool-calling':
+        return 'Tool Calling';
+      case 'general':
+        return 'General Purpose';
+      case 'research':
+        return 'Research';
+      case 'orchestration':
+        return 'Orchestration';
+      default:
+        return titleCase(v || '');
     }
   }
 
@@ -792,9 +994,13 @@
       ['Role', titleCase((detail && detail.role) || '—')],
       ['Model', (detail && detail.model) || '—'],
       ['Provider', detail && detail.provider ? titleCase(detail.provider) : '—'],
-      ['Temperature', detail && detail.temperature != null ? String(detail.temperature) : '—'],
+      ['Temperature', detail && detail.temperature != null ? String(detail.temperature) : '—']
     ];
-    return facts.map(function (f) { return '<dt>' + esc(f[0]) + '</dt><dd>' + esc(f[1]) + '</dd>'; }).join('');
+    return facts
+      .map(function (f) {
+        return '<dt>' + esc(f[0]) + '</dt><dd>' + esc(f[1]) + '</dd>';
+      })
+      .join('');
   }
 
   function overviewEdits(detail) {
@@ -815,7 +1021,8 @@
     if (reasoning !== (detail.reasoning_effort || '')) out.reasoning_effort = reasoning;
     var maxRaw = val('ov-maxtokens').trim();
     var maxNum = maxRaw === '' ? 0 : parseInt(maxRaw, 10);
-    if (!isNaN(maxNum) && maxNum !== Number(detail.max_output_tokens || 0)) out.max_output_tokens = maxNum;
+    if (!isNaN(maxNum) && maxNum !== Number(detail.max_output_tokens || 0))
+      out.max_output_tokens = maxNum;
     var web = checked('ov-websearch');
     if (web !== !!detail.allow_web_search) out.allow_web_search = web;
     var md = detail.metadata || {};
@@ -834,10 +1041,22 @@
   }
 
   function tagsDiffer(a, b) {
-    var na = (a || []).map(function (t) { return String(t).toLowerCase().trim(); }).filter(Boolean).sort();
-    var nb = (b || []).map(function (t) { return String(t).toLowerCase().trim(); }).filter(Boolean).sort();
+    var na = (a || [])
+      .map(function (t) {
+        return String(t).toLowerCase().trim();
+      })
+      .filter(Boolean)
+      .sort();
+    var nb = (b || [])
+      .map(function (t) {
+        return String(t).toLowerCase().trim();
+      })
+      .filter(Boolean)
+      .sort();
     if (na.length !== nb.length) return true;
-    for (var i = 0; i < na.length; i++) { if (na[i] !== nb[i]) return true; }
+    for (var i = 0; i < na.length; i++) {
+      if (na[i] !== nb[i]) return true;
+    }
     return false;
   }
 
@@ -849,10 +1068,15 @@
       overviewTagsInput = window.OriTagInput.createTagInput({
         container: host,
         initialTags: initial,
-        onChange: function () { markDirty('overview', true); },
+        onChange: function () {
+          markDirty('overview', true);
+        }
       });
     } else {
-      host.innerHTML = '<input id="ov-tags-text" type="text" value="' + esc((initial || []).join(', ')) + '" placeholder="tag1, tag2">';
+      host.innerHTML =
+        '<input id="ov-tags-text" type="text" value="' +
+        esc((initial || []).join(', ')) +
+        '" placeholder="tag1, tag2">';
     }
   }
 
@@ -865,13 +1089,21 @@
     host.innerHTML =
       '<div class="avatar-control">' +
       '<input type="file" id="ov-avatar-file" aria-label="Upload avatar image" accept="image/png,image/jpeg,image/gif,image/webp" class="avatar-control__file">' +
-      (hasImage ? '<button type="button" class="btn-ghost avatar-control__remove" id="ov-avatar-remove">Remove image</button>' : '') +
+      (hasImage
+        ? '<button type="button" class="btn-ghost avatar-control__remove" id="ov-avatar-remove">Remove image</button>'
+        : '') +
       '<span class="avatar-control__status" id="ov-avatar-status" aria-live="polite"></span>' +
       '</div>';
     var file = document.getElementById('ov-avatar-file');
-    if (file) file.addEventListener('change', function () { uploadAvatar(name, file.files && file.files[0]); });
+    if (file)
+      file.addEventListener('change', function () {
+        uploadAvatar(name, file.files && file.files[0]);
+      });
     var remove = document.getElementById('ov-avatar-remove');
-    if (remove) remove.addEventListener('click', function () { removeAvatar(name); });
+    if (remove)
+      remove.addEventListener('click', function () {
+        removeAvatar(name);
+      });
   }
 
   function uploadAvatar(name, fileObj) {
@@ -881,24 +1113,39 @@
     var form = new FormData();
     form.append('avatar', fileObj);
     fetch('/api/agents/' + encodeURIComponent(name) + '/avatar', { method: 'POST', body: form })
-      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (r) {
+        return r
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (d) {
+            return { status: r.status, data: d };
+          });
+      })
       .then(function (res) {
         if (res.status >= 200 && res.status < 300) afterAvatarChange(name, status, 'Uploaded.');
         else if (status) status.textContent = (res.data && res.data.message) || 'Upload failed.';
       })
-      .catch(function () { if (status) status.textContent = 'Network error.'; });
+      .catch(function () {
+        if (status) status.textContent = 'Network error.';
+      });
   }
 
   function removeAvatar(name) {
     var status = document.getElementById('ov-avatar-status');
     if (status) status.textContent = 'Removing…';
     fetch('/api/agents/' + encodeURIComponent(name) + '/avatar', { method: 'DELETE' })
-      .then(function (r) { return r.status; })
+      .then(function (r) {
+        return r.status;
+      })
       .then(function (code) {
         if (code >= 200 && code < 300) afterAvatarChange(name, status, 'Removed.');
         else if (status) status.textContent = 'Remove failed.';
       })
-      .catch(function () { if (status) status.textContent = 'Network error.'; });
+      .catch(function () {
+        if (status) status.textContent = 'Network error.';
+      });
   }
 
   function afterAvatarChange(name, status, msg) {
@@ -907,7 +1154,8 @@
       if (state.selected !== name) return;
       // Re-render avatar + card from the fresh metadata.
       var item = state.byName[name];
-      if (item && detail.metadata) item.metadata = Object.assign({}, item.metadata, detail.metadata);
+      if (item && detail.metadata)
+        item.metadata = Object.assign({}, item.metadata, detail.metadata);
       els.avatar.outerHTML = avatarMarkup(item, 'stage__avatar', 'stageAvatar');
       els.avatar = document.getElementById('stageAvatar');
       refreshRosterMeta(name, detail);
@@ -921,17 +1169,26 @@
     var rows = [
       ['Created', fmtDate(s.created_at)],
       ['Updated', fmtDate(s.updated_at)],
-      ['Last active', fmtDate(s.last_active)],
-    ].filter(function (r) { return r[1]; });
+      ['Last active', fmtDate(s.last_active)]
+    ].filter(function (r) {
+      return r[1];
+    });
     if (rows.length === 0) return '';
-    return '<dl class="stage-meta">' + rows.map(function (r) {
-      return '<dt>' + esc(r[0]) + '</dt><dd>' + esc(r[1]) + '</dd>';
-    }).join('') + '</dl>';
+    return (
+      '<dl class="stage-meta">' +
+      rows
+        .map(function (r) {
+          return '<dt>' + esc(r[0]) + '</dt><dd>' + esc(r[1]) + '</dd>';
+        })
+        .join('') +
+      '</dl>'
+    );
   }
 
-  var dateFmt = (typeof Intl !== 'undefined' && Intl.DateTimeFormat)
-    ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-    : null;
+  var dateFmt =
+    typeof Intl !== 'undefined' && Intl.DateTimeFormat
+      ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+      : null;
   function fmtDate(v) {
     if (!v) return '';
     var t = Date.parse(v);
@@ -971,10 +1228,13 @@
           '<form class="stage-form" id="promptForm" novalidate>' +
           '<textarea id="pr-prompt" class="stage-textarea" rows="16" spellcheck="false" ' +
           'placeholder="No system prompt set. Add one to steer this agent."></textarea>' +
-          '</form>' + saveBar('prompt');
-        document.getElementById('pr-prompt').value = (detail.system_prompt) || '';
+          '</form>' +
+          saveBar('prompt');
+        document.getElementById('pr-prompt').value = detail.system_prompt || '';
         wireDirty('prompt', document.getElementById('promptForm'));
-        wireSaveBar('prompt', function () { savePrompt(name); });
+        wireSaveBar('prompt', function () {
+          savePrompt(name);
+        });
       })
       .catch(function () {
         els.promptBody.innerHTML = '<p class="stage-hint">Could not load the system prompt.</p>';
@@ -1004,19 +1264,37 @@
     fetch('/api/agents/' + encodeURIComponent(name), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: JSON.stringify(body)
     })
       .then(function (r) {
-        return r.json().catch(function () { return {}; }).then(function (data) { return { status: r.status, data: data }; });
+        return r
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (data) {
+            return { status: r.status, data: data };
+          });
       })
       .then(function (res) {
         setSaving(tab, false);
         if (res.status >= 200 && res.status < 300) return onSaved(name, tab);
-        if (res.status === 409 && res.data && res.data.error === 'stale_agent_edit') return onStale(name, tab, res.data);
-        if (res.status === 409 && res.data && res.data.error === 'shared_agent_edit_requires_confirmation') return onSharedConfirm(name, tab, fields, res.data);
-        if (res.status === 409 && res.data && res.data.error === 'entry_agent_removal_blocked') return showStatus(tab, res.data.message || 'Blocked.', 'error');
+        if (res.status === 409 && res.data && res.data.error === 'stale_agent_edit')
+          return onStale(name, tab, res.data);
+        if (
+          res.status === 409 &&
+          res.data &&
+          res.data.error === 'shared_agent_edit_requires_confirmation'
+        )
+          return onSharedConfirm(name, tab, fields, res.data);
+        if (res.status === 409 && res.data && res.data.error === 'entry_agent_removal_blocked')
+          return showStatus(tab, res.data.message || 'Blocked.', 'error');
         // Validation / other errors surface their message inline.
-        showStatus(tab, (res.data && res.data.message) || ('Save failed (' + res.status + ').'), 'error');
+        showStatus(
+          tab,
+          (res.data && res.data.message) || 'Save failed (' + res.status + ').',
+          'error'
+        );
       })
       .catch(function (err) {
         setSaving(tab, false);
@@ -1044,16 +1322,24 @@
   }
 
   function onStale(name, tab, data) {
-    showBanner(tab,
+    showBanner(
+      tab,
       'This agent was changed elsewhere since you loaded it. Reload the latest version to continue — your unsaved edits in this tab will be replaced.',
-      'Reload latest', function () {
+      'Reload latest',
+      function () {
         fetchDetail(name, true).then(function (detail) {
           if (state.selected !== name) return;
           state.dirty[tab] = false;
-          if (tab === 'overview') { renderVitals(state.byName[name], detail); renderOverview(name, detail); }
-          else if (tab === 'prompt') { els.promptBody.dataset.loadedFor = ''; renderPrompt(name); }
+          if (tab === 'overview') {
+            renderVitals(state.byName[name], detail);
+            renderOverview(name, detail);
+          } else if (tab === 'prompt') {
+            els.promptBody.dataset.loadedFor = '';
+            renderPrompt(name);
+          }
         });
-      });
+      }
+    );
     if (data && data.current_version && state.detailCache[name]) {
       // Keep the cached version in sync so a subsequent explicit reload lines up.
       state.detailCache[name]._staleVersion = data.current_version;
@@ -1062,7 +1348,13 @@
 
   function onSharedConfirm(name, tab, fields, data) {
     var n = (data && data.workspace_count) || 'multiple';
-    var ok = window.confirm('“' + name + '” is attached to ' + n + ' workspaces. This change affects all of them. Apply it?');
+    var ok = window.confirm(
+      '“' +
+        name +
+        '” is attached to ' +
+        n +
+        ' workspaces. This change affects all of them. Apply it?'
+    );
     if (ok) submitPatch(name, tab, fields, true);
     else showStatus(tab, 'Save cancelled.', 'muted');
   }
@@ -1074,9 +1366,10 @@
 
     // CLI / built-in agents cannot be attached — show the membership read-only.
     if (!isEditable(detail)) {
-      els.workspacesBody.innerHTML = members.length === 0
-        ? '<p class="stage-hint">Not attached to any workspace.</p>'
-        : members.map(readonlyWsRow).join('');
+      els.workspacesBody.innerHTML =
+        members.length === 0
+          ? '<p class="stage-hint">Not attached to any workspace.</p>'
+          : members.map(readonlyWsRow).join('');
       return;
     }
 
@@ -1089,16 +1382,19 @@
       .catch(function () {
         if (state.selected !== name) return;
         // Fall back to a read-only view of current memberships.
-        els.workspacesBody.innerHTML = (members.length === 0
-          ? '<p class="stage-hint">Not attached to any workspace.</p>'
-          : members.map(readonlyWsRow).join('')) +
+        els.workspacesBody.innerHTML =
+          (members.length === 0
+            ? '<p class="stage-hint">Not attached to any workspace.</p>'
+            : members.map(readonlyWsRow).join('')) +
           '<p class="stage-hint">Could not load the full workspace list to edit assignments.</p>';
       });
   }
 
   function readonlyWsRow(ws) {
     var nm = esc(ws.name || 'Workspace');
-    var link = ws.id ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + nm + '</a>' : nm;
+    var link = ws.id
+      ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + nm + '</a>'
+      : nm;
     var pill = ws.entry_point ? '<span class="ws-entry-pill">Entry agent</span>' : '';
     return '<div class="ws-row"><span>' + link + '</span>' + pill + '</div>';
   }
@@ -1106,45 +1402,80 @@
   function renderWorkspacesEditor(name, members, all) {
     var memberIds = {};
     var entryIds = {};
-    members.forEach(function (m) { memberIds[m.id] = true; if (m.entry_point) entryIds[m.id] = true; });
+    members.forEach(function (m) {
+      memberIds[m.id] = true;
+      if (m.entry_point) entryIds[m.id] = true;
+    });
 
-    var rows = all.map(function (ws) {
-      var isMember = !!memberIds[ws.id];
-      var isEntry = !!entryIds[ws.id];
-      // The agent can't be unassigned from a workspace it's the entry agent of;
-      // lock that checkbox and explain, matching the server guard.
-      var disabled = isEntry ? ' disabled' : '';
-      var pill = isEntry ? '<span class="ws-entry-pill">Entry agent</span>' : '';
-      return '<label class="ws-check' + (disabled ? ' is-locked' : '') + '">' +
-        '<input type="checkbox" data-ws-id="' + esc(ws.id) + '"' + (isMember ? ' checked' : '') + disabled + '>' +
-        '<span class="ws-check__name">' + esc(ws.name || ws.id) + '</span>' + pill + '</label>';
-    }).join('');
+    var rows = all
+      .map(function (ws) {
+        var isMember = !!memberIds[ws.id];
+        var isEntry = !!entryIds[ws.id];
+        // The agent can't be unassigned from a workspace it's the entry agent of;
+        // lock that checkbox and explain, matching the server guard.
+        var disabled = isEntry ? ' disabled' : '';
+        var pill = isEntry ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+        return (
+          '<label class="ws-check' +
+          (disabled ? ' is-locked' : '') +
+          '">' +
+          '<input type="checkbox" data-ws-id="' +
+          esc(ws.id) +
+          '"' +
+          (isMember ? ' checked' : '') +
+          disabled +
+          '>' +
+          '<span class="ws-check__name">' +
+          esc(ws.name || ws.id) +
+          '</span>' +
+          pill +
+          '</label>'
+        );
+      })
+      .join('');
 
     els.workspacesBody.innerHTML =
-      (all.length === 0 ? '<p class="stage-hint">No workspaces exist yet. Create one from the Workspaces page.</p>' : '') +
-      '<form class="ws-list" id="workspacesForm">' + rows + '</form>' +
+      (all.length === 0
+        ? '<p class="stage-hint">No workspaces exist yet. Create one from the Workspaces page.</p>'
+        : '') +
+      '<form class="ws-list" id="workspacesForm">' +
+      rows +
+      '</form>' +
       saveBar('workspaces');
 
     wireDirty('workspaces', document.getElementById('workspacesForm'));
-    wireSaveBar('workspaces', function () { saveWorkspaces(name, members); });
+    wireSaveBar('workspaces', function () {
+      saveWorkspaces(name, members);
+    });
   }
 
   function saveWorkspaces(name, members) {
     var checks = els.workspacesBody.querySelectorAll('input[data-ws-id]');
     var desired = [];
-    checks.forEach(function (c) { if (c.checked) desired.push(c.getAttribute('data-ws-id')); });
+    checks.forEach(function (c) {
+      if (c.checked) desired.push(c.getAttribute('data-ws-id'));
+    });
     // Entry-agent memberships have disabled (unchecked-proof) boxes but must stay
     // in the desired set so the server doesn't try to remove them.
-    members.forEach(function (m) { if (m.entry_point && desired.indexOf(m.id) === -1) desired.push(m.id); });
+    members.forEach(function (m) {
+      if (m.entry_point && desired.indexOf(m.id) === -1) desired.push(m.id);
+    });
 
     setSaving('workspaces', true);
     fetch('/api/agents/' + encodeURIComponent(name) + '/workspaces', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ workspace_ids: desired }),
+      body: JSON.stringify({ workspace_ids: desired })
     })
       .then(function (r) {
-        return r.json().catch(function () { return {}; }).then(function (data) { return { status: r.status, data: data }; });
+        return r
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (data) {
+            return { status: r.status, data: data };
+          });
       })
       .then(function (res) {
         setSaving('workspaces', false);
@@ -1152,28 +1483,50 @@
           state.dirty.workspaces = false;
           // Reflect the reconciled membership everywhere.
           var item = state.byName[name];
-          if (item) { item.workspaces = res.data.workspaces || []; item.workspace_count = res.data.workspace_count || 0; }
+          if (item) {
+            item.workspaces = res.data.workspaces || [];
+            item.workspace_count = res.data.workspace_count || 0;
+          }
           refreshRosterMeta(name, state.detailCache[name] || {});
           renderWorkspaces(name, item, state.detailCache[name]);
           showStatus('workspaces', 'Saved.', 'ok');
-        } else if (res.status === 409 && res.data && res.data.error === 'entry_agent_removal_blocked') {
+        } else if (
+          res.status === 409 &&
+          res.data &&
+          res.data.error === 'entry_agent_removal_blocked'
+        ) {
           showStatus('workspaces', res.data.message || 'Cannot remove the entry agent.', 'error');
         } else {
-          showStatus('workspaces', (res.data && res.data.message) || ('Save failed (' + res.status + ').'), 'error');
+          showStatus(
+            'workspaces',
+            (res.data && res.data.message) || 'Save failed (' + res.status + ').',
+            'error'
+          );
         }
       })
-      .catch(function () { setSaving('workspaces', false); showStatus('workspaces', 'Network error — not saved.', 'error'); });
+      .catch(function () {
+        setSaving('workspaces', false);
+        showStatus('workspaces', 'Network error — not saved.', 'error');
+      });
   }
 
   function fetchWorkspaces() {
     if (state.allWorkspaces) return Promise.resolve(state.allWorkspaces);
     return fetch('/api/workspaces')
-      .then(function (r) { if (!r.ok) throw new Error('workspaces ' + r.status); return r.json(); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('workspaces ' + r.status);
+        return r.json();
+      })
       .then(function (data) {
         var list = (data && data.workspaces) || [];
         // Only assignable (non-trashed / non-missing) workspaces.
-        list = list.filter(function (w) { var s = String(w.status || '').toLowerCase(); return s !== 'trashed' && s !== 'missing'; });
-        list.sort(function (a, b) { return String(a.name || '').localeCompare(String(b.name || '')); });
+        list = list.filter(function (w) {
+          var s = String(w.status || '').toLowerCase();
+          return s !== 'trashed' && s !== 'missing';
+        });
+        list.sort(function (a, b) {
+          return String(a.name || '').localeCompare(String(b.name || ''));
+        });
         state.allWorkspaces = list;
         return list;
       });
@@ -1193,7 +1546,10 @@
       field('Role', selectInput('cr-role', ROLES, 'general', titleCase), 'cr-role') +
       field('Model', textInput('cr-model', 'gpt-4o-mini'), 'cr-model') +
       field('Description', textareaInput('cr-description', '', 3), 'cr-description') +
-      field('Favorite', '<label class="check"><input id="cr-favorite" type="checkbox"> Favorited</label>') +
+      field(
+        'Favorite',
+        '<label class="check"><input id="cr-favorite" type="checkbox"> Favorited</label>'
+      ) +
       field('Tags', '<div id="cr-tags-host"></div>', 'cr-tags-host') +
       field('Avatar color', colorInput('cr-avatarcolor', '#4f46e5'), 'cr-avatarcolor') +
       '</form>' +
@@ -1205,7 +1561,10 @@
     createTagsInput = null;
     var tagHost = document.getElementById('cr-tags-host');
     if (window.OriTagInput && tagHost) {
-      createTagsInput = window.OriTagInput.createTagInput({ container: tagHost, placeholder: 'Add tag…' });
+      createTagsInput = window.OriTagInput.createTagInput({
+        container: tagHost,
+        placeholder: 'Add tag…'
+      });
     } else if (tagHost) {
       tagHost.innerHTML = '<input id="cr-tags-text" type="text" placeholder="tag1, tag2">';
     }
@@ -1219,16 +1578,31 @@
   function closeCreate() {
     state.creating = false;
     els.createPanel.hidden = true;
-    if (state.selected) { els.stage.hidden = false; }
-    else { els.placeholder.hidden = false; }
+    if (state.selected) {
+      els.stage.hidden = false;
+    } else {
+      els.placeholder.hidden = false;
+    }
   }
 
   function submitCreate() {
     var name = val('cr-name').trim();
     var status = document.querySelector('#savebar-create .save-status');
-    if (!name) { status.textContent = 'Name is required.'; status.className = 'save-status is-error'; return; }
-    var crTags = createTagsInput ? createTagsInput.getTags()
-      : (val('cr-tags-text') ? val('cr-tags-text').split(',').map(function (t) { return t.trim(); }).filter(Boolean) : []);
+    if (!name) {
+      status.textContent = 'Name is required.';
+      status.className = 'save-status is-error';
+      return;
+    }
+    var crTags = createTagsInput
+      ? createTagsInput.getTags()
+      : val('cr-tags-text')
+        ? val('cr-tags-text')
+            .split(',')
+            .map(function (t) {
+              return t.trim();
+            })
+            .filter(Boolean)
+        : [];
     var body = {
       name: name,
       type: 'tool-calling',
@@ -1237,41 +1611,70 @@
       description: val('cr-description'),
       tags: crTags,
       favorite: checked('cr-favorite'),
-      avatar_color: val('cr-avatarcolor'),
+      avatar_color: val('cr-avatarcolor')
     };
     var submit = document.getElementById('createSubmit');
-    submit.disabled = true; submit.textContent = 'Creating…';
-    fetch('/api/agents', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
-      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+    submit.disabled = true;
+    submit.textContent = 'Creating…';
+    fetch('/api/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+      .then(function (r) {
+        return r
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (d) {
+            return { status: r.status, data: d };
+          });
+      })
       .then(function (res) {
-        submit.disabled = false; submit.textContent = 'Create agent';
+        submit.disabled = false;
+        submit.textContent = 'Create agent';
         if (res.status >= 200 && res.status < 300) {
           reloadThenSelect(name);
           closeCreate();
         } else {
-          status.textContent = (res.data && res.data.message) || ('Create failed (' + res.status + ').');
+          status.textContent =
+            (res.data && res.data.message) || 'Create failed (' + res.status + ').';
           status.className = 'save-status is-error';
         }
       })
-      .catch(function () { submit.disabled = false; submit.textContent = 'Create agent'; status.textContent = 'Network error.'; status.className = 'save-status is-error'; });
+      .catch(function () {
+        submit.disabled = false;
+        submit.textContent = 'Create agent';
+        status.textContent = 'Network error.';
+        status.className = 'save-status is-error';
+      });
   }
 
   // Reload the roster from the server, then select the named agent if present.
   function reloadThenSelect(name) {
     fetch('/api/agents/dashboard/list?sort_by=name&order=asc')
-      .then(function (r) { return r.json(); })
+      .then(function (r) {
+        return r.json();
+      })
       .then(function (data) {
         var agents = Array.isArray(data) ? data : (data && data.agents) || [];
         state.agents = agents;
         state.byName = {};
-        agents.forEach(function (a) { state.byName[a.name] = a; });
+        agents.forEach(function (a) {
+          state.byName[a.name] = a;
+        });
         state.detailCache = {};
         pruneChecked();
         populateFilterOptions();
         applyFilterSort();
         if (name && state.byName[name]) selectAgent(name, { push: true });
         else if (state.filtered[0]) selectAgent(state.filtered[0].name, { push: false });
-        else { els.stage.hidden = true; els.placeholder.hidden = false; state.selected = null; }
+        else {
+          els.stage.hidden = true;
+          els.placeholder.hidden = false;
+          state.selected = null;
+        }
       });
   }
 
@@ -1280,13 +1683,27 @@
   function onDeleteClick() {
     var name = state.selected;
     if (!name) return;
-    if (!window.confirm('Delete “' + name + '”? This permanently removes the agent and cannot be undone.')) return;
+    if (
+      !window.confirm(
+        'Delete “' + name + '”? This permanently removes the agent and cannot be undone.'
+      )
+    )
+      return;
     deleteAgent(name);
   }
 
   function deleteAgent(name) {
     fetch('/api/agents?name=' + encodeURIComponent(name), { method: 'DELETE' })
-      .then(function (r) { return r.json().catch(function () { return {}; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (r) {
+        return r
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (d) {
+            return { status: r.status, data: d };
+          });
+      })
       .then(function (res) {
         if (res.status >= 200 && res.status < 300) {
           resetDirty();
@@ -1294,10 +1711,12 @@
           reloadThenSelect(null);
         } else {
           // Attached-to-workspace (409) or built-in (400): surface on the stage.
-          window.alert((res.data && res.data.message) || ('Delete failed (' + res.status + ').'));
+          window.alert((res.data && res.data.message) || 'Delete failed (' + res.status + ').');
         }
       })
-      .catch(function () { window.alert('Network error — agent not deleted.'); });
+      .catch(function () {
+        window.alert('Network error — agent not deleted.');
+      });
   }
 
   function refreshRosterMeta(name, detail) {
@@ -1353,7 +1772,10 @@
     var idx = TAB_ORDER.indexOf(current);
     if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
       e.preventDefault();
-      var next = e.key === 'ArrowRight' ? (idx + 1) % TAB_ORDER.length : (idx - 1 + TAB_ORDER.length) % TAB_ORDER.length;
+      var next =
+        e.key === 'ArrowRight'
+          ? (idx + 1) % TAB_ORDER.length
+          : (idx - 1 + TAB_ORDER.length) % TAB_ORDER.length;
       requestTab(TAB_ORDER[next], true);
     } else if (e.key === 'Home') {
       e.preventDefault();
@@ -1368,8 +1790,12 @@
 
   function wireDirty(tab, form) {
     if (!form) return;
-    form.addEventListener('input', function () { markDirty(tab, true); });
-    form.addEventListener('change', function () { markDirty(tab, true); });
+    form.addEventListener('input', function () {
+      markDirty(tab, true);
+    });
+    form.addEventListener('change', function () {
+      markDirty(tab, true);
+    });
   }
 
   function markDirty(tab, on) {
@@ -1388,12 +1814,20 @@
     if (!bar) return;
     bar.querySelector('[data-role="save"]').addEventListener('click', onSave);
     var revert = bar.querySelector('[data-role="revert"]');
-    if (revert) revert.addEventListener('click', function () {
-      state.dirty[tab] = false;
-      if (tab === 'overview') renderOverview(state.selected, state.detailCache[state.selected]);
-      else if (tab === 'prompt') { els.promptBody.dataset.loadedFor = ''; renderPrompt(state.selected); }
-      else if (tab === 'workspaces') renderWorkspaces(state.selected, state.byName[state.selected], state.detailCache[state.selected]);
-    });
+    if (revert)
+      revert.addEventListener('click', function () {
+        state.dirty[tab] = false;
+        if (tab === 'overview') renderOverview(state.selected, state.detailCache[state.selected]);
+        else if (tab === 'prompt') {
+          els.promptBody.dataset.loadedFor = '';
+          renderPrompt(state.selected);
+        } else if (tab === 'workspaces')
+          renderWorkspaces(
+            state.selected,
+            state.byName[state.selected],
+            state.detailCache[state.selected]
+          );
+      });
     markDirty(tab, false);
   }
 
@@ -1401,7 +1835,10 @@
     var bar = document.getElementById('savebar-' + tab);
     if (!bar) return;
     var save = bar.querySelector('[data-role="save"]');
-    if (save) { save.disabled = on || !state.dirty[tab]; save.textContent = on ? 'Saving…' : 'Save'; }
+    if (save) {
+      save.disabled = on || !state.dirty[tab];
+      save.textContent = on ? 'Saving…' : 'Save';
+    }
   }
 
   function showStatus(tab, msg, kind) {
@@ -1413,7 +1850,9 @@
     status.className = 'save-status is-' + (kind || 'muted');
     if (kind === 'ok' || kind === 'muted') {
       window.clearTimeout(status._t);
-      status._t = window.setTimeout(function () { status.textContent = ''; }, 2600);
+      status._t = window.setTimeout(function () {
+        status.textContent = '';
+      }, 2600);
     }
   }
 
@@ -1429,7 +1868,10 @@
     btn.type = 'button';
     btn.className = 'conflict-banner__action';
     btn.textContent = actionLabel;
-    btn.addEventListener('click', function () { clearBanner(tab); onAction(); });
+    btn.addEventListener('click', function () {
+      clearBanner(tab);
+      onAction();
+    });
     banner.appendChild(btn);
     panel.insertBefore(banner, panel.firstChild);
   }
@@ -1441,7 +1883,9 @@
 
   /* ---- unsaved guard ------------------------------------------------------- */
 
-  function anyDirty() { return !!(state.dirty.overview || state.dirty.prompt || state.dirty.workspaces); }
+  function anyDirty() {
+    return !!(state.dirty.overview || state.dirty.prompt || state.dirty.workspaces);
+  }
 
   function guardUnsaved() {
     if (!anyDirty()) return true;
@@ -1450,7 +1894,11 @@
     return ok;
   }
 
-  function resetDirty() { state.dirty.overview = false; state.dirty.prompt = false; state.dirty.workspaces = false; }
+  function resetDirty() {
+    state.dirty.overview = false;
+    state.dirty.prompt = false;
+    state.dirty.workspaces = false;
+  }
 
   /* ---- roster interaction -------------------------------------------------- */
 
@@ -1459,7 +1907,10 @@
   // click there only changes bulk-selection state (PRD FR3/FR4).
   function onListClick(e) {
     var open = e.target.closest('.roster-card__open');
-    if (open && open.dataset.open) { selectAgent(open.dataset.open); return; }
+    if (open && open.dataset.open) {
+      selectAgent(open.dataset.open);
+      return;
+    }
 
     // Shift-click on (or near) a checkbox extends a contiguous range from the
     // anchor. The native toggle still fires via onListChange; here we only widen
@@ -1469,7 +1920,9 @@
       e.preventDefault();
       var card = check.closest('.roster-card');
       var idx = card ? Number(card.dataset.index) : -1;
-      if (idx >= 0) { rangeSelectTo(idx); }
+      if (idx >= 0) {
+        rangeSelectTo(idx);
+      }
     }
   }
 
@@ -1513,8 +1966,9 @@
       var c = open.closest('.roster-card');
       var i = c ? Number(c.dataset.index) : -1;
       if (i < 0) return;
-      if (e.shiftKey) { rangeSelectTo(i); }
-      else {
+      if (e.shiftKey) {
+        rangeSelectTo(i);
+      } else {
         var name = c.dataset.name;
         var nowChecked = !state.checked.has(name);
         setChecked(name, nowChecked);
@@ -1549,7 +2003,9 @@
   // Check every agent in the current filtered result set — and only those, never
   // agents hidden by the active filters (PRD FR7).
   function selectAllVisible() {
-    state.filtered.forEach(function (a) { state.checked.add(a.name); });
+    state.filtered.forEach(function (a) {
+      state.checked.add(a.name);
+    });
     reflectCheckedInDom();
     updateBulkBar();
     announce(state.checked.size + ' agent' + (state.checked.size === 1 ? '' : 's') + ' selected.');
@@ -1595,9 +2051,13 @@
   function hiddenCheckedCount() {
     if (state.checked.size === 0) return 0;
     var visible = {};
-    state.filtered.forEach(function (a) { visible[a.name] = true; });
+    state.filtered.forEach(function (a) {
+      visible[a.name] = true;
+    });
     var hidden = 0;
-    state.checked.forEach(function (name) { if (!visible[name]) hidden++; });
+    state.checked.forEach(function (name) {
+      if (!visible[name]) hidden++;
+    });
     return hidden;
   }
 
@@ -1630,11 +2090,20 @@
     if (isPermanent(agent)) {
       var role = String(agent.role || '').toLowerCase();
       var source = String(agent.source || '').toLowerCase();
-      if (source === 'cli' || role === 'cli_agent') return { eligible: false, reason: 'Built-in CLI agent.' };
+      if (source === 'cli' || role === 'cli_agent')
+        return { eligible: false, reason: 'Built-in CLI agent.' };
       return { eligible: false, reason: 'System assistant.' };
     }
     if ((agent.workspace_count || 0) > 0) {
-      return { eligible: false, reason: 'Attached to ' + agent.workspace_count + ' workspace' + (agent.workspace_count === 1 ? '' : 's') + '.' };
+      return {
+        eligible: false,
+        reason:
+          'Attached to ' +
+          agent.workspace_count +
+          ' workspace' +
+          (agent.workspace_count === 1 ? '' : 's') +
+          '.'
+      };
     }
     return { eligible: true, reason: '' };
   }
@@ -1675,23 +2144,51 @@
 
   function deleteGroupHTML(title, rows, danger) {
     if (!rows.length) return '';
-    var items = rows.map(function (r) {
-      var agent = state.byName[r.name];
-      var reason = r.reason ? '<span class="bulk-dialog__reason">' + esc(r.reason) + '</span>' : '';
-      var wsLink = '';
-      if (agent && Array.isArray(agent.workspaces) && agent.workspaces.length) {
-        var ws = agent.workspaces[0];
-        if (ws && ws.id) wsLink = ' <a class="bulk-dialog__wslink" href="/workspaces/' + encodeURIComponent(ws.id) + '">' + esc(ws.name || 'workspace') + '</a>';
-      }
-      return '<li><span class="bulk-dialog__agent">' + esc(r.name) + '</span>' + reason + wsLink + '</li>';
-    }).join('');
-    return '<div class="bulk-dialog__group' + (danger ? ' is-danger' : '') + '">' +
-      '<h3 class="bulk-dialog__grouptitle">' + esc(title) + ' (' + rows.length + ')</h3>' +
-      '<ul class="bulk-dialog__grouplist">' + items + '</ul></div>';
+    var items = rows
+      .map(function (r) {
+        var agent = state.byName[r.name];
+        var reason = r.reason
+          ? '<span class="bulk-dialog__reason">' + esc(r.reason) + '</span>'
+          : '';
+        var wsLink = '';
+        if (agent && Array.isArray(agent.workspaces) && agent.workspaces.length) {
+          var ws = agent.workspaces[0];
+          if (ws && ws.id)
+            wsLink =
+              ' <a class="bulk-dialog__wslink" href="/workspaces/' +
+              encodeURIComponent(ws.id) +
+              '">' +
+              esc(ws.name || 'workspace') +
+              '</a>';
+        }
+        return (
+          '<li><span class="bulk-dialog__agent">' +
+          esc(r.name) +
+          '</span>' +
+          reason +
+          wsLink +
+          '</li>'
+        );
+      })
+      .join('');
+    return (
+      '<div class="bulk-dialog__group' +
+      (danger ? ' is-danger' : '') +
+      '">' +
+      '<h3 class="bulk-dialog__grouptitle">' +
+      esc(title) +
+      ' (' +
+      rows.length +
+      ')</h3>' +
+      '<ul class="bulk-dialog__grouplist">' +
+      items +
+      '</ul></div>'
+    );
   }
 
   function closeBulkDelete() {
-    if (els.bulkDeleteDialog.open && typeof els.bulkDeleteDialog.close === 'function') els.bulkDeleteDialog.close();
+    if (els.bulkDeleteDialog.open && typeof els.bulkDeleteDialog.close === 'function')
+      els.bulkDeleteDialog.close();
     else els.bulkDeleteDialog.removeAttribute('open');
     // Return focus to a stable control rather than a possibly-removed card.
     if (els.selectAll) els.selectAll.focus();
@@ -1701,8 +2198,15 @@
     var btn = els.bulkDeleteConfirm;
     if (btn.disabled || btn.dataset.busy === '1') return; // prevent double submit
     var names;
-    try { names = JSON.parse(btn.dataset.names || '[]'); } catch (e) { names = []; }
-    if (!names.length) { closeBulkDelete(); return; }
+    try {
+      names = JSON.parse(btn.dataset.names || '[]');
+    } catch (e) {
+      names = [];
+    }
+    if (!names.length) {
+      closeBulkDelete();
+      return;
+    }
 
     // If the focused agent is among those being deleted, honor the unsaved guard.
     if (state.selected && names.indexOf(state.selected) !== -1 && !guardUnsaved()) return;
@@ -1716,17 +2220,35 @@
     fetch('/api/agents/bulk', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ operation: 'delete', agent_names: names }),
+      body: JSON.stringify({ operation: 'delete', agent_names: names })
     })
-      .then(function (r) { return r.json().catch(function () { return null; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (r) {
+        return r
+          .json()
+          .catch(function () {
+            return null;
+          })
+          .then(function (d) {
+            return { status: r.status, data: d };
+          });
+      })
       .then(function (res) {
         btn.dataset.busy = '';
         btn.textContent = restoreLabel;
-        if (res.status < 200 || res.status >= 300 || !res.data || !Array.isArray(res.data.results)) {
+        if (
+          res.status < 200 ||
+          res.status >= 300 ||
+          !res.data ||
+          !Array.isArray(res.data.results)
+        ) {
           // Do NOT claim any deletion happened on a malformed/error response.
           announce('Bulk delete failed.');
-          els.bulkDeleteBody.insertAdjacentHTML('afterbegin',
-            '<p class="bulk-dialog__error" role="alert">Delete failed (' + res.status + '). No agents were changed.</p>');
+          els.bulkDeleteBody.insertAdjacentHTML(
+            'afterbegin',
+            '<p class="bulk-dialog__error" role="alert">Delete failed (' +
+              res.status +
+              '). No agents were changed.</p>'
+          );
           btn.disabled = false;
           return;
         }
@@ -1737,8 +2259,10 @@
         btn.disabled = false;
         btn.textContent = restoreLabel;
         announce('Network error — no agents deleted.');
-        els.bulkDeleteBody.insertAdjacentHTML('afterbegin',
-          '<p class="bulk-dialog__error" role="alert">Network error — no agents were deleted.</p>');
+        els.bulkDeleteBody.insertAdjacentHTML(
+          'afterbegin',
+          '<p class="bulk-dialog__error" role="alert">Network error — no agents were deleted.</p>'
+        );
         console.error('[roster] bulk delete failed', err);
       });
   }
@@ -1781,12 +2305,25 @@
     els.bulkResultSummary.textContent = parts.join(' · ');
 
     // List only non-success results — those are the ones worth inspecting.
-    var rows = results.filter(function (r) { return r.status !== 'succeeded'; }).map(function (r) {
-      var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
-      return '<li class="bulk-result__item is-' + esc(r.status) + '">' +
-        '<span class="bulk-result__name">' + esc(r.name) + '</span>' +
-        '<span class="bulk-result__reason">' + reason + '</span></li>';
-    }).join('');
+    var rows = results
+      .filter(function (r) {
+        return r.status !== 'succeeded';
+      })
+      .map(function (r) {
+        var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
+        return (
+          '<li class="bulk-result__item is-' +
+          esc(r.status) +
+          '">' +
+          '<span class="bulk-result__name">' +
+          esc(r.name) +
+          '</span>' +
+          '<span class="bulk-result__reason">' +
+          reason +
+          '</span></li>'
+        );
+      })
+      .join('');
     els.bulkResultList.innerHTML = rows;
     els.bulkResult.hidden = false;
   }
@@ -1819,31 +2356,48 @@
         '<div id="bulkTagsInputHost"></div>';
       var host = document.getElementById('bulkTagsInputHost');
       if (window.OriTagInput && host) {
-        bulkTagsInput = window.OriTagInput.createTagInput({ container: host, placeholder: 'Add tag…' });
+        bulkTagsInput = window.OriTagInput.createTagInput({
+          container: host,
+          placeholder: 'Add tag…'
+        });
       } else if (host) {
-        host.innerHTML = '<input id="bulkTagsText" type="text" class="bulk-dialog__text" placeholder="tag1, tag2">';
+        host.innerHTML =
+          '<input id="bulkTagsText" type="text" class="bulk-dialog__text" placeholder="tag1, tag2">';
       }
     } else {
       // Remove: offer the union of tags across the checked set as a checklist so
       // the user picks from values that actually exist (PRD FR27).
       var union = tagsUnion(Array.from(state.checked));
       if (union.length === 0) {
-        els.bulkTagsBody.innerHTML = '<p class="bulk-dialog__none">The selected agents have no tags to remove.</p>';
+        els.bulkTagsBody.innerHTML =
+          '<p class="bulk-dialog__none">The selected agents have no tags to remove.</p>';
         els.bulkTagsConfirm.disabled = true;
       } else {
         els.bulkTagsBody.innerHTML =
           '<p class="bulk-dialog__lead">Remove these tags from every selected agent that has them.</p>' +
-          '<div class="bulk-tags-checklist">' + union.map(function (t) {
-            return '<label class="bulk-tags-checklist__item"><input type="checkbox" value="' + esc(t) + '"> ' + esc(t) + '</label>';
-          }).join('') + '</div>';
+          '<div class="bulk-tags-checklist">' +
+          union
+            .map(function (t) {
+              return (
+                '<label class="bulk-tags-checklist__item"><input type="checkbox" value="' +
+                esc(t) +
+                '"> ' +
+                esc(t) +
+                '</label>'
+              );
+            })
+            .join('') +
+          '</div>';
       }
     }
-    if (typeof dlg.showModal === 'function') dlg.showModal(); else dlg.setAttribute('open', '');
+    if (typeof dlg.showModal === 'function') dlg.showModal();
+    else dlg.setAttribute('open', '');
   }
 
   function closeBulkTags() {
     var dlg = els.bulkTagsDialog;
-    if (dlg.open && typeof dlg.close === 'function') dlg.close(); else dlg.removeAttribute('open');
+    if (dlg.open && typeof dlg.close === 'function') dlg.close();
+    else dlg.removeAttribute('open');
     bulkTagsInput = null;
     if (els.selectAll) els.selectAll.focus();
   }
@@ -1857,10 +2411,15 @@
       var tags = (a && a.metadata && a.metadata.tags) || [];
       tags.forEach(function (t) {
         var key = String(t).toLowerCase();
-        if (!seen[key]) { seen[key] = true; out.push(t); }
+        if (!seen[key]) {
+          seen[key] = true;
+          out.push(t);
+        }
       });
     });
-    out.sort(function (a, b) { return String(a).localeCompare(String(b)); });
+    out.sort(function (a, b) {
+      return String(a).localeCompare(String(b));
+    });
     return out;
   }
 
@@ -1876,11 +2435,20 @@
         tags = txt ? txt.value.split(',') : [];
       }
     } else {
-      els.bulkTagsBody.querySelectorAll('input[type="checkbox"]:checked').forEach(function (c) { tags.push(c.value); });
+      els.bulkTagsBody.querySelectorAll('input[type="checkbox"]:checked').forEach(function (c) {
+        tags.push(c.value);
+      });
     }
-    tags = tags.map(function (t) { return String(t).trim(); }).filter(Boolean);
+    tags = tags
+      .map(function (t) {
+        return String(t).trim();
+      })
+      .filter(Boolean);
     if (tags.length === 0) {
-      els.bulkTagsBody.insertAdjacentHTML('afterbegin', '<p class="bulk-dialog__error" role="alert">Enter at least one tag.</p>');
+      els.bulkTagsBody.insertAdjacentHTML(
+        'afterbegin',
+        '<p class="bulk-dialog__error" role="alert">Enter at least one tag.</p>'
+      );
       return;
     }
     var op = mode === 'add' ? 'add_tags' : 'remove_tags';
@@ -1888,20 +2456,34 @@
     btn.disabled = true;
     var restore = btn.textContent;
     btn.textContent = 'Working…';
-    submitBulkMetadata({ operation: op, agent_names: Array.from(state.checked), tags: tags }, function () {
-      btn.dataset.busy = ''; btn.disabled = false; btn.textContent = restore;
-    }, closeBulkTags);
+    submitBulkMetadata(
+      { operation: op, agent_names: Array.from(state.checked), tags: tags },
+      function () {
+        btn.dataset.busy = '';
+        btn.disabled = false;
+        btn.textContent = restore;
+      },
+      closeBulkTags
+    );
   }
 
   function runBulkFavorite(favorite) {
     if (state.checked.size === 0) return;
     if (state.selected && state.checked.has(state.selected) && !guardUnsaved()) return;
     var btns = [els.bulkFavorite, els.bulkUnfavorite];
-    btns.forEach(function (b) { b.disabled = true; });
+    btns.forEach(function (b) {
+      b.disabled = true;
+    });
     announce(favorite ? 'Favoriting…' : 'Unfavoriting…');
-    submitBulkMetadata({ operation: 'set_favorite', agent_names: Array.from(state.checked), favorite: favorite }, function () {
-      btns.forEach(function (b) { b.disabled = false; });
-    }, null);
+    submitBulkMetadata(
+      { operation: 'set_favorite', agent_names: Array.from(state.checked), favorite: favorite },
+      function () {
+        btns.forEach(function (b) {
+          b.disabled = false;
+        });
+      },
+      null
+    );
   }
 
   // Shared bulk-metadata POST with shared-definition confirmation retry. `always`
@@ -1911,23 +2493,50 @@
     fetch('/api/agents/bulk', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(payload)
     })
-      .then(function (r) { return r.json().catch(function () { return null; }).then(function (d) { return { status: r.status, data: d }; }); })
+      .then(function (r) {
+        return r
+          .json()
+          .catch(function () {
+            return null;
+          })
+          .then(function (d) {
+            return { status: r.status, data: d };
+          });
+      })
       .then(function (res) {
         if (always) always();
-        if (res.status < 200 || res.status >= 300 || !res.data || !Array.isArray(res.data.results)) {
+        if (
+          res.status < 200 ||
+          res.status >= 300 ||
+          !res.data ||
+          !Array.isArray(res.data.results)
+        ) {
           announce('Bulk update failed.');
           return;
         }
         var results = res.data.results;
         // Any agent needing shared-definition confirmation → ask once, resend
         // with confirm_shared_edit for the whole batch (PRD FR31).
-        var needsConfirm = results.some(function (r) { return r.reason_code === 'shared_edit_requires_confirmation'; });
+        var needsConfirm = results.some(function (r) {
+          return r.reason_code === 'shared_edit_requires_confirmation';
+        });
         if (needsConfirm && !payload.confirm_shared_edit) {
-          var n = results.filter(function (r) { return r.reason_code === 'shared_edit_requires_confirmation'; }).length;
-          if (window.confirm(n + ' selected agent(s) are attached to multiple workspaces. This change affects all of them. Apply it?')) {
-            submitBulkMetadata(Object.assign({}, payload, { confirm_shared_edit: true }), always, onDone);
+          var n = results.filter(function (r) {
+            return r.reason_code === 'shared_edit_requires_confirmation';
+          }).length;
+          if (
+            window.confirm(
+              n +
+                ' selected agent(s) are attached to multiple workspaces. This change affects all of them. Apply it?'
+            )
+          ) {
+            submitBulkMetadata(
+              Object.assign({}, payload, { confirm_shared_edit: true }),
+              always,
+              onDone
+            );
             return;
           }
         }
@@ -1954,12 +2563,25 @@
     if (summary.skipped) parts.push(summary.skipped + ' skipped');
     if (summary.failed) parts.push(summary.failed + ' failed');
     els.bulkResultSummary.textContent = parts.join(' · ');
-    var rows = results.filter(function (r) { return r.status !== 'succeeded'; }).map(function (r) {
-      var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
-      return '<li class="bulk-result__item is-' + esc(r.status) + '">' +
-        '<span class="bulk-result__name">' + esc(r.name) + '</span>' +
-        '<span class="bulk-result__reason">' + reason + '</span></li>';
-    }).join('');
+    var rows = results
+      .filter(function (r) {
+        return r.status !== 'succeeded';
+      })
+      .map(function (r) {
+        var reason = r.message ? esc(r.message) : esc(r.reason_code || r.status);
+        return (
+          '<li class="bulk-result__item is-' +
+          esc(r.status) +
+          '">' +
+          '<span class="bulk-result__name">' +
+          esc(r.name) +
+          '</span>' +
+          '<span class="bulk-result__reason">' +
+          reason +
+          '</span></li>'
+        );
+      })
+      .join('');
     els.bulkResultList.innerHTML = rows;
     els.bulkResult.hidden = false;
     var msg = (summary.succeeded || 0) + ' updated';
@@ -1967,8 +2589,17 @@
     announce(msg + '.');
   }
 
-  function onSearch() { state.query = els.search.value || ''; applyFilterSort(); syncUrl(state.selected, false); }
-  function onSort() { state.sort = els.sort.value || 'name-asc'; applyFilterSort(); if (state.selected) highlightSelected(); syncUrl(state.selected, false); }
+  function onSearch() {
+    state.query = els.search.value || '';
+    applyFilterSort();
+    syncUrl(state.selected, false);
+  }
+  function onSort() {
+    state.sort = els.sort.value || 'name-asc';
+    applyFilterSort();
+    if (state.selected) highlightSelected();
+    syncUrl(state.selected, false);
+  }
 
   /* ---- form field builders ------------------------------------------------- */
 
@@ -1981,27 +2612,66 @@
     return '<div class="field">' + lab + '<div class="field__control">' + control + '</div></div>';
   }
   function textInput(id, value, placeholder) {
-    return '<input id="' + id + '" type="text" value="' + esc(value) + '"' +
-      (placeholder ? ' placeholder="' + esc(placeholder) + '"' : '') + '>';
+    return (
+      '<input id="' +
+      id +
+      '" type="text" value="' +
+      esc(value) +
+      '"' +
+      (placeholder ? ' placeholder="' + esc(placeholder) + '"' : '') +
+      '>'
+    );
   }
   // A read-only text input for derived values (e.g. Provider, set by the model).
   // Kept as an <input> so the form still submits its value, but not user-editable.
   function readonlyInput(id, value, title) {
-    return '<input id="' + id + '" class="field__readonly" type="text" readonly tabindex="-1" value="' + esc(value) + '"' +
-      (title ? ' title="' + esc(title) + '"' : '') + '>';
+    return (
+      '<input id="' +
+      id +
+      '" class="field__readonly" type="text" readonly tabindex="-1" value="' +
+      esc(value) +
+      '"' +
+      (title ? ' title="' + esc(title) + '"' : '') +
+      '>'
+    );
   }
   function numInput(id, value, min, max, step) {
-    return '<input id="' + id + '" type="number" value="' + esc(value === '' ? '' : value) + '"' +
-      (min !== '' ? ' min="' + min + '"' : '') + (max ? ' max="' + max + '"' : '') + (step ? ' step="' + step + '"' : '') + '>';
+    return (
+      '<input id="' +
+      id +
+      '" type="number" value="' +
+      esc(value === '' ? '' : value) +
+      '"' +
+      (min !== '' ? ' min="' + min + '"' : '') +
+      (max ? ' max="' + max + '"' : '') +
+      (step ? ' step="' + step + '"' : '') +
+      '>'
+    );
   }
   function checkInput(id, on) {
-    return '<label class="check"><input id="' + id + '" type="checkbox"' + (on ? ' checked' : '') + '> Allowed</label>';
+    return (
+      '<label class="check"><input id="' +
+      id +
+      '" type="checkbox"' +
+      (on ? ' checked' : '') +
+      '> Allowed</label>'
+    );
   }
   function selectInput(id, options, value, labeler) {
-    var opts = options.map(function (o) {
-      var label = labeler ? labeler(o) : o;
-      return '<option value="' + esc(o) + '"' + (o === value ? ' selected' : '') + '>' + esc(label) + '</option>';
-    }).join('');
+    var opts = options
+      .map(function (o) {
+        var label = labeler ? labeler(o) : o;
+        return (
+          '<option value="' +
+          esc(o) +
+          '"' +
+          (o === value ? ' selected' : '') +
+          '>' +
+          esc(label) +
+          '</option>'
+        );
+      })
+      .join('');
     return '<select id="' + id + '">' + opts + '</select>';
   }
   function textareaInput(id, value, rows) {
@@ -2010,17 +2680,29 @@
   // Color picker + hex text, kept in sync, for the avatar color field.
   function colorInput(id, value) {
     var v = /^#[0-9a-fA-F]{6}$/.test(String(value)) ? value : '#4f46e5';
-    return '<span class="color-input">' +
-      '<input id="' + id + '" type="color" value="' + esc(v) + '">' +
-      '<input id="' + id + '-hex" type="text" class="color-input__hex" value="' + esc(v) + '" maxlength="7" spellcheck="false" aria-label="Avatar color hex">' +
-      '</span>';
+    return (
+      '<span class="color-input">' +
+      '<input id="' +
+      id +
+      '" type="color" value="' +
+      esc(v) +
+      '">' +
+      '<input id="' +
+      id +
+      '-hex" type="text" class="color-input__hex" value="' +
+      esc(v) +
+      '" maxlength="7" spellcheck="false" aria-label="Avatar color hex">' +
+      '</span>'
+    );
   }
   // Keep the color picker and its hex text field in sync (either drives the other).
   function wireColorInput(id) {
     var picker = document.getElementById(id);
     var hex = document.getElementById(id + '-hex');
     if (!picker || !hex) return;
-    picker.addEventListener('input', function () { hex.value = picker.value; });
+    picker.addEventListener('input', function () {
+      hex.value = picker.value;
+    });
     hex.addEventListener('input', function () {
       if (/^#[0-9a-fA-F]{6}$/.test(hex.value)) picker.value = hex.value;
     });
@@ -2030,7 +2712,13 @@
   // model that isn't in the catalog (custom, or a provider without a key) is
   // preserved under a "Current" group so switching to a picker never drops it.
   function modelSelectInput(id, currentValue, currentProvider, typeFilter) {
-    return '<select id="' + id + '">' + modelOptionsHTML(currentValue, currentProvider, typeFilter) + '</select>';
+    return (
+      '<select id="' +
+      id +
+      '">' +
+      modelOptionsHTML(currentValue, currentProvider, typeFilter) +
+      '</select>'
+    );
   }
   // Build the grouped <option>/<optgroup> markup for the model picker. Each option
   // carries the data the overview surfaces: provider (for provider sync), pricing
@@ -2054,16 +2742,24 @@
         if (sel) matched = true;
         opts += modelOptionHTML(m.value, m.provider || p.name, m, sel);
       });
-      if (opts) groups += '<optgroup label="' + esc(p.display_name || p.name) + '">' + opts + '</optgroup>';
+      if (opts)
+        groups += '<optgroup label="' + esc(p.display_name || p.name) + '">' + opts + '</optgroup>';
     });
     // Preserve the agent's current model when the type filter excluded it (its real
     // category differs) or it isn't in the catalog at all. Enrich it from the full
     // catalog so its note/warning still show even outside the filtered groups.
     if (currentValue && !matched) {
       var meta = modelMeta(currentValue);
-      groups = '<optgroup label="Current">' +
-        modelOptionHTML(currentValue, (meta && meta.provider) || currentProvider || '', meta, true) +
-        '</optgroup>' + groups;
+      groups =
+        '<optgroup label="Current">' +
+        modelOptionHTML(
+          currentValue,
+          (meta && meta.provider) || currentProvider || '',
+          meta,
+          true
+        ) +
+        '</optgroup>' +
+        groups;
     }
     return groups;
   }
@@ -2071,33 +2767,53 @@
   // for a truly unknown model). Encodes the data the overview reads back.
   function modelOptionHTML(value, provider, meta, selected) {
     var pricing = meta && meta.pricing ? meta.pricing : '';
-    var goodFor = meta && Array.isArray(meta.good_for) && meta.good_for.length ? meta.good_for[0] : '';
+    var goodFor =
+      meta && Array.isArray(meta.good_for) && meta.good_for.length ? meta.good_for[0] : '';
     var legacy = !!(meta && meta.is_legacy);
     var dep = meta && meta.deprecation_date ? meta.deprecation_date : '';
     var label = (meta && meta.label) || value;
-    return '<option value="' + esc(value) + '"' +
-      ' data-provider="' + esc(provider) + '"' +
+    return (
+      '<option value="' +
+      esc(value) +
+      '"' +
+      ' data-provider="' +
+      esc(provider) +
+      '"' +
       (pricing ? ' data-pricing="' + esc(pricing) + '"' : '') +
       (goodFor ? ' data-goodfor="' + esc(goodFor) + '"' : '') +
       (legacy ? ' data-legacy="1"' : '') +
       (dep ? ' data-deprecation="' + esc(dep) + '"' : '') +
-      (selected ? ' selected' : '') + '>' +
-      esc(label) + (legacy ? ' ⚠' : '') + (pricing ? ' · ' + esc(pricing) : '') +
-      '</option>';
+      (selected ? ' selected' : '') +
+      '>' +
+      esc(label) +
+      (legacy ? ' ⚠' : '') +
+      (pricing ? ' · ' + esc(pricing) : '') +
+      '</option>'
+    );
   }
   function saveBar(tab) {
-    return '<div class="save-bar" id="savebar-' + tab + '">' +
+    return (
+      '<div class="save-bar" id="savebar-' +
+      tab +
+      '">' +
       '<span class="dirty-note"></span>' +
       '<span class="save-status is-muted"></span>' +
       '<button type="button" class="btn-ghost" data-role="revert">Revert</button>' +
       '<button type="button" class="btn-primary" data-role="save" disabled>Save</button>' +
-      '</div>';
+      '</div>'
+    );
   }
 
   /* ---- misc helpers -------------------------------------------------------- */
 
-  function val(id) { var el = document.getElementById(id); return el ? el.value : ''; }
-  function checked(id) { var el = document.getElementById(id); return !!(el && el.checked); }
+  function val(id) {
+    var el = document.getElementById(id);
+    return el ? el.value : '';
+  }
+  function checked(id) {
+    var el = document.getElementById(id);
+    return !!(el && el.checked);
+  }
 
   function vital(label, value) {
     return '<span class="vital"><span>' + esc(label) + '</span><b>' + esc(value) + '</b></span>';
@@ -2107,24 +2823,58 @@
     var idAttr = id ? ' id="' + id + '"' : '';
     var image = agent && agent.metadata && agent.metadata.avatar_image;
     if (image) {
-      return '<div class="' + className + '"' + idAttr + ' style="padding:0;overflow:hidden;">' +
-        '<img src="/avatars/' + esc(String(image)) + '" alt="" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover;"></div>';
+      return (
+        '<div class="' +
+        className +
+        '"' +
+        idAttr +
+        ' style="padding:0;overflow:hidden;">' +
+        '<img src="/avatars/' +
+        esc(String(image)) +
+        '" alt="" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover;"></div>'
+      );
     }
-    var color = (agent && agent.metadata && agent.metadata.avatar_color) || colorFor(agent ? agent.name : '');
-    return '<div class="' + className + '"' + idAttr + ' style="background:' + esc(color) + ';">' + esc(initials(agent ? agent.name : '')) + '</div>';
+    var color =
+      (agent && agent.metadata && agent.metadata.avatar_color) || colorFor(agent ? agent.name : '');
+    return (
+      '<div class="' +
+      className +
+      '"' +
+      idAttr +
+      ' style="background:' +
+      esc(color) +
+      ';">' +
+      esc(initials(agent ? agent.name : '')) +
+      '</div>'
+    );
   }
 
   function initials(name) {
-    var parts = String(name || '?').trim().split(/\s+/);
+    var parts = String(name || '?')
+      .trim()
+      .split(/\s+/);
     if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
   }
 
   function colorFor(name) {
     // 700-level shades so white initials clear WCAG AA contrast (>= 4.5:1).
-    var palette = ['#4338ca', '#0e7490', '#6d28d9', '#047857', '#b45309', '#be185d', '#1d4ed8', '#b91c1c'];
+    var palette = [
+      '#4338ca',
+      '#0e7490',
+      '#6d28d9',
+      '#047857',
+      '#b45309',
+      '#be185d',
+      '#1d4ed8',
+      '#b91c1c'
+    ];
     var sum = 0;
-    String(name || '').split('').forEach(function (c) { sum += c.charCodeAt(0); });
+    String(name || '')
+      .split('')
+      .forEach(function (c) {
+        sum += c.charCodeAt(0);
+      });
     return palette[sum % palette.length];
   }
 
@@ -2136,7 +2886,9 @@
     var source = String(agent.source || '').toLowerCase();
     var role = String(agent.role || '').toLowerCase();
     if (source === 'cli' || role === 'cli_agent') return true;
-    var name = String(agent.name || '').trim().toLowerCase();
+    var name = String(agent.name || '')
+      .trim()
+      .toLowerCase();
     return name === 'ori' || name === '__assistant__';
   }
 
@@ -2157,9 +2909,10 @@
   // Locale-aware relative "last active" so the Recently Active sort is legible
   // (PRD FR60). Returns '' when there's no usable timestamp. A zero/epoch value
   // (never active) is treated as missing rather than "55 years ago".
-  var relTimeFmt = (typeof Intl !== 'undefined' && Intl.RelativeTimeFormat)
-    ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-    : null;
+  var relTimeFmt =
+    typeof Intl !== 'undefined' && Intl.RelativeTimeFormat
+      ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+      : null;
   function lastActiveLabel(agent) {
     var t = lastActive(agent);
     if (!t) return '';
@@ -2168,8 +2921,12 @@
     if (absMin < 1) return 'Active now';
     if (!relTimeFmt) return '';
     var units = [
-      ['year', 525600], ['month', 43200], ['week', 10080],
-      ['day', 1440], ['hour', 60], ['minute', 1],
+      ['year', 525600],
+      ['month', 43200],
+      ['week', 10080],
+      ['day', 1440],
+      ['hour', 60],
+      ['minute', 1]
     ];
     for (var i = 0; i < units.length; i++) {
       var perUnit = units[i][1];
@@ -2182,9 +2939,13 @@
   }
 
   function titleCase(s) {
-    s = String(s || '').replace(/[_-]+/g, ' ').trim();
+    s = String(s || '')
+      .replace(/[_-]+/g, ' ')
+      .trim();
     if (!s) return '';
-    return s.replace(/\w\S*/g, function (w) { return w.charAt(0).toUpperCase() + w.slice(1); });
+    return s.replace(/\w\S*/g, function (w) {
+      return w.charAt(0).toUpperCase() + w.slice(1);
+    });
   }
 
   // Serialize search, sort, filters, focused agent, and active tab to the URL.
@@ -2203,7 +2964,9 @@
     if (f.assignment) params.set('assign', f.assignment);
     if (f.favorite) params.set('fav', '1');
     if (f.tag) params.append('tag', f.tag);
-    f.health.forEach(function (h) { params.append('health', h); });
+    f.health.forEach(function (h) {
+      params.append('health', h);
+    });
 
     var qs = params.toString();
     var url = window.location.pathname + (qs ? '?' + qs : '');
@@ -2225,12 +2988,18 @@
     if (els.sort) els.sort.value = state.sort;
 
     var f = { health: new Set(), role: '', source: '', assignment: '', tag: '', favorite: false };
-    var role = p.get('role'); if (role) f.role = role;
-    var source = p.get('source'); if (source === 'user' || source === 'cli') f.source = source;
-    var assign = p.get('assign'); if (assign === 'library' || assign === 'assigned') f.assignment = assign;
+    var role = p.get('role');
+    if (role) f.role = role;
+    var source = p.get('source');
+    if (source === 'user' || source === 'cli') f.source = source;
+    var assign = p.get('assign');
+    if (assign === 'library' || assign === 'assigned') f.assignment = assign;
     if (p.get('fav') === '1') f.favorite = true;
-    var tag = p.get('tag'); if (tag) f.tag = tag;
-    p.getAll('health').forEach(function (h) { if (h === 'needs' || h === 'ready' || h === 'disabled') f.health.add(h); });
+    var tag = p.get('tag');
+    if (tag) f.tag = tag;
+    p.getAll('health').forEach(function (h) {
+      if (h === 'needs' || h === 'ready' || h === 'disabled') f.health.add(h);
+    });
     state.filters = f;
     reflectFiltersInControls();
   }
@@ -2254,8 +3023,20 @@
     if (tab && TAB_ORDER.indexOf(tab) !== -1 && tab !== 'overview') requestTab(tab, false);
   }
 
-  function safeStorageGet() { try { return window.localStorage.getItem(STORAGE_KEY); } catch (e) { return null; } }
-  function safeStorageSet(v) { try { window.localStorage.setItem(STORAGE_KEY, v); } catch (e) { /* ignore */ } }
+  function safeStorageGet() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+  function safeStorageSet(v) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, v);
+    } catch (e) {
+      /* ignore */
+    }
+  }
 
   function cssEscape(s) {
     if (window.CSS && window.CSS.escape) return window.CSS.escape(s);
@@ -2264,7 +3045,10 @@
 
   function esc(s) {
     return String(s == null ? '' : s)
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 })();

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -864,7 +864,7 @@
     var hasImage = !!(md && md.avatar_image);
     host.innerHTML =
       '<div class="avatar-control">' +
-      '<input type="file" id="ov-avatar-file" accept="image/png,image/jpeg,image/gif,image/webp" class="avatar-control__file">' +
+      '<input type="file" id="ov-avatar-file" aria-label="Upload avatar image" accept="image/png,image/jpeg,image/gif,image/webp" class="avatar-control__file">' +
       (hasImage ? '<button type="button" class="btn-ghost avatar-control__remove" id="ov-avatar-remove">Remove image</button>' : '') +
       '<span class="avatar-control__status" id="ov-avatar-status" aria-live="polite"></span>' +
       '</div>';

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -47,6 +47,35 @@
             </label>
           </div>
 
+          <div class="roster-filters" role="group" aria-label="Filter agents">
+            <label class="roster-filter">
+              <span class="visually-hidden">Filter by role</span>
+              <select id="filterRole" aria-label="Filter by role"><option value="">All roles</option></select>
+            </label>
+            <label class="roster-filter">
+              <span class="visually-hidden">Filter by source</span>
+              <select id="filterSource" aria-label="Filter by source">
+                <option value="">All sources</option>
+                <option value="user">User</option>
+                <option value="cli">Built-in</option>
+              </select>
+            </label>
+            <label class="roster-filter">
+              <span class="visually-hidden">Filter by assignment</span>
+              <select id="filterAssignment" aria-label="Filter by assignment">
+                <option value="">Library &amp; assigned</option>
+                <option value="library">Library only</option>
+                <option value="assigned">Assigned only</option>
+              </select>
+            </label>
+            <label class="roster-filter">
+              <span class="visually-hidden">Filter by tag</span>
+              <select id="filterTag" aria-label="Filter by tag"><option value="">All tags</option></select>
+            </label>
+            <button type="button" id="filterFavorite" class="roster-filter-toggle" aria-pressed="false">★ Favorites</button>
+            <button type="button" id="clearFilters" class="roster-linkbtn" hidden>Clear filters</button>
+          </div>
+
           <div class="roster-selectbar" role="group" aria-label="Bulk selection">
             <button type="button" id="rosterSelectAll" class="roster-linkbtn">Select all visible</button>
             <button type="button" id="rosterClearSelection" class="roster-linkbtn" hidden>Clear selection</button>
@@ -103,8 +132,12 @@
           </dialog>
 
           <div class="roster-empty" id="rosterEmpty" hidden>
-            <p>No agents match your search.</p>
-            <button type="button" id="rosterClearSearch" class="roster-linkbtn">Clear search</button>
+            <p id="rosterEmptyMsg">No agents match your search.</p>
+            <div class="roster-empty__actions">
+              <button type="button" id="rosterClearSearch" class="roster-linkbtn" hidden>Clear search</button>
+              <button type="button" id="rosterEmptyClearFilters" class="roster-linkbtn" hidden>Clear filters</button>
+              <button type="button" id="rosterEmptyCreate" class="roster-linkbtn" hidden>Create your first agent</button>
+            </div>
           </div>
         </section>
 

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -68,6 +68,28 @@
           </div>
           <p class="visually-hidden" id="bulkLive" role="status" aria-live="polite"></p>
 
+          <!-- Persistent bulk-result surface: partial-success results stay
+               inspectable here until dismissed (PRD FR44/FR45). -->
+          <div class="bulk-result" id="bulkResult" role="region" aria-label="Bulk action results" hidden>
+            <div class="bulk-result__head">
+              <span class="bulk-result__summary" id="bulkResultSummary"></span>
+              <button type="button" class="roster-linkbtn" id="bulkResultDismiss">Dismiss</button>
+            </div>
+            <ul class="bulk-result__list" id="bulkResultList"></ul>
+          </div>
+
+          <!-- Bulk-delete confirmation. Native <dialog> traps focus and closes on
+               Escape before submission (PRD FR34/FR85). -->
+          <dialog class="bulk-dialog" id="bulkDeleteDialog" aria-labelledby="bulkDeleteTitle">
+            <h2 class="bulk-dialog__title" id="bulkDeleteTitle">Delete agents</h2>
+            <p class="bulk-dialog__lead">Deleting an agent is permanent and cannot be undone.</p>
+            <div class="bulk-dialog__body" id="bulkDeleteBody"></div>
+            <div class="bulk-dialog__actions">
+              <button type="button" class="btn-ghost" id="bulkDeleteCancel">Cancel</button>
+              <button type="button" class="btn-danger" id="bulkDeleteConfirm">Delete</button>
+            </div>
+          </dialog>
+
           <div class="roster-empty" id="rosterEmpty" hidden>
             <p>No agents match your search.</p>
             <button type="button" id="rosterClearSearch" class="roster-linkbtn">Clear search</button>

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {{template "head.tmpl" .}}
+<link rel="stylesheet" href="/css/tag-input.css">
 <link rel="stylesheet" href="/css/agents-roster.css">
 
 <body class="bg-light agents-roster-page" data-sidebar-default="hidden">
@@ -90,6 +91,17 @@
             </div>
           </dialog>
 
+          <!-- Bulk tag add/remove. Body is rebuilt per mode (add = tag entry,
+               remove = checklist of tags across the checked set). -->
+          <dialog class="bulk-dialog" id="bulkTagsDialog" aria-labelledby="bulkTagsTitle">
+            <h2 class="bulk-dialog__title" id="bulkTagsTitle">Tags</h2>
+            <div class="bulk-dialog__body" id="bulkTagsBody"></div>
+            <div class="bulk-dialog__actions">
+              <button type="button" class="btn-ghost" id="bulkTagsCancel">Cancel</button>
+              <button type="button" class="btn-primary" id="bulkTagsConfirm">Apply</button>
+            </div>
+          </dialog>
+
           <div class="roster-empty" id="rosterEmpty" hidden>
             <p>No agents match your search.</p>
             <button type="button" id="rosterClearSearch" class="roster-linkbtn">Clear search</button>
@@ -159,6 +171,9 @@
   <script defer src="/js/app.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/themeManager.js"></script>
+  <!-- Shared tag-entry widget (exposes window.OriTagInput). Loaded as a module so
+       the roster's Overview + bulk tag flows reuse it instead of duplicating. -->
+  <script type="module" src="/js/modules/tag-input.js"></script>
   <script defer src="/js/agents-roster.js"></script>
 </body>
 

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -46,9 +46,27 @@
             </label>
           </div>
 
-          <ul class="roster-list" id="rosterList" role="listbox" aria-label="Agents" tabindex="0" aria-activedescendant="">
+          <div class="roster-selectbar" role="group" aria-label="Bulk selection">
+            <button type="button" id="rosterSelectAll" class="roster-linkbtn">Select all visible</button>
+            <button type="button" id="rosterClearSelection" class="roster-linkbtn" hidden>Clear selection</button>
+          </div>
+
+          <ul class="roster-list" id="rosterList" role="list" aria-label="Agents">
             <!-- roster cards injected here -->
           </ul>
+
+          <!-- Bulk action bar: revealed when at least one agent is checked. -->
+          <div class="bulk-bar" id="bulkBar" role="region" aria-label="Bulk actions" hidden>
+            <div class="bulk-bar__count" id="bulkCount" aria-live="polite"></div>
+            <div class="bulk-bar__actions">
+              <button type="button" class="bulk-bar__btn" id="bulkAddTags">Add tags</button>
+              <button type="button" class="bulk-bar__btn" id="bulkRemoveTags">Remove tags</button>
+              <button type="button" class="bulk-bar__btn" id="bulkFavorite">Favorite</button>
+              <button type="button" class="bulk-bar__btn" id="bulkUnfavorite">Unfavorite</button>
+              <button type="button" class="bulk-bar__btn bulk-bar__btn--danger" id="bulkDelete">Delete</button>
+            </div>
+          </div>
+          <p class="visually-hidden" id="bulkLive" role="status" aria-live="polite"></p>
 
           <div class="roster-empty" id="rosterEmpty" hidden>
             <p>No agents match your search.</p>

--- a/tests/agents-roster.a11y.spec.js
+++ b/tests/agents-roster.a11y.spec.js
@@ -33,6 +33,11 @@ for (const theme of ['light', 'dark']) {
       await expect(page.locator('#stageName')).toHaveText(name);
       await expect(page.locator('#overviewFacts .stage-form')).toBeVisible();
 
+      // Exercise the bulk surfaces so axe covers checked cards, the revealed
+      // action bar, and the filter controls, not just the resting roster.
+      await page.locator(`.roster-card[data-name="${name}"] .roster-card__check`).check();
+      await expect(page.locator('#bulkBar')).toBeVisible();
+
       await page.addScriptTag({ url: 'https://cdn.jsdelivr.net/npm/axe-core@4.10.3/axe.min.js' });
       const results = await page.evaluate(async () => {
         const root = document.querySelector('.roster-layout');
@@ -41,6 +46,16 @@ for (const theme of ['light', 'dark']) {
         });
       });
       expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+
+      // Also scan the bulk-delete confirmation dialog (focus-trapped modal).
+      await page.locator('#bulkDelete').click();
+      await expect(page.locator('#bulkDeleteDialog')).toBeVisible();
+      const dialogResults = await page.evaluate(async () => {
+        return await window.axe.run(document.querySelector('#bulkDeleteDialog'), {
+          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+        });
+      });
+      expect(dialogResults.violations, JSON.stringify(dialogResults.violations, null, 2)).toEqual([]);
     } finally {
       await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
     }

--- a/tests/agents-roster.a11y.spec.js
+++ b/tests/agents-roster.a11y.spec.js
@@ -10,7 +10,7 @@ for (const theme of ['light', 'dark']) {
   test(`agents roster accessibility (${theme})`, async ({ page, request }) => {
     const name = `PW A11y ${theme} ${Date.now()}`;
     const create = await request.post(`${baseUrl}/api/agents`, {
-      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' }
     });
     expect(create.ok()).toBeTruthy();
 
@@ -23,12 +23,12 @@ for (const theme of ['light', 'dark']) {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
       await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, {
-        waitUntil: 'domcontentloaded',
+        waitUntil: 'domcontentloaded'
       });
       await expect(page.locator('#stageName')).toHaveText(name);
       await expect(page.locator('#overviewFacts .stage-form')).toBeVisible();
@@ -42,7 +42,7 @@ for (const theme of ['light', 'dark']) {
       const results = await page.evaluate(async () => {
         const root = document.querySelector('.roster-layout');
         return await window.axe.run(root, {
-          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] }
         });
       });
       expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
@@ -52,12 +52,16 @@ for (const theme of ['light', 'dark']) {
       await expect(page.locator('#bulkDeleteDialog')).toBeVisible();
       const dialogResults = await page.evaluate(async () => {
         return await window.axe.run(document.querySelector('#bulkDeleteDialog'), {
-          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+          runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] }
         });
       });
-      expect(dialogResults.violations, JSON.stringify(dialogResults.violations, null, 2)).toEqual([]);
+      expect(dialogResults.violations, JSON.stringify(dialogResults.violations, null, 2)).toEqual(
+        []
+      );
     } finally {
-      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+      await request
+        .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`)
+        .catch(() => undefined);
     }
   });
 }

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -368,4 +368,57 @@ test.describe('Agents roster', () => {
       await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(plain)}`).catch(() => undefined);
     }
   });
+
+  test('edge cases: no-eligible delete disabled, focused-agent deletion falls back', async ({ page, request }) => {
+    const prefix = `PWEdge${Date.now()}`;
+    const a = `${prefix} A`;
+    const b = `${prefix} B`;
+    for (const n of [a, b]) {
+      const r = await request.post(`${baseUrl}/api/agents`, {
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+      });
+      expect(r.ok()).toBeTruthy();
+    }
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      // No-eligible delete: select only Ori (protected) → Delete button disabled.
+      await page.goto(`${baseUrl}/agents`, { waitUntil: 'domcontentloaded' });
+      await page.locator('#rosterSearch').fill('Ori');
+      const ori = page.locator('.roster-card[data-name="Ori"]');
+      await expect(ori).toHaveCount(1);
+      await ori.locator('.roster-card__check').check();
+      await page.locator('#bulkDelete').click();
+      await expect(page.locator('#bulkDeleteConfirm')).toBeDisabled();
+      await expect(page.locator('#bulkDeleteBody')).toContainText('None of the selected agents can be deleted');
+      await page.locator('#bulkDeleteCancel').click();
+
+      // Focused-agent deletion: focus A, select A, delete → stage falls back.
+      await page.locator('#rosterSearch').fill(prefix);
+      await page.locator(`.roster-card[data-name="${a}"] .roster-card__open`).click();
+      await expect(page.locator('#stageName')).toHaveText(a);
+      await page.locator(`.roster-card[data-name="${a}"] .roster-card__check`).check();
+      await page.locator('#bulkDelete').click();
+      await expect(page.locator('#bulkDeleteConfirm')).toHaveText(/Delete 1 agent/);
+      await page.locator('#bulkDeleteConfirm').click();
+
+      // A is gone from the server; the stage no longer shows A.
+      await expect
+        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(a)}/detail`)).status())
+        .toBe(404);
+      await expect(page.locator('#stageName')).not.toHaveText(a);
+    } finally {
+      for (const n of [a, b]) {
+        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+      }
+    }
+  });
 });

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -10,7 +10,7 @@ test.describe('Agents roster', () => {
     const name = `PW Roster ${Date.now()}`;
 
     const create = await request.post(`${baseUrl}/api/agents`, {
-      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' }
     });
     expect(create.ok()).toBeTruthy();
 
@@ -21,13 +21,13 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
       // Roster is the default Agents view; deep-link straight to our agent.
       await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, {
-        waitUntil: 'domcontentloaded',
+        waitUntil: 'domcontentloaded'
       });
 
       await expect(page.locator('#rosterList')).toBeVisible();
@@ -66,13 +66,15 @@ test.describe('Agents roster', () => {
         .toBe(404);
     } finally {
       // Best-effort cleanup if the test bailed before the delete step.
-      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+      await request
+        .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`)
+        .catch(() => undefined);
     }
   });
 
   test('multi-select: independent focus/check, select all, range, hidden count, clear, reload', async ({
     page,
-    request,
+    request
   }) => {
     // A unique prefix so a search narrows the roster to exactly our test agents.
     const prefix = `PWMulti${Date.now()}`;
@@ -80,7 +82,7 @@ test.describe('Agents roster', () => {
 
     for (const n of names) {
       const r = await request.post(`${baseUrl}/api/agents`, {
-        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' }
       });
       expect(r.ok()).toBeTruthy();
     }
@@ -91,7 +93,7 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
@@ -143,12 +145,17 @@ test.describe('Agents roster', () => {
       await expect(page.locator('#bulkBar')).toBeHidden();
     } finally {
       for (const n of names) {
-        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+        await request
+          .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`)
+          .catch(() => undefined);
       }
     }
   });
 
-  test('bulk delete: mixed selection deletes eligible and reports skipped', async ({ page, request }) => {
+  test('bulk delete: mixed selection deletes eligible and reports skipped', async ({
+    page,
+    request
+  }) => {
     const prefix = `PWDel${Date.now()}`;
     // Two plain (deletable) agents + one attached agent (skipped).
     const loose1 = `${prefix} Loose1`;
@@ -157,7 +164,7 @@ test.describe('Agents roster', () => {
     const names = [loose1, loose2, attached];
     for (const n of names) {
       const r = await request.post(`${baseUrl}/api/agents`, {
-        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' }
       });
       expect(r.ok()).toBeTruthy();
     }
@@ -165,7 +172,7 @@ test.describe('Agents roster', () => {
     // Attach one agent to a fresh workspace so it is protected from deletion.
     let wsId = '';
     const wsResp = await request.post(`${baseUrl}/api/workspaces`, {
-      data: { name: `${prefix} WS`, entry_agent_name: attached },
+      data: { name: `${prefix} WS`, entry_agent_name: attached }
     });
     if (wsResp.ok()) {
       const wsJson = await wsResp.json();
@@ -178,7 +185,7 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
@@ -204,15 +211,26 @@ test.describe('Agents roster', () => {
 
       // Server persistence: loose agents gone (404), attached survives (200).
       await expect
-        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(loose1)}/detail`)).status())
+        .poll(async () =>
+          (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(loose1)}/detail`)).status()
+        )
         .toBe(404);
       await expect
-        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(attached)}/detail`)).status())
+        .poll(async () =>
+          (
+            await request.get(`${baseUrl}/api/agents/${encodeURIComponent(attached)}/detail`)
+          ).status()
+        )
         .toBe(200);
     } finally {
-      if (wsId) await request.delete(`${baseUrl}/api/workspaces/${encodeURIComponent(wsId)}`).catch(() => undefined);
+      if (wsId)
+        await request
+          .delete(`${baseUrl}/api/workspaces/${encodeURIComponent(wsId)}`)
+          .catch(() => undefined);
       for (const n of names) {
-        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+        await request
+          .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`)
+          .catch(() => undefined);
       }
     }
   });
@@ -222,7 +240,7 @@ test.describe('Agents roster', () => {
     const names = [`${prefix} One`, `${prefix} Two`];
     for (const n of names) {
       const r = await request.post(`${baseUrl}/api/agents`, {
-        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini', tags: ['keep'] },
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini', tags: ['keep'] }
       });
       expect(r.ok()).toBeTruthy();
     }
@@ -233,7 +251,7 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
@@ -246,7 +264,9 @@ test.describe('Agents roster', () => {
       await page.locator('#bulkFavorite').click();
       await expect
         .poll(async () => {
-          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(names[0])}/detail`);
+          const r = await request.get(
+            `${baseUrl}/api/agents/${encodeURIComponent(names[0])}/detail`
+          );
           return (await r.json()).metadata?.favorite;
         })
         .toBe(true);
@@ -264,14 +284,18 @@ test.describe('Agents roster', () => {
 
       await expect
         .poll(async () => {
-          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(names[1])}/detail`);
+          const r = await request.get(
+            `${baseUrl}/api/agents/${encodeURIComponent(names[1])}/detail`
+          );
           const tags = (await r.json()).metadata?.tags || [];
           return tags.slice().sort().join(',');
         })
         .toBe('content,keep');
     } finally {
       for (const n of names) {
-        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+        await request
+          .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`)
+          .catch(() => undefined);
       }
     }
   });
@@ -279,7 +303,7 @@ test.describe('Agents roster', () => {
   test('single-agent overview: edit tags and favorite persist', async ({ page, request }) => {
     const name = `PWOv ${Date.now()}`;
     const create = await request.post(`${baseUrl}/api/agents`, {
-      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' }
     });
     expect(create.ok()).toBeTruthy();
 
@@ -289,11 +313,13 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
-      await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, { waitUntil: 'domcontentloaded' });
+      await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, {
+        waitUntil: 'domcontentloaded'
+      });
       await expect(page.locator('#stageName')).toHaveText(name);
 
       // Favorite + add a tag via the Overview form.
@@ -313,19 +339,24 @@ test.describe('Agents roster', () => {
         })
         .toBe('true:research');
     } finally {
-      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+      await request
+        .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`)
+        .catch(() => undefined);
     }
   });
 
-  test('filters + URL: tag filter narrows roster, survives reload, excludes checked', async ({ page, request }) => {
+  test('filters + URL: tag filter narrows roster, survives reload, excludes checked', async ({
+    page,
+    request
+  }) => {
     const prefix = `PWFil${Date.now()}`;
     const tagged = `${prefix} Tagged`;
     const plain = `${prefix} Plain`;
     const r1 = await request.post(`${baseUrl}/api/agents`, {
-      data: { name: tagged, type: 'tool-calling', model: 'gpt-4o-mini', tags: [`${prefix}tag`] },
+      data: { name: tagged, type: 'tool-calling', model: 'gpt-4o-mini', tags: [`${prefix}tag`] }
     });
     const r2 = await request.post(`${baseUrl}/api/agents`, {
-      data: { name: plain, type: 'tool-calling', model: 'gpt-4o-mini' },
+      data: { name: plain, type: 'tool-calling', model: 'gpt-4o-mini' }
     });
     expect(r1.ok() && r2.ok()).toBeTruthy();
 
@@ -335,7 +366,7 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
@@ -364,18 +395,25 @@ test.describe('Agents roster', () => {
       await page.locator('#clearFilters').click();
       await expect(page.locator('.roster-card')).toHaveCount(2);
     } finally {
-      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(tagged)}`).catch(() => undefined);
-      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(plain)}`).catch(() => undefined);
+      await request
+        .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(tagged)}`)
+        .catch(() => undefined);
+      await request
+        .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(plain)}`)
+        .catch(() => undefined);
     }
   });
 
-  test('edge cases: no-eligible delete disabled, focused-agent deletion falls back', async ({ page, request }) => {
+  test('edge cases: no-eligible delete disabled, focused-agent deletion falls back', async ({
+    page,
+    request
+  }) => {
     const prefix = `PWEdge${Date.now()}`;
     const a = `${prefix} A`;
     const b = `${prefix} B`;
     for (const n of [a, b]) {
       const r = await request.post(`${baseUrl}/api/agents`, {
-        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' }
       });
       expect(r.ok()).toBeTruthy();
     }
@@ -386,7 +424,7 @@ test.describe('Agents roster', () => {
         route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+          body: JSON.stringify({ needs_onboarding: false, completed: true })
         })
       );
 
@@ -398,7 +436,9 @@ test.describe('Agents roster', () => {
       await ori.locator('.roster-card__check').check();
       await page.locator('#bulkDelete').click();
       await expect(page.locator('#bulkDeleteConfirm')).toBeDisabled();
-      await expect(page.locator('#bulkDeleteBody')).toContainText('None of the selected agents can be deleted');
+      await expect(page.locator('#bulkDeleteBody')).toContainText(
+        'None of the selected agents can be deleted'
+      );
       await page.locator('#bulkDeleteCancel').click();
 
       // Focused-agent deletion: focus A, select A, delete → stage falls back.
@@ -412,12 +452,16 @@ test.describe('Agents roster', () => {
 
       // A is gone from the server; the stage no longer shows A.
       await expect
-        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(a)}/detail`)).status())
+        .poll(async () =>
+          (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(a)}/detail`)).status()
+        )
         .toBe(404);
       await expect(page.locator('#stageName')).not.toHaveText(a);
     } finally {
       for (const n of [a, b]) {
-        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+        await request
+          .delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`)
+          .catch(() => undefined);
       }
     }
   });

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -216,4 +216,104 @@ test.describe('Agents roster', () => {
       }
     }
   });
+
+  test('bulk metadata: add tags and favorite across a selection', async ({ page, request }) => {
+    const prefix = `PWMeta${Date.now()}`;
+    const names = [`${prefix} One`, `${prefix} Two`];
+    for (const n of names) {
+      const r = await request.post(`${baseUrl}/api/agents`, {
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini', tags: ['keep'] },
+      });
+      expect(r.ok()).toBeTruthy();
+    }
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents`, { waitUntil: 'domcontentloaded' });
+      await page.locator('#rosterSearch').fill(prefix);
+      await expect(page.locator('.roster-card')).toHaveCount(2);
+
+      // Select both, favorite them.
+      await page.locator('#rosterSelectAll').click();
+      await page.locator('#bulkFavorite').click();
+      await expect
+        .poll(async () => {
+          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(names[0])}/detail`);
+          return (await r.json()).metadata?.favorite;
+        })
+        .toBe(true);
+
+      // Re-select (reload cleared selection) and add a tag.
+      await page.locator('#rosterSearch').fill(prefix);
+      await page.locator('#rosterSelectAll').click();
+      await page.locator('#bulkAddTags').click();
+      await expect(page.locator('#bulkTagsDialog')).toBeVisible();
+      // Type into the shared tag input and commit with Enter.
+      const tagField = page.locator('#bulkTagsInputHost .tag-input-field');
+      await tagField.fill('content');
+      await tagField.press('Enter');
+      await page.locator('#bulkTagsConfirm').click();
+
+      await expect
+        .poll(async () => {
+          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(names[1])}/detail`);
+          const tags = (await r.json()).metadata?.tags || [];
+          return tags.slice().sort().join(',');
+        })
+        .toBe('content,keep');
+    } finally {
+      for (const n of names) {
+        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+      }
+    }
+  });
+
+  test('single-agent overview: edit tags and favorite persist', async ({ page, request }) => {
+    const name = `PWOv ${Date.now()}`;
+    const create = await request.post(`${baseUrl}/api/agents`, {
+      data: { name, type: 'tool-calling', model: 'gpt-4o-mini' },
+    });
+    expect(create.ok()).toBeTruthy();
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents?agent=${encodeURIComponent(name)}`, { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#stageName')).toHaveText(name);
+
+      // Favorite + add a tag via the Overview form.
+      await page.locator('#ov-favorite').check();
+      const tagField = page.locator('#ov-tags-host .tag-input-field');
+      await tagField.fill('research');
+      await tagField.press('Enter');
+      const save = page.locator('#savebar-overview [data-role="save"]');
+      await expect(save).toBeEnabled();
+      await save.click();
+
+      await expect
+        .poll(async () => {
+          const r = await request.get(`${baseUrl}/api/agents/${encodeURIComponent(name)}/detail`);
+          const d = await r.json();
+          return `${d.metadata?.favorite}:${(d.metadata?.tags || []).join(',')}`;
+        })
+        .toBe('true:research');
+    } finally {
+      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
+    }
+  });
 });

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -316,4 +316,56 @@ test.describe('Agents roster', () => {
       await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
     }
   });
+
+  test('filters + URL: tag filter narrows roster, survives reload, excludes checked', async ({ page, request }) => {
+    const prefix = `PWFil${Date.now()}`;
+    const tagged = `${prefix} Tagged`;
+    const plain = `${prefix} Plain`;
+    const r1 = await request.post(`${baseUrl}/api/agents`, {
+      data: { name: tagged, type: 'tool-calling', model: 'gpt-4o-mini', tags: [`${prefix}tag`] },
+    });
+    const r2 = await request.post(`${baseUrl}/api/agents`, {
+      data: { name: plain, type: 'tool-calling', model: 'gpt-4o-mini' },
+    });
+    expect(r1.ok() && r2.ok()).toBeTruthy();
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents`, { waitUntil: 'domcontentloaded' });
+      await page.locator('#rosterSearch').fill(prefix);
+      await expect(page.locator('.roster-card')).toHaveCount(2);
+
+      // Check both, then apply a tag filter that hides one → 1 hidden checked.
+      await page.locator('#rosterSelectAll').click();
+      await page.locator('#filterTag').selectOption(`${prefix}tag`);
+      await expect(page.locator('.roster-card')).toHaveCount(1);
+      await expect(page.locator(`.roster-card[data-name="${tagged}"]`)).toBeVisible();
+      await expect(page.locator('#bulkCount')).toHaveText(/1 hidden by filters/);
+
+      // The tag filter is reflected in the URL.
+      await expect.poll(() => new URL(page.url()).searchParams.get('tag')).toBe(`${prefix}tag`);
+
+      // Reload restores the filter (still 1 shown) but clears checked selection.
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#filterTag')).toHaveValue(`${prefix}tag`);
+      await page.locator('#rosterSearch').fill(prefix);
+      await expect(page.locator('.roster-card')).toHaveCount(1);
+      await expect(page.locator('#bulkBar')).toBeHidden();
+
+      // Clear filters restores both.
+      await page.locator('#clearFilters').click();
+      await expect(page.locator('.roster-card')).toHaveCount(2);
+    } finally {
+      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(tagged)}`).catch(() => undefined);
+      await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(plain)}`).catch(() => undefined);
+    }
+  });
 });

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -69,4 +69,82 @@ test.describe('Agents roster', () => {
       await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(name)}`).catch(() => undefined);
     }
   });
+
+  test('multi-select: independent focus/check, select all, range, hidden count, clear, reload', async ({
+    page,
+    request,
+  }) => {
+    // A unique prefix so a search narrows the roster to exactly our test agents.
+    const prefix = `PWMulti${Date.now()}`;
+    const names = [`${prefix} Alpha`, `${prefix} Bravo`, `${prefix} Charlie`];
+
+    for (const n of names) {
+      const r = await request.post(`${baseUrl}/api/agents`, {
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+      });
+      expect(r.ok()).toBeTruthy();
+    }
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents`, { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#rosterList')).toBeVisible();
+
+      // Narrow the roster to our three agents.
+      await page.locator('#rosterSearch').fill(prefix);
+      const cards = page.locator('.roster-card');
+      await expect(cards).toHaveCount(3);
+
+      const alpha = page.locator(`.roster-card[data-name="${names[0]}"]`);
+      const bravo = page.locator(`.roster-card[data-name="${names[1]}"]`);
+      const charlie = page.locator(`.roster-card[data-name="${names[2]}"]`);
+
+      // Checking Alpha changes only bulk state — it does NOT focus Alpha.
+      await alpha.locator('.roster-card__check').check();
+      await expect(alpha).toHaveClass(/is-checked/);
+      await expect(page.locator('#bulkBar')).toBeVisible();
+      await expect(page.locator('#bulkCount')).toHaveText('1 selected');
+
+      // Focusing Bravo (open button) drives the stage but leaves Alpha checked
+      // and does not check Bravo.
+      await bravo.locator('.roster-card__open').click();
+      await expect(page.locator('#stageName')).toHaveText(names[1]);
+      await expect(alpha).toHaveClass(/is-checked/);
+      await expect(bravo).not.toHaveClass(/is-checked/);
+
+      // Select all visible → all three checked.
+      await page.locator('#rosterClearSelection').click();
+      await page.locator('#rosterSelectAll').click();
+      await expect(page.locator('#bulkCount')).toHaveText('3 selected');
+      await expect(charlie).toHaveClass(/is-checked/);
+
+      // Narrow the filter so two checked agents become hidden.
+      await page.locator('#rosterSearch').fill(`${prefix} Alpha`);
+      await expect(cards).toHaveCount(1);
+      await expect(page.locator('#bulkCount')).toHaveText('3 selected · 2 hidden by filters');
+
+      // Clear selection hides the bar.
+      await page.locator('#rosterClearSelection').click();
+      await expect(page.locator('#bulkBar')).toBeHidden();
+
+      // A reload starts with zero checked agents.
+      await page.locator('#rosterSelectAll').click();
+      await expect(page.locator('#bulkBar')).toBeVisible();
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#rosterList')).toBeVisible();
+      await expect(page.locator('#bulkBar')).toBeHidden();
+    } finally {
+      for (const n of names) {
+        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+      }
+    }
+  });
 });

--- a/tests/agents-roster.spec.ts
+++ b/tests/agents-roster.spec.ts
@@ -147,4 +147,73 @@ test.describe('Agents roster', () => {
       }
     }
   });
+
+  test('bulk delete: mixed selection deletes eligible and reports skipped', async ({ page, request }) => {
+    const prefix = `PWDel${Date.now()}`;
+    // Two plain (deletable) agents + one attached agent (skipped).
+    const loose1 = `${prefix} Loose1`;
+    const loose2 = `${prefix} Loose2`;
+    const attached = `${prefix} Attached`;
+    const names = [loose1, loose2, attached];
+    for (const n of names) {
+      const r = await request.post(`${baseUrl}/api/agents`, {
+        data: { name: n, type: 'tool-calling', model: 'gpt-4o-mini' },
+      });
+      expect(r.ok()).toBeTruthy();
+    }
+
+    // Attach one agent to a fresh workspace so it is protected from deletion.
+    let wsId = '';
+    const wsResp = await request.post(`${baseUrl}/api/workspaces`, {
+      data: { name: `${prefix} WS`, entry_agent_name: attached },
+    });
+    if (wsResp.ok()) {
+      const wsJson = await wsResp.json();
+      wsId = wsJson?.folder?.id || wsJson?.id || '';
+    }
+
+    try {
+      await page.addInitScript(() => window.localStorage.setItem('ori-theme', 'dark'));
+      await page.route('**/api/onboarding/status', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ needs_onboarding: false, completed: true }),
+        })
+      );
+
+      await page.goto(`${baseUrl}/agents`, { waitUntil: 'domcontentloaded' });
+      await page.locator('#rosterSearch').fill(prefix);
+      await expect(page.locator('.roster-card')).toHaveCount(3);
+
+      // Check all three, open the confirmation dialog.
+      await page.locator('#rosterSelectAll').click();
+      await page.locator('#bulkDelete').click();
+      const dialog = page.locator('#bulkDeleteDialog');
+      await expect(dialog).toBeVisible();
+      // Two eligible → button names the eligible count.
+      await expect(page.locator('#bulkDeleteConfirm')).toHaveText(/Delete 2 agents/);
+      await expect(page.locator('#bulkDeleteBody')).toContainText('Will be skipped');
+
+      await page.locator('#bulkDeleteConfirm').click();
+
+      // Result surface reports the skipped agent and stays inspectable.
+      await expect(page.locator('#bulkResult')).toBeVisible();
+      await expect(page.locator('#bulkResultSummary')).toContainText('2 deleted');
+      await expect(page.locator('#bulkResultList')).toContainText(attached);
+
+      // Server persistence: loose agents gone (404), attached survives (200).
+      await expect
+        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(loose1)}/detail`)).status())
+        .toBe(404);
+      await expect
+        .poll(async () => (await request.get(`${baseUrl}/api/agents/${encodeURIComponent(attached)}/detail`)).status())
+        .toBe(200);
+    } finally {
+      if (wsId) await request.delete(`${baseUrl}/api/workspaces/${encodeURIComponent(wsId)}`).catch(() => undefined);
+      for (const n of names) {
+        await request.delete(`${baseUrl}/api/agents?name=${encodeURIComponent(n)}`).catch(() => undefined);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Adds a session-only bulk-selection model, safe bulk deletion, bulk tag/favorite actions, richer roster/Overview metadata, and URL-backed filters to the Agents page — extending the existing master-detail roster/stage rather than replacing it.

Implements `tasks/prd-agents-roster-bulk-management.md` across 7 commits (one feature, one PR).

## What's included

- **Bulk API** — `POST /api/agents/bulk` (delete / add_tags / remove_tags / set_favorite): bounded (max 100), deduped, partial-success, stable reason codes (`protected_agent` / `read_only_agent` / `attached_agent` / `agent_not_found` / `shared_edit_requires_confirmation`). Shares the deletion lifecycle and guards with the single-agent handlers so the two paths can't drift. Route registered exact-before-generic.
- **Multi-select** — each card carries a labeled checkbox + a separate open/focus button (replaces listbox semantics). Session-only checked set, never persisted to URL/localStorage; Select All Visible, Clear Selection, Shift-click / Shift+Space range, and a bulk bar that discloses `N selected · M hidden by filters`.
- **Safe bulk deletion** — focus-trapping `<dialog>` previews eligible vs. skipped agents with reasons and a count-specific button; server re-checks eligibility; per-agent results reconcile the roster and remain inspectable in a persistent surface. Malformed/network responses never claim a deletion.
- **Metadata** — cards show favorite, textual status, role/model/workspace usage, last-active (Intl), up to two tags + N (full list to AT). Overview edits description/tags/favorite/avatar color+image with read-only timestamps; Create panel gains tags/favorite/avatar color. Bulk tag/favorite with shared-edit confirmation, reusing the shared `OriTagInput` widget.
- **Filters + URL** — status-tile filters plus role/source/assignment/tag/favorite; search matches tags; search/sort/filters/focused-agent/tab serialize to the URL and restore on load & popstate (checked state excluded). Distinct empty states.
- **A11y/responsive** — WCAG-AA contrast fixes, extended light/dark axe coverage (checked cards, bulk bar, delete dialog), reduced-motion, responsive bulk bar.

## Testing

- 9 Playwright e2e + 2 axe specs (light/dark) in `tests/agents-roster*.spec` — all pass against an isolated smoke server.
- 755 JS module tests, Go unit tests, ESLint, and Prettier all clean.
- Only failing Go test is `internal/llm TestProviderIntegration` (live OpenAI 429 quota — pre-existing, unrelated).
- Manual test guide: `tasks/test-guide-agents-roster-bulk-management.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)