### PR TITLE
fix(home): restore advisory prompt interactions

### DIFF
--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -1018,6 +1018,11 @@
         }
       };
     }
+    // Bootstrap appends the backdrop to <body>. Keep the modal in the same
+    // stacking context so page-level layers cannot place the backdrop above it.
+    if (els.thinkingModal.parentElement !== document.body) {
+      document.body.appendChild(els.thinkingModal);
+    }
     if (typeof bootstrap === 'undefined' || !bootstrap.Modal) return null;
     if (homeAssistantThinkingModalInstance) return homeAssistantThinkingModalInstance;
     homeAssistantThinkingModalInstance = bootstrap.Modal.getOrCreateInstance(els.thinkingModal);
@@ -4185,9 +4190,34 @@
     return null;
   }
 
+  function looksLikeAdvisoryRequest(prompt) {
+    var text = normalizeToken(prompt);
+    if (!text) return false;
+
+    var phrases = [
+      'how should',
+      'what should',
+      'what would you recommend',
+      'what do you recommend',
+      'recommend an approach',
+      'give me a game plan',
+      'help me understand',
+      'review this',
+      'compare the',
+      'explain the tradeoffs',
+      'explain the trade-offs'
+    ];
+
+    for (var i = 0; i < phrases.length; i++) {
+      if (text.indexOf(phrases[i]) >= 0) return true;
+    }
+    return false;
+  }
+
   function looksLikeImplementationRequest(prompt) {
     var text = normalizeToken(prompt);
     if (!text) return false;
+    if (looksLikeAdvisoryRequest(text)) return false;
 
     var phrases = [
       'make ori able to',
@@ -4207,7 +4237,10 @@
         return true;
       }
     }
-    if (text.indexOf('ori') >= 0 && (text.indexOf('implement') >= 0 || text.indexOf('support') >= 0)) {
+    if (/^(please\s+)?(implement|build|create|add|fix|update|make)\b/.test(text)) {
+      return true;
+    }
+    if (/^(can|could|would)\s+you\s+(please\s+)?(implement|build|create|add|fix|update|make)\b/.test(text)) {
       return true;
     }
     return false;
@@ -6801,6 +6834,18 @@
     return matchedAgent === 'ori' || matchedAgent === 'system assistant';
   }
 
+  function shouldRunMatchedAdvisoryInline(prompt, routeData, agentName) {
+    if (!looksLikeAdvisoryRequest(prompt)) return false;
+    if (routePolicyRequiresSpecialist(routeData)) return false;
+
+    var matchedAgent = normalizeToken(agentName);
+    if (matchedAgent !== 'ori' && matchedAgent !== 'system assistant') return false;
+    if (getHomeAssistantHandoffPolicy(routeData) !== 'assistant') return false;
+
+    var routingPolicy = normalizeToken(routeData && routeData.routing_policy);
+    return !routingPolicy || routingPolicy === 'assistant_preferred' || routingPolicy === 'assistant_only';
+  }
+
   function routeMatchesWorkspaceEntryAgent(routeData) {
     var matchedAgent = normalizeToken(routeData && routeData.matched_agent);
     var entryAgent = normalizeToken(homeAssistantState.workspaceEntryAgentName);
@@ -8344,11 +8389,20 @@
     var dispatchIntent = options && options.intent ? options.intent : homeAssistantState.pendingIntent;
     var appLaunchRequest = options && options.appLaunchRequest ? options.appLaunchRequest : null;
     var dispatchMessage = buildAskOriDispatchMessage(prompt, appLaunchRequest, dispatchIntent, routeContext);
+    var responseMode = normalizeToken(options && options.responseMode);
+    var advisoryMode = responseMode === 'advisory';
 
-    setHomeAssistantBusy(true, 'Running Capability…');
+    setHomeAssistantBusy(true, advisoryMode ? 'Thinking…' : 'Running Capability…');
     renderHomeAssistantActions([]);
-    appendHomeAssistantMessage('assistant', 'Using the current capability setup to answer this directly.');
-    setHomeAssistantRoutingSummary('Capability Direct', 'Running the request inline with the selected agent.');
+    if (!advisoryMode) {
+      appendHomeAssistantMessage('assistant', 'Using the current capability setup to answer this directly.');
+    }
+    setHomeAssistantRoutingSummary(
+      advisoryMode ? agentName : 'Capability Direct',
+      advisoryMode
+        ? 'Inspecting the request and preparing a grounded recommendation.'
+        : 'Running the request inline with the selected agent.'
+    );
 
     try {
       var data = await API.post('/api/chat', {
@@ -8358,11 +8412,18 @@
       });
       var responseText = String(data && data.response || '').trim();
       if (!responseText) {
-        responseText = 'The capability ran, but no text response was returned.';
+        responseText = advisoryMode
+          ? 'Ori completed the request, but no text response was returned.'
+          : 'The capability ran, but no text response was returned.';
       }
 
       appendHomeAssistantMessage('assistant', responseText);
-      setHomeAssistantRoutingSummary('Capability Direct', 'Completed inline with "' + agentName + '".');
+      setHomeAssistantRoutingSummary(
+        advisoryMode ? agentName : 'Capability Direct',
+        advisoryMode
+          ? 'Answered inline with "' + agentName + '".'
+          : 'Completed inline with "' + agentName + '".'
+      );
       renderHomeAssistantActions([
         {
           label: 'Continue in Chat',
@@ -8377,8 +8438,16 @@
       ]);
     } catch (error) {
       dashLog.debug('Direct capability execution failed', { error: error && error.message || error, agent: agentName });
-      appendHomeAssistantMessage('assistant', 'I could not run that capability directly right now.');
-      setHomeAssistantRoutingSummary('Capability Direct Failed', 'Direct execution failed.');
+      appendHomeAssistantMessage(
+        'assistant',
+        advisoryMode
+          ? 'I could not get Ori\'s recommendation right now.'
+          : 'I could not run that capability directly right now.'
+      );
+      setHomeAssistantRoutingSummary(
+        advisoryMode ? 'Ori Reply Failed' : 'Capability Direct Failed',
+        advisoryMode ? 'The inline assistant request failed.' : 'Direct execution failed.'
+      );
       renderHomeAssistantActions([
         {
           label: 'Retry',
@@ -8394,6 +8463,11 @@
     } finally {
       setHomeAssistantBusy(false);
     }
+  }
+
+  function runAdvisoryTaskDirect(prompt, agentName, options) {
+    var advisoryOptions = Object.assign({}, options || {}, { responseMode: 'advisory' });
+    return runCapabilityTaskDirect(prompt, agentName, advisoryOptions);
   }
 
   function formatWorkspaceScheduleTask(task) {
@@ -11053,6 +11127,14 @@
 
         if (homeAssistantState.pendingIntent && homeAssistantState.pendingIntent.key === 'utility_direct') {
           await runUtilityTaskDirect(text, match.agent.name);
+          return;
+        }
+        if (shouldRunMatchedAdvisoryInline(text, routeData, match.agent.name)) {
+          await runAdvisoryTaskDirect(text, match.agent.name, {
+            routeContext: routeContext,
+            intent: homeAssistantState.pendingIntent,
+            appLaunchRequest: appLaunchRequest
+          });
           return;
         }
         var matchedCapabilityHandled = await handleCapabilityResolutionFlow({

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1799,6 +1799,132 @@ test.describe('Floating Workspace Assistant', () => {
   });
 });
 
+test.describe('Home Advisory Routing', () => {
+  async function installCompletedOnboarding(page) {
+    await page.route('**/api/onboarding/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ needs_onboarding: false, completed: true, skipped: true })
+      });
+    });
+  }
+
+  async function installAssistantPreferredOriRoute(page) {
+    await page.route('**/api/home-assistant/route', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          intent: 'general_task',
+          intent_label: 'general task',
+          routing_policy: 'assistant_preferred',
+          context_mode: 'direct',
+          handoff_policy: 'assistant',
+          matched_agent: 'Ori',
+          score: 5,
+          requires_creation: false,
+          workspace_recommended: false,
+          route_mode: 'specialist_handoff',
+          target_surface: 'chat',
+          reasons: ['fallback to system assistant'],
+          suggested_agent_name: 'Task Assistant',
+          suggested_agent_type: 'general'
+        })
+      });
+    });
+  }
+
+  test('answers implementation advisory questions inline with Ori', async ({ page }) => {
+    let chatCalls = 0;
+    let chatQuestion = '';
+    await installCompletedOnboarding(page);
+    await installAssistantPreferredOriRoute(page);
+    await page.route('**/api/chat', async route => {
+      chatCalls += 1;
+      chatQuestion = String(route.request().postDataJSON().question || '');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          response:
+            'Use the existing task and worktree records as the source of truth, then add a read-only implementation status projection.'
+        })
+      });
+    });
+
+    await page.goto('/');
+    await page.evaluate(() => {
+      (window as any).__assistantChatOpens = 0;
+      (window as any).chatPanel = {
+        open() {
+          (window as any).__assistantChatOpens += 1;
+        }
+      };
+      (window as any).sessionManager = {
+        sessions: [],
+        activeSessionId: '',
+        async createSessionWithAgent(agentName: string) {
+          const session = { id: 'sess-ori-advisory', agent_name: agentName };
+          this.sessions.push(session);
+          this.activeSessionId = session.id;
+          return session;
+        }
+      };
+      (window as any).sendMessageToChat = async () => {};
+    });
+
+    const prompt =
+      'How should we improve visibility into ongoing implementations in the Ori DevOps workspace?';
+    await page.locator('#homeAssistantInput').fill(prompt);
+    await page.locator('#homeAssistantSendBtn').click();
+
+    await expect.poll(() => chatCalls).toBe(1);
+    expect(chatQuestion).toContain(prompt);
+    await expect(page.locator('#homeAssistantConversation')).toContainText(
+      'Use the existing task and worktree records as the source of truth'
+    );
+    await expect(page.locator('#homeAssistantRoutingSummary')).toContainText(
+      'Answered inline with "Ori".'
+    );
+
+    const actions = page.locator('#homeAssistantActions');
+    await expect(actions.getByText('Create Workspace', { exact: true })).toHaveCount(0);
+    const continueButton = actions.getByText('Continue in Chat', { exact: true });
+    await expect(continueButton).toBeEnabled();
+    await continueButton.click();
+    await expect.poll(() => page.evaluate(() => (window as any).__assistantChatOpens)).toBe(1);
+  });
+
+  test('keeps explicit implementation commands in the workspace capability flow', async ({
+    page
+  }) => {
+    let chatCalls = 0;
+    await installCompletedOnboarding(page);
+    await installAssistantPreferredOriRoute(page);
+    await page.route('**/api/chat', async route => {
+      chatCalls += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: 'unexpected' })
+      });
+    });
+
+    await page.goto('/');
+    await page
+      .locator('#homeAssistantInput')
+      .fill('Implement support for deployment status in Ori');
+    await page.locator('#homeAssistantSendBtn').click();
+
+    await expect(page.locator('#homeAssistantRoutingSummary')).toContainText('Workspace Available');
+    await expect(
+      page.locator('#homeAssistantActions').getByText('Create Workspace', { exact: true })
+    ).toBeVisible();
+    expect(chatCalls).toBe(0);
+  });
+});
+
 test.describe('Home Workspace Routing', () => {
   async function installWorkspaceAssistantMocks(
     page,


### PR DESCRIPTION
## Summary\n\n- Route advisory implementation questions to Ori for inline answers instead of the workspace capability modal.\n- Keep explicit implementation commands in the workspace capability flow.\n- Move the Home assistant modal into the document body so its actions are not blocked by the Bootstrap backdrop.\n- Add regression coverage for routing and Continue in Chat clickability.\n\n## Validation\n\n- npm run lint\n- PLAYWRIGHT_BASE_URL=http://127.0.0.1:32124 npx playwright test tests/smoke.spec.ts --grep "Home Advisory Routing" --workers=1 (2 passed)