### PR TITLE
chore(wt): add 'wt demo' — one-command isolated demo server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,8 @@ SMOKE_DIR=$(mktemp -d)
 HOME="$SMOKE_DIR" ORI_DATA_DIR="$SMOKE_DIR" PORT=8931 ./bin/ori-agent
 ```
 
+**Shorthand: `wt demo [port]`** (from `scripts/wt.sh`, default port 8931) builds the current worktree and launches this exact recipe — sandboxed temp `HOME`/`ORI_DATA_DIR`, started from *inside* the sandbox so the plugin store is isolated too. Use it for the per-group **Demo:** checkpoint (see the manual-test protocol): drive every new user-visible surface in a real browser before its PR opens.
+
 Rules:
 - Start the server as a tracked background process (`run_in_background`) and stop it by PID — never `pkill -f <pattern>`.
 - Keep every smoke artifact under `$SMOKE_DIR`; cleanup is then a single `rm -rf "$SMOKE_DIR"` of a temp path. Nothing under the real `$HOME` should ever need deleting after a smoke test.

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -13,6 +13,7 @@
 #   wt ls                   # List worktrees
 #   wt status               # Show ahead/behind/merged vs dev for all worktrees
 #   wt cd <name>            # Navigate to a worktree
+#   wt demo [port]          # Build current worktree + serve an ISOLATED demo sandbox (default port 8931)
 #   wt merge [name]         # Local merge into dev (legacy; prefer wt pr)
 #
 # Planning docs live in the dev worktree's tasks/ folder (gitignored). Create
@@ -628,6 +629,31 @@ function wt_dispatch {
   ls)
     git worktree list
     ;;
+  demo)
+    # Build the CURRENT worktree and serve it from an isolated demo sandbox,
+    # so a feature branch can be seen running (and manually tested) before its
+    # PR ever opens. Isolation rules (see repo CLAUDE.md "Smoke Testing"):
+    #   - HOME is overridden so "Ori Workspaces" never touches the real tree
+    #   - ORI_DATA_DIR is overridden so DB/vaults/templates are sandboxed
+    #   - the server is launched from INSIDE the sandbox because the plugin
+    #     store resolves relative to the launch directory
+    # Foreground process: Ctrl-C stops it. The sandbox is a throwaway temp dir.
+    local demo_root
+    demo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [[ -z "$demo_root" ]]; then
+      echo "wt demo must run inside a git worktree"
+      return 1
+    fi
+    local demo_port="${2:-8931}"
+    echo "Building $demo_root ..."
+    (cd "$demo_root" && go build -o bin/ori-agent ./cmd/server) || return 1
+    local demo_dir
+    demo_dir="$(mktemp -d "${TMPDIR:-/tmp}/ori-demo.XXXXXX")" || return 1
+    echo "Demo sandbox: $demo_dir   (safe to rm -rf when done)"
+    echo "Branch:       $(git -C "$demo_root" branch --show-current)"
+    echo "URL:          http://localhost:$demo_port   (Ctrl-C to stop)"
+    (cd "$demo_dir" && HOME="$demo_dir" ORI_DATA_DIR="$demo_dir" PORT="$demo_port" "$demo_root/bin/ori-agent")
+    ;;
   cd)
     local name="$2"
     if [[ -z "$name" ]]; then
@@ -859,6 +885,7 @@ function wt_dispatch {
     echo "  wt ls            - List worktrees"
     echo "  wt status        - Show ahead/behind/merged vs $BASE_BRANCH for all worktrees"
     echo "  wt cd <name>     - Navigate to worktree"
+    echo "  wt demo [port]   - Build current worktree + serve an isolated demo sandbox (default 8931)"
     echo "  wt merge [name]  - Local merge into $BASE_BRANCH (legacy; prefer wt pr)"
     ;;
   esac


### PR DESCRIPTION
Tooling for the updated manual-test protocol (born from the Personal HQ epic retro: every group shipped with green unit tests, but the feature was never seen running until after the final merge — and a Details-vs-Map placement mismatch was caught only then).

## What
`wt demo [port]` (default 8931):
- builds the **current worktree** (`go build ./cmd/server`)
- creates a throwaway sandbox and serves from **inside** it with `HOME` + `ORI_DATA_DIR` overridden — real Ori Workspaces / DB / vaults / templates / launch-dir-relative plugin store all untouched
- prints sandbox path, branch, and URL; Ctrl-C stops it

Also points the repo CLAUDE.md smoke-testing section at `wt demo` as the shorthand for the required isolation recipe.

## Protocol context (global CLAUDE.md, updated separately)
Every task-list group that touches user-visible surface now gets a `Demo:` sub-item before its `Commit:` — Claude runs `wt demo`, drives the new surface in a real browser, screenshots it, and test guides must open with "How to run this build" + "Where it appears".

## Verification
`zsh -n` clean; sourced help shows the command; **live-tested**: built this worktree, served on :8947 from the sandbox, `/health` → `{"status":"ok"}` and `/api/settings/email-oauth` responded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)