### PR TITLE
feat(workspace): redesign reusable agent setup

### DIFF
--- a/internal/projecttemplates/agents.go
+++ b/internal/projecttemplates/agents.go
@@ -28,13 +28,13 @@ var ErrRosterRequired = errors.New("template must declare at least one agent; th
 // not a load error.
 const MaxTemplateAgents = 10
 
-// AgentSpec declares one agent a template seeds onto a workspace created from
-// it. Like ToolDefaults, this package carries the spec as data only — it never
-// creates or resolves agents. Role/Type/Model/Provider are trimmed and carried
-// verbatim; canonicalizing them against the real agent enums and resolving empty
-// values to defaults happens in the workspace-creation (seeding) layer, keeping
-// this file-copy engine domain-blind. The first surviving entry in a template's
-// roster is the workspace entry agent; the rest are specialist sub-agents.
+// AgentSpec declares one reusable agent a template recommends and attaches to a
+// workspace created from it. Like ToolDefaults, this package carries the spec as
+// data only — it never creates or resolves agents. Role/Type/Model/Provider are
+// trimmed and carried verbatim; canonicalizing them against the real agent enums
+// and resolving empty values to defaults happens in the workspace-creation layer,
+// keeping this file-copy engine domain-blind. The first surviving entry becomes
+// the workspace's primary routing agent; the rest are workspace specialists.
 type AgentSpec struct {
 	Name         string       `json:"name"`
 	Role         string       `json:"role,omitempty"`

--- a/internal/projecttemplates/templates.go
+++ b/internal/projecttemplates/templates.go
@@ -137,10 +137,10 @@ type Template struct {
 	// this template binds (apply-if-present). Names only — bound in the
 	// workspace-creation layer, not here.
 	Tools ToolDefaults `json:"tools"`
-	// Agents is the roster of agents seeded onto a workspace created from this
-	// template, in declaration order: the first is the workspace entry agent,
-	// the rest are specialist sub-agents. Carried as data only; agents are
-	// created/attached in the workspace-creation layer (see AgentSpec).
+	// Agents is the ordered set of reusable agents a workspace attaches from
+	// this template. The first becomes that workspace's primary routing agent;
+	// the rest are workspace specialists. Carried as data only; global agent
+	// definitions and workspace attachments are resolved in creation (see AgentSpec).
 	Agents []AgentSpec `json:"agents,omitempty"`
 	// Warnings are non-fatal authoring problems computed at load time (legacy
 	// onboarding block, missing agent roster). They surface through the list

--- a/internal/sessionhttp/project_templates.go
+++ b/internal/sessionhttp/project_templates.go
@@ -86,6 +86,85 @@ func (h *Handler) handleTemplateAgentPlan(w http.ResponseWriter, r *http.Request
 	_ = orihttp.RespondSuccess(w, h.buildTemplateAgentPlan(tpl))
 }
 
+// handleTemplateAgentCreate immediately saves one template-declared agent as a
+// reusable global definition. It deliberately does not create or mutate a
+// workspace: the wizard will attach the saved definition through its normal
+// atomic workspace-create request. This lets a first-time template user make a
+// reusable agent explicit before they commit to a workspace.
+func (h *Handler) handleTemplateAgentCreate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		_ = orihttp.RespondMethodNotAllowed(w)
+		return
+	}
+
+	var req struct {
+		TemplateID   string `json:"template_id,omitempty"`
+		TemplatePath string `json:"template_path,omitempty"`
+		Blank        bool   `json:"blank,omitempty"`
+		AgentIndex   int    `json:"agent_index"`
+	}
+	if !orihttp.ParseJSONBody(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.TemplateID) != "" && strings.TrimSpace(req.TemplatePath) != "" {
+		_ = orihttp.RespondBadRequest(w, "specify either template_id or template_path, not both")
+		return
+	}
+
+	var (
+		tpl projecttemplates.Template
+		err error
+	)
+	switch {
+	case strings.TrimSpace(req.TemplateID) != "" || strings.TrimSpace(req.TemplatePath) != "":
+		tpl, err = h.resolveProjectTemplate(req.TemplateID, req.TemplatePath)
+	case req.Blank:
+		tpl = blankWorkspaceTemplate()
+	default:
+		_ = orihttp.RespondBadRequest(w, "choose a blueprint before creating an agent")
+		return
+	}
+	if err != nil {
+		h.respondWorkspaceProjectError(w, err)
+		return
+	}
+	if req.AgentIndex < 0 || req.AgentIndex >= len(tpl.Agents) {
+		_ = orihttp.RespondBadRequest(w, "template agent index is out of range")
+		return
+	}
+	if h.agentStore == nil {
+		_ = orihttp.RespondInternalError(w, "agent store is unavailable")
+		return
+	}
+
+	spec := tpl.Agents[req.AgentIndex]
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		_ = orihttp.RespondBadRequest(w, "template agent name is required")
+		return
+	}
+	created := false
+	if _, exists := h.agentStore.GetAgent(name); !exists {
+		cfg, _ := h.templateAgentCreateConfig(spec)
+		if err := h.agentStore.CreateAgent(name, cfg); err != nil {
+			_ = orihttp.RespondBadRequest(w, err.Error())
+			return
+		}
+		created = true
+	}
+
+	plan := h.buildTemplateAgentPlan(tpl)
+	_ = orihttp.RespondSuccess(w, struct {
+		Created bool                  `json:"created"`
+		Agent   templateAgentPlanItem `json:"agent"`
+		Plan    templateAgentPlan     `json:"plan"`
+	}{
+		Created: created,
+		Agent:   plan.Agents[req.AgentIndex],
+		Plan:    plan,
+	})
+}
+
 // instantiateWorkspaceProject creates a project folder from a template inside
 // the workspace's folder, persists ProjectPath in both the session store and
 // the folder store, and publishes project.created. On any failure after the

--- a/internal/sessionhttp/project_templates.go
+++ b/internal/sessionhttp/project_templates.go
@@ -98,10 +98,11 @@ func (h *Handler) handleTemplateAgentCreate(w http.ResponseWriter, r *http.Reque
 	}
 
 	var req struct {
-		TemplateID   string `json:"template_id,omitempty"`
-		TemplatePath string `json:"template_path,omitempty"`
-		Blank        bool   `json:"blank,omitempty"`
-		AgentIndex   int    `json:"agent_index"`
+		TemplateID   string                 `json:"template_id,omitempty"`
+		TemplatePath string                 `json:"template_path,omitempty"`
+		Blank        bool                   `json:"blank,omitempty"`
+		AgentIndex   int                    `json:"agent_index"`
+		Override     *templateAgentOverride `json:"override,omitempty"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
@@ -131,6 +132,21 @@ func (h *Handler) handleTemplateAgentCreate(w http.ResponseWriter, r *http.Reque
 	if req.AgentIndex < 0 || req.AgentIndex >= len(tpl.Agents) {
 		_ = orihttp.RespondBadRequest(w, "template agent index is out of range")
 		return
+	}
+	if req.Override != nil {
+		if req.Override.Index == nil {
+			index := req.AgentIndex
+			req.Override.Index = &index
+		}
+		if *req.Override.Index != req.AgentIndex {
+			_ = orihttp.RespondBadRequest(w, "agent override must match the selected template agent")
+			return
+		}
+		tpl, err = applyTemplateAgentOverrides(tpl, []templateAgentOverride{*req.Override})
+		if err != nil {
+			_ = orihttp.RespondBadRequest(w, err.Error())
+			return
+		}
 	}
 	if h.agentStore == nil {
 		_ = orihttp.RespondInternalError(w, "agent store is unavailable")

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -45,7 +45,12 @@ type templateAgentPlan struct {
 }
 
 type templateAgentPlanItem struct {
-	Name            string                        `json:"name"`
+	Name string `json:"name"`
+	// Scope is intentionally explicit in the plan so the UI never describes a
+	// template agent as workspace-only. Template agents are global reusable
+	// definitions; a workspace gets an attachment with its own role, context,
+	// and custom instructions.
+	Scope           string                        `json:"scope"`
 	Action          string                        `json:"action"`
 	EntryPoint      bool                          `json:"entry_point"`
 	Role            string                        `json:"role,omitempty"`
@@ -351,6 +356,7 @@ func (h *Handler) buildTemplateAgentPlanItem(spec projecttemplates.AgentSpec, en
 	name := strings.TrimSpace(spec.Name)
 	item := templateAgentPlanItem{
 		Name:       name,
+		Scope:      "reusable",
 		Action:     "create",
 		EntryPoint: entryPoint,
 		Tools:      spec.Tools,

--- a/internal/sessionhttp/template_agents.go
+++ b/internal/sessionhttp/template_agents.go
@@ -3,9 +3,6 @@ package sessionhttp
 import (
 	"fmt"
 	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/johnjallday/ori-agent/internal/agent"
 	"github.com/johnjallday/ori-agent/internal/logger"
@@ -420,26 +417,4 @@ func (h *Handler) bindSeededAgentTools(workspaceID string, created []createdAgen
 		}
 	}
 	return warnings
-}
-
-// attachWorkspaceSpecialist adds a non-entry agent to the workspace as a fresh
-// AgentInstance, mirroring the add-agent endpoint. It is a no-op if an instance
-// for the agent already exists.
-func attachWorkspaceSpecialist(ws *session.Workspace, name string) {
-	name = strings.TrimSpace(name)
-	if ws == nil || name == "" {
-		return
-	}
-	for _, inst := range ws.AgentInstances {
-		if strings.EqualFold(strings.TrimSpace(inst.Name), name) {
-			return
-		}
-	}
-	ws.AgentInstances = append(ws.AgentInstances, session.AgentInstance{
-		ID:             uuid.New().String(),
-		Name:           name,
-		InstanceNumber: 1,
-		NodeID:         fmt.Sprintf("%s-1-node-%s", name, uuid.New().String()[:8]),
-		CreatedAt:      time.Now(),
-	})
 }

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -345,6 +345,68 @@ func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
 	}
 }
 
+func TestCreateTemplateAgentImmediatelySavesReusableDefinition(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	handler.SetSystemModelReader(fakeSystemModelReader{provider: "codex", model: "gpt-5.3-codex"})
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "reaper-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+		"name":"Reaper Song",
+		"agents":[{"name":"Reaper Producer","role":"orchestrator","system_prompt":"produce the song"}]
+	}`
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(manifest), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	newCreateRequest := func() *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/api/workspaces/template-agent-create", bytes.NewBufferString(`{"template_id":"reaper-template","agent_index":0}`))
+		req.Header.Set("Content-Type", "application/json")
+		return req
+	}
+	req := newCreateRequest()
+	w := httptest.NewRecorder()
+	handler.HandleWorkspaces(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Created bool                  `json:"created"`
+		Agent   templateAgentPlanItem `json:"agent"`
+		Plan    templateAgentPlan     `json:"plan"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if !response.Created || response.Agent.Name != "Reaper Producer" || response.Agent.Action != "reuse" {
+		t.Fatalf("unexpected create response: %+v", response)
+	}
+	if len(response.Plan.Agents) != 1 || response.Plan.Agents[0].Action != "reuse" {
+		t.Fatalf("expected refreshed reuse plan, got %+v", response.Plan)
+	}
+	ag, ok := handler.agentStore.GetAgent("Reaper Producer")
+	if !ok || ag == nil || ag.Settings.SystemPrompt != "produce the song" || ag.Settings.Model != "gpt-5.3-codex" {
+		t.Fatalf("template defaults were not saved: %+v", ag)
+	}
+
+	// Calling the action again is idempotent and does not mutate the saved definition.
+	w = httptest.NewRecorder()
+	handler.HandleWorkspaces(w, newCreateRequest())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected idempotent 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode repeat response: %v", err)
+	}
+	if response.Created {
+		t.Fatalf("repeat create unexpectedly reported a new definition: %+v", response)
+	}
+}
+
 func TestCreateWorkspaceAppliesTemplateAgentOverrides(t *testing.T) {
 	handler, _, _, cleanup := templateTestEnv(t)
 	defer cleanup()

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -474,6 +474,161 @@ func TestCreateWorkspaceCanSkipTemplateAgentRoster(t *testing.T) {
 	}
 }
 
+func TestCreateWorkspaceComposesTemplateAndExistingAgentsAtomically(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	if err := handler.agentStore.CreateAgent("Mix Engineer", nil); err != nil {
+		t.Fatalf("CreateAgent Mix Engineer: %v", err)
+	}
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(`{
+		"name":"Roster Template",
+		"agents":[
+			{"name":"Campaign Lead","role":"orchestrator"},
+			{"name":"Copywriter","type":"general"}
+		]
+	}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := postCreateWorkspace(t, handler, `{
+		"name":"Launch",
+		"template_id":"roster-template",
+		"existing_agent_names":["mix engineer"],
+		"entry_agent_name":"Mix Engineer"
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	wsID := resp["folder"].(map[string]any)["id"].(string)
+	ws, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if got := currentWorkspaceEntryAgentName(ws); got != "Mix Engineer" {
+		t.Fatalf("entry agent = %q, want Mix Engineer", got)
+	}
+	if got, want := len(ws.AgentInstances), 3; got != want {
+		t.Fatalf("agent instances = %d, want %d: %#v", got, want, ws.AgentInstances)
+	}
+	for _, name := range []string{"Campaign Lead", "Copywriter", "Mix Engineer"} {
+		if !wsHasAgent(ws, name) {
+			t.Fatalf("workspace roster missing %q: %#v", name, ws.AgentInstances)
+		}
+	}
+	if _, ok := handler.agentStore.GetAgent("Mix Engineer"); !ok {
+		t.Fatal("existing agent must remain a shared saved definition")
+	}
+}
+
+func TestCreateWorkspaceWithExistingAgentsCanOptOutOfTemplateRoster(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	if err := handler.agentStore.CreateAgent("Mix Engineer", nil); err != nil {
+		t.Fatalf("CreateAgent Mix Engineer: %v", err)
+	}
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(`{
+		"name":"Roster Template",
+		"agents":[{"name":"Campaign Lead","role":"orchestrator"}]
+	}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := postCreateWorkspace(t, handler, `{
+		"name":"Solo Mix",
+		"template_id":"roster-template",
+		"create_template_agents":false,
+		"existing_agent_names":["Mix Engineer"]
+	}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	wsID := resp["folder"].(map[string]any)["id"].(string)
+	ws, err := handler.store.GetWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if got := currentWorkspaceEntryAgentName(ws); got != "Mix Engineer" {
+		t.Fatalf("entry agent = %q, want first existing selection", got)
+	}
+	if len(ws.AgentInstances) != 1 || !wsHasAgent(ws, "Mix Engineer") {
+		t.Fatalf("workspace should only contain selected existing agent, got %#v", ws.AgentInstances)
+	}
+	if _, ok := handler.agentStore.GetAgent("Campaign Lead"); ok {
+		t.Fatal("template roster must not seed when create_template_agents is false")
+	}
+}
+
+func TestCreateWorkspaceRejectsInvalidExistingAgentCompositionBeforePersistence(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+
+	tplDir := filepath.Join(handler.templatesRootResolver(), "roster-template")
+	if err := os.MkdirAll(tplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tplDir, "template.json"), []byte(`{
+		"name":"Roster Template",
+		"agents":[{"name":"Campaign Lead","role":"orchestrator"}]
+	}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, body := range []string{
+		`{"name":"Invalid Missing","template_id":"roster-template","existing_agent_names":["Missing Agent"]}`,
+		`{"name":"Invalid Duplicate","template_id":"roster-template","existing_agent_names":["Missing Agent","missing agent"]}`,
+	} {
+		w, _ := postCreateWorkspace(t, handler, body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	workspaces, err := handler.store.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkspaces: %v", err)
+	}
+	if len(workspaces) != 0 {
+		t.Fatalf("invalid composition must not persist workspaces: %#v", workspaces)
+	}
+	if _, ok := handler.agentStore.GetAgent("Campaign Lead"); ok {
+		t.Fatal("invalid composition must be rejected before template agents are created")
+	}
+}
+
+func TestCreateWorkspaceRejectsDuplicateExistingAgentNames(t *testing.T) {
+	handler, _, _, cleanup := templateTestEnv(t)
+	defer cleanup()
+	if err := handler.agentStore.CreateAgent("Mix Engineer", nil); err != nil {
+		t.Fatalf("CreateAgent Mix Engineer: %v", err)
+	}
+
+	w, _ := postCreateWorkspace(t, handler, `{
+		"name":"Duplicate Mix",
+		"blank":true,
+		"existing_agent_names":["Mix Engineer","mix engineer"]
+	}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	workspaces, err := handler.store.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkspaces: %v", err)
+	}
+	if len(workspaces) != 0 {
+		t.Fatalf("duplicate composition must not persist workspace: %#v", workspaces)
+	}
+}
+
 func TestCreateProjectForExistingWorkspace(t *testing.T) {
 	handler, baseDir, events, cleanup := templateTestEnv(t)
 	defer cleanup()

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -337,6 +337,9 @@ func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
 	if len(plan.Agents) != 2 || plan.Agents[0].Action != "create" || plan.Agents[0].Model != "gpt-5.3-codex" {
 		t.Fatalf("unexpected planned agents: %+v", plan.Agents)
 	}
+	if plan.Agents[0].Scope != "reusable" || plan.Agents[1].Scope != "reusable" {
+		t.Fatalf("template agent scope = %#v, want reusable global definitions", plan.Agents)
+	}
 	if plan.Agents[0].SystemPrompt != "lead it" {
 		t.Fatalf("expected system prompt in plan, got %q", plan.Agents[0].SystemPrompt)
 	}

--- a/internal/sessionhttp/workspace_create_template_test.go
+++ b/internal/sessionhttp/workspace_create_template_test.go
@@ -345,7 +345,7 @@ func TestCreateWorkspaceTemplateAgentPlanEndpoint(t *testing.T) {
 	}
 }
 
-func TestCreateTemplateAgentImmediatelySavesReusableDefinition(t *testing.T) {
+func TestCreateTemplateAgentSavesReusableDefinitionWithSetupOverride(t *testing.T) {
 	handler, _, _, cleanup := templateTestEnv(t)
 	defer cleanup()
 	handler.SetSystemModelReader(fakeSystemModelReader{provider: "codex", model: "gpt-5.3-codex"})
@@ -363,7 +363,7 @@ func TestCreateTemplateAgentImmediatelySavesReusableDefinition(t *testing.T) {
 	}
 
 	newCreateRequest := func() *http.Request {
-		req := httptest.NewRequest(http.MethodPost, "/api/workspaces/template-agent-create", bytes.NewBufferString(`{"template_id":"reaper-template","agent_index":0}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/workspaces/template-agent-create", bytes.NewBufferString(`{"template_id":"reaper-template","agent_index":0,"override":{"index":0,"name":"My Reaper Producer","model":"gpt-5.3-codex","system_prompt":"produce with deliberate restraint"}}`))
 		req.Header.Set("Content-Type", "application/json")
 		return req
 	}
@@ -382,15 +382,15 @@ func TestCreateTemplateAgentImmediatelySavesReusableDefinition(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if !response.Created || response.Agent.Name != "Reaper Producer" || response.Agent.Action != "reuse" {
+	if !response.Created || response.Agent.Name != "My Reaper Producer" || response.Agent.Action != "reuse" {
 		t.Fatalf("unexpected create response: %+v", response)
 	}
 	if len(response.Plan.Agents) != 1 || response.Plan.Agents[0].Action != "reuse" {
 		t.Fatalf("expected refreshed reuse plan, got %+v", response.Plan)
 	}
-	ag, ok := handler.agentStore.GetAgent("Reaper Producer")
-	if !ok || ag == nil || ag.Settings.SystemPrompt != "produce the song" || ag.Settings.Model != "gpt-5.3-codex" {
-		t.Fatalf("template defaults were not saved: %+v", ag)
+	ag, ok := handler.agentStore.GetAgent("My Reaper Producer")
+	if !ok || ag == nil || ag.Settings.SystemPrompt != "produce with deliberate restraint" || ag.Settings.Model != "gpt-5.3-codex" {
+		t.Fatalf("setup override was not saved: %+v", ag)
 	}
 
 	// Calling the action again is idempotent and does not mutate the saved definition.

--- a/internal/sessionhttp/workspace_entry.go
+++ b/internal/sessionhttp/workspace_entry.go
@@ -281,19 +281,40 @@ func toWorkspaceAgentInstances(items []session.AgentInstance) []agentworkspace.A
 }
 
 func (h *Handler) validateWorkspaceEntryAgent(requestedAgentName string) (string, error) {
+	requested := strings.TrimSpace(requestedAgentName)
+	if requested == "" {
+		return "", nil
+	}
+	canonical, err := h.validateAttachableWorkspaceAgent(requested)
+	if err != nil {
+		return "", fmt.Errorf("entry agent %q does not exist", requested)
+	}
+	return canonical, nil
+}
+
+// validateAttachableWorkspaceAgent resolves a saved agent name using the
+// canonical casing from the agent store. CLI agents are deliberately absent
+// from this store, so they are rejected alongside any other non-persisted or
+// read-only source.
+func (h *Handler) validateAttachableWorkspaceAgent(requestedAgentName string) (string, error) {
 	if h == nil || h.agentStore == nil {
 		return "", fmt.Errorf("agent store is unavailable")
 	}
 
 	requested := strings.TrimSpace(requestedAgentName)
 	if requested == "" {
-		return "", nil
+		return "", fmt.Errorf("agent name cannot be empty")
 	}
 
-	if existing, ok := h.agentStore.GetAgent(requested); !ok || existing == nil {
-		return "", fmt.Errorf("entry agent %q does not exist", requested)
+	for _, name := range h.agentStore.ListAgents() {
+		if !strings.EqualFold(strings.TrimSpace(name), requested) {
+			continue
+		}
+		if existing, ok := h.agentStore.GetAgent(name); ok && existing != nil {
+			return name, nil
+		}
 	}
-	return requested, nil
+	return "", fmt.Errorf("agent %q does not exist or cannot be attached", requested)
 }
 
 func (h *Handler) defaultSessionAgentNameForWorkspace(ctx context.Context, workspaceID string) string {

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -207,17 +207,22 @@ func splitWorkspaceBootstrapValues(raw string) []string {
 
 // createWorkspaceRequest is the JSON body of POST /api/workspaces.
 type createWorkspaceRequest struct {
-	Name                   string                     `json:"name"`
-	Kind                   string                     `json:"kind,omitempty"`
-	WorkspacePreset        string                     `json:"workspace_preset,omitempty"`
-	Description            string                     `json:"description,omitempty"`
-	ParentID               string                     `json:"parent_id,omitempty"`
-	OrderIndex             *int                       `json:"order_index,omitempty"`
-	Color                  string                     `json:"color,omitempty"`
-	ProjectPath            string                     `json:"project_path,omitempty"`
-	FolderSlug             string                     `json:"folder_slug,omitempty"`
-	Location               string                     `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
-	EntryAgentName         string                     `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
+	Name            string `json:"name"`
+	Kind            string `json:"kind,omitempty"`
+	WorkspacePreset string `json:"workspace_preset,omitempty"`
+	Description     string `json:"description,omitempty"`
+	ParentID        string `json:"parent_id,omitempty"`
+	OrderIndex      *int   `json:"order_index,omitempty"`
+	Color           string `json:"color,omitempty"`
+	ProjectPath     string `json:"project_path,omitempty"`
+	FolderSlug      string `json:"folder_slug,omitempty"`
+	Location        string `json:"location,omitempty"`         // Optional custom directory for workspace folder (overrides default root)
+	EntryAgentName  string `json:"entry_agent_name,omitempty"` // Optional existing agent name; otherwise a workspace manager is created automatically
+	// ExistingAgentNames is an optional ordered roster of saved definitions to
+	// attach while the workspace is created. A nil slice preserves the legacy
+	// entry-agent-only behavior; a present (including empty) slice opts into the
+	// additive template-plus-existing composition contract.
+	ExistingAgentNames     []string                   `json:"existing_agent_names,omitempty"`
 	WorkspaceBootstrap     *workspaceBootstrapRequest `json:"workspace_bootstrap,omitempty"`
 	TemplateID             string                     `json:"template_id,omitempty"`   // Optional project template from the library
 	TemplatePath           string                     `json:"template_path,omitempty"` // Optional arbitrary folder used as a project template. NOT restricted to the templates library: resolveProjectTemplate/LoadFolder will stat and copy from any path the caller supplies. Acceptable for this admin-facing, local-first, single-user app; do not expose this endpoint to untrusted callers without adding a path allowlist.
@@ -335,6 +340,16 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+	}
+
+	composition, err := h.validateCreateWorkspaceAgentComposition(req)
+	if err != nil {
+		_ = orihttp.RespondBadRequest(w, err.Error())
+		return
+	}
+	if composition.usesExistingAgentRoster {
+		req.ExistingAgentNames = composition.existingAgentNames
+		req.EntryAgentName = composition.entryAgentName
 	}
 
 	ws := buildCreateWorkspace(req, kind, requestedTags, resolvedTemplate, templateResolved)
@@ -474,15 +489,57 @@ func buildCreateWorkspace(req createWorkspaceRequest, kind session.WorkspaceKind
 	return ws
 }
 
-// selectCreateWorkspaceEntryAgent applies the create-time entry-agent policy:
-// an explicitly named agent wins; otherwise a template roster seeds agents
-// (first = entry agent), with a "<Name> Manager" auto-created when the
-// template declares no roster; otherwise groups auto-create a "<Name>
-// Manager". Concrete non-template workspaces stay agent-less so the UI can
-// prompt the user to create one with their choice of model/provider.
+// selectCreateWorkspaceEntryAgent applies the create-time entry-agent policy.
+// Legacy callers that omit existing_agent_names keep their historical explicit
+// entry-agent behavior. Callers that include it compose a template/Blank roster
+// first, then attach the validated existing definitions, and only then apply an
+// explicit primary. This keeps creation atomic and never requires best-effort
+// post-create attachment requests.
 // Returns ok=false when an error response has already been written.
 func (h *Handler) selectCreateWorkspaceEntryAgent(w http.ResponseWriter, ws *session.Workspace, req createWorkspaceRequest, kind session.WorkspaceKind, tmpl projecttemplates.Template, templateResolved bool) (seedAgentsResult, bool) {
 	var seed seedAgentsResult
+	usesExistingAgentRoster := req.ExistingAgentNames != nil
+
+	if usesExistingAgentRoster {
+		switch {
+		case templateResolved && createTemplateAgentsEnabled(req):
+			if tmpl.HasAgents() {
+				seed = h.seedTemplateAgents(ws, tmpl)
+			}
+			if !seed.EntrySet {
+				if agentName := h.autoCreateManagerEntryAgent(ws); agentName != "" {
+					setWorkspaceEntryAgent(ws, agentName)
+					seed.EntrySet = true
+				}
+			}
+		case req.Blank && kind != session.WorkspaceKindGroup && createTemplateAgentsEnabled(req):
+			blankTpl, err := applyTemplateAgentOverrides(blankWorkspaceTemplate(), req.TemplateAgentOverrides)
+			if err != nil {
+				_ = orihttp.RespondBadRequest(w, err.Error())
+				return seed, false
+			}
+			seed = h.seedTemplateAgents(ws, blankTpl)
+		case kind == session.WorkspaceKindGroup:
+			if agentName := h.autoCreateManagerEntryAgent(ws); agentName != "" {
+				setWorkspaceEntryAgent(ws, agentName)
+				seed.EntrySet = true
+			}
+		}
+
+		for _, name := range req.ExistingAgentNames {
+			attachWorkspaceSpecialist(ws, name)
+		}
+
+		if req.EntryAgentName != "" {
+			setWorkspaceEntryAgent(ws, req.EntryAgentName)
+			seed.EntrySet = true
+		} else if !seed.EntrySet && len(req.ExistingAgentNames) > 0 {
+			setWorkspaceEntryAgent(ws, req.ExistingAgentNames[0])
+			seed.EntrySet = true
+		}
+		return seed, true
+	}
+
 	switch {
 	case req.EntryAgentName != "":
 		entryAgentName, err := h.validateWorkspaceEntryAgent(req.EntryAgentName)
@@ -536,6 +593,56 @@ func (h *Handler) selectCreateWorkspaceEntryAgent(w http.ResponseWriter, ws *ses
 
 func createTemplateAgentsEnabled(req createWorkspaceRequest) bool {
 	return req.CreateTemplateAgents == nil || *req.CreateTemplateAgents
+}
+
+type createWorkspaceAgentComposition struct {
+	usesExistingAgentRoster bool
+	existingAgentNames      []string
+	entryAgentName          string
+}
+
+// validateCreateWorkspaceAgentComposition canonicalizes saved-agent selections
+// before any workspace or template agent is persisted. A nil slice is a legacy
+// request and intentionally takes the old entry-agent selection path.
+func (h *Handler) validateCreateWorkspaceAgentComposition(req createWorkspaceRequest) (createWorkspaceAgentComposition, error) {
+	composition := createWorkspaceAgentComposition{
+		usesExistingAgentRoster: req.ExistingAgentNames != nil,
+	}
+	if !composition.usesExistingAgentRoster {
+		return composition, nil
+	}
+
+	composition.existingAgentNames = make([]string, 0, len(req.ExistingAgentNames))
+	seen := make(map[string]string, len(req.ExistingAgentNames))
+	for index, requestedName := range req.ExistingAgentNames {
+		requestedName = strings.TrimSpace(requestedName)
+		if requestedName == "" {
+			return composition, fmt.Errorf("existing_agent_names[%d] cannot be empty", index)
+		}
+		canonicalName, err := h.validateAttachableWorkspaceAgent(requestedName)
+		if err != nil {
+			return composition, err
+		}
+		key := strings.ToLower(strings.TrimSpace(canonicalName))
+		if original, alreadySelected := seen[key]; alreadySelected {
+			return composition, fmt.Errorf("existing agent %q duplicates %q", requestedName, original)
+		}
+		seen[key] = canonicalName
+		composition.existingAgentNames = append(composition.existingAgentNames, canonicalName)
+	}
+
+	if requestedPrimary := strings.TrimSpace(req.EntryAgentName); requestedPrimary != "" {
+		canonicalPrimary, err := h.validateAttachableWorkspaceAgent(requestedPrimary)
+		if err != nil {
+			return composition, fmt.Errorf("entry agent %q does not exist or cannot be attached", requestedPrimary)
+		}
+		if _, selected := seen[strings.ToLower(strings.TrimSpace(canonicalPrimary))]; !selected {
+			return composition, fmt.Errorf("entry_agent_name %q must also be selected in existing_agent_names", requestedPrimary)
+		}
+		composition.entryAgentName = canonicalPrimary
+	}
+
+	return composition, nil
 }
 
 // createTemplateContext bundles the template-resolution results that folder

--- a/internal/sessionhttp/workspace_handler.go
+++ b/internal/sessionhttp/workspace_handler.go
@@ -65,6 +65,9 @@ func (h *Handler) HandleWorkspaces(w http.ResponseWriter, r *http.Request) {
 	case "template-agent-plan":
 		h.handleTemplateAgentPlan(w, r)
 		return
+	case "template-agent-create":
+		h.handleTemplateAgentCreate(w, r)
+		return
 	}
 
 	// Handle sub-paths like {id}/agents, {id}/layout

--- a/internal/sessionhttp/workspace_handler_agents.go
+++ b/internal/sessionhttp/workspace_handler_agents.go
@@ -43,10 +43,15 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		return
 	}
 
-	if req.AgentName == "" {
+	if strings.TrimSpace(req.AgentName) == "" {
 		_ = orihttp.RespondBadRequest(w, "agent_name is required")
 		return
 	}
+	// This long-standing endpoint can attach a workspace-local definition that
+	// has not yet been persisted in the global store. Create-time composition is
+	// stricter and validates saved definitions before persistence; keep this
+	// endpoint backward compatible while sharing its idempotent instance helper.
+	agentName := strings.TrimSpace(req.AgentName)
 
 	// Get the workspace
 	workspace, err := h.store.GetWorkspace(r.Context(), workspaceID)
@@ -60,38 +65,15 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 		return
 	}
 
-	// Count existing instances of this agent type
-	instanceCount := 0
-	for _, inst := range workspace.AgentInstances {
-		if inst.Name == req.AgentName {
-			instanceCount++
-		}
-	}
-
-	// Create new agent instance
-	instanceNumber := instanceCount + 1
-	nodeID := req.AgentName + "-node-" + uuid.New().String()[:8]
-	if instanceNumber > 1 {
-		nodeID = fmt.Sprintf("%s-%d-node-%s", req.AgentName, instanceNumber, uuid.New().String()[:8])
-	}
-
-	newInstance := session.AgentInstance{
-		ID:             uuid.New().String(),
-		Name:           req.AgentName,
-		InstanceNumber: instanceNumber,
-		NodeID:         nodeID,
-		CreatedAt:      time.Now(),
-	}
-
 	// Add to workspace. Capture the prior agent count first: adding the first
 	// agent to an otherwise-agentless workspace makes it the coordinator (via the
 	// single-agent default), which is when pre-existing unassigned tasks should
 	// be claimed.
 	firstAgentAdded := len(workspace.AgentInstances) == 0
-	workspace.AgentInstances = append(workspace.AgentInstances, newInstance)
+	newInstance, added := attachWorkspaceSpecialist(workspace, agentName)
 
 	if strings.TrimSpace(currentWorkspaceEntryAgentName(workspace)) == "" {
-		setWorkspaceEntryAgent(workspace, req.AgentName)
+		setWorkspaceEntryAgent(workspace, agentName)
 	}
 
 	workspace.UpdatedAt = time.Now()
@@ -110,26 +92,54 @@ func (h *Handler) addWorkspaceAgent(w http.ResponseWriter, r *http.Request, work
 	// template starter tasks) so they are owned, not orphaned. Runs after the
 	// folder-store sync above so the sweep resolves the now-coordinator agent.
 	tasksClaimed := 0
-	if firstAgentAdded {
+	if firstAgentAdded && added {
 		tasksClaimed = h.claimUnassignedTasksForEntryAgentLogged(workspaceID)
 	}
 
 	logger.Info("Agent added to workspace", logger.Fields{
 		"workspace_id":    workspaceID,
-		"agent_name":      req.AgentName,
+		"agent_name":      agentName,
 		"instance_id":     newInstance.ID,
-		"instance_number": instanceNumber,
+		"instance_number": newInstance.InstanceNumber,
 	})
 
 	response := map[string]any{
-		"success":        true,
-		"agent_instance": newInstance,
-		"workspace":      workspace,
+		"success":          true,
+		"agent_instance":   newInstance,
+		"workspace":        workspace,
+		"already_attached": !added,
 	}
 	if tasksClaimed > 0 {
 		response["tasks_claimed"] = tasksClaimed
 	}
 	_ = orihttp.RespondCreated(w, response)
+}
+
+// attachWorkspaceSpecialist attaches a saved definition to a workspace once.
+// It is shared by normal workspace-agent mutation, template roster seeding,
+// and create-time existing-agent composition. Existing definitions can belong
+// to many workspaces, but a single workspace must never receive two instances
+// of the same canonical name.
+func attachWorkspaceSpecialist(ws *session.Workspace, name string) (session.AgentInstance, bool) {
+	name = strings.TrimSpace(name)
+	if ws == nil || name == "" {
+		return session.AgentInstance{}, false
+	}
+	for _, inst := range ws.AgentInstances {
+		if strings.EqualFold(strings.TrimSpace(inst.Name), name) {
+			return inst, false
+		}
+	}
+
+	instance := session.AgentInstance{
+		ID:             uuid.New().String(),
+		Name:           name,
+		InstanceNumber: 1,
+		NodeID:         name + "-1-node-" + uuid.New().String()[:8],
+		CreatedAt:      time.Now(),
+	}
+	ws.AgentInstances = append(ws.AgentInstances, instance)
+	return instance, true
 }
 
 // removeWorkspaceAgent handles DELETE /api/workspaces/{id}/agents/{name}.

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -805,6 +805,31 @@
   font-size: 14px;
   line-height: 1.2;
 }
+.workspace-create-modal .workspace-agent-map-preview-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+}
+.workspace-create-modal .workspace-agent-map-create-all {
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 1px solid rgba(232, 181, 75, 0.72);
+  background: rgba(72, 54, 19, 0.24);
+  color: #f7d27a;
+  font-family: var(--wc-font-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-agent-map-create-all:hover:not(:disabled) {
+  background: rgba(232, 181, 75, 0.16);
+}
+.workspace-create-modal .workspace-agent-map-create-all:focus-visible {
+  outline: 2px solid var(--wc-ink-heading);
+  outline-offset: 2px;
+}
 .workspace-create-modal .workspace-agent-map-state {
   display: inline-flex;
   align-items: center;
@@ -1126,6 +1151,20 @@
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.6px;
+}
+button.workspace-agent-map-specialist-avatar {
+  padding: 0;
+  appearance: none;
+  cursor: pointer;
+}
+button.workspace-agent-map-specialist-avatar:hover {
+  box-shadow:
+    0 0 0 6px color-mix(in srgb, currentColor 10%, transparent),
+    0 0 22px color-mix(in srgb, currentColor 34%, transparent);
+}
+button.workspace-agent-map-specialist-avatar:focus-visible {
+  outline: 2px solid var(--wc-ink-heading);
+  outline-offset: 4px;
 }
 .workspace-create-modal .workspace-agent-map-specialist-avatar::before,
 .workspace-create-modal .workspace-agent-map-specialist-avatar::after {

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -869,6 +869,24 @@
   border-radius: 50%;
   transform: translateX(-50%);
 }
+.workspace-create-modal .workspace-agent-map-canvas.is-team {
+  min-height: 372px;
+  place-items: start center;
+}
+.workspace-create-modal .workspace-agent-map-canvas.is-team::before {
+  top: 205px;
+  right: 18%;
+  bottom: auto;
+  left: 18%;
+  background: color-mix(in srgb, var(--wc-faction) 38%, transparent);
+  box-shadow: 0 0 18px rgba(70, 211, 154, 0.22);
+}
+.workspace-create-modal .workspace-agent-map-canvas.is-team::after {
+  top: 12px;
+}
+.workspace-create-modal .workspace-agent-map-canvas.is-team.has-many-specialists {
+  min-height: 458px;
+}
 .workspace-create-modal .workspace-agent-map-node {
   position: relative;
   z-index: 1;
@@ -880,6 +898,10 @@
   padding: 14px 16px 12px;
   color: var(--wc-faction);
   text-align: center;
+}
+.workspace-create-modal .workspace-agent-map-canvas.is-team .workspace-agent-map-node {
+  align-self: start;
+  margin-top: 16px;
 }
 .workspace-create-modal .workspace-agent-map-avatar {
   position: absolute;
@@ -1027,6 +1049,113 @@
   color: var(--wc-ink-dim);
   font-size: 11px;
 }
+.workspace-create-modal .workspace-agent-map-specialists {
+  position: absolute;
+  z-index: 1;
+  right: 8%;
+  bottom: 18px;
+  left: 8%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 14px 22px;
+  align-items: start;
+  justify-items: center;
+}
+.workspace-create-modal .workspace-agent-map-specialist {
+  position: relative;
+  display: grid;
+  width: min(142px, 100%);
+  justify-items: center;
+  gap: 4px;
+  color: var(--wc-faction);
+  text-align: center;
+}
+.workspace-create-modal .workspace-agent-map-specialist::before {
+  position: absolute;
+  top: -30px;
+  left: 50%;
+  width: 1px;
+  height: 22px;
+  background: color-mix(in srgb, var(--wc-faction) 45%, transparent);
+  content: "";
+}
+.workspace-create-modal .workspace-agent-map-specialist-avatar {
+  position: relative;
+  display: grid;
+  width: 56px;
+  height: 56px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle at 50% 31%,
+      color-mix(in srgb, currentColor 18%, transparent),
+      transparent 55%
+    ),
+    rgba(7, 16, 20, 0.78);
+  box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 7%, transparent);
+  font-family: var(--wc-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+}
+.workspace-create-modal .workspace-agent-map-specialist-avatar::before,
+.workspace-create-modal .workspace-agent-map-specialist-avatar::after {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  content: "";
+}
+.workspace-create-modal .workspace-agent-map-specialist-avatar::before {
+  top: 6px;
+  left: 6px;
+  border-top: 1px solid currentColor;
+  border-left: 1px solid currentColor;
+}
+.workspace-create-modal .workspace-agent-map-specialist-avatar::after {
+  right: 6px;
+  bottom: 6px;
+  border-right: 1px solid currentColor;
+  border-bottom: 1px solid currentColor;
+}
+.workspace-create-modal .workspace-agent-map-specialist strong {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--wc-ink-heading);
+  font-size: 12px;
+  line-height: 1.15;
+}
+.workspace-create-modal .workspace-agent-map-specialist small {
+  color: var(--wc-ink-dim);
+  font-size: 10px;
+  line-height: 1.25;
+}
+.workspace-create-modal .workspace-agent-map-specialist.is-new {
+  color: #f7d27a;
+}
+.workspace-create-modal
+  .workspace-agent-map-specialist.is-new
+  .workspace-agent-map-specialist-avatar {
+  opacity: 0.68;
+}
+.workspace-create-modal .workspace-agent-map-specialist-create-badge {
+  position: absolute;
+  right: -5px;
+  bottom: -3px;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border: 2px solid var(--wc-panel-deep);
+  border-radius: 50%;
+  background: #f7d27a;
+  color: #2a210e;
+  font-family: var(--wc-font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+}
 .workspace-create-modal .workspace-agent-map-status {
   margin: 0;
   padding: 9px 12px 10px;
@@ -1056,6 +1185,17 @@
   }
   .workspace-create-modal .workspace-agent-map-canvas {
     min-height: 224px;
+  }
+  .workspace-create-modal .workspace-agent-map-canvas.is-team {
+    min-height: 422px;
+  }
+  .workspace-create-modal .workspace-agent-map-canvas.is-team.has-many-specialists {
+    min-height: 508px;
+  }
+  .workspace-create-modal .workspace-agent-map-specialists {
+    right: 5%;
+    left: 5%;
+    gap: 16px 10px;
   }
 }
 

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -909,9 +909,11 @@
   display: grid;
   width: 106px;
   height: 106px;
+  padding: 0;
   place-items: center;
   border: 1px solid currentColor;
   border-radius: 50%;
+  appearance: none;
   background:
     radial-gradient(
       circle at 50% 30%,
@@ -922,6 +924,23 @@
   box-shadow:
     0 0 0 6px color-mix(in srgb, currentColor 8%, transparent),
     0 0 30px color-mix(in srgb, currentColor 24%, transparent);
+}
+.workspace-create-modal .workspace-agent-map-avatar:disabled {
+  cursor: default;
+}
+.workspace-create-modal .workspace-agent-map-node.is-actionable .workspace-agent-map-avatar {
+  cursor: pointer;
+}
+.workspace-create-modal .workspace-agent-map-node.is-actionable .workspace-agent-map-avatar:hover {
+  box-shadow:
+    0 0 0 8px color-mix(in srgb, currentColor 11%, transparent),
+    0 0 38px color-mix(in srgb, currentColor 36%, transparent);
+}
+.workspace-create-modal
+  .workspace-agent-map-node.is-actionable
+  .workspace-agent-map-avatar:focus-visible {
+  outline: 2px solid var(--wc-ink-heading);
+  outline-offset: 5px;
 }
 .workspace-create-modal .workspace-agent-map-avatar::before,
 .workspace-create-modal .workspace-agent-map-avatar::after {
@@ -989,6 +1008,14 @@
   display: grid;
   place-items: center;
   opacity: 1;
+}
+.workspace-create-modal .workspace-agent-map-node.is-new .workspace-agent-map-node-kicker::after {
+  display: block;
+  margin-top: 5px;
+  color: var(--wc-ink-dim);
+  content: "CLICK + TO CREATE REUSABLE AGENT";
+  font-size: 8px;
+  letter-spacing: 0.7px;
 }
 .workspace-create-modal .workspace-agent-map-node.is-missing,
 .workspace-create-modal .workspace-agent-map-node.is-loading,

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -410,13 +410,25 @@
   background: transparent;
 }
 /* Role hues. */
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="orchestrator"] { --wc-agent-dot: var(--wc-faction); }
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="researcher"] { --wc-agent-dot: #6cb2ff; }
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="validator"] { --wc-agent-dot: #e5b567; }
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="synthesizer"] { --wc-agent-dot: #b892ff; }
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="analyzer"] { --wc-agent-dot: #5fd0c8; }
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="orchestrator"] {
+  --wc-agent-dot: var(--wc-faction);
+}
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="researcher"] {
+  --wc-agent-dot: #6cb2ff;
+}
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="validator"] {
+  --wc-agent-dot: #e5b567;
+}
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="synthesizer"] {
+  --wc-agent-dot: #b892ff;
+}
+.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="analyzer"] {
+  --wc-agent-dot: #5fd0c8;
+}
 /* Validator reads as a "checkpoint": a mid-filled dot (◉) vs the hollow default. */
-.workspace-create-modal .workspace-template-briefing-agent-chip[data-role="validator"] .workspace-template-briefing-agent-dot {
+.workspace-create-modal
+  .workspace-template-briefing-agent-chip[data-role="validator"]
+  .workspace-template-briefing-agent-dot {
   background: color-mix(in srgb, var(--wc-agent-dot) 55%, transparent);
 }
 /* Entry agent: the lead — solid green dot and a brighter chip. */
@@ -426,7 +438,9 @@
   background: color-mix(in srgb, var(--wc-faction) 9%, transparent);
   color: var(--wc-ink);
 }
-.workspace-create-modal .workspace-template-briefing-agent-chip.is-entry .workspace-template-briefing-agent-dot {
+.workspace-create-modal
+  .workspace-template-briefing-agent-chip.is-entry
+  .workspace-template-briefing-agent-dot {
   background: var(--wc-faction);
   border-color: var(--wc-faction);
 }
@@ -526,7 +540,9 @@
 }
 /* A locked reuse row hides the right-hand model column (the sub-line already
    names the saved model); forking reveals the full editable layout. */
-.workspace-create-modal .workspace-template-agent-row.is-reuse:not([data-forked="true"]) .workspace-template-agent-model {
+.workspace-create-modal
+  .workspace-template-agent-row.is-reuse:not([data-forked="true"])
+  .workspace-template-agent-model {
   display: none;
 }
 .workspace-create-modal .workspace-template-agent-fork-btn {
@@ -555,8 +571,210 @@
   font-size: 11px;
   color: var(--wc-faction);
 }
-.workspace-create-modal .workspace-template-agent-row[data-forked="true"] .workspace-template-agent-fork-note {
+.workspace-create-modal
+  .workspace-template-agent-row[data-forked="true"]
+  .workspace-template-agent-fork-note {
   display: block;
+}
+
+/* Final review: plain-language assistant cards keep setup readable by default;
+   deeper configuration only appears after an intentional Customize action. */
+.workspace-create-modal .workspace-wizard-step-heading {
+  margin: 2px 0 14px;
+}
+.workspace-create-modal .workspace-wizard-eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-wizard-step-heading h2,
+.workspace-create-modal .workspace-team-review h3,
+.workspace-create-modal .workspace-existing-agent-roster h3 {
+  margin: 0;
+  color: var(--wc-ink-heading);
+  font-size: 18px;
+  line-height: 1.2;
+}
+.workspace-create-modal .workspace-wizard-step-heading p,
+.workspace-create-modal .workspace-team-review-head p {
+  margin: 5px 0 0;
+  color: var(--wc-ink-dim);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.workspace-create-modal .workspace-wizard-inline-action {
+  border: 0;
+  padding: 2px 0;
+  background: transparent;
+  color: var(--wc-faction);
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.workspace-create-modal .workspace-wizard-inline-action:hover {
+  color: var(--wc-ink);
+  text-decoration: underline;
+}
+.workspace-create-modal .workspace-review-summary,
+.workspace-create-modal .workspace-team-review,
+.workspace-create-modal .workspace-existing-agent-roster {
+  margin-bottom: 10px;
+  border: 1px solid var(--wc-line);
+  background: var(--wc-panel-2);
+}
+.workspace-create-modal .workspace-review-summary {
+  padding: 0 12px;
+}
+.workspace-create-modal .workspace-review-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+}
+.workspace-create-modal .workspace-review-summary-row + .workspace-review-summary-row {
+  border-top: 1px solid var(--wc-line);
+}
+.workspace-create-modal .workspace-review-summary-row span,
+.workspace-create-modal .workspace-review-summary-row small {
+  display: block;
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-review-summary-row strong {
+  display: block;
+  margin: 2px 0;
+  color: var(--wc-ink);
+  font-size: 13px;
+}
+.workspace-create-modal .workspace-team-review,
+.workspace-create-modal .workspace-existing-agent-roster {
+  padding: 12px;
+}
+.workspace-create-modal .workspace-team-review-head,
+.workspace-create-modal .workspace-existing-agent-roster-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.workspace-create-modal .workspace-agent-avatar {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--wc-faction-deep);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--wc-faction) 14%, transparent);
+  color: var(--wc-faction);
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+.workspace-create-modal .workspace-template-agent-summary-card,
+.workspace-create-modal .workspace-team-agent-card,
+.workspace-create-modal .workspace-existing-agent-card {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px;
+  border: 1px solid var(--wc-line);
+  background: rgba(4, 8, 12, 0.24);
+}
+.workspace-create-modal .workspace-template-agent-summary-copy,
+.workspace-create-modal .workspace-team-agent-copy,
+.workspace-create-modal .workspace-existing-agent-card-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.workspace-create-modal .workspace-template-agent-summary-copy strong,
+.workspace-create-modal .workspace-team-agent-copy strong,
+.workspace-create-modal .workspace-existing-agent-card-copy strong {
+  display: block;
+  color: var(--wc-ink);
+  font-size: 13px;
+}
+.workspace-create-modal .workspace-template-agent-summary-copy span,
+.workspace-create-modal .workspace-template-agent-summary-copy small,
+.workspace-create-modal .workspace-team-agent-copy span,
+.workspace-create-modal .workspace-team-agent-copy small,
+.workspace-create-modal .workspace-existing-agent-card-copy span,
+.workspace-create-modal .workspace-existing-agent-card-copy small {
+  display: block;
+  overflow-wrap: anywhere;
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.workspace-create-modal .workspace-template-agent-summary-action,
+.workspace-create-modal .workspace-team-agent-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+.workspace-create-modal .workspace-existing-agent-team,
+.workspace-create-modal .workspace-existing-agent-roster-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 9px;
+}
+.workspace-create-modal .workspace-team-drop-zone {
+  margin-top: 9px;
+  padding: 11px;
+  border: 1px dashed var(--wc-line-bright);
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+}
+.workspace-create-modal .workspace-team-drop-zone.is-drag-over {
+  border-color: var(--wc-faction);
+  background: color-mix(in srgb, var(--wc-faction) 10%, transparent);
+  color: var(--wc-ink);
+}
+.workspace-create-modal .workspace-existing-agent-roster-status {
+  margin-top: 7px;
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+}
+.workspace-create-modal .workspace-wizard-icon-action {
+  border: 0;
+  background: transparent;
+  color: var(--wc-ink-dim);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+@media (max-width: 575.98px) {
+  .workspace-create-modal .workspace-create-stepper {
+    gap: 5px;
+    font-size: 8px;
+    letter-spacing: 0.8px;
+  }
+  .workspace-create-modal .workspace-create-step-sep {
+    display: none;
+  }
+  .workspace-create-modal .workspace-template-agent-summary-card,
+  .workspace-create-modal .workspace-team-agent-card,
+  .workspace-create-modal .workspace-existing-agent-card {
+    align-items: flex-start;
+  }
+  .workspace-create-modal .workspace-template-agent-summary-action,
+  .workspace-create-modal .workspace-team-agent-actions {
+    flex-direction: column;
+    align-items: flex-end;
+  }
 }
 
 /* color picker: keep the swatch colors, tactical active ring */

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -830,6 +830,107 @@
   outline: 2px solid var(--wc-ink-heading);
   outline-offset: 2px;
 }
+.workspace-create-modal .workspace-template-agent-setup {
+  margin-top: 12px;
+  border: 1px solid color-mix(in srgb, var(--wc-faction) 52%, var(--wc-line));
+  background:
+    linear-gradient(105deg, color-mix(in srgb, var(--wc-faction) 11%, transparent), transparent 52%),
+    var(--wc-panel-2);
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--wc-faction) 68%, transparent);
+}
+.workspace-create-modal .workspace-template-agent-setup-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 13px 14px 9px;
+  border-bottom: 1px solid var(--wc-line);
+}
+.workspace-create-modal .workspace-template-agent-setup-head .workspace-wizard-eyebrow {
+  margin-bottom: 3px;
+}
+.workspace-create-modal .workspace-template-agent-setup-head h3 {
+  margin: 0;
+  color: var(--wc-ink-heading);
+  font-size: 16px;
+}
+.workspace-create-modal .workspace-template-agent-setup-cancel {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--wc-line-bright);
+  background: transparent;
+  color: var(--wc-ink-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+.workspace-create-modal .workspace-template-agent-setup-cancel:hover {
+  color: var(--wc-ink-heading);
+  border-color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-template-agent-setup-description {
+  margin: 10px 14px 0;
+  color: var(--wc-ink-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.workspace-create-modal .workspace-template-agent-setup-form {
+  display: grid;
+  gap: 6px;
+  padding: 13px 14px 14px;
+}
+.workspace-create-modal .workspace-template-agent-setup-form label {
+  color: var(--wc-ink-heading);
+  font-family: var(--wc-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-template-agent-setup-form label span {
+  color: var(--wc-ink-muted);
+  font-weight: 500;
+}
+.workspace-create-modal .workspace-template-agent-setup-form textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+.workspace-create-modal .workspace-template-agent-setup-status {
+  min-height: 18px;
+  margin: 2px 0 0;
+  color: var(--wc-ink-muted);
+  font-size: 12px;
+}
+.workspace-create-modal .workspace-template-agent-setup-status.is-error {
+  color: #f57b72;
+}
+.workspace-create-modal .workspace-template-agent-setup-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  margin-top: 3px;
+}
+.workspace-create-modal .workspace-template-agent-setup-save {
+  min-height: 32px;
+  padding: 5px 11px;
+  border: 1px solid var(--wc-faction);
+  background: color-mix(in srgb, var(--wc-faction) 16%, transparent);
+  color: var(--wc-faction);
+  font-family: var(--wc-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.workspace-create-modal .workspace-template-agent-setup-save:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--wc-faction) 28%, transparent);
+}
+.workspace-create-modal .workspace-template-agent-setup-save:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
 .workspace-create-modal .workspace-agent-map-state {
   display: inline-flex;
   align-items: center;

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -833,7 +833,7 @@
 .workspace-create-modal .workspace-agent-map-canvas {
   position: relative;
   display: grid;
-  min-height: 184px;
+  min-height: 242px;
   place-items: center;
   isolation: isolate;
   overflow: hidden;
@@ -861,10 +861,10 @@
   box-shadow: 0 0 24px rgba(70, 211, 154, 0.34);
 }
 .workspace-create-modal .workspace-agent-map-canvas::after {
-  top: 16px;
+  top: 18px;
   left: 50%;
-  width: 132px;
-  height: 132px;
+  width: 156px;
+  height: 156px;
   border: 1px solid color-mix(in srgb, var(--wc-faction) 25%, transparent);
   border-radius: 50%;
   transform: translateX(-50%);
@@ -873,79 +873,135 @@
   position: relative;
   z-index: 1;
   display: grid;
-  width: min(270px, calc(100% - 32px));
-  min-height: 124px;
+  width: min(300px, calc(100% - 32px));
   place-items: center;
   align-content: center;
-  gap: 3px;
-  padding: 18px 16px 14px;
-  border: 2px solid var(--wc-faction);
-  background: rgba(7, 16, 20, 0.83);
+  gap: 4px;
+  padding: 14px 16px 12px;
   color: var(--wc-faction);
-  box-shadow:
-    0 0 0 1px rgba(70, 211, 154, 0.12) inset,
-    0 16px 34px rgba(0, 0, 0, 0.24);
-  clip-path: polygon(
-    0 0,
-    calc(100% - 14px) 0,
-    100% 14px,
-    100% 100%,
-    14px 100%,
-    0 calc(100% - 14px)
-  );
   text-align: center;
 }
-.workspace-create-modal .workspace-agent-map-node::before {
+.workspace-create-modal .workspace-agent-map-avatar {
   position: absolute;
-  top: 8px;
-  left: 10px;
-  width: 8px;
-  height: 8px;
+  top: -3px;
+  display: grid;
+  width: 106px;
+  height: 106px;
+  place-items: center;
+  border: 1px solid currentColor;
   border-radius: 50%;
-  background: var(--wc-faction);
-  box-shadow: 0 0 12px var(--wc-faction);
+  background:
+    radial-gradient(
+      circle at 50% 30%,
+      color-mix(in srgb, currentColor 20%, transparent),
+      transparent 57%
+    ),
+    rgba(7, 16, 20, 0.82);
+  box-shadow:
+    0 0 0 6px color-mix(in srgb, currentColor 8%, transparent),
+    0 0 30px color-mix(in srgb, currentColor 24%, transparent);
+}
+.workspace-create-modal .workspace-agent-map-avatar::before,
+.workspace-create-modal .workspace-agent-map-avatar::after {
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-color: currentColor;
   content: "";
 }
+.workspace-create-modal .workspace-agent-map-avatar::before {
+  top: 10px;
+  left: 10px;
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+.workspace-create-modal .workspace-agent-map-avatar::after {
+  right: 10px;
+  bottom: 10px;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+.workspace-create-modal .workspace-agent-map-avatar-figure {
+  width: 84px;
+  height: 84px;
+  overflow: visible;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+.workspace-create-modal .workspace-agent-map-avatar-head {
+  fill: color-mix(in srgb, currentColor 10%, transparent);
+}
+.workspace-create-modal .workspace-agent-map-avatar-eye {
+  fill: currentColor;
+  stroke: none;
+}
+.workspace-create-modal .workspace-agent-map-avatar-placeholder,
+.workspace-create-modal .workspace-agent-map-avatar-create-badge {
+  display: none;
+}
+.workspace-create-modal .workspace-agent-map-avatar-create-badge {
+  position: absolute;
+  right: -5px;
+  bottom: 5px;
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--wc-panel-deep);
+  border-radius: 50%;
+  background: #f7d27a;
+  color: #2a210e;
+  font-family: var(--wc-font-mono);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 19px;
+}
 .workspace-create-modal .workspace-agent-map-node.is-new {
-  border-color: rgba(232, 181, 75, 0.82);
-  background: rgba(24, 22, 14, 0.76);
   color: #f7d27a;
 }
-.workspace-create-modal .workspace-agent-map-node.is-new::before {
-  background: #f7d27a;
-  box-shadow: 0 0 12px #f7d27a;
+.workspace-create-modal .workspace-agent-map-node.is-new .workspace-agent-map-avatar-figure {
+  opacity: 0.68;
+}
+.workspace-create-modal .workspace-agent-map-node.is-new .workspace-agent-map-avatar-create-badge {
+  display: grid;
+  place-items: center;
+  opacity: 1;
 }
 .workspace-create-modal .workspace-agent-map-node.is-missing,
 .workspace-create-modal .workspace-agent-map-node.is-loading,
 .workspace-create-modal .workspace-agent-map-node.is-checking {
-  border-style: dashed;
-  border-color: var(--wc-line-bright);
-  background: rgba(7, 16, 20, 0.54);
   color: var(--wc-ink-faint);
   opacity: 0.72;
 }
-.workspace-create-modal .workspace-agent-map-node.is-missing::before,
-.workspace-create-modal .workspace-agent-map-node.is-loading::before,
-.workspace-create-modal .workspace-agent-map-node.is-checking::before {
-  background: var(--wc-ink-faint);
+.workspace-create-modal .workspace-agent-map-node.is-missing .workspace-agent-map-avatar,
+.workspace-create-modal .workspace-agent-map-node.is-loading .workspace-agent-map-avatar,
+.workspace-create-modal .workspace-agent-map-node.is-checking .workspace-agent-map-avatar {
+  border-style: dashed;
   box-shadow: none;
 }
-.workspace-create-modal .workspace-agent-map-node-mark {
-  width: 25px;
-  height: 25px;
-  margin-bottom: 2px;
-  border: 1px solid currentColor;
-  transform: rotate(45deg);
+.workspace-create-modal .workspace-agent-map-node.is-missing .workspace-agent-map-avatar-figure,
+.workspace-create-modal .workspace-agent-map-node.is-loading .workspace-agent-map-avatar-figure,
+.workspace-create-modal .workspace-agent-map-node.is-checking .workspace-agent-map-avatar-figure {
+  display: none;
 }
-.workspace-create-modal .workspace-agent-map-node-mark::after {
+.workspace-create-modal
+  .workspace-agent-map-node.is-missing
+  .workspace-agent-map-avatar-placeholder,
+.workspace-create-modal
+  .workspace-agent-map-node.is-loading
+  .workspace-agent-map-avatar-placeholder,
+.workspace-create-modal
+  .workspace-agent-map-node.is-checking
+  .workspace-agent-map-avatar-placeholder {
   display: block;
-  width: 7px;
-  height: 7px;
-  margin: 8px;
-  background: currentColor;
-  content: "";
+  color: var(--wc-ink-dim);
+  font-family: var(--wc-font-mono);
+  font-size: 34px;
+  font-weight: 700;
 }
 .workspace-create-modal .workspace-agent-map-node-kicker {
+  margin-top: 112px;
   color: var(--wc-faction);
   font-family: var(--wc-font-mono);
   font-size: 9px;
@@ -999,7 +1055,7 @@
     align-items: flex-end;
   }
   .workspace-create-modal .workspace-agent-map-canvas {
-    min-height: 166px;
+    min-height: 224px;
   }
 }
 

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -779,6 +779,206 @@
   line-height: 1;
   cursor: pointer;
 }
+
+/* Blueprint map preview: a compact visual promise of the workspace's primary
+   routing agent, intentionally distinct from the full interactive Map view. */
+.workspace-create-modal .workspace-agent-map-preview {
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid var(--wc-line-bright);
+  background: var(--wc-panel-2);
+}
+.workspace-create-modal .workspace-agent-map-preview-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--wc-line);
+}
+.workspace-create-modal .workspace-agent-map-preview-head .workspace-wizard-eyebrow {
+  margin-bottom: 3px;
+}
+.workspace-create-modal .workspace-agent-map-preview h3 {
+  margin: 0;
+  color: var(--wc-ink-heading);
+  font-size: 14px;
+  line-height: 1.2;
+}
+.workspace-create-modal .workspace-agent-map-state {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 1px solid var(--wc-line-bright);
+  color: var(--wc-ink-faint);
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-agent-map-state.is-ready {
+  border-color: color-mix(in srgb, var(--wc-faction) 60%, var(--wc-line));
+  color: var(--wc-faction);
+}
+.workspace-create-modal .workspace-agent-map-state.is-new {
+  border-color: rgba(232, 181, 75, 0.64);
+  color: #f7d27a;
+}
+.workspace-create-modal .workspace-agent-map-state.is-missing {
+  border-style: dashed;
+  color: var(--wc-ink-dim);
+}
+.workspace-create-modal .workspace-agent-map-canvas {
+  position: relative;
+  display: grid;
+  min-height: 184px;
+  place-items: center;
+  isolation: isolate;
+  overflow: hidden;
+  background:
+    linear-gradient(rgba(82, 196, 214, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(82, 196, 214, 0.08) 1px, transparent 1px),
+    radial-gradient(circle at 50% 45%, rgba(70, 211, 154, 0.14), transparent 50%),
+    var(--wc-panel-deep);
+  background-size:
+    28px 28px,
+    28px 28px,
+    auto,
+    auto;
+}
+.workspace-create-modal .workspace-agent-map-canvas::before,
+.workspace-create-modal .workspace-agent-map-canvas::after {
+  position: absolute;
+  content: "";
+  pointer-events: none;
+}
+.workspace-create-modal .workspace-agent-map-canvas::before {
+  inset: 50% 18% auto;
+  height: 1px;
+  background: color-mix(in srgb, var(--wc-faction) 48%, transparent);
+  box-shadow: 0 0 24px rgba(70, 211, 154, 0.34);
+}
+.workspace-create-modal .workspace-agent-map-canvas::after {
+  top: 16px;
+  left: 50%;
+  width: 132px;
+  height: 132px;
+  border: 1px solid color-mix(in srgb, var(--wc-faction) 25%, transparent);
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+.workspace-create-modal .workspace-agent-map-node {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: min(270px, calc(100% - 32px));
+  min-height: 124px;
+  place-items: center;
+  align-content: center;
+  gap: 3px;
+  padding: 18px 16px 14px;
+  border: 2px solid var(--wc-faction);
+  background: rgba(7, 16, 20, 0.83);
+  color: var(--wc-faction);
+  box-shadow:
+    0 0 0 1px rgba(70, 211, 154, 0.12) inset,
+    0 16px 34px rgba(0, 0, 0, 0.24);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
+  text-align: center;
+}
+.workspace-create-modal .workspace-agent-map-node::before {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--wc-faction);
+  box-shadow: 0 0 12px var(--wc-faction);
+  content: "";
+}
+.workspace-create-modal .workspace-agent-map-node.is-new {
+  border-color: rgba(232, 181, 75, 0.82);
+  background: rgba(24, 22, 14, 0.76);
+  color: #f7d27a;
+}
+.workspace-create-modal .workspace-agent-map-node.is-new::before {
+  background: #f7d27a;
+  box-shadow: 0 0 12px #f7d27a;
+}
+.workspace-create-modal .workspace-agent-map-node.is-missing,
+.workspace-create-modal .workspace-agent-map-node.is-loading,
+.workspace-create-modal .workspace-agent-map-node.is-checking {
+  border-style: dashed;
+  border-color: var(--wc-line-bright);
+  background: rgba(7, 16, 20, 0.54);
+  color: var(--wc-ink-faint);
+  opacity: 0.72;
+}
+.workspace-create-modal .workspace-agent-map-node.is-missing::before,
+.workspace-create-modal .workspace-agent-map-node.is-loading::before,
+.workspace-create-modal .workspace-agent-map-node.is-checking::before {
+  background: var(--wc-ink-faint);
+  box-shadow: none;
+}
+.workspace-create-modal .workspace-agent-map-node-mark {
+  width: 25px;
+  height: 25px;
+  margin-bottom: 2px;
+  border: 1px solid currentColor;
+  transform: rotate(45deg);
+}
+.workspace-create-modal .workspace-agent-map-node-mark::after {
+  display: block;
+  width: 7px;
+  height: 7px;
+  margin: 8px;
+  background: currentColor;
+  content: "";
+}
+.workspace-create-modal .workspace-agent-map-node-kicker {
+  color: var(--wc-faction);
+  font-family: var(--wc-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1.4px;
+}
+.workspace-create-modal .workspace-agent-map-node.is-new .workspace-agent-map-node-kicker {
+  color: #f7d27a;
+}
+.workspace-create-modal .workspace-agent-map-node.is-missing .workspace-agent-map-node-kicker,
+.workspace-create-modal .workspace-agent-map-node.is-loading .workspace-agent-map-node-kicker,
+.workspace-create-modal .workspace-agent-map-node.is-checking .workspace-agent-map-node-kicker {
+  color: var(--wc-ink-faint);
+}
+.workspace-create-modal .workspace-agent-map-node strong {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--wc-ink-heading);
+  font-size: 17px;
+  line-height: 1.15;
+}
+.workspace-create-modal .workspace-agent-map-node span:last-child {
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+}
+.workspace-create-modal .workspace-agent-map-status {
+  margin: 0;
+  padding: 9px 12px 10px;
+  border-top: 1px solid var(--wc-line);
+  color: var(--wc-ink-dim);
+  font-size: 12px;
+  line-height: 1.45;
+}
 @media (max-width: 575.98px) {
   .workspace-create-modal .workspace-create-stepper {
     gap: 5px;
@@ -797,6 +997,9 @@
   .workspace-create-modal .workspace-team-agent-actions {
     flex-direction: column;
     align-items: flex-end;
+  }
+  .workspace-create-modal .workspace-agent-map-canvas {
+    min-height: 166px;
   }
 }
 

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -459,6 +459,29 @@
 .workspace-create-modal .workspace-template-agent-warnings {
   color: var(--wc-ink-dim);
 }
+.workspace-create-modal .workspace-template-agent-advanced {
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--wc-line);
+}
+.workspace-create-modal .workspace-template-agent-advanced summary {
+  cursor: pointer;
+  color: var(--wc-ink-dim);
+  font-family: var(--wc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+.workspace-create-modal .workspace-template-agent-advanced[open] .workspace-template-agent-toggle {
+  margin-top: 8px;
+}
+.workspace-create-modal .workspace-template-agent-advanced-help {
+  display: block;
+  margin-top: 6px;
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+  line-height: 1.4;
+}
 .workspace-create-modal .workspace-template-agent-toggle,
 .workspace-create-modal .workspace-template-agent-row {
   background: var(--wc-panel-2);

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -335,6 +335,14 @@ const sessionManager = {
     document
       .getElementById('workspaceAgentMapAvatarAction')
       ?.addEventListener('click', () => this.createTemplateAgentFromPreview());
+    document.getElementById('workspaceAgentMapSpecialists')?.addEventListener('click', event => {
+      const action = event.target.closest('[data-template-agent-index]');
+      const agentIndex = Number.parseInt(action?.dataset.templateAgentIndex || '', 10);
+      if (Number.isInteger(agentIndex)) void this.createTemplateAgentFromPreview(agentIndex);
+    });
+    document
+      .getElementById('workspaceAgentMapCreateAll')
+      ?.addEventListener('click', () => this.createAllTemplateAgentsFromPreview());
 
     document.getElementById('addExistingAgentBtn')?.addEventListener('click', () => {
       void this.openExistingAgentRoster();
@@ -4298,6 +4306,7 @@ const sessionManager = {
     const canvas = document.querySelector('.workspace-agent-map-canvas');
     const specialists = document.getElementById('workspaceAgentMapSpecialists');
     const avatarAction = document.getElementById('workspaceAgentMapAvatarAction');
+    const createAll = document.getElementById('workspaceAgentMapCreateAll');
     const kicker = document.getElementById('workspaceAgentMapNodeKicker');
     const name = document.getElementById('workspaceAgentMapNodeName');
     const detail = document.getElementById('workspaceAgentMapNodeDetail');
@@ -4309,6 +4318,7 @@ const sessionManager = {
       !canvas ||
       !specialists ||
       !avatarAction ||
+      !createAll ||
       !kicker ||
       !name ||
       !detail ||
@@ -4372,11 +4382,12 @@ const sessionManager = {
             .join('')
             .slice(0, 2)
             .toUpperCase() || 'A';
+        const avatar = isNew
+          ? `<button type="button" class="workspace-agent-map-specialist-avatar" data-template-agent-index="${agent.templateAgentIndex}" aria-label="Create ${this.escapeHtml(agent.name)} as a reusable agent now">${this.escapeHtml(initials)}<span class="workspace-agent-map-specialist-create-badge" aria-hidden="true">+</span></button>`
+          : `<span class="workspace-agent-map-specialist-avatar" aria-hidden="true">${this.escapeHtml(initials)}</span>`;
         return `
           <div class="workspace-agent-map-specialist${isNew ? ' is-new' : ''}">
-            <span class="workspace-agent-map-specialist-avatar">${this.escapeHtml(initials)}${
-              isNew ? '<span class="workspace-agent-map-specialist-create-badge">+</span>' : ''
-            }</span>
+            ${avatar}
             <strong>${this.escapeHtml(agent.name)}</strong>
             <small>Workspace specialist · ${this.escapeHtml(memberLifecycle(agent))}</small>
           </div>`;
@@ -4461,6 +4472,9 @@ const sessionManager = {
     title.textContent =
       team.length > 1 ? `Workspace team · ${team.length} agents` : 'Primary workspace agent';
     specialists.innerHTML = specialistMarkup;
+    createAll.hidden = createdAgents.length < 2;
+    createAll.disabled = false;
+    createAll.textContent = `Create all ${createdAgents.length}`;
     avatarAction.disabled = !canCreatePrimary;
     avatarAction.dataset.templateAgentIndex = canCreatePrimary
       ? String(primary.templateAgentIndex)
@@ -4478,10 +4492,22 @@ const sessionManager = {
     status.textContent = next.status;
   },
 
-  async createTemplateAgentFromPreview() {
+  async createTemplateAgentFromPreview(requestedAgentIndex, options = {}) {
     const avatarAction = document.getElementById('workspaceAgentMapAvatarAction');
-    const agentIndex = Number.parseInt(avatarAction?.dataset.templateAgentIndex || '', 10);
-    if (!Number.isInteger(agentIndex) || !avatarAction || avatarAction.disabled) return;
+    const agentIndex = Number.isInteger(requestedAgentIndex)
+      ? requestedAgentIndex
+      : Number.parseInt(avatarAction?.dataset.templateAgentIndex || '', 10);
+    const plannedAgent = this.includedTemplateAgents()[agentIndex];
+    const trigger = document.querySelector(
+      `[data-template-agent-index="${Number.isInteger(agentIndex) ? agentIndex : ''}"]`
+    );
+    if (
+      !Number.isInteger(agentIndex) ||
+      !plannedAgent ||
+      (!trigger && !options.silent) ||
+      (trigger && trigger.disabled)
+    )
+      return false;
 
     const fields = window.ProjectTemplateCard?.getPayloadFields?.() || {};
     const templateId = String(fields.template_id || '').trim();
@@ -4490,12 +4516,10 @@ const sessionManager = {
       Boolean(window.ProjectTemplateCard?.getSelectedTemplate?.()?.blank) &&
       !templateId &&
       !templatePath;
-    const primaryName = String(
-      document.getElementById('workspaceAgentMapNodeName')?.textContent || ''
-    ).trim();
+    const agentName = String(plannedAgent.name || 'agent').trim();
 
-    avatarAction.disabled = true;
-    avatarAction.setAttribute('aria-label', `Creating ${primaryName || 'agent'}…`);
+    if (trigger) trigger.disabled = true;
+    if (trigger === avatarAction) avatarAction.setAttribute('aria-label', `Creating ${agentName}…`);
     try {
       const response = await fetch('/api/workspaces/template-agent-create', {
         method: 'POST',
@@ -4509,7 +4533,7 @@ const sessionManager = {
       });
       const result = await response.json().catch(() => ({}));
       if (!response.ok || result.error) {
-        throw new Error(result.error || `Could not create ${primaryName || 'agent'}.`);
+        throw new Error(result.error || `Could not create ${agentName}.`);
       }
 
       if (result.plan) {
@@ -4519,18 +4543,47 @@ const sessionManager = {
       } else {
         await this.refreshTemplateAgentPlan();
       }
-      const savedName = String(result.agent?.name || primaryName || 'Agent').trim();
+      const savedName = String(result.agent?.name || agentName || 'Agent').trim();
       const message = result.created
         ? `${savedName} is now saved in Your Agents and ready for this workspace.`
         : `${savedName} is already saved in Your Agents and ready for this workspace.`;
-      this.announceWorkspaceTeamChange(message);
-      this.showToast(message, 'success');
+      if (!options.silent) {
+        this.announceWorkspaceTeamChange(message);
+        this.showToast(message, 'success');
+      }
+      return true;
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Could not create the reusable agent.';
-      this.announceWorkspaceTeamChange(message);
-      this.showToast(message, 'error');
+      if (!options.silent) {
+        this.announceWorkspaceTeamChange(message);
+        this.showToast(message, 'error');
+      }
       this.renderWorkspaceAgentMapPreview();
+      return false;
+    }
+  },
+
+  async createAllTemplateAgentsFromPreview() {
+    const agentIndexes = this.includedTemplateAgents()
+      .map((agent, index) => ({ agent, index }))
+      .filter(({ agent }) => String(agent?.action || '').toLowerCase() === 'create')
+      .map(({ index }) => index);
+    if (agentIndexes.length < 2) return;
+
+    const createAll = document.getElementById('workspaceAgentMapCreateAll');
+    if (createAll) createAll.disabled = true;
+    let createdCount = 0;
+    for (const agentIndex of agentIndexes) {
+      if (await this.createTemplateAgentFromPreview(agentIndex, { silent: true }))
+        createdCount += 1;
+    }
+    if (createdCount > 0) {
+      const message = `${createdCount} reusable agent${createdCount === 1 ? '' : 's'} ${
+        createdCount === 1 ? 'is' : 'are'
+      } now saved in Your Agents and ready for this workspace.`;
+      this.announceWorkspaceTeamChange(message);
+      this.showToast(message, 'success');
     }
   },
 

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -4285,23 +4285,91 @@ const sessionManager = {
   },
 
   // The map is a compact, read-only preview rather than a second canvas. It
-  // makes the distinction between a saved reusable agent, a first-use agent
-  // that will be created globally, and an intentionally agent-free setup
+  // makes both the primary-agent hierarchy and the complete included team
   // visible before the user enters the detailed review step.
   renderWorkspaceAgentMapPreview() {
     const node = document.getElementById('workspaceAgentMapNode');
     const state = document.getElementById('workspaceAgentMapState');
+    const title = document.getElementById('workspaceAgentMapPreviewTitle');
+    const canvas = document.querySelector('.workspace-agent-map-canvas');
+    const specialists = document.getElementById('workspaceAgentMapSpecialists');
     const kicker = document.getElementById('workspaceAgentMapNodeKicker');
     const name = document.getElementById('workspaceAgentMapNodeName');
     const detail = document.getElementById('workspaceAgentMapNodeDetail');
     const status = document.getElementById('workspaceAgentMapStatus');
-    if (!node || !state || !kicker || !name || !detail || !status) return;
+    if (
+      !node ||
+      !state ||
+      !title ||
+      !canvas ||
+      !specialists ||
+      !kicker ||
+      !name ||
+      !detail ||
+      !status
+    )
+      return;
 
-    const templatePrimary = this.includedTemplateAgents().find(agent =>
-      Boolean(agent?.entry_point)
+    const team = [];
+    const teamNames = new Set();
+    const addTeamMember = member => {
+      const memberName = String(member?.name || '').trim();
+      const key = this.existingAgentKey(memberName);
+      if (!memberName || teamNames.has(key)) return;
+      teamNames.add(key);
+      team.push({ ...member, name: memberName });
+    };
+    this.includedTemplateAgents().forEach(agent =>
+      addTeamMember({ ...agent, source: 'blueprint' })
     );
-    const explicitPrimary =
-      this.existingAgentPrimaryName || (!templatePrimary ? this.existingAgentSelections[0] : '');
+    this.existingAgentSelections.forEach(selectedName => {
+      const savedAgent = this.findExistingRosterAgent(selectedName);
+      addTeamMember({
+        name: savedAgent?.name || selectedName,
+        action: 'reuse',
+        source: 'existing'
+      });
+    });
+
+    const primaryName = this.resolvedWorkspacePrimaryName();
+    const primary = team.find(
+      agent => this.existingAgentKey(agent.name) === this.existingAgentKey(primaryName)
+    );
+    const teamSpecialists = primary
+      ? team.filter(
+          agent => this.existingAgentKey(agent.name) !== this.existingAgentKey(primary.name)
+        )
+      : [];
+    const createdAgents = team.filter(
+      agent => String(agent.action || '').toLowerCase() === 'create'
+    );
+    const memberLifecycle = agent => {
+      if (String(agent.action || '').toLowerCase() === 'create') return 'New reusable agent';
+      return agent.source === 'existing'
+        ? 'Saved agent · Will be attached'
+        : 'Saved reusable agent';
+    };
+    const specialistMarkup = teamSpecialists
+      .map(agent => {
+        const isNew = String(agent.action || '').toLowerCase() === 'create';
+        const initials =
+          String(agent.name || '')
+            .split(/\s+/)
+            .filter(Boolean)
+            .map(part => part[0])
+            .join('')
+            .slice(0, 2)
+            .toUpperCase() || 'A';
+        return `
+          <div class="workspace-agent-map-specialist${isNew ? ' is-new' : ''}">
+            <span class="workspace-agent-map-specialist-avatar">${this.escapeHtml(initials)}${
+              isNew ? '<span class="workspace-agent-map-specialist-create-badge">+</span>' : ''
+            }</span>
+            <strong>${this.escapeHtml(agent.name)}</strong>
+            <small>Workspace specialist · ${this.escapeHtml(memberLifecycle(agent))}</small>
+          </div>`;
+      })
+      .join('');
 
     let next = {
       state: 'checking',
@@ -4321,16 +4389,34 @@ const sessionManager = {
         detail: 'Could not check blueprint agent',
         status: this.templateAgentPlanError
       };
-    } else if (templatePrimary) {
-      const agentName = String(templatePrimary.name || 'Blueprint agent').trim();
-      if (String(templatePrimary.action || '').toLowerCase() === 'reuse') {
+    } else if (primary) {
+      const agentName = primary.name;
+      const isNew = String(primary.action || '').toLowerCase() === 'create';
+      const specialistNames = teamSpecialists.map(agent => agent.name);
+      const createdNames = createdAgents
+        .filter(
+          agent =>
+            !isNew || this.existingAgentKey(agent.name) !== this.existingAgentKey(primary.name)
+        )
+        .map(agent => agent.name);
+      const specialistSentence = specialistNames.length
+        ? ` ${specialistNames.join(', ')} will join as workspace specialist${
+            specialistNames.length === 1 ? '' : 's'
+          }.`
+        : '';
+      const creationSentence = createdNames.length
+        ? ` ${createdNames.join(', ')} ${
+            createdNames.length === 1 ? 'is' : 'are'
+          } not in Your Agents yet and will be added when you create the workspace.`
+        : '';
+      if (!isNew) {
         next = {
           state: 'ready',
           label: 'Ready',
           kicker: 'PRIMARY WORKSPACE AGENT',
           name: agentName,
-          detail: 'Saved reusable agent',
-          status: `${agentName} is already in Your Agents and will be attached as this workspace's primary agent.`
+          detail: memberLifecycle(primary),
+          status: `${agentName} will be this workspace's primary agent.${specialistSentence}${creationSentence}`
         };
       } else {
         next = {
@@ -4338,20 +4424,10 @@ const sessionManager = {
           label: 'New agent',
           kicker: 'PRIMARY WORKSPACE AGENT',
           name: agentName,
-          detail: 'New reusable agent',
-          status: `${agentName} is not in Your Agents yet. It will be added to Your Agents and attached as this workspace's primary agent when you create the workspace.`
+          detail: memberLifecycle(primary),
+          status: `${agentName} will be added to Your Agents as this workspace's primary agent.${specialistSentence}${creationSentence}`
         };
       }
-    } else if (explicitPrimary) {
-      const agentName = String(explicitPrimary).trim();
-      next = {
-        state: 'ready',
-        label: 'Ready',
-        kicker: 'PRIMARY WORKSPACE AGENT',
-        name: agentName,
-        detail: 'Saved reusable agent',
-        status: `${agentName} will be attached as this workspace's primary agent.`
-      };
     } else if (this.templateAgentPlan) {
       next = {
         state: 'missing',
@@ -4365,7 +4441,12 @@ const sessionManager = {
     }
 
     node.className = `workspace-agent-map-node is-${next.state}`;
+    canvas.classList.toggle('is-team', teamSpecialists.length > 0);
+    canvas.classList.toggle('has-many-specialists', teamSpecialists.length > 3);
     state.className = `workspace-agent-map-state is-${next.state}`;
+    title.textContent =
+      team.length > 1 ? `Workspace team · ${team.length} agents` : 'Primary workspace agent';
+    specialists.innerHTML = specialistMarkup;
     state.textContent = next.label;
     kicker.textContent = next.kicker;
     name.textContent = next.name;

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -4540,7 +4540,21 @@ const sessionManager = {
     title.textContent = `Create ${plannedAgent.name}`;
     description.textContent = `${plannedAgent.name} will be saved in Your Agents and can be reused in future workspaces. You can still cancel this workspace afterward.`;
     name.value = String(plannedAgent.name || '');
-    model.value = String(plannedAgent.model || '');
+    const modelSource = String(plannedAgent.model_source || '').trim();
+    const explicitModel = ['template', 'existing'].includes(modelSource)
+      ? String(plannedAgent.model || '').trim()
+      : '';
+    const explicitProvider = explicitModel ? String(plannedAgent.provider || '').trim() : '';
+    const inheritedModel = String(plannedAgent.model || '').trim();
+    const inheritedLabel = inheritedModel
+      ? `${String(plannedAgent.provider || '').trim() ? `${plannedAgent.provider} / ` : ''}${inheritedModel}`
+      : 'App default';
+    model.innerHTML = this.renderTemplateAgentModelOptions(
+      plannedAgent,
+      explicitModel,
+      explicitProvider,
+      inheritedLabel
+    );
     prompt.value = String(plannedAgent.system_prompt || '');
     save.textContent = `Save ${plannedAgent.name}`;
     save.disabled = false;
@@ -4591,12 +4605,21 @@ const sessionManager = {
       return;
     }
 
+    const selectedModel = String(modelInput?.value || '').trim();
+    const selectedProvider = String(
+      modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || ''
+    ).trim();
     const override = {
       index: agentIndex,
       name,
-      model: String(modelInput?.value || '').trim(),
       system_prompt: String(promptInput?.value || '').trim()
     };
+    // An empty picker value intentionally means "inherit the blueprint/system
+    // default". Omit it from the override so that default survives creation.
+    if (selectedModel) {
+      override.model = selectedModel;
+      override.provider = selectedProvider;
+    }
     if (save) save.disabled = true;
     if (status) {
       status.textContent = `Saving ${name} to Your Agents…`;

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -38,6 +38,7 @@ const sessionManager = {
   // Populated when the modal opens (defaults to the first/Blank template).
   workspaceTemplate: null,
   templateAgentPlan: null,
+  templateAgentPlanError: '',
   templateAgentPlanRequestId: 0,
   templateAgentPlanTimer: null,
   existingAgentRoster: [],
@@ -3494,6 +3495,7 @@ const sessionManager = {
 
   resetTemplateAgentReview() {
     this.templateAgentPlan = null;
+    this.templateAgentPlanError = '';
     this.templateAgentPlanRequestId += 1;
     if (this.templateAgentPlanTimer) {
       clearTimeout(this.templateAgentPlanTimer);
@@ -3577,6 +3579,8 @@ const sessionManager = {
   },
 
   setTemplateAgentReviewLoading() {
+    this.templateAgentPlan = null;
+    this.templateAgentPlanError = '';
     const review = document.getElementById('templateAgentReview');
     const summary = document.getElementById('templateAgentReviewSummary');
     const status = document.getElementById('templateAgentReviewStatus');
@@ -3593,10 +3597,12 @@ const sessionManager = {
       warnings.hidden = true;
       warnings.innerHTML = '';
     }
+    this.renderWorkspaceAgentMapPreview();
   },
 
   renderTemplateAgentPlanError(message) {
     this.templateAgentPlan = null;
+    this.templateAgentPlanError = message || 'Could not load blueprint agents.';
     const review = document.getElementById('templateAgentReview');
     const summary = document.getElementById('templateAgentReviewSummary');
     const status = document.getElementById('templateAgentReviewStatus');
@@ -3610,6 +3616,7 @@ const sessionManager = {
     if (status) status.textContent = message || 'Could not load blueprint agents.';
     if (list) list.innerHTML = '';
     if (toggle) toggle.checked = true;
+    this.renderWorkspaceAgentMapPreview();
   },
 
   renderTemplateAgentPlan(plan) {
@@ -4277,6 +4284,95 @@ const sessionManager = {
       .join('');
   },
 
+  // The map is a compact, read-only preview rather than a second canvas. It
+  // makes the distinction between a saved reusable agent, a first-use agent
+  // that will be created globally, and an intentionally agent-free setup
+  // visible before the user enters the detailed review step.
+  renderWorkspaceAgentMapPreview() {
+    const node = document.getElementById('workspaceAgentMapNode');
+    const state = document.getElementById('workspaceAgentMapState');
+    const kicker = document.getElementById('workspaceAgentMapNodeKicker');
+    const name = document.getElementById('workspaceAgentMapNodeName');
+    const detail = document.getElementById('workspaceAgentMapNodeDetail');
+    const status = document.getElementById('workspaceAgentMapStatus');
+    if (!node || !state || !kicker || !name || !detail || !status) return;
+
+    const templatePrimary = this.includedTemplateAgents().find(agent =>
+      Boolean(agent?.entry_point)
+    );
+    const explicitPrimary =
+      this.existingAgentPrimaryName || (!templatePrimary ? this.existingAgentSelections[0] : '');
+
+    let next = {
+      state: 'checking',
+      label: 'Checking',
+      kicker: 'AGENT SETUP',
+      name: 'Checking agent setup',
+      detail: 'This workspace needs a primary agent.',
+      status: 'Checking the reusable agent for this workspace…'
+    };
+
+    if (this.templateAgentPlanError) {
+      next = {
+        state: 'missing',
+        label: 'Needs attention',
+        kicker: 'AGENT SETUP',
+        name: 'Agent setup unavailable',
+        detail: 'Could not check blueprint agent',
+        status: this.templateAgentPlanError
+      };
+    } else if (templatePrimary) {
+      const agentName = String(templatePrimary.name || 'Blueprint agent').trim();
+      if (String(templatePrimary.action || '').toLowerCase() === 'reuse') {
+        next = {
+          state: 'ready',
+          label: 'Ready',
+          kicker: 'PRIMARY WORKSPACE AGENT',
+          name: agentName,
+          detail: 'Saved reusable agent',
+          status: `${agentName} is already in Your Agents and will be attached as this workspace's primary agent.`
+        };
+      } else {
+        next = {
+          state: 'new',
+          label: 'New agent',
+          kicker: 'PRIMARY WORKSPACE AGENT',
+          name: agentName,
+          detail: 'New reusable agent',
+          status: `${agentName} is not in Your Agents yet. It will be added to Your Agents and attached as this workspace's primary agent when you create the workspace.`
+        };
+      }
+    } else if (explicitPrimary) {
+      const agentName = String(explicitPrimary).trim();
+      next = {
+        state: 'ready',
+        label: 'Ready',
+        kicker: 'PRIMARY WORKSPACE AGENT',
+        name: agentName,
+        detail: 'Saved reusable agent',
+        status: `${agentName} will be attached as this workspace's primary agent.`
+      };
+    } else if (this.templateAgentPlan) {
+      next = {
+        state: 'missing',
+        label: 'No agent selected',
+        kicker: 'PRIMARY WORKSPACE AGENT',
+        name: 'Choose an agent',
+        detail: 'No primary agent staged',
+        status:
+          'No primary workspace agent is selected. You can add a saved agent in Review & Create; otherwise starter tasks will remain unassigned.'
+      };
+    }
+
+    node.className = `workspace-agent-map-node is-${next.state}`;
+    state.className = `workspace-agent-map-state is-${next.state}`;
+    state.textContent = next.label;
+    kicker.textContent = next.kicker;
+    name.textContent = next.name;
+    detail.textContent = next.detail;
+    status.textContent = next.status;
+  },
+
   refreshWorkspaceReview() {
     const summary = document.getElementById('workspaceReviewSummary');
     const heading = document.getElementById('workspaceTeamHeading');
@@ -4325,6 +4421,7 @@ const sessionManager = {
         </div>`;
     }
     this.renderExistingAgentTeam();
+    this.renderWorkspaceAgentMapPreview();
   },
 
   announceWorkspaceTeamChange(message) {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -40,12 +40,18 @@ const sessionManager = {
   templateAgentPlan: null,
   templateAgentPlanRequestId: 0,
   templateAgentPlanTimer: null,
+  existingAgentRoster: [],
+  existingAgentRosterLoaded: false,
+  existingAgentRosterLoading: false,
+  existingAgentRosterError: '',
+  existingAgentSelections: [],
+  existingAgentPrimaryName: '',
   // True once the user manually changes "Agent behavior", so selecting a
   // Starting point no longer overwrites their choice. Reset on modal open.
   behaviorOverridden: false,
 
-  // Create-workspace wizard step (1 = Select Blueprint, 2 = Construct). Import
-  // mode is single-step and always renders the step-2 layout. Reset on open.
+  // Create-workspace wizard step (1 = Choose Blueprint, 2 = Workspace Details,
+  // 3 = Review & Create). Import mode remains a single-step details layout.
   wizardStep: 1,
 
   // Auto mode state
@@ -167,60 +173,68 @@ const sessionManager = {
   // Bind all event listeners
   bindEvents() {
     // New chat button - show modal
-    document.getElementById('newChatBtn')?.addEventListener('click', (e) => {
+    document.getElementById('newChatBtn')?.addEventListener('click', e => {
       e.preventDefault();
       e.stopPropagation();
       this.showCreateChatModal();
     });
 
     // New note button - open note modal (workspace selectable)
-    document.getElementById('newNoteBtn')?.addEventListener('click', (e) => {
+    document.getElementById('newNoteBtn')?.addEventListener('click', e => {
       e.preventDefault();
       e.stopPropagation();
       this.openNoteCreateModal(this.activeFolder || null);
     });
 
     // New task button - open task modal (workspace can be selected in modal if not active)
-    document.getElementById('newTaskBtn')?.addEventListener('click', (e) => {
+    document.getElementById('newTaskBtn')?.addEventListener('click', e => {
       e.preventDefault();
       e.stopPropagation();
       // Open task modal - if no active folder, user can select workspace in the modal
       this.openTaskModalForWorkspace(this.activeFolder || null);
     });
 
-    document.getElementById('createFirstSessionBtn')?.addEventListener('click', () => this.handleEmptyStateAction());
+    document
+      .getElementById('createFirstSessionBtn')
+      ?.addEventListener('click', () => this.handleEmptyStateAction());
 
     // Create chat modal - create button
-    document.getElementById('createChatBtn')?.addEventListener('click', () => this.handleCreateChatFromModal());
+    document
+      .getElementById('createChatBtn')
+      ?.addEventListener('click', () => this.handleCreateChatFromModal());
 
     // Toggle sidebar (from inside session sidebar)
-    document.getElementById('toggleSessionSidebarBtn')?.addEventListener('click', () => this.toggleSidebar());
+    document
+      .getElementById('toggleSessionSidebarBtn')
+      ?.addEventListener('click', () => this.toggleSidebar());
 
     // Toggle sidebar (from navbar)
-    document.getElementById('sessionsToggle')?.addEventListener('click', () => this.toggleSidebar());
+    document
+      .getElementById('sessionsToggle')
+      ?.addEventListener('click', () => this.toggleSidebar());
 
     // Search input
     const searchInput = document.getElementById('sessionSearchInput');
-    searchInput?.addEventListener('input', (e) => this.handleSearchInput(e.target.value));
+    searchInput?.addEventListener('input', e => this.handleSearchInput(e.target.value));
 
     const clearSearch = document.getElementById('clearSessionSearch');
     clearSearch?.addEventListener('click', () => this.clearSearch());
 
     // Sort dropdown
-    document.getElementById('sortDropdownBtn')?.addEventListener('click', (e) => {
+    document.getElementById('sortDropdownBtn')?.addEventListener('click', e => {
       e.stopPropagation();
       this.toggleDropdown('sortDropdown');
     });
 
     // Filter dropdown
-    document.getElementById('filterDropdownBtn')?.addEventListener('click', (e) => {
+    document.getElementById('filterDropdownBtn')?.addEventListener('click', e => {
       e.stopPropagation();
       this.toggleDropdown('filterDropdown');
     });
 
     // Sort options
     document.querySelectorAll('#sortDropdown .session-dropdown-item').forEach(item => {
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         const sort = e.target.dataset.sort;
         this.setSortOrder(sort);
         this.closeDropdowns();
@@ -228,24 +242,37 @@ const sessionManager = {
     });
 
     // Folder tree toggle
-    document.getElementById('folderTreeToggle')?.addEventListener('click', () => this.toggleFolderTree());
+    document
+      .getElementById('folderTreeToggle')
+      ?.addEventListener('click', () => this.toggleFolderTree());
 
     // Add folder button
-    document.getElementById('addFolderBtn')?.addEventListener('click', (e) => {
+    document.getElementById('addFolderBtn')?.addEventListener('click', e => {
       e.stopPropagation();
       this.showAddWorkspaceModal();
     });
 
     // Create folder button
-    document.getElementById('createFolderBtn')?.addEventListener('click', () => this.createFolder());
+    document
+      .getElementById('createFolderBtn')
+      ?.addEventListener('click', () => this.createFolder());
 
-    // Wizard navigation (Select Blueprint → Construct).
-    document.getElementById('wizardNextBtn')?.addEventListener('click', () => this.goToWizardStep(2));
-    document.getElementById('wizardBackBtn')?.addEventListener('click', () => this.goToWizardStep(1));
-    // Double-clicking a blueprint selects it and jumps straight to Construct.
-    document.getElementById('addFolderModal')?.addEventListener('workspace-template-advance', () => {
-      if (!this.importModeEnabled) this.goToWizardStep(2);
-    });
+    // Wizard navigation (Choose Blueprint → Details → Review).
+    document
+      .getElementById('wizardNextBtn')
+      ?.addEventListener('click', () => this.goToWizardStep(this.wizardStep + 1));
+    document
+      .getElementById('wizardBackBtn')
+      ?.addEventListener('click', () => this.goToWizardStep(this.wizardStep - 1));
+    document
+      .getElementById('wizardEditBlueprintBtn')
+      ?.addEventListener('click', () => this.goToWizardStep(1));
+    // Double-clicking a blueprint still skips only to the Details step.
+    document
+      .getElementById('addFolderModal')
+      ?.addEventListener('workspace-template-advance', () => {
+        if (!this.importModeEnabled) this.goToWizardStep(2);
+      });
 
     // Name field: live folder-slug preview, clear the inline error on edit, and
     // Enter to advance (step 1) or create (step 2). The field is a single
@@ -255,13 +282,13 @@ const sessionManager = {
       this.clearWorkspaceNameError();
       this.updateWorkspaceNameHint();
     });
-    workspaceNameInput?.addEventListener('keydown', (event) => {
+    workspaceNameInput?.addEventListener('keydown', event => {
       if (event.key !== 'Enter') return;
       event.preventDefault();
-      if (this.importModeEnabled || this.wizardStep === 2) {
+      if (this.importModeEnabled || this.wizardStep === 3) {
         this.createFolder();
       } else {
-        this.goToWizardStep(2);
+        this.goToWizardStep(this.wizardStep + 1);
       }
     });
 
@@ -275,21 +302,70 @@ const sessionManager = {
     // Unified Template picker selection (dispatched by ProjectTemplateCard):
     // prefill name/description (never clobbering typed input) and apply the
     // template's Agent-behavior default.
-    document.getElementById('addFolderModal')?.addEventListener('workspace-template-selected', (event) => {
-      const template = event?.detail?.template || null;
-      this.workspaceTemplate = template;
-      this.prefillTemplateValue(document.getElementById('folderNameInput'), template?.name || '', 'autofillName');
-      this.prefillTemplateValue(document.getElementById('folderDescriptionInput'), template?.description || '', 'autofillDescription');
-      this.updateWorkspaceNameHint();
-      this.applyTemplateBehavior(template);
-      this.updateWizardRecap(template);
-      void this.refreshTemplateAgentPlan();
-      // Show the REAPER Setup card only for the Reaper Song template.
-      window.ReaperSetupCard?.showForTemplate?.(template);
-    });
+    document
+      .getElementById('addFolderModal')
+      ?.addEventListener('workspace-template-selected', event => {
+        const template = event?.detail?.template || null;
+        this.workspaceTemplate = template;
+        this.prefillTemplateValue(
+          document.getElementById('folderNameInput'),
+          template?.name || '',
+          'autofillName'
+        );
+        this.prefillTemplateValue(
+          document.getElementById('folderDescriptionInput'),
+          template?.description || '',
+          'autofillDescription'
+        );
+        this.updateWorkspaceNameHint();
+        this.applyTemplateBehavior(template);
+        this.updateWizardRecap(template);
+        void this.refreshTemplateAgentPlan();
+        this.refreshWorkspaceReview();
+        // Show the REAPER Setup card only for the Reaper Song template.
+        window.ReaperSetupCard?.showForTemplate?.(template);
+      });
 
     document.getElementById('templateAgentReviewToggle')?.addEventListener('change', () => {
       this.updateTemplateAgentReviewDisabledState();
+      this.refreshWorkspaceReview();
+    });
+
+    document.getElementById('addExistingAgentBtn')?.addEventListener('click', () => {
+      void this.openExistingAgentRoster();
+    });
+    document.getElementById('closeExistingAgentRosterBtn')?.addEventListener('click', () => {
+      this.closeExistingAgentRoster();
+    });
+    document.getElementById('existingAgentRosterSearch')?.addEventListener('input', () => {
+      this.renderExistingAgentRoster();
+    });
+    document.getElementById('existingAgentRosterList')?.addEventListener('click', event => {
+      const button = event.target.closest('[data-existing-agent-add]');
+      if (button) this.addExistingAgent(button.dataset.existingAgentAdd || '');
+    });
+    document.getElementById('existingAgentTeamList')?.addEventListener('click', event => {
+      const remove = event.target.closest('[data-existing-agent-remove]');
+      if (remove) this.removeExistingAgent(remove.dataset.existingAgentRemove || '');
+      const primary = event.target.closest('[data-existing-agent-primary]');
+      if (primary) this.requestExistingAgentPrimary(primary.dataset.existingAgentPrimary || '');
+    });
+    document.getElementById('workspaceReviewSummary')?.addEventListener('click', event => {
+      const edit = event.target.closest('[data-wizard-edit-step]');
+      if (edit) this.goToWizardStep(Number(edit.dataset.wizardEditStep));
+    });
+    const dropZone = document.getElementById('workspaceTeamDropZone');
+    dropZone?.addEventListener('dragover', event => {
+      event.preventDefault();
+      dropZone.classList.add('is-drag-over');
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+    });
+    dropZone?.addEventListener('dragleave', () => dropZone.classList.remove('is-drag-over'));
+    dropZone?.addEventListener('drop', event => {
+      event.preventDefault();
+      dropZone.classList.remove('is-drag-over');
+      const agentName = event.dataTransfer?.getData('application/x-ori-agent-name') || '';
+      this.addExistingAgent(agentName, { announceDrop: true });
     });
 
     document.getElementById('projectTemplatePathInput')?.addEventListener('input', () => {
@@ -297,7 +373,7 @@ const sessionManager = {
     });
 
     const importToggle = document.getElementById('folderImportToggle');
-    importToggle?.addEventListener('change', (event) => {
+    importToggle?.addEventListener('change', event => {
       const checked = Boolean(event?.currentTarget?.checked);
       this.setImportModeEnabled(checked);
       if (!checked) {
@@ -306,12 +382,12 @@ const sessionManager = {
     });
 
     const importPathInput = document.getElementById('folderImportPathInput');
-    importPathInput?.addEventListener('input', (event) => {
+    importPathInput?.addEventListener('input', event => {
       this.importAllowDuplicate = false;
       this.clearImportDuplicateWarning();
       this.prefillWorkspaceNameFromImportPath(event?.target?.value || '');
     });
-    importPathInput?.addEventListener('blur', (event) => {
+    importPathInput?.addEventListener('blur', event => {
       void this.checkImportDuplicate(event?.target?.value || '');
     });
 
@@ -338,7 +414,7 @@ const sessionManager = {
 
     // Folder color options
     document.querySelectorAll('.folder-color-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => {
+      btn.addEventListener('click', e => {
         document.querySelectorAll('.folder-color-btn').forEach(b => b.classList.remove('active'));
         e.target.classList.add('active');
         this.updateBehaviorHint();
@@ -355,19 +431,18 @@ const sessionManager = {
     });
 
     const addFolderModal = document.getElementById('addFolderModal');
-    addFolderModal?.addEventListener('show.bs.modal', (event) => {
+    addFolderModal?.addEventListener('show.bs.modal', event => {
       const trigger = event?.relatedTarget || null;
       const pendingImportMode = String(addFolderModal.dataset.pendingImportMode || '') === 'true';
       const triggerImportMode = String(trigger?.dataset?.workspaceImportMode || '') === 'true';
       const importMode = trigger ? triggerImportMode : pendingImportMode;
       const entryPoint = String(
-        trigger?.dataset?.workspaceEntryPoint ||
-        addFolderModal.dataset.pendingEntryPoint ||
-        ''
+        trigger?.dataset?.workspaceEntryPoint || addFolderModal.dataset.pendingEntryPoint || ''
       ).trim();
 
       this.resetAddWorkspaceModalForm({ preserveAskOri: true });
-      this.importEntryPoint = entryPoint || (importMode ? 'workspace_hub_import' : 'workspace_hub_create');
+      this.importEntryPoint =
+        entryPoint || (importMode ? 'workspace_hub_import' : 'workspace_hub_create');
       if (importMode) {
         this.setImportModeEnabled(true);
       }
@@ -384,7 +459,7 @@ const sessionManager = {
 
     // Session context menu actions
     document.querySelectorAll('#sessionContextMenu .session-context-item').forEach(item => {
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         const action = e.currentTarget.dataset.action;
         this.handleSessionContextAction(action);
       });
@@ -392,7 +467,7 @@ const sessionManager = {
 
     // Folder context menu actions
     document.querySelectorAll('#folderContextMenu .session-context-item').forEach(item => {
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         e.stopPropagation();
         const action = e.currentTarget.dataset.action;
         this.handleFolderContextAction(action);
@@ -403,8 +478,9 @@ const sessionManager = {
     this.setupResizeHandle();
 
     // Session list scroll (for virtual scroll)
-    document.getElementById('sessionListContainer')?.addEventListener('scroll',
-      () => this.handleScroll());
+    document
+      .getElementById('sessionListContainer')
+      ?.addEventListener('scroll', () => this.handleScroll());
 
     // Session files panel toggle
     document.getElementById('sessionFilesToggle')?.addEventListener('click', () => {
@@ -424,14 +500,14 @@ const sessionManager = {
     });
 
     // Chat mode toggle - Manual
-    document.getElementById('chatConfigModeManual')?.addEventListener('change', function() {
+    document.getElementById('chatConfigModeManual')?.addEventListener('change', function () {
       if (this.checked) {
         sessionManager.handleChatModeChange('manual');
       }
     });
 
     // Chat mode toggle - Auto
-    document.getElementById('chatConfigModeAuto')?.addEventListener('change', async function() {
+    document.getElementById('chatConfigModeAuto')?.addEventListener('change', async function () {
       if (this.checked) {
         await sessionManager.checkChatLlmAvailability();
         sessionManager.handleChatModeChange('auto');
@@ -441,7 +517,7 @@ const sessionManager = {
 
   // Setup keyboard shortcuts
   setupKeyboardShortcuts() {
-    document.addEventListener('keydown', (e) => {
+    document.addEventListener('keydown', e => {
       // Ctrl/Cmd + N - New session
       if ((e.ctrlKey || e.metaKey) && e.key === 'n') {
         e.preventDefault();
@@ -516,7 +592,7 @@ const sessionManager = {
     const workspaceIds = [...new Set(this.sessions.map(s => s.folder_id).filter(Boolean))];
 
     // Fetch stats for each unique workspace
-    const fetchPromises = workspaceIds.map(async (workspaceId) => {
+    const fetchPromises = workspaceIds.map(async workspaceId => {
       try {
         const response = await fetch(`/api/orchestration/tasks?workspace_id=${workspaceId}`);
         if (response.ok) {
@@ -641,7 +717,7 @@ const sessionManager = {
 
       const data = await response.json();
       this.tags = (data.tags || [])
-        .map((tag) => (typeof tag === 'string' ? tag : tag?.name))
+        .map(tag => (typeof tag === 'string' ? tag : tag?.name))
         .filter(Boolean);
       this.renderTagFilters();
     } catch (error) {
@@ -696,7 +772,7 @@ const sessionManager = {
       ${rootSessions.map(session => this.renderSessionItem(session)).join('')}
     `;
 
-    container.onclick = (e) => {
+    container.onclick = e => {
       if (e.target === container) {
         this.clearSelection();
       }
@@ -719,7 +795,9 @@ const sessionManager = {
           <span>Notes (${this.noteSearchResults.length})</span>
         </div>
         <div class="search-notes-list">
-          ${this.noteSearchResults.map(note => `
+          ${this.noteSearchResults
+            .map(
+              note => `
             <div class="search-note-result" data-note-id="${note.id}">
               <svg class="search-note-result-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13"/>
@@ -730,7 +808,9 @@ const sessionManager = {
                 ${note.snippets && note.snippets.length > 0 ? `<div class="search-note-result-snippet">${note.snippets[0]}</div>` : ''}
               </div>
             </div>
-          `).join('')}
+          `
+            )
+            .join('')}
         </div>
       </div>
     `;
@@ -759,14 +839,23 @@ const sessionManager = {
         </div>
         <div class="session-item-footer">
           <span class="session-preview">${this.escapeHtml(preview)}</span>
-          ${tags.length > 0 ? `
+          ${
+            tags.length > 0
+              ? `
             <div class="session-tags">
-              ${tags.slice(0, 3).map(tag => `
+              ${tags
+                .slice(0, 3)
+                .map(
+                  tag => `
                 <span class="session-tag" data-color="${this.getTagColor(tag)}">${this.escapeHtml(tag)}</span>
-              `).join('')}
+              `
+                )
+                .join('')}
               ${tags.length > 3 ? `<span class="session-tag" data-color="0">+${tags.length - 3}</span>` : ''}
             </div>
-          ` : ''}
+          `
+              : ''
+          }
         </div>
       </div>
     `;
@@ -789,19 +878,19 @@ const sessionManager = {
       const folderId = item.dataset.folderId;
 
       // Click to collapse/expand folder sessions
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         e.stopPropagation();
         this.toggleFolderSessions(folderId);
       });
 
       // Right-click context menu
-      item.addEventListener('contextmenu', (e) => {
+      item.addEventListener('contextmenu', e => {
         e.preventDefault();
         this.showFolderContextMenu(e, folderId);
       });
 
       // Drop target
-      item.addEventListener('dragover', (e) => {
+      item.addEventListener('dragover', e => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         item.classList.add('drag-over');
@@ -815,7 +904,7 @@ const sessionManager = {
         item.classList.remove('drag-over');
       });
 
-      item.addEventListener('drop', async (e) => {
+      item.addEventListener('drop', async e => {
         e.preventDefault();
         e.stopPropagation();
         item.classList.remove('drag-over');
@@ -829,7 +918,8 @@ const sessionManager = {
           }
           item.classList.add('drop-success');
           setTimeout(() => item.classList.remove('drop-success'), 700);
-          const fileText = files.length === 1 ? 'file reference' : `${files.length} file references`;
+          const fileText =
+            files.length === 1 ? 'file reference' : `${files.length} file references`;
           this.showToast(`Created ${fileText} in ${folderName}`, 'success');
           return;
         }
@@ -865,7 +955,7 @@ const sessionManager = {
     // Toggle nested sessions visibility
     container.querySelectorAll('.folder-collapse-btn').forEach(button => {
       const folderId = button.dataset.folderId;
-      button.addEventListener('click', (e) => {
+      button.addEventListener('click', e => {
         e.stopPropagation();
         this.toggleFolderSessions(folderId);
       });
@@ -875,7 +965,7 @@ const sessionManager = {
 
     // Bind task section events
     container.querySelectorAll('.folder-tasks-header').forEach(header => {
-      header.addEventListener('click', (e) => {
+      header.addEventListener('click', e => {
         if (e.target.closest('.folder-tasks-add-btn')) return; // Don't open on add click
         e.stopPropagation();
         const workspaceId = header.dataset.workspaceId;
@@ -884,7 +974,7 @@ const sessionManager = {
     });
 
     container.querySelectorAll('.folder-tasks-add-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => {
+      btn.addEventListener('click', e => {
         e.stopPropagation();
         const workspaceId = btn.dataset.workspaceId;
         this.openTaskModalForWorkspace(workspaceId);
@@ -893,7 +983,7 @@ const sessionManager = {
 
     // Bind scheduled tasks section events
     container.querySelectorAll('.folder-schedules-header').forEach(header => {
-      header.addEventListener('click', (e) => {
+      header.addEventListener('click', e => {
         e.stopPropagation();
         const workspaceId = header.dataset.workspaceId;
         this.openScheduledTasksPanel(workspaceId);
@@ -903,27 +993,29 @@ const sessionManager = {
 
   // Render folder items recursively
   renderFolderItems(folders, depth = 0) {
-    return folders.map(folder => {
-      const isActive = folder.id === this.activeFolder;
-      const colorStyle = folder.color ? `color: ${folder.color};` : '';
-      const children = folder.children || [];
-      const folderSessions = this.sessionsByFolder?.get(folder.id) || [];
-      const isCollapsed = this.collapsedFolderIds.has(folder.id);
-      
-      const hasAccent = Boolean(folder.color);
-      const accentStyles = hasAccent
-        ? `data-has-accent="true" style="--folder-accent-bg: ${this.hexToRgba(folder.color, 0.12)}; --folder-accent-bg-hover: ${this.hexToRgba(folder.color, 0.18)}; --folder-accent-border: ${this.hexToRgba(folder.color, 0.35)};"`
-        : ``;
-      // Get notes for this folder
-      const folderNotes = this.notesByFolder?.get(folder.id) || [];
-      // Get tasks for this workspace
-      const workspaceTasks = this.tasksByWorkspace?.get(folder.id) || [];
-      const taskCount = workspaceTasks.length;
-      const hasContent = folderSessions.length > 0 || folderNotes.length > 0;
+    return folders
+      .map(folder => {
+        const isActive = folder.id === this.activeFolder;
+        const colorStyle = folder.color ? `color: ${folder.color};` : '';
+        const children = folder.children || [];
+        const folderSessions = this.sessionsByFolder?.get(folder.id) || [];
+        const isCollapsed = this.collapsedFolderIds.has(folder.id);
 
-      // Tasks section - clickable header that opens the task modal
-      const tasksHtml = taskCount > 0
-        ? `
+        const hasAccent = Boolean(folder.color);
+        const accentStyles = hasAccent
+          ? `data-has-accent="true" style="--folder-accent-bg: ${this.hexToRgba(folder.color, 0.12)}; --folder-accent-bg-hover: ${this.hexToRgba(folder.color, 0.18)}; --folder-accent-border: ${this.hexToRgba(folder.color, 0.35)};"`
+          : ``;
+        // Get notes for this folder
+        const folderNotes = this.notesByFolder?.get(folder.id) || [];
+        // Get tasks for this workspace
+        const workspaceTasks = this.tasksByWorkspace?.get(folder.id) || [];
+        const taskCount = workspaceTasks.length;
+        const hasContent = folderSessions.length > 0 || folderNotes.length > 0;
+
+        // Tasks section - clickable header that opens the task modal
+        const tasksHtml =
+          taskCount > 0
+            ? `
           <div class="folder-tasks-wrapper ${isCollapsed ? 'collapsed' : ''}">
             <div class="folder-tasks-header" data-workspace-id="${folder.id}">
               <svg class="folder-tasks-header-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -939,16 +1031,17 @@ const sessionManager = {
             </div>
           </div>
         `
-        : '';
+            : '';
 
-      // Get scheduled tasks for this workspace
-      const workspaceScheduledTasks = this.scheduledTasksByWorkspace?.get(folder.id) || [];
-      const scheduledTaskCount = workspaceScheduledTasks.length;
-      const enabledScheduleCount = workspaceScheduledTasks.filter(st => st.enabled).length;
+        // Get scheduled tasks for this workspace
+        const workspaceScheduledTasks = this.scheduledTasksByWorkspace?.get(folder.id) || [];
+        const scheduledTaskCount = workspaceScheduledTasks.length;
+        const enabledScheduleCount = workspaceScheduledTasks.filter(st => st.enabled).length;
 
-      // Schedules section - clickable header that opens the scheduled tasks panel
-      const schedulesHtml = scheduledTaskCount > 0
-        ? `
+        // Schedules section - clickable header that opens the scheduled tasks panel
+        const schedulesHtml =
+          scheduledTaskCount > 0
+            ? `
           <div class="folder-schedules-wrapper ${isCollapsed ? 'collapsed' : ''}">
             <div class="folder-schedules-header" data-workspace-id="${folder.id}">
               <svg class="folder-schedules-header-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -959,41 +1052,51 @@ const sessionManager = {
             </div>
           </div>
         `
-        : '';
+            : '';
 
-      const sessionsHtml = folderSessions.length > 0
-        ? `
+        const sessionsHtml =
+          folderSessions.length > 0
+            ? `
           <div class="folder-sessions ${isCollapsed ? 'collapsed' : ''}" ${accentStyles}>
             ${folderSessions.map(session => this.renderSessionItem(session)).join('')}
           </div>
         `
-        : '';
+            : '';
 
-      const notesHtml = folderNotes.length > 0
-        ? `
+        const notesHtml =
+          folderNotes.length > 0
+            ? `
           <div class="folder-notes-section ${isCollapsed ? 'collapsed' : ''}">
-            ${folderNotes.map(note => `
+            ${folderNotes
+              .map(
+                note => `
               <div class="folder-note-item" data-note-id="${note.id}" data-folder-id="${folder.id}" draggable="true">
                 <svg class="folder-note-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13"/>
                 </svg>
                 <span class="folder-note-name">${this.escapeHtml(note.name)}</span>
               </div>
-            `).join('')}
+            `
+              )
+              .join('')}
           </div>
         `
-        : '';
+            : '';
 
-      const folderTitle = folder.description ? this.escapeHtml(folder.description) : folder.name;
-      return `
+        const folderTitle = folder.description ? this.escapeHtml(folder.description) : folder.name;
+        return `
         <div class="folder-item ${isActive ? 'active' : ''} ${isCollapsed ? 'collapsed' : ''}" data-folder-id="${folder.id}" style="padding-left: ${8 + depth * 12}px;" title="${folderTitle}">
-          ${hasContent ? `
+          ${
+            hasContent
+              ? `
             <button class="folder-collapse-btn" data-folder-id="${folder.id}" title="${isCollapsed ? 'Show content' : 'Hide content'}">
               <svg viewBox="0 0 24 24" fill="currentColor">
                 <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
               </svg>
             </button>
-          ` : '<span class="folder-collapse-spacer"></span>'}
+          `
+              : '<span class="folder-collapse-spacer"></span>'
+          }
           <svg class="folder-icon" viewBox="0 0 24 24" fill="currentColor" style="${colorStyle}">
             <path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/>
           </svg>
@@ -1006,7 +1109,8 @@ const sessionManager = {
         ${schedulesHtml}
         ${children.length > 0 ? `<div class="folder-children">${this.renderFolderItems(children, depth + 1)}</div>` : ''}
       `;
-    }).join('');
+      })
+      .join('');
   },
 
   // Bind events for session items in a container
@@ -1015,10 +1119,10 @@ const sessionManager = {
       const sessionId = item.dataset.sessionId;
 
       // Click to switch session or multi-select
-      item.addEventListener('click', (e) => this.handleSessionClick(e, sessionId));
+      item.addEventListener('click', e => this.handleSessionClick(e, sessionId));
 
       // Right-click context menu
-      item.addEventListener('contextmenu', (e) => {
+      item.addEventListener('contextmenu', e => {
         e.preventDefault();
         if (!this.selectedSessionIds.includes(sessionId)) {
           this.setSelection([sessionId], this.getSessionIndex(sessionId));
@@ -1028,7 +1132,7 @@ const sessionManager = {
 
       // Drag and drop
       item.setAttribute('draggable', 'true');
-      item.addEventListener('dragstart', (e) => this.handleDragStart(e, sessionId));
+      item.addEventListener('dragstart', e => this.handleDragStart(e, sessionId));
       item.addEventListener('dragend', () => this.handleDragEnd());
     });
   },
@@ -1073,7 +1177,10 @@ const sessionManager = {
 
   // Persist collapsed folder state
   saveCollapsedFolders() {
-    localStorage.setItem('sessionFolderCollapsed', JSON.stringify(Array.from(this.collapsedFolderIds)));
+    localStorage.setItem(
+      'sessionFolderCollapsed',
+      JSON.stringify(Array.from(this.collapsedFolderIds))
+    );
   },
 
   // Update empty state copy and visibility
@@ -1113,7 +1220,6 @@ const sessionManager = {
     this.showCreateChatModal();
   },
 
-
   // Render loading state
   renderLoadingState() {
     const loadingState = document.getElementById('sessionsLoading');
@@ -1143,14 +1249,18 @@ const sessionManager = {
       return;
     }
 
-    container.innerHTML = this.tags.map(tag => `
+    container.innerHTML = this.tags
+      .map(
+        tag => `
       <button class="session-dropdown-item ${this.filterTags.includes(tag) ? 'active' : ''}" data-tag="${this.escapeHtml(tag)}">
         <span class="session-tag" data-color="${this.getTagColor(tag)}" style="margin-right: 6px;">${this.escapeHtml(tag)}</span>
       </button>
-    `).join('');
+    `
+      )
+      .join('');
 
     container.querySelectorAll('.session-dropdown-item').forEach(item => {
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         const tag = e.currentTarget.dataset.tag;
         this.toggleTagFilter(tag);
       });
@@ -1183,20 +1293,22 @@ const sessionManager = {
     const llmWarningMessage = document.getElementById('chatLlmWarningMessage');
     const createBtnText = document.getElementById('createChatBtnText');
 
-    this.chatAutoMode = (mode === 'auto');
+    this.chatAutoMode = mode === 'auto';
 
     if (mode === 'auto') {
       // Inside a workspace, "auto" means the workspace entry agent — not the
       // generic system assistant — so label it as a plain chat. Prefer the
       // explicit workspaceId; fall back to the live select for user toggles.
-      const inWorkspace = workspaceId !== undefined
-        ? Boolean(String(workspaceId).trim())
-        : Boolean(document.getElementById('chatWorkspaceSelect')?.value);
+      const inWorkspace =
+        workspaceId !== undefined
+          ? Boolean(String(workspaceId).trim())
+          : Boolean(document.getElementById('chatWorkspaceSelect')?.value);
       if (this.chatLlmAvailable) {
         if (manualSection) manualSection.classList.add('d-none');
         if (autoSection) autoSection.classList.remove('d-none');
         if (llmWarning) llmWarning.classList.add('d-none');
-        if (createBtnText) createBtnText.textContent = inWorkspace ? 'Start Chat' : 'Start Assistant';
+        if (createBtnText)
+          createBtnText.textContent = inWorkspace ? 'Start Chat' : 'Start Assistant';
       } else {
         // LLM not available - show warning with action button
         if (manualSection) manualSection.classList.add('d-none');
@@ -1205,9 +1317,11 @@ const sessionManager = {
         if (createBtnText) createBtnText.textContent = 'Go to Settings';
         if (llmWarningMessage) {
           if (!this.chatSystemModelConfigured) {
-            llmWarningMessage.textContent = 'Assistant mode requires a System Model to be configured.';
+            llmWarningMessage.textContent =
+              'Assistant mode requires a System Model to be configured.';
           } else {
-            llmWarningMessage.textContent = 'Assistant mode requires an LLM provider. Please set up an API key or install Ollama.';
+            llmWarningMessage.textContent =
+              'Assistant mode requires an LLM provider. Please set up an API key or install Ollama.';
           }
         }
       }
@@ -1224,7 +1338,9 @@ const sessionManager = {
     if (!agentSelect) return;
 
     const normalizedAgents = Array.isArray(agents) ? agents : [];
-    const availableAgents = normalizedAgents.filter((agent) => String(agent?.status || '') !== 'disabled');
+    const availableAgents = normalizedAgents.filter(
+      agent => String(agent?.status || '') !== 'disabled'
+    );
     if (availableAgents.length === 0) {
       agentSelect.innerHTML = `<option value="">${this.escapeHtml(emptyLabel)}</option>`;
       agentSelect.disabled = true;
@@ -1232,7 +1348,10 @@ const sessionManager = {
     }
 
     agentSelect.innerHTML = availableAgents
-      .map((agent) => `<option value="${this.escapeHtml(agent.name)}">${this.escapeHtml(agent.name)}</option>`)
+      .map(
+        agent =>
+          `<option value="${this.escapeHtml(agent.name)}">${this.escapeHtml(agent.name)}</option>`
+      )
       .join('');
     agentSelect.disabled = false;
   },
@@ -1242,11 +1361,13 @@ const sessionManager = {
     if (!autoModeText) return;
 
     if (workspaceId) {
-      autoModeText.textContent = "You'll chat with this workspace's entry agent, which has the workspace context by default. Switch to Direct agent chat to talk to a different workspace agent.";
+      autoModeText.textContent =
+        "You'll chat with this workspace's entry agent, which has the workspace context by default. Switch to Direct agent chat to talk to a different workspace agent.";
       return;
     }
 
-    autoModeText.textContent = 'Assistant starts as the system assistant. Pick a workspace to keep context scoped, or continue here before deciding where the work belongs.';
+    autoModeText.textContent =
+      'Assistant starts as the system assistant. Pick a workspace to keep context scoped, or continue here before deciding where the work belongs.';
   },
 
   buildAssistantSessionTitle(initialMessage) {
@@ -1388,9 +1509,7 @@ const sessionManager = {
       this.populateChatAgentSelect(
         agentSelect,
         agents,
-        workspaceId
-          ? 'No direct-chat agents in this workspace'
-          : 'No direct-chat agents available'
+        workspaceId ? 'No direct-chat agents in this workspace' : 'No direct-chat agents available'
       );
 
       // Show the modal
@@ -1428,9 +1547,9 @@ const sessionManager = {
 
     // Get initial messages before closing modal
     const autoMessageInput = document.getElementById('chatAutoMessage');
-    const autoInitialMessage = this.chatAutoMode ? (autoMessageInput?.value?.trim() || '') : '';
+    const autoInitialMessage = this.chatAutoMode ? autoMessageInput?.value?.trim() || '' : '';
     const manualMessageInput = document.getElementById('chatManualMessage');
-    const manualInitialMessage = !this.chatAutoMode ? (manualMessageInput?.value?.trim() || '') : '';
+    const manualInitialMessage = !this.chatAutoMode ? manualMessageInput?.value?.trim() || '' : '';
 
     // Validate message in auto mode
     if (this.chatAutoMode && this.chatLlmAvailable && !autoInitialMessage) {
@@ -1484,9 +1603,11 @@ const sessionManager = {
 
       if (!agentName) {
         if (window.Toast) {
-          Toast.warning(workspaceId
-            ? "No direct-chat agent is available in this workspace. Add an agent, or switch to auto mode to use the workspace's entry agent."
-            : 'No direct-chat agent is available. Add an agent or use Assistant.');
+          Toast.warning(
+            workspaceId
+              ? "No direct-chat agent is available in this workspace. Add an agent, or switch to auto mode to use the workspace's entry agent."
+              : 'No direct-chat agent is available. Add an agent or use Assistant.'
+          );
         }
         return;
       }
@@ -1538,17 +1659,17 @@ const sessionManager = {
       newDropZone.addEventListener('click', () => {
         document.getElementById('chatFileInput')?.click();
       });
-      newDropZone.addEventListener('dragover', (e) => {
+      newDropZone.addEventListener('dragover', e => {
         e.preventDefault();
         e.stopPropagation();
         newDropZone.classList.add('drag-active');
       });
-      newDropZone.addEventListener('dragleave', (e) => {
+      newDropZone.addEventListener('dragleave', e => {
         e.preventDefault();
         e.stopPropagation();
         newDropZone.classList.remove('drag-active');
       });
-      newDropZone.addEventListener('drop', (e) => {
+      newDropZone.addEventListener('drop', e => {
         e.preventDefault();
         e.stopPropagation();
         newDropZone.classList.remove('drag-active');
@@ -1563,7 +1684,7 @@ const sessionManager = {
       const newFileInput = fileInput.cloneNode(true);
       fileInput.parentNode.replaceChild(newFileInput, fileInput);
 
-      newFileInput.addEventListener('change', (e) => {
+      newFileInput.addEventListener('change', e => {
         const files = e.target?.files;
         if (files && files.length > 0) {
           this.addChatFiles(Array.from(files));
@@ -1576,7 +1697,7 @@ const sessionManager = {
   addChatFiles(files) {
     const maxSize = 10 * 1024 * 1024; // 10MB
 
-    files.forEach((file) => {
+    files.forEach(file => {
       if (file.size > maxSize) {
         if (window.Toast) {
           Toast.warning(`${file.name} exceeds 10MB limit`);
@@ -1584,7 +1705,7 @@ const sessionManager = {
         return;
       }
       // Avoid duplicates
-      if (!this.chatPendingFiles.some((f) => f.name === file.name && f.size === file.size)) {
+      if (!this.chatPendingFiles.some(f => f.name === file.name && f.size === file.size)) {
         this.chatPendingFiles.push(file);
       }
     });
@@ -1604,14 +1725,15 @@ const sessionManager = {
 
     container.style.display = 'block';
 
-    const formatSize = (bytes) => {
+    const formatSize = bytes => {
       if (!bytes) return '';
       if (bytes < 1024) return bytes + ' B';
       if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
       return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
     };
 
-    const items = this.chatPendingFiles.map((file, index) => `
+    const items = this.chatPendingFiles.map(
+      (file, index) => `
       <div class="chat-selected-file-item" data-index="${index}">
         <span class="chat-file-name">${this.escapeHtml(file.name)}</span>
         <span class="chat-file-size">${formatSize(file.size)}</span>
@@ -1621,13 +1743,14 @@ const sessionManager = {
           </svg>
         </button>
       </div>
-    `);
+    `
+    );
 
     container.innerHTML = items.join('');
 
     // Bind remove buttons
-    container.querySelectorAll('.chat-file-remove').forEach((btn) => {
-      btn.addEventListener('click', (e) => {
+    container.querySelectorAll('.chat-file-remove').forEach(btn => {
+      btn.addEventListener('click', e => {
         e.stopPropagation();
         const index = parseInt(btn.dataset.index, 10);
         this.chatPendingFiles.splice(index, 1);
@@ -1672,7 +1795,7 @@ const sessionManager = {
     const result = [];
     const seen = new Set();
 
-    source.forEach((agent) => {
+    source.forEach(agent => {
       const isString = typeof agent === 'string';
       const name = String(isString ? agent : agent?.name || '').trim();
       if (!name) return;
@@ -1727,14 +1850,16 @@ const sessionManager = {
     if (!workspaceId) return globalAgents;
 
     try {
-      const response = await fetch(`/api/orchestration/workspace?id=${encodeURIComponent(workspaceId)}`);
+      const response = await fetch(
+        `/api/orchestration/workspace?id=${encodeURIComponent(workspaceId)}`
+      );
       if (!response.ok) return globalAgents;
 
       const workspace = await response.json();
       const names = [];
       const seen = new Set();
 
-      const addName = (value) => {
+      const addName = value => {
         const name = String(value || '').trim();
         if (!name) return;
         const key = name.toLowerCase();
@@ -1744,16 +1869,20 @@ const sessionManager = {
       };
 
       if (Array.isArray(workspace?.agent_instances)) {
-        workspace.agent_instances.forEach((instance) => addName(instance?.name));
+        workspace.agent_instances.forEach(instance => addName(instance?.name));
       }
       if (Array.isArray(workspace?.agents)) {
-        workspace.agents.forEach((name) => addName(name));
+        workspace.agents.forEach(name => addName(name));
       }
 
       if (names.length === 0) return globalAgents;
 
-      const globalByName = new Map(globalAgents.map((agent) => [String(agent.name || '').toLowerCase(), agent]));
-      return names.map((name) => globalByName.get(name.toLowerCase()) || { name, model: '', description: '' });
+      const globalByName = new Map(
+        globalAgents.map(agent => [String(agent.name || '').toLowerCase(), agent])
+      );
+      return names.map(
+        name => globalByName.get(name.toLowerCase()) || { name, model: '', description: '' }
+      );
     } catch (error) {
       console.error('Failed to fetch workspace agents:', error);
       return globalAgents;
@@ -1783,7 +1912,9 @@ const sessionManager = {
             </div>
             <div class="modal-body">
               <div class="list-group list-group-flush">
-                ${agents.map(agent => `
+                ${agents
+                  .map(
+                    agent => `
                   <button type="button" class="list-group-item list-group-item-action bg-dark text-light border-secondary agent-picker-item ${agent.name === currentAgentName ? 'active' : ''}"
                           data-agent-name="${this.escapeHtml(agent.name)}">
                     <div class="d-flex justify-content-between align-items-center">
@@ -1795,7 +1926,9 @@ const sessionManager = {
                     </div>
                     ${agent.description ? `<small class="text-muted d-block mt-1">${this.escapeHtml(agent.description)}</small>` : ''}
                   </button>
-                `).join('')}
+                `
+                  )
+                  .join('')}
               </div>
             </div>
             <div class="modal-footer border-secondary">
@@ -1947,12 +2080,16 @@ const sessionManager = {
           </div>
           <div class="modal-body">
             <div class="agent-picker-list">
-              ${agents.map(agent => `
+              ${agents
+                .map(
+                  agent => `
                 <button class="agent-picker-item modern-btn modern-btn-secondary w-100 mb-2 text-start" data-agent="${agent.name}">
                   <span class="agent-name">${this.escapeHtml(agent.name)}</span>
                   ${agent.description ? `<small class="text-muted d-block">${this.escapeHtml(agent.description)}</small>` : ''}
                 </button>
-              `).join('')}
+              `
+                )
+                .join('')}
             </div>
           </div>
         </div>
@@ -1972,7 +2109,7 @@ const sessionManager = {
 
     // Handle close
     modal.querySelector('.btn-close').addEventListener('click', () => modal.remove());
-    modal.addEventListener('click', (e) => {
+    modal.addEventListener('click', e => {
       if (e.target === modal) modal.remove();
     });
   },
@@ -2265,7 +2402,7 @@ const sessionManager = {
     const editBtn = document.getElementById('chatEditAgentBtn');
     if (editBtn && !editBtn.dataset.bound) {
       editBtn.dataset.bound = 'true';
-      editBtn.addEventListener('click', (event) => {
+      editBtn.addEventListener('click', event => {
         event.preventDefault();
         const agentName = editBtn.dataset.agentName || this.getActiveSession()?.agent_name;
         if (!agentName) {
@@ -2294,7 +2431,7 @@ const sessionManager = {
 
     const form = document.getElementById('editAgentForm');
     if (form) {
-      form.addEventListener('submit', (event) => event.preventDefault());
+      form.addEventListener('submit', event => event.preventDefault());
     }
 
     const saveBtn = document.getElementById('editAgentSaveBtn');
@@ -2304,20 +2441,26 @@ const sessionManager = {
 
     const tagsInput = document.getElementById('editAgentTagsInput');
     if (tagsInput) {
-      tagsInput.addEventListener('keydown', (event) => {
+      tagsInput.addEventListener('keydown', event => {
         if (event.key === 'Enter' && tagsInput.value.trim()) {
           event.preventDefault();
           this.addEditAgentTag(tagsInput.value.trim());
           tagsInput.value = '';
-        } else if (event.key === 'Backspace' && !tagsInput.value && this.editAgentSelectedTags.length > 0) {
-          this.removeEditAgentTag(this.editAgentSelectedTags[this.editAgentSelectedTags.length - 1]);
+        } else if (
+          event.key === 'Backspace' &&
+          !tagsInput.value &&
+          this.editAgentSelectedTags.length > 0
+        ) {
+          this.removeEditAgentTag(
+            this.editAgentSelectedTags[this.editAgentSelectedTags.length - 1]
+          );
         }
       });
     }
 
     const tagsContainer = document.getElementById('editAgentTagsContainer');
     if (tagsContainer && tagsInput) {
-      tagsContainer.addEventListener('click', (event) => {
+      tagsContainer.addEventListener('click', event => {
         if (event.target === tagsContainer) {
           tagsInput.focus();
         }
@@ -2326,7 +2469,7 @@ const sessionManager = {
 
     const colorInput = document.getElementById('editAgentAvatarColor');
     if (colorInput) {
-      colorInput.addEventListener('input', (event) => {
+      colorInput.addEventListener('input', event => {
         this.updateEditAgentColorPreview(event.target.value);
       });
     }
@@ -2334,7 +2477,7 @@ const sessionManager = {
     // Listen for Type changes to update Model options
     const typeSelect = document.getElementById('editAgentTypeSelect');
     if (typeSelect) {
-      typeSelect.addEventListener('change', (event) => {
+      typeSelect.addEventListener('change', event => {
         const modelSelect = document.getElementById('editAgentModelSelect');
         const currentModel = modelSelect?.value;
         this.updateEditAgentModelOptions(event.target.value, currentModel);
@@ -2433,7 +2576,7 @@ const sessionManager = {
     const seen = new Set();
     const normalized = [];
 
-    servers.forEach((server) => {
+    servers.forEach(server => {
       let record = null;
 
       if (typeof server === 'string') {
@@ -2450,10 +2593,13 @@ const sessionManager = {
         const name = typeof server.name === 'string' ? server.name.trim() : '';
         if (name) {
           const enabled = server.enabled !== false;
-          const statusRaw = typeof server.status === 'string' ? server.status.trim().toLowerCase() : '';
+          const statusRaw =
+            typeof server.status === 'string' ? server.status.trim().toLowerCase() : '';
           const toolCount = Number.isFinite(server.tool_count)
             ? server.tool_count
-            : (Number.isFinite(server.toolCount) ? server.toolCount : 0);
+            : Number.isFinite(server.toolCount)
+              ? server.toolCount
+              : 0;
 
           record = {
             name,
@@ -2490,7 +2636,8 @@ const sessionManager = {
     if (!container) return;
 
     if (options.workspaceScoped) {
-      container.innerHTML = '<span class="agent-edit-mcp-empty">Workspace-scoped. Configure MCP bindings from the target workspace.</span>';
+      container.innerHTML =
+        '<span class="agent-edit-mcp-empty">Workspace-scoped. Configure MCP bindings from the target workspace.</span>';
       return;
     }
 
@@ -2500,25 +2647,28 @@ const sessionManager = {
     }
 
     if (options.error) {
-      container.innerHTML = '<span class="agent-edit-mcp-error">Could not load MCP server status.</span>';
+      container.innerHTML =
+        '<span class="agent-edit-mcp-error">Could not load MCP server status.</span>';
       return;
     }
 
     const enabledServers = this.normalizeEditAgentMCPServers(servers, true);
     if (enabledServers.length === 0) {
-      container.innerHTML = '<span class="agent-edit-mcp-empty">No MCP preferences saved for this agent.</span>';
+      container.innerHTML =
+        '<span class="agent-edit-mcp-empty">No MCP preferences saved for this agent.</span>';
       return;
     }
 
-    container.innerHTML = enabledServers.map((server) => {
-      const statusClass = this.getEditAgentMCPStatusClass(server.status);
-      const statusLabel = statusClass === 'configured' ? 'configured' : (server.status || 'configured');
-      const toolCount = Number.isFinite(server.tool_count) ? server.tool_count : 0;
-      const toolText = toolCount > 0
-        ? `${toolCount} tool${toolCount === 1 ? '' : 's'}`
-        : 'tool count unknown';
+    container.innerHTML = enabledServers
+      .map(server => {
+        const statusClass = this.getEditAgentMCPStatusClass(server.status);
+        const statusLabel =
+          statusClass === 'configured' ? 'configured' : server.status || 'configured';
+        const toolCount = Number.isFinite(server.tool_count) ? server.tool_count : 0;
+        const toolText =
+          toolCount > 0 ? `${toolCount} tool${toolCount === 1 ? '' : 's'}` : 'tool count unknown';
 
-      return `
+        return `
         <span class="agent-edit-mcp-pill">
           <span class="agent-edit-mcp-name">${this.escapeHtml(server.name)}</span>
           <span class="agent-edit-mcp-meta">
@@ -2527,7 +2677,8 @@ const sessionManager = {
           </span>
         </span>
       `;
-    }).join('');
+      })
+      .join('');
   },
 
   async ensureEditAgentModelOptions() {
@@ -2540,24 +2691,26 @@ const sessionManager = {
 
     // Set default fallback models if no providers loaded
     if (!this.editAgentProvidersData || this.editAgentProvidersData.length === 0) {
-      this.editAgentProvidersData = [{
-        name: 'default',
-        display_name: 'Default',
-        models: [
-          { value: 'gpt-5', label: 'gpt-5', type: 'research' },
-          { value: 'gpt-5-mini', label: 'gpt-5-mini', type: 'general' },
-          { value: 'gpt-5-nano', label: 'gpt-5-nano', type: 'tool-calling' },
-          { value: 'gpt-4o', label: 'gpt-4o', type: 'general' },
-          { value: 'gpt-4o-mini', label: 'gpt-4o-mini', type: 'tool-calling' },
-          { value: 'claude-3-5-sonnet-20241022', label: 'claude-3-5-sonnet', type: 'general' },
-          { value: 'claude-3-haiku-20240307', label: 'claude-3-haiku', type: 'tool-calling' },
-          { value: 'gemini-2.5-flash', label: 'gemini-2.5-flash', type: 'tool-calling' },
-          { value: 'gemini-2.5-pro', label: 'gemini-2.5-pro', type: 'research' },
-          { value: 'llama3.2', label: 'llama3.2', type: 'tool-calling' },
-          { value: 'mistral', label: 'mistral', type: 'tool-calling' },
-          { value: 'codellama', label: 'codellama', type: 'general' }
-        ]
-      }];
+      this.editAgentProvidersData = [
+        {
+          name: 'default',
+          display_name: 'Default',
+          models: [
+            { value: 'gpt-5', label: 'gpt-5', type: 'research' },
+            { value: 'gpt-5-mini', label: 'gpt-5-mini', type: 'general' },
+            { value: 'gpt-5-nano', label: 'gpt-5-nano', type: 'tool-calling' },
+            { value: 'gpt-4o', label: 'gpt-4o', type: 'general' },
+            { value: 'gpt-4o-mini', label: 'gpt-4o-mini', type: 'tool-calling' },
+            { value: 'claude-3-5-sonnet-20241022', label: 'claude-3-5-sonnet', type: 'general' },
+            { value: 'claude-3-haiku-20240307', label: 'claude-3-haiku', type: 'tool-calling' },
+            { value: 'gemini-2.5-flash', label: 'gemini-2.5-flash', type: 'tool-calling' },
+            { value: 'gemini-2.5-pro', label: 'gemini-2.5-pro', type: 'research' },
+            { value: 'llama3.2', label: 'llama3.2', type: 'tool-calling' },
+            { value: 'mistral', label: 'mistral', type: 'tool-calling' },
+            { value: 'codellama', label: 'codellama', type: 'general' }
+          ]
+        }
+      ];
     }
 
     this.editAgentModelOptionsLoaded = true;
@@ -2573,11 +2726,11 @@ const sessionManager = {
     if (!this.editAgentProvidersData) return;
 
     // Group models by provider
-    this.editAgentProvidersData.forEach((provider) => {
+    this.editAgentProvidersData.forEach(provider => {
       if (!provider.models || provider.models.length === 0) return;
 
       // Filter models by agent type
-      const filteredModels = provider.models.filter((model) => {
+      const filteredModels = provider.models.filter(model => {
         // If model has no type, include it for all agent types
         if (!model.type) return true;
         return model.type === agentType;
@@ -2589,7 +2742,7 @@ const sessionManager = {
       const optgroup = document.createElement('optgroup');
       optgroup.label = provider.display_name || provider.name;
 
-      filteredModels.forEach((model) => {
+      filteredModels.forEach(model => {
         const option = document.createElement('option');
         option.value = model.value;
         option.textContent = model.label || model.value;
@@ -2618,7 +2771,7 @@ const sessionManager = {
 
   ensureEditAgentSelectOption(selectEl, value) {
     if (!selectEl || !value) return;
-    const exists = Array.from(selectEl.options).some((option) => option.value === value);
+    const exists = Array.from(selectEl.options).some(option => option.value === value);
     if (exists) return;
     const option = document.createElement('option');
     option.value = value;
@@ -2638,9 +2791,9 @@ const sessionManager = {
     const input = document.getElementById('editAgentTagsInput');
     if (!container || !input) return;
 
-    container.querySelectorAll('.agent-edit-tag').forEach((tag) => tag.remove());
+    container.querySelectorAll('.agent-edit-tag').forEach(tag => tag.remove());
 
-    this.editAgentSelectedTags.forEach((tag) => {
+    this.editAgentSelectedTags.forEach(tag => {
       const tagEl = document.createElement('span');
       tagEl.className = 'agent-edit-tag';
 
@@ -2652,7 +2805,7 @@ const sessionManager = {
       removeBtn.className = 'agent-edit-tag-remove';
       removeBtn.setAttribute('aria-label', `Remove tag ${tag}`);
       removeBtn.textContent = 'x';
-      removeBtn.addEventListener('click', (event) => {
+      removeBtn.addEventListener('click', event => {
         event.stopPropagation();
         this.removeEditAgentTag(tag);
       });
@@ -2673,7 +2826,7 @@ const sessionManager = {
   },
 
   removeEditAgentTag(tag) {
-    this.editAgentSelectedTags = this.editAgentSelectedTags.filter((item) => item !== tag);
+    this.editAgentSelectedTags = this.editAgentSelectedTags.filter(item => item !== tag);
     this.renderEditAgentTags();
   },
 
@@ -2691,9 +2844,22 @@ const sessionManager = {
     const role = roleSelect?.value;
     const model = modelSelect?.value;
     const selectedModelOption = modelSelect?.selectedOptions?.[0] || null;
-    const selectedProvider = String(selectedModelOption?.getAttribute('data-provider') || this.editAgentCurrentProvider || '').trim();
-    const validProviders = new Set(['openai', 'codex', 'claude_code', 'claude', 'gemini', 'ollama', 'lmstudio', 'mlx_lm']);
-    const resolvedProvider = validProviders.has(selectedProvider) ? selectedProvider : String(this.editAgentCurrentProvider || '').trim();
+    const selectedProvider = String(
+      selectedModelOption?.getAttribute('data-provider') || this.editAgentCurrentProvider || ''
+    ).trim();
+    const validProviders = new Set([
+      'openai',
+      'codex',
+      'claude_code',
+      'claude',
+      'gemini',
+      'ollama',
+      'lmstudio',
+      'mlx_lm'
+    ]);
+    const resolvedProvider = validProviders.has(selectedProvider)
+      ? selectedProvider
+      : String(this.editAgentCurrentProvider || '').trim();
 
     if (!newName) {
       this.showEditAgentError('Name is required.');
@@ -2728,17 +2894,21 @@ const sessionManager = {
     const originalText = saveBtn?.innerHTML;
     if (saveBtn) {
       saveBtn.disabled = true;
-      saveBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Saving...';
+      saveBtn.innerHTML =
+        '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Saving...';
     }
 
     try {
-      const response = await fetch(`/api/agents/${encodeURIComponent(this.editAgentOriginalName)}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(payload)
-      });
+      const response = await fetch(
+        `/api/agents/${encodeURIComponent(this.editAgentOriginalName)}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(payload)
+        }
+      );
 
       if (!response.ok) {
         let errorMessage = 'Failed to update agent.';
@@ -2757,7 +2927,7 @@ const sessionManager = {
       this.editAgentOriginalName = updatedName;
       this.editAgentCurrentProvider = resolvedProvider || this.editAgentCurrentProvider;
 
-      this.sessions.forEach((session) => {
+      this.sessions.forEach(session => {
         if (session.agent_name === previousName) {
           session.agent_name = updatedName;
         }
@@ -2806,7 +2976,7 @@ const sessionManager = {
   setEditAgentFormEnabled(enabled) {
     const form = document.getElementById('editAgentForm');
     if (form) {
-      form.querySelectorAll('input, select, textarea, button').forEach((element) => {
+      form.querySelectorAll('input, select, textarea, button').forEach(element => {
         element.disabled = !enabled;
       });
     }
@@ -2973,15 +3143,17 @@ const sessionManager = {
     if (ids.length === 0) return;
 
     try {
-      await Promise.all(ids.map(async (id) => {
-        const response = await fetch(`/api/sessions/${id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ folder_id: folderId })
-        });
+      await Promise.all(
+        ids.map(async id => {
+          const response = await fetch(`/api/sessions/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ folder_id: folderId })
+          });
 
-        if (!response.ok) throw new Error('Failed to move session');
-      }));
+          if (!response.ok) throw new Error('Failed to move session');
+        })
+      );
 
       // Refresh sessions and folders
       await this.loadSessions();
@@ -3020,14 +3192,16 @@ const sessionManager = {
   },
 
   getWorkspaceBootstrapFromModal() {
-    const description = String(document.getElementById('folderDescriptionInput')?.value || '').trim();
+    const description = String(
+      document.getElementById('folderDescriptionInput')?.value || ''
+    ).trim();
     const systems = String(document.getElementById('folderSystemsInput')?.value || '').trim();
     const context = String(document.getElementById('folderContextInput')?.value || '').trim();
     const systemsList = systems
       ? systems
-        .split(/[\n,;]+/)
-        .map((value) => value.trim())
-        .filter(Boolean)
+          .split(/[\n,;]+/)
+          .map(value => value.trim())
+          .filter(Boolean)
       : [];
 
     return {
@@ -3042,7 +3216,9 @@ const sessionManager = {
   },
 
   extractFolderNameFromPath(pathValue) {
-    const trimmed = String(pathValue || '').trim().replace(/[\\/]+$/, '');
+    const trimmed = String(pathValue || '')
+      .trim()
+      .replace(/[\\/]+$/, '');
     if (!trimmed) return '';
     const parts = trimmed.split(/[\\/]/);
     return parts[parts.length - 1] || '';
@@ -3101,6 +3277,7 @@ const sessionManager = {
       this.scheduleTemplateAgentPlanRefresh();
     } else {
       this.resetTemplateAgentReview();
+      this.resetExistingAgentTeam();
     }
     window.ProjectTemplateCard?.syncState?.();
     this.refreshWizardChrome();
@@ -3235,7 +3412,7 @@ const sessionManager = {
       headers: { 'Content-Type': 'application/json' },
       body,
       keepalive: true
-    }).catch((error) => {
+    }).catch(error => {
       console.debug('Failed to send import duplicate telemetry:', error);
     });
   },
@@ -3275,9 +3452,12 @@ const sessionManager = {
       parentSelect.value = '';
       groupOptions.setWorkspaceParentSelectState(parentSelect, groups.length);
     }
-    document.querySelectorAll('#addFolderModal .folder-color-btn').forEach((btn) => btn.classList.remove('active'));
-    const defaultColorBtn = document.querySelector('#addFolderModal .folder-color-btn[data-color=""]')
-      || document.querySelector('#addFolderModal .folder-color-btn');
+    document
+      .querySelectorAll('#addFolderModal .folder-color-btn')
+      .forEach(btn => btn.classList.remove('active'));
+    const defaultColorBtn =
+      document.querySelector('#addFolderModal .folder-color-btn[data-color=""]') ||
+      document.querySelector('#addFolderModal .folder-color-btn');
     if (defaultColorBtn) {
       defaultColorBtn.classList.add('active');
     }
@@ -3304,6 +3484,7 @@ const sessionManager = {
     this.workspaceTemplate = null;
     window.ProjectTemplateCard?.reset?.();
     this.resetTemplateAgentReview();
+    this.resetExistingAgentTeam();
     window.ReaperSetupCard?.hide?.();
     this.updateBehaviorHint();
     // Refresh the folder-slug preview now that the name value is settled (the
@@ -3336,6 +3517,7 @@ const sessionManager = {
       warnings.innerHTML = '';
     }
     if (toggle) toggle.checked = true;
+    this.refreshWorkspaceReview();
   },
 
   scheduleTemplateAgentPlanRefresh() {
@@ -3355,8 +3537,10 @@ const sessionManager = {
     // Blank ships a synthetic single-agent roster (Workspace Manager). It has no
     // template_id/path, so signal it explicitly — but an ad-hoc folder override
     // (template_path) takes precedence and is no longer "blank".
-    const isBlank = Boolean(window.ProjectTemplateCard?.getSelectedTemplate?.()?.blank)
-      && !templateId && !templatePath;
+    const isBlank =
+      Boolean(window.ProjectTemplateCard?.getSelectedTemplate?.()?.blank) &&
+      !templateId &&
+      !templatePath;
     const requestId = ++this.templateAgentPlanRequestId;
 
     if (this.importModeEnabled || (!templateId && !templatePath && !isBlank)) {
@@ -3444,8 +3628,8 @@ const sessionManager = {
     if (review) review.hidden = false;
     if (toggle) toggle.checked = true;
 
-    const createCount = agents.filter((agent) => agent.action === 'create').length;
-    const reuseCount = agents.filter((agent) => agent.action === 'reuse').length;
+    const createCount = agents.filter(agent => agent.action === 'create').length;
+    const reuseCount = agents.filter(agent => agent.action === 'reuse').length;
     const parts = [];
     if (reuseCount) parts.push(`${reuseCount} reused`);
     if (createCount) parts.push(`${createCount} new`);
@@ -3457,24 +3641,28 @@ const sessionManager = {
       const model = String(plan.system_model || '').trim();
       // Applies to any blueprint's roster, not just Blank — the message names
       // where agents without an explicit model get theirs from.
-      status.textContent = provider && model
-        ? `Agents without their own model use ${provider} / ${model}.`
-        : 'Agents without their own model use the app default because no system model is configured.';
+      status.textContent =
+        provider && model
+          ? `Agents without their own model use ${provider} / ${model}.`
+          : 'Agents without their own model use the app default because no system model is configured.';
     }
     if (list) {
-      list.innerHTML = agents.map((agent, index) => this.renderTemplateAgentPlanRow(agent, index)).join('');
+      list.innerHTML = agents
+        .map((agent, index) => this.renderTemplateAgentPlanRow(agent, index))
+        .join('');
     }
-    const warningMessages = [
-      ...(Array.isArray(plan.warnings) ? plan.warnings : [])
-    ].filter((msg) => typeof msg === 'string' && msg.trim());
+    const warningMessages = [...(Array.isArray(plan.warnings) ? plan.warnings : [])].filter(
+      msg => typeof msg === 'string' && msg.trim()
+    );
     if (warnings) {
       warnings.hidden = warningMessages.length === 0;
       warnings.innerHTML = warningMessages
-        .map((msg) => `<div>${this.escapeHtml(msg)}</div>`)
+        .map(msg => `<div>${this.escapeHtml(msg)}</div>`)
         .join('');
     }
     this.bindTemplateAgentReviewInputs();
     this.updateTemplateAgentReviewDisabledState();
+    this.refreshWorkspaceReview();
   },
 
   renderTemplateAgentPlanRow(agent, index) {
@@ -3488,39 +3676,51 @@ const sessionManager = {
     const tools = this.templateAgentToolsLabel(agent?.tools);
     const name = String(agent?.name || '').trim();
     const systemPrompt = String(agent?.system_prompt || '').trim();
-    const editableModel = ['template', 'existing'].includes(String(agent?.model_source || '').trim()) ? model : '';
+    const editableModel = ['template', 'existing'].includes(
+      String(agent?.model_source || '').trim()
+    )
+      ? model
+      : '';
     const editableProvider = editableModel ? provider : '';
-    const modelText = model
-      ? `${provider ? `${provider} / ` : ''}${model}`
-      : 'App default';
-    const modelOptions = this.renderTemplateAgentModelOptions(agent, editableModel, editableProvider, modelText);
+    const modelText = model ? `${provider ? `${provider} / ` : ''}${model}` : 'App default';
+    const modelOptions = this.renderTemplateAgentModelOptions(
+      agent,
+      editableModel,
+      editableProvider,
+      modelText
+    );
     const promptState = systemPrompt ? 'Prompt set' : 'No prompt';
     const isReuse = action === 'reuse';
     // The role/type chip pair shared by both the compact reuse view and the
     // editable view. The action chip lives only in the editable view so its
     // "Reuse -> Create" flip on fork targets a single element.
     const roleChips = [
-      agent?.entry_point ? '<span class="workspace-template-agent-chip entry">Entry</span>' : '<span class="workspace-template-agent-chip">Specialist</span>',
+      agent?.entry_point
+        ? '<span class="workspace-template-agent-chip entry">Entry</span>'
+        : '<span class="workspace-template-agent-chip">Specialist</span>',
       role ? `<span class="workspace-template-agent-chip">${this.escapeHtml(role)}</span>` : '',
       type ? `<span class="workspace-template-agent-chip">${this.escapeHtml(type)}</span>` : '',
       tools ? `<span class="workspace-template-agent-chip">${this.escapeHtml(tools)}</span>` : ''
-    ].filter(Boolean).join('');
+    ]
+      .filter(Boolean)
+      .join('');
     const chips = `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>${roleChips}`;
 
-    // Reuse view: a name-matched agent already exists, so it is linked, not
-    // created. Shown compact and locked; "Make a workspace copy" reveals the
-    // editable view (below) and forks a fresh, workspace-scoped agent.
-    const reuseView = isReuse ? `
-        <div class="workspace-template-agent-reuse">
-          <div class="workspace-template-agent-reuse-head">
-            <span class="workspace-template-agent-reuse-name">${this.escapeHtml(name)}</span>
-            <div class="workspace-template-agent-meta">
-              <span class="workspace-template-agent-chip reuse">Reuse</span>${roleChips}
-            </div>
+    const designation = agent?.entry_point ? 'Primary assistant' : 'Specialist';
+    const provision = isReuse ? 'Existing agent · Will be linked' : 'New agent · Will be created';
+    const summaryAction = isReuse
+      ? '<button type="button" class="workspace-template-agent-fork-btn">Make a workspace copy</button>'
+      : '<button type="button" class="workspace-wizard-inline-action workspace-template-agent-customize-btn" aria-expanded="false">Customize</button>';
+    const summaryView = `
+        <div class="workspace-template-agent-summary-card">
+          ${this.renderAgentAvatar(name, 'workspace-agent-avatar')}
+          <div class="workspace-template-agent-summary-copy">
+            <strong>${this.escapeHtml(name)}</strong>
+            <span>${designation} · ${provision}</span>
+            <small>${this.escapeHtml(modelText)} · ${this.escapeHtml(source)}</small>
           </div>
-          <div class="workspace-template-agent-reuse-sub">Using your existing agent${model ? ` · ${this.escapeHtml(modelText)}` : ''}</div>
-          <button type="button" class="workspace-template-agent-fork-btn">Make a workspace copy</button>
-        </div>` : '';
+          <div class="workspace-template-agent-summary-action">${summaryAction}</div>
+        </div>`;
 
     return `
       <div class="workspace-template-agent-row${isReuse ? ' is-reuse' : ''}"
@@ -3531,8 +3731,8 @@ const sessionManager = {
            data-original-model="${this.escapeHtml(editableModel)}"
            data-original-provider="${this.escapeHtml(editableProvider)}"
            data-original-system-prompt="${this.escapeHtml(systemPrompt)}">
-        ${reuseView}
-        <div class="workspace-template-agent-main"${isReuse ? ' hidden' : ''}>
+        ${summaryView}
+        <div class="workspace-template-agent-main" hidden>
           <div class="workspace-template-agent-fields">
             <label class="workspace-template-agent-field">
               <span>Name</span>
@@ -3560,29 +3760,26 @@ const sessionManager = {
                       placeholder="Optional system prompt">${this.escapeHtml(systemPrompt)}</textarea>
           </details>
         </div>
-        <div class="workspace-template-agent-model">
-          <strong>${this.escapeHtml(modelText)}</strong>
-          <span class="workspace-template-agent-model-source">${this.escapeHtml(source)}</span>
-        </div>
       </div>
     `;
   },
 
   renderTemplateAgentModelOptions(agent, currentModel, currentProvider, inheritedLabel) {
     const source = String(agent?.model_source || '').trim();
-    const inheritedText = source === 'system'
-      ? `Use system model (${inheritedLabel})`
-      : `Use default (${inheritedLabel})`;
+    const inheritedText =
+      source === 'system'
+        ? `Use system model (${inheritedLabel})`
+        : `Use default (${inheritedLabel})`;
     const options = [
       `<option value="" data-provider=""${currentModel ? '' : ' selected'}>${this.escapeHtml(inheritedText)}</option>`
     ];
     let foundCurrent = !currentModel;
     const providers = Array.isArray(this.editAgentProvidersData) ? this.editAgentProvidersData : [];
-    providers.forEach((provider) => {
+    providers.forEach(provider => {
       const models = Array.isArray(provider?.models) ? provider.models : [];
       if (models.length === 0) return;
       const groupOptions = [];
-      models.forEach((model) => {
+      models.forEach(model => {
         const value = String(model?.value || model?.id || '').trim();
         if (!value) return;
         const optionProvider = String(model?.provider || provider?.name || '').trim();
@@ -3599,7 +3796,9 @@ const sessionManager = {
       );
     });
     if (currentModel && !foundCurrent) {
-      options.splice(1, 0,
+      options.splice(
+        1,
+        0,
         `<option value="${this.escapeHtml(currentModel)}" data-provider="${this.escapeHtml(currentProvider)}" selected>${this.escapeHtml(currentModel)} (current)</option>`
       );
     }
@@ -3609,13 +3808,17 @@ const sessionManager = {
   bindTemplateAgentReviewInputs() {
     const list = document.getElementById('templateAgentReviewList');
     if (!list) return;
-    list.querySelectorAll('.workspace-template-agent-row').forEach((row) => {
-      row.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
+    list.querySelectorAll('.workspace-template-agent-row').forEach(row => {
+      row.querySelectorAll('.workspace-template-agent-control').forEach(control => {
         control.addEventListener('input', () => this.updateTemplateAgentReviewRowState(row));
         control.addEventListener('change', () => this.updateTemplateAgentReviewRowState(row));
       });
-      row.querySelector('.workspace-template-agent-fork-btn')
+      row
+        .querySelector('.workspace-template-agent-fork-btn')
         ?.addEventListener('click', () => this.forkTemplateAgentRow(row));
+      row
+        .querySelector('.workspace-template-agent-customize-btn')
+        ?.addEventListener('click', () => this.toggleTemplateAgentCustomization(row));
       this.updateTemplateAgentReviewRowState(row);
     });
   },
@@ -3626,11 +3829,11 @@ const sessionManager = {
   // rename-fork override path carry the edits. The existing agent is untouched.
   forkTemplateAgentRow(row) {
     if (!row) return;
-    const reuseView = row.querySelector('.workspace-template-agent-reuse');
+    const summaryView = row.querySelector('.workspace-template-agent-summary-card');
     const main = row.querySelector('.workspace-template-agent-main');
     const nameInput = row.querySelector('.workspace-template-agent-name-input');
     row.dataset.forked = 'true';
-    if (reuseView) reuseView.hidden = true;
+    if (summaryView) summaryView.hidden = true;
     if (main) main.hidden = false;
     if (nameInput) {
       nameInput.value = this.suggestForkedAgentName(row.dataset.originalName || nameInput.value);
@@ -3638,6 +3841,16 @@ const sessionManager = {
       nameInput.select?.();
     }
     this.updateTemplateAgentReviewRowState(row);
+  },
+
+  toggleTemplateAgentCustomization(row) {
+    const main = row?.querySelector('.workspace-template-agent-main');
+    const button = row?.querySelector('.workspace-template-agent-customize-btn');
+    if (!main || !button) return;
+    main.hidden = !main.hidden;
+    button.setAttribute('aria-expanded', String(!main.hidden));
+    button.textContent = main.hidden ? 'Customize' : 'Hide details';
+    if (!main.hidden) row.querySelector('.workspace-template-agent-name-input')?.focus();
   },
 
   suggestForkedAgentName(base) {
@@ -3659,9 +3872,15 @@ const sessionManager = {
     const originalPrompt = row.dataset.originalSystemPrompt || '';
     const name = String(nameInput?.value || '').trim();
     const model = String(modelInput?.value || '').trim();
-    const provider = String(modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || '').trim();
+    const provider = String(
+      modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || ''
+    ).trim();
     const prompt = String(promptInput?.value || '').trim();
-    const dirty = name !== originalName || model !== originalModel || provider !== originalProvider || prompt !== originalPrompt;
+    const dirty =
+      name !== originalName ||
+      model !== originalModel ||
+      provider !== originalProvider ||
+      prompt !== originalPrompt;
     row.classList.toggle('is-edited', dirty);
 
     if (actionChip && row.dataset.originalAction === 'reuse') {
@@ -3671,9 +3890,10 @@ const sessionManager = {
       actionChip.classList.toggle('reuse', !renamed);
     }
     if (sourceLabel && modelInput) {
-      sourceLabel.textContent = model !== originalModel || provider !== originalProvider
-        ? 'Custom model'
-        : this.templateAgentModelSourceLabel(this.findTemplateAgentPlanItemSource(row));
+      sourceLabel.textContent =
+        model !== originalModel || provider !== originalProvider
+          ? 'Custom model'
+          : this.templateAgentModelSourceLabel(this.findTemplateAgentPlanItemSource(row));
     }
     if (promptState) {
       promptState.textContent = prompt ? 'Prompt set' : 'No prompt';
@@ -3686,7 +3906,9 @@ const sessionManager = {
 
   findTemplateAgentPlanItem(row) {
     const index = Number.parseInt(row?.dataset?.templateAgentIndex || '', 10);
-    const agents = Array.isArray(this.templateAgentPlan?.agents) ? this.templateAgentPlan.agents : [];
+    const agents = Array.isArray(this.templateAgentPlan?.agents)
+      ? this.templateAgentPlan.agents
+      : [];
     return Number.isInteger(index) && agents[index] ? agents[index] : null;
   },
 
@@ -3706,7 +3928,9 @@ const sessionManager = {
       const promptInput = row.querySelector('.workspace-template-agent-prompt-input');
       const name = String(nameInput?.value || '').trim();
       const model = String(modelInput?.value || '').trim();
-      const provider = String(modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || '').trim();
+      const provider = String(
+        modelInput?.selectedOptions?.[0]?.getAttribute('data-provider') || ''
+      ).trim();
       const systemPrompt = String(promptInput?.value || '').trim();
       if (!name) {
         nameInput?.focus();
@@ -3714,7 +3938,9 @@ const sessionManager = {
       }
       if (!/^[a-zA-Z0-9_\- ]+$/.test(name)) {
         nameInput?.focus();
-        throw new Error('Template agent names can use letters, numbers, spaces, underscores, and hyphens.');
+        throw new Error(
+          'Template agent names can use letters, numbers, spaces, underscores, and hyphens.'
+        );
       }
       const duplicateKey = name.toLowerCase();
       if (names.has(duplicateKey)) {
@@ -3732,7 +3958,9 @@ const sessionManager = {
       const promptChanged = systemPrompt !== originalPrompt;
       if (row.dataset.originalAction === 'reuse' && !renamed && (modelChanged || promptChanged)) {
         nameInput?.focus();
-        throw new Error(`Rename "${name}" before changing its model or prompt. Existing shared agents are reused as-is.`);
+        throw new Error(
+          `Rename "${name}" before changing its model or prompt. Existing shared agents are reused as-is.`
+        );
       }
 
       const override = { index };
@@ -3784,15 +4012,321 @@ const sessionManager = {
     return parts.join(' / ');
   },
 
+  resetExistingAgentTeam() {
+    this.existingAgentSelections = [];
+    this.existingAgentPrimaryName = '';
+    this.existingAgentRosterError = '';
+    const panel = document.getElementById('existingAgentRosterPanel');
+    if (panel) panel.hidden = true;
+    const search = document.getElementById('existingAgentRosterSearch');
+    if (search) search.value = '';
+    const list = document.getElementById('existingAgentTeamList');
+    if (list) list.innerHTML = '';
+    this.refreshWorkspaceReview();
+  },
+
+  existingAgentKey(name) {
+    return String(name || '')
+      .trim()
+      .toLocaleLowerCase();
+  },
+
+  findExistingRosterAgent(name) {
+    const key = this.existingAgentKey(name);
+    return (
+      this.existingAgentRoster.find(agent => this.existingAgentKey(agent?.name) === key) || null
+    );
+  },
+
+  isExistingAgentAttachable(agent) {
+    return Boolean(agent?.name) && String(agent?.source || 'user').toLowerCase() !== 'cli';
+  },
+
+  templateAgentIsAlreadyIncluded(name) {
+    const key = this.existingAgentKey(name);
+    return (this.templateAgentPlan?.agents || []).some(
+      agent =>
+        String(agent?.action || '').toLowerCase() === 'reuse' &&
+        this.existingAgentKey(agent?.name) === key
+    );
+  },
+
+  async openExistingAgentRoster() {
+    const panel = document.getElementById('existingAgentRosterPanel');
+    if (panel) panel.hidden = false;
+    const search = document.getElementById('existingAgentRosterSearch');
+    search?.focus();
+    if (!this.existingAgentRosterLoaded && !this.existingAgentRosterLoading) {
+      await this.loadExistingAgentRoster();
+    } else {
+      this.renderExistingAgentRoster();
+    }
+  },
+
+  closeExistingAgentRoster() {
+    const panel = document.getElementById('existingAgentRosterPanel');
+    if (panel) panel.hidden = true;
+  },
+
+  async loadExistingAgentRoster() {
+    this.existingAgentRosterLoading = true;
+    this.existingAgentRosterError = '';
+    this.renderExistingAgentRoster();
+    try {
+      const response = await fetch('/api/agents/dashboard/list?sort_by=name&order=asc');
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data?.error || `Request failed (${response.status})`);
+      const items = Array.isArray(data) ? data : Array.isArray(data?.agents) ? data.agents : [];
+      this.existingAgentRoster = items.filter(agent => String(agent?.name || '').trim());
+      this.existingAgentRosterLoaded = true;
+    } catch (error) {
+      console.warn('Failed to load existing agent roster:', error);
+      this.existingAgentRosterError =
+        'Your saved agents could not be loaded. You can still create the included workspace setup.';
+    } finally {
+      this.existingAgentRosterLoading = false;
+      this.renderExistingAgentRoster();
+    }
+  },
+
+  renderExistingAgentRoster() {
+    const list = document.getElementById('existingAgentRosterList');
+    const status = document.getElementById('existingAgentRosterStatus');
+    if (!list || !status) return;
+    if (this.existingAgentRosterLoading) {
+      status.textContent = 'Loading your saved agents…';
+      list.innerHTML = '';
+      return;
+    }
+    if (this.existingAgentRosterError) {
+      status.innerHTML = `${this.escapeHtml(this.existingAgentRosterError)} <button type="button" class="workspace-wizard-inline-action" data-existing-agent-retry>Retry</button>`;
+      list.innerHTML = '';
+      status.querySelector('[data-existing-agent-retry]')?.addEventListener('click', () => {
+        this.existingAgentRosterLoaded = false;
+        void this.loadExistingAgentRoster();
+      });
+      return;
+    }
+    const query = String(document.getElementById('existingAgentRosterSearch')?.value || '')
+      .trim()
+      .toLowerCase();
+    const matches = this.existingAgentRoster.filter(agent => {
+      const haystack =
+        `${agent?.name || ''} ${agent?.role || ''} ${agent?.model || ''}`.toLowerCase();
+      return !query || haystack.includes(query);
+    });
+    status.textContent = matches.length
+      ? `${matches.length} saved agent${matches.length === 1 ? '' : 's'}`
+      : 'No matching saved agents.';
+    list.innerHTML = matches.map(agent => this.renderExistingAgentRosterCard(agent)).join('');
+    list.querySelectorAll('[draggable="true"]').forEach(card => {
+      card.addEventListener('dragstart', event => {
+        const name = card.dataset.existingAgentName || '';
+        event.dataTransfer?.setData('application/x-ori-agent-name', name);
+        if (event.dataTransfer) event.dataTransfer.effectAllowed = 'copy';
+      });
+    });
+  },
+
+  renderExistingAgentRosterCard(agent) {
+    const name = String(agent?.name || '').trim();
+    const key = this.existingAgentKey(name);
+    const selected = this.existingAgentSelections.some(
+      selectedName => this.existingAgentKey(selectedName) === key
+    );
+    const alreadyIncluded = this.templateAgentIsAlreadyIncluded(name);
+    const attachable = this.isExistingAgentAttachable(agent);
+    const disabled = selected || alreadyIncluded || !attachable;
+    const reason = selected
+      ? 'Added to this workspace'
+      : alreadyIncluded
+        ? 'Already included by this blueprint'
+        : !attachable
+          ? 'Built-in CLI agents cannot be attached'
+          : '';
+    const workspaceCount = Number(agent?.workspace_count) || 0;
+    return `
+      <article class="workspace-existing-agent-card" ${attachable && !selected && !alreadyIncluded ? 'draggable="true"' : ''} data-existing-agent-name="${this.escapeHtml(name)}">
+        ${this.renderAgentAvatar(name, 'workspace-agent-avatar')}
+        <div class="workspace-existing-agent-card-copy">
+          <strong>${this.escapeHtml(name)}</strong>
+          <span>${this.escapeHtml(agent?.model || 'Uses saved agent model')} · ${workspaceCount === 1 ? '1 workspace' : `${workspaceCount} workspaces`}</span>
+          ${reason ? `<small>${this.escapeHtml(reason)}</small>` : ''}
+        </div>
+        <button type="button" class="modern-btn modern-btn-secondary" data-existing-agent-add="${this.escapeHtml(name)}" ${disabled ? 'disabled' : ''} aria-label="Add ${this.escapeHtml(name)} to this workspace">${selected ? 'Added' : alreadyIncluded ? 'Included' : attachable ? 'Add' : 'Unavailable'}</button>
+      </article>`;
+  },
+
+  renderAgentAvatar(name, className = '') {
+    const initials =
+      String(name || '')
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map(part => part[0])
+        .join('')
+        .toUpperCase() || 'A';
+    return `<span class="${className}" aria-hidden="true">${this.escapeHtml(initials)}</span>`;
+  },
+
+  addExistingAgent(name, options = {}) {
+    const agent = this.findExistingRosterAgent(name);
+    if (!agent || !this.isExistingAgentAttachable(agent)) return;
+    const canonicalName = String(agent.name).trim();
+    if (this.templateAgentIsAlreadyIncluded(canonicalName)) return;
+    if (
+      this.existingAgentSelections.some(
+        selectedName => this.existingAgentKey(selectedName) === this.existingAgentKey(canonicalName)
+      )
+    )
+      return;
+    this.existingAgentSelections.push(canonicalName);
+    if (!this.includedTemplateHasEntryAgent() && !this.existingAgentPrimaryName) {
+      this.existingAgentPrimaryName = canonicalName;
+    }
+    this.renderExistingAgentRoster();
+    this.refreshWorkspaceReview();
+    if (options.announceDrop)
+      this.announceWorkspaceTeamChange(`${canonicalName} will be attached to this workspace.`);
+  },
+
+  removeExistingAgent(name) {
+    const key = this.existingAgentKey(name);
+    const removedPrimary = this.existingAgentKey(this.existingAgentPrimaryName) === key;
+    this.existingAgentSelections = this.existingAgentSelections.filter(
+      selectedName => this.existingAgentKey(selectedName) !== key
+    );
+    if (removedPrimary) {
+      this.existingAgentPrimaryName = this.includedTemplateHasEntryAgent()
+        ? ''
+        : this.existingAgentSelections[0] || '';
+      if (this.existingAgentPrimaryName)
+        this.announceWorkspaceTeamChange(
+          `${this.existingAgentPrimaryName} is now the primary assistant.`
+        );
+    }
+    this.renderExistingAgentRoster();
+    this.refreshWorkspaceReview();
+  },
+
+  requestExistingAgentPrimary(name) {
+    const agent = this.findExistingRosterAgent(name);
+    if (
+      !agent ||
+      !this.existingAgentSelections.some(
+        selectedName => this.existingAgentKey(selectedName) === this.existingAgentKey(name)
+      )
+    )
+      return;
+    const confirmed = window.confirm(
+      `${agent.name} will receive new starter and setup tasks as the primary assistant. Its saved prompt, model, and tools will be used as-is. Make it primary?`
+    );
+    if (!confirmed) return;
+    this.existingAgentPrimaryName = String(agent.name).trim();
+    this.refreshWorkspaceReview();
+    this.announceWorkspaceTeamChange(`${agent.name} is now the primary assistant.`);
+  },
+
+  includedTemplateAgents() {
+    const included = Boolean(document.getElementById('templateAgentReviewToggle')?.checked);
+    return included && Array.isArray(this.templateAgentPlan?.agents)
+      ? this.templateAgentPlan.agents
+      : [];
+  },
+
+  includedTemplateHasEntryAgent() {
+    return this.includedTemplateAgents().some(agent => Boolean(agent?.entry_point));
+  },
+
+  resolvedWorkspacePrimaryName() {
+    if (this.existingAgentPrimaryName) return this.existingAgentPrimaryName;
+    const templateEntry = this.includedTemplateAgents().find(agent => Boolean(agent?.entry_point));
+    return String(templateEntry?.name || this.existingAgentSelections[0] || '').trim();
+  },
+
+  renderExistingAgentTeam() {
+    const list = document.getElementById('existingAgentTeamList');
+    if (!list) return;
+    const primary = this.resolvedWorkspacePrimaryName();
+    list.innerHTML = this.existingAgentSelections
+      .map(name => {
+        const agent = this.findExistingRosterAgent(name) || { name };
+        const isPrimary = this.existingAgentKey(name) === this.existingAgentKey(primary);
+        return `
+        <article class="workspace-team-agent-card">
+          ${this.renderAgentAvatar(name, 'workspace-agent-avatar')}
+          <div class="workspace-team-agent-copy">
+            <strong>${this.escapeHtml(name)}</strong>
+            <span>${isPrimary ? 'Primary assistant' : 'Specialist'} · Existing agent · Will be attached</span>
+            <small>${this.escapeHtml(agent?.model || 'Uses existing agent model')}</small>
+          </div>
+          <div class="workspace-team-agent-actions">
+            ${isPrimary ? '' : `<button type="button" class="workspace-wizard-inline-action" data-existing-agent-primary="${this.escapeHtml(name)}">Make Primary</button>`}
+            <button type="button" class="workspace-wizard-inline-action" data-existing-agent-remove="${this.escapeHtml(name)}">Remove</button>
+          </div>
+        </article>`;
+      })
+      .join('');
+  },
+
+  refreshWorkspaceReview() {
+    const summary = document.getElementById('workspaceReviewSummary');
+    const heading = document.getElementById('workspaceTeamHeading');
+    const teamSummary = document.getElementById('workspaceTeamSummary');
+    const selectedTemplate = window.ProjectTemplateCard?.getSelectedTemplate?.();
+    const name = String(document.getElementById('folderNameInput')?.value || '').trim();
+    const templateAgents = this.includedTemplateAgents();
+    const existingCount = this.existingAgentSelections.length;
+    const total = templateAgents.length + existingCount;
+    const created = templateAgents.filter(agent => String(agent?.action || '') === 'create').length;
+    const reused = templateAgents.filter(agent => String(agent?.action || '') === 'reuse').length;
+    if (heading) heading.textContent = total === 1 ? 'Workspace Assistant' : 'Workspace Team';
+    if (teamSummary) {
+      const parts = [];
+      if (created) parts.push(`${created} new agent${created === 1 ? '' : 's'} will be created`);
+      if (existingCount)
+        parts.push(
+          `${existingCount} existing agent${existingCount === 1 ? '' : 's'} will be attached`
+        );
+      if (reused)
+        parts.push(`${reused} existing assistant${reused === 1 ? '' : 's'} will be linked`);
+      teamSummary.textContent =
+        parts.join(' · ') ||
+        'No assistant will be added. Starter tasks will remain unassigned until you add one.';
+    }
+    if (summary) {
+      const blueprint =
+        selectedTemplate?.blank || !selectedTemplate?.name
+          ? 'Blank workspace'
+          : selectedTemplate.name;
+      const slug = name ? this.slugifyWorkspaceName(name) : 'Set a workspace name';
+      summary.innerHTML = `
+        <div class="workspace-review-summary-row">
+          <div><span>Blueprint</span><strong>${this.escapeHtml(blueprint)}</strong></div>
+          <button type="button" class="workspace-wizard-inline-action" data-wizard-edit-step="1">Edit</button>
+        </div>
+        <div class="workspace-review-summary-row">
+          <div><span>Workspace</span><strong>${this.escapeHtml(name || 'Untitled workspace')}</strong><small>Folder: ${this.escapeHtml(slug)}</small></div>
+          <button type="button" class="workspace-wizard-inline-action" data-wizard-edit-step="2">Edit</button>
+        </div>`;
+    }
+    this.renderExistingAgentTeam();
+  },
+
+  announceWorkspaceTeamChange(message) {
+    const region = document.getElementById('workspaceTeamLiveRegion');
+    if (region && message) region.textContent = message;
+  },
+
   updateTemplateAgentReviewDisabledState() {
     const review = document.getElementById('templateAgentReview');
     const toggle = document.getElementById('templateAgentReviewToggle');
     if (!review || !toggle) return;
     review.classList.toggle('is-disabled', !toggle.checked);
-    review.querySelectorAll('.workspace-template-agent-control').forEach((control) => {
+    review.querySelectorAll('.workspace-template-agent-control').forEach(control => {
       control.disabled = !toggle.checked;
     });
-    review.querySelectorAll('.workspace-template-agent-fork-btn').forEach((btn) => {
+    review.querySelectorAll('.workspace-template-agent-fork-btn').forEach(btn => {
       btn.disabled = !toggle.checked;
     });
   },
@@ -3815,10 +4349,13 @@ const sessionManager = {
   // Friendly label for an Agent behavior profile value.
   behaviorProfileLabel(profile) {
     switch (profile) {
-      case 'research': return 'Research';
-      case 'software_project': return 'Software Project';
+      case 'research':
+        return 'Research';
+      case 'software_project':
+        return 'Software Project';
       case 'general':
-      default: return 'General';
+      default:
+        return 'General';
     }
   },
 
@@ -3848,57 +4385,85 @@ const sessionManager = {
     hint.textContent = parts.join(' · ');
   },
 
-  // ----- Create-workspace wizard (Select Blueprint → Construct) -----
+  // ----- Create-workspace wizard (Choose Blueprint → Details → Review) -----
 
-  // Renders the wizard chrome for the current mode + step: which step panel is
-  // visible, the stepper, and which footer buttons show. Import mode is a
-  // single step that always shows the step-2 layout with no stepper/Back/Next.
+  // Renders the wizard chrome for the current mode + step. Import remains a
+  // single-step workflow and never exposes Create-only progress or review UI.
   refreshWizardChrome() {
     const importMode = Boolean(this.importModeEnabled);
     const step = importMode ? 2 : this.wizardStep;
 
     const step1 = document.getElementById('wizardStep1');
     const step2 = document.getElementById('wizardStep2');
+    const step3 = document.getElementById('wizardStep3');
     const stepper = document.getElementById('wizardStepper');
     const backBtn = document.getElementById('wizardBackBtn');
     const nextBtn = document.getElementById('wizardNextBtn');
     const createBtn = document.getElementById('createFolderBtn');
 
-    // The workspace name field is a single element relocated to the visible
-    // step's mount, so it's the first input on Select Blueprint yet stays
-    // editable on Construct (and in import mode's single-step layout).
-    this.relocateWizardNameField(step);
-    // Keep the folder-slug preview in sync with import mode (which hides it).
+    this.relocateWizardReviewFields();
     this.updateWorkspaceNameHint();
 
-    if (step1) step1.hidden = importMode || step !== 1;
-    if (step2) step2.hidden = step !== 2;
-    if (stepper) stepper.hidden = importMode;
-    stepper?.querySelectorAll('.workspace-create-step').forEach((el) => {
-      el.classList.toggle('is-active', String(el.dataset.step || '') === String(step));
+    if (step1) {
+      step1.hidden = importMode || step !== 1;
+      step1.setAttribute('aria-hidden', String(step1.hidden));
+    }
+    if (step2) {
+      step2.hidden = step !== 2;
+      step2.setAttribute('aria-hidden', String(step2.hidden));
+    }
+    if (step3) {
+      step3.hidden = importMode || step !== 3;
+      step3.setAttribute('aria-hidden', String(step3.hidden));
+    }
+    if (stepper) {
+      stepper.hidden = importMode;
+      stepper.setAttribute('aria-hidden', String(importMode));
+    }
+    stepper?.querySelectorAll('.workspace-create-step').forEach(el => {
+      const current = String(el.dataset.step || '') === String(step);
+      el.classList.toggle('is-active', current);
+      if (current) el.setAttribute('aria-current', 'step');
+      else el.removeAttribute('aria-current');
     });
 
     const onStep1 = !importMode && step === 1;
-    if (nextBtn) nextBtn.hidden = !onStep1;
-    if (backBtn) backBtn.hidden = importMode || step !== 2;
-    // createFolderBtn stays hidden on step 1; its disabled state is owned by the
-    // REAPER setup card, so only toggle visibility here.
-    if (createBtn) createBtn.hidden = onStep1;
+    if (nextBtn) {
+      nextBtn.hidden = importMode || step === 3;
+      nextBtn.textContent = onStep1 ? 'Continue →' : 'Review & Create →';
+    }
+    if (backBtn) backBtn.hidden = importMode || onStep1;
+    if (createBtn) {
+      createBtn.hidden = !importMode && step !== 3;
+      if (!this.isCreatingFolder) {
+        const selected = window.ProjectTemplateCard?.getSelectedTemplate?.();
+        createBtn.textContent = importMode
+          ? 'Import Folder'
+          : selected?.blank || !selected?.name
+            ? 'Create Workspace'
+            : `Create ${selected.name}`;
+      }
+    }
     // The step-2 recap names the chosen blueprint; import mode has no blueprint.
     const recap = document.getElementById('wizardStep2Recap');
     if (recap) recap.hidden = importMode;
+    if (!importMode && step === 3) this.refreshWorkspaceReview();
   },
 
-  // Moves the single #wizardNameField (which owns #folderNameInput) into the
-  // mount for the given effective step. appendChild preserves the input's value,
-  // focus, and listeners, so no cross-step syncing is needed.
-  relocateWizardNameField(step) {
-    const field = document.getElementById('wizardNameField');
-    if (!field) return;
-    const mount = document.getElementById(step === 2 ? 'wizardStep2NameMount' : 'wizardStep1NameMount');
-    if (mount && field.parentElement !== mount) {
-      mount.appendChild(field);
-    }
+  // Keep the source controls single-instance while moving their review-only
+  // cards into Step 3. This preserves their values, event listeners, and the
+  // existing REAPER readiness controller without shadow inputs.
+  relocateWizardReviewFields() {
+    const mount = document.getElementById('wizardStep3ReviewMount');
+    if (!mount) return;
+    ['projectTemplateOpenAfterCreate', 'reaperSetupCard'].forEach(id => {
+      const field = document.getElementById(id);
+      if (field && field.parentElement !== mount) mount.appendChild(field);
+    });
+    const templateMount = document.getElementById('templateAgentReviewMount');
+    const review = document.getElementById('templateAgentReview');
+    if (review && templateMount && review.parentElement !== templateMount)
+      templateMount.appendChild(review);
   },
 
   // Shows the folder the current name will map to on disk, so the name→folder
@@ -3935,28 +4500,37 @@ const sessionManager = {
     hint?.classList.remove('is-error');
   },
 
-  // Sets the step-2 recap line ("Constructing: <icon> <name>") from the selected
+  // Sets the step-2 recap line from the selected
   // blueprint, falling back to a Blank-workspace label.
   updateWizardRecap(template) {
     const nameEl = document.getElementById('wizardStep2RecapName');
     const iconEl = document.getElementById('wizardStep2RecapIcon');
     const isBlank = !template || template.blank || !template.id;
-    if (nameEl) nameEl.textContent = isBlank ? 'Blank workspace' : (template.name || template.id);
-    if (iconEl) iconEl.textContent = (template && template.icon) ? template.icon : '✍';
+    if (nameEl) nameEl.textContent = isBlank ? 'Blank workspace' : template.name || template.id;
+    if (iconEl) iconEl.textContent = template && template.icon ? template.icon : '✍';
   },
 
   // Moves the wizard to a step and re-renders chrome. Scrolls the modal body to
   // the top and moves focus to the step's primary control.
   goToWizardStep(step) {
-    this.wizardStep = step === 2 ? 2 : 1;
+    const targetStep = Math.max(1, Math.min(3, Number(step) || 1));
+    if (!this.importModeEnabled && targetStep >= 3) {
+      const name = document.getElementById('folderNameInput')?.value.trim() || '';
+      if (!name) {
+        this.wizardStep = 2;
+        this.refreshWizardChrome();
+        this.setWorkspaceNameError('Workspace name is required');
+        document.getElementById('folderNameInput')?.focus();
+        return;
+      }
+    }
+    this.wizardStep = targetStep;
     this.refreshWizardChrome();
     const body = document.querySelector('#addFolderModal .modal-body');
     if (body) body.scrollTop = 0;
-    if (this.wizardStep === 2) {
-      document.getElementById('folderNameInput')?.focus();
-    } else {
-      document.querySelector('#templateBuiltinGrid .workspace-template-card.is-selected')?.focus();
-    }
+    const heading = document.getElementById(`wizardStep${this.wizardStep}Title`);
+    if (heading) heading.focus();
+    else if (this.wizardStep === 2) document.getElementById('folderNameInput')?.focus();
   },
 
   // Applies a Template's default Agent behavior to the select, unless the user
@@ -4043,13 +4617,16 @@ const sessionManager = {
   async openProjectAfterWorkspaceCreate(workspaceId) {
     const id = String(workspaceId || '').trim();
     if (!id) return;
-    const response = await fetch(
-      `/api/workspaces/${encodeURIComponent(id)}/project/open`,
-      { method: 'POST' }
-    );
+    const response = await fetch(`/api/workspaces/${encodeURIComponent(id)}/project/open`, {
+      method: 'POST'
+    });
     const result = await response.json().catch(() => ({}));
     if (!response.ok || result.error) {
-      throw new Error(result.error || result.message || 'The system default application did not accept the project file.');
+      throw new Error(
+        result.error ||
+          result.message ||
+          'The system default application did not accept the project file.'
+      );
     }
   },
 
@@ -4115,11 +4692,17 @@ const sessionManager = {
       // Agent behavior profile (mapped from the Starting point or manually
       // overridden). Sent for both create and import; the backend maps it via
       // workspacesettings.ProfileDefaults.
-      payload.workspace_preset = document.getElementById('folderPresetSelect')?.value?.trim() || 'general';
-      const buildSlugConflictMessage = (conflict) => {
-        const requestedSlug = typeof conflict?.requested_slug === 'string' ? conflict.requested_slug.trim() : '';
-        const suggestedSlug = typeof conflict?.suggested_slug === 'string' ? conflict.suggested_slug.trim() : '';
-        const location = typeof conflict?.location === 'string' ? conflict.location.trim().replace(/[\\/]+$/, '') : '';
+      payload.workspace_preset =
+        document.getElementById('folderPresetSelect')?.value?.trim() || 'general';
+      const buildSlugConflictMessage = conflict => {
+        const requestedSlug =
+          typeof conflict?.requested_slug === 'string' ? conflict.requested_slug.trim() : '';
+        const suggestedSlug =
+          typeof conflict?.suggested_slug === 'string' ? conflict.suggested_slug.trim() : '';
+        const location =
+          typeof conflict?.location === 'string'
+            ? conflict.location.trim().replace(/[\\/]+$/, '')
+            : '';
         const suggestedPath = location && suggestedSlug ? `${location}/${suggestedSlug}` : '';
         const parts = [
           `A workspace folder named "${requestedSlug || 'this workspace'}" already exists on disk.`
@@ -4147,13 +4730,18 @@ const sessionManager = {
           Object.assign(payload, templateFields);
           // Blank blueprint (no template_id/path, no ad-hoc folder override):
           // tell the backend to seed the synthetic single-agent roster.
-          if (window.ProjectTemplateCard.getSelectedTemplate?.()?.blank
-            && !templateFields.template_id && !templateFields.template_path) {
+          if (
+            window.ProjectTemplateCard.getSelectedTemplate?.()?.blank &&
+            !templateFields.template_id &&
+            !templateFields.template_path
+          ) {
             payload.blank = true;
           }
         }
         if (this.templateAgentPlan?.has_agents) {
-          const createTemplateAgents = Boolean(document.getElementById('templateAgentReviewToggle')?.checked);
+          const createTemplateAgents = Boolean(
+            document.getElementById('templateAgentReviewToggle')?.checked
+          );
           payload.create_template_agents = createTemplateAgents;
           if (createTemplateAgents) {
             const templateAgentOverrides = this.collectTemplateAgentOverrides();
@@ -4161,6 +4749,15 @@ const sessionManager = {
               payload.template_agent_overrides = templateAgentOverrides;
             }
           }
+        }
+        if (this.existingAgentSelections.length > 0) {
+          payload.existing_agent_names = [...this.existingAgentSelections];
+          const selectedPrimary = this.existingAgentSelections.find(
+            agentName =>
+              this.existingAgentKey(agentName) ===
+              this.existingAgentKey(this.existingAgentPrimaryName)
+          );
+          if (selectedPrimary) payload.entry_agent_name = selectedPrimary;
         }
         if (window.WorkspaceTagsCard) {
           Object.assign(payload, window.WorkspaceTagsCard.getPayloadFields());
@@ -4186,14 +4783,18 @@ const sessionManager = {
 
         if (response.status === 409 && importEnabled && result.duplicate) {
           this.showImportDuplicateWarning(result.duplicate);
-          this.showToast('This folder is already imported. Open the existing workspace or click "Import Anyway".', 'warning');
+          this.showToast(
+            'This folder is already imported. Open the existing workspace or click "Import Anyway".',
+            'warning'
+          );
           return;
         }
 
         if (response.status === 409 && !importEnabled && result.conflict?.type === 'folder_slug') {
-          const suggestedSlug = typeof result.conflict.suggested_slug === 'string'
-            ? result.conflict.suggested_slug.trim()
-            : '';
+          const suggestedSlug =
+            typeof result.conflict.suggested_slug === 'string'
+              ? result.conflict.suggested_slug.trim()
+              : '';
           if (!suggestedSlug) {
             throw new Error(result.error || 'Failed to create workspace');
           }
@@ -4232,7 +4833,9 @@ const sessionManager = {
       }
 
       if (!response.ok || result.error) {
-        const fallbackMessage = importEnabled ? 'Failed to import folder as workspace' : 'Failed to create workspace';
+        const fallbackMessage = importEnabled
+          ? 'Failed to import folder as workspace'
+          : 'Failed to create workspace';
         throw new Error(result.error || fallbackMessage);
       }
 
@@ -4244,25 +4847,28 @@ const sessionManager = {
       // Seeded template agents that could not be created surface here (non-fatal).
       if (Array.isArray(result.agent_warnings)) {
         result.agent_warnings
-          .filter((msg) => typeof msg === 'string' && msg)
-          .forEach((msg) => this.showToast(msg, 'warning'));
+          .filter(msg => typeof msg === 'string' && msg)
+          .forEach(msg => this.showToast(msg, 'warning'));
       }
       // A roster entry matched an existing agent by name; the existing
       // definition was reused instead of the template's (PRD FR7).
       if (Array.isArray(result.agent_reuse_notices)) {
         result.agent_reuse_notices
-          .filter((msg) => typeof msg === 'string' && msg)
-          .forEach((msg) => this.showToast(msg, 'info'));
+          .filter(msg => typeof msg === 'string' && msg)
+          .forEach(msg => this.showToast(msg, 'info'));
       }
       if (window.ProjectTemplateCard) window.ProjectTemplateCard.reset();
       if (window.WorkspaceTagsCard) window.WorkspaceTagsCard.reset();
       window.OriTagInput?.clearTagPoolCache?.();
 
-      const createdWorkspaceId = result && result.folder && result.folder.id
-        ? String(result.folder.id)
+      const createdWorkspaceId =
+        result && result.folder && result.folder.id ? String(result.folder.id) : '';
+      const askOriSeedNoteRaw = modalElement
+        ? String(modalElement.dataset.askOriSeedNote || '')
         : '';
-      const askOriSeedNoteRaw = modalElement ? String(modalElement.dataset.askOriSeedNote || '') : '';
-      const askOriSeedTaskRaw = modalElement ? String(modalElement.dataset.askOriSeedTask || '') : '';
+      const askOriSeedTaskRaw = modalElement
+        ? String(modalElement.dataset.askOriSeedTask || '')
+        : '';
       if (modalElement) {
         delete modalElement.dataset.askOriPostCreate;
         delete modalElement.dataset.askOriSeedNote;
@@ -4322,7 +4928,6 @@ const sessionManager = {
       // (assigned to the entry agent); the create response reports how many.
       const seededStarterTasks = Number(result?.seeded_starter_tasks) || 0;
 
-
       if (
         bootstrapApplyResult.invitedAgents > 0 ||
         bootstrapApplyResult.boundMCPs > 0 ||
@@ -4333,28 +4938,48 @@ const sessionManager = {
         seededStarterTasks > 0
       ) {
         const summaryParts = [];
-        if (bootstrapApplyResult.invitedAgents > 0) summaryParts.push(`${bootstrapApplyResult.invitedAgents} agent${bootstrapApplyResult.invitedAgents === 1 ? '' : 's'} invited`);
-        if (bootstrapApplyResult.boundMCPs > 0) summaryParts.push(`${bootstrapApplyResult.boundMCPs} MCP${bootstrapApplyResult.boundMCPs === 1 ? '' : 's'} bound`);
-        if (bootstrapApplyResult.attachedSkills > 0) summaryParts.push(`${bootstrapApplyResult.attachedSkills} skill${bootstrapApplyResult.attachedSkills === 1 ? '' : 's'} attached`);
-        if (bootstrapApplyResult.addedPlugins > 0) summaryParts.push(`${bootstrapApplyResult.addedPlugins} plugin${bootstrapApplyResult.addedPlugins === 1 ? '' : 's'} added`);
-        if (askOriSeedResult.tasksCreated > 0) summaryParts.push(`${askOriSeedResult.tasksCreated} Assistant task`);
-        if (askOriSeedResult.notesCreated > 0) summaryParts.push(`${askOriSeedResult.notesCreated} Assistant note`);
-        if (seededStarterTasks > 0) summaryParts.push(`${seededStarterTasks} starter task${seededStarterTasks === 1 ? '' : 's'} added`);
+        if (bootstrapApplyResult.invitedAgents > 0)
+          summaryParts.push(
+            `${bootstrapApplyResult.invitedAgents} agent${bootstrapApplyResult.invitedAgents === 1 ? '' : 's'} invited`
+          );
+        if (bootstrapApplyResult.boundMCPs > 0)
+          summaryParts.push(
+            `${bootstrapApplyResult.boundMCPs} MCP${bootstrapApplyResult.boundMCPs === 1 ? '' : 's'} bound`
+          );
+        if (bootstrapApplyResult.attachedSkills > 0)
+          summaryParts.push(
+            `${bootstrapApplyResult.attachedSkills} skill${bootstrapApplyResult.attachedSkills === 1 ? '' : 's'} attached`
+          );
+        if (bootstrapApplyResult.addedPlugins > 0)
+          summaryParts.push(
+            `${bootstrapApplyResult.addedPlugins} plugin${bootstrapApplyResult.addedPlugins === 1 ? '' : 's'} added`
+          );
+        if (askOriSeedResult.tasksCreated > 0)
+          summaryParts.push(`${askOriSeedResult.tasksCreated} Assistant task`);
+        if (askOriSeedResult.notesCreated > 0)
+          summaryParts.push(`${askOriSeedResult.notesCreated} Assistant note`);
+        if (seededStarterTasks > 0)
+          summaryParts.push(
+            `${seededStarterTasks} starter task${seededStarterTasks === 1 ? '' : 's'} added`
+          );
         const summaryText = summaryParts.join(', ');
-        if (
-          askOriSeedResult.errors.length > 0 ||
-          bootstrapApplyResult.failures.length > 0
-        ) {
+        if (askOriSeedResult.errors.length > 0 || bootstrapApplyResult.failures.length > 0) {
           const firstFailure = bootstrapApplyResult.failures[0];
           this.showToast(
             `${importEnabled ? 'Workspace imported' : 'Workspace created'} with partial setup (${summaryText}).${firstFailure ? ` ${firstFailure}` : ''}`,
             'warning'
           );
         } else {
-          this.showToast(`${importEnabled ? 'Workspace imported' : 'Workspace created'} with setup (${summaryText}).`, 'success');
+          this.showToast(
+            `${importEnabled ? 'Workspace imported' : 'Workspace created'} with setup (${summaryText}).`,
+            'success'
+          );
         }
       } else {
-        this.showToast(importEnabled ? 'Workspace imported successfully' : 'Workspace created successfully', 'success');
+        this.showToast(
+          importEnabled ? 'Workspace imported successfully' : 'Workspace created successfully',
+          'success'
+        );
       }
 
       if (createdWorkspaceId && openProjectAfterCreate) {
@@ -4384,7 +5009,10 @@ const sessionManager = {
       }
     } catch (error) {
       console.error('Failed to create folder:', error);
-      this.showToast(error && error.message ? error.message : 'Failed to create workspace', 'error');
+      this.showToast(
+        error && error.message ? error.message : 'Failed to create workspace',
+        'error'
+      );
     } finally {
       this.isCreatingFolder = false;
       if (createBtn) {
@@ -4396,7 +5024,8 @@ const sessionManager = {
 
   // Delete folder
   async deleteFolder(folderId) {
-    if (!confirm('Are you sure you want to delete this workspace? Sessions will be moved to root.')) return;
+    if (!confirm('Are you sure you want to delete this workspace? Sessions will be moved to root.'))
+      return;
 
     try {
       const response = await fetch(`/api/workspaces/${folderId}`, {
@@ -4731,7 +5360,7 @@ const sessionManager = {
     };
 
     input.addEventListener('blur', saveRename);
-    input.addEventListener('keydown', (e) => {
+    input.addEventListener('keydown', e => {
       if (e.key === 'Enter') {
         e.preventDefault();
         input.blur();
@@ -4773,7 +5402,7 @@ const sessionManager = {
     };
 
     input.addEventListener('blur', saveRename);
-    input.addEventListener('keydown', (e) => {
+    input.addEventListener('keydown', e => {
       if (e.key === 'Enter') {
         e.preventDefault();
         input.blur();
@@ -4791,7 +5420,9 @@ const sessionManager = {
   slugifyWorkspaceName(value) {
     const s = String(value || '').trim();
     if (!s) return 'untitled';
-    let slug = s.normalize('NFD').replace(/\p{Mn}/gu, '')
+    let slug = s
+      .normalize('NFD')
+      .replace(/\p{Mn}/gu, '')
       .toLowerCase()
       .replace(/[^a-z0-9-]+/g, '-')
       .replace(/-{2,}/g, '-')
@@ -4801,9 +5432,12 @@ const sessionManager = {
   },
 
   buildWorkspaceSlugConflictMessage(conflict) {
-    const requestedSlug = typeof conflict?.requested_slug === 'string' ? conflict.requested_slug.trim() : '';
-    const suggestedSlug = typeof conflict?.suggested_slug === 'string' ? conflict.suggested_slug.trim() : '';
-    const location = typeof conflict?.location === 'string' ? conflict.location.trim().replace(/[\\/]+$/, '') : '';
+    const requestedSlug =
+      typeof conflict?.requested_slug === 'string' ? conflict.requested_slug.trim() : '';
+    const suggestedSlug =
+      typeof conflict?.suggested_slug === 'string' ? conflict.suggested_slug.trim() : '';
+    const location =
+      typeof conflict?.location === 'string' ? conflict.location.trim().replace(/[\\/]+$/, '') : '';
     const suggestedPath = location && suggestedSlug ? `${location}/${suggestedSlug}` : '';
 
     const parts = [
@@ -4833,10 +5467,14 @@ const sessionManager = {
       });
       const result = await response.json().catch(() => ({}));
       if (response.status === 409 && result?.conflict?.type === 'folder_slug') {
-        const suggestedSlug = typeof result.conflict.suggested_slug === 'string'
-          ? result.conflict.suggested_slug.trim()
-          : '';
-        if (suggestedSlug && window.confirm(this.buildWorkspaceSlugConflictMessage(result.conflict))) {
+        const suggestedSlug =
+          typeof result.conflict.suggested_slug === 'string'
+            ? result.conflict.suggested_slug.trim()
+            : '';
+        if (
+          suggestedSlug &&
+          window.confirm(this.buildWorkspaceSlugConflictMessage(result.conflict))
+        ) {
           return this.renameFolder(folderId, newName, suggestedSlug);
         }
         const cancelled = new Error(result?.error || 'Workspace rename cancelled');
@@ -4924,7 +5562,7 @@ const sessionManager = {
     });
 
     // Close on click outside
-    const closePopup = (e) => {
+    const closePopup = e => {
       if (!popup.contains(e.target)) {
         popup.remove();
         document.removeEventListener('click', closePopup);
@@ -4991,14 +5629,18 @@ const sessionManager = {
         </svg>
         No Workspace
       </div>
-      ${assignableFolders.map(folder => `
+      ${assignableFolders
+        .map(
+          folder => `
         <div class="move-folder-item ${folder.id === currentFolderId ? 'selected' : ''}" data-folder-id="${folder.id}">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="${folder.color || 'currentColor'}" class="me-2">
             <path d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"/>
           </svg>
           ${this.escapeHtml(`${folder.depth > 0 ? `${'--'.repeat(folder.depth)} ` : ''}${folder.name}`)}
         </div>
-      `).join('')}
+      `
+        )
+        .join('')}
     `;
 
     // Bind click handlers
@@ -5167,7 +5809,9 @@ const sessionManager = {
             <div class="modal-body">
               <p class="text-muted small mb-3">Select a new agent for this session. Future messages will use the selected agent.</p>
               <div class="list-group list-group-flush">
-                ${agents.map(agent => `
+                ${agents
+                  .map(
+                    agent => `
                   <button type="button" class="list-group-item list-group-item-action bg-dark text-light border-secondary change-agent-item ${agent.name === session.agent_name ? 'active' : ''}"
                           data-agent-name="${this.escapeHtml(agent.name)}">
                     <div class="d-flex justify-content-between align-items-center">
@@ -5178,7 +5822,9 @@ const sessionManager = {
                       ${agent.name === session.agent_name ? '<span class="badge bg-success">Current</span>' : ''}
                     </div>
                   </button>
-                `).join('')}
+                `
+                  )
+                  .join('')}
               </div>
             </div>
             <div class="modal-footer border-secondary">
@@ -5285,7 +5931,7 @@ const sessionManager = {
     let startX = 0;
     let startWidth = 0;
 
-    handle.addEventListener('mousedown', (e) => {
+    handle.addEventListener('mousedown', e => {
       isResizing = true;
       startX = e.clientX;
       startWidth = sidebar.offsetWidth;
@@ -5294,7 +5940,7 @@ const sessionManager = {
       document.body.style.userSelect = 'none';
     });
 
-    document.addEventListener('mousemove', (e) => {
+    document.addEventListener('mousemove', e => {
       if (!isResizing) return;
 
       const width = startWidth + (e.clientX - startX);
@@ -5326,7 +5972,10 @@ const sessionManager = {
       this.setSelection([sessionId], this.getSessionIndex(sessionId));
     }
     e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('application/x-ori-session-ids', JSON.stringify(this.selectedSessionIds));
+    e.dataTransfer.setData(
+      'application/x-ori-session-ids',
+      JSON.stringify(this.selectedSessionIds)
+    );
     e.dataTransfer.setData('text/plain', String(sessionId));
     e.currentTarget.classList.add('dragging');
     document.getElementById('folderTreeSection')?.classList.add('dragging');
@@ -5627,7 +6276,9 @@ const sessionManager = {
             message += ` to workspace "${result.workspace_name}"`;
           }
           if (result.agent_name) {
-            message += result.workspace_name ? ` with agent "${result.agent_name}"` : ` to agent "${result.agent_name}"`;
+            message += result.workspace_name
+              ? ` with agent "${result.agent_name}"`
+              : ` to agent "${result.agent_name}"`;
           }
           Toast.success(message);
         }
@@ -5680,7 +6331,9 @@ const sessionManager = {
   },
 
   // Escape HTML
-  escapeHtml(text) { return window.NoteEditor?.escapeHtml(text) ?? String(text ?? ''); },
+  escapeHtml(text) {
+    return window.NoteEditor?.escapeHtml(text) ?? String(text ?? '');
+  },
 
   // Convert hex color to rgba string
   hexToRgba(hex, alpha) {
@@ -5730,7 +6383,12 @@ const sessionManager = {
   // Show toast notification
   showToast(message, type = 'info') {
     const normalizedType = (type || 'info').toLowerCase();
-    const toastType = normalizedType === 'danger' ? 'error' : normalizedType === 'warn' ? 'warning' : normalizedType;
+    const toastType =
+      normalizedType === 'danger'
+        ? 'error'
+        : normalizedType === 'warn'
+          ? 'warning'
+          : normalizedType;
 
     if (typeof window.notifyToast === 'function') {
       window.notifyToast(message, toastType);
@@ -5773,28 +6431,62 @@ const sessionManager = {
   noteModalHideInProgress: false,
   noteModalAllowHide: false,
   noteAIGeneratedDraft: null,
-  get noteLive() { return this._ensureMount()?.live ?? null; },
-  set noteLive(_v) { /* no-op — mount owns the live instance */ },
+  get noteLive() {
+    return this._ensureMount()?.live ?? null;
+  },
+  set noteLive(_v) {
+    /* no-op — mount owns the live instance */
+  },
   // Back-compat: the original sessionManager exposed `noteLiveState` as a
   // bare object. That alias still resolves to the controller's state.
-  get noteLiveState() { return this._ensureLive()?.state; },
+  get noteLiveState() {
+    return this._ensureLive()?.state;
+  },
   // Field-level back-compat. Callers that read/write `this.noteLive*` keep
   // working — the getters/setters target the controller's state.
-  get noteLiveActiveLineIndex() { return this._ensureLive()?.state.activeLineIndex ?? null; },
-  set noteLiveActiveLineIndex(v) { const s = this._ensureLive()?.state; if (s) s.activeLineIndex = v; },
-  get noteLiveActiveRange() { return this._ensureLive()?.state.activeRange ?? null; },
-  set noteLiveActiveRange(v) { const s = this._ensureLive()?.state; if (s) s.activeRange = v; },
-  get noteLiveSelectionAnchorIndex() { return this._ensureLive()?.state.selectionAnchorIndex ?? null; },
-  set noteLiveSelectionAnchorIndex(v) { const s = this._ensureLive()?.state; if (s) s.selectionAnchorIndex = v; },
-  get noteLiveSelectionFocusIndex() { return this._ensureLive()?.state.selectionFocusIndex ?? null; },
-  set noteLiveSelectionFocusIndex(v) { const s = this._ensureLive()?.state; if (s) s.selectionFocusIndex = v; },
-  get noteLivePointerDown() { return this._ensureLive()?.state.pointerDown ?? null; },
-  set noteLivePointerDown(v) { const s = this._ensureLive()?.state; if (s) s.pointerDown = v; },
+  get noteLiveActiveLineIndex() {
+    return this._ensureLive()?.state.activeLineIndex ?? null;
+  },
+  set noteLiveActiveLineIndex(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.activeLineIndex = v;
+  },
+  get noteLiveActiveRange() {
+    return this._ensureLive()?.state.activeRange ?? null;
+  },
+  set noteLiveActiveRange(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.activeRange = v;
+  },
+  get noteLiveSelectionAnchorIndex() {
+    return this._ensureLive()?.state.selectionAnchorIndex ?? null;
+  },
+  set noteLiveSelectionAnchorIndex(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.selectionAnchorIndex = v;
+  },
+  get noteLiveSelectionFocusIndex() {
+    return this._ensureLive()?.state.selectionFocusIndex ?? null;
+  },
+  set noteLiveSelectionFocusIndex(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.selectionFocusIndex = v;
+  },
+  get noteLivePointerDown() {
+    return this._ensureLive()?.state.pointerDown ?? null;
+  },
+  set noteLivePointerDown(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.pointerDown = v;
+  },
   get noteLiveCollapsedHeadings() {
     const s = this._ensureLive()?.state;
     return s ? s.collapsedHeadings : new Set();
   },
-  set noteLiveCollapsedHeadings(v) { const s = this._ensureLive()?.state; if (s) s.collapsedHeadings = v; },
+  set noteLiveCollapsedHeadings(v) {
+    const s = this._ensureLive()?.state;
+    if (s) s.collapsedHeadings = v;
+  },
 
   // _ensureMount builds the four-controller bundle on first access. The
   // mount factory wires history/autosave/toc/live to a shared sub-host.
@@ -5807,40 +6499,57 @@ const sessionManager = {
     // _readNoteSelection).
     this.noteMount = window.NoteEditor.mount({
       getContent: () => this.getNoteContentValue(),
-      setContent: (v) => this.setNoteContentValue(v),
+      setContent: v => this.setNoteContentValue(v),
       getContentLines: () => this.getNoteContentLines(),
-      setContentLines: (lines) => this.setNoteContentLines(lines),
+      setContentLines: lines => this.setNoteContentLines(lines),
       isPreviewMode: () => this.isNotePreviewMode,
       onAutosaveFlush: () => this.autoSaveNote(),
       aiAssist: {
         readSelection: () => this._readNoteSelection(),
-        showToast: (msg, kind) => this.showToast?.(msg, kind),
-      },
+        showToast: (msg, kind) => this.showToast?.(msg, kind)
+      }
     });
     window.NoteWikilinks?.setWorkspaceContext(
-      () => this.noteModalWorkspaceId || this.currentNote?.workspace_id || null,
+      () => this.noteModalWorkspaceId || this.currentNote?.workspace_id || null
     );
     // Left-rail Notes tab: lazy-init the list. The rail is always shown when
     // the editor is in preview mode, so the user can switch to Notes even
     // when this note has no headings.
     window.NoteRailNotes?.initRail({
-      workspaceIdResolver: () => this.noteModalWorkspaceId || this.currentNote?.workspace_id || null,
-      activeNoteId: this.currentNote?.id || null,
+      workspaceIdResolver: () =>
+        this.noteModalWorkspaceId || this.currentNote?.workspace_id || null,
+      activeNoteId: this.currentNote?.id || null
     });
     return this.noteMount;
   },
 
-  _ensureLive() { return this._ensureMount()?.live ?? null; },
+  _ensureLive() {
+    return this._ensureMount()?.live ?? null;
+  },
   // Compat alias kept for any sites that still spell it _ensureLiveState.
-  _ensureLiveState() { return this._ensureLive()?.state; },
+  _ensureLiveState() {
+    return this._ensureLive()?.state;
+  },
   // History / autosave / toc all live in the mount bundle. Backward-compat
   // getters/setters keep call sites that read `this.note*` working.
-  get noteHistory() { return this._ensureMount()?.history ?? null; },
-  set noteHistory(_v) { /* no-op — mount owns it */ },
-  get noteAutoSave() { return this._ensureMount()?.autosave ?? null; },
-  set noteAutoSave(_v) { /* no-op — mount owns it */ },
-  get noteToc() { return this._ensureMount()?.toc ?? null; },
-  set noteToc(_v) { /* no-op — mount owns it */ },
+  get noteHistory() {
+    return this._ensureMount()?.history ?? null;
+  },
+  set noteHistory(_v) {
+    /* no-op — mount owns it */
+  },
+  get noteAutoSave() {
+    return this._ensureMount()?.autosave ?? null;
+  },
+  set noteAutoSave(_v) {
+    /* no-op — mount owns it */
+  },
+  get noteToc() {
+    return this._ensureMount()?.toc ?? null;
+  },
+  set noteToc(_v) {
+    /* no-op — mount owns it */
+  },
 
   // Load notes for a folder
   async loadFolderNotes(folderId) {
@@ -5860,9 +6569,8 @@ const sessionManager = {
   async createFileReferenceNote(folderId, file) {
     const name = `📎 ${file.name}`;
     const sizeKB = (file.size / 1024).toFixed(1);
-    const sizeStr = file.size > 1024 * 1024
-      ? `${(file.size / (1024 * 1024)).toFixed(1)} MB`
-      : `${sizeKB} KB`;
+    const sizeStr =
+      file.size > 1024 * 1024 ? `${(file.size / (1024 * 1024)).toFixed(1)} MB` : `${sizeKB} KB`;
 
     // Upload file to server
     let serverPath = '';
@@ -5890,11 +6598,24 @@ const sessionManager = {
 
     let content = `**File:** ${file.name}\n**Size:** ${sizeStr}\n**Type:** ${file.type || 'unknown'}\n**Path:** ${serverPath}`;
 
-    const textExtensions = ['txt', 'md', 'json', 'xml', 'html', 'css', 'js', 'ts', 'csv', 'yaml', 'yml'];
+    const textExtensions = [
+      'txt',
+      'md',
+      'json',
+      'xml',
+      'html',
+      'css',
+      'js',
+      'ts',
+      'csv',
+      'yaml',
+      'yml'
+    ];
     const ext = file.name.split('.').pop()?.toLowerCase();
 
     // For text files, include readable preview
-    if (textExtensions.includes(ext) && file.size < 50 * 1024) { // Under 50KB
+    if (textExtensions.includes(ext) && file.size < 50 * 1024) {
+      // Under 50KB
       try {
         const text = await file.text();
         const preview = text.length > 2000 ? text.substring(0, 2000) + '\n...' : text;
@@ -6102,14 +6823,18 @@ const sessionManager = {
 
     return `
       <div class="folder-notes-section">
-        ${notes.map(note => `
+        ${notes
+          .map(
+            note => `
           <div class="folder-note-item" data-note-id="${note.id}" data-folder-id="${folderId}" draggable="true">
             <svg class="folder-note-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
               <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,9V3.5L18.5,9H13"/>
             </svg>
             <span class="folder-note-name">${this.escapeHtml(note.name)}</span>
           </div>
-        `).join('')}
+        `
+          )
+          .join('')}
       </div>
     `;
   },
@@ -6122,7 +6847,7 @@ const sessionManager = {
   bindNoteEvents() {
     // Note click to open editor (folder tree items). Routes via openNote so
     // it respects the user's notes_open_behavior preference.
-    document.addEventListener('click', (e) => {
+    document.addEventListener('click', e => {
       const noteItem = e.target.closest('.folder-note-item');
       if (noteItem) {
         e.preventDefault();
@@ -6139,11 +6864,10 @@ const sessionManager = {
         const noteId = searchNoteItem.dataset.noteId;
         this.openNote(noteId);
       }
-
     });
 
     // Note context menu
-    document.addEventListener('contextmenu', (e) => {
+    document.addEventListener('contextmenu', e => {
       const noteItem = e.target.closest('.folder-note-item');
       if (noteItem) {
         e.preventDefault();
@@ -6156,7 +6880,7 @@ const sessionManager = {
 
     // Note context menu actions
     document.querySelectorAll('#noteContextMenu .session-context-item').forEach(item => {
-      item.addEventListener('click', (e) => {
+      item.addEventListener('click', e => {
         e.stopPropagation();
         const action = e.currentTarget.dataset.action;
         this.handleNoteContextAction(action);
@@ -6165,11 +6889,17 @@ const sessionManager = {
 
     // Note editor save button
     document.getElementById('saveNoteBtn')?.addEventListener('click', () => this.saveCurrentNote());
-    document.getElementById('noteCopyBtn')?.addEventListener('click', () => this.copyCurrentNoteContent());
-    document.getElementById('noteOpenInPageBtn')?.addEventListener('click', () => this.openCurrentNoteAsPage());
+    document
+      .getElementById('noteCopyBtn')
+      ?.addEventListener('click', () => this.copyCurrentNoteContent());
+    document
+      .getElementById('noteOpenInPageBtn')
+      ?.addEventListener('click', () => this.openCurrentNoteAsPage());
 
     // Auto-save: listen for input changes on note title and content
-    document.getElementById('noteNameInput')?.addEventListener('input', () => this.scheduleNoteAutoSave());
+    document
+      .getElementById('noteNameInput')
+      ?.addEventListener('input', () => this.scheduleNoteAutoSave());
     document.getElementById('noteContentInput')?.addEventListener('input', () => {
       this.scheduleNoteAutoSave();
       if (this.isNotePreviewMode) {
@@ -6180,7 +6910,7 @@ const sessionManager = {
 
     // Auto-save before modal close (if there are unsaved changes). The hide
     // event is cancellable; hidden.bs.modal is too late to protect edits.
-    document.getElementById('noteEditorModal')?.addEventListener('hide.bs.modal', (event) => {
+    document.getElementById('noteEditorModal')?.addEventListener('hide.bs.modal', event => {
       this.handleNoteModalBeforeHide(event);
     });
     document.getElementById('noteEditorModal')?.addEventListener('hidden.bs.modal', () => {
@@ -6188,13 +6918,13 @@ const sessionManager = {
     });
 
     // Note workspace selector
-    document.getElementById('noteWorkspaceChange')?.addEventListener('click', (e) => {
+    document.getElementById('noteWorkspaceChange')?.addEventListener('click', e => {
       e.preventDefault();
       e.stopPropagation();
       this.showNoteWorkspaceSelector();
     });
 
-    document.getElementById('noteWorkspaceSelect')?.addEventListener('change', (e) => {
+    document.getElementById('noteWorkspaceSelect')?.addEventListener('change', e => {
       const workspaceId = e.target.value;
       if (!workspaceId) {
         this.noteModalWorkspaceId = null;
@@ -6205,25 +6935,41 @@ const sessionManager = {
     });
 
     // Note preview toggle
-    document.getElementById('notePreviewToggle')?.addEventListener('click', () => this.toggleNotePreview());
+    document
+      .getElementById('notePreviewToggle')
+      ?.addEventListener('click', () => this.toggleNotePreview());
 
     // Note AI generation toggle
     window.NoteEditor?.bindGenerateToggleButton?.();
 
     // Rail collapse toggles (TOC + AI Assist). The buttons stay hidden until
     // the corresponding feature (tasks 3.0 / 4.0) reveals them.
-    document.getElementById('noteTocToggle')?.addEventListener('click', () => this.toggleNoteTocRail());
-    document.getElementById('noteAssistToggle')?.addEventListener('click', () => this.toggleNoteAssistRail());
+    document
+      .getElementById('noteTocToggle')
+      ?.addEventListener('click', () => this.toggleNoteTocRail());
+    document
+      .getElementById('noteAssistToggle')
+      ?.addEventListener('click', () => this.toggleNoteAssistRail());
 
     // Note AI generation buttons
-    document.getElementById('noteAIGenerateBtn')?.addEventListener('click', () => this.generateNoteWithAI());
-    document.getElementById('noteAICancelBtn')?.addEventListener('click', () => this.hideNoteAIPanel());
-    document.getElementById('noteAIReplaceBtn')?.addEventListener('click', () => this.applyGeneratedNoteDraft('replace'));
-    document.getElementById('noteAIAppendBtn')?.addEventListener('click', () => this.applyGeneratedNoteDraft('append'));
-    document.getElementById('noteAIInsertBtn')?.addEventListener('click', () => this.applyGeneratedNoteDraft('insert'));
+    document
+      .getElementById('noteAIGenerateBtn')
+      ?.addEventListener('click', () => this.generateNoteWithAI());
+    document
+      .getElementById('noteAICancelBtn')
+      ?.addEventListener('click', () => this.hideNoteAIPanel());
+    document
+      .getElementById('noteAIReplaceBtn')
+      ?.addEventListener('click', () => this.applyGeneratedNoteDraft('replace'));
+    document
+      .getElementById('noteAIAppendBtn')
+      ?.addEventListener('click', () => this.applyGeneratedNoteDraft('append'));
+    document
+      .getElementById('noteAIInsertBtn')
+      ?.addEventListener('click', () => this.applyGeneratedNoteDraft('insert'));
 
     // Note drag start
-    document.addEventListener('dragstart', (e) => {
+    document.addEventListener('dragstart', e => {
       const noteItem = e.target.closest('.folder-note-item');
       if (noteItem) {
         const noteId = noteItem.dataset.noteId;
@@ -6237,7 +6983,7 @@ const sessionManager = {
     });
 
     // Note drag end
-    document.addEventListener('dragend', (e) => {
+    document.addEventListener('dragend', e => {
       const noteItem = e.target.closest('.folder-note-item');
       if (noteItem) {
         noteItem.classList.remove('dragging');
@@ -6322,7 +7068,10 @@ const sessionManager = {
       return;
     }
 
-    this.showToast('No attached file found in this note. Re-drop the file to enable this feature.', 'error');
+    this.showToast(
+      'No attached file found in this note. Re-drop the file to enable this feature.',
+      'error'
+    );
   },
 
   // Attach file from server storage
@@ -6415,7 +7164,7 @@ const sessionManager = {
       window.NoteAIAssist?.onNoteOpened({
         noteId: null,
         workspaceId: workspaceId || null,
-        agentId: this._resolveWorkspaceAgentId(),
+        agentId: this._resolveWorkspaceAgentId()
       });
     });
 
@@ -6457,9 +7206,15 @@ const sessionManager = {
     if (changeBtn) changeBtn.style.display = allowChange ? 'inline-flex' : 'none';
   },
 
-  normalizeNoteVaultReference(ref) { return window.NoteEditor?.normalizeVaultReference(ref) ?? null; },
-  showNoteVaultReferenceBadge(ref) { window.NoteEditor?.showVaultReferenceBadge(ref); },
-  hideNoteVaultReferenceBadge() { window.NoteEditor?.hideVaultReferenceBadge(); },
+  normalizeNoteVaultReference(ref) {
+    return window.NoteEditor?.normalizeVaultReference(ref) ?? null;
+  },
+  showNoteVaultReferenceBadge(ref) {
+    window.NoteEditor?.showVaultReferenceBadge(ref);
+  },
+  hideNoteVaultReferenceBadge() {
+    window.NoteEditor?.hideVaultReferenceBadge();
+  },
 
   showNoteWorkspaceSelector() {
     const badge = document.getElementById('noteWorkspaceBadge');
@@ -6538,11 +7293,13 @@ const sessionManager = {
       const elsewhere = await window.NotePresence?.isOpenElsewhere?.(noteId);
       if (elsewhere?.open && elsewhere.surface === 'page') {
         const proceed = window.confirm(
-          'This note is already open in another browser tab. Open it here too?',
+          'This note is already open in another browser tab. Open it here too?'
         );
         if (!proceed) return;
       }
-    } catch (_) { /* non-fatal */ }
+    } catch (_) {
+      /* non-fatal */
+    }
 
     const note = await this.getNote(noteId);
     if (!note) return;
@@ -6630,7 +7387,7 @@ const sessionManager = {
       window.NoteAIAssist?.onNoteOpened({
         noteId: note.id,
         workspaceId: this.noteModalWorkspaceId,
-        agentId: this._resolveWorkspaceAgentId(),
+        agentId: this._resolveWorkspaceAgentId()
       });
     });
     // Backlinks: notes referencing this one via [[wikilinks]]. Hidden when none.
@@ -6695,7 +7452,7 @@ const sessionManager = {
         isPreviewMode: this.isNotePreviewMode,
         textareaLen: (contentInput.value || '').length,
         previewDisplay: previewContent.style.display,
-        previewInnerHTMLLen: previewContent.innerHTML.length,
+        previewInnerHTMLLen: previewContent.innerHTML.length
       });
       this.setNotePreviewMode(false);
     }
@@ -6797,7 +7554,8 @@ const sessionManager = {
         this.showNoteWorkspaceBadge(workspaceId, false);
         window.NoteBacklinks?.announceNoteSaved?.(created.id, noteContent.includes('[['));
         const lastSaved = document.getElementById('noteLastSaved');
-        if (lastSaved) lastSaved.textContent = `Last saved: ${this.formatDateTime(created.updated_at || created.created_at)}`;
+        if (lastSaved)
+          lastSaved.textContent = `Last saved: ${this.formatDateTime(created.updated_at || created.created_at)}`;
       } else {
         this.updateNoteSaveStatus('error');
       }
@@ -6815,7 +7573,8 @@ const sessionManager = {
       this.noteAutoSave?.markClean();
       this.showToast('Note saved', 'success');
       const lastSaved = document.getElementById('noteLastSaved');
-      if (lastSaved) lastSaved.textContent = `Last saved: ${this.formatDateTime(updated.updated_at || this.currentNote.updated_at)}`;
+      if (lastSaved)
+        lastSaved.textContent = `Last saved: ${this.formatDateTime(updated.updated_at || this.currentNote.updated_at)}`;
 
       // Refresh folder tree to show updated note name
       this.renderFolderTree();
@@ -6829,9 +7588,13 @@ const sessionManager = {
   // =============================================================================
 
   // Schedule auto-save with debounce
-  _ensureNoteAutoSave() { return this._ensureMount()?.autosave ?? null; },
+  _ensureNoteAutoSave() {
+    return this._ensureMount()?.autosave ?? null;
+  },
 
-  scheduleNoteAutoSave() { this._ensureNoteAutoSave()?.schedule(); },
+  scheduleNoteAutoSave() {
+    this._ensureNoteAutoSave()?.schedule();
+  },
 
   // Performs one autosave attempt. Called by the timer or by handleNoteModalClose.
   async autoSaveNote() {
@@ -6851,7 +7614,10 @@ const sessionManager = {
           this.currentNote = { ...this.currentNote, ...updated };
           this.renderFolderTree();
           // Notify other tabs so any open Backlinks panel can re-fetch.
-          window.NoteBacklinks?.announceNoteSaved?.(this.currentNote.id, noteContent.includes('[['));
+          window.NoteBacklinks?.announceNoteSaved?.(
+            this.currentNote.id,
+            noteContent.includes('[[')
+          );
           return true;
         } else {
           return false;
@@ -6884,10 +7650,9 @@ const sessionManager = {
     const saveBtn = document.getElementById('saveNoteBtn');
     if (!saveBtn) return;
     const isCreate = !this.currentNote?.id;
-    saveBtn.textContent = isCreate
-      ? 'Create note'
-      : (status === 'error' ? 'Retry save' : 'Save now');
-    saveBtn.hidden = !isCreate && !(status === 'unsaved' || status === 'error' || status === 'saving');
+    saveBtn.textContent = isCreate ? 'Create note' : status === 'error' ? 'Retry save' : 'Save now';
+    saveBtn.hidden =
+      !isCreate && !(status === 'unsaved' || status === 'error' || status === 'saving');
     saveBtn.disabled = status === 'saving';
   },
 
@@ -6907,22 +7672,26 @@ const sessionManager = {
     if (this.noteModalHideInProgress) return;
     this.noteModalHideInProgress = true;
 
-    timer.flushImmediate().then((saved) => {
-      if (saved === false) {
+    timer
+      .flushImmediate()
+      .then(saved => {
+        if (saved === false) {
+          this.showToast('Save failed. Retry save before closing this note.', 'error');
+          this.updateNoteSaveStatus('error');
+          return;
+        }
+        this.noteModalAllowHide = true;
+        const modal = bootstrap.Modal.getInstance(document.getElementById('noteEditorModal'));
+        modal?.hide();
+      })
+      .catch(error => {
+        console.error('Auto-save before modal close failed:', error);
         this.showToast('Save failed. Retry save before closing this note.', 'error');
         this.updateNoteSaveStatus('error');
-        return;
-      }
-      this.noteModalAllowHide = true;
-      const modal = bootstrap.Modal.getInstance(document.getElementById('noteEditorModal'));
-      modal?.hide();
-    }).catch((error) => {
-      console.error('Auto-save before modal close failed:', error);
-      this.showToast('Save failed. Retry save before closing this note.', 'error');
-      this.updateNoteSaveStatus('error');
-    }).finally(() => {
-      this.noteModalHideInProgress = false;
-    });
+      })
+      .finally(() => {
+        this.noteModalHideInProgress = false;
+      });
   },
 
   handleNoteModalHidden() {
@@ -6930,7 +7699,9 @@ const sessionManager = {
     this.noteModalHideInProgress = false;
   },
 
-  resetNoteAutoSaveState() { this._ensureNoteAutoSave()?.reset(); },
+  resetNoteAutoSaveState() {
+    this._ensureNoteAutoSave()?.reset();
+  },
 
   // =============================================================================
   // Note Editor Rails (TOC + AI Assist)
@@ -6939,14 +7710,30 @@ const sessionManager = {
   // showNoteTocRail() / showNoteAssistRail() once they have content to display.
   // The collapse toggle is per-rail and persisted in localStorage.
 
-  _applyNoteRailState() { window.NoteEditor?.applyAllRailState(); },
-  _applyNoteRailCollapsed(rail) { window.NoteEditor?.applyRailCollapsed(rail); },
-  toggleNoteTocRail() { window.NoteEditor?.toggleRail('toc'); },
-  toggleNoteAssistRail() { window.NoteEditor?.toggleRail('assist'); },
-  showNoteTocRail() { window.NoteEditor?.showRail('toc'); },
-  hideNoteTocRail() { window.NoteEditor?.hideRail('toc'); },
-  showNoteAssistRail() { window.NoteEditor?.showRail('assist'); },
-  hideNoteAssistRail() { window.NoteEditor?.hideRail('assist'); },
+  _applyNoteRailState() {
+    window.NoteEditor?.applyAllRailState();
+  },
+  _applyNoteRailCollapsed(rail) {
+    window.NoteEditor?.applyRailCollapsed(rail);
+  },
+  toggleNoteTocRail() {
+    window.NoteEditor?.toggleRail('toc');
+  },
+  toggleNoteAssistRail() {
+    window.NoteEditor?.toggleRail('assist');
+  },
+  showNoteTocRail() {
+    window.NoteEditor?.showRail('toc');
+  },
+  hideNoteTocRail() {
+    window.NoteEditor?.hideRail('toc');
+  },
+  showNoteAssistRail() {
+    window.NoteEditor?.showRail('assist');
+  },
+  hideNoteAssistRail() {
+    window.NoteEditor?.hideRail('assist');
+  },
 
   // =============================================================================
   // Note AI Assist (selection action bar + sidebar wiring)
@@ -6955,17 +7742,23 @@ const sessionManager = {
   // AI Assist is now wired through the mount() call (see _ensureMount).
   // _initNoteAIAssist stays as a no-op for any historical callers; the
   // first time `_ensureMount` runs, NoteAIAssist is hooked up.
-  _initNoteAIAssist() { this._ensureMount(); },
+  _initNoteAIAssist() {
+    this._ensureMount();
+  },
 
   async _setNoteAIAgentDefault(workspaceId) {
     return window.NoteEditor?.applyAgentDefaultForWorkspace(workspaceId);
   },
 
-  _wireNoteAIAgentChange() { window.NoteEditor?.wireAgentChangeHandler(); },
-  _resolveWorkspaceAgentId() { return window.NoteEditor?.getSelectedAgentId() ?? null; },
+  _wireNoteAIAgentChange() {
+    window.NoteEditor?.wireAgentChangeHandler();
+  },
+  _resolveWorkspaceAgentId() {
+    return window.NoteEditor?.getSelectedAgentId() ?? null;
+  },
   _wireNoteSelectionTracking() {
     window.NoteEditor?.wireSelectionTracking({
-      onChange: () => window.NoteAIAssist?.onSelectionChanged(this._readNoteSelection()),
+      onChange: () => window.NoteAIAssist?.onSelectionChanged(this._readNoteSelection())
     });
   },
 
@@ -6974,10 +7767,12 @@ const sessionManager = {
   _readNoteSelection() {
     const modal = document.getElementById('noteEditorModal');
     if (!modal || !modal.classList.contains('show')) return null;
-    return window.NoteEditor?.readSelection({
-      getContent: () => this.getNoteContentValue(),
-      isPreviewMode: () => this.isNotePreviewMode,
-    }) ?? null;
+    return (
+      window.NoteEditor?.readSelection({
+        getContent: () => this.getNoteContentValue(),
+        isPreviewMode: () => this.isNotePreviewMode
+      }) ?? null
+    );
   },
 
   // =============================================================================
@@ -6989,18 +7784,30 @@ const sessionManager = {
 
   // Debounced wrapper called from the input listener — TOC rebuild is cheap
   // but we still avoid running on every keystroke.
-  _ensureNoteToc() { return this._ensureMount()?.toc ?? null; },
+  _ensureNoteToc() {
+    return this._ensureMount()?.toc ?? null;
+  },
 
-  _scheduleNoteTocRebuild() { this._ensureNoteToc()?.scheduleRebuild(); },
-  _renderNoteTocOutline() { this._ensureNoteToc()?.rebuild(); },
+  _scheduleNoteTocRebuild() {
+    this._ensureNoteToc()?.scheduleRebuild();
+  },
+  _renderNoteTocOutline() {
+    this._ensureNoteToc()?.rebuild();
+  },
   _scrollNoteToHeading(position) {
     window.NoteEditor?.scrollToHeadingPosition(this.getNoteContentValue(), position);
   },
   _findRenderedHeadingByPosition(position) {
-    return window.NoteEditor?.findRenderedHeadingByPosition(this.getNoteContentValue(), position) ?? null;
+    return (
+      window.NoteEditor?.findRenderedHeadingByPosition(this.getNoteContentValue(), position) ?? null
+    );
   },
-  _attachNoteTocActiveObserver() { this._ensureNoteToc()?.attachObserver(); },
-  _teardownNoteTocActiveObserver() { this.noteToc?.detachObserver(); },
+  _attachNoteTocActiveObserver() {
+    this._ensureNoteToc()?.attachObserver();
+  },
+  _teardownNoteTocActiveObserver() {
+    this.noteToc?.detachObserver();
+  },
   _setActiveTocEntry(lineIndex) {
     window.NoteEditor?.setActiveTocEntry(lineIndex, this.getNoteContentValue());
   },
@@ -7009,8 +7816,12 @@ const sessionManager = {
   // Note AI Generation
   // =============================================================================
 
-  _openGeneratePanelByDefault() { window.NoteEditor?.openGeneratePanelByDefault(); },
-  toggleNoteAIPanel() { window.NoteEditor?.toggleGeneratePanel(); },
+  _openGeneratePanelByDefault() {
+    window.NoteEditor?.openGeneratePanelByDefault();
+  },
+  toggleNoteAIPanel() {
+    window.NoteEditor?.toggleGeneratePanel();
+  },
   hideNoteAIPanel() {
     this.noteAIGeneratedDraft = null;
     window.NoteEditor?.closeGeneratePanel();
@@ -7020,7 +7831,11 @@ const sessionManager = {
   // so the dropdown filters to that workspace's bound agents instead of every
   // agent in the system.
   async loadNoteAIAgents() {
-    const workspaceId = this.noteModalWorkspaceId || this.currentNote?.workspace_id || this.currentNote?.folder_id || '';
+    const workspaceId =
+      this.noteModalWorkspaceId ||
+      this.currentNote?.workspace_id ||
+      this.currentNote?.folder_id ||
+      '';
     return window.NoteEditor?.loadAgentsIntoDropdown(workspaceId);
   },
 
@@ -7041,7 +7856,9 @@ const sessionManager = {
     if (panelSelection && panelSelection.text) {
       const ok = window.NoteAIAssist?.dispatchAsk?.(panelSelection, prompt);
       if (!ok) {
-        window.NoteEditor?.setGenerateError?.('Could not dispatch — select a workspace agent first.');
+        window.NoteEditor?.setGenerateError?.(
+          'Could not dispatch — select a workspace agent first.'
+        );
         return;
       }
       window.NoteEditor?.closeGeneratePanel?.();
@@ -7050,7 +7867,11 @@ const sessionManager = {
 
     const agentSelect = document.getElementById('noteAIAgentSelect');
     const agentId = agentSelect?.value || '';
-    const workspaceId = this.noteModalWorkspaceId || this.currentNote?.workspace_id || this.currentNote?.folder_id || '';
+    const workspaceId =
+      this.noteModalWorkspaceId ||
+      this.currentNote?.workspace_id ||
+      this.currentNote?.folder_id ||
+      '';
 
     window.NoteEditor?.setGenerateError?.('');
     window.NoteEditor?.setGenerateStatus?.('');
@@ -7070,20 +7891,24 @@ const sessionManager = {
 
       if (!response.ok) {
         let payload = null;
-        try { payload = await response.json(); } catch (_) {}
+        try {
+          payload = await response.json();
+        } catch (_) {}
         throw new Error(payload?.error || 'Failed to generate note');
       }
 
       const result = await response.json();
       this.noteAIGeneratedDraft = {
         title: result.title || '',
-        content: result.content || '',
+        content: result.content || ''
       };
       window.NoteEditor?.setGenerateDraft?.(this.noteAIGeneratedDraft);
       this.showToast('AI draft generated', 'success');
     } catch (error) {
       console.error('Note AI generation failed:', error);
-      window.NoteEditor?.setGenerateError?.(error.message || 'Failed to generate note content. Please try again.');
+      window.NoteEditor?.setGenerateError?.(
+        error.message || 'Failed to generate note content. Please try again.'
+      );
     } finally {
       window.NoteEditor?.setGenerateBusy?.(false);
     }
@@ -7112,7 +7937,9 @@ const sessionManager = {
         ? `${currentContent.replace(/\s+$/, '')}\n\n${draftContent}`
         : draftContent;
     } else if (mode === 'insert') {
-      const start = Number.isInteger(contentInput.selectionStart) ? contentInput.selectionStart : currentContent.length;
+      const start = Number.isInteger(contentInput.selectionStart)
+        ? contentInput.selectionStart
+        : currentContent.length;
       const end = Number.isInteger(contentInput.selectionEnd) ? contentInput.selectionEnd : start;
       nextContent = `${currentContent.slice(0, start)}${draftContent}${currentContent.slice(end)}`;
       const cursor = start + draftContent.length;
@@ -7254,8 +8081,12 @@ const sessionManager = {
     this.noteLiveCollapsedHeadings = new Set();
   },
 
-  getNoteContentValue() { return window.NoteEditor?.getContentValue() ?? ''; },
-  setNoteContentValue(value) { window.NoteEditor?.setContentValue(value); },
+  getNoteContentValue() {
+    return window.NoteEditor?.getContentValue() ?? '';
+  },
+  setNoteContentValue(value) {
+    window.NoteEditor?.setContentValue(value);
+  },
 
   pushNoteUndoState() {
     if (!this.noteHistory) this.resetNoteHistory();
@@ -7275,7 +8106,9 @@ const sessionManager = {
       this.renderNoteLiveEditor();
       const lines = this.getNoteContentLines();
       const focusIndex = Math.max(0, Math.min(options.focusLineIndex ?? 0, lines.length - 1));
-      const focusLine = document.querySelector(`.note-live-line-rendered[data-line-index="${focusIndex}"]`);
+      const focusLine = document.querySelector(
+        `.note-live-line-rendered[data-line-index="${focusIndex}"]`
+      );
       focusLine?.focus({ preventScroll: true });
     }
   },
@@ -7296,8 +8129,12 @@ const sessionManager = {
     return true;
   },
 
-  isNoteUndoShortcut(event) { return window.NoteEditor?.isUndoShortcut(event) ?? false; },
-  isNoteRedoShortcut(event) { return window.NoteEditor?.isRedoShortcut(event) ?? false; },
+  isNoteUndoShortcut(event) {
+    return window.NoteEditor?.isUndoShortcut(event) ?? false;
+  },
+  isNoteRedoShortcut(event) {
+    return window.NoteEditor?.isRedoShortcut(event) ?? false;
+  },
 
   handleNoteHistoryShortcut(event) {
     if (this.isNoteUndoShortcut(event)) {
@@ -7323,15 +8160,25 @@ const sessionManager = {
     this.renderNoteLiveEditor();
   },
 
-  getNoteContentLines() { return window.NoteEditor?.getContentLines() ?? ['']; },
-  setNoteContentLines(lines) { window.NoteEditor?.setContentLines(lines); },
+  getNoteContentLines() {
+    return window.NoteEditor?.getContentLines() ?? [''];
+  },
+  setNoteContentLines(lines) {
+    window.NoteEditor?.setContentLines(lines);
+  },
 
   // The following four helpers were moved to note-editor.js as the first slice
   // of the v2 task 1.0 extraction. The thin delegators stay here so existing
   // callers (this.noteHeadingLevel(...), etc.) keep working untouched.
-  noteHeadingLevel(line) { return window.NoteEditor?.parseHeadingLevel(line) ?? 0; },
-  noteLineKindClass(line) { return window.NoteEditor?.lineKindClass(line) ?? ''; },
-  parseNoteTaskLine(line) { return window.NoteEditor?.parseTaskLine(line) ?? null; },
+  noteHeadingLevel(line) {
+    return window.NoteEditor?.parseHeadingLevel(line) ?? 0;
+  },
+  noteLineKindClass(line) {
+    return window.NoteEditor?.lineKindClass(line) ?? '';
+  },
+  parseNoteTaskLine(line) {
+    return window.NoteEditor?.parseTaskLine(line) ?? null;
+  },
   normalizeCompactTaskListMarkdown(text) {
     return window.NoteEditor?.normalizeCompactTaskListMarkdown(text) ?? String(text || '');
   },
@@ -7340,7 +8187,9 @@ const sessionManager = {
     window.NoteEditor?.pruneCollapsedHeadings(lines, this.noteLiveCollapsedHeadings);
   },
 
-  renderNoteLiveEditor(options = {}) { this._ensureMount()?.render(options); },
+  renderNoteLiveEditor(options = {}) {
+    this._ensureMount()?.render(options);
+  },
 
   renderNoteLiveInputLine(line, index) {
     return window.NoteEditor?.renderEditingLine(line, index) ?? '';
@@ -7361,7 +8210,9 @@ const sessionManager = {
     return window.NoteEditor?.renderTaskLine(line, index) ?? '';
   },
 
-  bindNoteLiveEditorEvents(previewContent) { this._ensureLive()?.bindEvents(previewContent); },
+  bindNoteLiveEditorEvents(previewContent) {
+    this._ensureLive()?.bindEvents(previewContent);
+  },
 
   noteLiveSelectionContains(container, node) {
     return window.NoteEditor?.selectionContains(container, node) ?? false;
@@ -7386,44 +8237,69 @@ const sessionManager = {
     return window.NoteEditor?.getSelectedLineRange(container) ?? null;
   },
 
-  isNoteLivePrintableKey(event) { return window.NoteEditor?.isPrintableKey(event) ?? false; },
+  isNoteLivePrintableKey(event) {
+    return window.NoteEditor?.isPrintableKey(event) ?? false;
+  },
 
   toggleNoteHeadingFold(lineIndex) {
     this._ensureLive()?.toggleHeadingFold(lineIndex);
     // Restore focus to the fold button so keyboard users keep their place.
-    document.querySelector(`.note-heading-fold[data-line-index="${lineIndex}"]`)
+    document
+      .querySelector(`.note-heading-fold[data-line-index="${lineIndex}"]`)
       ?.focus({ preventScroll: true });
   },
 
   toggleNoteTaskLine(lineIndex, checked) {
     this._ensureLive()?.toggleTaskLine(lineIndex, checked);
-    document.querySelector(`.note-task-checkbox[data-line-index="${lineIndex}"]`)
+    document
+      .querySelector(`.note-task-checkbox[data-line-index="${lineIndex}"]`)
       ?.focus({ preventScroll: true });
   },
 
-  deleteNoteLiveLineRange(range) { this._ensureLive()?.deleteRange(range); },
-  replaceNoteLiveLineRange(range, replacement) { this._ensureLive()?.replaceRange(range, replacement); },
-  editNoteLiveLineRange(range) { this._ensureLive()?.editRange(range); },
+  deleteNoteLiveLineRange(range) {
+    this._ensureLive()?.deleteRange(range);
+  },
+  replaceNoteLiveLineRange(range, replacement) {
+    this._ensureLive()?.replaceRange(range, replacement);
+  },
+  editNoteLiveLineRange(range) {
+    this._ensureLive()?.editRange(range);
+  },
   activateNoteLiveLine(lineIndex, cursorPosition = null) {
     this._ensureLive()?.activate(lineIndex, cursorPosition);
   },
 
+  handleNoteLiveInputChange(input) {
+    this._ensureLive()?.handleInputChange(input);
+  },
+  handleNoteLiveRangeInputChange(input) {
+    this._ensureLive()?.handleRangeInputChange(input);
+  },
+  handleNoteLiveRangeInputKeydown(event, input) {
+    this._ensureLive()?.handleRangeInputKeydown(event, input);
+  },
+  handleNoteLiveInputKeydown(event, input) {
+    this._ensureLive()?.handleInputKeydown(event, input);
+  },
+  resizeNoteLiveInput(input) {
+    window.NoteEditor?.resizeLiveInput(input);
+  },
 
-  handleNoteLiveInputChange(input) { this._ensureLive()?.handleInputChange(input); },
-  handleNoteLiveRangeInputChange(input) { this._ensureLive()?.handleRangeInputChange(input); },
-  handleNoteLiveRangeInputKeydown(event, input) { this._ensureLive()?.handleRangeInputKeydown(event, input); },
-  handleNoteLiveInputKeydown(event, input) { this._ensureLive()?.handleInputKeydown(event, input); },
-  resizeNoteLiveInput(input) { window.NoteEditor?.resizeLiveInput(input); },
-
-  renderMarkdownLine(line) { return window.NoteEditor?.renderMarkdownLine(line) ?? ''; },
-  renderInlineMarkdown(text) { return window.NoteEditor?.renderInlineMarkdown(text) ?? ''; },
+  renderMarkdownLine(line) {
+    return window.NoteEditor?.renderMarkdownLine(line) ?? '';
+  },
+  renderInlineMarkdown(text) {
+    return window.NoteEditor?.renderInlineMarkdown(text) ?? '';
+  },
 
   // Toggle preview mode
   toggleNotePreview() {
     this.setNotePreviewMode(!this.isNotePreviewMode);
   },
 
-  renderMarkdown(text) { return window.NoteEditor?.renderMarkdown(text) ?? ''; },
+  renderMarkdown(text) {
+    return window.NoteEditor?.renderMarkdown(text) ?? '';
+  },
 
   // Prompt to rename note
   async promptRenameNote(noteId) {
@@ -7636,7 +8512,9 @@ const sessionManager = {
       if (this.activeSessionId) {
         await this.loadSessionTasks();
       } else if (this.currentTaskWorkspaceId) {
-        const tasksResponse = await fetch(`/api/orchestration/tasks?workspace_id=${this.currentTaskWorkspaceId}`);
+        const tasksResponse = await fetch(
+          `/api/orchestration/tasks?workspace_id=${this.currentTaskWorkspaceId}`
+        );
         if (tasksResponse.ok) {
           const data = await tasksResponse.json();
           this.workspaceTasks = data.tasks || [];
@@ -7676,19 +8554,27 @@ const sessionManager = {
   // Initialize main task panel events
   initMainTaskPanel() {
     // Tasks button in chat header
-    document.getElementById('chatTasksBtn')?.addEventListener('click', () => this.toggleMainTaskPanel());
+    document
+      .getElementById('chatTasksBtn')
+      ?.addEventListener('click', () => this.toggleMainTaskPanel());
 
     // Close button
-    document.getElementById('mainTaskPanelClose')?.addEventListener('click', () => this.closeMainTaskPanel());
+    document
+      .getElementById('mainTaskPanelClose')
+      ?.addEventListener('click', () => this.closeMainTaskPanel());
 
     // Backdrop click to close
-    document.getElementById('mainTaskModalBackdrop')?.addEventListener('click', () => this.closeMainTaskPanel());
+    document
+      .getElementById('mainTaskModalBackdrop')
+      ?.addEventListener('click', () => this.closeMainTaskPanel());
 
     // Add task button - opens modal
-    document.getElementById('mainTaskAddBtn')?.addEventListener('click', () => this.openTaskModal());
+    document
+      .getElementById('mainTaskAddBtn')
+      ?.addEventListener('click', () => this.openTaskModal());
 
     // Input enter key - opens modal with prefilled title
-    document.getElementById('mainTaskInput')?.addEventListener('keydown', (e) => {
+    document.getElementById('mainTaskInput')?.addEventListener('keydown', e => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         const input = document.getElementById('mainTaskInput');
@@ -7704,13 +8590,21 @@ const sessionManager = {
     );
     if (!hasSharedTaskController) {
       // Task modal event handlers
-      document.getElementById('taskModalClose')?.addEventListener('click', () => this.closeTaskModal());
-      document.getElementById('taskModalCancel')?.addEventListener('click', () => this.closeTaskModal());
-      document.getElementById('taskModalSave')?.addEventListener('click', () => this.saveTaskFromModal());
-      document.querySelector('.task-modal-backdrop')?.addEventListener('click', () => this.closeTaskModal());
+      document
+        .getElementById('taskModalClose')
+        ?.addEventListener('click', () => this.closeTaskModal());
+      document
+        .getElementById('taskModalCancel')
+        ?.addEventListener('click', () => this.closeTaskModal());
+      document
+        .getElementById('taskModalSave')
+        ?.addEventListener('click', () => this.saveTaskFromModal());
+      document
+        .querySelector('.task-modal-backdrop')
+        ?.addEventListener('click', () => this.closeTaskModal());
 
       // Schedule fields toggle
-      document.getElementById('taskModalScheduleEnabled')?.addEventListener('change', (e) => {
+      document.getElementById('taskModalScheduleEnabled')?.addEventListener('change', e => {
         const scheduleFields = document.getElementById('taskModalScheduleFields');
         if (scheduleFields) {
           scheduleFields.style.display = e.target.checked ? 'block' : 'none';
@@ -7723,7 +8617,7 @@ const sessionManager = {
       });
 
       // Modal escape key for task modal
-      document.getElementById('taskModal')?.addEventListener('keydown', (e) => {
+      document.getElementById('taskModal')?.addEventListener('keydown', e => {
         if (e.key === 'Escape') {
           this.closeTaskModal();
         }
@@ -7731,7 +8625,7 @@ const sessionManager = {
     }
 
     // Escape key for main task modal
-    document.getElementById('mainTaskModal')?.addEventListener('keydown', (e) => {
+    document.getElementById('mainTaskModal')?.addEventListener('keydown', e => {
       if (e.key === 'Escape') {
         this.closeMainTaskPanel();
       }
@@ -7904,26 +8798,26 @@ const sessionManager = {
       `;
 
       // Bind click for details
-      itemEl.addEventListener('click', (e) => {
+      itemEl.addEventListener('click', e => {
         if (!e.target.closest('button')) {
           this.showScheduledTaskDetails(st);
         }
       });
 
       // Toggle button
-      itemEl.querySelector('.scheduled-task-toggle')?.addEventListener('click', (e) => {
+      itemEl.querySelector('.scheduled-task-toggle')?.addEventListener('click', e => {
         e.stopPropagation();
         this.toggleScheduledTaskEnabled(st.id, !st.enabled);
       });
 
       // Trigger button
-      itemEl.querySelector('.scheduled-task-trigger')?.addEventListener('click', (e) => {
+      itemEl.querySelector('.scheduled-task-trigger')?.addEventListener('click', e => {
         e.stopPropagation();
         this.triggerScheduledTask(st.id);
       });
 
       // Delete button
-      itemEl.querySelector('.scheduled-task-delete')?.addEventListener('click', (e) => {
+      itemEl.querySelector('.scheduled-task-delete')?.addEventListener('click', e => {
         e.stopPropagation();
         this.deleteScheduledTask(st.id);
       });
@@ -7952,7 +8846,9 @@ const sessionManager = {
         return `Every ${minutes} minute${minutes > 1 ? 's' : ''}`;
       }
       case 'once':
-        return schedule.execute_at ? `Once at ${new Date(schedule.execute_at).toLocaleString()}` : 'Once';
+        return schedule.execute_at
+          ? `Once at ${new Date(schedule.execute_at).toLocaleString()}`
+          : 'Once';
       case 'cron':
         return `Cron: ${schedule.cron_expr || 'custom'}`;
       default:
@@ -7971,12 +8867,20 @@ const sessionManager = {
 
     const statusEl = document.getElementById('scheduleDetailStatus');
     statusEl.textContent = st.enabled ? 'Enabled' : 'Disabled';
-    statusEl.className = 'schedule-detail-badge ' + (st.enabled ? 'badge-enabled' : 'badge-disabled');
+    statusEl.className =
+      'schedule-detail-badge ' + (st.enabled ? 'badge-enabled' : 'badge-disabled');
 
-    document.getElementById('scheduleDetailSchedule').textContent = this.getScheduleDescription(st.schedule);
-    document.getElementById('scheduleDetailNextRun').textContent = st.next_run ? new Date(st.next_run).toLocaleString() : 'Not scheduled';
-    document.getElementById('scheduleDetailLastRun').textContent = st.last_run ? new Date(st.last_run).toLocaleString() : 'Never';
-    document.getElementById('scheduleDetailExecutions').textContent = `${st.execution_count || 0} total, ${st.failure_count || 0} failures`;
+    document.getElementById('scheduleDetailSchedule').textContent = this.getScheduleDescription(
+      st.schedule
+    );
+    document.getElementById('scheduleDetailNextRun').textContent = st.next_run
+      ? new Date(st.next_run).toLocaleString()
+      : 'Not scheduled';
+    document.getElementById('scheduleDetailLastRun').textContent = st.last_run
+      ? new Date(st.last_run).toLocaleString()
+      : 'Never';
+    document.getElementById('scheduleDetailExecutions').textContent =
+      `${st.execution_count || 0} total, ${st.failure_count || 0} failures`;
 
     // Render execution history
     this.renderExecutionHistory(st.execution_history || []);
@@ -8005,13 +8909,17 @@ const sessionManager = {
     // Show last 10 executions (reversed to show most recent first)
     const recentHistory = history.slice().reverse().slice(0, 10);
 
-    container.innerHTML = recentHistory.map(exec => `
+    container.innerHTML = recentHistory
+      .map(
+        exec => `
       <div class="history-item ${exec.status}">
         <span class="history-time">${new Date(exec.executed_at).toLocaleString()}</span>
         <span class="history-status">${exec.status === 'success' ? '✓' : '✗'}</span>
         ${exec.error ? `<span class="history-error" title="${this.escapeHtml(exec.error)}">${this.escapeHtml(exec.error.substring(0, 30))}...</span>` : ''}
       </div>
-    `).join('');
+    `
+      )
+      .join('');
   },
 
   // Toggle scheduled task enabled/disabled
@@ -8033,7 +8941,8 @@ const sessionManager = {
       // Reload and refresh
       if (this.currentScheduledTaskWorkspaceId) {
         await this.loadWorkspaceScheduledTasks(this.currentScheduledTaskWorkspaceId);
-        const tasks = this.scheduledTasksByWorkspace.get(this.currentScheduledTaskWorkspaceId) || [];
+        const tasks =
+          this.scheduledTasksByWorkspace.get(this.currentScheduledTaskWorkspaceId) || [];
         this.renderScheduledTasksList(tasks);
         this.renderFolderTree();
       }
@@ -8068,7 +8977,12 @@ const sessionManager = {
 
   // Delete/clear schedule from a task
   async deleteScheduledTask(taskId) {
-    if (!confirm('Are you sure you want to delete this schedule? The task itself will remain but will no longer run on a schedule.')) return;
+    if (
+      !confirm(
+        'Are you sure you want to delete this schedule? The task itself will remain but will no longer run on a schedule.'
+      )
+    )
+      return;
 
     try {
       const response = await fetch(`/api/orchestration/tasks/${taskId}`, {
@@ -8089,7 +9003,8 @@ const sessionManager = {
       // Reload and refresh the scheduled tasks list
       if (this.currentScheduledTaskWorkspaceId) {
         await this.loadWorkspaceScheduledTasks(this.currentScheduledTaskWorkspaceId);
-        const tasks = this.scheduledTasksByWorkspace.get(this.currentScheduledTaskWorkspaceId) || [];
+        const tasks =
+          this.scheduledTasksByWorkspace.get(this.currentScheduledTaskWorkspaceId) || [];
         this.renderScheduledTasksList(tasks);
         this.renderFolderTree();
       }
@@ -8119,12 +9034,20 @@ const sessionManager = {
   // Initialize scheduled tasks modal events
   initScheduledTasksModal() {
     // Close buttons
-    document.getElementById('scheduledTasksModalClose')?.addEventListener('click', () => this.closeScheduledTasksModal());
-    document.getElementById('scheduledTasksModalBackdrop')?.addEventListener('click', () => this.closeScheduledTasksModal());
+    document
+      .getElementById('scheduledTasksModalClose')
+      ?.addEventListener('click', () => this.closeScheduledTasksModal());
+    document
+      .getElementById('scheduledTasksModalBackdrop')
+      ?.addEventListener('click', () => this.closeScheduledTasksModal());
 
     // Detail modal close
-    document.getElementById('scheduleDetailClose')?.addEventListener('click', () => this.closeScheduledTaskDetailModal());
-    document.getElementById('scheduleDetailBackdrop')?.addEventListener('click', () => this.closeScheduledTaskDetailModal());
+    document
+      .getElementById('scheduleDetailClose')
+      ?.addEventListener('click', () => this.closeScheduledTaskDetailModal());
+    document
+      .getElementById('scheduleDetailBackdrop')
+      ?.addEventListener('click', () => this.closeScheduledTaskDetailModal());
 
     // Detail modal actions
     document.getElementById('scheduleDetailToggleBtn')?.addEventListener('click', () => {
@@ -8154,14 +9077,22 @@ const sessionManager = {
     });
 
     // Escape key handlers (document-level for reliable closing)
-    document.addEventListener('keydown', (e) => {
+    document.addEventListener('keydown', e => {
       if (e.key === 'Escape') {
         const detailModal = document.getElementById('scheduledTaskDetailModal');
         const listModal = document.getElementById('scheduledTasksModal');
         // Close detail modal first if visible, then list modal
-        if (detailModal && detailModal.style.display !== 'none' && detailModal.style.display !== '') {
+        if (
+          detailModal &&
+          detailModal.style.display !== 'none' &&
+          detailModal.style.display !== ''
+        ) {
           this.closeScheduledTaskDetailModal();
-        } else if (listModal && listModal.style.display !== 'none' && listModal.style.display !== '') {
+        } else if (
+          listModal &&
+          listModal.style.display !== 'none' &&
+          listModal.style.display !== ''
+        ) {
           this.closeScheduledTasksModal();
         }
       }
@@ -8301,19 +9232,19 @@ const sessionManager = {
       });
 
       // Edit click
-      taskEl.querySelector('.main-task-edit')?.addEventListener('click', (e) => {
+      taskEl.querySelector('.main-task-edit')?.addEventListener('click', e => {
         e.stopPropagation();
         this.openTaskModal(task.id);
       });
 
       // Execute click
-      taskEl.querySelector('.main-task-execute')?.addEventListener('click', (e) => {
+      taskEl.querySelector('.main-task-execute')?.addEventListener('click', e => {
         e.stopPropagation();
         this.executeTask(task.id);
       });
 
       // Delete click
-      taskEl.querySelector('.main-task-delete')?.addEventListener('click', (e) => {
+      taskEl.querySelector('.main-task-delete')?.addEventListener('click', e => {
         e.stopPropagation();
         this.deleteMainTask(task.id);
       });
@@ -8337,7 +9268,9 @@ const sessionManager = {
       if (this.activeSessionId) {
         await this.loadSessionTasks();
       } else if (this.currentTaskWorkspaceId) {
-        const tasksResponse = await fetch(`/api/orchestration/tasks?workspace_id=${this.currentTaskWorkspaceId}`);
+        const tasksResponse = await fetch(
+          `/api/orchestration/tasks?workspace_id=${this.currentTaskWorkspaceId}`
+        );
         if (tasksResponse.ok) {
           const data = await tasksResponse.json();
           this.workspaceTasks = data.tasks || [];
@@ -8614,8 +9547,12 @@ const sessionManager = {
         break;
       case 'interval': {
         // Combine value and unit into interval_minutes
-        const intervalValue = parseInt(document.getElementById('taskModalScheduleIntervalValue')?.value || '1', 10);
-        const intervalUnit = document.getElementById('taskModalScheduleIntervalUnit')?.value || 'hours';
+        const intervalValue = parseInt(
+          document.getElementById('taskModalScheduleIntervalValue')?.value || '1',
+          10
+        );
+        const intervalUnit =
+          document.getElementById('taskModalScheduleIntervalUnit')?.value || 'hours';
         let intervalMinutes = intervalValue;
         if (intervalUnit === 'hours') {
           intervalMinutes = intervalValue * 60;
@@ -8808,7 +9745,9 @@ document.addEventListener('DOMContentLoaded', () => {
       window.history.replaceState(null, '', cleanUrl);
       sessionManager.openNoteEditor(openNoteId);
     }
-  } catch (_) { /* non-fatal */ }
+  } catch (_) {
+    /* non-fatal */
+  }
 
   // ?create=1 opens the Create Workspace modal after navigation (home-page
   // first-run CTA links to /workspaces?create=1). One-shot: scrubbed from
@@ -8822,7 +9761,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const cleanUrl = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
       window.history.replaceState(null, '', cleanUrl);
       // Defer a frame so init()'s show.bs.modal handler is bound first.
-      requestAnimationFrame(() => sessionManager.showAddWorkspaceModal({ entryPoint: 'home_first_run' }));
+      requestAnimationFrame(() =>
+        sessionManager.showAddWorkspaceModal({ entryPoint: 'home_first_run' })
+      );
     }
-  } catch (_) { /* non-fatal */ }
+  } catch (_) {
+    /* non-fatal */
+  }
 });

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -3562,7 +3562,7 @@ const sessionManager = {
       const data = await response.json().catch(() => ({}));
       if (requestId !== this.templateAgentPlanRequestId) return;
       if (!response.ok || data.error) {
-        this.renderTemplateAgentPlanError(data.error || 'Could not load template agents.');
+        this.renderTemplateAgentPlanError(data.error || 'Could not load blueprint agents.');
         return;
       }
       this.templateAgentPlan = data;
@@ -3572,7 +3572,7 @@ const sessionManager = {
     } catch (error) {
       if (requestId !== this.templateAgentPlanRequestId) return;
       console.error('Failed to load template agent plan:', error);
-      this.renderTemplateAgentPlanError('Could not load template agents.');
+      this.renderTemplateAgentPlanError('Could not load blueprint agents.');
     }
   },
 
@@ -3586,7 +3586,7 @@ const sessionManager = {
       review.hidden = false;
       review.classList.remove('is-disabled');
     }
-    if (summary) summary.textContent = 'Checking template roster...';
+    if (summary) summary.textContent = 'Checking reusable agents...';
     if (status) status.textContent = '';
     if (list) list.innerHTML = '';
     if (warnings) {
@@ -3606,8 +3606,8 @@ const sessionManager = {
       review.hidden = false;
       review.classList.remove('is-disabled');
     }
-    if (summary) summary.textContent = 'Template agents could not be checked.';
-    if (status) status.textContent = message || 'Could not load template agents.';
+    if (summary) summary.textContent = 'Blueprint agents could not be checked.';
+    if (status) status.textContent = message || 'Could not load blueprint agents.';
     if (list) list.innerHTML = '';
     if (toggle) toggle.checked = true;
   },
@@ -3631,10 +3631,16 @@ const sessionManager = {
     const createCount = agents.filter(agent => agent.action === 'create').length;
     const reuseCount = agents.filter(agent => agent.action === 'reuse').length;
     const parts = [];
-    if (reuseCount) parts.push(`${reuseCount} reused`);
-    if (createCount) parts.push(`${createCount} new`);
+    if (reuseCount) {
+      parts.push(`${reuseCount} saved agent${reuseCount === 1 ? '' : 's'} will be attached`);
+    }
+    if (createCount) {
+      parts.push(
+        `${createCount} reusable agent${createCount === 1 ? '' : 's'} will be added to Your Agents and attached`
+      );
+    }
     if (summary) {
-      summary.textContent = `${parts.join(' / ')} agent${agents.length === 1 ? '' : 's'} attached to this workspace.`;
+      summary.textContent = parts.join(' · ');
     }
     if (status) {
       const provider = String(plan.system_provider || '').trim();
@@ -3706,8 +3712,10 @@ const sessionManager = {
       .join('');
     const chips = `<span class="workspace-template-agent-chip ${action} workspace-template-agent-action">${actionLabel}</span>${roleChips}`;
 
-    const designation = agent?.entry_point ? 'Primary assistant' : 'Specialist';
-    const provision = isReuse ? 'Existing agent · Will be linked' : 'New agent · Will be created';
+    const designation = agent?.entry_point ? 'Primary workspace agent' : 'Workspace specialist';
+    const provision = isReuse
+      ? 'Saved agent · Will be attached'
+      : 'New reusable agent · Added to Your Agents and attached';
     const summaryAction = isReuse
       ? '<button type="button" class="workspace-template-agent-fork-btn">Make a workspace copy</button>'
       : '<button type="button" class="workspace-wizard-inline-action workspace-template-agent-customize-btn" aria-expanded="false">Customize</button>';
@@ -3716,8 +3724,8 @@ const sessionManager = {
           ${this.renderAgentAvatar(name, 'workspace-agent-avatar')}
           <div class="workspace-template-agent-summary-copy">
             <strong>${this.escapeHtml(name)}</strong>
-            <span>${designation} · ${provision}</span>
-            <small>${this.escapeHtml(modelText)} · ${this.escapeHtml(source)}</small>
+            <span>${provision}</span>
+            <small>${designation} · ${this.escapeHtml(modelText)} · ${this.escapeHtml(source)}</small>
           </div>
           <div class="workspace-template-agent-summary-action">${summaryAction}</div>
         </div>`;
@@ -4202,7 +4210,7 @@ const sessionManager = {
         : this.existingAgentSelections[0] || '';
       if (this.existingAgentPrimaryName)
         this.announceWorkspaceTeamChange(
-          `${this.existingAgentPrimaryName} is now the primary assistant.`
+          `${this.existingAgentPrimaryName} is now this workspace's primary agent.`
         );
     }
     this.renderExistingAgentRoster();
@@ -4219,12 +4227,12 @@ const sessionManager = {
     )
       return;
     const confirmed = window.confirm(
-      `${agent.name} will receive new starter and setup tasks as the primary assistant. Its saved prompt, model, and tools will be used as-is. Make it primary?`
+      `${agent.name} will become this workspace's primary routing agent and receive new starter and setup tasks. Its saved prompt, model, and tools stay reusable. Make it primary?`
     );
     if (!confirmed) return;
     this.existingAgentPrimaryName = String(agent.name).trim();
     this.refreshWorkspaceReview();
-    this.announceWorkspaceTeamChange(`${agent.name} is now the primary assistant.`);
+    this.announceWorkspaceTeamChange(`${agent.name} is now this workspace's primary agent.`);
   },
 
   includedTemplateAgents() {
@@ -4257,7 +4265,7 @@ const sessionManager = {
           ${this.renderAgentAvatar(name, 'workspace-agent-avatar')}
           <div class="workspace-team-agent-copy">
             <strong>${this.escapeHtml(name)}</strong>
-            <span>${isPrimary ? 'Primary assistant' : 'Specialist'} · Existing agent · Will be attached</span>
+            <span>${isPrimary ? 'Primary workspace agent' : 'Workspace specialist'} · Saved agent · Will be attached</span>
             <small>${this.escapeHtml(agent?.model || 'Uses existing agent model')}</small>
           </div>
           <div class="workspace-team-agent-actions">
@@ -4283,16 +4291,22 @@ const sessionManager = {
     if (heading) heading.textContent = total === 1 ? 'Workspace Assistant' : 'Workspace Team';
     if (teamSummary) {
       const parts = [];
-      if (created) parts.push(`${created} new agent${created === 1 ? '' : 's'} will be created`);
+      if (created) {
+        parts.push(
+          `${created} reusable agent${created === 1 ? '' : 's'} will be added to Your Agents and attached`
+        );
+      }
       if (existingCount)
         parts.push(
-          `${existingCount} existing agent${existingCount === 1 ? '' : 's'} will be attached`
+          `${existingCount} saved agent${existingCount === 1 ? '' : 's'} will be attached`
         );
       if (reused)
-        parts.push(`${reused} existing assistant${reused === 1 ? '' : 's'} will be linked`);
+        parts.push(
+          `${reused} blueprint agent${reused === 1 ? '' : 's'} already saved and attached`
+        );
       teamSummary.textContent =
         parts.join(' · ') ||
-        'No assistant will be added. Starter tasks will remain unassigned until you add one.';
+        'No agent will be attached. Starter tasks will remain unassigned until you add one.';
     }
     if (summary) {
       const blueprint =

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -332,6 +332,10 @@ const sessionManager = {
       this.refreshWorkspaceReview();
     });
 
+    document
+      .getElementById('workspaceAgentMapAvatarAction')
+      ?.addEventListener('click', () => this.createTemplateAgentFromPreview());
+
     document.getElementById('addExistingAgentBtn')?.addEventListener('click', () => {
       void this.openExistingAgentRoster();
     });
@@ -4293,6 +4297,7 @@ const sessionManager = {
     const title = document.getElementById('workspaceAgentMapPreviewTitle');
     const canvas = document.querySelector('.workspace-agent-map-canvas');
     const specialists = document.getElementById('workspaceAgentMapSpecialists');
+    const avatarAction = document.getElementById('workspaceAgentMapAvatarAction');
     const kicker = document.getElementById('workspaceAgentMapNodeKicker');
     const name = document.getElementById('workspaceAgentMapNodeName');
     const detail = document.getElementById('workspaceAgentMapNodeDetail');
@@ -4303,6 +4308,7 @@ const sessionManager = {
       !title ||
       !canvas ||
       !specialists ||
+      !avatarAction ||
       !kicker ||
       !name ||
       !detail ||
@@ -4319,8 +4325,8 @@ const sessionManager = {
       teamNames.add(key);
       team.push({ ...member, name: memberName });
     };
-    this.includedTemplateAgents().forEach(agent =>
-      addTeamMember({ ...agent, source: 'blueprint' })
+    this.includedTemplateAgents().forEach((agent, templateAgentIndex) =>
+      addTeamMember({ ...agent, source: 'blueprint', templateAgentIndex })
     );
     this.existingAgentSelections.forEach(selectedName => {
       const savedAgent = this.findExistingRosterAgent(selectedName);
@@ -4342,6 +4348,12 @@ const sessionManager = {
       : [];
     const createdAgents = team.filter(
       agent => String(agent.action || '').toLowerCase() === 'create'
+    );
+    const canCreatePrimary = Boolean(
+      primary &&
+      primary.source === 'blueprint' &&
+      String(primary.action || '').toLowerCase() === 'create' &&
+      Number.isInteger(primary.templateAgentIndex)
     );
     const memberLifecycle = agent => {
       if (String(agent.action || '').toLowerCase() === 'create') return 'New reusable agent';
@@ -4421,11 +4433,11 @@ const sessionManager = {
       } else {
         next = {
           state: 'new',
-          label: 'New agent',
+          label: 'Create agent',
           kicker: 'PRIMARY WORKSPACE AGENT',
           name: agentName,
-          detail: memberLifecycle(primary),
-          status: `${agentName} will be added to Your Agents as this workspace's primary agent.${specialistSentence}${creationSentence}`
+          detail: 'Not in Your Agents yet · Create reusable agent',
+          status: `${agentName} is not in Your Agents yet. Select its + avatar to create and save this reusable agent now.${specialistSentence}${creationSentence}`
         };
       }
     } else if (this.templateAgentPlan) {
@@ -4440,18 +4452,86 @@ const sessionManager = {
       };
     }
 
-    node.className = `workspace-agent-map-node is-${next.state}`;
+    node.className = `workspace-agent-map-node is-${next.state}${
+      canCreatePrimary ? ' is-actionable' : ''
+    }`;
     canvas.classList.toggle('is-team', teamSpecialists.length > 0);
     canvas.classList.toggle('has-many-specialists', teamSpecialists.length > 3);
     state.className = `workspace-agent-map-state is-${next.state}`;
     title.textContent =
       team.length > 1 ? `Workspace team · ${team.length} agents` : 'Primary workspace agent';
     specialists.innerHTML = specialistMarkup;
+    avatarAction.disabled = !canCreatePrimary;
+    avatarAction.dataset.templateAgentIndex = canCreatePrimary
+      ? String(primary.templateAgentIndex)
+      : '';
+    avatarAction.setAttribute(
+      'aria-label',
+      canCreatePrimary
+        ? `Create ${primary.name} as a reusable agent now. It will remain in Your Agents if you cancel this workspace.`
+        : `${next.name} is this workspace's primary agent`
+    );
     state.textContent = next.label;
     kicker.textContent = next.kicker;
     name.textContent = next.name;
     detail.textContent = next.detail;
     status.textContent = next.status;
+  },
+
+  async createTemplateAgentFromPreview() {
+    const avatarAction = document.getElementById('workspaceAgentMapAvatarAction');
+    const agentIndex = Number.parseInt(avatarAction?.dataset.templateAgentIndex || '', 10);
+    if (!Number.isInteger(agentIndex) || !avatarAction || avatarAction.disabled) return;
+
+    const fields = window.ProjectTemplateCard?.getPayloadFields?.() || {};
+    const templateId = String(fields.template_id || '').trim();
+    const templatePath = String(fields.template_path || '').trim();
+    const isBlank =
+      Boolean(window.ProjectTemplateCard?.getSelectedTemplate?.()?.blank) &&
+      !templateId &&
+      !templatePath;
+    const primaryName = String(
+      document.getElementById('workspaceAgentMapNodeName')?.textContent || ''
+    ).trim();
+
+    avatarAction.disabled = true;
+    avatarAction.setAttribute('aria-label', `Creating ${primaryName || 'agent'}…`);
+    try {
+      const response = await fetch('/api/workspaces/template-agent-create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          template_id: templateId || undefined,
+          template_path: templatePath || undefined,
+          blank: isBlank || undefined,
+          agent_index: agentIndex
+        })
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok || result.error) {
+        throw new Error(result.error || `Could not create ${primaryName || 'agent'}.`);
+      }
+
+      if (result.plan) {
+        this.templateAgentPlan = result.plan;
+        this.templateAgentPlanError = '';
+        this.renderTemplateAgentPlan(result.plan);
+      } else {
+        await this.refreshTemplateAgentPlan();
+      }
+      const savedName = String(result.agent?.name || primaryName || 'Agent').trim();
+      const message = result.created
+        ? `${savedName} is now saved in Your Agents and ready for this workspace.`
+        : `${savedName} is already saved in Your Agents and ready for this workspace.`;
+      this.announceWorkspaceTeamChange(message);
+      this.showToast(message, 'success');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Could not create the reusable agent.';
+      this.announceWorkspaceTeamChange(message);
+      this.showToast(message, 'error');
+      this.renderWorkspaceAgentMapPreview();
+    }
   },
 
   refreshWorkspaceReview() {

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -41,6 +41,10 @@ const sessionManager = {
   templateAgentPlanError: '',
   templateAgentPlanRequestId: 0,
   templateAgentPlanTimer: null,
+  // Overrides chosen while explicitly saving a blueprint agent from step 1.
+  // They must accompany final workspace creation so it attaches the exact
+  // global definition the user just named and configured.
+  templateAgentPrecreateOverrides: new Map(),
   existingAgentRoster: [],
   existingAgentRosterLoaded: false,
   existingAgentRosterLoading: false,
@@ -307,6 +311,8 @@ const sessionManager = {
       .getElementById('addFolderModal')
       ?.addEventListener('workspace-template-selected', event => {
         const template = event?.detail?.template || null;
+        this.templateAgentPrecreateOverrides = new Map();
+        this.closeTemplateAgentSetup();
         this.workspaceTemplate = template;
         this.prefillTemplateValue(
           document.getElementById('folderNameInput'),
@@ -334,15 +340,27 @@ const sessionManager = {
 
     document
       .getElementById('workspaceAgentMapAvatarAction')
-      ?.addEventListener('click', () => this.createTemplateAgentFromPreview());
+      ?.addEventListener('click', () => this.openTemplateAgentSetup());
     document.getElementById('workspaceAgentMapSpecialists')?.addEventListener('click', event => {
       const action = event.target.closest('[data-template-agent-index]');
       const agentIndex = Number.parseInt(action?.dataset.templateAgentIndex || '', 10);
-      if (Number.isInteger(agentIndex)) void this.createTemplateAgentFromPreview(agentIndex);
+      if (Number.isInteger(agentIndex)) this.openTemplateAgentSetup(agentIndex);
     });
     document
       .getElementById('workspaceAgentMapCreateAll')
       ?.addEventListener('click', () => this.createAllTemplateAgentsFromPreview());
+    document
+      .getElementById('workspaceTemplateAgentSetupForm')
+      ?.addEventListener('submit', event => {
+        event.preventDefault();
+        void this.saveTemplateAgentFromSetup();
+      });
+    document
+      .getElementById('workspaceTemplateAgentSetupCancel')
+      ?.addEventListener('click', () => this.closeTemplateAgentSetup());
+    document
+      .getElementById('workspaceTemplateAgentSetupBack')
+      ?.addEventListener('click', () => this.closeTemplateAgentSetup());
 
     document.getElementById('addExistingAgentBtn')?.addEventListener('click', () => {
       void this.openExistingAgentRoster();
@@ -3508,6 +3526,8 @@ const sessionManager = {
   resetTemplateAgentReview() {
     this.templateAgentPlan = null;
     this.templateAgentPlanError = '';
+    this.templateAgentPrecreateOverrides = new Map();
+    this.closeTemplateAgentSetup();
     this.templateAgentPlanRequestId += 1;
     if (this.templateAgentPlanTimer) {
       clearTimeout(this.templateAgentPlanTimer);
@@ -3945,7 +3965,7 @@ const sessionManager = {
     if (!review || !toggle || !toggle.checked) return [];
 
     const rows = Array.from(review.querySelectorAll('.workspace-template-agent-row'));
-    const overrides = [];
+    const overridesByIndex = new Map(this.templateAgentPrecreateOverrides || []);
     const names = new Map();
     for (const row of rows) {
       const index = Number.parseInt(row.dataset.templateAgentIndex || '', 10);
@@ -4008,10 +4028,10 @@ const sessionManager = {
       }
       if (promptChanged) override.system_prompt = systemPrompt;
       if (Object.keys(override).length > 1) {
-        overrides.push(override);
+        overridesByIndex.set(index, { ...overridesByIndex.get(index), ...override });
       }
     }
-    return overrides;
+    return Array.from(overridesByIndex.values()).sort((left, right) => left.index - right.index);
   },
 
   templateAgentModelSourceLabel(source) {
@@ -4296,9 +4316,8 @@ const sessionManager = {
       .join('');
   },
 
-  // The map is a compact, read-only preview rather than a second canvas. It
-  // makes both the primary-agent hierarchy and the complete included team
-  // visible before the user enters the detailed review step.
+  // The map is a compact visual preview rather than a second canvas. Missing
+  // agents expose a deliberate + action that opens the setup card below it.
   renderWorkspaceAgentMapPreview() {
     const node = document.getElementById('workspaceAgentMapNode');
     const state = document.getElementById('workspaceAgentMapState');
@@ -4383,7 +4402,7 @@ const sessionManager = {
             .slice(0, 2)
             .toUpperCase() || 'A';
         const avatar = isNew
-          ? `<button type="button" class="workspace-agent-map-specialist-avatar" data-template-agent-index="${agent.templateAgentIndex}" aria-label="Create ${this.escapeHtml(agent.name)} as a reusable agent now">${this.escapeHtml(initials)}<span class="workspace-agent-map-specialist-create-badge" aria-hidden="true">+</span></button>`
+          ? `<button type="button" class="workspace-agent-map-specialist-avatar" data-template-agent-index="${agent.templateAgentIndex}" aria-label="Set up ${this.escapeHtml(agent.name)} as a reusable agent">${this.escapeHtml(initials)}<span class="workspace-agent-map-specialist-create-badge" aria-hidden="true">+</span></button>`
           : `<span class="workspace-agent-map-specialist-avatar" aria-hidden="true">${this.escapeHtml(initials)}</span>`;
         return `
           <div class="workspace-agent-map-specialist${isNew ? ' is-new' : ''}">
@@ -4448,7 +4467,7 @@ const sessionManager = {
           kicker: 'PRIMARY WORKSPACE AGENT',
           name: agentName,
           detail: 'Not in Your Agents yet · Create reusable agent',
-          status: `${agentName} is not in Your Agents yet. Select its + avatar to create and save this reusable agent now.${specialistSentence}${creationSentence}`
+          status: `${agentName} is not in Your Agents yet. Select its + avatar to set up and save this reusable agent.${specialistSentence}${creationSentence}`
         };
       }
     } else if (this.templateAgentPlan) {
@@ -4474,7 +4493,7 @@ const sessionManager = {
     specialists.innerHTML = specialistMarkup;
     createAll.hidden = createdAgents.length < 2;
     createAll.disabled = false;
-    createAll.textContent = `Create all ${createdAgents.length}`;
+    createAll.textContent = `Create all defaults (${createdAgents.length})`;
     avatarAction.disabled = !canCreatePrimary;
     avatarAction.dataset.templateAgentIndex = canCreatePrimary
       ? String(primary.templateAgentIndex)
@@ -4482,7 +4501,7 @@ const sessionManager = {
     avatarAction.setAttribute(
       'aria-label',
       canCreatePrimary
-        ? `Create ${primary.name} as a reusable agent now. It will remain in Your Agents if you cancel this workspace.`
+        ? `Set up ${primary.name} as a reusable agent. It will remain in Your Agents if you cancel this workspace.`
         : `${next.name} is this workspace's primary agent`
     );
     state.textContent = next.label;
@@ -4490,6 +4509,105 @@ const sessionManager = {
     name.textContent = next.name;
     detail.textContent = next.detail;
     status.textContent = next.status;
+  },
+
+  openTemplateAgentSetup(requestedAgentIndex) {
+    const avatarAction = document.getElementById('workspaceAgentMapAvatarAction');
+    const agentIndex = Number.isInteger(requestedAgentIndex)
+      ? requestedAgentIndex
+      : Number.parseInt(avatarAction?.dataset.templateAgentIndex || '', 10);
+    const plannedAgent = this.includedTemplateAgents()[agentIndex];
+    if (
+      !Number.isInteger(agentIndex) ||
+      !plannedAgent ||
+      String(plannedAgent.action || '').toLowerCase() !== 'create'
+    )
+      return;
+
+    const card = document.getElementById('workspaceTemplateAgentSetup');
+    const index = document.getElementById('workspaceTemplateAgentSetupIndex');
+    const title = document.getElementById('workspaceTemplateAgentSetupTitle');
+    const description = document.getElementById('workspaceTemplateAgentSetupDescription');
+    const name = document.getElementById('workspaceTemplateAgentSetupName');
+    const model = document.getElementById('workspaceTemplateAgentSetupModel');
+    const prompt = document.getElementById('workspaceTemplateAgentSetupPrompt');
+    const save = document.getElementById('workspaceTemplateAgentSetupSave');
+    const status = document.getElementById('workspaceTemplateAgentSetupStatus');
+    if (!card || !index || !title || !description || !name || !model || !prompt || !save || !status)
+      return;
+
+    index.value = String(agentIndex);
+    title.textContent = `Create ${plannedAgent.name}`;
+    description.textContent = `${plannedAgent.name} will be saved in Your Agents and can be reused in future workspaces. You can still cancel this workspace afterward.`;
+    name.value = String(plannedAgent.name || '');
+    model.value = String(plannedAgent.model || '');
+    prompt.value = String(plannedAgent.system_prompt || '');
+    save.textContent = `Save ${plannedAgent.name}`;
+    save.disabled = false;
+    status.textContent = '';
+    status.classList.remove('is-error');
+    card.hidden = false;
+    requestAnimationFrame(() => {
+      card.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
+      name.focus();
+      name.select();
+    });
+  },
+
+  closeTemplateAgentSetup() {
+    const card = document.getElementById('workspaceTemplateAgentSetup');
+    const status = document.getElementById('workspaceTemplateAgentSetupStatus');
+    if (card) card.hidden = true;
+    if (status) {
+      status.textContent = '';
+      status.classList.remove('is-error');
+    }
+  },
+
+  async saveTemplateAgentFromSetup() {
+    const indexInput = document.getElementById('workspaceTemplateAgentSetupIndex');
+    const nameInput = document.getElementById('workspaceTemplateAgentSetupName');
+    const modelInput = document.getElementById('workspaceTemplateAgentSetupModel');
+    const promptInput = document.getElementById('workspaceTemplateAgentSetupPrompt');
+    const status = document.getElementById('workspaceTemplateAgentSetupStatus');
+    const save = document.getElementById('workspaceTemplateAgentSetupSave');
+    const agentIndex = Number.parseInt(indexInput?.value || '', 10);
+    const name = String(nameInput?.value || '').trim();
+    if (!Number.isInteger(agentIndex) || !this.includedTemplateAgents()[agentIndex]) return;
+    if (!name) {
+      if (status) {
+        status.textContent = 'Enter a name for this reusable agent.';
+        status.classList.add('is-error');
+      }
+      nameInput?.focus();
+      return;
+    }
+    if (!/^[a-zA-Z0-9_\- ]+$/.test(name)) {
+      if (status) {
+        status.textContent = 'Names can use letters, numbers, spaces, underscores, and hyphens.';
+        status.classList.add('is-error');
+      }
+      nameInput?.focus();
+      return;
+    }
+
+    const override = {
+      index: agentIndex,
+      name,
+      model: String(modelInput?.value || '').trim(),
+      system_prompt: String(promptInput?.value || '').trim()
+    };
+    if (save) save.disabled = true;
+    if (status) {
+      status.textContent = `Saving ${name} to Your Agents…`;
+      status.classList.remove('is-error');
+    }
+    const created = await this.createTemplateAgentFromPreview(agentIndex, { override });
+    if (!created) {
+      if (save) save.disabled = false;
+      return;
+    }
+    this.closeTemplateAgentSetup();
   },
 
   async createTemplateAgentFromPreview(requestedAgentIndex, options = {}) {
@@ -4501,13 +4619,7 @@ const sessionManager = {
     const trigger = document.querySelector(
       `[data-template-agent-index="${Number.isInteger(agentIndex) ? agentIndex : ''}"]`
     );
-    if (
-      !Number.isInteger(agentIndex) ||
-      !plannedAgent ||
-      (!trigger && !options.silent) ||
-      (trigger && trigger.disabled)
-    )
-      return false;
+    if (!Number.isInteger(agentIndex) || !plannedAgent || (trigger && trigger.disabled)) return false;
 
     const fields = window.ProjectTemplateCard?.getPayloadFields?.() || {};
     const templateId = String(fields.template_id || '').trim();
@@ -4528,7 +4640,8 @@ const sessionManager = {
           template_id: templateId || undefined,
           template_path: templatePath || undefined,
           blank: isBlank || undefined,
-          agent_index: agentIndex
+          agent_index: agentIndex,
+          override: options.override || undefined
         })
       });
       const result = await response.json().catch(() => ({}));
@@ -4539,6 +4652,9 @@ const sessionManager = {
       if (result.plan) {
         this.templateAgentPlan = result.plan;
         this.templateAgentPlanError = '';
+        if (options.override) {
+          this.templateAgentPrecreateOverrides.set(agentIndex, options.override);
+        }
         this.renderTemplateAgentPlan(result.plan);
       } else {
         await this.refreshTemplateAgentPlan();

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -77,10 +77,10 @@
                 </div>
               </div>
 
-              <!-- A deliberately small, non-interactive map preview makes the
-                   primary-agent state tangible before the user reaches review.
-                   Its avatar is a visual identity, not a substitute for the
-                   plainly stated lifecycle status below. -->
+              <!-- A deliberately small, non-interactive team preview makes the
+                   primary-agent hierarchy tangible before the user reaches
+                   review. Its avatars are visual identities, not substitutes
+                   for the plainly stated lifecycle status below. -->
               <section id="workspaceAgentMapPreview" class="workspace-agent-map-preview" aria-labelledby="workspaceAgentMapPreviewTitle">
                 <div class="workspace-agent-map-preview-head">
                   <div>
@@ -109,6 +109,7 @@
                     <strong id="workspaceAgentMapNodeName">Checking agent setup</strong>
                     <span id="workspaceAgentMapNodeDetail">This workspace needs a primary agent.</span>
                   </div>
+                  <div id="workspaceAgentMapSpecialists" class="workspace-agent-map-specialists"></div>
                 </div>
                 <p id="workspaceAgentMapStatus" class="workspace-agent-map-status" aria-live="polite">Checking the reusable agent for this workspace…</p>
               </section>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -57,7 +57,7 @@
               </div>
               <div id="templateBriefing" class="workspace-template-briefing mb-2">
                 <div id="templateBriefingDefault" class="workspace-template-briefing-default">
-                  Blank begins with a Workspace Manager assistant. You can add more teammates after creation.
+                  Blank uses the reusable Workspace Manager agent as its primary workspace assistant. You can add more teammates after creation.
                 </div>
                 <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
                 <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
@@ -117,7 +117,7 @@
               <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
                 <div class="workspace-template-agent-review-head">
                   <div>
-                    <div class="workspace-template-agent-review-title">Included assistant</div>
+                    <div class="workspace-template-agent-review-title">Blueprint agents</div>
                     <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
                   </div>
                 </div>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -120,14 +120,18 @@
                     <div class="workspace-template-agent-review-title">Included assistant</div>
                     <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
                   </div>
-                  <label class="workspace-template-agent-toggle" title="Clear this to create the workspace without the assistant included by this blueprint.">
-                    <input type="checkbox" id="templateAgentReviewToggle" checked>
-                    <span>Include</span>
-                  </label>
                 </div>
                 <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>
                 <div id="templateAgentReviewList" class="workspace-template-agent-list"></div>
                 <div id="templateAgentReviewWarnings" class="workspace-template-agent-warnings" hidden></div>
+                <details class="workspace-template-agent-advanced">
+                  <summary>Advanced team options</summary>
+                  <label class="workspace-template-agent-toggle" title="Clear this to create the workspace without the assistant included by this blueprint.">
+                    <input type="checkbox" id="templateAgentReviewToggle" checked>
+                    <span>Include blueprint assistant/team</span>
+                  </label>
+                  <span class="workspace-template-agent-advanced-help">Clear this to create without the included assistant/team. Starter tasks will remain unassigned unless you add an existing agent.</span>
+                </details>
               </div>
 
               <!-- REAPER Setup card: shown only when the Reaper Song template is

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -76,6 +76,29 @@
                   </div>
                 </div>
               </div>
+
+              <!-- A deliberately small, non-interactive map preview makes the
+                   primary-agent state tangible before the user reaches review.
+                   The separate status line carries the same information for
+                   assistive technology and narrow layouts. -->
+              <section id="workspaceAgentMapPreview" class="workspace-agent-map-preview" aria-labelledby="workspaceAgentMapPreviewTitle">
+                <div class="workspace-agent-map-preview-head">
+                  <div>
+                    <span class="workspace-wizard-eyebrow">Workspace preview</span>
+                    <h3 id="workspaceAgentMapPreviewTitle">Primary workspace agent</h3>
+                  </div>
+                  <span id="workspaceAgentMapState" class="workspace-agent-map-state">Checking</span>
+                </div>
+                <div class="workspace-agent-map-canvas" aria-hidden="true">
+                  <div id="workspaceAgentMapNode" class="workspace-agent-map-node is-loading">
+                    <span class="workspace-agent-map-node-mark"></span>
+                    <span id="workspaceAgentMapNodeKicker" class="workspace-agent-map-node-kicker">AGENT SETUP</span>
+                    <strong id="workspaceAgentMapNodeName">Checking agent setup</strong>
+                    <span id="workspaceAgentMapNodeDetail">This workspace needs a primary agent.</span>
+                  </div>
+                </div>
+                <p id="workspaceAgentMapStatus" class="workspace-agent-map-status" aria-live="polite">Checking the reusable agent for this workspace…</p>
+              </section>
             </section>
 
             <!-- ===== STEP 2 · WORKSPACE DETAILS ===== -->

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -79,8 +79,8 @@
 
               <!-- A deliberately small, non-interactive map preview makes the
                    primary-agent state tangible before the user reaches review.
-                   The separate status line carries the same information for
-                   assistive technology and narrow layouts. -->
+                   Its avatar is a visual identity, not a substitute for the
+                   plainly stated lifecycle status below. -->
               <section id="workspaceAgentMapPreview" class="workspace-agent-map-preview" aria-labelledby="workspaceAgentMapPreviewTitle">
                 <div class="workspace-agent-map-preview-head">
                   <div>
@@ -91,7 +91,20 @@
                 </div>
                 <div class="workspace-agent-map-canvas" aria-hidden="true">
                   <div id="workspaceAgentMapNode" class="workspace-agent-map-node is-loading">
-                    <span class="workspace-agent-map-node-mark"></span>
+                    <div class="workspace-agent-map-avatar">
+                      <svg class="workspace-agent-map-avatar-figure" viewBox="0 0 96 96" focusable="false">
+                        <path class="workspace-agent-map-avatar-antenna" d="M48 15V8m0 0 6-5" />
+                        <rect class="workspace-agent-map-avatar-head" x="25" y="19" width="46" height="37" rx="12" />
+                        <path class="workspace-agent-map-avatar-visor" d="M33 36h30" />
+                        <circle class="workspace-agent-map-avatar-eye" cx="40" cy="36" r="2.5" />
+                        <circle class="workspace-agent-map-avatar-eye" cx="56" cy="36" r="2.5" />
+                        <path class="workspace-agent-map-avatar-neck" d="M42 56v7h12v-7" />
+                        <path class="workspace-agent-map-avatar-body" d="M20 86c2-16 13-24 28-24s26 8 28 24" />
+                        <path class="workspace-agent-map-avatar-collar" d="M36 65l12 9 12-9" />
+                      </svg>
+                      <span class="workspace-agent-map-avatar-placeholder">?</span>
+                      <span class="workspace-agent-map-avatar-create-badge">+</span>
+                    </div>
                     <span id="workspaceAgentMapNodeKicker" class="workspace-agent-map-node-kicker">AGENT SETUP</span>
                     <strong id="workspaceAgentMapNodeName">Checking agent setup</strong>
                     <span id="workspaceAgentMapNodeDetail">This workspace needs a primary agent.</span>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -136,8 +136,8 @@
                   <input id="workspaceTemplateAgentSetupIndex" type="hidden">
                   <label for="workspaceTemplateAgentSetupName">Name</label>
                   <input id="workspaceTemplateAgentSetupName" class="modern-input" type="text" autocomplete="off" maxlength="100" required>
-                  <label for="workspaceTemplateAgentSetupModel">Model <span>optional</span></label>
-                  <input id="workspaceTemplateAgentSetupModel" class="modern-input" type="text" autocomplete="off" placeholder="Use blueprint default">
+                  <label for="workspaceTemplateAgentSetupModel">Model</label>
+                  <select id="workspaceTemplateAgentSetupModel" class="modern-input"></select>
                   <label for="workspaceTemplateAgentSetupPrompt">Instructions <span>optional</span></label>
                   <textarea id="workspaceTemplateAgentSetupPrompt" class="modern-input" rows="4" placeholder="Use the blueprint instructions"></textarea>
                   <p id="workspaceTemplateAgentSetupStatus" class="workspace-template-agent-setup-status" aria-live="polite"></p>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -77,7 +77,7 @@
                 </div>
               </div>
 
-              <!-- A deliberately small, non-interactive team preview makes the
+              <!-- A deliberately small team preview makes the
                    primary-agent hierarchy tangible before the user reaches
                    review. Its avatars are visual identities, not substitutes
                    for the plainly stated lifecycle status below. -->
@@ -89,10 +89,10 @@
                   </div>
                   <span id="workspaceAgentMapState" class="workspace-agent-map-state">Checking</span>
                 </div>
-                <div class="workspace-agent-map-canvas" aria-hidden="true">
+                <div class="workspace-agent-map-canvas">
                   <div id="workspaceAgentMapNode" class="workspace-agent-map-node is-loading">
-                    <div class="workspace-agent-map-avatar">
-                      <svg class="workspace-agent-map-avatar-figure" viewBox="0 0 96 96" focusable="false">
+                    <button id="workspaceAgentMapAvatarAction" type="button" class="workspace-agent-map-avatar" disabled aria-label="Primary workspace agent is loading">
+                      <svg class="workspace-agent-map-avatar-figure" viewBox="0 0 96 96" focusable="false" aria-hidden="true">
                         <path class="workspace-agent-map-avatar-antenna" d="M48 15V8m0 0 6-5" />
                         <rect class="workspace-agent-map-avatar-head" x="25" y="19" width="46" height="37" rx="12" />
                         <path class="workspace-agent-map-avatar-visor" d="M33 36h30" />
@@ -102,14 +102,14 @@
                         <path class="workspace-agent-map-avatar-body" d="M20 86c2-16 13-24 28-24s26 8 28 24" />
                         <path class="workspace-agent-map-avatar-collar" d="M36 65l12 9 12-9" />
                       </svg>
-                      <span class="workspace-agent-map-avatar-placeholder">?</span>
-                      <span class="workspace-agent-map-avatar-create-badge">+</span>
-                    </div>
+                      <span class="workspace-agent-map-avatar-placeholder" aria-hidden="true">?</span>
+                      <span class="workspace-agent-map-avatar-create-badge" aria-hidden="true">+</span>
+                    </button>
                     <span id="workspaceAgentMapNodeKicker" class="workspace-agent-map-node-kicker">AGENT SETUP</span>
                     <strong id="workspaceAgentMapNodeName">Checking agent setup</strong>
                     <span id="workspaceAgentMapNodeDetail">This workspace needs a primary agent.</span>
                   </div>
-                  <div id="workspaceAgentMapSpecialists" class="workspace-agent-map-specialists"></div>
+                  <div id="workspaceAgentMapSpecialists" class="workspace-agent-map-specialists" aria-hidden="true"></div>
                 </div>
                 <p id="workspaceAgentMapStatus" class="workspace-agent-map-status" aria-live="polite">Checking the reusable agent for this workspace…</p>
               </section>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -87,7 +87,10 @@
                     <span class="workspace-wizard-eyebrow">Workspace preview</span>
                     <h3 id="workspaceAgentMapPreviewTitle">Primary workspace agent</h3>
                   </div>
-                  <span id="workspaceAgentMapState" class="workspace-agent-map-state">Checking</span>
+                  <div class="workspace-agent-map-preview-actions">
+                    <button id="workspaceAgentMapCreateAll" type="button" class="workspace-agent-map-create-all" hidden></button>
+                    <span id="workspaceAgentMapState" class="workspace-agent-map-state">Checking</span>
+                  </div>
                 </div>
                 <div class="workspace-agent-map-canvas">
                   <div id="workspaceAgentMapNode" class="workspace-agent-map-node is-loading">
@@ -109,7 +112,7 @@
                     <strong id="workspaceAgentMapNodeName">Checking agent setup</strong>
                     <span id="workspaceAgentMapNodeDetail">This workspace needs a primary agent.</span>
                   </div>
-                  <div id="workspaceAgentMapSpecialists" class="workspace-agent-map-specialists" aria-hidden="true"></div>
+                  <div id="workspaceAgentMapSpecialists" class="workspace-agent-map-specialists"></div>
                 </div>
                 <p id="workspaceAgentMapStatus" class="workspace-agent-map-status" aria-live="polite">Checking the reusable agent for this workspace…</p>
               </section>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -5,40 +5,37 @@
     <div class="modal-content" style="background: var(--bg-primary); border: 1px solid var(--border-color);">
       <div class="modal-header" style="border-bottom: 1px solid var(--border-color);">
         <h6 id="folderModalTitle" class="modal-title" style="color: var(--text-primary);">Create Workspace</h6>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close create workspace"></button>
       </div>
       <div class="modal-body workspace-create-modal-body">
         <div class="workspace-create-layout">
           <div class="workspace-create-main-fields">
 
-            <!-- Wizard stepper: hidden in import mode (single-step). -->
-            <div id="wizardStepper" class="workspace-create-stepper" aria-hidden="true">
-              <span class="workspace-create-step is-active" data-step="1">
-                <span class="workspace-create-step-num">1</span>Select Blueprint
+            <!-- Wizard stepper: hidden in Import mode, which remains single-step. -->
+            <div id="wizardStepper" class="workspace-create-stepper" aria-label="Create Workspace progress">
+              <span class="workspace-create-step is-active" data-step="1" aria-current="step">
+                <span class="workspace-create-step-num">1</span>Choose Blueprint
               </span>
               <span class="workspace-create-step-sep">→</span>
               <span class="workspace-create-step" data-step="2">
-                <span class="workspace-create-step-num">2</span>Construct
+                <span class="workspace-create-step-num">2</span>Workspace Details
+              </span>
+              <span class="workspace-create-step-sep">→</span>
+              <span class="workspace-create-step" data-step="3">
+                <span class="workspace-create-step-num">3</span>Review &amp; Create
               </span>
             </div>
 
-            <!-- ===== STEP 1 · SELECT BLUEPRINT: template grid + user templates ===== -->
-            <div id="wizardStep1">
-
-              <!-- Workspace name: the first input users reach. This is the single
-                   canonical #folderNameInput; refreshWizardChrome() relocates the
-                   #wizardNameField wrapper into #wizardStep2NameMount on Construct
-                   so the same field stays editable there (no dueling inputs). -->
-              <div id="wizardStep1NameMount">
-                <div id="wizardNameField" class="workspace-create-name-field mb-3">
-                  <label for="folderNameInput" class="workspace-create-section-title" style="display: block; margin-bottom: 6px;">Workspace name</label>
-                  <input type="text" id="folderNameInput" class="modern-input w-100" placeholder="Name your workspace" aria-describedby="workspaceNameHint">
-                  <div id="workspaceNameHint" class="workspace-create-name-hint" aria-live="polite"></div>
-                </div>
+            <!-- ===== STEP 1 · CHOOSE BLUEPRINT ===== -->
+            <section id="wizardStep1" aria-labelledby="wizardStep1Title">
+              <div class="workspace-wizard-step-heading">
+                <span class="workspace-wizard-eyebrow">Step 1 of 3</span>
+                <h2 id="wizardStep1Title" tabindex="-1">Choose a blueprint</h2>
+                <p>Start with a proven workspace shape, or begin with a clean slate.</p>
               </div>
 
               <div id="workspaceCreateBlueprintHeader" class="workspace-create-section-header d-flex align-items-center justify-content-between" style="margin-bottom: 6px;">
-                <span class="workspace-create-section-title">Select Blueprint</span>
+                <span class="workspace-create-section-title">Blueprints</span>
                 <button type="button" id="projectTemplateManageLink" class="modern-btn modern-btn-secondary" style="font-size: 11px; padding: 2px 8px; white-space: nowrap;">Manage…</button>
               </div>
               <div id="templatePicker" role="radiogroup" aria-label="Workspace template">
@@ -50,7 +47,7 @@
               </div>
               <div id="projectTemplateEmptyHint" style="margin-top: -2px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);" hidden></div>
               <div class="workspace-create-step-hint" style="margin-top: 4px; font-size: 12px; color: var(--text-secondary);">
-                Pick a blueprint (or Blank), then continue to name and configure it. Double-click a blueprint to skip ahead.
+                Pick a blueprint (or Blank), then continue to name and tailor the workspace. Double-click remains a shortcut.
               </div>
 
               <!-- Briefing: the selected blueprint's description + what it deploys.
@@ -60,11 +57,11 @@
               </div>
               <div id="templateBriefing" class="workspace-template-briefing mb-2">
                 <div id="templateBriefingDefault" class="workspace-template-briefing-default">
-                  Starting from a blank workspace with a Workspace Manager agent. You can add tools, more agents, and structure after it's created.
+                  Blank begins with a Workspace Manager assistant. You can add more teammates after creation.
                 </div>
                 <div id="projectTemplateDescription" class="workspace-template-briefing-desc" aria-live="polite" hidden></div>
                 <div id="templateBriefingDeploys" class="workspace-template-briefing-deploys" hidden>
-                  <div class="workspace-template-briefing-deploys-kicker">Deploys</div>
+                  <div class="workspace-template-briefing-deploys-kicker">Includes</div>
                   <div id="templateBriefingAgentsRow" class="workspace-template-briefing-row workspace-template-briefing-row-addons" hidden>
                     <span class="workspace-template-briefing-row-label">Agents</span>
                     <div id="templateBriefingAgentsValue" class="workspace-template-briefing-chips workspace-template-briefing-agents"></div>
@@ -79,21 +76,33 @@
                   </div>
                 </div>
               </div>
-            </div>
+            </section>
 
-            <!-- ===== STEP 2 · CONSTRUCT: name, description, agents, advanced ===== -->
-            <div id="wizardStep2" hidden>
+            <!-- ===== STEP 2 · WORKSPACE DETAILS ===== -->
+            <section id="wizardStep2" hidden aria-labelledby="wizardStep2Title">
+              <div class="workspace-wizard-step-heading">
+                <span class="workspace-wizard-eyebrow">Step 2 of 3</span>
+                <h2 id="wizardStep2Title" tabindex="-1">Workspace details</h2>
+                <p>Name the space and add the context Ori should carry into its review.</p>
+              </div>
 
               <!-- Recap of the blueprint chosen on step 1. -->
               <div id="wizardStep2Recap" class="workspace-create-recap mb-2">
                 <span id="wizardStep2RecapIcon" class="workspace-create-recap-icon" aria-hidden="true">✍</span>
-                <span class="workspace-create-recap-label">Constructing</span>
+                <span class="workspace-create-recap-label">Selected blueprint</span>
                 <span id="wizardStep2RecapName" class="workspace-create-recap-name">Blank workspace</span>
+                <button type="button" id="wizardEditBlueprintBtn" class="workspace-wizard-inline-action">Edit</button>
               </div>
 
-              <!-- Editable workspace name on Construct. #wizardNameField is moved
-                   here from step 1 by refreshWizardChrome(); this is just its mount. -->
-              <div id="wizardStep2NameMount" class="mb-2"></div>
+              <div id="wizardNameField" class="workspace-create-name-field mb-3">
+                <label for="folderNameInput" class="workspace-create-section-title" style="display: block; margin-bottom: 6px;">Workspace name</label>
+                <input type="text" id="folderNameInput" class="modern-input w-100" placeholder="Name your workspace" aria-describedby="workspaceNameHint">
+                <div id="workspaceNameHint" class="workspace-create-name-hint" aria-live="polite"></div>
+              </div>
+
+              <!-- Setup cards are mounted here while editing and relocated to the
+                   final review step by sessions.js. -->
+              <div id="wizardStep2ReviewMount"></div>
 
               <div id="projectTemplateOpenAfterCreate" class="workspace-setup-card mb-2" hidden>
                 <label class="d-flex align-items-start gap-2 mb-0" for="projectTemplateOpenAfterCreateToggle" style="cursor: pointer;">
@@ -108,12 +117,12 @@
               <div id="templateAgentReview" class="workspace-template-agent-review mb-2" hidden>
                 <div class="workspace-template-agent-review-head">
                   <div>
-                    <div class="workspace-template-agent-review-title">Template Agents</div>
+                    <div class="workspace-template-agent-review-title">Included assistant</div>
                     <div id="templateAgentReviewSummary" class="workspace-template-agent-review-summary" aria-live="polite"></div>
                   </div>
-                  <label class="workspace-template-agent-toggle">
+                  <label class="workspace-template-agent-toggle" title="Clear this to create the workspace without the assistant included by this blueprint.">
                     <input type="checkbox" id="templateAgentReviewToggle" checked>
-                    <span>Attach</span>
+                    <span>Include</span>
                   </label>
                 </div>
                 <div id="templateAgentReviewStatus" class="workspace-template-agent-review-status" aria-live="polite"></div>
@@ -240,7 +249,51 @@
                 </div>
               </div>
 
-            </div>
+            </section>
+
+            <!-- ===== STEP 3 · REVIEW & CREATE ===== -->
+            <section id="wizardStep3" hidden aria-labelledby="wizardStep3Title">
+              <div class="workspace-wizard-step-heading">
+                <span class="workspace-wizard-eyebrow">Step 3 of 3</span>
+                <h2 id="wizardStep3Title" tabindex="-1">Review &amp; create</h2>
+                <p>Confirm the workspace, its assistant or team, and anything that needs attention first.</p>
+              </div>
+
+              <div id="workspaceReviewSummary" class="workspace-review-summary" aria-live="polite"></div>
+
+              <section id="workspaceTeamReview" class="workspace-team-review" aria-labelledby="workspaceTeamHeading">
+                <div class="workspace-team-review-head">
+                  <div>
+                    <span class="workspace-wizard-eyebrow">Your setup</span>
+                    <h3 id="workspaceTeamHeading">Workspace Assistant</h3>
+                    <p id="workspaceTeamSummary" class="workspace-team-review-summary" aria-live="polite"></p>
+                  </div>
+                  <button type="button" id="addExistingAgentBtn" class="modern-btn modern-btn-secondary">+ Add Existing Agent</button>
+                </div>
+                <div id="templateAgentReviewMount"></div>
+                <div id="existingAgentTeamList" class="workspace-existing-agent-team" aria-live="polite"></div>
+                <div id="workspaceTeamDropZone" class="workspace-team-drop-zone" tabindex="0" aria-label="Drop an existing agent here to attach it to this workspace">
+                  Drop an existing agent here to attach it — it stays in its other workspaces.
+                </div>
+                <div id="workspaceTeamLiveRegion" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
+              </section>
+
+              <section id="existingAgentRosterPanel" class="workspace-existing-agent-roster" hidden aria-labelledby="existingAgentRosterTitle">
+                <div class="workspace-existing-agent-roster-head">
+                  <div>
+                    <span class="workspace-wizard-eyebrow">Your Agents</span>
+                    <h3 id="existingAgentRosterTitle">Add a saved agent</h3>
+                  </div>
+                  <button type="button" id="closeExistingAgentRosterBtn" class="workspace-wizard-icon-action" aria-label="Close Your Agents">×</button>
+                </div>
+                <label class="visually-hidden" for="existingAgentRosterSearch">Search your agents</label>
+                <input type="search" id="existingAgentRosterSearch" class="modern-input w-100" placeholder="Search saved agents">
+                <div id="existingAgentRosterStatus" class="workspace-existing-agent-roster-status" aria-live="polite"></div>
+                <div id="existingAgentRosterList" class="workspace-existing-agent-roster-list"></div>
+              </section>
+
+              <div id="wizardStep3ReviewMount"></div>
+            </section>
           </div>
         </div>
       </div>

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -116,6 +116,37 @@
                 </div>
                 <p id="workspaceAgentMapStatus" class="workspace-agent-map-status" aria-live="polite">Checking the reusable agent for this workspace…</p>
               </section>
+
+              <!-- The preview's + actions open this focused setup card before
+                   anything is saved globally. Keeping it in the wizard avoids
+                   a second modal stack while making the saved-agent boundary
+                   explicit. -->
+              <section id="workspaceTemplateAgentSetup" class="workspace-template-agent-setup" hidden aria-labelledby="workspaceTemplateAgentSetupTitle">
+                <div class="workspace-template-agent-setup-head">
+                  <div>
+                    <span class="workspace-wizard-eyebrow">Set up reusable agent</span>
+                    <h3 id="workspaceTemplateAgentSetupTitle">Create agent</h3>
+                  </div>
+                  <button id="workspaceTemplateAgentSetupCancel" type="button" class="workspace-template-agent-setup-cancel" aria-label="Close agent setup">×</button>
+                </div>
+                <p id="workspaceTemplateAgentSetupDescription" class="workspace-template-agent-setup-description">
+                  This will be saved in Your Agents and can be reused in future workspaces.
+                </p>
+                <form id="workspaceTemplateAgentSetupForm" class="workspace-template-agent-setup-form">
+                  <input id="workspaceTemplateAgentSetupIndex" type="hidden">
+                  <label for="workspaceTemplateAgentSetupName">Name</label>
+                  <input id="workspaceTemplateAgentSetupName" class="modern-input" type="text" autocomplete="off" maxlength="100" required>
+                  <label for="workspaceTemplateAgentSetupModel">Model <span>optional</span></label>
+                  <input id="workspaceTemplateAgentSetupModel" class="modern-input" type="text" autocomplete="off" placeholder="Use blueprint default">
+                  <label for="workspaceTemplateAgentSetupPrompt">Instructions <span>optional</span></label>
+                  <textarea id="workspaceTemplateAgentSetupPrompt" class="modern-input" rows="4" placeholder="Use the blueprint instructions"></textarea>
+                  <p id="workspaceTemplateAgentSetupStatus" class="workspace-template-agent-setup-status" aria-live="polite"></p>
+                  <div class="workspace-template-agent-setup-actions">
+                    <button id="workspaceTemplateAgentSetupBack" type="button" class="workspace-wizard-inline-action">Cancel</button>
+                    <button id="workspaceTemplateAgentSetupSave" type="submit" class="workspace-template-agent-setup-save">Save reusable agent</button>
+                  </div>
+                </form>
+              </section>
             </section>
 
             <!-- ===== STEP 2 · WORKSPACE DETAILS ===== -->

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -129,6 +129,40 @@ func TestRenderCreateWorkspaceProjectOpenOption(t *testing.T) {
 	}
 }
 
+func TestRenderCreateWorkspaceWizardReviewContract(t *testing.T) {
+	r := NewTemplateRenderer()
+	if err := r.LoadTemplates(); err != nil {
+		t.Fatalf("LoadTemplates failed: %v", err)
+	}
+
+	html, err := r.RenderTemplate("workspaces", TemplateData{Title: "Workspaces - Ori Agent"})
+	if err != nil {
+		t.Fatalf("RenderTemplate(workspaces) failed: %v", err)
+	}
+	for _, want := range []string{
+		`id="wizardStep1"`,
+		`id="wizardStep2"`,
+		`id="wizardStep3"`,
+		`aria-current="step"`,
+		`Choose Blueprint`,
+		`Workspace Details`,
+		`Review &amp; Create`,
+		`id="workspaceTeamLiveRegion"`,
+		`id="addExistingAgentBtn"`,
+		`id="existingAgentRosterPanel"`,
+		`aria-label="Close create workspace"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rendered Create Workspace wizard missing %q", want)
+		}
+	}
+	for _, gone := range []string{"Select Blueprint", "Construct", "Template Agents"} {
+		if strings.Contains(html, gone) {
+			t.Errorf("rendered Create Workspace wizard contains stale copy %q", gone)
+		}
+	}
+}
+
 func TestRenderAgentsDetailDefaultsSidebarHidden(t *testing.T) {
 	r := NewTemplateRenderer()
 	if err := r.LoadTemplates(); err != nil {

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -150,6 +150,9 @@ func TestRenderCreateWorkspaceWizardReviewContract(t *testing.T) {
 		`id="workspaceTeamLiveRegion"`,
 		`id="addExistingAgentBtn"`,
 		`id="existingAgentRosterPanel"`,
+		`id="workspaceAgentMapPreview"`,
+		`id="workspaceAgentMapNode"`,
+		`id="workspaceAgentMapStatus"`,
 		`aria-label="Close create workspace"`,
 	} {
 		if !strings.Contains(html, want) {

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -611,7 +611,7 @@ test('review visualizes every included template agent and its lifecycle', async 
   );
 });
 
-test('primary avatar immediately creates a reusable template agent', async ({ page }) => {
+test('primary avatar opens setup before saving a reusable template agent', async ({ page }) => {
   let createPayload: Record<string, unknown> | null = null;
   await page.route('**/api/workspaces/template-agent-plan**', async route => {
     await route.fulfill({
@@ -641,7 +641,7 @@ test('primary avatar immediately creates a reusable template agent', async ({ pa
       body: JSON.stringify({
         created: true,
         agent: {
-          name: 'Reaper Producer',
+          name: 'My Reaper Producer',
           scope: 'reusable',
           action: 'reuse',
           entry_point: true,
@@ -652,7 +652,7 @@ test('primary avatar immediately creates a reusable template agent', async ({ pa
           has_agents: true,
           agents: [
             {
-              name: 'Reaper Producer',
+              name: 'My Reaper Producer',
               scope: 'reusable',
               action: 'reuse',
               entry_point: true,
@@ -670,15 +670,31 @@ test('primary avatar immediately creates a reusable template agent', async ({ pa
   await cardByLabel(page, 'Reaper Song').click();
   const action = page.locator('#workspaceAgentMapAvatarAction');
   await expect(action).toBeEnabled();
-  await expect(action).toHaveAccessibleName(/create reaper producer as a reusable agent now/i);
+  await expect(action).toHaveAccessibleName(/set up reaper producer as a reusable agent/i);
   await action.click();
+
+  await expect(page.locator('#workspaceTemplateAgentSetup')).toBeVisible();
+  await expect(page.locator('#workspaceTemplateAgentSetupName')).toHaveValue('Reaper Producer');
+  expect(createPayload).toBeNull();
+  await page.locator('#workspaceTemplateAgentSetupName').fill('My Reaper Producer');
+  await page.locator('#workspaceTemplateAgentSetupModel').fill('gpt-5.3-codex');
+  await page.locator('#workspaceTemplateAgentSetupPrompt').fill('Produce with deliberate restraint.');
+  await page.locator('#workspaceTemplateAgentSetupSave').click();
 
   await expect(page.locator('#workspaceAgentMapState')).toHaveText('Ready');
   await expect(page.locator('#workspaceAgentMapNodeDetail')).toHaveText('Saved reusable agent');
-  expect(createPayload).toMatchObject({ agent_index: 0 });
+  expect(createPayload).toMatchObject({
+    agent_index: 0,
+    override: {
+      index: 0,
+      name: 'My Reaper Producer',
+      model: 'gpt-5.3-codex',
+      system_prompt: 'Produce with deliberate restraint.'
+    }
+  });
 });
 
-test('team preview creates every missing reusable agent', async ({ page }) => {
+test('team preview exposes specialist setup and keeps create-all as a defaults shortcut', async ({ page }) => {
   const createdIndexes: number[] = [];
   const agentNames = ['Research Lead', 'Source Scout', 'Synthesis Writer'];
   const plan = () => ({
@@ -719,7 +735,16 @@ test('team preview creates every missing reusable agent', async ({ page }) => {
   await cardByLabel(page, 'Research Project').click();
   const createAll = page.locator('#workspaceAgentMapCreateAll');
   await expect(createAll).toBeVisible();
-  await expect(createAll).toHaveText('Create all 2');
+  await expect(createAll).toHaveText('Create all defaults (2)');
+
+  const specialist = page.locator('button.workspace-agent-map-specialist-avatar[data-template-agent-index="1"]');
+  await expect(specialist).toBeVisible();
+  await specialist.click();
+  await expect(page.locator('#workspaceTemplateAgentSetup')).toBeVisible();
+  await expect(page.locator('#workspaceTemplateAgentSetupName')).toHaveValue('Source Scout');
+  await page.locator('#workspaceTemplateAgentSetupBack').click();
+  expect(createdIndexes).toEqual([]);
+
   await createAll.click();
 
   await expect.poll(() => createdIndexes.length).toBe(2);

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -572,4 +572,14 @@ test('review explains a first-use template agent as reusable and workspace-prima
   await expect(review).toContainText('Reaper Producer');
   await expect(review).toContainText('New reusable agent · Added to Your Agents and attached');
   await expect(review).toContainText('Primary workspace agent');
+  const preview = page.locator('#workspaceAgentMapPreview');
+  await expect(preview).toContainText('Reaper Producer');
+  await expect(preview).toContainText('New agent');
+  await expect(preview).toContainText('not in Your Agents yet');
+  await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-new/);
+
+  await review.locator('.workspace-template-agent-advanced summary').click();
+  await review.locator('#templateAgentReviewToggle').uncheck();
+  await expect(preview).toContainText('No agent selected');
+  await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-missing/);
 });

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -512,7 +512,7 @@ test('review attaches a saved agent and submits the complete team atomically', a
   await expect(page.locator('#existingAgentRosterPanel')).toBeVisible();
   await page.locator('[data-existing-agent-add="Research Scout"]').click();
   await expect(page.locator('#existingAgentTeamList')).toContainText('Research Scout');
-  await expect(page.locator('#existingAgentTeamList')).toContainText('Primary assistant');
+  await expect(page.locator('#existingAgentTeamList')).toContainText('Primary workspace agent');
   await page.locator('[data-existing-agent-name="Data Miner"]').evaluate(card => {
     const data = new DataTransfer();
     data.setData('application/x-ori-agent-name', 'Data Miner');
@@ -537,4 +537,39 @@ test('review attaches a saved agent and submits the complete team atomically', a
   await page.waitForURL('**/workspaces/atomic-team');
   expect(payload?.existing_agent_names).toEqual(['Research Scout', 'Data Miner']);
   expect(payload?.entry_agent_name).toBe('Research Scout');
+});
+
+test('review explains a first-use template agent as reusable and workspace-primary', async ({
+  page
+}) => {
+  await page.route('**/api/workspaces/template-agent-plan**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        has_agents: true,
+        agents: [
+          {
+            name: 'Reaper Producer',
+            scope: 'reusable',
+            action: 'create',
+            entry_point: true,
+            role: 'orchestrator',
+            model_source: 'agent_default'
+          }
+        ],
+        warnings: []
+      })
+    });
+  });
+  await openCreateModal(page);
+  await cardByLabel(page, 'Reaper Song').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
+
+  const review = page.locator('#templateAgentReview');
+  await expect(review).toContainText('Blueprint agents');
+  await expect(review).toContainText('Reaper Producer');
+  await expect(review).toContainText('New reusable agent · Added to Your Agents and attached');
+  await expect(review).toContainText('Primary workspace agent');
 });

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -539,9 +539,7 @@ test('review attaches a saved agent and submits the complete team atomically', a
   expect(payload?.entry_agent_name).toBe('Research Scout');
 });
 
-test('review explains a first-use template agent as reusable and workspace-primary', async ({
-  page
-}) => {
+test('review visualizes every included template agent and its lifecycle', async ({ page }) => {
   await page.route('**/api/workspaces/template-agent-plan**', async route => {
     await route.fulfill({
       status: 200,
@@ -550,11 +548,27 @@ test('review explains a first-use template agent as reusable and workspace-prima
         has_agents: true,
         agents: [
           {
-            name: 'Reaper Producer',
+            name: 'Research Lead',
             scope: 'reusable',
-            action: 'create',
+            action: 'reuse',
             entry_point: true,
             role: 'orchestrator',
+            model_source: 'agent_default'
+          },
+          {
+            name: 'Source Scout',
+            scope: 'reusable',
+            action: 'reuse',
+            entry_point: false,
+            role: 'specialist',
+            model_source: 'agent_default'
+          },
+          {
+            name: 'Synthesis Writer',
+            scope: 'reusable',
+            action: 'create',
+            entry_point: false,
+            role: 'specialist',
             model_source: 'agent_default'
           }
         ],
@@ -569,15 +583,20 @@ test('review explains a first-use template agent as reusable and workspace-prima
 
   const review = page.locator('#templateAgentReview');
   await expect(review).toContainText('Blueprint agents');
-  await expect(review).toContainText('Reaper Producer');
+  await expect(review).toContainText('Research Lead');
   await expect(review).toContainText('New reusable agent · Added to Your Agents and attached');
   await expect(review).toContainText('Primary workspace agent');
   const preview = page.locator('#workspaceAgentMapPreview');
-  await expect(preview).toContainText('Reaper Producer');
-  await expect(preview).toContainText('New agent');
-  await expect(preview).toContainText('not in Your Agents yet');
-  await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-new/);
-  await expect(page.locator('.workspace-agent-map-avatar-create-badge')).toHaveCSS(
+  await expect(preview).toContainText('Workspace team · 3 agents');
+  await expect(preview).toContainText('Research Lead');
+  await expect(preview).toContainText('Source Scout');
+  await expect(preview).toContainText('Synthesis Writer');
+  await expect(preview).toContainText('Synthesis Writer is not in Your Agents yet');
+  await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-ready/);
+  await expect(page.locator('#workspaceAgentMapSpecialists')).toHaveText(
+    /Source Scout[\s\S]*Synthesis Writer/
+  );
+  await expect(page.locator('.workspace-agent-map-specialist-create-badge')).toHaveCSS(
     'display',
     'grid'
   );

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -677,3 +677,53 @@ test('primary avatar immediately creates a reusable template agent', async ({ pa
   await expect(page.locator('#workspaceAgentMapNodeDetail')).toHaveText('Saved reusable agent');
   expect(createPayload).toMatchObject({ agent_index: 0 });
 });
+
+test('team preview creates every missing reusable agent', async ({ page }) => {
+  const createdIndexes: number[] = [];
+  const agentNames = ['Research Lead', 'Source Scout', 'Synthesis Writer'];
+  const plan = () => ({
+    has_agents: true,
+    agents: agentNames.map((name, index) => ({
+      name,
+      scope: 'reusable',
+      action: createdIndexes.includes(index) || index === 2 ? 'reuse' : 'create',
+      entry_point: index === 0,
+      role: index === 0 ? 'orchestrator' : 'specialist',
+      model_source: 'agent_default'
+    })),
+    warnings: []
+  });
+  await page.route('**/api/workspaces/template-agent-plan**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(plan())
+    });
+  });
+  await page.route('**/api/workspaces/template-agent-create', async route => {
+    const payload = route.request().postDataJSON();
+    createdIndexes.push(payload.agent_index);
+    const nextPlan = plan();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        created: true,
+        agent: nextPlan.agents[payload.agent_index],
+        plan: nextPlan
+      })
+    });
+  });
+
+  await openCreateModal(page);
+  await cardByLabel(page, 'Research Project').click();
+  const createAll = page.locator('#workspaceAgentMapCreateAll');
+  await expect(createAll).toBeVisible();
+  await expect(createAll).toHaveText('Create all 2');
+  await createAll.click();
+
+  await expect.poll(() => createdIndexes.length).toBe(2);
+  expect(createdIndexes).toEqual([0, 1]);
+  await expect(createAll).toBeHidden();
+  await expect(page.locator('#workspaceAgentMapState')).toHaveText('Ready');
+});

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -29,10 +29,29 @@ async function openCreateModal(page: Page) {
   await expect(cardByLabel(page, 'Content Production')).toBeVisible();
 }
 
+async function advanceToWorkspaceDetails(page: Page) {
+  await page.locator('#wizardNextBtn').click();
+  await expect(page.locator('#wizardStep2')).toBeVisible();
+}
+
+async function advanceToReview(page: Page) {
+  await page.locator('#wizardNextBtn').click();
+  await expect(page.locator('#wizardStep3')).toBeVisible();
+}
+
+async function returnToBlueprints(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as unknown as { sessionManager: { goToWizardStep: (step: number) => void } }
+    ).sessionManager.goToWizardStep(1);
+  });
+  await expect(page.locator('#wizardStep1')).toBeVisible();
+}
+
 function cardByLabel(page: Page, label: string) {
-  return page
-    .locator('#templatePicker .workspace-template-card')
-    .filter({ has: page.locator('.workspace-template-card-label', { hasText: new RegExp(`^${label}$`) }) });
+  return page.locator('#templatePicker .workspace-template-card').filter({
+    has: page.locator('.workspace-template-card-label', { hasText: new RegExp(`^${label}$`) })
+  });
 }
 
 async function routeProjectEntryTemplates(page: Page) {
@@ -43,9 +62,19 @@ async function routeProjectEntryTemplates(page: Page) {
       body: JSON.stringify({
         templates_root: '/tmp/templates',
         templates: [
-          { id: 'research-project', name: 'Research Project', builtin: true, behavior_profile: 'research' },
+          {
+            id: 'research-project',
+            name: 'Research Project',
+            builtin: true,
+            behavior_profile: 'research'
+          },
           { id: 'travels', name: 'Travels', builtin: true, behavior_profile: 'general' },
-          { id: 'content-production', name: 'Content Production', builtin: true, behavior_profile: 'general' },
+          {
+            id: 'content-production',
+            name: 'Content Production',
+            builtin: true,
+            behavior_profile: 'general'
+          },
           {
             id: 'auto-project',
             name: 'Auto Project',
@@ -81,7 +110,13 @@ async function stubWorkspaceReview(page: Page) {
     const w = window as unknown as { WorkspaceBootstrapReview?: Record<string, unknown> };
     const r = (w.WorkspaceBootstrapReview = w.WorkspaceBootstrapReview || {});
     r.ensureReviewed = async () => ({ ready: true });
-    r.applyPlan = async () => ({ invitedAgents: 0, boundMCPs: 0, attachedSkills: 0, addedPlugins: 0, failures: [] });
+    r.applyPlan = async () => ({
+      invitedAgents: 0,
+      boundMCPs: 0,
+      attachedSkills: 0,
+      addedPlugins: 0,
+      failures: []
+    });
   });
 }
 
@@ -92,8 +127,11 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/workspaces');
 });
 
-test('starting point sets Agent behavior; manual override is preserved; reopen resets', async ({ page }) => {
+test('starting point sets Agent behavior; manual override is preserved; reopen resets', async ({
+  page
+}) => {
   await openCreateModal(page);
+  await advanceToWorkspaceDetails(page);
 
   const sel = page.locator('#folderPresetSelect');
   const hint = page.locator('#folderBehaviorHint');
@@ -106,7 +144,9 @@ test('starting point sets Agent behavior; manual override is preserved; reopen r
 
   // Pick Research Project -> research, hint updates (value/hint update even
   // while the Advanced section is collapsed).
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Research Project').click();
+  await advanceToWorkspaceDetails(page);
   await expect(sel).toHaveValue('research');
   await expect(hint).toHaveText('Agent behavior: Research');
 
@@ -120,7 +160,9 @@ test('starting point sets Agent behavior; manual override is preserved; reopen r
   await expect(hint).toHaveText('Agent behavior: Software Project');
 
   // Pick Travels (maps to general) -> override is preserved.
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Travels').click();
+  await advanceToWorkspaceDetails(page);
   await expect(sel).toHaveValue('software_project');
 
   // Close + reopen -> reset to defaults, disclosure collapsed.
@@ -132,12 +174,15 @@ test('starting point sets Agent behavior; manual override is preserved; reopen r
   await expect(page.locator('#addFolderModal')).toBeHidden();
 
   await openCreateModal(page);
+  await advanceToWorkspaceDetails(page);
   await expect(sel).toHaveValue('general');
   await expect(hint).toHaveText('Agent behavior: General');
   await expect(disclosure).toHaveJSProperty('open', false);
 });
 
-test('switching starting points updates auto-filled name, but never typed input', async ({ page }) => {
+test('switching starting points updates auto-filled name, but never typed input', async ({
+  page
+}) => {
   await openCreateModal(page);
   const name = page.locator('#folderNameInput');
 
@@ -150,20 +195,27 @@ test('switching starting points updates auto-filled name, but never typed input'
   await cardByLabel(page, 'Content Production').click();
   await expect(name).toHaveValue('Content Production');
 
+  await advanceToWorkspaceDetails(page);
+
   // Typed input is never clobbered by a later card switch.
   await name.fill('My Custom Name');
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Research Project').click();
   await expect(name).toHaveValue('My Custom Name');
 
   // Blank clears an auto-filled value (clean slate) but leaves typed input.
+  await advanceToWorkspaceDetails(page);
   await name.fill('');
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Travels').click();
   await expect(name).toHaveValue('Travels');
   await cardByLabel(page, 'Blank').click();
   await expect(name).toHaveValue('');
 });
 
-test('project-open option follows template defaults and resets for non-library flows', async ({ page }) => {
+test('project-open option follows template defaults and resets for non-library flows', async ({
+  page
+}) => {
   await routeProjectEntryTemplates(page);
   await openCreateModal(page);
 
@@ -173,27 +225,43 @@ test('project-open option follows template defaults and resets for non-library f
   await expect(toggle).not.toBeChecked();
 
   await cardByLabel(page, 'Auto Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(panel).toBeVisible();
   await expect(toggle).toBeChecked();
 
   await toggle.uncheck();
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Manual Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(panel).toBeVisible();
   await expect(toggle).not.toBeChecked();
   await toggle.check();
 
   // Every template change reapplies that template's own default.
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Auto Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(toggle).toBeChecked();
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Manual Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(toggle).not.toBeChecked();
 
+  await returnToBlueprints(page);
   await cardByLabel(page, 'No Entry').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(panel).toBeHidden();
   await expect(toggle).not.toBeChecked();
 
   // An ad-hoc path overrides the selected library template and clears launch.
+  await returnToBlueprints(page);
   await cardByLabel(page, 'Auto Project').click();
+  await advanceToWorkspaceDetails(page);
   await page.locator('#folderAdvancedDisclosure .workspace-advanced-summary').click();
   await page.locator('#projectTemplatePathInput').fill('/tmp/ad-hoc-template');
   await expect(panel).toBeHidden();
@@ -201,8 +269,9 @@ test('project-open option follows template defaults and resets for non-library f
 
   // Import mode never carries a launch choice.
   await page.evaluate(() => {
-    (window as unknown as { sessionManager: { setImportModeEnabled: (enabled: boolean) => void } })
-      .sessionManager.setImportModeEnabled(true);
+    (
+      window as unknown as { sessionManager: { setImportModeEnabled: (enabled: boolean) => void } }
+    ).sessionManager.setImportModeEnabled(true);
   });
   await expect(panel).toBeHidden();
   await expect(toggle).not.toBeChecked();
@@ -214,11 +283,14 @@ test('project-open option follows template defaults and resets for non-library f
   });
   await expect(page.locator('#addFolderModal')).toBeHidden();
   await openCreateModal(page);
+  await advanceToWorkspaceDetails(page);
   await expect(panel).toBeHidden();
   await expect(toggle).not.toBeChecked();
 });
 
-test('live Reaper Song defaults to launch, supports keyboard opt-out, and never opens on reload', async ({ page }) => {
+test('live Reaper Song defaults to launch, supports keyboard opt-out, and never opens on reload', async ({
+  page
+}) => {
   let openCalls = 0;
   await page.route('**/api/workspaces/**/project/open', async route => {
     openCalls += 1;
@@ -227,6 +299,8 @@ test('live Reaper Song defaults to launch, supports keyboard opt-out, and never 
 
   await openCreateModal(page);
   await cardByLabel(page, 'Reaper Song').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
 
   const panel = page.locator('#projectTemplateOpenAfterCreate');
   const toggle = page.locator('#projectTemplateOpenAfterCreateToggle');
@@ -242,7 +316,9 @@ test('live Reaper Song defaults to launch, supports keyboard opt-out, and never 
   await expect.poll(() => openCalls).toBe(0);
 });
 
-test('checked project-open option posts exactly once after create and before navigation', async ({ page }) => {
+test('checked project-open option posts exactly once after create and before navigation', async ({
+  page
+}) => {
   await routeProjectEntryTemplates(page);
   await openCreateModal(page);
   await stubWorkspaceReview(page);
@@ -250,7 +326,11 @@ test('checked project-open option posts exactly once after create and before nav
   const calls: string[] = [];
   await page.route('**/api/workspaces/created-open/project/open', async route => {
     calls.push('open');
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ message: 'ok' }) });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'ok' })
+    });
   });
   await page.route('**/api/workspaces', async route => {
     calls.push('create');
@@ -262,6 +342,8 @@ test('checked project-open option posts exactly once after create and before nav
   });
 
   await cardByLabel(page, 'Auto Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(page.locator('#projectTemplateOpenAfterCreateToggle')).toBeChecked();
   await page.locator('#createFolderBtn').click();
   await page.waitForURL('**/workspaces/created-open');
@@ -269,7 +351,9 @@ test('checked project-open option posts exactly once after create and before nav
   await expect.poll(() => calls).toEqual(['create', 'open']);
 });
 
-test('unchecked project-open option creates and navigates without an open request', async ({ page }) => {
+test('unchecked project-open option creates and navigates without an open request', async ({
+  page
+}) => {
   await routeProjectEntryTemplates(page);
   await openCreateModal(page);
   await stubWorkspaceReview(page);
@@ -288,6 +372,8 @@ test('unchecked project-open option creates and navigates without an open reques
   });
 
   await cardByLabel(page, 'Manual Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await expect(page.locator('#projectTemplateOpenAfterCreateToggle')).not.toBeChecked();
   await page.locator('#createFolderBtn').click();
   await page.waitForURL('**/workspaces/created-closed');
@@ -317,6 +403,8 @@ test('project-open failure still navigates and shows a one-time retry notice', a
   });
 
   await cardByLabel(page, 'Auto Project').click();
+  await advanceToWorkspaceDetails(page);
+  await advanceToReview(page);
   await page.locator('#createFolderBtn').click();
   await page.waitForURL('**/workspaces/created-failure');
   const retryNotice = page.locator('.toast-message', { hasText: 'Use Open Project to try again' });
@@ -337,25 +425,44 @@ test('createFolder submits workspace_preset for create and import', async ({ pag
     const w = window as unknown as { WorkspaceBootstrapReview?: Record<string, unknown> };
     const r = (w.WorkspaceBootstrapReview = w.WorkspaceBootstrapReview || {});
     r.ensureReviewed = async () => ({ ready: true });
-    r.applyPlan = async () => ({ invitedAgents: 0, boundMCPs: 0, attachedSkills: 0, addedPlugins: 0, failures: [] });
+    r.applyPlan = async () => ({
+      invitedAgents: 0,
+      boundMCPs: 0,
+      attachedSkills: 0,
+      addedPlugins: 0,
+      failures: []
+    });
   });
 
   const captured: Record<string, string | undefined> = {};
   // Register import first so the more specific path wins for that URL.
-  await page.route('**/api/workspaces/import', async (route) => {
+  await page.route('**/api/workspaces/import', async route => {
     captured.import = route.request().postDataJSON()?.workspace_preset;
-    await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'stubbed' }) });
+    await route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'stubbed' })
+    });
   });
-  await page.route('**/api/workspaces', async (route) => {
+  await page.route('**/api/workspaces', async route => {
     captured.create = route.request().postDataJSON()?.workspace_preset;
-    await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'stubbed' }) });
+    await route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'stubbed' })
+    });
   });
 
   // CREATE: Research Project -> expect workspace_preset 'research'.
   await cardByLabel(page, 'Research Project').click();
+  await advanceToWorkspaceDetails(page);
   await page.fill('#folderNameInput', 'E2E Preset WS');
   await page.fill('#folderDescriptionInput', 'e2e preset submission test');
-  await page.evaluate(() => (window as unknown as { sessionManager: { createFolder: () => Promise<void> } }).sessionManager.createFolder());
+  await page.evaluate(() =>
+    (
+      window as unknown as { sessionManager: { createFolder: () => Promise<void> } }
+    ).sessionManager.createFolder()
+  );
   await expect.poll(() => captured.create).toBe('research');
 
   // IMPORT: enable import mode + a path, then submit again.
@@ -367,6 +474,67 @@ test('createFolder submits workspace_preset for create and import', async ({ pag
     const pathInput = document.getElementById('folderImportPathInput') as HTMLInputElement | null;
     if (pathInput) pathInput.value = '/tmp/e2e-folder';
   });
-  await page.evaluate(() => (window as unknown as { sessionManager: { createFolder: () => Promise<void> } }).sessionManager.createFolder());
+  await page.evaluate(() =>
+    (
+      window as unknown as { sessionManager: { createFolder: () => Promise<void> } }
+    ).sessionManager.createFolder()
+  );
   await expect.poll(() => captured.import).toBe('research');
+});
+
+test('review attaches a saved agent and submits the complete team atomically', async ({ page }) => {
+  await page.route('**/api/workspaces/template-agent-plan**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ has_agents: false, agents: [], warnings: [] })
+    });
+  });
+  await page.route('**/api/agents/dashboard/list**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        agents: [
+          { name: 'Research Scout', model: 'gpt-5.5', workspace_count: 2 },
+          { name: 'Data Miner', model: 'gpt-5.5-mini', workspace_count: 0 }
+        ]
+      })
+    });
+  });
+  await openCreateModal(page);
+  await cardByLabel(page, 'Blank').click();
+  await advanceToWorkspaceDetails(page);
+  await page.locator('#folderNameInput').fill('Atomic Team');
+  await advanceToReview(page);
+
+  await page.locator('#addExistingAgentBtn').click();
+  await expect(page.locator('#existingAgentRosterPanel')).toBeVisible();
+  await page.locator('[data-existing-agent-add="Research Scout"]').click();
+  await expect(page.locator('#existingAgentTeamList')).toContainText('Research Scout');
+  await expect(page.locator('#existingAgentTeamList')).toContainText('Primary assistant');
+  await page.locator('[data-existing-agent-name="Data Miner"]').evaluate(card => {
+    const data = new DataTransfer();
+    data.setData('application/x-ori-agent-name', 'Data Miner');
+    document
+      .getElementById('workspaceTeamDropZone')
+      ?.dispatchEvent(
+        new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: data })
+      );
+  });
+  await expect(page.locator('#existingAgentTeamList')).toContainText('Data Miner');
+
+  let payload: Record<string, unknown> | undefined;
+  await page.route('**/api/workspaces', async route => {
+    payload = route.request().postDataJSON();
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ folder: { id: 'atomic-team' }, seeded_starter_tasks: 0 })
+    });
+  });
+  await page.locator('#createFolderBtn').click();
+  await page.waitForURL('**/workspaces/atomic-team');
+  expect(payload?.existing_agent_names).toEqual(['Research Scout', 'Data Miner']);
+  expect(payload?.entry_agent_name).toBe('Research Scout');
 });

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -553,7 +553,9 @@ test('review visualizes every included template agent and its lifecycle', async 
             action: 'reuse',
             entry_point: true,
             role: 'orchestrator',
-            model_source: 'agent_default'
+            model: 'gpt-5.3-codex',
+            provider: 'codex',
+            model_source: 'template'
           },
           {
             name: 'Source Scout',
@@ -646,6 +648,8 @@ test('primary avatar opens setup before saving a reusable template agent', async
           action: 'reuse',
           entry_point: true,
           role: 'orchestrator',
+          model: 'gpt-5.3-codex',
+          provider: 'codex',
           model_source: 'existing'
         },
         plan: {
@@ -657,6 +661,8 @@ test('primary avatar opens setup before saving a reusable template agent', async
               action: 'reuse',
               entry_point: true,
               role: 'orchestrator',
+              model: 'gpt-5.3-codex',
+              provider: 'codex',
               model_source: 'existing'
             }
           ],
@@ -677,7 +683,7 @@ test('primary avatar opens setup before saving a reusable template agent', async
   await expect(page.locator('#workspaceTemplateAgentSetupName')).toHaveValue('Reaper Producer');
   expect(createPayload).toBeNull();
   await page.locator('#workspaceTemplateAgentSetupName').fill('My Reaper Producer');
-  await page.locator('#workspaceTemplateAgentSetupModel').fill('gpt-5.3-codex');
+  await page.locator('#workspaceTemplateAgentSetupModel').selectOption('gpt-5.3-codex');
   await page.locator('#workspaceTemplateAgentSetupPrompt').fill('Produce with deliberate restraint.');
   await page.locator('#workspaceTemplateAgentSetupSave').click();
 
@@ -689,6 +695,7 @@ test('primary avatar opens setup before saving a reusable template agent', async
       index: 0,
       name: 'My Reaper Producer',
       model: 'gpt-5.3-codex',
+      provider: 'codex',
       system_prompt: 'Produce with deliberate restraint.'
     }
   });

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -577,9 +577,17 @@ test('review explains a first-use template agent as reusable and workspace-prima
   await expect(preview).toContainText('New agent');
   await expect(preview).toContainText('not in Your Agents yet');
   await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-new/);
+  await expect(page.locator('.workspace-agent-map-avatar-create-badge')).toHaveCSS(
+    'display',
+    'grid'
+  );
 
   await review.locator('.workspace-template-agent-advanced summary').click();
   await review.locator('#templateAgentReviewToggle').uncheck();
   await expect(preview).toContainText('No agent selected');
   await expect(page.locator('#workspaceAgentMapNode')).toHaveClass(/is-missing/);
+  await expect(page.locator('.workspace-agent-map-avatar-placeholder')).toHaveCSS(
+    'display',
+    'block'
+  );
 });

--- a/tests/create-workspace-behavior.spec.ts
+++ b/tests/create-workspace-behavior.spec.ts
@@ -610,3 +610,70 @@ test('review visualizes every included template agent and its lifecycle', async 
     'block'
   );
 });
+
+test('primary avatar immediately creates a reusable template agent', async ({ page }) => {
+  let createPayload: Record<string, unknown> | null = null;
+  await page.route('**/api/workspaces/template-agent-plan**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        has_agents: true,
+        agents: [
+          {
+            name: 'Reaper Producer',
+            scope: 'reusable',
+            action: 'create',
+            entry_point: true,
+            role: 'orchestrator',
+            model_source: 'agent_default'
+          }
+        ],
+        warnings: []
+      })
+    });
+  });
+  await page.route('**/api/workspaces/template-agent-create', async route => {
+    createPayload = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        created: true,
+        agent: {
+          name: 'Reaper Producer',
+          scope: 'reusable',
+          action: 'reuse',
+          entry_point: true,
+          role: 'orchestrator',
+          model_source: 'existing'
+        },
+        plan: {
+          has_agents: true,
+          agents: [
+            {
+              name: 'Reaper Producer',
+              scope: 'reusable',
+              action: 'reuse',
+              entry_point: true,
+              role: 'orchestrator',
+              model_source: 'existing'
+            }
+          ],
+          warnings: []
+        }
+      })
+    });
+  });
+
+  await openCreateModal(page);
+  await cardByLabel(page, 'Reaper Song').click();
+  const action = page.locator('#workspaceAgentMapAvatarAction');
+  await expect(action).toBeEnabled();
+  await expect(action).toHaveAccessibleName(/create reaper producer as a reusable agent now/i);
+  await action.click();
+
+  await expect(page.locator('#workspaceAgentMapState')).toHaveText('Ready');
+  await expect(page.locator('#workspaceAgentMapNodeDetail')).toHaveText('Saved reusable agent');
+  expect(createPayload).toMatchObject({ agent_index: 0 });
+});


### PR DESCRIPTION
## Summary
- redesign the Create Workspace wizard into blueprint, details, and review steps
- show the full blueprint team as an interactive visual preview before workspace creation
- let users configure and save missing lead or specialist agents as reusable global agents, including a provider-grouped model picker
- support selecting existing agents and preserve configured agent overrides through atomic workspace creation

## Validation
- go test ./internal/sessionhttp ./internal/web
- npm run lint -- --quiet
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:32128 npx playwright test tests/create-workspace-behavior.spec.ts --workers=1