### PR TITLE
feat: agent role catalog & progression

### DIFF
--- a/internal/agentcatalog/catalog.go
+++ b/internal/agentcatalog/catalog.go
@@ -1,0 +1,163 @@
+// Package agentcatalog defines the static Role Catalog: a small, curated set
+// of agent presets (display identity, model tier, starter prompt, starter
+// skills) offered as the default way to create an agent. See
+// tasks/prd-agent-role-catalog.md section A.
+package agentcatalog
+
+import (
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// ModelTier is a coarse capability tier a catalog entry declares. It is
+// resolved to a concrete model through the existing model-category system
+// (internal/store.ModelCategoryStore), never hard-coded to a specific model.
+type ModelTier string
+
+const (
+	TierFast     ModelTier = "fast"     // cost-optimized, tool-calling oriented
+	TierBalanced ModelTier = "balanced" // general purpose
+	TierDeep     ModelTier = "deep"     // deepest reasoning tier
+)
+
+// defaultCategoryIDs maps a tier to the built-in model-category ID it
+// resolves through. These IDs come from types.DefaultCategories(); the
+// mapping is 1:1 by design (tool-calling/general-purpose/research).
+var defaultCategoryIDs = map[ModelTier]string{
+	TierFast:     "cat_default_tool_calling",
+	TierBalanced: "cat_default_general_purpose",
+	TierDeep:     "cat_default_research",
+}
+
+// DefaultCategoryID returns the built-in model-category ID a tier resolves
+// through, or "" for an unknown tier.
+func DefaultCategoryID(tier ModelTier) string {
+	return defaultCategoryIDs[tier]
+}
+
+// Entry describes one curated catalog role: a display identity plus the
+// presets a "Catalog" creation applies (role, model tier, starter prompt,
+// starter skills). Display fields are presentation-only — Slug is the only
+// value persisted on the created agent's Role.
+type Entry struct {
+	Slug        types.AgentRole `json:"slug"`
+	DisplayName string          `json:"display_name"`
+	Emblem      string          `json:"emblem"`       // Bootstrap Icons name, no "bi-" prefix
+	AccentColor string          `json:"accent_color"` // hex color
+	Tagline     string          `json:"tagline"`
+	Description string          `json:"description"`
+	ModelTier   ModelTier       `json:"model_tier"`
+
+	StarterPrompt string `json:"starter_prompt"`
+	// StarterSkills lists built-in skill names to enable at creation. Must
+	// stay within the spark-stage slot cap (2, see FR10) so no agent is born
+	// over-cap. Empty in v1: the repo ships no universal built-in skill set
+	// for non-CLI agents to draw from (skills are user/data-dir scoped); the
+	// application path is fully wired for whenever one is added.
+	StarterSkills []string `json:"starter_skills"`
+
+	// SupportsDomain is true only for the Specialist entry: creation accepts
+	// an optional free-text domain that feeds the created agent's
+	// RoutingProfile.Domains and is appended to its starter prompt.
+	SupportsDomain bool `json:"supports_domain"`
+}
+
+// registry is the static, ordered Role Catalog (FR A.1): exactly one entry
+// per types.AgentRole value, excluding RoleGeneral and RoleCLIAgent. Order is
+// display order in the catalog card grid.
+var registry = []Entry{
+	{
+		Slug:        types.RoleOrchestrator,
+		DisplayName: "Commander",
+		Emblem:      "diagram-3",
+		AccentColor: "#f59e0b",
+		Tagline:     "Leads the workspace — receives requests, dispatches tasks, coordinates the team",
+		Description: "Front door for the workspace. Triages incoming work and dispatches it to the right specialist instead of doing domain work itself.",
+		ModelTier:   TierBalanced,
+		StarterPrompt: "You are the Commander for this workspace. You receive incoming requests, decide whether " +
+			"to handle them directly or dispatch them to the right specialist agent, and keep the team's work " +
+			"moving. Prefer delegating domain-specific work to a specialist over doing it yourself; step in " +
+			"directly only for coordination, triage, and short administrative tasks.",
+		StarterSkills: []string{},
+	},
+	{
+		Slug:        types.RoleResearcher,
+		DisplayName: "Researcher",
+		Emblem:      "search",
+		AccentColor: "#0ea5e9",
+		Tagline:     "Gathers information from the web and files",
+		Description: "Finds and summarizes information from the web, documents, and other sources, with clear sourcing.",
+		ModelTier:   TierDeep,
+		StarterPrompt: "You are a Researcher. Your job is to gather information — from the web, files, and other " +
+			"sources — and report back clearly sourced findings. Prioritize accuracy and say where information " +
+			"came from.",
+		StarterSkills: []string{},
+	},
+	{
+		Slug:        types.RoleAnalyzer,
+		DisplayName: "Analyzer",
+		Emblem:      "graph-up",
+		AccentColor: "#8b5cf6",
+		Tagline:     "Digs into data and code to explain what's going on",
+		Description: "Investigates data, code, and logs and explains what's actually happening, precisely and with reasoning shown.",
+		ModelTier:   TierDeep,
+		StarterPrompt: "You are an Analyzer. You dig into data, code, and logs to explain what is actually going " +
+			"on. Be precise, show your reasoning, and flag uncertainty rather than guessing.",
+		StarterSkills: []string{},
+	},
+	{
+		Slug:        types.RoleSynthesizer,
+		DisplayName: "Writer",
+		Emblem:      "pencil-square",
+		AccentColor: "#22c55e",
+		Tagline:     "Turns findings into briefs, docs, and emails",
+		Description: "Turns findings, notes, and raw material into clear briefs, documents, and emails.",
+		ModelTier:   TierBalanced,
+		StarterPrompt: "You are a Writer. You turn findings, notes, and raw material into clear briefs, " +
+			"documents, and emails. Prioritize clarity and the right tone for the audience over exhaustive detail.",
+		StarterSkills: []string{},
+	},
+	{
+		Slug:        types.RoleValidator,
+		DisplayName: "Reviewer",
+		Emblem:      "shield-check",
+		AccentColor: "#ef4444",
+		Tagline:     "Reviews, fact-checks, and catches mistakes",
+		Description: "Checks work for mistakes, verifies facts, and flags problems before they ship.",
+		ModelTier:   TierBalanced,
+		StarterPrompt: "You are a Reviewer. You check other people's and agents' work for mistakes, verify " +
+			"facts, and flag anything that looks wrong before it ships. Be specific about what you checked and " +
+			"what you found.",
+		StarterSkills: []string{},
+	},
+	{
+		Slug:        types.RoleSpecialist,
+		DisplayName: "Specialist",
+		Emblem:      "gem",
+		AccentColor: "#14b8a6",
+		Tagline:     "Deep expert in one domain you define",
+		Description: "A focused expert in a single domain you name at creation (e.g. \"reaper\", \"tax\").",
+		ModelTier:   TierFast,
+		StarterPrompt: "You are a Specialist with deep expertise in one domain. Focus on that domain, use the " +
+			"tools and context available to you, and be explicit when a request falls outside your area.",
+		StarterSkills:  []string{},
+		SupportsDomain: true,
+	},
+}
+
+// Registry returns a copy of the static Role Catalog, safe for callers to
+// range over or serialize without risking mutation of package state.
+func Registry() []Entry {
+	out := make([]Entry, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// Find returns the catalog entry for the given role slug.
+func Find(slug types.AgentRole) (Entry, bool) {
+	for _, e := range registry {
+		if e.Slug == slug {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}

--- a/internal/agentcatalog/catalog_test.go
+++ b/internal/agentcatalog/catalog_test.go
@@ -1,0 +1,113 @@
+package agentcatalog
+
+import (
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// sparkStageSlotCap mirrors the spark-stage slot cap from PRD FR10 (2 active
+// skill slots). Starter skill lists must never exceed it so no catalog agent
+// is born already over-cap.
+const sparkStageSlotCap = 2
+
+func TestRegistryHasExactlySixEntries(t *testing.T) {
+	entries := Registry()
+	if len(entries) != 6 {
+		t.Fatalf("expected exactly 6 catalog entries, got %d", len(entries))
+	}
+}
+
+func TestRegistryEntriesHaveUniqueValidSlugs(t *testing.T) {
+	forbidden := map[types.AgentRole]bool{
+		types.RoleGeneral:  true,
+		types.RoleCLIAgent: true,
+	}
+	seen := make(map[types.AgentRole]bool)
+
+	for _, e := range Registry() {
+		if e.Slug == "" {
+			t.Fatalf("entry %q has empty slug", e.DisplayName)
+		}
+		if forbidden[e.Slug] {
+			t.Fatalf("entry %q uses forbidden slug %q", e.DisplayName, e.Slug)
+		}
+		if seen[e.Slug] {
+			t.Fatalf("duplicate slug %q", e.Slug)
+		}
+		seen[e.Slug] = true
+	}
+}
+
+func TestRegistryEntriesStarterSkillsWithinSparkCap(t *testing.T) {
+	for _, e := range Registry() {
+		if len(e.StarterSkills) > sparkStageSlotCap {
+			t.Errorf("entry %q has %d starter skills, exceeds spark-stage cap of %d",
+				e.DisplayName, len(e.StarterSkills), sparkStageSlotCap)
+		}
+	}
+}
+
+func TestRegistryEntriesHaveNonEmptyDisplayFields(t *testing.T) {
+	for _, e := range Registry() {
+		if e.DisplayName == "" {
+			t.Errorf("entry with slug %q has empty display name", e.Slug)
+		}
+		if e.Emblem == "" {
+			t.Errorf("entry %q has empty emblem", e.DisplayName)
+		}
+		if e.AccentColor == "" {
+			t.Errorf("entry %q has empty accent color", e.DisplayName)
+		}
+		if e.Tagline == "" {
+			t.Errorf("entry %q has empty tagline", e.DisplayName)
+		}
+		if e.Description == "" {
+			t.Errorf("entry %q has empty description", e.DisplayName)
+		}
+		if e.StarterPrompt == "" {
+			t.Errorf("entry %q has empty starter prompt", e.DisplayName)
+		}
+		if e.ModelTier == "" {
+			t.Errorf("entry %q has empty model tier", e.DisplayName)
+		}
+	}
+}
+
+func TestRegistryReturnsIndependentCopy(t *testing.T) {
+	first := Registry()
+	first[0].DisplayName = "Mutated"
+
+	second := Registry()
+	if second[0].DisplayName == "Mutated" {
+		t.Fatal("Registry() returned a slice sharing backing storage with package state")
+	}
+}
+
+func TestFindReturnsEntryForKnownSlug(t *testing.T) {
+	entry, ok := Find(types.RoleOrchestrator)
+	if !ok {
+		t.Fatal("expected to find orchestrator entry")
+	}
+	if entry.DisplayName != "Commander" {
+		t.Fatalf("expected DisplayName 'Commander', got %q", entry.DisplayName)
+	}
+}
+
+func TestFindReturnsFalseForUnknownSlug(t *testing.T) {
+	if _, ok := Find(types.RoleGeneral); ok {
+		t.Fatal("expected RoleGeneral to not be in the catalog")
+	}
+	if _, ok := Find(types.AgentRole("nonexistent")); ok {
+		t.Fatal("expected unknown slug to not be found")
+	}
+}
+
+func TestOnlySpecialistSupportsDomain(t *testing.T) {
+	for _, e := range Registry() {
+		expected := e.Slug == types.RoleSpecialist
+		if e.SupportsDomain != expected {
+			t.Errorf("entry %q: SupportsDomain=%v, expected %v", e.DisplayName, e.SupportsDomain, expected)
+		}
+	}
+}

--- a/internal/agentcatalog/model_resolve.go
+++ b/internal/agentcatalog/model_resolve.go
@@ -1,0 +1,39 @@
+package agentcatalog
+
+import (
+	"slices"
+	"sort"
+)
+
+// ResolveModel picks a concrete model for the given tier from the current
+// model-category assignments (model ID -> assigned category IDs, as returned
+// by store.ModelCategoryStore.GetAllModelAssignments()). It reuses the
+// existing model-category system rather than a hard-coded model list (see
+// PRD technical considerations).
+//
+// Returns ok=false when no model is currently assigned to the tier's
+// category — callers should fall back to the caller's own default model and
+// surface a non-blocking notice (FR A.6).
+func ResolveModel(tier ModelTier, modelAssignments map[string][]string) (model string, ok bool) {
+	categoryID := DefaultCategoryID(tier)
+	if categoryID == "" {
+		return "", false
+	}
+
+	var candidates []string
+	for modelID, categoryIDs := range modelAssignments {
+		if slices.Contains(categoryIDs, categoryID) {
+			candidates = append(candidates, modelID)
+		}
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+
+	// Deterministic choice: alphabetically first. The model-category
+	// assignments are a flat set with no ranking, so any deterministic tie
+	// break is as good as another; alphabetical keeps behavior stable and
+	// easy to reason about in tests.
+	sort.Strings(candidates)
+	return candidates[0], true
+}

--- a/internal/agentcatalog/model_resolve_test.go
+++ b/internal/agentcatalog/model_resolve_test.go
@@ -1,0 +1,48 @@
+package agentcatalog
+
+import "testing"
+
+func TestResolveModelPicksDeterministicCandidate(t *testing.T) {
+	assignments := map[string][]string{
+		"gpt-5-nano":    {"cat_default_tool_calling"},
+		"gpt-4o-mini":   {"cat_default_tool_calling", "cat_default_general_purpose"},
+		"claude-3-opus": {"cat_default_research"},
+	}
+
+	model, ok := ResolveModel(TierFast, assignments)
+	if !ok {
+		t.Fatal("expected a model to resolve for TierFast")
+	}
+	// Alphabetically first of {gpt-4o-mini, gpt-5-nano}.
+	if model != "gpt-4o-mini" {
+		t.Fatalf("expected gpt-4o-mini, got %q", model)
+	}
+}
+
+func TestResolveModelFallsBackWhenCategoryUnassigned(t *testing.T) {
+	assignments := map[string][]string{
+		"gpt-5-nano": {"cat_default_tool_calling"},
+	}
+
+	if _, ok := ResolveModel(TierDeep, assignments); ok {
+		t.Fatal("expected no model assigned to the research category")
+	}
+}
+
+func TestResolveModelHandlesEmptyAssignments(t *testing.T) {
+	if _, ok := ResolveModel(TierBalanced, nil); ok {
+		t.Fatal("expected no match against nil assignments")
+	}
+	if _, ok := ResolveModel(TierBalanced, map[string][]string{}); ok {
+		t.Fatal("expected no match against empty assignments")
+	}
+}
+
+func TestResolveModelUnknownTier(t *testing.T) {
+	assignments := map[string][]string{
+		"gpt-5-nano": {"cat_default_tool_calling"},
+	}
+	if _, ok := ResolveModel(ModelTier("unknown"), assignments); ok {
+		t.Fatal("expected no match for an unknown tier")
+	}
+}

--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/cliagent"
 	orihttp "github.com/johnjallday/ori-agent/internal/http"
 	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/skills"
 	"github.com/johnjallday/ori-agent/internal/store"
 	"github.com/johnjallday/ori-agent/internal/types"
 	"github.com/johnjallday/ori-agent/internal/workspace"
@@ -90,6 +91,13 @@ type Handler struct {
 	// nil when disabled). Injected so agenthttp stays decoupled from the
 	// externalagents package.
 	codexSync func() any
+	// modelCategoryStore resolves a catalog entry's model tier to a concrete
+	// configured model for catalog-create. Nil is a safe no-op (falls back to
+	// the store's default model).
+	modelCategoryStore ModelCategoryReader
+	// skillsManager enables a catalog entry's starter skills at catalog-create
+	// time. Nil is a safe no-op (no starter skills applied).
+	skillsManager *skills.Manager
 }
 
 func New(state store.Store) *Handler {
@@ -287,15 +295,21 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		MaxOutputTokens int                        `json:"max_output_tokens,omitempty"`
 		AllowWebSearch  *bool                      `json:"allow_web_search,omitempty"`
 		RoutingProfile  *types.AgentRoutingProfile `json:"routing_profile,omitempty"`
+		// CatalogRole selects a Role Catalog entry (see internal/agentcatalog)
+		// instead of the free-form fields above: role, model, and starter
+		// prompt/skills come from the entry. Domain is Specialist-only.
+		CatalogRole string `json:"catalog_role,omitempty"`
+		Domain      string `json:"domain,omitempty"`
 	}
 	if !orihttp.ParseJSONBody(w, r, &req) {
 		return
 	}
 	logger.Debug("CreateAgent request", logger.Fields{
 		"name": req.Name, "type": req.Type, "model": req.Model, "temperature": req.Temperature,
+		"catalog_role": req.CatalogRole,
 	})
 
-	if isSystemAssistantAgent(req.Name) {
+	if isSystemAssistantAgent(req.Name) || strings.EqualFold(strings.TrimSpace(req.Name), "catalog") {
 		orihttp.BadRequest(w, "reserved agent name")
 		return
 	}
@@ -304,6 +318,11 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if err := validateAgentName(req.Name); err != nil {
 		logger.Error("CreateAgent error: invalid agent name", logger.Fields{"error": err})
 		orihttp.BadRequest(w, err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.CatalogRole) != "" {
+		h.handleCatalogCreate(w, req.Name, req.CatalogRole, req.Domain)
 		return
 	}
 

--- a/internal/agenthttp/agents.go
+++ b/internal/agenthttp/agents.go
@@ -432,6 +432,9 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		AvatarColor    *string                    `json:"avatar_color,omitempty"`
 		Favorite       *bool                      `json:"favorite,omitempty"`
 		RoutingProfile *types.AgentRoutingProfile `json:"routing_profile,omitempty"`
+		// ExpertMode lifts stage-based skill slot caps for this agent (PRD FR13).
+		// Metadata-only; does not touch model/prompt/skills.
+		ExpertMode *bool `json:"expert_mode,omitempty"`
 		// ExpectedVersion is the optimistic-concurrency token the client received
 		// from GET /api/agents/{name}. When present and no longer matching the
 		// stored agent, the update is rejected as stale (PRD FR13). Omitted =
@@ -546,6 +549,10 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RoutingProfile != nil {
 		agent.Metadata.RoutingProfile = cloneRoutingProfile(req.RoutingProfile)
+	}
+	if req.ExpertMode != nil {
+		expert := *req.ExpertMode
+		agent.Metadata.ExpertMode = &expert
 	}
 
 	newName := agentName

--- a/internal/agenthttp/agents_bulk.go
+++ b/internal/agenthttp/agents_bulk.go
@@ -25,7 +25,25 @@ const (
 	bulkOpAddTags     bulkOperation = "add_tags"
 	bulkOpRemoveTags  bulkOperation = "remove_tags"
 	bulkOpSetFavorite bulkOperation = "set_favorite"
+	// bulkOpSetRole assigns the catalog role (or clears it to Unspecialized/
+	// "general") across a batch of agents. Metadata-only — never touches
+	// model/prompt/skills (PRD FR9, Group 5.4).
+	bulkOpSetRole bulkOperation = "set_role"
 )
+
+// bulkAssignableRoles are the values bulkOpSetRole accepts: the 6 catalog
+// roles plus "general" (Unspecialized) to clear a role. cli_agent is
+// deliberately excluded — CLI agents are read-only and already rejected by
+// metadataMutationTarget.
+var bulkAssignableRoles = map[types.AgentRole]bool{
+	types.RoleGeneral:      true,
+	types.RoleOrchestrator: true,
+	types.RoleResearcher:   true,
+	types.RoleAnalyzer:     true,
+	types.RoleSynthesizer:  true,
+	types.RoleValidator:    true,
+	types.RoleSpecialist:   true,
+}
 
 // bulkStatus is the per-agent outcome (PRD FR49).
 type bulkStatus string
@@ -49,11 +67,12 @@ const (
 
 // bulkRequest is the POST /api/agents/bulk body (PRD FR46).
 type bulkRequest struct {
-	AgentNames        []string      `json:"agent_names"`
-	Operation         bulkOperation `json:"operation"`
-	Tags              []string      `json:"tags,omitempty"`
-	Favorite          *bool         `json:"favorite,omitempty"`
-	ConfirmSharedEdit bool          `json:"confirm_shared_edit,omitempty"`
+	AgentNames        []string         `json:"agent_names"`
+	Operation         bulkOperation    `json:"operation"`
+	Tags              []string         `json:"tags,omitempty"`
+	Favorite          *bool            `json:"favorite,omitempty"`
+	Role              *types.AgentRole `json:"role,omitempty"`
+	ConfirmSharedEdit bool             `json:"confirm_shared_edit,omitempty"`
 }
 
 // bulkResult is one per-agent outcome in the response (PRD FR49).
@@ -108,7 +127,7 @@ func (h *Handler) HandleBulk(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch req.Operation {
-	case bulkOpDelete, bulkOpAddTags, bulkOpRemoveTags, bulkOpSetFavorite:
+	case bulkOpDelete, bulkOpAddTags, bulkOpRemoveTags, bulkOpSetFavorite, bulkOpSetRole:
 	default:
 		orihttp.BadRequest(w, fmt.Sprintf("unsupported operation %q", req.Operation))
 		return
@@ -118,6 +137,18 @@ func (h *Handler) HandleBulk(w http.ResponseWriter, r *http.Request) {
 	if req.Operation == bulkOpSetFavorite && req.Favorite == nil {
 		orihttp.BadRequest(w, "set_favorite requires a boolean \"favorite\" field")
 		return
+	}
+
+	// set_role requires one of the 6 catalog roles or "general" (Unspecialized).
+	if req.Operation == bulkOpSetRole {
+		if req.Role == nil {
+			orihttp.BadRequest(w, "set_role requires a \"role\" field")
+			return
+		}
+		if !bulkAssignableRoles[*req.Role] {
+			orihttp.BadRequest(w, fmt.Sprintf("unsupported role %q", *req.Role))
+			return
+		}
 	}
 
 	// Normalize tags once for tag operations; an empty resulting set is rejected
@@ -140,6 +171,8 @@ func (h *Handler) HandleBulk(w http.ResponseWriter, r *http.Request) {
 			results = append(results, h.bulkTagOne(name, req.Operation, tags, req.ConfirmSharedEdit))
 		case bulkOpSetFavorite:
 			results = append(results, h.bulkFavoriteOne(name, *req.Favorite))
+		case bulkOpSetRole:
+			results = append(results, h.bulkRoleOne(name, *req.Role, req.ConfirmSharedEdit))
 		}
 	}
 
@@ -204,6 +237,25 @@ func (h *Handler) bulkFavoriteOne(name string, favorite bool) bulkResult {
 	}
 	ag.Metadata.Favorite = favorite
 	if res, ok := h.persistMetadataMutation(name, ag, []string{"favorite"}); !ok {
+		return res
+	}
+	return bulkResult{Name: name, Status: bulkStatusSucceeded}
+}
+
+// bulkRoleOne assigns a catalog role (or "general" to clear it back to
+// Unspecialized) on one agent. Metadata-only: role is a shared-definition
+// field like model/prompt, so a definition attached to >1 workspace requires
+// confirm_shared_edit, matching the single-agent PATCH rules (PRD FR9).
+func (h *Handler) bulkRoleOne(name string, role types.AgentRole, confirmed bool) bulkResult {
+	ag, code, msg := h.metadataMutationTarget(name, true, confirmed)
+	if code != "" {
+		return bulkResult{Name: name, Status: bulkStatusSkipped, ReasonCode: code, Message: msg}
+	}
+	if ag.Role == role {
+		return bulkResult{Name: name, Status: bulkStatusSucceeded}
+	}
+	ag.Role = role
+	if res, ok := h.persistMetadataMutation(name, ag, []string{"role"}); !ok {
 		return res
 	}
 	return bulkResult{Name: name, Status: bulkStatusSucceeded}

--- a/internal/agenthttp/agents_bulk_test.go
+++ b/internal/agenthttp/agents_bulk_test.go
@@ -290,6 +290,49 @@ func TestBulkSetFavorite(t *testing.T) {
 	}
 }
 
+func TestBulkSetRoleRequiresRoleField(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":["A"],"operation":"set_role"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestBulkSetRoleRejectsUnknownRole(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	rr := rawBulk(t, h, `{"agent_names":["A"],"operation":"set_role","role":"wizard"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown role, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestBulkSetRoleAssignsCatalogRole(t *testing.T) {
+	h := guardTestHandler(t, []string{"A", "B"}, nil)
+	resp := postBulk(t, h, `{"agent_names":["A","B"],"operation":"set_role","role":"researcher"}`)
+	if resp.Summary.Succeeded != 2 {
+		t.Fatalf("expected 2 successes, got %+v", resp.Summary)
+	}
+	for _, name := range []string{"A", "B"} {
+		ag, _ := h.State.GetAgent(name)
+		if ag.Role != types.RoleResearcher {
+			t.Errorf("%s role = %q, want researcher", name, ag.Role)
+		}
+	}
+}
+
+func TestBulkSetRoleClearsToUnspecialized(t *testing.T) {
+	h := guardTestHandler(t, []string{"A"}, nil)
+	postBulk(t, h, `{"agent_names":["A"],"operation":"set_role","role":"specialist"}`)
+	resp := postBulk(t, h, `{"agent_names":["A"],"operation":"set_role","role":"general"}`)
+	if resp.Summary.Succeeded != 1 {
+		t.Fatalf("expected 1 success, got %+v", resp.Summary)
+	}
+	ag, _ := h.State.GetAgent("A")
+	if ag.Role != types.RoleGeneral {
+		t.Errorf("role = %q, want general (Unspecialized)", ag.Role)
+	}
+}
+
 // --- helpers ----------------------------------------------------------------
 
 type fakeSessionPurger struct {

--- a/internal/agenthttp/catalog.go
+++ b/internal/agenthttp/catalog.go
@@ -1,0 +1,126 @@
+package agenthttp
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/johnjallday/ori-agent/internal/agentcatalog"
+	orihttp "github.com/johnjallday/ori-agent/internal/http"
+	"github.com/johnjallday/ori-agent/internal/logger"
+	"github.com/johnjallday/ori-agent/internal/skills"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// ModelCategoryReader resolves a catalog entry's model tier to the current
+// model-category assignments. Satisfied by store.ModelCategoryStore; kept
+// narrow so agenthttp only depends on what it needs.
+type ModelCategoryReader interface {
+	GetAllModelAssignments() map[string][]string
+}
+
+// CatalogHandler serves GET /api/agents/catalog: the static Role Catalog, so
+// the UI never hard-codes entries (PRD FR A.3).
+func CatalogHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		orihttp.MethodNotAllowed(w)
+		return
+	}
+	orihttp.WriteJSON(w, map[string]any{
+		"entries": agentcatalog.Registry(),
+	})
+}
+
+// SetModelCategoryStore wires model-category resolution for catalog-create
+// (fast/balanced/deep -> a concrete configured model).
+func (h *Handler) SetModelCategoryStore(s ModelCategoryReader) {
+	h.modelCategoryStore = s
+}
+
+// SetSkillsManager wires the skills manager so catalog-create can enable a
+// catalog entry's starter skills.
+func (h *Handler) SetSkillsManager(m *skills.Manager) {
+	h.skillsManager = m
+}
+
+// handleCatalogCreate creates an agent from a Role Catalog entry: role,
+// resolved model, starter prompt, and starter skills are applied, and (for
+// the Specialist entry only) an optional domain feeds RoutingProfile.Domains
+// and the starter prompt (PRD FR A.4-6, FR "Resolved: yes" on Specialist
+// domain).
+func (h *Handler) handleCatalogCreate(w http.ResponseWriter, name, catalogRole, domain string) {
+	entry, ok := agentcatalog.Find(types.AgentRole(strings.ToLower(strings.TrimSpace(catalogRole))))
+	if !ok {
+		orihttp.BadRequest(w, fmt.Sprintf("unknown catalog role %q", catalogRole))
+		return
+	}
+
+	systemPrompt := entry.StarterPrompt
+	domain = strings.TrimSpace(domain)
+	if entry.SupportsDomain && domain != "" {
+		systemPrompt = fmt.Sprintf("%s Your domain focus is: %s.", systemPrompt, domain)
+	}
+
+	var modelAssignments map[string][]string
+	if h.modelCategoryStore != nil {
+		modelAssignments = h.modelCategoryStore.GetAllModelAssignments()
+	}
+	resolvedModel, modelResolved := agentcatalog.ResolveModel(entry.ModelTier, modelAssignments)
+
+	config := &store.CreateAgentConfig{
+		Role:         entry.Slug,
+		Model:        resolvedModel, // "" falls back to the store's default model
+		SystemPrompt: systemPrompt,
+	}
+
+	if err := h.State.CreateAgent(name, config); err != nil {
+		logger.Error("CatalogCreateAgent error", logger.Fields{"error": err})
+		orihttp.BadRequest(w, err.Error())
+		return
+	}
+
+	ag, ok := h.State.GetAgent(name)
+	if ok && ag != nil {
+		if entry.SupportsDomain && domain != "" {
+			if ag.Metadata == nil {
+				ag.Metadata = &types.AgentMetadata{}
+			}
+			ag.Metadata.RoutingProfile = &types.AgentRoutingProfile{Domains: []string{domain}}
+			if err := h.State.SetAgent(name, ag); err != nil {
+				logger.Error("Failed to set catalog agent domain metadata", logger.Fields{"err": err})
+			}
+		}
+	}
+
+	if h.skillsManager != nil {
+		for _, skillName := range entry.StarterSkills {
+			if err := h.skillsManager.SetSkillEnabled(name, skillName, true); err != nil {
+				logger.Error("Failed to enable starter skill", logger.Fields{"skill": skillName, "err": err})
+			}
+		}
+	}
+
+	logger.Info("Agent created from catalog", logger.Fields{"agent": name, "catalog_role": string(entry.Slug)})
+
+	if h.ActivityLogger != nil {
+		details := map[string]any{
+			"catalog_role": string(entry.Slug),
+			"model":        resolvedModel,
+		}
+		if err := h.ActivityLogger.LogActivity(name, types.ActivityEventCreated, details, ""); err != nil {
+			logger.Error("Failed to log activity", logger.Fields{"err": err})
+		}
+	}
+
+	resp := map[string]any{
+		"success":      true,
+		"message":      "Agent '" + name + "' created successfully",
+		"catalog_role": string(entry.Slug),
+	}
+	if !modelResolved {
+		resp["model_category_fallback"] = true
+		resp["notice"] = fmt.Sprintf("No model is configured for the %q tier yet; used your default model instead.", entry.ModelTier)
+	}
+	orihttp.Success(w, resp)
+}

--- a/internal/agenthttp/catalog_test.go
+++ b/internal/agenthttp/catalog_test.go
@@ -143,6 +143,43 @@ func TestCatalogNameReservedForEndpoint(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentExpertModeMetadataOnly(t *testing.T) {
+	h := catalogTestHandler(t)
+	if err := h.State.CreateAgent("Worker", &store.CreateAgentConfig{
+		Model:        "gpt-4o-mini",
+		SystemPrompt: "original prompt",
+		Role:         types.RoleResearcher,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	body := `{"expert_mode":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/agents/Worker", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	ag, ok := h.State.GetAgent("Worker")
+	if !ok || ag == nil {
+		t.Fatal("agent missing after update")
+	}
+	if ag.Metadata == nil || ag.Metadata.ExpertMode == nil || !*ag.Metadata.ExpertMode {
+		t.Fatalf("expected expert_mode=true, got %+v", ag.Metadata)
+	}
+	// Metadata-only: model and prompt untouched.
+	if ag.Settings.Model != "gpt-4o-mini" {
+		t.Errorf("expert-mode update changed model to %q", ag.Settings.Model)
+	}
+	if ag.Settings.SystemPrompt != "original prompt" {
+		t.Errorf("expert-mode update changed system prompt to %q", ag.Settings.SystemPrompt)
+	}
+	if ag.Role != types.RoleResearcher {
+		t.Errorf("expert-mode update changed role to %q", ag.Role)
+	}
+}
+
 func TestPlainCreateUnaffectedByCatalogChanges(t *testing.T) {
 	h := catalogTestHandler(t)
 	body := `{"name":"Plain Agent","model":"gpt-4o-mini","system_prompt":"hello"}`

--- a/internal/agenthttp/catalog_test.go
+++ b/internal/agenthttp/catalog_test.go
@@ -1,0 +1,170 @@
+package agenthttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// fakeModelCategoryReader is a minimal ModelCategoryReader for tests, avoiding
+// a dependency on the on-disk store.ModelCategoryStore implementation.
+type fakeModelCategoryReader struct {
+	assignments map[string][]string
+}
+
+func (f *fakeModelCategoryReader) GetAllModelAssignments() map[string][]string {
+	return f.assignments
+}
+
+func catalogTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	tmpDir := t.TempDir()
+	st, err := store.NewFileStore(filepath.Join(tmpDir, "agents_index.json"), types.Settings{Model: "default-model", Temperature: 1.0})
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	return New(st)
+}
+
+func TestCatalogHandlerReturnsSixEntries(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/catalog", nil)
+	rr := httptest.NewRecorder()
+	CatalogHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "\"entries\"") {
+		t.Fatalf("expected entries key in response, got %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Commander") {
+		t.Fatalf("expected Commander entry in response, got %s", rr.Body.String())
+	}
+}
+
+func TestCatalogHandlerRejectsNonGet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/catalog", nil)
+	rr := httptest.NewRecorder()
+	CatalogHandler(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestCatalogCreateAppliesPresetsAndResolvesModel(t *testing.T) {
+	h := catalogTestHandler(t)
+	h.SetModelCategoryStore(&fakeModelCategoryReader{
+		assignments: map[string][]string{"claude-3-haiku-20240307": {"cat_default_tool_calling"}},
+	})
+
+	body := `{"name":"Reaper Specialist","catalog_role":"specialist","domain":"reaper"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agents", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	ag, ok := h.State.GetAgent("Reaper Specialist")
+	if !ok || ag == nil {
+		t.Fatal("expected agent to be created")
+	}
+	if ag.Role != types.RoleSpecialist {
+		t.Errorf("expected role specialist, got %q", ag.Role)
+	}
+	if ag.Settings.Model != "claude-3-haiku-20240307" {
+		t.Errorf("expected resolved model, got %q", ag.Settings.Model)
+	}
+	if !strings.Contains(ag.Settings.SystemPrompt, "reaper") {
+		t.Errorf("expected domain to be woven into system prompt, got %q", ag.Settings.SystemPrompt)
+	}
+	if ag.Metadata == nil || ag.Metadata.RoutingProfile == nil {
+		t.Fatal("expected routing profile to be set")
+	}
+	if len(ag.Metadata.RoutingProfile.Domains) != 1 || ag.Metadata.RoutingProfile.Domains[0] != "reaper" {
+		t.Errorf("expected domains=[reaper], got %v", ag.Metadata.RoutingProfile.Domains)
+	}
+	if ag.Evolution == nil || ag.Evolution.Stage != types.AgentStageSpark || ag.Evolution.Level != 0 {
+		t.Errorf("expected fresh evolution at spark/0, got %+v", ag.Evolution)
+	}
+}
+
+func TestCatalogCreateFallsBackToDefaultModelWhenCategoryUnconfigured(t *testing.T) {
+	h := catalogTestHandler(t)
+	// No model-category store wired at all.
+
+	body := `{"name":"Commander One","catalog_role":"orchestrator"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agents", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "model_category_fallback") {
+		t.Fatalf("expected fallback notice, got %s", rr.Body.String())
+	}
+
+	ag, ok := h.State.GetAgent("Commander One")
+	if !ok || ag == nil {
+		t.Fatal("expected agent to be created")
+	}
+	if ag.Settings.Model != "default-model" {
+		t.Errorf("expected fallback to store default model, got %q", ag.Settings.Model)
+	}
+	if ag.Role != types.RoleOrchestrator {
+		t.Errorf("expected role orchestrator, got %q", ag.Role)
+	}
+}
+
+func TestCatalogCreateUnknownRoleRejected(t *testing.T) {
+	h := catalogTestHandler(t)
+	body := `{"name":"Bad","catalog_role":"wizard"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agents", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown catalog role, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCatalogNameReservedForEndpoint(t *testing.T) {
+	h := catalogTestHandler(t)
+	body := `{"name":"catalog","catalog_role":"researcher"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agents", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for reserved name 'catalog', got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPlainCreateUnaffectedByCatalogChanges(t *testing.T) {
+	h := catalogTestHandler(t)
+	body := `{"name":"Plain Agent","model":"gpt-4o-mini","system_prompt":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agents", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	ag, ok := h.State.GetAgent("Plain Agent")
+	if !ok || ag == nil {
+		t.Fatal("expected agent to be created")
+	}
+	if ag.Settings.Model != "gpt-4o-mini" {
+		t.Errorf("expected explicit model, got %q", ag.Settings.Model)
+	}
+	if ag.Settings.SystemPrompt != "hello" {
+		t.Errorf("expected explicit system prompt, got %q", ag.Settings.SystemPrompt)
+	}
+	// Plain (non-catalog) creation defaults to RoleGeneral.
+	if ag.Role != types.RoleGeneral {
+		t.Errorf("expected default role general, got %q", ag.Role)
+	}
+}

--- a/internal/evolution/service.go
+++ b/internal/evolution/service.go
@@ -24,6 +24,10 @@ const (
 	defaultDuplicateWindow time.Duration = 30 * time.Second
 	defaultMaxXPPerHour    int64         = 200
 	defaultXPPerLevel      int64         = 100
+	// taskXPMultiplier scales AwardTaskXP relative to BaseMessageXP: a
+	// completed task represents more work than a single chat message.
+	// Tunable — see PRD open question on validating this against real accrual.
+	taskXPMultiplier int64 = 5
 )
 
 type AgentStore interface {
@@ -153,12 +157,27 @@ func (s *Service) AwardMessageXP(agentName string, tokenCount int, userMessage s
 		tokenCount = 0
 	}
 	xp := s.cfg.BaseMessageXP + int64(tokenCount/s.cfg.TokensPerXP)
-	return s.awardXP(agentName, xp, userMessage, true, false)
+	return s.awardXP(agentName, xp, userMessage, true, false, false)
 }
 
 // AwardFeedXP grants XP for a validated feed action.
 func (s *Service) AwardFeedXP(agentName string, source string) error {
-	return s.awardXP(agentName, s.cfg.FeedXP, source, false, true)
+	return s.awardXP(agentName, s.cfg.FeedXP, source, false, true, false)
+}
+
+// AwardTaskXP grants XP for a completed workspace task run — worth more than
+// a single chat message (taskXPMultiplier x the base message award), since a
+// completed task represents more work. Unlike AwardMessageXP there is no
+// duplicate-message check: distinct task completions are never "the same
+// message" repeated. The hourly cap still applies. A nil receiver (evolution
+// disabled) is a safe no-op, matching how workspace.TaskExecutor calls this
+// through an optional interface.
+func (s *Service) AwardTaskXP(agentName string) error {
+	if s == nil {
+		return nil
+	}
+	xp := s.cfg.BaseMessageXP * taskXPMultiplier
+	return s.awardXP(agentName, xp, "", false, false, true)
 }
 
 // EvaluateStageTransitions returns the expected stage for a given level.
@@ -278,7 +297,7 @@ func (s *Service) GetSuggestions(agentName string) ([]Suggestion, error) {
 	return suggestions, nil
 }
 
-func (s *Service) awardXP(agentName string, requestedXP int64, userMessage string, enableDuplicateCheck bool, incrementFeedCount bool) error {
+func (s *Service) awardXP(agentName string, requestedXP int64, userMessage string, enableDuplicateCheck bool, incrementFeedCount bool, logTaskEvent bool) error {
 	if s == nil {
 		return fmt.Errorf("evolution service is nil")
 	}
@@ -366,6 +385,11 @@ func (s *Service) awardXP(agentName string, requestedXP int64, userMessage strin
 			"source":     source,
 			"awarded_xp": awardXP,
 			"feed_count": feedCount,
+		})
+	}
+	if logTaskEvent {
+		s.logActivity(agentName, types.ActivityEventEvolutionTask, map[string]any{
+			"awarded_xp": awardXP,
 		})
 	}
 	if previousStage != newStage {

--- a/internal/evolution/service.go
+++ b/internal/evolution/service.go
@@ -185,6 +185,16 @@ func (s *Service) EvaluateStageTransitions(level int) types.AgentStage {
 	return stageForLevel(level)
 }
 
+// XPPerLevel returns the flat XP-per-level threshold, so callers (e.g. the
+// evolution HTTP handler) can compute an agent's progress toward its next
+// level without duplicating the leveling formula.
+func (s *Service) XPPerLevel() int64 {
+	if s == nil {
+		return defaultXPPerLevel
+	}
+	return s.cfg.XPPerLevel
+}
+
 // SelectPath sets a specialization path for an agent once it reaches Learner stage.
 func (s *Service) SelectPath(agentName string, requestedPath types.AgentPath) error {
 	if s == nil {

--- a/internal/evolution/service_test.go
+++ b/internal/evolution/service_test.go
@@ -216,6 +216,89 @@ func TestService_AwardFeedXP_IncrementsFeedCount(t *testing.T) {
 	}
 }
 
+func TestService_AwardTaskXP_WorthMoreThanMessage(t *testing.T) {
+	svc, agentStore, assistantProgressStore := newTestService(&Config{BaseMessageXP: 10})
+	logSink := &fakeActivityLogger{}
+	svc.SetActivityLogger(logSink)
+
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("AwardTaskXP() failed: %v", err)
+	}
+
+	evolution := agentStore.agents["alpha"].Evolution
+	if evolution == nil {
+		t.Fatal("expected evolution to be initialized")
+	}
+	if evolution.Experience != 50 {
+		t.Errorf("expected task XP 50 (5x base message XP of 10), got %d", evolution.Experience)
+	}
+	if assistantProgressStore.progress.Experience != 50 {
+		t.Errorf("expected assistant XP 50, got %d", assistantProgressStore.progress.Experience)
+	}
+	if len(logSink.events) != 1 || logSink.events[0] != types.ActivityEventEvolutionTask {
+		t.Fatalf("expected one evolution_task activity log, got %v", logSink.events)
+	}
+}
+
+func TestService_AwardTaskXP_NoMessageDuplicateSuppression(t *testing.T) {
+	svc, agentStore, _ := newTestService(&Config{BaseMessageXP: 10})
+
+	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("first task award failed: %v", err)
+	}
+	// Back-to-back task completions (empty "message") must not be suppressed
+	// the way identical chat messages are.
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("second task award failed: %v", err)
+	}
+
+	if agentStore.agents["alpha"].Evolution.Experience != 100 {
+		t.Errorf("expected both task completions to award XP (100 total), got %d",
+			agentStore.agents["alpha"].Evolution.Experience)
+	}
+}
+
+func TestService_AwardTaskXP_RespectsHourlyCapAcrossChatAndTask(t *testing.T) {
+	svc, agentStore, _ := newTestService(&Config{
+		BaseMessageXP: 10,
+		MaxXPPerHour:  60,
+	})
+
+	now := time.Date(2026, 2, 7, 13, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+
+	if err := svc.AwardMessageXP("alpha", 0, "hello"); err != nil {
+		t.Fatalf("message award failed: %v", err)
+	}
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("task award failed: %v", err)
+	}
+
+	// 10 (message) + 50 (task) = 60, exactly the cap.
+	if agentStore.agents["alpha"].Evolution.Experience != 60 {
+		t.Errorf("expected combined chat+task XP to hit the cap at 60, got %d",
+			agentStore.agents["alpha"].Evolution.Experience)
+	}
+
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("third award failed: %v", err)
+	}
+	if agentStore.agents["alpha"].Evolution.Experience != 60 {
+		t.Errorf("expected hourly cap to block further task XP, got %d",
+			agentStore.agents["alpha"].Evolution.Experience)
+	}
+}
+
+func TestService_AwardTaskXP_NilServiceIsSafeNoOp(t *testing.T) {
+	var svc *Service
+	if err := svc.AwardTaskXP("alpha"); err != nil {
+		t.Fatalf("expected nil service AwardTaskXP to be a safe no-op, got error: %v", err)
+	}
+}
+
 func TestService_SelectPath_GatesBeforeLearner(t *testing.T) {
 	svc, _, _ := newTestService(nil)
 

--- a/internal/evolutionhttp/handler.go
+++ b/internal/evolutionhttp/handler.go
@@ -26,6 +26,10 @@ type EvolutionService interface {
 	AwardFeedXP(agentName string, source string) error
 	SelectPath(agentName string, requestedPath types.AgentPath) error
 	GetSuggestions(agentName string) ([]evolution.Suggestion, error)
+	// XPPerLevel returns the flat XP-per-level threshold, so GetAgentEvolution
+	// can report progress toward the next level (PRD FR18) without callers
+	// having to duplicate the leveling formula.
+	XPPerLevel() int64
 }
 
 type Handler struct {
@@ -90,10 +94,16 @@ func (h *Handler) GetAgentEvolution(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	orihttp.WriteJSON(w, map[string]any{
+	resp := map[string]any{
 		"agent":     agentName,
 		"evolution": ag.Evolution,
-	})
+	}
+	// xp_per_level lets the UI render an XP bar toward the next level (PRD
+	// FR18) without duplicating the leveling formula client-side.
+	if h.evolutionService != nil {
+		resp["xp_per_level"] = h.evolutionService.XPPerLevel()
+	}
+	orihttp.WriteJSON(w, resp)
 }
 
 func (h *Handler) FeedAgent(w http.ResponseWriter, r *http.Request) {

--- a/internal/evolutionhttp/handler_test.go
+++ b/internal/evolutionhttp/handler_test.go
@@ -49,6 +49,10 @@ type fakeEvolutionService struct {
 	calls int
 }
 
+func (f *fakeEvolutionService) XPPerLevel() int64 {
+	return 100
+}
+
 func (f *fakeEvolutionService) AwardFeedXP(agentName string, _ string) error {
 	if f.err != nil {
 		return f.err
@@ -165,6 +169,13 @@ func TestHandler_GetAgentEvolution(t *testing.T) {
 	}
 	if evolution.Stage != types.AgentStageSpark {
 		t.Errorf("expected default stage spark, got %q", evolution.Stage)
+	}
+	var xpPerLevel int64
+	if err := json.Unmarshal(body["xp_per_level"], &xpPerLevel); err != nil {
+		t.Fatalf("failed to decode xp_per_level: %v", err)
+	}
+	if xpPerLevel != 100 {
+		t.Errorf("expected xp_per_level 100, got %d", xpPerLevel)
 	}
 }
 

--- a/internal/modelcategoryhttp/handler.go
+++ b/internal/modelcategoryhttp/handler.go
@@ -25,6 +25,13 @@ func NewHandler(categoryStore store.ModelCategoryStore) *Handler {
 	}
 }
 
+// Store returns the underlying model-category store, so other handlers
+// (e.g. the catalog-create path in agenthttp) can reuse the same
+// category-to-model resolution without duplicating storage wiring.
+func (h *Handler) Store() store.ModelCategoryStore {
+	return h.store
+}
+
 // GetAllHandler returns all categories, assignments, and view preference
 // GET /api/model-categories
 func (h *Handler) GetAllHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/builder_handlers.go
+++ b/internal/server/builder_handlers.go
@@ -423,6 +423,9 @@ func (b *ServerBuilder) initializeHandlers() {
 		ExternalAgents:    b.externalAgentsCache,
 		ConfigManager:     b.configManager,
 	})
+	// Enforce stage-based active-skill slot caps (PRD section C). Reads the
+	// agent's stage + expert flag through the store on each check, no caching.
+	b.skillsManager.SetLoadoutResolver(newLoadoutResolverAdapter(b.st))
 	b.skillsHandler = skillshttp.New(b.skillsManager, b.st, b.llmFactory, b.configManager)
 	b.chatHandler.SetSkillsManager(b.skillsManager)
 

--- a/internal/server/builder_workflow.go
+++ b/internal/server/builder_workflow.go
@@ -332,6 +332,12 @@ func (b *ServerBuilder) initializeTaskExecution() {
 	// provider profiles, so wire the LLM task handler directly for scheduling
 	// decisions (per-provider concurrency, local timeouts) — WS6.
 	b.taskExecutor.SetProviderResolver(b.taskHandler)
+	// Only wire when non-nil: b.evolutionService is a concrete *evolution.Service
+	// and passing a nil pointer through the TaskXPAwarder interface would leave
+	// a non-nil interface with a nil value, defeating the executor's nil check.
+	if b.evolutionService != nil {
+		b.taskExecutor.SetEvolutionAwarder(b.evolutionService)
+	}
 
 	b.stepExecutor = workspace.NewStepExecutor(b.workspaceStore, taskExecutionHandler, workspace.StepExecutorConfig{
 		PollInterval: 5 * time.Second,

--- a/internal/server/loadout_resolver_adapter.go
+++ b/internal/server/loadout_resolver_adapter.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"github.com/johnjallday/ori-agent/internal/skills"
+	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
+)
+
+// loadoutResolverAdapter resolves an agent's active-skill slot budget from the
+// agent store so skills.Manager can enforce stage-based caps (PRD section C).
+// It reads through the store on every call — no caching — so stage growth and
+// expert-mode toggles take effect immediately.
+type loadoutResolverAdapter struct {
+	store store.Store
+}
+
+func newLoadoutResolverAdapter(s store.Store) *loadoutResolverAdapter {
+	return &loadoutResolverAdapter{store: s}
+}
+
+func (a *loadoutResolverAdapter) ResolveAgentLoadout(agentName string) (skills.AgentLoadout, bool) {
+	if a == nil || a.store == nil {
+		return skills.AgentLoadout{}, false
+	}
+	ag, ok := a.store.GetAgent(agentName)
+	if !ok || ag == nil {
+		return skills.AgentLoadout{}, false
+	}
+
+	stage := types.AgentStageSpark
+	if ag.Evolution != nil && ag.Evolution.Stage != "" {
+		stage = ag.Evolution.Stage
+	}
+
+	return skills.AgentLoadout{
+		SlotCap:    types.SkillSlotsForStage(stage),
+		ExpertMode: ag.Metadata.IsExpertMode(ag.Role),
+		Stage:      string(stage),
+	}, true
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -142,8 +142,15 @@ func registerAgentRoutes(mux *http.ServeMux, s *Server) {
 		agentHandler.SetClaudeSyncProvider(s.Handlers.ExternalAgents.ClaudeSyncData)
 		agentHandler.SetCodexSyncProvider(s.Handlers.ExternalAgents.CodexSyncData)
 	}
+	if s.Handlers.ModelCategory != nil {
+		agentHandler.SetModelCategoryStore(s.Handlers.ModelCategory.Store())
+	}
+	if s.Handlers.Skills != nil {
+		agentHandler.SetSkillsManager(s.Handlers.Skills.Manager())
+	}
 	avatarHandler := agenthttp.NewAvatarHandler(s.Storage.AgentStore)
 	mux.Handle("/api/agents", agentHandler)
+	mux.HandleFunc("/api/agents/catalog", agenthttp.CatalogHandler)
 	if s.Handlers.Evolution != nil {
 		mux.HandleFunc("/api/evolution/assistant", s.Handlers.Evolution.GetAssistantProgress)
 		mux.HandleFunc("/api/evolution/suggestions", s.Handlers.Evolution.GetSuggestions)

--- a/internal/skills/errors.go
+++ b/internal/skills/errors.go
@@ -10,6 +10,10 @@ var (
 	ErrSkillNotFound           = errors.New("skill not found")
 	ErrSkillRenameNotSupported = errors.New("renaming skills is not supported")
 	ErrSkillReadOnly           = errors.New("skill source is read-only")
+	// ErrSkillSlotCapReached is returned when enabling a skill would exceed the
+	// agent's stage-based active-skill slot cap (PRD FR10-11). Wrapped with a
+	// message naming the cap and current stage so the HTTP layer can surface it.
+	ErrSkillSlotCapReached = errors.New("skill slot cap reached")
 )
 
 // SkillConflict represents a duplicate skill name across discovery paths.

--- a/internal/skills/loadout.go
+++ b/internal/skills/loadout.go
@@ -1,0 +1,116 @@
+package skills
+
+import (
+	"fmt"
+	"sort"
+)
+
+// sourceEnableRank orders skill sources for deterministic cap-filling on a
+// bulk "*" enable (PRD FR14: "starter/built-in skills first, then
+// alphabetical"). Lower rank fills first. Repo/.agents skills ship with the
+// app and stand in for "built-in"; user/personal/CLI skills come after.
+var sourceEnableRank = map[string]int{
+	SourceRepo:         0,
+	SourceAgentsCompat: 1,
+	SourceAgent:        2,
+	SourcePersonal:     3,
+	SourceClaude:       4,
+	SourceCodex:        5,
+}
+
+func sourceRank(source string) int {
+	if r, ok := sourceEnableRank[source]; ok {
+		return r
+	}
+	return 99
+}
+
+// resolveLoadout returns the agent's cap budget, or ok=false when no resolver
+// is wired or the agent is unresolvable (fail open — never block a toggle).
+func (m *Manager) resolveLoadout(agentName string) (AgentLoadout, bool) {
+	if m.loadoutResolver == nil {
+		return AgentLoadout{}, false
+	}
+	return m.loadoutResolver.ResolveAgentLoadout(agentName)
+}
+
+// enforceSlotCapForEnable rejects enabling a not-yet-enabled skill when the
+// agent is already at (or over) its stage-based slot cap. Idempotent
+// re-enables of an already-active skill are always allowed, and over-cap
+// grandfathered agents keep everything — the cap only blocks *new* enables
+// (PRD FR12). Expert-mode and unresolvable agents bypass entirely.
+func (m *Manager) enforceSlotCapForEnable(agentName, skillKey string) error {
+	loadout, ok := m.resolveLoadout(agentName)
+	if !ok || loadout.ExpertMode {
+		return nil
+	}
+
+	skillsList, err := m.ListSkills(agentName)
+	if err != nil {
+		return err
+	}
+
+	enabledCount := 0
+	for _, s := range skillsList {
+		if !s.Enabled {
+			continue
+		}
+		enabledCount++
+		if normalizeSkillKey(s.Name) == skillKey {
+			// Already enabled → re-enabling is a no-op, never blocked.
+			return nil
+		}
+	}
+
+	if enabledCount >= loadout.SlotCap {
+		return fmt.Errorf("%w: the %s stage allows %d active skills (%d in use). Disable a skill or enable expert mode to add more",
+			ErrSkillSlotCapReached, loadout.Stage, loadout.SlotCap, enabledCount)
+	}
+	return nil
+}
+
+// enableAllWithinCap implements the bulk "*" enable for a non-expert agent by
+// filling active-skill slots deterministically up to the cap rather than
+// blanket-enabling every skill. Order: currently-enabled first (never demote a
+// grandfathered skill out of the kept set), then built-in/source rank, then
+// alphabetical. Expert / unresolvable agents fall back to the legacy wildcard
+// enable (unrestricted). PRD FR14.
+func (m *Manager) enableAllWithinCap(agentName string) error {
+	loadout, ok := m.resolveLoadout(agentName)
+	if !ok || loadout.ExpertMode {
+		return m.updateSkillState(agentName, "*", func(state *SkillState) {
+			state.Enabled = true
+		})
+	}
+
+	skillsList, err := m.ListSkills(agentName)
+	if err != nil {
+		return err
+	}
+
+	sort.SliceStable(skillsList, func(i, j int) bool {
+		a, b := skillsList[i], skillsList[j]
+		// Currently-enabled skills sort first so a bulk enable never demotes
+		// an agent's existing loadout below the cap.
+		if a.Enabled != b.Enabled {
+			return a.Enabled
+		}
+		if ra, rb := sourceRank(a.Source), sourceRank(b.Source); ra != rb {
+			return ra < rb
+		}
+		return normalizeSkillKey(a.Name) < normalizeSkillKey(b.Name)
+	})
+
+	// Write explicit per-skill state for every skill: the first `cap` in the
+	// deterministic order enabled, the rest disabled. Explicit state avoids
+	// leaving a wildcard "*" default that would silently enable future skills.
+	for i, s := range skillsList {
+		enabled := i < loadout.SlotCap
+		if setErr := m.updateSkillState(agentName, s.Name, func(state *SkillState) {
+			state.Enabled = enabled
+		}); setErr != nil {
+			return setErr
+		}
+	}
+	return nil
+}

--- a/internal/skills/loadout_test.go
+++ b/internal/skills/loadout_test.go
@@ -1,0 +1,210 @@
+package skills
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// fakeLoadoutResolver returns a fixed loadout for every agent.
+type fakeLoadoutResolver struct {
+	loadout AgentLoadout
+	ok      bool
+}
+
+func (f fakeLoadoutResolver) ResolveAgentLoadout(string) (AgentLoadout, bool) {
+	return f.loadout, f.ok
+}
+
+// newLoadoutTestManager builds a manager backed by `count` repo skills named
+// skill-0..skill-(count-1), all initially disabled, plus the given resolver.
+func newLoadoutTestManager(t *testing.T, count int, resolver LoadoutResolver) *Manager {
+	t.Helper()
+	tmpDir := t.TempDir()
+	agentStorePath := filepath.Join(tmpDir, "agents.json")
+	if err := os.WriteFile(agentStorePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write agents.json: %v", err)
+	}
+	for i := 0; i < count; i++ {
+		name := "skill-" + string(rune('0'+i))
+		dir := filepath.Join(tmpDir, "agents", "skills", name)
+		writeTestSkill(t, dir, name, "desc", "prompt")
+	}
+	m := NewManager(ManagerConfig{AgentStorePath: agentStorePath})
+	m.SetLoadoutResolver(resolver)
+	return m
+}
+
+func enabledSkillNames(t *testing.T, m *Manager, agent string) []string {
+	t.Helper()
+	list, err := m.ListSkills(agent)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	var out []string
+	for _, s := range list {
+		if s.Enabled {
+			out = append(out, s.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestSetSkillEnabled_RejectsEnableAtCap(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, fakeLoadoutResolver{
+		loadout: AgentLoadout{SlotCap: 2, Stage: "spark"},
+		ok:      true,
+	})
+
+	if err := m.SetSkillEnabled("agent", "skill-0", true); err != nil {
+		t.Fatalf("first enable failed: %v", err)
+	}
+	if err := m.SetSkillEnabled("agent", "skill-1", true); err != nil {
+		t.Fatalf("second enable failed: %v", err)
+	}
+	// Third enable is over the spark cap of 2.
+	err := m.SetSkillEnabled("agent", "skill-2", true)
+	if !errors.Is(err, ErrSkillSlotCapReached) {
+		t.Fatalf("expected ErrSkillSlotCapReached, got %v", err)
+	}
+	if got := enabledSkillNames(t, m, "agent"); len(got) != 2 {
+		t.Errorf("expected 2 enabled skills after rejected enable, got %v", got)
+	}
+}
+
+func TestSetSkillEnabled_ReEnableAlreadyEnabledAllowedAtCap(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, fakeLoadoutResolver{
+		loadout: AgentLoadout{SlotCap: 2, Stage: "spark"},
+		ok:      true,
+	})
+	mustEnable(t, m, "skill-0")
+	mustEnable(t, m, "skill-1")
+
+	// Re-enabling an already-active skill at cap is a no-op, never rejected.
+	if err := m.SetSkillEnabled("agent", "skill-0", true); err != nil {
+		t.Fatalf("re-enable of already-enabled skill should be allowed, got %v", err)
+	}
+}
+
+func TestSetSkillEnabled_OverCapGrandfatherKeepsAndBlocksNew(t *testing.T) {
+	// Start with a generous cap so we can enable 4 skills, then drop the cap
+	// to 2 to simulate an agent grandfathered over its stage cap.
+	resolver := &mutableLoadoutResolver{loadout: AgentLoadout{SlotCap: 4, Stage: "learner"}, ok: true}
+	m := newLoadoutTestManager(t, 5, resolver)
+
+	for _, n := range []string{"skill-0", "skill-1", "skill-2", "skill-3"} {
+		mustEnable(t, m, n)
+	}
+
+	// Now the agent is over its (lowered) cap.
+	resolver.loadout = AgentLoadout{SlotCap: 2, Stage: "spark"}
+
+	// Existing skills all remain enabled (never auto-disabled).
+	if got := enabledSkillNames(t, m, "agent"); len(got) != 4 {
+		t.Fatalf("grandfathered agent should keep all 4 skills, got %v", got)
+	}
+	// A new enable is blocked while over cap.
+	if err := m.SetSkillEnabled("agent", "skill-4", true); !errors.Is(err, ErrSkillSlotCapReached) {
+		t.Fatalf("expected over-cap new enable to be rejected, got %v", err)
+	}
+	// Disabling is still allowed even while over cap.
+	if err := m.SetSkillEnabled("agent", "skill-0", false); err != nil {
+		t.Fatalf("disable while over cap should be allowed, got %v", err)
+	}
+	if got := enabledSkillNames(t, m, "agent"); len(got) != 3 {
+		t.Errorf("expected 3 enabled after disabling one, got %v", got)
+	}
+}
+
+func TestSetSkillEnabled_ExpertModeBypassesCap(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, fakeLoadoutResolver{
+		loadout: AgentLoadout{SlotCap: 2, Stage: "spark", ExpertMode: true},
+		ok:      true,
+	})
+	for _, n := range []string{"skill-0", "skill-1", "skill-2", "skill-3", "skill-4"} {
+		if err := m.SetSkillEnabled("agent", n, true); err != nil {
+			t.Fatalf("expert-mode enable of %s should never be capped, got %v", n, err)
+		}
+	}
+	if got := enabledSkillNames(t, m, "agent"); len(got) != 5 {
+		t.Errorf("expected all 5 skills enabled under expert mode, got %v", got)
+	}
+}
+
+func TestSetSkillEnabled_NoResolverMeansNoCap(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, nil)
+	m.SetLoadoutResolver(nil) // explicit: no enforcement wired
+	for _, n := range []string{"skill-0", "skill-1", "skill-2", "skill-3", "skill-4"} {
+		if err := m.SetSkillEnabled("agent", n, true); err != nil {
+			t.Fatalf("without a resolver there is no cap, got %v enabling %s", err, n)
+		}
+	}
+}
+
+func TestSetSkillEnabled_UnresolvableAgentFailsOpen(t *testing.T) {
+	m := newLoadoutTestManager(t, 3, fakeLoadoutResolver{ok: false})
+	for _, n := range []string{"skill-0", "skill-1", "skill-2"} {
+		if err := m.SetSkillEnabled("agent", n, true); err != nil {
+			t.Fatalf("unresolvable agent should fail open (no cap), got %v", err)
+		}
+	}
+}
+
+func TestSetSkillEnabled_BulkWildcardFillsUpToCap(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, fakeLoadoutResolver{
+		loadout: AgentLoadout{SlotCap: 3, Stage: "learner"},
+		ok:      true,
+	})
+
+	if err := m.SetSkillEnabled("agent", "*", true); err != nil {
+		t.Fatalf("bulk enable failed: %v", err)
+	}
+
+	got := enabledSkillNames(t, m, "agent")
+	if len(got) != 3 {
+		t.Fatalf("expected bulk enable to fill exactly the cap (3), got %v", got)
+	}
+	// All repo skills share the same source rank, so the deterministic order is
+	// alphabetical: skill-0, skill-1, skill-2.
+	want := []string{"skill-0", "skill-1", "skill-2"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("deterministic fill mismatch at %d: got %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestSetSkillEnabled_BulkWildcardExpertEnablesAll(t *testing.T) {
+	m := newLoadoutTestManager(t, 5, fakeLoadoutResolver{
+		loadout: AgentLoadout{SlotCap: 2, Stage: "spark", ExpertMode: true},
+		ok:      true,
+	})
+	if err := m.SetSkillEnabled("agent", "*", true); err != nil {
+		t.Fatalf("bulk enable failed: %v", err)
+	}
+	if got := enabledSkillNames(t, m, "agent"); len(got) != 5 {
+		t.Errorf("expert bulk enable should enable all 5 skills, got %v", got)
+	}
+}
+
+// mustEnable enables a skill and fails the test on error.
+func mustEnable(t *testing.T, m *Manager, name string) {
+	t.Helper()
+	if err := m.SetSkillEnabled("agent", name, true); err != nil {
+		t.Fatalf("enable %s: %v", name, err)
+	}
+}
+
+// mutableLoadoutResolver lets a test change the loadout mid-run to simulate
+// stage/cap changes.
+type mutableLoadoutResolver struct {
+	loadout AgentLoadout
+	ok      bool
+}
+
+func (r *mutableLoadoutResolver) ResolveAgentLoadout(string) (AgentLoadout, bool) {
+	return r.loadout, r.ok
+}

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -27,11 +27,30 @@ type ManagerConfig struct {
 	ConfigManager     *config.Manager
 }
 
+// AgentLoadout describes an agent's active-skill slot budget for cap
+// enforcement (PRD section C). Stage is carried only for error messages.
+type AgentLoadout struct {
+	SlotCap    int
+	ExpertMode bool
+	Stage      string
+}
+
+// LoadoutResolver resolves an agent's slot cap and expert-mode flag at check
+// time (read through the agent store, never cached — PRD technical notes).
+// Implemented by an adapter over the agent store in the server package.
+type LoadoutResolver interface {
+	// ResolveAgentLoadout returns the agent's loadout budget. ok=false means
+	// the agent is not resolvable, in which case the caller applies no cap
+	// (fail open — a missing agent should never block a skill toggle).
+	ResolveAgentLoadout(agentName string) (loadout AgentLoadout, ok bool)
+}
+
 type Manager struct {
 	agentStorePath    string
 	personalSkillsDir string
 	externalAgents    *externalagents.Cache
 	configManager     *config.Manager
+	loadoutResolver   LoadoutResolver
 }
 
 func NewManager(cfg ManagerConfig) *Manager {
@@ -41,6 +60,13 @@ func NewManager(cfg ManagerConfig) *Manager {
 		externalAgents:    cfg.ExternalAgents,
 		configManager:     cfg.ConfigManager,
 	}
+}
+
+// SetLoadoutResolver wires stage-based slot-cap enforcement for the per-agent
+// skill-enable path. When nil (unset), SetSkillEnabled behaves as it did
+// before caps existed — no enforcement — preserving legacy callers.
+func (m *Manager) SetLoadoutResolver(resolver LoadoutResolver) {
+	m.loadoutResolver = resolver
 }
 
 func (m *Manager) GetSkill(agentName, skillName string) (*Skill, bool, error) {

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -125,6 +125,17 @@ func (m *Manager) SetSkillTrusted(agentName, skillName string, trusted bool) err
 }
 
 func (m *Manager) SetSkillEnabled(agentName, skillName string, enabled bool) error {
+	key := normalizeSkillKey(skillName)
+	if enabled {
+		// Bulk "*" enable fills up to the cap deterministically for non-expert
+		// agents rather than blanket-enabling everything (PRD FR14).
+		if key == "*" {
+			return m.enableAllWithinCap(agentName)
+		}
+		if err := m.enforceSlotCapForEnable(agentName, key); err != nil {
+			return err
+		}
+	}
 	return m.updateSkillState(agentName, skillName, func(state *SkillState) {
 		state.Enabled = enabled
 	})

--- a/internal/skillshttp/handlers.go
+++ b/internal/skillshttp/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/johnjallday/ori-agent/internal/llm"
 	"github.com/johnjallday/ori-agent/internal/skills"
 	"github.com/johnjallday/ori-agent/internal/store"
+	"github.com/johnjallday/ori-agent/internal/types"
 )
 
 type Handler struct {
@@ -198,9 +199,43 @@ func (h *Handler) listSkills(w http.ResponseWriter, r *http.Request) {
 		"agent":  agentName,
 		"skills": skillsList,
 	}
+	if loadout := h.agentLoadout(agentName, skillsList); loadout != nil {
+		response["loadout"] = loadout
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response)
+}
+
+// agentLoadout returns the agent's active-skill slot budget (stage, cap, used,
+// expert flag) so the UI can render slot usage and disable the enable control
+// at cap (PRD FR11). Returns nil for agents not in the store (e.g. CLI agents
+// or the global/no-agent listing), which the UI treats as "no cap".
+func (h *Handler) agentLoadout(agentName string, skillsList []skills.Skill) map[string]any {
+	if h.store == nil || strings.TrimSpace(agentName) == "" {
+		return nil
+	}
+	ag, ok := h.store.GetAgent(agentName)
+	if !ok || ag == nil {
+		return nil
+	}
+
+	stage := types.AgentStageSpark
+	if ag.Evolution != nil && ag.Evolution.Stage != "" {
+		stage = ag.Evolution.Stage
+	}
+	used := 0
+	for _, s := range skillsList {
+		if s.Enabled {
+			used++
+		}
+	}
+	return map[string]any{
+		"stage":       string(stage),
+		"slot_cap":    types.SkillSlotsForStage(stage),
+		"slots_used":  used,
+		"expert_mode": ag.Metadata.IsExpertMode(ag.Role),
+	}
 }
 
 func (h *Handler) createSkill(w http.ResponseWriter, r *http.Request) {
@@ -714,6 +749,12 @@ func (h *Handler) setSkillEnabled(w http.ResponseWriter, r *http.Request, name s
 		return
 	}
 	if err := h.manager.SetSkillEnabled(agentName, name, *req.Enabled); err != nil {
+		if errors.Is(err, skills.ErrSkillSlotCapReached) {
+			// The cap message already names the stage and slot count; surface it
+			// verbatim as a 409 so the UI can show it to the user.
+			orihttp.Conflict(w, err.Error())
+			return
+		}
 		orihttp.InternalError(w, err.Error())
 		return
 	}

--- a/internal/skillshttp/handlers.go
+++ b/internal/skillshttp/handlers.go
@@ -59,6 +59,13 @@ func New(manager *skills.Manager, st store.Store, llmFactory *llm.Factory, cfg *
 	}
 }
 
+// Manager returns the underlying skills manager, so other handlers (e.g. the
+// catalog-create path in agenthttp) can enable skills without duplicating
+// manager wiring.
+func (h *Handler) Manager() *skills.Manager {
+	return h.manager
+}
+
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:

--- a/internal/skillshttp/handlers_test.go
+++ b/internal/skillshttp/handlers_test.go
@@ -140,6 +140,66 @@ func TestCreateSkill_FallsBackToLocalCreationWhenSkillsCLIUnavailable(t *testing
 	}
 }
 
+func TestListSkills_IncludesAgentLoadout(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentStorePath := filepath.Join(tmpDir, "agents", "index.json")
+	manager := skills.NewManager(skills.ManagerConfig{AgentStorePath: agentStorePath})
+
+	// A repo skill so the loadout has something to reference.
+	skillDir := filepath.Join(tmpDir, "agents", "skills", "repo-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	skillMd := "---\nname: repo-skill\ndescription: Repo skill\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMd), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	agentStore := &testAgentStore{agents: map[string]*agent.Agent{
+		"Worker": {
+			Role:      types.RoleResearcher, // catalog role -> expert defaults OFF
+			Evolution: &types.AgentEvolution{Stage: types.AgentStageInfant},
+			Metadata:  &types.AgentMetadata{},
+		},
+	}}
+	handler := New(manager, agentStore, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/skills?agent=Worker", nil)
+	rec := httptest.NewRecorder()
+	handler.listSkills(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Loadout *struct {
+			Stage      string `json:"stage"`
+			SlotCap    int    `json:"slot_cap"`
+			SlotsUsed  int    `json:"slots_used"`
+			ExpertMode bool   `json:"expert_mode"`
+		} `json:"loadout"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Loadout == nil {
+		t.Fatal("expected loadout in response")
+	}
+	if resp.Loadout.Stage != string(types.AgentStageInfant) {
+		t.Errorf("stage = %q, want infant", resp.Loadout.Stage)
+	}
+	if resp.Loadout.SlotCap != 3 {
+		t.Errorf("slot_cap = %d, want 3 (infant)", resp.Loadout.SlotCap)
+	}
+	if resp.Loadout.SlotsUsed != 0 {
+		t.Errorf("slots_used = %d, want 0 (repo skill disabled by default)", resp.Loadout.SlotsUsed)
+	}
+	if resp.Loadout.ExpertMode {
+		t.Errorf("expert_mode = true, want false for a catalog-role agent with unset flag")
+	}
+}
+
 func TestResolvePromptProvider_UsesModelOnlyAgentConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := config.NewManager(filepath.Join(tmpDir, "settings.json"))

--- a/internal/types/agent_extended.go
+++ b/internal/types/agent_extended.go
@@ -240,6 +240,7 @@ const (
 	ActivityEventEvolutionFeed  ActivityEventType = "evolution_feed"  // Feed action granted evolution XP
 	ActivityEventEvolutionStage ActivityEventType = "evolution_stage" // Evolution stage changed
 	ActivityEventEvolutionPath  ActivityEventType = "evolution_path"  // Evolution path selected/changed
+	ActivityEventEvolutionTask  ActivityEventType = "evolution_task"  // Completed task run granted evolution XP
 )
 
 // ActivityLog represents a single activity log entry for an agent

--- a/internal/types/agent_extended.go
+++ b/internal/types/agent_extended.go
@@ -26,6 +26,27 @@ const (
 	AgentStageSentient AgentStage = "sentient"
 )
 
+// stageSkillSlots maps an evolution stage to the number of active skill
+// slots it grants (PRD FR10). Slot growth ties loadout usefulness to
+// progression; an agent's stage-appropriate cap is looked up here.
+var stageSkillSlots = map[AgentStage]int{
+	AgentStageSpark:    2,
+	AgentStageInfant:   3,
+	AgentStageLearner:  4,
+	AgentStageExpert:   5,
+	AgentStageSentient: 6,
+}
+
+// SkillSlotsForStage returns the number of active-skill slots granted at the
+// given evolution stage. An unrecognized or empty stage defaults to the
+// spark-stage cap (the lowest), never an unbounded/unlimited result.
+func SkillSlotsForStage(stage AgentStage) int {
+	if slots, ok := stageSkillSlots[stage]; ok {
+		return slots
+	}
+	return stageSkillSlots[AgentStageSpark]
+}
+
 // AgentPath represents the specialization path for an agent.
 type AgentPath string
 
@@ -69,6 +90,22 @@ type AgentMetadata struct {
 	ReviewEnabled     *bool                `json:"review_enabled,omitempty"`     // Whether conversation review is enabled for this agent
 	ReviewSensitivity string               `json:"review_sensitivity,omitempty"` // Review sensitivity level: "low", "medium", "high" (default: "medium")
 	RoutingProfile    *AgentRoutingProfile `json:"routing_profile,omitempty"`    // User-defined routing hints for specialist selection
+	// ExpertMode lifts stage-based active-skill slot caps (see SkillSlotsForStage)
+	// for this agent when true. Nil means unset; IsExpertMode resolves the
+	// default from the agent's role.
+	ExpertMode *bool `json:"expert_mode,omitempty"`
+}
+
+// IsExpertMode reports whether the agent bypasses stage-based skill slot
+// caps (PRD FR13). When explicitly set, that value wins. When unset,
+// pre-existing/Unspecialized agents (empty or "general" role) default to
+// expert mode ON — they predate the loadout-cap system; catalog-created
+// agents (any other role) default OFF.
+func (m *AgentMetadata) IsExpertMode(role AgentRole) bool {
+	if m != nil && m.ExpertMode != nil {
+		return *m.ExpertMode
+	}
+	return role == "" || role == RoleGeneral
 }
 
 // AgentEvolution tracks progression state for an agent.

--- a/internal/types/agent_extended_test.go
+++ b/internal/types/agent_extended_test.go
@@ -449,6 +449,54 @@ func TestDashboardStats_Struct(t *testing.T) {
 	}
 }
 
+func TestSkillSlotsForStage(t *testing.T) {
+	cases := []struct {
+		stage AgentStage
+		want  int
+	}{
+		{AgentStageSpark, 2},
+		{AgentStageInfant, 3},
+		{AgentStageLearner, 4},
+		{AgentStageExpert, 5},
+		{AgentStageSentient, 6},
+		{"", 2},            // unknown/empty defaults to the lowest cap
+		{"bogus-stage", 2}, // unrecognized value defaults to the lowest cap
+	}
+	for _, tc := range cases {
+		if got := SkillSlotsForStage(tc.stage); got != tc.want {
+			t.Errorf("SkillSlotsForStage(%q) = %d, want %d", tc.stage, got, tc.want)
+		}
+	}
+}
+
+func TestAgentMetadata_IsExpertMode(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	cases := []struct {
+		name string
+		m    *AgentMetadata
+		role AgentRole
+		want bool
+	}{
+		{"nil metadata, general role -> ON (unspecialized default)", nil, RoleGeneral, true},
+		{"nil metadata, empty role -> ON (unspecialized default)", nil, "", true},
+		{"nil metadata, catalog role -> OFF", nil, RoleResearcher, false},
+		{"unset flag, general role -> ON", &AgentMetadata{}, RoleGeneral, true},
+		{"unset flag, catalog role -> OFF", &AgentMetadata{}, RoleOrchestrator, false},
+		{"explicit true wins regardless of role", &AgentMetadata{ExpertMode: &trueVal}, RoleResearcher, true},
+		{"explicit false wins regardless of role", &AgentMetadata{ExpertMode: &falseVal}, RoleGeneral, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.IsExpertMode(tc.role); got != tc.want {
+				t.Errorf("IsExpertMode() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // Helper function for float comparison
 func abs(x float64) float64 {
 	if x < 0 {

--- a/internal/web/static/css/agents-roster.css
+++ b/internal/web/static/css/agents-roster.css
@@ -443,6 +443,57 @@
   border-color: var(--border-color, #e5e7eb);
 }
 
+/* Progression row: role chip (emblem + name, or a neutral Unspecialized
+   badge) plus a level/stage chip. Additive to the existing card layout. */
+.roster-card__progress {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.roster-card__role-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 7px 1px 5px;
+  border-radius: 999px;
+  color: var(--role-accent, var(--text-secondary, #6b7280));
+  background: color-mix(in srgb, var(--role-accent, #9ca3af) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--role-accent, #9ca3af) 30%, transparent);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster-card__role-chip.is-unspecialized {
+  color: var(--text-secondary, #6b7280);
+  background: color-mix(in srgb, var(--border-color, #9ca3af) 20%, transparent);
+  border-color: var(--border-color, #d1d5db);
+  font-weight: 500;
+  font-style: italic;
+}
+
+.roster-card__role-emblem {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.roster-card__level-chip {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 999px;
+  color: var(--text-secondary, #6b7280);
+  background: var(--bg-tertiary, #f3f4f6);
+  border: 1px solid var(--border-color, #e5e7eb);
+  white-space: nowrap;
+}
+
 .roster-empty {
   text-align: center;
   color: var(--text-secondary, #6b7280);
@@ -921,6 +972,90 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+/* Progression block: role emblem + name, level/stage, XP bar, slot usage.
+   Sits below the hero, above the Overview/Prompt/Workspaces tabs. */
+.stage__progression {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  padding: 14px 24px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  background: var(--bg-secondary, #f9fafb);
+}
+
+.stage__progression:empty {
+  display: none;
+}
+
+.stage__progression-role {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--role-accent, var(--text-primary, #111827));
+}
+
+.stage__progression-emblem {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--role-accent, var(--text-secondary, #6b7280));
+  background: color-mix(in srgb, var(--role-accent, #9ca3af) 16%, transparent);
+}
+
+.stage__progression-level {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  white-space: nowrap;
+}
+
+.stage__progression-xp {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 160px;
+  min-width: 140px;
+}
+
+.stage__progression-xpbar {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-tertiary, #e5e7eb);
+  overflow: hidden;
+}
+
+.stage__progression-xpfill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--primary-color, #4f46e5);
+  transition: width 0.3s ease;
+}
+
+.stage__progression-xplabel {
+  font-size: 11px;
+  color: var(--text-secondary, #6b7280);
+  white-space: nowrap;
+}
+
+.stage__progression-slots {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  white-space: nowrap;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-tertiary, #f3f4f6);
+  border: 1px solid var(--border-color, #e5e7eb);
 }
 
 .vital {

--- a/internal/web/static/css/workspace-construct.css
+++ b/internal/web/static/css/workspace-construct.css
@@ -376,6 +376,17 @@
   flex-wrap: wrap;
   gap: 6px;
 }
+/* No-Commander nudge (PRD FR23): non-blocking, so it reads as informational
+   rather than an error — amber accent, no icon that implies a hard stop. */
+.workspace-create-modal .workspace-template-briefing-nudge {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, #f59e0b 45%, var(--wc-line));
+  background: color-mix(in srgb, #f59e0b 10%, transparent);
+  color: var(--wc-ink-dim);
+  font-size: 11px;
+  line-height: 1.45;
+}
 .workspace-create-modal .workspace-template-briefing-chip {
   font-family: var(--wc-font-mono);
   font-size: 10px;

--- a/internal/web/static/js/agents-detail.js
+++ b/internal/web/static/js/agents-detail.js
@@ -305,11 +305,11 @@ async function showMissingAgentState(message) {
   let detail = 'Return to the agents directory or open the relevant workspace to repair the missing reference.';
 
   if (recovery?.workspaceId && recovery.isEntryAgent) {
-    title = 'Workspace entry agent is missing';
+    title = 'Workspace Commander is missing';
     body = requestedName
-      ? `"${requestedName}" is still referenced as the entry agent for "${recovery.workspaceName}", but the runnable agent definition no longer exists.`
-      : `The entry agent for "${recovery.workspaceName}" no longer exists.`;
-    detail = 'Create a replacement entry agent to restore workspace routing, chats, and task execution. You can also open the workspace first to inspect the current configuration.';
+      ? `"${requestedName}" is still referenced as the Commander for "${recovery.workspaceName}", but the runnable agent definition no longer exists.`
+      : `The Commander for "${recovery.workspaceName}" no longer exists.`;
+    detail = 'Create a replacement Commander to restore workspace routing, chats, and task execution. You can also open the workspace first to inspect the current configuration.';
   } else if (recovery?.workspaceId) {
     body = requestedName
       ? `"${requestedName}" is still referenced inside "${recovery.workspaceName}", but the runnable agent definition no longer exists.`
@@ -337,7 +337,7 @@ async function showMissingAgentState(message) {
     if (recovery?.workspaceId) {
       metaItems.push({
         label: 'Recovery',
-        value: recovery.isEntryAgent ? 'Create entry agent' : 'Repair workspace link'
+        value: recovery.isEntryAgent ? 'Create Commander' : 'Repair workspace link'
       });
     }
 

--- a/internal/web/static/js/agents-detail.js
+++ b/internal/web/static/js/agents-detail.js
@@ -6,6 +6,7 @@ let isEditingConfig = false;
 let isEditingPrompt = false;
 let availableProviders = []; // Cache for available providers and models from API
 let currentAgentSkills = [];
+let currentAgentLoadout = null; // {stage, slot_cap, slots_used, expert_mode} or null
 let globalMCPServers = [];
 let globalMCPStats = {};
 let profileSelectedTags = [];
@@ -549,6 +550,19 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   document.getElementById('editModel')?.addEventListener('change', updateEditReasoningVisibility);
   setupProfileEditor();
+
+  const expertToggle = document.getElementById('expertModeToggle');
+  if (expertToggle) {
+    expertToggle.addEventListener('change', async () => {
+      const desired = expertToggle.checked;
+      expertToggle.disabled = true;
+      const ok = await setAgentExpertMode(desired);
+      if (!ok) {
+        expertToggle.checked = !desired;
+      }
+      expertToggle.disabled = false;
+    });
+  }
 
   const pluginPanel = document.getElementById('pluginManagerPanel');
   if (pluginPanel) {
@@ -1881,6 +1895,8 @@ async function renderSkills() {
     const data = await response.json();
     const skills = Array.isArray(data.skills) ? data.skills : [];
     currentAgentSkills = skills;
+    currentAgentLoadout = data.loadout || null;
+    renderSkillSlotUsage();
 
     if (skills.length === 0) {
       container.innerHTML = '<div class="text-center py-3" style="color: var(--text-secondary);">No skills available for this agent.</div>';
@@ -1891,6 +1907,11 @@ async function renderSkills() {
     }
 
     skills.sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
+
+    // At cap (non-expert) means no *new* skills can be enabled; already-enabled
+    // ones can still be toggled off.
+    const atCap = Boolean(currentAgentLoadout) && !currentAgentLoadout.expert_mode &&
+      currentAgentLoadout.slots_used >= currentAgentLoadout.slot_cap;
 
     container.innerHTML = '';
     skills.forEach(skill => {
@@ -1903,6 +1924,13 @@ async function renderSkills() {
       const isTrusted = Boolean(skill?.trusted);
       const validationErrors = Array.isArray(skill?.validation_errors) ? skill.validation_errors : [];
       const hasErrors = validationErrors.length > 0;
+
+      // Only disabled skills are blocked at cap; enabled skills can always be
+      // toggled off (and grandfathered over-cap skills stay usable).
+      const capBlocked = atCap && !isEnabled;
+      const capTooltip = currentAgentLoadout
+        ? `At the ${currentAgentLoadout.stage} stage cap of ${currentAgentLoadout.slot_cap} active skills. Disable another skill or turn on Expert mode to add more.`
+        : '';
 
       const item = document.createElement('div');
       item.style.cssText = 'padding: 12px; border: 1px solid var(--border-color); border-radius: 8px; background: var(--bg-secondary); display: flex; flex-direction: column; gap: 8px;';
@@ -1918,8 +1946,8 @@ async function renderSkills() {
         ${hasErrors ? `<div style="font-size: 11px; color: var(--danger-color);">${escapeHtml(validationErrors.join('; '))}</div>` : ''}
         <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: auto; padding-top: 4px;">
           <span style="font-size: 12px; color: var(--text-secondary);">Enabled</span>
-          <div class="form-check form-switch m-0">
-            <input class="form-check-input" type="checkbox" data-action="toggle-skill-enabled" ${isEnabled ? 'checked' : ''}>
+          <div class="form-check form-switch m-0"${capBlocked ? ` title="${escapeAttr(capTooltip)}"` : ''}>
+            <input class="form-check-input" type="checkbox" data-action="toggle-skill-enabled" ${isEnabled ? 'checked' : ''} ${capBlocked ? 'disabled' : ''}>
           </div>
         </div>
       `;
@@ -1964,6 +1992,10 @@ async function setSkillEnabled(agent, skillName, enabled) {
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
       const message = data?.error || 'Failed to update skill state';
+      // A 409 is the slot-cap rejection; its message names the stage and cap.
+      if (response.status === 409 && typeof showToast === 'function') {
+        showToast(message, 'error');
+      }
       console.error('Failed to update skill state:', message);
       return false;
     }
@@ -1972,6 +2004,64 @@ async function setSkillEnabled(agent, skillName, enabled) {
     return true;
   } catch (error) {
     console.error('Failed to update skill state:', error);
+    return false;
+  }
+}
+
+// renderSkillSlotUsage updates the "N/M slots" badge and the expert-mode row
+// from the current agent's loadout (populated by the skills list response).
+function renderSkillSlotUsage() {
+  const badge = document.getElementById('skillSlotUsage');
+  const expertRow = document.getElementById('expertModeRow');
+  const expertToggle = document.getElementById('expertModeToggle');
+  const loadout = currentAgentLoadout;
+
+  if (badge) {
+    if (loadout && !loadout.expert_mode) {
+      badge.textContent = `${loadout.slots_used}/${loadout.slot_cap} slots`;
+      badge.title = `${loadout.stage} stage grants ${loadout.slot_cap} active skill slots`;
+      badge.style.display = '';
+    } else if (loadout && loadout.expert_mode) {
+      badge.textContent = `${loadout.slots_used} active · expert`;
+      badge.title = 'Expert mode: slot cap lifted';
+      badge.style.display = '';
+    } else {
+      badge.style.display = 'none';
+    }
+  }
+
+  if (expertRow && expertToggle) {
+    if (loadout) {
+      expertRow.style.setProperty('display', 'flex', 'important');
+      expertToggle.checked = Boolean(loadout.expert_mode);
+    } else {
+      expertRow.style.setProperty('display', 'none', 'important');
+    }
+  }
+}
+
+// setAgentExpertMode PATCHes the agent's expert_mode flag, then reloads skills
+// so the slot badge and at-cap toggles reflect the new state.
+async function setAgentExpertMode(enabled) {
+  const name = currentAgent?.name || agentName;
+  if (!name) return false;
+  try {
+    const response = await fetch(`/api/agents/${encodeURIComponent(name)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expert_mode: enabled })
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      if (typeof showToast === 'function') {
+        showToast(data?.error || 'Failed to update expert mode', 'error');
+      }
+      return false;
+    }
+    await renderSkills();
+    return true;
+  } catch (error) {
+    console.error('Failed to update expert mode:', error);
     return false;
   }
 }

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -86,6 +86,7 @@
       name: document.getElementById('stageName'),
       klass: document.getElementById('stageClass'),
       vitals: document.getElementById('stageVitals'),
+      progression: document.getElementById('stageProgression'),
       overviewFacts: document.getElementById('overviewFacts'),
       overviewDesc: document.getElementById('overviewDesc'),
       promptBody: document.getElementById('promptBody'),
@@ -103,6 +104,7 @@
       bulkLive: document.getElementById('bulkLive'),
       bulkAddTags: document.getElementById('bulkAddTags'),
       bulkRemoveTags: document.getElementById('bulkRemoveTags'),
+      bulkSetRole: document.getElementById('bulkSetRole'),
       bulkFavorite: document.getElementById('bulkFavorite'),
       bulkUnfavorite: document.getElementById('bulkUnfavorite'),
       bulkDelete: document.getElementById('bulkDelete'),
@@ -195,6 +197,9 @@
     els.bulkRemoveTags.addEventListener('click', function () {
       openBulkTags('remove');
     });
+    els.bulkSetRole.addEventListener('click', function () {
+      openBulkTags('role');
+    });
     els.bulkTagsCancel.addEventListener('click', closeBulkTags);
     els.bulkTagsConfirm.addEventListener('click', runBulkTags);
     els.bulkTagsDialog.addEventListener('cancel', function (e) {
@@ -235,7 +240,14 @@
     });
 
     loadProviders();
-    loadAgents();
+    // Wait for the role catalog (emblem/accent-color lookup) so the first
+    // paint of roster cards renders correct role chips instead of a
+    // flash-of-Unspecialized while the catalog fetch is still in flight.
+    if (window.RoleCatalog) {
+      window.RoleCatalog.ready().then(loadAgents);
+    } else {
+      loadAgents();
+    }
   }
 
   /* ---- data ---------------------------------------------------------------- */
@@ -276,6 +288,11 @@
         state.byName = {};
         agents.forEach(function (a) {
           state.byName[a.name] = a;
+          // Compare-on-refresh stage-up detection (PRD FR19): no-ops on first
+          // sight of an agent, fires a toast on genuine forward progress.
+          if (window.StageUpToast && a.evolution && a.evolution.stage) {
+            window.StageUpToast.check(a.name, a.evolution.stage);
+          }
         });
         pruneChecked();
         applyUrlToState();
@@ -328,6 +345,11 @@
       switch (state.sort) {
         case 'name-desc':
           return b.name.localeCompare(a.name);
+        case 'level-desc':
+          return (
+            ((b.evolution && b.evolution.level) || 0) - ((a.evolution && a.evolution.level) || 0) ||
+            a.name.localeCompare(b.name)
+          );
         case 'workspaces-desc':
           return (
             (b.workspace_count || 0) - (a.workspace_count || 0) || a.name.localeCompare(b.name)
@@ -364,7 +386,12 @@
   function matchesFilters(a) {
     var f = state.filters;
     if (f.health.size > 0 && !f.health.has(agentHealth(a))) return false;
-    if (f.role && String(a.role || '').toLowerCase() !== f.role.toLowerCase()) return false;
+    if (f.role === UNSPECIALIZED_FILTER_VALUE) {
+      var isUnspec = window.RoleCatalog ? window.RoleCatalog.isUnspecialized(a.role) : !a.role;
+      if (!isUnspec) return false;
+    } else if (f.role && String(a.role || '').toLowerCase() !== f.role.toLowerCase()) {
+      return false;
+    }
     if (f.source && agentSourceKind(a) !== f.source) return false;
     if (f.assignment === 'library' && (a.workspace_count || 0) > 0) return false;
     if (f.assignment === 'assigned' && (a.workspace_count || 0) === 0) return false;
@@ -434,27 +461,37 @@
     onFilterChange();
   }
 
-  // Populate the Role and Tag filter dropdowns from the values actually present
-  // in the roster, preserving the current selection when still valid.
+  // Role filter sentinel for "no role / general" (PRD FR20: "6 roles +
+  // Unspecialized"). Distinct from "" (which means "All roles").
+  var UNSPECIALIZED_FILTER_VALUE = 'unspecialized';
+
+  // Populate the Role and Tag filter dropdowns. Role is a fixed list — the 6
+  // catalog roles (in catalog order) plus Unspecialized — regardless of which
+  // roles are actually present in the current roster, so the option never
+  // shifts under the user (PRD FR20). Tags stay dynamically derived.
   function populateFilterOptions() {
-    var roles = {};
     var tags = {};
     state.agents.forEach(function (a) {
-      var role = String(a.role || '').trim();
-      if (role) roles[role.toLowerCase()] = role;
       var t = a.metadata && Array.isArray(a.metadata.tags) ? a.metadata.tags : [];
       t.forEach(function (tag) {
         var k = String(tag).toLowerCase();
         if (k) tags[k] = tag;
       });
     });
-    fillSelect(els.filterRole, 'All roles', roles, state.filters.role, titleCase);
-    fillSelect(els.filterTag, 'All tags', tags, state.filters.tag, null);
-    // A previously-selected value that no longer exists falls back to "all".
-    if (state.filters.role && !roles[state.filters.role.toLowerCase()]) {
-      state.filters.role = '';
-      els.filterRole.value = '';
+
+    if (els.filterRole) {
+      var roleOrder = (window.RoleCatalog && window.RoleCatalog.orderedRoles) || [];
+      var html = '<option value="">All roles</option>';
+      roleOrder.forEach(function (slug) {
+        html += '<option value="' + esc(slug) + '">' + esc(roleLabel(slug)) + '</option>';
+      });
+      html +=
+        '<option value="' + UNSPECIALIZED_FILTER_VALUE + '">' + esc(roleLabel('general')) + '</option>';
+      els.filterRole.innerHTML = html;
+      if (state.filters.role) els.filterRole.value = state.filters.role;
     }
+
+    fillSelect(els.filterTag, 'All tags', tags, state.filters.tag, null);
     if (state.filters.tag && !tags[state.filters.tag.toLowerCase()]) {
       state.filters.tag = '';
       els.filterTag.value = '';
@@ -575,8 +612,6 @@
     var status = healthKind(agent);
     var statusText = titleCase(String(agent.status || 'idle'));
     var metaBits = [];
-    var role = titleCase(agent.role || '');
-    if (role) metaBits.push(role);
     if (agent.model) metaBits.push(agent.model);
     var wc = agent.workspace_count || 0;
     metaBits.push(wc === 0 ? 'Library' : wc + ' workspace' + (wc === 1 ? '' : 's'));
@@ -591,12 +626,22 @@
     // Concise spoken label so screen readers don't read the raw dot markup, and
     // it carries the FULL tag list even when the visible chips are truncated
     // (PRD FR59).
+    var roleLbl = roleLabel(agent.role);
+    var evolution = agent.evolution || {};
+    var stage = evolution.stage || 'spark';
+    var level = evolution.level || 0;
+    var progressLabel = 'Lv ' + level + ' · ' + titleCase(stage);
+
     var wcLabel =
       wc === 0 ? 'library agent, unattached' : wc + ' workspace' + (wc === 1 ? '' : 's');
     var openLabel =
       agent.name +
       (permanent ? ', built-in' : '') +
       (favorite ? ', favorite' : '') +
+      ', ' +
+      roleLbl +
+      ', ' +
+      progressLabel +
       ', ' +
       statusText +
       ', ' +
@@ -610,6 +655,7 @@
       ? '<span class="roster-card__fav" title="Favorite" aria-hidden="true">★</span>'
       : '';
     var tagsRow = tagsRowHTML(tags);
+    var progressRow = permanent ? '' : roleProgressRowHTML(agent.role, roleLbl, progressLabel);
 
     // A labeled checkbox and a separate open/focus button are siblings — never
     // nested — so the checkbox is not a child of an interactive element and the
@@ -647,6 +693,7 @@
       '<span class="roster-card__meta">' +
       esc(metaBits.join(' · ')) +
       '</span>' +
+      progressRow +
       tagsRow +
       '</span>' +
       '<span class="roster-card__status is-' +
@@ -658,6 +705,30 @@
 
     if (isChecked) li.classList.add('is-checked');
     return li;
+  }
+
+  // Role chip (emblem + name for a catalog role; a neutral italic badge with
+  // no emblem for Unspecialized — PRD FR7/FR17) plus a level/stage chip.
+  // Purely decorative (aria-hidden); the spoken label carries the same info
+  // via openLabel.
+  function roleProgressRowHTML(role, roleLbl, progressLabel) {
+    var entry = window.RoleCatalog ? window.RoleCatalog.entry(role) : null;
+    var roleChip;
+    if (entry) {
+      roleChip =
+        '<span class="roster-card__role-chip" style="--role-accent: ' +
+        esc(entry.accent_color) +
+        ';">' +
+        '<i class="bi bi-' +
+        esc(entry.emblem) +
+        ' roster-card__role-emblem"></i>' +
+        esc(roleLbl) +
+        '</span>';
+    } else {
+      roleChip = '<span class="roster-card__role-chip is-unspecialized">' + esc(roleLbl) + '</span>';
+    }
+    var levelChip = '<span class="roster-card__level-chip">' + esc(progressLabel) + '</span>';
+    return '<span class="roster-card__progress" aria-hidden="true">' + roleChip + levelChip + '</span>';
   }
 
   // Up to two visible tag chips + a "+N" indicator when more exist. The full list
@@ -750,11 +821,15 @@
     els.avatar.outerHTML = avatarMarkup(listItem, 'stage__avatar', 'stageAvatar');
     els.avatar = document.getElementById('stageAvatar');
     els.name.textContent = listItem.name;
-    els.klass.textContent = titleCase(listItem.role || listItem.type || 'agent');
+    els.klass.textContent = listItem.role
+      ? roleLabel(listItem.role)
+      : titleCase(listItem.type || 'agent');
     // Deep-link to the full agent detail page (/agents/{name}). The server routes
     // this to the rich editor for catalog agents and to the dedicated read-only
     // pages for the built-in Claude Code / Codex CLI agents.
     els.stageFullPage.href = '/agents/' + encodeURIComponent(name);
+
+    renderProgression(name, listItem);
 
     els.workspacesBody.innerHTML = '<p class="stage-hint">Loading…</p>';
     els.overviewFacts.innerHTML = '<p class="stage-hint">Loading…</p>';
@@ -775,6 +850,102 @@
         els.overviewFacts.innerHTML = '<p class="stage-hint">Could not load agent details.</p>';
         renderWorkspaces(name, listItem, null);
         console.error('[roster] detail failed', err);
+      });
+  }
+
+  // Stage-panel progression block (PRD FR18): role emblem + name, level,
+  // stage, an XP bar toward the next level, and slot usage. Built-in/CLI
+  // agents don't have a catalog role or evolution, so the block is hidden
+  // for them. Renders synchronously from the already-loaded list item, then
+  // fills in the XP bar and slot usage once their (fast, independent)
+  // fetches resolve.
+  function renderProgression(name, listItem) {
+    if (!els.progression) return;
+    if (isPermanent(listItem)) {
+      els.progression.innerHTML = '';
+      return;
+    }
+
+    var role = listItem.role || '';
+    var entry = window.RoleCatalog ? window.RoleCatalog.entry(role) : null;
+    var lbl = roleLabel(role);
+    var evo = listItem.evolution || {};
+    var stage = evo.stage || 'spark';
+    var level = evo.level || 0;
+
+    var emblemHtml = entry
+      ? '<span class="stage__progression-emblem" style="--role-accent: ' +
+        esc(entry.accent_color) +
+        ';"><i class="bi bi-' +
+        esc(entry.emblem) +
+        '"></i></span>'
+      : '';
+    var roleStyle = entry ? ' style="--role-accent: ' + esc(entry.accent_color) + ';"' : '';
+
+    els.progression.innerHTML =
+      '<span class="stage__progression-role"' +
+      roleStyle +
+      '>' +
+      emblemHtml +
+      esc(lbl) +
+      '</span>' +
+      '<span class="stage__progression-level">Lv ' +
+      level +
+      ' · ' +
+      esc(titleCase(stage)) +
+      '</span>' +
+      '<span class="stage__progression-xp" id="stageProgressionXp"></span>' +
+      '<span class="stage__progression-slots" id="stageProgressionSlots">…</span>';
+
+    fetch('/api/agents/' + encodeURIComponent(name) + '/evolution')
+      .then(function (r) {
+        if (!r.ok) throw new Error('evolution ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        if (state.selected !== name) return;
+        var e = (data && data.evolution) || {};
+        var xpPerLevel = data && data.xp_per_level;
+        if (e.stage) window.StageUpToast && window.StageUpToast.check(name, e.stage);
+        var xpHost = document.getElementById('stageProgressionXp');
+        if (!xpHost || !xpPerLevel) return;
+        var xp = Number(e.experience || 0);
+        var intoLevel = xp % xpPerLevel;
+        var pct = Math.max(0, Math.min(100, Math.round((intoLevel / xpPerLevel) * 100)));
+        xpHost.innerHTML =
+          '<span class="stage__progression-xpbar"><span class="stage__progression-xpfill" style="width: ' +
+          pct +
+          '%;"></span></span>' +
+          '<span class="stage__progression-xplabel">' +
+          intoLevel +
+          ' / ' +
+          xpPerLevel +
+          ' XP</span>';
+      })
+      .catch(function (err) {
+        console.error('[roster] evolution fetch failed', err);
+      });
+
+    fetch('/api/skills?agent=' + encodeURIComponent(name))
+      .then(function (r) {
+        if (!r.ok) throw new Error('skills ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        if (state.selected !== name) return;
+        var slotsHost = document.getElementById('stageProgressionSlots');
+        if (!slotsHost) return;
+        var loadout = data && data.loadout;
+        if (!loadout) {
+          slotsHost.textContent = '';
+          return;
+        }
+        slotsHost.textContent = loadout.expert_mode
+          ? loadout.slots_used + ' active · expert'
+          : loadout.slots_used + '/' + loadout.slot_cap + ' slots';
+      })
+      .catch(function (err) {
+        console.error('[roster] loadout fetch failed', err);
       });
   }
 
@@ -845,7 +1016,7 @@
     var md = detail.metadata || {};
     els.overviewFacts.innerHTML =
       '<form class="stage-form" id="overviewForm" novalidate>' +
-      field('Role', selectInput('ov-role', ROLES, detail.role, titleCase), 'ov-role') +
+      field('Role', selectInput('ov-role', ROLES, detail.role, roleLabel), 'ov-role') +
       field('Type', selectInput('ov-type', TYPES, agentType, typeLabel), 'ov-type') +
       field(
         'Model',
@@ -991,7 +1162,7 @@
 
   function readonlyFacts(detail) {
     var facts = [
-      ['Role', titleCase((detail && detail.role) || '—')],
+      ['Role', (detail && detail.role) ? roleLabel(detail.role) : '—'],
       ['Model', (detail && detail.model) || '—'],
       ['Provider', detail && detail.provider ? titleCase(detail.provider) : '—'],
       ['Temperature', detail && detail.temperature != null ? String(detail.temperature) : '—']
@@ -1543,7 +1714,7 @@
     els.createBody.innerHTML =
       '<form class="stage-form" id="createForm" novalidate>' +
       field('Name', textInput('cr-name', '', 'Unique agent name'), 'cr-name') +
-      field('Role', selectInput('cr-role', ROLES, 'general', titleCase), 'cr-role') +
+      field('Role', selectInput('cr-role', ROLES, 'general', roleLabel), 'cr-role') +
       field('Model', textInput('cr-model', 'gpt-4o-mini'), 'cr-model') +
       field('Description', textareaInput('cr-description', '', 3), 'cr-description') +
       field(
@@ -2340,15 +2511,38 @@
 
   var bulkTagsInput = null; // active OriTagInput instance for the add flow
 
+  // Reused for tags AND bulk role assignment (PRD FR9, Group 5.4): the dialog
+  // is a generic "bulk edit" shell keyed by dlg.dataset.mode.
   function openBulkTags(mode) {
     if (state.checked.size === 0) return;
     if (state.selected && state.checked.has(state.selected) && !guardUnsaved()) return;
     var dlg = els.bulkTagsDialog;
     dlg.dataset.mode = mode;
-    els.bulkTagsTitle.textContent = mode === 'add' ? 'Add tags' : 'Remove tags';
+    var titles = { add: 'Add tags', remove: 'Remove tags', role: 'Set role' };
+    els.bulkTagsTitle.textContent = titles[mode] || '';
     els.bulkTagsConfirm.disabled = false;
-    els.bulkTagsConfirm.textContent = mode === 'add' ? 'Add tags' : 'Remove tags';
+    els.bulkTagsConfirm.textContent = mode === 'role' ? 'Set role' : titles[mode];
     bulkTagsInput = null;
+
+    if (mode === 'role') {
+      var roleOrder = (window.RoleCatalog && window.RoleCatalog.orderedRoles) || [];
+      var options = roleOrder
+        .map(function (slug) {
+          return '<option value="' + esc(slug) + '">' + esc(roleLabel(slug)) + '</option>';
+        })
+        .join('');
+      options +=
+        '<option value="general">' + esc(roleLabel('general')) + '</option>';
+      els.bulkTagsBody.innerHTML =
+        '<p class="bulk-dialog__lead">Assign one role to every selected agent. Metadata only — model, prompt, and skills are unchanged.</p>' +
+        '<label class="bulk-dialog__field"><span class="visually-hidden">Role</span>' +
+        '<select id="bulkRoleSelect" class="bulk-dialog__text">' +
+        options +
+        '</select></label>';
+      if (typeof dlg.showModal === 'function') dlg.showModal();
+      else dlg.setAttribute('open', '');
+      return;
+    }
 
     if (mode === 'add') {
       els.bulkTagsBody.innerHTML =
@@ -2427,6 +2621,27 @@
     var btn = els.bulkTagsConfirm;
     if (btn.disabled || btn.dataset.busy === '1') return;
     var mode = els.bulkTagsDialog.dataset.mode;
+
+    if (mode === 'role') {
+      var roleSel = document.getElementById('bulkRoleSelect');
+      var role = roleSel ? roleSel.value : '';
+      if (!role) return;
+      btn.dataset.busy = '1';
+      btn.disabled = true;
+      var restoreRole = btn.textContent;
+      btn.textContent = 'Working…';
+      submitBulkMetadata(
+        { operation: 'set_role', agent_names: Array.from(state.checked), role: role },
+        function () {
+          btn.dataset.busy = '';
+          btn.disabled = false;
+          btn.textContent = restoreRole;
+        },
+        closeBulkTags
+      );
+      return;
+    }
+
     var tags = [];
     if (mode === 'add') {
       if (bulkTagsInput) tags = bulkTagsInput.getTags();
@@ -2938,6 +3153,12 @@
     return '';
   }
 
+  // roleLabel wraps RoleCatalog.label with a fallback for the (brief) window
+  // before role-catalog.js's fetch resolves, or if it failed to load.
+  function roleLabel(role) {
+    return window.RoleCatalog ? window.RoleCatalog.label(role) : titleCase(role || 'Unspecialized');
+  }
+
   function titleCase(s) {
     s = String(s || '')
       .replace(/[_-]+/g, ' ')
@@ -2983,7 +3204,13 @@
     state.query = p.get('q') || '';
     if (els.search) els.search.value = state.query;
     var sort = p.get('sort') || 'name-asc';
-    var validSorts = { 'name-asc': 1, 'name-desc': 1, 'workspaces-desc': 1, 'active-desc': 1 };
+    var validSorts = {
+      'name-asc': 1,
+      'name-desc': 1,
+      'level-desc': 1,
+      'workspaces-desc': 1,
+      'active-desc': 1
+    };
     state.sort = validSorts[sort] ? sort : 'name-asc';
     if (els.sort) els.sort.value = state.sort;
 

--- a/internal/web/static/js/agents-roster.js
+++ b/internal/web/static/js/agents-roster.js
@@ -1540,7 +1540,7 @@
       els.workspacesBody.innerHTML =
         members.length === 0
           ? '<p class="stage-hint">Not attached to any workspace.</p>'
-          : members.map(readonlyWsRow).join('');
+          : members.map(function (ws) { return readonlyWsRow(ws, listItem.role); }).join('');
       return;
     }
 
@@ -1548,7 +1548,7 @@
     fetchWorkspaces()
       .then(function (all) {
         if (state.selected !== name) return;
-        renderWorkspacesEditor(name, members, all);
+        renderWorkspacesEditor(name, members, all, listItem.role);
       })
       .catch(function () {
         if (state.selected !== name) return;
@@ -1561,31 +1561,34 @@
       });
   }
 
-  function readonlyWsRow(ws) {
+  function readonlyWsRow(ws, role) {
     var nm = esc(ws.name || 'Workspace');
     var link = ws.id
       ? '<a href="/workspaces/' + encodeURIComponent(ws.id) + '">' + nm + '</a>'
       : nm;
-    var pill = ws.entry_point ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+    var pill = ws.entry_point
+      ? '<span class="ws-entry-pill">' + esc(commanderSlotLabel(role)) + '</span>'
+      : '';
     return '<div class="ws-row"><span>' + link + '</span>' + pill + '</div>';
   }
 
-  function renderWorkspacesEditor(name, members, all) {
+  function renderWorkspacesEditor(name, members, all, role) {
     var memberIds = {};
     var entryIds = {};
     members.forEach(function (m) {
       memberIds[m.id] = true;
       if (m.entry_point) entryIds[m.id] = true;
     });
+    var commanderLbl = commanderSlotLabel(role);
 
     var rows = all
       .map(function (ws) {
         var isMember = !!memberIds[ws.id];
         var isEntry = !!entryIds[ws.id];
-        // The agent can't be unassigned from a workspace it's the entry agent of;
+        // The agent can't be unassigned from a workspace it's the Commander of;
         // lock that checkbox and explain, matching the server guard.
         var disabled = isEntry ? ' disabled' : '';
-        var pill = isEntry ? '<span class="ws-entry-pill">Entry agent</span>' : '';
+        var pill = isEntry ? '<span class="ws-entry-pill">' + esc(commanderLbl) + '</span>' : '';
         return (
           '<label class="ws-check' +
           (disabled ? ' is-locked' : '') +
@@ -1666,7 +1669,7 @@
           res.data &&
           res.data.error === 'entry_agent_removal_blocked'
         ) {
-          showStatus('workspaces', res.data.message || 'Cannot remove the entry agent.', 'error');
+          showStatus('workspaces', res.data.message || 'Cannot remove the Commander.', 'error');
         } else {
           showStatus(
             'workspaces',
@@ -3157,6 +3160,14 @@
   // before role-catalog.js's fetch resolves, or if it failed to load.
   function roleLabel(role) {
     return window.RoleCatalog ? window.RoleCatalog.label(role) : titleCase(role || 'Unspecialized');
+  }
+
+  // Commander-slot label (PRD FR21/FR22): "Commander" when the entry-slot
+  // holder's role is orchestrator, "Acting Commander" otherwise (e.g. a solo
+  // Specialist holding the slot). Distinct from roleLabel, which names the
+  // agent's own role rather than its Commander-slot status.
+  function commanderSlotLabel(role) {
+    return String(role || '').trim().toLowerCase() === 'orchestrator' ? 'Commander' : 'Acting Commander';
   }
 
   function titleCase(s) {

--- a/internal/web/static/js/modules/agents-catalog.js
+++ b/internal/web/static/js/modules/agents-catalog.js
@@ -1,0 +1,232 @@
+/**
+ * Agents Create page: Catalog / Custom tabs.
+ *
+ * Owns the ARIA tablist toggle and the Catalog tab (card grid fetched from
+ * GET /api/agents/catalog, one-field create via POST /api/agents with
+ * catalog_role). The Custom tab's form and behavior (agents-create.js) are
+ * untouched by this module.
+ */
+(function () {
+  'use strict';
+
+  let catalogEntries = [];
+  let selectedEntry = null;
+
+  function byId(id) {
+    return document.getElementById(id);
+  }
+
+  // ---------------------------------------------------------------------
+  // Tabs (ARIA APG tabs pattern: click + Left/Right/Home/End keyboard nav)
+  // ---------------------------------------------------------------------
+  function initTabs() {
+    const tabs = [byId('catalogTabBtn'), byId('customTabBtn')];
+    const panels = {
+      catalogTabBtn: byId('catalogTabPanel'),
+      customTabBtn: byId('customTabPanel')
+    };
+    if (!tabs[0] || !tabs[1]) return;
+
+    function activate(tab) {
+      tabs.forEach(function (t) {
+        const isActive = t === tab;
+        t.classList.toggle('is-active', isActive);
+        t.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        t.tabIndex = isActive ? 0 : -1;
+        const panel = panels[t.id];
+        if (panel) panel.hidden = !isActive;
+      });
+      tab.focus();
+    }
+
+    tabs.forEach(function (tab, i) {
+      tab.addEventListener('click', function () {
+        activate(tab);
+      });
+      tab.addEventListener('keydown', function (e) {
+        let targetIndex = null;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          targetIndex = (i + 1) % tabs.length;
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          targetIndex = (i - 1 + tabs.length) % tabs.length;
+        } else if (e.key === 'Home') {
+          targetIndex = 0;
+        } else if (e.key === 'End') {
+          targetIndex = tabs.length - 1;
+        }
+        if (targetIndex !== null) {
+          e.preventDefault();
+          activate(tabs[targetIndex]);
+        }
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Catalog grid
+  // ---------------------------------------------------------------------
+  async function loadCatalog() {
+    const grid = byId('catalogGrid');
+    if (!grid) return;
+    try {
+      const response = await fetch('/api/agents/catalog');
+      if (!response.ok) throw new Error('Failed to load catalog');
+      const data = await response.json();
+      catalogEntries = Array.isArray(data.entries) ? data.entries : [];
+      renderCatalogGrid();
+    } catch (error) {
+      console.error('Error loading agent catalog:', error);
+      showCatalogError('Could not load the role catalog. Try reloading the page.');
+    }
+  }
+
+  function renderCatalogGrid() {
+    const grid = byId('catalogGrid');
+    if (!grid) return;
+    grid.innerHTML = catalogEntries.map(function (entry) {
+      return (
+        '<button type="button" class="catalog-card" role="radio" aria-checked="false" ' +
+        'data-slug="' + escapeAttr(entry.slug) + '" style="--catalog-accent: ' + escapeAttr(entry.accent_color) + ';">' +
+        '<span class="catalog-card-emblem"><i class="bi bi-' + escapeAttr(entry.emblem) + '" aria-hidden="true"></i></span>' +
+        '<span class="catalog-card-name">' + escapeHtml(entry.display_name) + '</span>' +
+        '<span class="catalog-card-tagline">' + escapeHtml(entry.tagline) + '</span>' +
+        '</button>'
+      );
+    }).join('');
+
+    grid.querySelectorAll('.catalog-card').forEach(function (card) {
+      card.addEventListener('click', function () {
+        selectEntry(card.dataset.slug);
+      });
+    });
+  }
+
+  function selectEntry(slug) {
+    selectedEntry = catalogEntries.find(function (e) { return e.slug === slug; }) || null;
+    if (!selectedEntry) return;
+
+    document.querySelectorAll('#catalogGrid .catalog-card').forEach(function (card) {
+      const isSelected = card.dataset.slug === slug;
+      card.classList.toggle('is-selected', isSelected);
+      card.setAttribute('aria-checked', isSelected ? 'true' : 'false');
+    });
+
+    const selectionCard = byId('catalogSelectionCard');
+    if (selectionCard) selectionCard.hidden = false;
+
+    const nameInput = byId('catalogAgentName');
+    if (nameInput && !nameInput.value.trim()) {
+      nameInput.value = selectedEntry.display_name;
+    }
+
+    const domainGroup = byId('catalogDomainGroup');
+    if (domainGroup) domainGroup.hidden = !selectedEntry.supports_domain;
+
+    renderPresetSummary();
+    hideCatalogModelNotice();
+    hideCatalogError();
+  }
+
+  function tierLabel(tier) {
+    switch (tier) {
+      case 'fast': return 'Fast';
+      case 'balanced': return 'Balanced';
+      case 'deep': return 'Deep reasoning';
+      default: return tier;
+    }
+  }
+
+  function renderPresetSummary() {
+    const summary = byId('catalogPresetSummary');
+    if (!summary || !selectedEntry) return;
+    const skillsLine = (selectedEntry.starter_skills && selectedEntry.starter_skills.length > 0)
+      ? escapeHtml(selectedEntry.starter_skills.join(', '))
+      : 'none — starts with an empty loadout';
+    summary.innerHTML =
+      '<div><strong>Role:</strong> ' + escapeHtml(selectedEntry.display_name) + '</div>' +
+      '<div><strong>Model tier:</strong> ' + escapeHtml(tierLabel(selectedEntry.model_tier)) + '</div>' +
+      '<div><strong>Starter skills:</strong> ' + skillsLine + '</div>' +
+      '<div>' + escapeHtml(selectedEntry.description) + '</div>';
+  }
+
+  function showCatalogModelNotice(message) {
+    const notice = byId('catalogModelNotice');
+    if (!notice) return;
+    notice.textContent = message;
+    notice.hidden = false;
+  }
+
+  function hideCatalogModelNotice() {
+    const notice = byId('catalogModelNotice');
+    if (notice) notice.hidden = true;
+  }
+
+  function showCatalogError(message) {
+    const box = byId('catalogError');
+    if (!box) return;
+    box.textContent = message;
+    box.hidden = false;
+    box.focus();
+  }
+
+  function hideCatalogError() {
+    const box = byId('catalogError');
+    if (box) box.hidden = true;
+  }
+
+  async function createFromCatalog() {
+    if (!selectedEntry) return;
+    const nameInput = byId('catalogAgentName');
+    const name = nameInput ? nameInput.value.trim() : '';
+    const nameError = byId('catalogAgentNameError');
+    if (!name) {
+      if (nameError) nameError.textContent = 'Agent name is required.';
+      if (nameInput) nameInput.classList.add('is-invalid');
+      return;
+    }
+    if (nameError) nameError.textContent = '';
+    if (nameInput) nameInput.classList.remove('is-invalid');
+
+    const domainInput = byId('catalogDomain');
+    const domain = (selectedEntry.supports_domain && domainInput) ? domainInput.value.trim() : '';
+
+    const createBtn = byId('catalogCreateBtn');
+    if (createBtn) createBtn.disabled = true;
+    hideCatalogError();
+
+    try {
+      const response = await fetch('/api/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name,
+          catalog_role: selectedEntry.slug,
+          domain: domain
+        })
+      });
+
+      const result = await response.json().catch(function () { return {}; });
+      if (!response.ok) {
+        throw new Error(result.error || 'Failed to create agent');
+      }
+
+      if (result.model_category_fallback) {
+        showCatalogModelNotice(result.notice || 'Used your default model — the selected tier has no configured model yet.');
+      }
+
+      window.location.href = '/agents';
+    } catch (error) {
+      console.error('Error creating agent from catalog:', error);
+      showCatalogError(error.message || 'Failed to create agent');
+    } finally {
+      if (createBtn) createBtn.disabled = false;
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initTabs();
+    loadCatalog();
+    const createBtn = byId('catalogCreateBtn');
+    if (createBtn) createBtn.addEventListener('click', createFromCatalog);
+  });
+})();

--- a/internal/web/static/js/modules/dashboard.js
+++ b/internal/web/static/js/modules/dashboard.js
@@ -7344,13 +7344,13 @@
 
   function renderWorkspaceRepairState(prompt, routeContext, intent, routeData, resolution) {
     var workspaceName = resolution.selectedWorkspaceName || 'This workspace';
-    var reason = resolution.repairReason || 'its entry agent is unavailable';
+    var reason = resolution.repairReason || 'its Commander is unavailable';
     appendHomeAssistantMessage(
       'assistant',
-      '"' + workspaceName + '" looks like the right workspace, but its entry agent needs attention before Ori can continue.'
+      '"' + workspaceName + '" looks like the right workspace, but its Commander needs attention before Ori can continue.'
     );
     setHomeAssistantRoutingSummary(
-      'Entry Agent Required',
+      'Commander Required',
       '"' + workspaceName + '" matched this task but needs workspace setup before Ori can continue.',
       {
         detail: reason

--- a/internal/web/static/js/modules/project-templates-manage.js
+++ b/internal/web/static/js/modules/project-templates-manage.js
@@ -347,6 +347,7 @@ function ptcElements() {
     briefingDeploys: document.getElementById('templateBriefingDeploys'),
     briefingAgentsRow: document.getElementById('templateBriefingAgentsRow'),
     briefingAgentsValue: document.getElementById('templateBriefingAgentsValue'),
+    briefingNoCommanderNudge: document.getElementById('templateBriefingNoCommanderNudge'),
     briefingScaffoldRow: document.getElementById('templateBriefingScaffoldRow'),
     briefingScaffoldValue: document.getElementById('templateBriefingScaffoldValue'),
     briefingAddonsRow: document.getElementById('templateBriefingAddonsRow'),
@@ -539,15 +540,20 @@ function ptcRenderBriefing(els, importMode, templatePath) {
   if (els.briefingAgentsValue) {
     els.briefingAgentsValue.innerHTML = '';
     // One chip per agent: a role-hued dot + name. The first roster entry is the
-    // workspace entry agent (solid dot, brighter chip); the rest are specialists.
+    // workspace Commander (solid dot, brighter chip); the rest are specialists.
     briefingAgents.forEach((agent, index) => {
       const isEntry = index === 0;
       const chip = document.createElement('span');
       chip.className = 'workspace-template-briefing-agent-chip';
       if (isEntry) chip.classList.add('is-entry');
       if (agent.role) chip.dataset.role = agent.role;
+      // Commander-slot label (PRD FR21/FR22): "Commander" when this agent's
+      // own role is orchestrator, "Acting Commander" otherwise.
+      const commanderLabel = String(agent.role || '').trim().toLowerCase() === 'orchestrator'
+        ? 'Commander'
+        : 'Acting Commander';
       const roleLabel = isEntry
-        ? `entry agent${agent.role ? ` · ${agent.role}` : ''}`
+        ? `${commanderLabel}${agent.role ? ` · ${agent.role}` : ''}`
         : agent.role;
       if (roleLabel) chip.title = `${agent.name} — ${roleLabel}`;
       const dot = document.createElement('span');
@@ -557,6 +563,14 @@ function ptcRenderBriefing(els, importMode, templatePath) {
       chip.appendChild(document.createTextNode(agent.name));
       els.briefingAgentsValue.appendChild(chip);
     });
+  }
+
+  // No-Commander nudge (PRD FR23): non-blocking — the blueprint remains
+  // selectable and creatable either way; this only informs the choice.
+  if (els.briefingNoCommanderNudge) {
+    const needsNudge =
+      briefingAgents.length >= 3 && !briefingAgents.some((a) => a.role === 'orchestrator');
+    els.briefingNoCommanderNudge.hidden = !needsNudge;
   }
 
   const showScaffold = Boolean(showBriefing && template.has_skeleton);

--- a/internal/web/static/js/modules/role-catalog.js
+++ b/internal/web/static/js/modules/role-catalog.js
@@ -1,0 +1,98 @@
+/**
+ * Role Catalog lookup: fetches GET /api/agents/catalog once and exposes a
+ * shared slug -> {displayName, emblem, accentColor, tagline} map, so every
+ * surface that renders a role (roster card, stage panel, filters, Map
+ * insignia) uses the same identity instead of re-deriving it (PRD design
+ * consideration: "consistent everywhere the role appears").
+ *
+ * Usage:
+ *   RoleCatalog.ready().then(function () { ... })
+ *   RoleCatalog.label(role)   // display name, or "Unspecialized" for ""/"general"
+ *   RoleCatalog.entry(role)   // full catalog entry, or null for Unspecialized/unknown
+ */
+(function () {
+  'use strict';
+
+  var byRole = {};
+  var loaded = false;
+  var loadPromise = null;
+
+  function load() {
+    if (loadPromise) return loadPromise;
+    loadPromise = fetch('/api/agents/catalog')
+      .then(function (r) {
+        if (!r.ok) throw new Error('catalog ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var entries = Array.isArray(data.entries) ? data.entries : [];
+        entries.forEach(function (e) {
+          if (e && e.slug) byRole[e.slug] = e;
+        });
+        loaded = true;
+      })
+      .catch(function (err) {
+        console.error('[role-catalog] failed to load', err);
+        loaded = true; // don't retry forever; callers fall back to raw labels
+      });
+    return loadPromise;
+  }
+
+  function normalizeRole(role) {
+    return String(role || '').trim().toLowerCase();
+  }
+
+  function isUnspecialized(role) {
+    var r = normalizeRole(role);
+    return r === '' || r === 'general';
+  }
+
+  // entry returns the catalog entry for a role slug, or null for
+  // Unspecialized (empty/"general") or any role not in the catalog
+  // (cli_agent, or a slug the catalog doesn't recognize).
+  function entry(role) {
+    if (isUnspecialized(role)) return null;
+    return byRole[normalizeRole(role)] || null;
+  }
+
+  // label returns the display name for a role: catalog display_name, or
+  // "Unspecialized" for empty/"general", or a titlecased fallback for any
+  // other unrecognized slug (e.g. cli_agent, or a catalog role before the
+  // catalog fetch resolves).
+  function label(role) {
+    if (isUnspecialized(role)) return 'Unspecialized';
+    var e = entry(role);
+    if (e) return e.display_name;
+    return String(role || '')
+      .replace(/[_-]+/g, ' ')
+      .trim()
+      .replace(/\w\S*/g, function (w) {
+        return w.charAt(0).toUpperCase() + w.slice(1);
+      });
+  }
+
+  // ORDERED_ROLES lists the 6 catalog role slugs in the catalog's own display
+  // order, for building fixed filter/picker option lists without waiting on
+  // a fetch that might still be in flight.
+  var ORDERED_ROLES = [
+    'orchestrator',
+    'researcher',
+    'analyzer',
+    'synthesizer',
+    'validator',
+    'specialist'
+  ];
+
+  window.RoleCatalog = {
+    ready: load,
+    isLoaded: function () {
+      return loaded;
+    },
+    entry: entry,
+    label: label,
+    isUnspecialized: isUnspecialized,
+    orderedRoles: ORDERED_ROLES
+  };
+
+  load();
+})();

--- a/internal/web/static/js/modules/sessions.js
+++ b/internal/web/static/js/modules/sessions.js
@@ -1399,7 +1399,7 @@ const sessionManager = {
 
     if (workspaceId) {
       autoModeText.textContent =
-        "You'll chat with this workspace's entry agent, which has the workspace context by default. Switch to Direct agent chat to talk to a different workspace agent.";
+        "You'll chat with this workspace's Commander, which has the workspace context by default. Switch to Direct agent chat to talk to a different workspace agent.";
       return;
     }
 
@@ -1642,7 +1642,7 @@ const sessionManager = {
         if (window.Toast) {
           Toast.warning(
             workspaceId
-              ? "No direct-chat agent is available in this workspace. Add an agent, or switch to auto mode to use the workspace's entry agent."
+              ? "No direct-chat agent is available in this workspace. Add an agent, or switch to auto mode to use the workspace's Commander."
               : 'No direct-chat agent is available. Add an agent or use Assistant.'
           );
         }

--- a/internal/web/static/js/modules/stage-up-toast.js
+++ b/internal/web/static/js/modules/stage-up-toast.js
@@ -1,0 +1,94 @@
+/**
+ * Stage-up toast: client-side detection of an agent's evolution stage
+ * advancing, so progression is *felt* wherever it happens — the roster page
+ * and, critically, the Map view where the user actually lives (PRD: "the
+ * stage-up toast is what makes progression felt... make sure toasts fire
+ * during normal Map-view task flows, not only while the roster page is
+ * open"). Detection is a simple before/after compare against a per-agent
+ * last-seen stage cached in localStorage; no server-side push is required.
+ *
+ * Requires modules/toast.js to be loaded on the page.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_PREFIX = 'ori.evolution.lastStage.';
+
+  // Mirrors the stage -> slot-cap table in internal/types/agent_extended.go
+  // (SkillSlotsForStage), so the toast can say "+1 skill slot" without an
+  // extra round trip.
+  var STAGE_SLOTS = { spark: 2, infant: 3, learner: 4, expert: 5, sentient: 6 };
+  var STAGE_ORDER = ['spark', 'infant', 'learner', 'expert', 'sentient'];
+
+  function cacheKey(agentName) {
+    return STORAGE_PREFIX + agentName;
+  }
+
+  function getCachedStage(agentName) {
+    try {
+      return window.localStorage.getItem(cacheKey(agentName));
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function setCachedStage(agentName, stage) {
+    try {
+      window.localStorage.setItem(cacheKey(agentName), stage);
+    } catch (e) {
+      // Storage unavailable (private mode, quota) — toast detection is
+      // best-effort, never load-bearing.
+    }
+  }
+
+  function stageLabel(stage) {
+    return stage ? stage.charAt(0).toUpperCase() + stage.slice(1) : stage;
+  }
+
+  // check compares `currentStage` against the cached last-seen stage for
+  // agentName. Shows a toast only on genuine forward progress (never on
+  // first sight of an agent, and never on a downgrade/no-op). Always updates
+  // the cache to the current stage.
+  function check(agentName, currentStage) {
+    if (!agentName || !currentStage) return;
+    var prev = getCachedStage(agentName);
+    setCachedStage(agentName, currentStage);
+    if (!prev || prev === currentStage) return;
+
+    var prevIdx = STAGE_ORDER.indexOf(prev);
+    var curIdx = STAGE_ORDER.indexOf(currentStage);
+    if (curIdx <= prevIdx) return;
+
+    var message = agentName + ' reached ' + stageLabel(currentStage) + ' stage';
+    var prevSlots = STAGE_SLOTS[prev] || 0;
+    var curSlots = STAGE_SLOTS[currentStage] || 0;
+    if (curSlots > prevSlots) {
+      message += ' — +1 skill slot';
+    }
+
+    if (window.Toast && typeof window.Toast.success === 'function') {
+      window.Toast.success(message, { title: 'Stage up' });
+    }
+  }
+
+  // checkByFetch fetches the agent's current evolution and runs check(). For
+  // callers (e.g. the Map view's task-completed handler) that don't already
+  // have the evolution payload in hand.
+  function checkByFetch(agentName) {
+    if (!agentName) return;
+    fetch('/api/agents/' + encodeURIComponent(agentName) + '/evolution')
+      .then(function (r) {
+        if (!r.ok) throw new Error('evolution ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var stage = data && data.evolution && data.evolution.stage;
+        if (stage) check(agentName, stage);
+      })
+      .catch(function (err) {
+        console.error('[stage-up-toast] fetch failed', err);
+      });
+  }
+
+  window.StageUpToast = { check: check, checkByFetch: checkByFetch };
+})();

--- a/internal/web/static/js/modules/templates-page.js
+++ b/internal/web/static/js/modules/templates-page.js
@@ -1149,7 +1149,7 @@ function tplAgentsLoad() {
 function tplAgentsDisplayName(agent, index) {
   const name = String(agent?.name || '').trim();
   if (name) return name;
-  return index === 0 ? 'Entry agent' : `Agent ${index + 1}`;
+  return index === 0 ? 'Commander' : `Agent ${index + 1}`;
 }
 
 function tplAgentsInitials(name, index) {
@@ -1163,7 +1163,7 @@ function tplAgentsInitials(name, index) {
 }
 
 function tplAgentsRoleLabel(agent, index) {
-  if (index === 0) return 'Entry agent';
+  if (index === 0) return 'Commander';
   const role = String(agent?.role || '').trim();
   if (!role) return 'Specialist';
   return role.replace(/[_-]+/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase());
@@ -1628,7 +1628,7 @@ async function tplAgentsSave() {
   const agents = tplAgentsCollect().filter(a => a.name);
   if (agents.length === 0) {
     tplToast(
-      'A template needs at least one agent — the first is the workspace entry agent.',
+      'A template needs at least one agent — the first is the workspace Commander.',
       'error'
     );
     return;

--- a/internal/web/static/js/modules/workspace-agent-detail.js
+++ b/internal/web/static/js/modules/workspace-agent-detail.js
@@ -198,7 +198,12 @@ export class WorkspaceAgentDetailPage {
     if (badges) {
       const chips = [];
       if (this.isEntryAgent) {
-        chips.push('<span class="wad-badge is-leader">Entry agent</span>');
+        // Commander-slot label (PRD FR21/FR22): "Commander" when this agent's
+        // own role is orchestrator, "Acting Commander" otherwise.
+        const commanderLabel = String(profile?.role || '').trim().toLowerCase() === 'orchestrator'
+          ? 'Commander'
+          : 'Acting Commander';
+        chips.push(`<span class="wad-badge is-leader">${this.escape(commanderLabel)}</span>`);
       }
       chips.push('<span class="wad-badge is-muted">Workspace-local</span>');
       const provider = String(profile?.provider || '').trim();

--- a/internal/web/static/js/modules/workspace-command-entry-node.test.js
+++ b/internal/web/static/js/modules/workspace-command-entry-node.test.js
@@ -82,7 +82,7 @@ test('accessible name on the command node includes role + orchestration copy (FR
   const view = makeView();
   const entry = agent({ name: 'Manager', key: 'manager', entry: true });
   const html = view.renderMapAgentUnits([entry, agent({ name: 'Writer', key: 'writer' })]);
-  assert.match(html, /aria-label="Select Manager, Entry Agent\. Routes work to 1 specialist agent\. Idle"/);
+  assert.match(html, /aria-label="Select Manager, Acting Commander\. Routes work to 1 specialist agent\. Idle"/);
 });
 
 test('missing entry agent shows a repair state, not a promoted specialist (FR77)', () => {
@@ -90,7 +90,7 @@ test('missing entry agent shows a repair state, not a promoted specialist (FR77)
   const spec = agent({ name: 'Writer', key: 'writer' });
   const html = view.renderMapAgentUnits([spec]);
   assert.match(html, /ws-cmd-map-command-repair/);
-  assert.match(html, /No entry agent/);
+  assert.match(html, /No Commander/);
   assert.match(html, /data-cmd-add-agent/);
   assert.ok(!html.includes('is-command-node'), 'no specialist is visually promoted to the command position');
   assert.match(html, /Writer/, 'the specialist still renders in the normal grid');

--- a/internal/web/static/js/modules/workspace-command.js
+++ b/internal/web/static/js/modules/workspace-command.js
@@ -1760,18 +1760,20 @@ export class WorkspaceCommandView {
           ? page.getAgentRosterStatus(name)
           : { key: 'idle', label: 'Idle' };
         const tone = this.statusTone(status.key, status.label);
+        const profile = page.getAgentProfile ? page.getAgentProfile(name) : null;
         let modelLabel = '';
-        if (page.getAgentProfile && page.getAgentModelPresentation) {
-          const m = page.getAgentModelPresentation(page.getAgentProfile(name));
+        if (profile && page.getAgentModelPresentation) {
+          const m = page.getAgentModelPresentation(profile);
           modelLabel = m && !m.empty ? m.model : '';
         }
+        const commanderLbl = keeper ? this.commanderLabel(profile && profile.role) : '';
         let skillCount = 0;
         if (page.getAgentSkillSummary) {
           const sk = page.getAgentSkillSummary(name);
           skillCount = (sk && sk.count) || 0;
         }
         const chips =
-          (keeper ? '<span class="ws-cmd-mchip is-keeper">★ Entry Agent</span>' : '') +
+          (keeper ? '<span class="ws-cmd-mchip is-keeper">★ ' + escapeHtml(commanderLbl) + '</span>' : '') +
           '<span class="ws-cmd-mchip">' +
           escapeHtml(modelLabel || '—') +
           '</span>' +
@@ -1779,7 +1781,9 @@ export class WorkspaceCommandView {
           skillCount +
           '</span>';
         const removeCtl = keeper
-          ? '<span class="ws-cmd-lock" title="Entry agent — can\'t be removed">🔒</span>'
+          ? '<span class="ws-cmd-lock" title="' +
+            escapeHtml(commanderLbl) +
+            ' — can\'t be removed">🔒</span>'
           : '<button type="button" class="ws-cmd-mrow-btn is-danger" data-cmd-modal-action="delete" data-cmd-id="' +
             escapeHtml(encoded) +
             '" title="Remove agent" aria-label="Remove ' +
@@ -2191,6 +2195,17 @@ export class WorkspaceCommandView {
     );
   }
 
+  // Commander-slot display label (PRD FR21/FR22): the agent holding the
+  // entry-agent slot shows as "Commander" when its role is orchestrator, or
+  // "Acting Commander" otherwise (e.g. a solo Specialist holding the slot).
+  // Display only — entry-agent mechanics, storage keys (entry_agent_name),
+  // and coordinator resolution are unchanged.
+  commanderLabel(role) {
+    return String(role || '').trim().toLowerCase() === 'orchestrator'
+      ? 'Commander'
+      : 'Acting Commander';
+  }
+
   reconcileAgentSelection(groups) {
     const agents = Array.isArray(groups) ? groups : [];
     const keys = new Set(agents.map(group => this.normalizeAgentKey(group.key || group.name)));
@@ -2355,7 +2370,13 @@ export class WorkspaceCommandView {
           agent.instanceCount +
           '×</span>'
         : '';
-    const entry = agent.entry ? '<span class="ws-cmd-roster-entry">Entry</span>' : '';
+    // Compact corner badge: fixed-width "CMD", full label in the title so
+    // Acting-Commander distinction is still available on hover/AT.
+    const entry = agent.entry
+      ? '<span class="ws-cmd-roster-entry" title="' +
+        escapeHtml(this.commanderLabel(agent.profile && agent.profile.role)) +
+        '">CMD</span>'
+      : '';
     return (
       '<button type="button" class="ws-cmd-roster-item' +
       (selected ? ' is-selected' : '') +
@@ -2408,9 +2429,16 @@ export class WorkspaceCommandView {
     const detailAction = target
       ? '<a class="ws-cmd-agent-action" href="' + escapeHtml(target.href) + '">Open Agent</a>'
       : '';
-    const entry = agent.entry ? '<span class="ws-cmd-badge is-keeper">★ Entry Agent</span>' : '';
+    const commanderLbl = agent.entry ? this.commanderLabel(agent.profile && agent.profile.role) : '';
+    const entry = agent.entry
+      ? '<span class="ws-cmd-badge is-keeper">★ ' + escapeHtml(commanderLbl) + '</span>'
+      : '';
     const remove = agent.entry
-      ? '<span class="ws-cmd-agent-lock" title="The entry agent cannot be removed">Entry agent locked</span>'
+      ? '<span class="ws-cmd-agent-lock" title="The ' +
+        escapeHtml(commanderLbl.toLowerCase()) +
+        ' cannot be removed">' +
+        escapeHtml(commanderLbl) +
+        ' locked</span>'
       : '<button type="button" class="ws-cmd-agent-action is-danger" data-cmd-remove-agent="' +
         escapeHtml(agent.encodedName) +
         '">Remove</button>';
@@ -3831,12 +3859,26 @@ export class WorkspaceCommandView {
     const selected = agent.key === this.selectedAgentKey;
     const destination = agent.destination || 'hub';
     const statusLabel = agent.status?.label || 'Idle';
+    const commanderLbl = agent.entry ? this.commanderLabel(agent.profile && agent.profile.role) : '';
+    // Station title (design consideration): pair role with the workspace it's
+    // stationed in, e.g. "Commander · Reaper Studio" — this is how
+    // domain-specialized identity is displayed without existing in the catalog.
+    const wsName = String((this.page && this.page.workspace && this.page.workspace.name) || '').trim();
+    const stationTitle = commanderLbl && wsName ? commanderLbl + ' · ' + wsName : commanderLbl;
     const entryBadge =
       agent.entry && !commandNode
-        ? '<span class="ws-cmd-map-entry-badge" title="Entry Agent"><i class="bi bi-star-fill" aria-hidden="true"></i><span>Entry</span></span>'
+        ? '<span class="ws-cmd-map-entry-badge" title="' +
+          escapeHtml(stationTitle) +
+          '"><i class="bi bi-star-fill" aria-hidden="true"></i><span>' +
+          escapeHtml(commanderLbl) +
+          '</span></span>'
         : '';
     const roleLine = commandNode
-      ? '<span class="ws-cmd-map-command-role">Entry Agent</span>'
+      ? '<span class="ws-cmd-map-command-role" title="' +
+        escapeHtml(stationTitle) +
+        '">' +
+        escapeHtml(commanderLbl) +
+        '</span>'
       : '';
     const orchestrationCopy =
       commandNode && this._commandNodeOrchestrationCopy
@@ -3848,7 +3890,7 @@ export class WorkspaceCommandView {
       'Select ' +
       escapeHtml(agent.name) +
       ', ' +
-      (agent.entry ? 'Entry Agent. ' : '') +
+      (agent.entry ? escapeHtml(stationTitle) + '. ' : '') +
       (commandNode && this._commandNodeOrchestrationCopy
         ? escapeHtml(this._commandNodeOrchestrationCopy) + '. '
         : '') +
@@ -3920,9 +3962,9 @@ export class WorkspaceCommandView {
     if (!entry) {
       return (
         '<div class="ws-cmd-map-command-repair">' +
-        '<strong>No entry agent</strong>' +
-        '<span>Chats, routing, and task orchestration need an entry agent.</span>' +
-        '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-agent>Create Entry Agent</button>' +
+        '<strong>No Commander</strong>' +
+        '<span>Chats, routing, and task orchestration need a Commander.</span>' +
+        '<button type="button" class="ws-cmd-agent-action is-primary" data-cmd-add-agent>Create Commander</button>' +
         '</div>' +
         '<div class="ws-cmd-map-agent-field">' +
         specialists.map((agent, index) => this.renderMapAgentUnit(agent, index, false)).join('') +
@@ -4386,7 +4428,7 @@ export class WorkspaceCommandView {
       { label: 'Units', value: agent.instanceCount }
     ];
     const statusEffects = [
-      agent.entry ? 'Entry Agent' : '',
+      agent.entry ? this.commanderLabel(agent.profile && agent.profile.role) : '',
       agent.status?.label || 'Idle',
       agent.model?.empty ? '' : agent.model?.label || ''
     ].filter(Boolean);
@@ -4761,7 +4803,7 @@ export class WorkspaceCommandView {
       '<header class="ws-cmd-map-quest-head"><span>New Quest</span>' +
       '<button type="button" class="ws-cmd-map-quest-close" data-cmd-map-quest-cancel aria-label="Close new quest">×</button></header>' +
       '<textarea class="ws-cmd-map-quest-input" data-cmd-map-quest-input rows="2" ' +
-      'placeholder="Describe the quest… (assigned to the entry agent)"' +
+      'placeholder="Describe the quest… (assigned to the Commander)"' +
       disabledAttr +
       '>' +
       draft +
@@ -4836,7 +4878,7 @@ export class WorkspaceCommandView {
       }
     }
     if (window.Toast) {
-      const target = assignee || 'the entry agent';
+      const target = assignee || 'the Commander';
       window.Toast.success(
         (start ? 'Quest started · assigned to ' : 'Quest assigned to ') + target
       );

--- a/internal/web/static/js/modules/workspace-command.test.js
+++ b/internal/web/static/js/modules/workspace-command.test.js
@@ -247,7 +247,7 @@ test('rendered command copy uses detailed-view vocabulary', () => {
   assert.doesNotMatch(container.innerHTML, /No schedules yet\./);
   assert.doesNotMatch(container.innerHTML, /No sessions yet\./);
   assert.doesNotMatch(container.innerHTML, /No linked folders yet\./);
-  assert.match(container.innerHTML, /★ Entry Agent/);
+  assert.match(container.innerHTML, /★ Acting Commander/);
   assert.match(container.innerHTML, />Model<\/span>/);
   assert.match(container.innerHTML, /Tasks · 1/);
   assert.match(container.innerHTML, /title="Run"/);
@@ -1505,7 +1505,7 @@ test('agents manager modal locks the entry agent from removal', () => {
   const html = commandView.statModalHTML('agents');
   assert.match(html, /Atlas/);
   assert.match(html, /Builder/);
-  assert.match(html, /★ Entry Agent/);
+  assert.match(html, /★ Acting Commander/);
   // Builder is removable; Atlas (entry agent) shows a lock, not a delete button.
   assert.match(html, /data-cmd-modal-action="delete" data-cmd-id="Builder"/);
   assert.doesNotMatch(html, /data-cmd-modal-action="delete" data-cmd-id="Atlas"/);
@@ -1740,7 +1740,7 @@ test('entry-agent stage exposes manager settings while other agents expose remov
   const other = commandView.agentStageHTML(otherAgent);
 
   assert.match(keeper, /data-cmd-manager-settings/);
-  assert.match(keeper, /Entry Agent/);
+  assert.match(keeper, /Acting Commander/);
   assert.doesNotMatch(keeper, /data-cmd-remove-agent/);
   assert.doesNotMatch(other, /data-cmd-manager-settings/);
   assert.match(other, /data-cmd-remove-agent/);
@@ -2293,7 +2293,7 @@ test('Operations Map renders units first and keeps support panels hidden by defa
     // here since there is no specialist in this fixture).
     assert.match(html, /is-command-node/);
     assert.match(html, /ws-cmd-map-command-role/);
-    assert.match(html, /Entry Agent/);
+    assert.match(html, /Acting Commander/);
     assert.doesNotMatch(html, /data-map-zone="mission"/);
     assert.doesNotMatch(html, /data-map-zone="tasks"/);
     assert.doesNotMatch(html, /data-map-zone="tools"/);

--- a/internal/web/static/js/modules/workspace-detail.js
+++ b/internal/web/static/js/modules/workspace-detail.js
@@ -2353,14 +2353,40 @@ export class WorkspaceDetailPage {
       issues.push({
         category: 'agent',
         severity: 'error',
-        title: 'Entry agent is missing',
+        title: 'Commander is missing',
         description:
-          'This workspace has no entry agent assigned. Create one so chats, routing, and task orchestration have a default manager.',
+          'This workspace has no Commander assigned. Create one so chats, routing, and task orchestration have a default manager.',
         action: 'entry_agent',
-        actionLabel: 'Create Entry Agent',
+        actionLabel: 'Create Commander',
         agentName: defaults.seedName || 'Workspace Manager',
-        meta: [workspaceName, 'No entry agent']
+        meta: [workspaceName, 'No Commander']
       });
+    }
+
+    // No-Commander nudge (PRD FR23): a workspace with 3+ agents and no
+    // orchestrator-role member reads as a flat team with no dedicated lead —
+    // the slot still works (an Acting Commander holds it), so this is a
+    // non-blocking suggestion, never an error, and never gates creation or
+    // operation. Skipped when the Commander is missing entirely (the error
+    // above already covers that case).
+    if (this.hasWorkspaceEntryAgentReference() && references.length >= 3) {
+      const hasOrchestrator = references.some(reference => {
+        const profile = this.getAgentProfile(reference.name);
+        return String(profile?.role || '').trim().toLowerCase() === 'orchestrator';
+      });
+      if (!hasOrchestrator) {
+        const workspaceName = String(this.workspace?.name || '').trim() || 'This workspace';
+        issues.push({
+          category: 'agent',
+          severity: 'warning',
+          title: 'This team has no dedicated Commander',
+          description:
+            "None of this workspace's agents has the Commander role — the slot is held by an Acting Commander. Assign the Commander role to one of them so dispatch work routes to the right specialist.",
+          action: 'assign_commander',
+          actionLabel: 'Assign a Commander',
+          meta: [workspaceName, `${references.length} agents`, 'No Commander role assigned']
+        });
+      }
     }
 
     if (this.agentCatalogLoadFailed) {
@@ -2387,14 +2413,14 @@ export class WorkspaceDetailPage {
         issues.push({
           category: 'agent',
           severity: 'error',
-          title: reference.isEntryAgent ? 'Entry agent is missing' : 'Workspace agent is missing',
+          title: reference.isEntryAgent ? 'Commander is missing' : 'Workspace agent is missing',
           description: reference.isEntryAgent
-            ? `"${reference.name}" is still assigned as the workspace entry agent, but the runnable agent definition no longer exists.`
+            ? `"${reference.name}" is still assigned as the workspace Commander, but the runnable agent definition no longer exists.`
             : `"${reference.name}" is still linked to this workspace, but the runnable agent definition no longer exists.`,
           action: reference.isEntryAgent ? 'entry_agent' : 'agent',
-          actionLabel: reference.isEntryAgent ? 'Create Entry Agent' : 'Recreate Agent',
+          actionLabel: reference.isEntryAgent ? 'Create Commander' : 'Recreate Agent',
           agentName: reference.name,
-          meta: [reference.name, reference.isEntryAgent ? 'Entry agent' : 'Workspace member']
+          meta: [reference.name, reference.isEntryAgent ? 'Commander' : 'Workspace member']
         });
       });
     }
@@ -2489,7 +2515,7 @@ export class WorkspaceDetailPage {
 
     const parts = [];
     if (agentIssueCount > 0) {
-      parts.push(`${agentIssueCount} missing agent${agentIssueCount === 1 ? '' : 's'}`);
+      parts.push(`${agentIssueCount} agent issue${agentIssueCount === 1 ? '' : 's'}`);
     }
     if (fileIssueCount > 0) {
       parts.push(`${fileIssueCount} linked file issue${fileIssueCount === 1 ? '' : 's'}`);
@@ -2550,7 +2576,7 @@ export class WorkspaceDetailPage {
         <button type="button"
                 class="workspace-detail-panel-btn workspace-detail-health-action"
                 onclick="window.workspaceDetail?.openWorkspaceHealthAgentRecovery('${encodeURIComponent(issue.agentName)}', 'entry')">
-          ${this.escapeHtml(issue.actionLabel || 'Create Entry Agent')}
+          ${this.escapeHtml(issue.actionLabel || 'Create Commander')}
         </button>
       `;
     } else if (issue?.action === 'agent' && issue?.agentName) {
@@ -2560,6 +2586,15 @@ export class WorkspaceDetailPage {
                 onclick="window.workspaceDetail?.openWorkspaceHealthAgentRecovery('${encodeURIComponent(issue.agentName)}', 'agent')">
           ${this.escapeHtml(issue.actionLabel || 'Recreate Agent')}
         </button>
+      `;
+    } else if (issue?.action === 'assign_commander') {
+      // Links to the roster's role picker/bulk "Set role" tool (Group 5)
+      // rather than a recovery onclick — there's nothing broken to repair,
+      // just a role to assign.
+      actionMarkup = `
+        <a class="workspace-detail-panel-btn workspace-detail-health-action" href="/agents">
+          ${this.escapeHtml(issue.actionLabel || 'Assign a Commander')}
+        </a>
       `;
     } else if (issue?.action === 'file' && issue?.fileId) {
       actionMarkup = `
@@ -3241,7 +3276,7 @@ export class WorkspaceDetailPage {
     if (this.isWorkspaceEntryAgent(normalizedName)) {
       const href = this.buildWorkspaceAgentRecoveryURL(normalizedName);
       if (href) {
-        const title = `Create entry agent ${normalizedName}`;
+        const title = `Create Commander ${normalizedName}`;
         return {
           kind: 'missing-entry',
           href,
@@ -3507,7 +3542,12 @@ export class WorkspaceDetailPage {
 
   renderWorkspaceAgentRoleBadge(agentName) {
     if (!this.isWorkspaceEntryAgent(agentName)) return '';
-    return '<span class="workspace-detail-agent-role-badge">Entry Agent</span>';
+    // Commander-slot label (PRD FR21/FR22): "Commander" when the holder's role
+    // is orchestrator, "Acting Commander" otherwise. Display only.
+    const profile = this.getAgentProfile(agentName);
+    const role = profile && profile.role ? String(profile.role).trim().toLowerCase() : '';
+    const label = role === 'orchestrator' ? 'Commander' : 'Acting Commander';
+    return '<span class="workspace-detail-agent-role-badge">' + label + '</span>';
   }
 
   getAgentGroupRolePresentation(group) {
@@ -5195,20 +5235,20 @@ export class WorkspaceDetailPage {
 
     const workspaceName = String(this.workspace?.name || '').trim() || 'this workspace';
     const entryAgentDefaults = this.buildWorkspaceEntryAgentDefaults();
-    // An entry agent is required for the workspace to operate, so this prompt is
+    // A Commander is required for the workspace to operate, so this prompt is
     // mandatory: there is no "create later" escape and it resolves only when the
     // user proceeds to create one.
     await this.showTaskConfirmDialog({
       eyebrow: 'Workspace Setup',
-      title: 'Create an entry agent for this workspace?',
-      message: `"${workspaceName}" cannot function until it has an entry agent.`,
-      confirmLabel: 'Create Entry Agent',
+      title: 'Create a Commander for this workspace?',
+      message: `"${workspaceName}" cannot function until it has a Commander.`,
+      confirmLabel: 'Create Commander',
       mandatory: true,
-      metaItems: [workspaceName, entryAgentDefaults.seedName, 'No entry agent'],
+      metaItems: [workspaceName, entryAgentDefaults.seedName, 'No Commander'],
       details: [
-        'The entry agent is required for this workspace to operate normally.',
-        'Chats, routing, and task orchestration depend on having an entry agent.',
-        'The first agent you add here will become the workspace entry agent automatically.',
+        'The Commander is required for this workspace to operate normally.',
+        'Chats, routing, and task orchestration depend on having a Commander.',
+        'The first agent you add here will become the workspace Commander automatically.',
         'You can rename or replace it later.'
       ]
     });
@@ -6484,7 +6524,7 @@ export class WorkspaceDetailPage {
     if (!normalizedAgentName || !normalizedKey) return;
 
     if (this.isWorkspaceEntryAgent(normalizedAgentName)) {
-      window.alert(`"${normalizedAgentName}" is the workspace entry agent and can't be removed.`);
+      window.alert(`"${normalizedAgentName}" is the workspace Commander and can't be removed.`);
       return;
     }
 
@@ -11609,6 +11649,7 @@ export class WorkspaceDetailPage {
         this.workspaceAgentProfiles.set(key, {
           name,
           type: String(agent?.type || '').trim(),
+          role: String(agent?.role || '').trim(),
           model: String(agent?.model || '').trim(),
           provider: String(agent?.provider || '').trim(),
           source:
@@ -11660,6 +11701,7 @@ export class WorkspaceDetailPage {
         const profile = {
           name,
           type: String(agent?.type || '').trim(),
+          role: String(agent?.role || '').trim(),
           source: String(agent?.source || 'user')
             .trim()
             .toLowerCase(),

--- a/internal/web/static/js/modules/workspace-detail.test.js
+++ b/internal/web/static/js/modules/workspace-detail.test.js
@@ -288,7 +288,74 @@ test('referenced agent with no global definition and no snapshot is a missing er
   const issues = page.collectWorkspaceHealthIssues();
   assert.equal(issues.length, 1);
   assert.equal(issues[0].severity, 'error');
-  assert.equal(issues[0].title, 'Entry agent is missing');
+  assert.equal(issues[0].title, 'Commander is missing');
+});
+
+test('3+ agents with no orchestrator role surfaces a non-blocking Commander nudge (FR23)', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    name: 'Trio',
+    entry_agent_name: 'Alpha',
+    agents: ['Alpha', 'Beta', 'Gamma'],
+    agent_instances: [{ name: 'Alpha', entry_point: true }, { name: 'Beta' }, { name: 'Gamma' }],
+    shared_data: {}
+  };
+  page.agentIndex = new Map([
+    ['alpha', { role: 'researcher' }],
+    ['beta', { role: 'analyzer' }],
+    ['gamma', { role: 'specialist' }]
+  ]);
+  page.workspaceAgentSnapshots = new Set(['alpha', 'beta', 'gamma']);
+  page.files = [];
+
+  const issues = page.collectWorkspaceHealthIssues();
+  const nudge = issues.find(issue => issue.title === 'This team has no dedicated Commander');
+  assert.ok(nudge, 'expected the no-Commander nudge to be present');
+  assert.equal(nudge.severity, 'warning', 'the nudge must never be an error (non-blocking)');
+  assert.equal(nudge.action, 'assign_commander');
+});
+
+test('3+ agents with an orchestrator role has no Commander nudge', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    name: 'Trio',
+    entry_agent_name: 'Alpha',
+    agents: ['Alpha', 'Beta', 'Gamma'],
+    agent_instances: [{ name: 'Alpha', entry_point: true }, { name: 'Beta' }, { name: 'Gamma' }],
+    shared_data: {}
+  };
+  page.agentIndex = new Map([
+    ['alpha', { role: 'orchestrator' }],
+    ['beta', { role: 'analyzer' }],
+    ['gamma', { role: 'specialist' }]
+  ]);
+  page.workspaceAgentSnapshots = new Set(['alpha', 'beta', 'gamma']);
+  page.files = [];
+
+  const issues = page.collectWorkspaceHealthIssues();
+  const nudge = issues.find(issue => issue.title === 'This team has no dedicated Commander');
+  assert.equal(nudge, undefined, 'a workspace with a Commander role should not get the nudge');
+});
+
+test('fewer than 3 agents never gets the no-Commander nudge', () => {
+  const page = new WorkspaceDetailPage('workspace-1');
+  page.workspace = {
+    name: 'Duo',
+    entry_agent_name: 'Alpha',
+    agents: ['Alpha', 'Beta'],
+    agent_instances: [{ name: 'Alpha', entry_point: true }, { name: 'Beta' }],
+    shared_data: {}
+  };
+  page.agentIndex = new Map([
+    ['alpha', { role: 'researcher' }],
+    ['beta', { role: 'analyzer' }]
+  ]);
+  page.workspaceAgentSnapshots = new Set(['alpha', 'beta']);
+  page.files = [];
+
+  const issues = page.collectWorkspaceHealthIssues();
+  const nudge = issues.find(issue => issue.title === 'This team has no dedicated Commander');
+  assert.equal(nudge, undefined, 'below the 3-agent threshold, no nudge should appear');
 });
 
 test('workspace detail summary chip counts tasks with reference URLs', () => {

--- a/internal/web/static/js/modules/workspace-map.js
+++ b/internal/web/static/js/modules/workspace-map.js
@@ -423,7 +423,7 @@
       '"></span>' +
       escapeHtml(statusText) +
       '</span>' +
-      (hasKeeper ? '<span class="ws-map-tile-crest" title="Entry agent (locked)">★</span>' : '') +
+      (hasKeeper ? '<span class="ws-map-tile-crest" title="Commander (locked)">★</span>' : '') +
       (isHQ ? '<span class="ws-map-tile-hq-badge" title="Personal HQ">HQ</span>' : '') +
       (isHQ ? structSVGHQ() : structSVG(pal)) +
       '<span class="ws-map-tile-name">' +
@@ -816,7 +816,7 @@
         escapeHtml(entry) +
         '</div>' +
         '<div class="ws-map-ov-keeper-badge">★ Locked · can&#39;t remove</div></div></div>'
-      : '<span class="ws-map-ov-none">No entry agent</span>';
+      : '<span class="ws-map-ov-none">No Commander</span>';
 
     var roster = agents.length
       ? agents
@@ -854,7 +854,7 @@
       folderOverviewHTML(ws, options) +
       tagsOverviewHTML(ws, options) +
       groupPreviewHTML(ws, options) +
-      '<div class="ws-map-ov-label">Entry agent</div>' +
+      '<div class="ws-map-ov-label">Commander</div>' +
       '<div class="ws-map-ov-keeperwrap">' +
       keeper +
       '</div>' +

--- a/internal/web/static/js/modules/workspace-map.test.js
+++ b/internal/web/static/js/modules/workspace-map.test.js
@@ -290,7 +290,7 @@ test('overviewBodyHTML falls back to empty-state copy when a workspace has no en
   const { overviewBodyHTML } = loadOriWorkspaceMap();
   const html = overviewBodyHTML({ id: 'a', name: 'Bare Workspace' });
 
-  assert.match(html, /No entry agent/);
+  assert.match(html, /No Commander/);
   assert.match(html, /No agents yet/);
 });
 

--- a/internal/web/static/js/modules/workspace-realtime.js
+++ b/internal/web/static/js/modules/workspace-realtime.js
@@ -200,6 +200,12 @@ class WorkspaceRealtime {
   handleTaskEvent(workspaceId, eventType, e) {
     try {
       const data = JSON.parse(e.data);
+      // A completed task may have bumped the executing agent's evolution
+      // stage (PRD FR15/FR19) — check here so the toast fires from the Map
+      // view's normal task flow, not only while the roster page is open.
+      if (eventType === 'task.completed' && data && data.agent && window.StageUpToast) {
+        window.StageUpToast.checkByFetch(data.agent);
+      }
       this.notifyListeners(workspaceId, {
         type: eventType,
         workspaceId: workspaceId,

--- a/internal/web/templates/components/workspace-hub.tmpl
+++ b/internal/web/templates/components/workspace-hub.tmpl
@@ -242,12 +242,12 @@
           <input id="launcherGroupNameInput" type="text" class="modern-input w-100 mb-2" placeholder="Group Name" autocomplete="off">
           <label for="launcherGroupDescriptionInput" style="display: block; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);">What this group is for</label>
           <textarea id="launcherGroupDescriptionInput" class="modern-input w-100" placeholder="Shared client, team, or initiative" rows="2" style="resize: vertical;"></textarea>
-          <label for="launcherGroupEntryAgentSelect" style="display: block; margin-top: 8px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);">Entry agent</label>
-          <select id="launcherGroupEntryAgentSelect" class="form-select form-select-sm w-100" aria-label="Entry agent for this group">
+          <label for="launcherGroupEntryAgentSelect" style="display: block; margin-top: 8px; margin-bottom: 6px; font-size: 12px; color: var(--text-secondary);">Commander</label>
+          <select id="launcherGroupEntryAgentSelect" class="form-select form-select-sm w-100" aria-label="Commander for this group">
             <option value="" selected>Auto-create group manager</option>
           </select>
           <div style="margin-top: 8px; font-size: 12px; color: var(--text-secondary);">
-            Selected workspaces will be organized under this group. The group is a full workspace too: it gets its own folder and entry agent, and can hold sessions, notes, and tasks.
+            Selected workspaces will be organized under this group. The group is a full workspace too: it gets its own folder and Commander, and can hold sessions, notes, and tasks.
           </div>
         </div>
         <div class="modal-footer" style="border-top: 1px solid var(--border-color);">

--- a/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
+++ b/internal/web/templates/components/workspaces/create-workspace-modal.tmpl
@@ -66,6 +66,11 @@
                     <span class="workspace-template-briefing-row-label">Agents</span>
                     <div id="templateBriefingAgentsValue" class="workspace-template-briefing-chips workspace-template-briefing-agents"></div>
                   </div>
+                  <!-- Non-blocking nudge (PRD FR23): shown when the blueprint seeds 3+
+                       agents and none has the Commander role. Never blocks selection. -->
+                  <div id="templateBriefingNoCommanderNudge" class="workspace-template-briefing-nudge" hidden>
+                    This team has no dedicated Commander — one agent will hold the slot as Acting Commander. You can assign the Commander role after creating the workspace.
+                  </div>
                   <div id="templateBriefingScaffoldRow" class="workspace-template-briefing-row" hidden>
                     <span class="workspace-template-briefing-row-label">Project folder</span>
                     <span id="templateBriefingScaffoldValue" class="workspace-template-briefing-row-value"></span>

--- a/internal/web/templates/pages/agents-create.tmpl
+++ b/internal/web/templates/pages/agents-create.tmpl
@@ -384,6 +384,124 @@
       align-items: center;
     }
 
+    /* ---------- Catalog / Custom tabs ---------- */
+    .agent-create-tabs {
+      display: flex;
+      gap: 6px;
+      margin-bottom: 16px;
+    }
+
+    .agent-create-tab {
+      appearance: none;
+      border: 1px solid color-mix(in srgb, var(--border-color) 78%, var(--primary-color) 22%);
+      background: var(--bg-secondary);
+      color: var(--text-secondary);
+      font-size: 14px;
+      font-weight: 600;
+      padding: 9px 18px;
+      border-radius: 10px 10px 0 0;
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .agent-create-tab:hover {
+      color: var(--text-primary);
+    }
+
+    .agent-create-tab.is-active {
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      border-bottom-color: var(--bg-primary);
+      box-shadow: 0 -2px 0 var(--primary-color) inset;
+    }
+
+    .agent-create-tab:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 24%, transparent);
+    }
+
+    /* ---------- Catalog card grid ---------- */
+    .catalog-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+      gap: 14px;
+    }
+
+    .catalog-card {
+      --catalog-accent: var(--primary-color);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      text-align: left;
+      padding: 16px 16px 14px;
+      border: 1px solid color-mix(in srgb, var(--border-color) 82%, var(--primary-color) 18%);
+      border-radius: 14px;
+      background: var(--bg-secondary);
+      cursor: pointer;
+      clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 12px, 100% 100%, 12px 100%, 0 calc(100% - 12px));
+      transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .catalog-card:hover {
+      transform: translateY(-2px);
+      border-color: color-mix(in srgb, var(--catalog-accent) 55%, var(--border-color) 45%);
+      box-shadow: 0 10px 22px rgba(0, 0, 0, 0.1);
+    }
+
+    .catalog-card:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--catalog-accent) 32%, transparent);
+    }
+
+    .catalog-card.is-selected {
+      border-color: var(--catalog-accent);
+      background: color-mix(in srgb, var(--catalog-accent) 10%, var(--bg-secondary));
+      box-shadow: 0 0 0 1px var(--catalog-accent);
+    }
+
+    .catalog-card-emblem {
+      width: 38px;
+      height: 38px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 10px;
+      font-size: 18px;
+      color: var(--catalog-accent);
+      background: color-mix(in srgb, var(--catalog-accent) 16%, transparent);
+    }
+
+    .catalog-card-name {
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+
+    .catalog-card-tagline {
+      font-size: 12px;
+      line-height: 1.4;
+      color: var(--text-secondary);
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .catalog-preset-summary {
+      font-size: 13px;
+      color: var(--text-secondary);
+      background: var(--bg-secondary);
+      border: 1px solid color-mix(in srgb, var(--border-color) 84%, var(--primary-color) 16%);
+      border-radius: 10px;
+      padding: 10px 12px;
+      line-height: 1.5;
+    }
+
+    .catalog-preset-summary strong {
+      color: var(--text-primary);
+    }
+
     .modern-btn:disabled,
     .btn:disabled {
       opacity: 0.5;
@@ -530,6 +648,54 @@
           <p>Configure and customize your AI agent</p>
         </div>
 
+        <div class="agent-create-tabs" role="tablist" aria-label="Agent creation mode">
+          <button type="button" class="agent-create-tab is-active" id="catalogTabBtn" role="tab"
+            aria-selected="true" aria-controls="catalogTabPanel" tabindex="0">Catalog</button>
+          <button type="button" class="agent-create-tab" id="customTabBtn" role="tab"
+            aria-selected="false" aria-controls="customTabPanel" tabindex="-1">Custom</button>
+        </div>
+
+        <section id="catalogTabPanel" class="agent-create-tabpanel" role="tabpanel" aria-labelledby="catalogTabBtn" tabindex="0">
+          <div id="catalogError" class="error-message" role="alert" aria-live="polite" hidden tabindex="-1"></div>
+
+          <div class="form-card modern-card">
+            <h2 class="form-section-title">Choose a Role</h2>
+            <div id="catalogGrid" class="catalog-grid" role="radiogroup" aria-label="Catalog role">
+              <!-- Populated by agents-catalog.js -->
+            </div>
+          </div>
+
+          <div id="catalogSelectionCard" class="form-card modern-card" hidden>
+            <h2 class="form-section-title">Configure &amp; Create</h2>
+
+            <div class="form-group">
+              <label class="form-label required" for="catalogAgentName">Agent Name</label>
+              <input type="text" id="catalogAgentName" class="form-input" autocomplete="off"
+                aria-describedby="catalogAgentNameError" required>
+              <div id="catalogAgentNameError" class="field-error" aria-live="polite"></div>
+            </div>
+
+            <div id="catalogDomainGroup" class="form-group" hidden>
+              <label class="form-label" for="catalogDomain">Domain</label>
+              <input type="text" id="catalogDomain" class="form-input" autocomplete="off" placeholder="e.g., reaper, tax, legal">
+              <div class="form-help">The single domain this Specialist focuses on.</div>
+            </div>
+
+            <div class="form-group">
+              <div class="form-label mb-1">Preset Summary</div>
+              <div id="catalogPresetSummary" class="catalog-preset-summary"></div>
+            </div>
+
+            <div id="catalogModelNotice" class="alert alert-warning" style="font-size: 0.85rem;" role="status" aria-live="polite" hidden></div>
+
+            <div class="form-actions">
+              <a href="/agents" class="modern-btn modern-btn-secondary">Cancel</a>
+              <button type="button" id="catalogCreateBtn" class="modern-btn modern-btn-primary">Create Agent</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="customTabPanel" class="agent-create-tabpanel" role="tabpanel" aria-labelledby="customTabBtn" tabindex="0" hidden>
         <form id="createAgentForm" novalidate>
         <div id="errorMessage" class="error-message" role="alert" aria-live="polite" hidden tabindex="-1"></div>
 
@@ -719,6 +885,7 @@
           </div>
         </div>
         </form>
+        </section>
       </div>
     </main>
   </div>
@@ -738,6 +905,7 @@
   <script defer src="/js/modules/resizer.js"></script>
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/agents-create.js"></script>
+  <script defer src="/js/modules/agents-catalog.js"></script>
   {{template "theme-init.tmpl" .}}
 </body>
 </html>

--- a/internal/web/templates/pages/agents-detail.tmpl
+++ b/internal/web/templates/pages/agents-detail.tmpl
@@ -451,11 +451,11 @@
             </p>
             <div id="missingAgentMeta" class="agent-missing-meta"></div>
             <div id="missingAgentDetail" class="agent-missing-detail">
-              If this agent belonged to a workspace, recreate its entry agent there so routing and task execution can resume cleanly.
+              If this agent belonged to a workspace, recreate its Commander there so routing and task execution can resume cleanly.
             </div>
             <div class="agent-missing-actions">
               <a id="missingAgentCreateEntryBtn" href="/workspaces" class="modern-btn modern-btn-primary" style="display: none;">
-                Create Entry Agent
+                Create Commander
               </a>
               <a id="missingAgentOpenWorkspaceBtn" href="/workspaces" class="modern-btn modern-btn-secondary" style="display: none;">
                 Open Workspace

--- a/internal/web/templates/pages/agents-detail.tmpl
+++ b/internal/web/templates/pages/agents-detail.tmpl
@@ -762,9 +762,21 @@
                     </svg>
                     Skills
                   </h3>
-                  <a id="openSkillsPageLink" href="/skills" class="modern-btn modern-btn-secondary btn-sm">
-                    Open Skills Page
-                  </a>
+                  <div class="d-flex align-items-center gap-2">
+                    <span id="skillSlotUsage" class="badge" style="display:none; font-size: 12px; background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-color);"></span>
+                    <a id="openSkillsPageLink" href="/skills" class="modern-btn modern-btn-secondary btn-sm">
+                      Open Skills Page
+                    </a>
+                  </div>
+                </div>
+                <div id="expertModeRow" class="d-flex align-items-center justify-content-between mb-3 p-2" style="display:none !important; border: 1px solid var(--border-color); border-radius: 8px; background: var(--bg-secondary);">
+                  <div>
+                    <div style="font-weight: 600; color: var(--text-primary); font-size: 13px;">Expert mode</div>
+                    <div style="font-size: 12px; color: var(--text-secondary);">Lifts the stage-based skill slot cap for this agent — enable any number of skills.</div>
+                  </div>
+                  <div class="form-check form-switch m-0">
+                    <input class="form-check-input" type="checkbox" id="expertModeToggle" role="switch" aria-label="Expert mode">
+                  </div>
                 </div>
                 <div id="skillsList" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px;">
                   <div class="text-center py-3" style="color: var(--text-secondary);">Loading skills...</div>

--- a/internal/web/templates/pages/agents-roster.tmpl
+++ b/internal/web/templates/pages/agents-roster.tmpl
@@ -41,6 +41,7 @@
               <select id="rosterSort" aria-label="Sort agents">
                 <option value="name-asc">Name A–Z</option>
                 <option value="name-desc">Name Z–A</option>
+                <option value="level-desc">Level (highest first)</option>
                 <option value="workspaces-desc">Most workspaces</option>
                 <option value="active-desc">Recently active</option>
               </select>
@@ -91,6 +92,7 @@
             <div class="bulk-bar__actions">
               <button type="button" class="bulk-bar__btn" id="bulkAddTags">Add tags</button>
               <button type="button" class="bulk-bar__btn" id="bulkRemoveTags">Remove tags</button>
+              <button type="button" class="bulk-bar__btn" id="bulkSetRole">Set role</button>
               <button type="button" class="bulk-bar__btn" id="bulkFavorite">Favorite</button>
               <button type="button" class="bulk-bar__btn" id="bulkUnfavorite">Unfavorite</button>
               <button type="button" class="bulk-bar__btn bulk-bar__btn--danger" id="bulkDelete">Delete</button>
@@ -164,6 +166,10 @@
               </div>
             </header>
 
+            <div class="stage__progression" id="stageProgression" aria-live="polite">
+              <!-- role emblem/name, level, stage, XP bar, slot usage injected -->
+            </div>
+
             <nav class="stage__tabs" role="tablist" aria-label="Agent detail sections">
               <button class="stage__tab is-active" role="tab" id="tab-overview" aria-controls="panel-overview" aria-selected="true" data-tab="overview" type="button">Overview</button>
               <button class="stage__tab" role="tab" id="tab-prompt" aria-controls="panel-prompt" aria-selected="false" data-tab="prompt" type="button" tabindex="-1">Prompt</button>
@@ -207,6 +213,9 @@
   <!-- Shared tag-entry widget (exposes window.OriTagInput). Loaded as a module so
        the roster's Overview + bulk tag flows reuse it instead of duplicating. -->
   <script type="module" src="/js/modules/tag-input.js"></script>
+  <script defer src="/js/modules/toast.js"></script>
+  <script defer src="/js/modules/role-catalog.js"></script>
+  <script defer src="/js/modules/stage-up-toast.js"></script>
   <script defer src="/js/agents-roster.js"></script>
 </body>
 

--- a/internal/web/templates/pages/templates.tmpl
+++ b/internal/web/templates/pages/templates.tmpl
@@ -165,7 +165,7 @@
                       <div id="tplStarterTasksList" class="d-flex flex-column gap-2 mb-2"></div>
                       <button id="tplStarterTaskAddBtn" type="button" class="modern-btn modern-btn-secondary btn-sm">Add task</button>
                       <div style="margin-top: 6px; font-size: 11px; color: var(--text-secondary);">
-                        Seeded into the workspace (assigned to the entry agent) on creation. Mark at most one task as the
+                        Seeded into the workspace (assigned to the Commander) on creation. Mark at most one task as the
                         <strong>setup task</strong> — it auto-starts once, when the workspace is first opened, and should
                         offer to adjust the defaults your files already scaffold. Suggested details headings:
                         <code>Created defaults</code>, <code>Questions to ask</code>, <code>Validation</code>, <code>How to apply changes</code>.
@@ -243,8 +243,8 @@
                         <div class="tpl-section-kicker">Seeded roster</div>
                         <h5 class="tpl-section-title">Agents</h5>
                         <p class="tpl-section-copy">
-                          Agents are created when a workspace is made from this template. The first card becomes the entry agent; the rest seed specialist sub-agents.
-                          Every template needs at least one agent — the entry agent owns the template's starter tasks.
+                          Agents are created when a workspace is made from this template. The first card becomes the Commander; the rest seed specialist sub-agents.
+                          Every template needs at least one agent — the Commander owns the template's starter tasks.
                         </p>
                       </div>
                       <div class="tpl-agents-actions">
@@ -254,7 +254,7 @@
                     </div>
                     <div id="tplAgentsEmpty" class="tpl-agents-empty" hidden>
                       <div class="tpl-agents-empty-title">No seeded agents</div>
-                      <div>Add at least one agent — until then, workspaces created from this template get an auto-created "&lt;Name&gt; Manager" as their entry agent.</div>
+                      <div>Add at least one agent — until then, workspaces created from this template get an auto-created "&lt;Name&gt; Manager" as their Commander.</div>
                     </div>
                     <div id="tplAgentsList" class="tpl-agents-grid mb-3"></div>
                   </div>

--- a/internal/web/templates/pages/workspace-canvas.tmpl
+++ b/internal/web/templates/pages/workspace-canvas.tmpl
@@ -713,6 +713,10 @@
   <script defer src="/js/modules/sidebar.js"></script>
   <script defer src="/js/modules/file-upload.js"></script>
   <script defer src="/js/modules/toast.js"></script>
+  <!-- Stage-up detection: fires a toast when a task-completion event bumps an
+       agent's evolution stage, so progression is felt from the Map view (not
+       only the roster page). -->
+  <script defer src="/js/modules/stage-up-toast.js"></script>
   <!-- Real-time workspace modules -->
   <script defer src="/js/modules/workspace-realtime.js"></script>
   <script defer src="/js/modules/message-timeline.js"></script>

--- a/internal/workspace/executor.go
+++ b/internal/workspace/executor.go
@@ -26,6 +26,7 @@ type TaskExecutor struct {
 	eventBus               *EventBus // Optional event bus for publishing events
 
 	providerResolver TaskProviderResolver // optional; overrides taskHandler assertion
+	evolutionAwarder TaskXPAwarder        // optional; awards XP for completed tasks
 
 	mu           sync.RWMutex
 	runningTasks map[string]*taskExecution
@@ -34,12 +35,29 @@ type TaskExecutor struct {
 	wg           sync.WaitGroup
 }
 
+// TaskXPAwarder grants evolution XP for a completed task run. Implemented by
+// evolution.Service; kept as a narrow interface so workspace doesn't depend
+// on the evolution package. A nil TaskXPAwarder (feature disabled/unwired)
+// is handled by simply never calling SetEvolutionAwarder.
+type TaskXPAwarder interface {
+	AwardTaskXP(agentName string) error
+}
+
 // SetProviderResolver wires provider-profile resolution for scheduling (WS6).
 // This is needed when the execution handler is a wrapper (e.g. a run bridge) that
 // does not itself implement TaskProviderResolver; without it the executor falls
 // back to type-asserting the task handler.
 func (te *TaskExecutor) SetProviderResolver(resolver TaskProviderResolver) {
 	te.providerResolver = resolver
+}
+
+// SetEvolutionAwarder wires the evolution service so completed task runs
+// award XP to the executing agent (PRD FR15-16). Never call this with a
+// possibly-nil concrete pointer wrapped in the interface — leave it unset
+// instead, so te.evolutionAwarder stays a true nil interface and the
+// executeTask nil-check below is reliable.
+func (te *TaskExecutor) SetEvolutionAwarder(awarder TaskXPAwarder) {
+	te.evolutionAwarder = awarder
 }
 
 // resolveProviderProfile resolves a task's provider profile, preferring an
@@ -546,6 +564,15 @@ func (te *TaskExecutor) executeTask(ws *Workspace, task Task, profile TaskProvid
 				}
 			}
 		} else {
+			// Award evolution XP to the executing agent for the completed task
+			// (PRD FR15-16). Best-effort: a nil awarder (feature disabled) or an
+			// award error never blocks task completion.
+			if te.evolutionAwarder != nil && task.To != "" {
+				if awardErr := te.evolutionAwarder.AwardTaskXP(task.To); awardErr != nil {
+					logger.Error("Failed to award task XP", logger.Fields{"agent": task.To, "task_id": task.ID, "error": awardErr})
+				}
+			}
+
 			// Refresh ws so autoStoreResult sees the post-mutation workspace.
 			// autoStoreResult is best-effort and does its own Save outside the
 			// per-workspace lock, so a concurrent Update can interleave; that's

--- a/internal/workspace/executor_test.go
+++ b/internal/workspace/executor_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,7 +18,8 @@ type fakeTaskHandler struct {
 	mu      sync.Mutex
 	seenIDs map[string]int
 
-	block <-chan struct{} // optional: hold ExecuteTask until closed
+	block     <-chan struct{} // optional: hold ExecuteTask until closed
+	returnErr error           // optional: return this error instead of a successful result
 }
 
 func (h *fakeTaskHandler) ExecuteTask(ctx context.Context, agentName string, task Task) (string, error) {
@@ -35,6 +37,9 @@ func (h *fakeTaskHandler) ExecuteTask(ctx context.Context, agentName string, tas
 		case <-ctx.Done():
 			return "", ctx.Err()
 		}
+	}
+	if h.returnErr != nil {
+		return "", h.returnErr
 	}
 	return "ok", nil
 }
@@ -280,6 +285,133 @@ func TestCheckAndExecuteTasks_SingleClaimPerTask(t *testing.T) {
 		if n != 1 {
 			t.Errorf("task %s executed %d times, want 1", id, n)
 		}
+	}
+}
+
+// fakeXPAwarder records AwardTaskXP calls so tests can assert whether task
+// completion (vs failure) actually triggered an award.
+type fakeXPAwarder struct {
+	mu     sync.Mutex
+	awards []string // agent names, in call order
+	err    error
+}
+
+func (a *fakeXPAwarder) AwardTaskXP(agentName string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.awards = append(a.awards, agentName)
+	return a.err
+}
+
+func (a *fakeXPAwarder) callCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.awards)
+}
+
+// waitForTaskStatus polls the store until the task reaches one of the target
+// statuses or the deadline passes, returning the final status seen.
+func waitForTaskStatus(t *testing.T, store Store, wsID, taskID string, deadline time.Time) TaskStatus {
+	t.Helper()
+	for time.Now().Before(deadline) {
+		fresh, err := store.Get(wsID)
+		if err == nil {
+			if task, taskErr := fresh.GetTask(taskID); taskErr == nil && task != nil {
+				if task.Status == TaskStatusCompleted || task.Status == TaskStatusFailed {
+					return task.Status
+				}
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("task %s did not reach a terminal status before deadline", taskID)
+	return ""
+}
+
+// TestExecuteTask_AwardsXPOnCompletion verifies a successfully completed task
+// awards XP to the executing agent exactly once (PRD FR15).
+func TestExecuteTask_AwardsXPOnCompletion(t *testing.T) {
+	store := newExecutorTestStore(t)
+	ws := newWorkspaceWithTasks(t, []Task{
+		{ID: "t1", To: "agent-a", Status: TaskStatusAssigned},
+	})
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	handler := &fakeTaskHandler{}
+	te := NewTaskExecutor(store, handler, ExecutorConfig{PollInterval: time.Hour, MaxConcurrent: 1})
+	t.Cleanup(te.Stop)
+
+	awarder := &fakeXPAwarder{}
+	te.SetEvolutionAwarder(awarder)
+
+	te.checkAndExecuteTasks()
+
+	status := waitForTaskStatus(t, store, ws.ID, "t1", time.Now().Add(2*time.Second))
+	if status != TaskStatusCompleted {
+		t.Fatalf("task status = %q, want completed", status)
+	}
+
+	if got := awarder.callCount(); got != 1 {
+		t.Fatalf("AwardTaskXP call count = %d, want 1", got)
+	}
+	if awarder.awards[0] != "agent-a" {
+		t.Errorf("AwardTaskXP called for agent %q, want agent-a", awarder.awards[0])
+	}
+}
+
+// TestExecuteTask_NoXPOnFailure verifies a failed task run awards no XP.
+func TestExecuteTask_NoXPOnFailure(t *testing.T) {
+	store := newExecutorTestStore(t)
+	ws := newWorkspaceWithTasks(t, []Task{
+		{ID: "t1", To: "agent-a", Status: TaskStatusAssigned},
+	})
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	handler := &fakeTaskHandler{returnErr: errors.New("boom")}
+	te := NewTaskExecutor(store, handler, ExecutorConfig{PollInterval: time.Hour, MaxConcurrent: 1})
+	t.Cleanup(te.Stop)
+
+	awarder := &fakeXPAwarder{}
+	te.SetEvolutionAwarder(awarder)
+
+	te.checkAndExecuteTasks()
+
+	status := waitForTaskStatus(t, store, ws.ID, "t1", time.Now().Add(2*time.Second))
+	if status != TaskStatusFailed {
+		t.Fatalf("task status = %q, want failed", status)
+	}
+
+	if got := awarder.callCount(); got != 0 {
+		t.Fatalf("AwardTaskXP call count = %d, want 0 for a failed task", got)
+	}
+}
+
+// TestExecuteTask_NilAwarderIsSafeNoOp verifies that never calling
+// SetEvolutionAwarder (feature disabled/unwired) does not panic and task
+// completion proceeds normally.
+func TestExecuteTask_NilAwarderIsSafeNoOp(t *testing.T) {
+	store := newExecutorTestStore(t)
+	ws := newWorkspaceWithTasks(t, []Task{
+		{ID: "t1", To: "agent-a", Status: TaskStatusAssigned},
+	})
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	handler := &fakeTaskHandler{}
+	te := NewTaskExecutor(store, handler, ExecutorConfig{PollInterval: time.Hour, MaxConcurrent: 1})
+	t.Cleanup(te.Stop)
+	// Deliberately not calling te.SetEvolutionAwarder.
+
+	te.checkAndExecuteTasks()
+
+	status := waitForTaskStatus(t, store, ws.ID, "t1", time.Now().Add(2*time.Second))
+	if status != TaskStatusCompleted {
+		t.Fatalf("task status = %q, want completed", status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Introduces a curated **Role Catalog** as the default way to create an agent, closes the gap where the existing (but UI-invisible) evolution/progression system only awarded XP from chat, adds stage-based loadout slot caps, surfaces progression across the roster, and renames the "entry agent" concept to the **Commander slot** everywhere it's user-visible.

- **Role catalog** (`internal/agentcatalog`): 6 curated presets — Commander/Researcher/Analyzer/Writer/Reviewer/Specialist — mapped onto the existing `types.AgentRole` enum (no new stored values). `GET /api/agents/catalog` serves the registry; catalog-create resolves a model via the existing model-category system, applies a starter prompt, and initializes `Evolution` at spark/0.
- **Create page**: `/agents/create` now opens on a Catalog tab (card grid, one-field create) with the existing free-form Custom tab preserved unchanged in a second tab.
- **Task-run XP**: `evolution.Service.AwardTaskXP` wired into `workspace.TaskExecutor` at `TaskStatusCompleted` — previously only chat messages awarded XP, so agents driven from Map view never progressed.
- **Loadout slot caps**: active-skill slots grow with stage (spark 2 → sentient 6), enforced in the skill-enable path via a `LoadoutResolver`; per-agent expert-mode flag lifts the cap; over-cap agents are grandfathered (never auto-disabled); cap-aware `"*"` bulk enable fills deterministically.
- **Roster progression UI**: role emblem + level/stage chips on cards, a progression block (XP bar, slot usage) in the stage panel, role filter + Level sort, single/bulk role assignment, and stage-up toasts that fire from both the roster and the Map view's task-completion stream.
- **Commander slot**: "entry agent" renamed to "Commander" across ~15 user-facing files (storage keys/identifiers unchanged); the slot-holder shows "Commander" or "Acting Commander" depending on its role, with a station title; a non-blocking nudge appears in diagnostics and the blueprint wizard when a 3+-agent team has no Commander role assigned.

One feature = one PR per this repo's workflow; all 6 task groups landed as separate commits within this branch.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` green (only failure: pre-existing `TestProviderIntegration`, hits real OpenAI API, unrelated to this change)
- [x] Full JS suite: 775/775 tests pass (`find internal/web/static/js -name "*.test.js" | xargs node --test`)
- [x] Demo-verified live on a sandboxed server for every group: catalog card grid + create flow, Custom tab unchanged, task-XP award via executor unit tests, slot-cap 409 + expert-mode bypass, roster role chips/progression block/bulk role dialog, Map view "ACTING COMMANDER" insignia + diagnostics healthy-state rendering
- [ ] Manual pass through `tasks/test-guide-agent-role-catalog.md` (golden path + edge cases) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)